### PR TITLE
E2E tests: interpreter include cases

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -124,16 +124,6 @@ runs:
         ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python"
         ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python3"
 
-        # Install pip manually
-        echo "Installing pip..."
-        curl -sS https://bootstrap.pypa.io/get-pip.py | "$PYTHON_BIN"
-
-        # Verify pip installation
-        if ! "$PYTHON_BIN" -m pip --version; then
-            echo "Error: Pip installation failed!"
-            exit 1
-        fi
-
         # Final verification of symlinks
         echo "Symlink verification:"
         ls -l "$INSTALL_DIR/usr/bin/python" "$INSTALL_DIR/usr/bin/python3"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -129,4 +129,11 @@ runs:
         # Print symlink verification
         ls -l $INSTALL_DIR/usr/bin/python*
 
+        # Install Black formatter
+        echo "Installing Black..."
+        $PYTHON_BIN -m pip install black --no-cache-dir
+
+        # Verify Black installation
+        $PYTHON_BIN -m black --version
+
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -82,6 +82,12 @@ runs:
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       shell: bash
       run: |
+        set -e  # Exit immediately if any command fails
+
+        echo "Updating system and installing dependencies..."
+        sudo apt update && sudo apt install -y \
+          libpython3.12 python3.12-venv python3.12-distutils python3.12-lib2to3 || { echo "Failed to install dependencies"; exit 1; }
+
         echo "Installing Python 3.12.7 (minimal) in ~/scratch..."
 
         # Set installation path
@@ -127,3 +133,10 @@ runs:
         # Final verification of symlinks
         echo "Symlink verification:"
         ls -l "$INSTALL_DIR/usr/bin/python" "$INSTALL_DIR/usr/bin/python3"
+
+        # Verify Python works after dependency installation
+        echo "Final Python check..."
+        $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
+
+        echo "Installation complete!"
+

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -86,14 +86,14 @@ runs:
 
         echo "Setting up Conda environment with Python 3.12..."
 
-        # Ensure conda is available
+        # Ensure Conda is available
         source "${HOME}/conda/etc/profile.d/conda.sh"
 
         # Define environment path
         CONDA_ENV_DIR="$HOME/scratch/python-env"
 
         # Create a new Conda environment with Python 3.12
-        conda create -y -p "$CONDA_ENV_DIR" python=3.12
+        conda create -y -p "$CONDA_ENV_DIR" python=3.12 pip setuptools
 
         # Activate environment
         conda activate "$CONDA_ENV_DIR"
@@ -109,13 +109,13 @@ runs:
             exit 1
         fi
 
-        # Install pip inside Conda environment
-        echo "Installing pip..."
+        # Install pip (just in case)
+        echo "Ensuring pip is installed..."
         conda install -y pip
 
-        # Install additional dependencies (optional)
-        echo "Installing additional dependencies..."
-        conda install -y python-venv python-distutils
+        # Verify Python modules are working
+        echo "Checking if Python modules work..."
+        $PYTHON_BIN -c "import venv, distutils, sys; print(f'Python {sys.version} modules are working!')"
 
         # Create symlinks for easy access
         echo "Creating symlinks..."

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -78,65 +78,52 @@ runs:
         # Verify that Python is reset
         python --version
 
-    - name: Install Prebuilt Python 3.12.7 in ~/scratch (Ubuntu Only)
+    - name: Create Conda Environment with Python 3.12 in ~/scratch
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       shell: bash
       run: |
         set -e  # Exit immediately if any command fails
 
-        echo "Updating system and installing dependencies..."
-        sudo apt update && sudo apt install -y \
-          libpython3.12 python3.12-venv python3.12-distutils python3.12-lib2to3 || { echo "Failed to install dependencies"; exit 1; }
+        echo "Setting up Conda environment with Python 3.12..."
 
-        echo "Installing Python 3.12.7 (minimal) in ~/scratch..."
+        # Ensure conda is available
+        source "${HOME}/conda/etc/profile.d/conda.sh"
 
-        # Set installation path
-        INSTALL_DIR="$HOME/scratch/python-custom"
-        mkdir -p "$INSTALL_DIR"
+        # Define environment path
+        CONDA_ENV_DIR="$HOME/scratch/python-env"
 
-        # List of required Python packages
-        PYTHON_PKGS=("python3.12" "python3.12-minimal" "python3.12-dev")
+        # Create a new Conda environment with Python 3.12
+        conda create -y -p "$CONDA_ENV_DIR" python=3.12
 
-        # Download and extract packages
-        for pkg in "${PYTHON_PKGS[@]}"; do
-            DEB_FILE="${pkg}_3.12.7-1ubuntu2_amd64.deb"
-            DEB_URL="http://archive.ubuntu.com/ubuntu/pool/main/p/python3.12/$DEB_FILE"
-
-            echo "Downloading $pkg..."
-            if curl -fLO "$DEB_URL"; then
-                echo "Extracting $DEB_FILE..."
-                dpkg-deb -x "$DEB_FILE" "$INSTALL_DIR" || { echo "Error extracting $DEB_FILE"; exit 1; }
-                rm -f "$DEB_FILE"  # Clean up after extraction
-            else
-                echo "Error: Failed to download $DEB_URL"
-                exit 1
-            fi
-        done
-
-        # Set Python binary path
-        PYTHON_BIN="$INSTALL_DIR/usr/bin/python3.12"
+        # Activate environment
+        conda activate "$CONDA_ENV_DIR"
 
         # Verify Python installation
+        PYTHON_BIN="$CONDA_ENV_DIR/bin/python"
+
         if [[ -x "$PYTHON_BIN" ]]; then
-            echo "Python successfully installed at $PYTHON_BIN"
+            echo "Python successfully installed in Conda environment at $PYTHON_BIN"
             $PYTHON_BIN --version
         else
-            echo "Error: Python binary not found!"
+            echo "Error: Python binary not found in Conda environment!"
             exit 1
         fi
 
-        # Create symlinks for easier access
+        # Install pip inside Conda environment
+        echo "Installing pip..."
+        conda install -y pip
+
+        # Install additional dependencies (optional)
+        echo "Installing additional dependencies..."
+        conda install -y python-venv python-distutils
+
+        # Create symlinks for easy access
         echo "Creating symlinks..."
-        ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python"
-        ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python3"
+        ln -sf "$PYTHON_BIN" "$HOME/scratch/python-env/bin/python"
+        ln -sf "$PYTHON_BIN" "$HOME/scratch/python-env/bin/python3"
 
-        # Final verification of symlinks
-        echo "Symlink verification:"
-        ls -l "$INSTALL_DIR/usr/bin/python" "$INSTALL_DIR/usr/bin/python3"
-
-        # Verify Python works after dependency installation
+        # Verify Python works after setup
         echo "Final Python check..."
         $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
 
-        echo "Installation complete!"
-
+        echo "Miniconda-based Python 3.12 setup complete!"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -86,54 +86,54 @@ runs:
 
         # Set installation path
         INSTALL_DIR="$HOME/scratch/python-custom"
-        mkdir -p $INSTALL_DIR
+        mkdir -p "$INSTALL_DIR"
 
-        # Download the correct Python 3.12.7 minimal package from Ubuntu archive
-        DEB_URL="http://archive.ubuntu.com/ubuntu/pool/main/p/python3.12/python3.12-minimal_3.12.7-1ubuntu2_amd64.deb"
-        curl -fLO "$DEB_URL"
+        # List of required Python packages
+        PYTHON_PKGS=("python3.12" "python3.12-minimal" "python3.12-dev")
 
-        # Verify the file format before extracting
-        if file python3.12-minimal_3.12.7-1ubuntu2_amd64.deb | grep -q "Debian binary package"; then
-            echo "Valid Debian package detected."
-        else
-            echo "Error: Downloaded file is not a valid .deb package!"
-            exit 1
-        fi
+        # Download and extract packages
+        for pkg in "${PYTHON_PKGS[@]}"; do
+            DEB_FILE="${pkg}_3.12.7-1ubuntu2_amd64.deb"
+            DEB_URL="http://archive.ubuntu.com/ubuntu/pool/main/p/python3.12/$DEB_FILE"
 
-        # Extract the .deb package manually (without sudo)
-        dpkg-deb -x python3.12-minimal_3.12.7-1ubuntu2_amd64.deb $INSTALL_DIR
+            echo "Downloading $pkg..."
+            if curl -fLO "$DEB_URL"; then
+                echo "Extracting $DEB_FILE..."
+                dpkg-deb -x "$DEB_FILE" "$INSTALL_DIR" || { echo "Error extracting $DEB_FILE"; exit 1; }
+                rm -f "$DEB_FILE"  # Clean up after extraction
+            else
+                echo "Error: Failed to download $DEB_URL"
+                exit 1
+            fi
+        done
 
-        # Set the correct path for Python binary
+        # Set Python binary path
         PYTHON_BIN="$INSTALL_DIR/usr/bin/python3.12"
 
         # Verify Python installation
         if [[ -x "$PYTHON_BIN" ]]; then
-            echo "Python successfully extracted."
+            echo "Python successfully installed at $PYTHON_BIN"
             $PYTHON_BIN --version
         else
-            echo "Error: Python binary not found in extracted directory."
+            echo "Error: Python binary not found!"
             exit 1
         fi
 
-        # Create symlinks for python and python3
+        # Create symlinks for easier access
+        echo "Creating symlinks..."
         ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python"
         ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python3"
 
-        # Manually install pip since `ensurepip` is disabled
-        echo "Installing pip manually..."
-        curl -sS https://bootstrap.pypa.io/get-pip.py | $PYTHON_BIN
+        # Install pip manually
+        echo "Installing pip..."
+        curl -sS https://bootstrap.pypa.io/get-pip.py | "$PYTHON_BIN"
 
         # Verify pip installation
-        $PYTHON_BIN -m pip --version
+        if ! "$PYTHON_BIN" -m pip --version; then
+            echo "Error: Pip installation failed!"
+            exit 1
+        fi
 
-        # Print symlink verification
-        ls -l $INSTALL_DIR/usr/bin/python*
-
-        # Install Black formatter
-        echo "Installing Black..."
-        $PYTHON_BIN -m pip install black --no-cache-dir
-
-        # Verify Black installation
-        $PYTHON_BIN -m black --version
-
-
+        # Final verification of symlinks
+        echo "Symlink verification:"
+        ls -l "$INSTALL_DIR/usr/bin/python" "$INSTALL_DIR/usr/bin/python3"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -115,10 +115,18 @@ runs:
             exit 1
         fi
 
+        # Create symlinks for python and python3
+        ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python"
+        ln -sf "$PYTHON_BIN" "$INSTALL_DIR/usr/bin/python3"
+
         # Manually install pip since `ensurepip` is disabled
         echo "Installing pip manually..."
         curl -sS https://bootstrap.pypa.io/get-pip.py | $PYTHON_BIN
 
         # Verify pip installation
         $PYTHON_BIN -m pip --version
+
+        # Print symlink verification
+        ls -l $INSTALL_DIR/usr/bin/python*
+
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -109,20 +109,11 @@ runs:
             exit 1
         fi
 
-        # Install pip (just in case)
-        echo "Ensuring pip is installed..."
-        conda install -y pip
-
         # Verify Python modules are working
         echo "Checking if Python modules work..."
         $PYTHON_BIN -c "import venv, distutils, sys; print(f'Python {sys.version} modules are working!')"
 
-        # Create symlinks for easy access
-        echo "Creating symlinks..."
-        ln -sf "$PYTHON_BIN" "$HOME/scratch/python-env/bin/python"
-        ln -sf "$PYTHON_BIN" "$HOME/scratch/python-env/bin/python3"
-
-        # Verify Python works after setup
+        # Final verification
         echo "Final Python check..."
         $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
 

--- a/.github/actions/install-r/action.yml
+++ b/.github/actions/install-r/action.yml
@@ -106,4 +106,6 @@ runs:
 
         echo "Custom R installed at $INSTALL_DIR"
 
+        ls /home/runner/scratch/R-4.4.1/bin
+
 

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -148,6 +148,8 @@ jobs:
           POSITRON_R_VER_SEL: 4.4.0
           POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_HIDDEN_PY: 3.12.7
+          POSITRON_HIDDEN_R: 4.4.1
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -148,7 +148,7 @@ jobs:
           POSITRON_R_VER_SEL: 4.4.0
           POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2
-          POSITRON_HIDDEN_PY: 3.12.7
+          POSITRON_HIDDEN_PY: "3.12.9 (Conda)"
           POSITRON_HIDDEN_R: 4.4.1
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
     secrets: inherit
 
   e2e-windows-electron:
@@ -67,7 +67,7 @@ jobs:
       currents_tags: "pull-request,browser/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
     secrets: inherit
 
   unit-tests:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   pr-tags:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pr-tags:

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { fail } from 'assert';
 import { InterpreterType } from '../../infra/fixtures/interpreter';
 import { test, tags } from '../_test.setup';
 
@@ -18,29 +17,28 @@ test.describe('Interpreter Includes/Excludes', {
 	tag: [tags.INTERPRETER]
 }, () => {
 
-	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
-
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]']], true);
+	// this is a CI only test
+	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings, logger }) {
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
 		if (hiddenPython) {
+			await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]']], true);
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, hiddenPython, true);
 		} else {
-			fail('Hidden Python version not set');
+			logger.log('Hidden Python version not set'); // use this for now so release test can essentially skip this case
 		}
 	});
 
-	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
-
-		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
+	test('R - Can Include an Interpreter', async function ({ app, r, userSettings, logger }) {
 
 		const hiddenR = process.env.POSITRON_HIDDEN_R;
 
 		if (hiddenR) {
+			await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, hiddenR, true);
 		} else {
-			fail('Hidden R version not set');
+			logger.log('Hidden R version not set'); // use this for now so release test can essentially skip this case
 		}
 	});
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -20,7 +20,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
 
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]']], true);
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -20,7 +20,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
 
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom/usr/bin"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom/usr/bin/"]']], true);
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
@@ -33,7 +33,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
 
-		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch/R-4.4.1/bin"]']], true);
+		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch/R-4.4.1/bin/"]']], true);
 
 		const hiddenR = process.env.POSITRON_HIDDEN_R;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { fail } from 'assert';
+import { InterpreterType } from '../../infra/fixtures/interpreter';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// export POSITRON_HIDDEN_PY='3.12.7'
+// export POSITRON_HIDDEN_R='4.2.3'
+
+test.describe('Interpreter Includes/Excludes', {
+	tag: [tags.WEB, tags.INTERPRETER]
+}, () => {
+
+	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
+
+		await userSettings.set([['python.interpreters.include', '[\"~/scratch\"]']], true);
+
+		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
+
+		if (hiddenPython) {
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, hiddenPython, true);
+		} else {
+			fail('Hidden Python version not set');
+		}
+	});
+
+	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
+
+		await userSettings.set([['positron.r.customRootFolders', '[\"~/scratch\"]']], true);
+
+		const hiddenR = process.env.POSITRON_HIDDEN_R;
+
+		if (hiddenR) {
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, hiddenR, true);
+		} else {
+			fail('Hidden R version not set');
+		}
+	});
+});

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -15,12 +15,12 @@ test.use({
 // export POSITRON_HIDDEN_R='4.2.3'
 
 test.describe('Interpreter Includes/Excludes', {
-	tag: [tags.WEB, tags.INTERPRETER]
+	tag: [tags.INTERPRETER]
 }, () => {
 
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
 
-		await userSettings.set([['python.interpreters.include', '[\"~/scratch\"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch"]']], true);
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
@@ -33,7 +33,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
 
-		await userSettings.set([['positron.r.customRootFolders', '[\"~/scratch\"]']], true);
+		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
 
 		const hiddenR = process.env.POSITRON_HIDDEN_R;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -20,7 +20,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
 
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom/usr/bin/"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom"]']], true);
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
@@ -33,7 +33,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
 
-		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch/R-4.4.1/bin/"]']], true);
+		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
 
 		const hiddenR = process.env.POSITRON_HIDDEN_R;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -20,7 +20,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings }) {
 
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-custom/usr/bin"]']], true);
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
@@ -33,7 +33,7 @@ test.describe('Interpreter Includes/Excludes', {
 
 	test('R - Can Include an Interpreter', async function ({ app, r, userSettings }) {
 
-		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
+		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch/R-4.4.1/bin"]']], true);
 
 		const hiddenR = process.env.POSITRON_HIDDEN_R;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -10,14 +10,11 @@ test.use({
 	suiteId: __filename
 });
 
-// export POSITRON_HIDDEN_PY='3.12.7'
-// export POSITRON_HIDDEN_R='4.2.3'
-
+// these are CI only tests; its not recommended to try and get your local machine to run these tests
 test.describe('Interpreter Includes/Excludes', {
-	tag: [tags.INTERPRETER]
+	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
 
-	// this is a CI only test
 	test('Python - Can Include an Interpreter', async function ({ app, python, userSettings, logger }) {
 
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;


### PR DESCRIPTION
Interpreter include tests.  Python and R are installed to ~/scratch by CI and added to search paths.  Tests then start the interpreters that would have otherwise not been detected.

Not recommended that you try and get this going locally.  Its not trivial.

### QA Notes

All tests should pass

@:interpreter @:web
