### PR TITLE
Fix current working directory cursor and add copy current working directory to clipboard

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -9,25 +9,4 @@
 
 .action-bar-button-icon.interrupt::before {
 	color: var(--vscode-errorForeground);
-}
-
-.positron-console .directory-label {
-	color: var(--positronActionBar-foreground);
-	font-size: 12px;
-	overflow: hidden;
-	display: flex;
-	max-width: 200px;
-	align-items: center;
-}
-
-.positron-console .directory-label .codicon {
-	color: var(--positronActionBar-foreground);
-	padding-top: 1px;
-}
-
-.positron-console .directory-label .label {
-	padding-left: 5px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -7,7 +7,7 @@
 import './actionBar.css';
 
 // React.
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -20,13 +20,14 @@ import { ActionBarRegion } from '../../../../../platform/positronActionBar/brows
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
-import { PositronActionBarContextProvider, usePositronActionBarContext } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, RuntimeStartMode } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ConsoleInstanceMenuButton } from './consoleInstanceMenuButton.js';
 import { multipleConsoleSessionsFeatureEnabled } from '../../../../services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.js';
 import { ConsoleInstanceInfoButton } from './consoleInstanceInfoButton.js';
+import { CurrentWorkingDirectory } from './currentWorkingDirectory.js';
 
 /**
  * Constants.
@@ -62,7 +63,6 @@ const positronRestartConsole = localize('positronRestartConsole', "Restart conso
 const positronShutdownConsole = localize('positronShutdownConsole', "Shutdown console");
 const positronStartConsole = localize('positronStartConsole', "Start console");
 const positronDeleteConsole = localize('positronDeleteConsole', "Delete console");
-const positronCurrentWorkingDirectory = localize('positronCurrentWorkingDirectory', "Current Working Directory");
 
 /**
  * Provides a localized label for the given runtime state. Only the transient
@@ -334,60 +334,6 @@ export const ActionBar = (props: ActionBarProps) => {
 		}
 
 		await positronConsoleContext.runtimeSessionService.deleteSession(positronConsoleContext.activePositronConsoleInstance.session.sessionId);
-	};
-
-	/**
-	 * CurrentWorkingDirectoryProps interface.
-	 */
-	interface CurrentWorkingDirectoryProps {
-		readonly directoryLabel: string;
-	}
-
-	/**
-	 * The current working directory component.
-	 * @returns The rendered component.
-	 */
-	const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => {
-		// Context hooks.
-		const context = usePositronActionBarContext();
-
-		// Reference hooks.
-		const ref = useRef<HTMLDivElement>(undefined!);
-
-		// State hooks.
-		const [mouseInside, setMouseInside] = useState(false);
-
-		// Hover useEffect.
-		useEffect(() => {
-			// If the mouse is inside, show the hover. This has the effect of showing the hover when
-			// mouseInside is set to true and updating the hover when the tooltip changes.
-			if (mouseInside) {
-				context.hoverManager.showHover(ref.current, props.directoryLabel);
-			}
-		}, [context.hoverManager, mouseInside, props.directoryLabel]);
-
-		// Render.
-		return (
-			<div
-				ref={ref}
-				aria-label={positronCurrentWorkingDirectory}
-				className='directory-label'
-				onMouseEnter={() => {
-					// Set the mouse inside state.
-					setMouseInside(true);
-				}}
-				onMouseLeave={() => {
-					// Clear the mouse inside state.
-					setMouseInside(false);
-
-					// Hide the hover.
-					context.hoverManager?.hideHover();
-				}}
-			>
-				<span className='codicon codicon-folder' role='presentation'></span>
-				<span className='label'>{!context.conserveSpace ? directoryLabel : '...'}</span>
-			</div>
-		);
 	};
 
 	// Render.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
@@ -1,10 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 .positron-console .console-core {
-	cursor: text;
 	width: 100%;
 }
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -54,8 +54,8 @@ export const ConsoleInstanceInfoButton = () => {
 		// Create the renderer.
 		const renderer = new PositronModalReactRenderer({
 			keybindingService: positronConsoleContext.keybindingService,
-			layoutService: positronConsoleContext.workbenchLayoutService,
-			container: positronConsoleContext.workbenchLayoutService.getContainer(DOM.getWindow(ref.current)),
+			layoutService: positronConsoleContext.layoutService,
+			container: positronConsoleContext.layoutService.getContainer(DOM.getWindow(ref.current)),
 			parent: ref.current
 		});
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.css
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.current-working-directory-label {
+	display: flex;
+	font-size: 12px;
+	overflow: hidden;
+	max-width: 200px;
+	align-items: center;
+	color: var(--positronActionBar-foreground);
+}
+
+.current-working-directory-label .codicon {
+	padding-top: 1px;
+	color: var(--positronActionBar-foreground);
+}
+
+.current-working-directory-label .label {
+	overflow: hidden;
+	padding-left: 5px;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './currentWorkingDirectory.css';
+
+// React.
+import React, { MouseEvent, useEffect, useRef, useState } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { usePositronConsoleContext } from '../positronConsoleContext.js';
+import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
+import { usePositronActionBarContext } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
+
+/**
+ * Localized strings for UI.
+ */
+const positronCurrentWorkingDirectory = localize(
+	'positronCurrentWorkingDirectory',
+	"Current Working Directory"
+);
+
+/**
+ * CurrentWorkingDirectoryProps interface.
+ */
+interface CurrentWorkingDirectoryProps {
+	readonly directoryLabel: string;
+}
+
+/**
+ * The current working directory component.
+ * @param props A CurrentWorkingDirectoryProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => {
+	// Context hooks.
+	const positronActionBarContext = usePositronActionBarContext();
+	const positronConsoleContext = usePositronConsoleContext();
+
+	// Reference hooks.
+	const ref = useRef<HTMLDivElement>(undefined!);
+
+	// State hooks.
+	const [mouseInside, setMouseInside] = useState(false);
+
+	// Hover useEffect.
+	useEffect(() => {
+		// If the mouse is inside, show the hover. This has the effect of showing the hover when
+		// mouseInside is set to true and updating the hover when the tooltip changes.
+		if (mouseInside) {
+			positronActionBarContext.hoverManager.showHover(ref.current, props.directoryLabel);
+		}
+	}, [mouseInside, positronActionBarContext.hoverManager, props.directoryLabel]);
+
+	/**
+	 * onMouseDown handler.
+	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 */
+	const mouseDownHandler = async (e: MouseEvent<HTMLElement>) => {
+		// Stop propagation.
+		e.stopPropagation();
+
+		// If the left mouse button was pressed, show the context menu.
+		if (e.button === 2) {
+			// Build the context menu entries.
+			const entries: CustomContextMenuEntry[] = [];
+			entries.push(new CustomContextMenuItem({
+				icon: 'copy',
+				label: localize('positron.dataExplorer.copy', "Copy"),
+				onSelected: async () => await positronConsoleContext.clipboardService.writeText(
+					props.directoryLabel
+				)
+			}));
+
+			// Show the context menu.
+			await showCustomContextMenu({
+				commandService: positronActionBarContext.commandService,
+				keybindingService: positronActionBarContext.keybindingService,
+				layoutService: positronConsoleContext.layoutService,
+				anchorElement: ref.current,
+				anchorPoint: {
+					clientX: e.clientX,
+					clientY: e.clientY
+				},
+				popupPosition: 'auto',
+				popupAlignment: 'auto',
+				width: 'max-content',
+				entries
+			});
+		}
+	};
+
+	// Render.
+	return (
+		<div
+			ref={ref}
+			aria-label={positronCurrentWorkingDirectory}
+			className='current-working-directory-label'
+			onMouseDown={mouseDownHandler}
+			onMouseEnter={() => {
+				// Set the mouse inside state.
+				setMouseInside(true);
+			}}
+			onMouseLeave={() => {
+				// Clear the mouse inside state.
+				setMouseInside(false);
+
+				// Hide the hover.
+				positronActionBarContext.hoverManager?.hideHover();
+			}}
+		>
+			<span className='codicon codicon-folder' role='presentation' />
+			<span className='label'>
+				{!positronActionBarContext.conserveSpace ? props.directoryLabel : '...'}
+			</span>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
@@ -67,13 +67,15 @@ export const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => 
 		// If the left mouse button was pressed, show the context menu.
 		if (e.button === 2) {
 			// Build the context menu entries.
-			const entries: CustomContextMenuEntry[] = [new CustomContextMenuItem({
-				icon: 'copy',
-				label: localize('positron.dataExplorer.copy', "Copy"),
-				onSelected: async () => await positronConsoleContext.clipboardService.writeText(
-					props.directoryLabel
-				)
-			})];
+			const entries: CustomContextMenuEntry[] = [
+				new CustomContextMenuItem({
+					icon: 'copy',
+					label: localize('positron.dataExplorer.copy', "Copy"),
+					onSelected: async () => await positronConsoleContext.clipboardService.writeText(
+						props.directoryLabel
+					)
+				})
+			];
 
 			// Show the context menu.
 			await showCustomContextMenu({

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
@@ -67,14 +67,13 @@ export const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => 
 		// If the left mouse button was pressed, show the context menu.
 		if (e.button === 2) {
 			// Build the context menu entries.
-			const entries: CustomContextMenuEntry[] = [];
-			entries.push(new CustomContextMenuItem({
+			const entries: CustomContextMenuEntry[] = [new CustomContextMenuItem({
 				icon: 'copy',
 				label: localize('positron.dataExplorer.copy', "Copy"),
 				onSelected: async () => await positronConsoleContext.clipboardService.writeText(
 					props.directoryLabel
 				)
-			}));
+			})];
 
 			// Show the context menu.
 			await showCustomContextMenu({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -16,7 +16,6 @@ import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { PositronActionBarServices } from '../../../../platform/positronActionBar/browser/positronActionBarState.js';
 import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -26,6 +25,7 @@ import { IRuntimeSessionService } from '../../../services/runtimeSession/common/
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron
@@ -33,9 +33,12 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
  */
 export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly clipboardService: IClipboardService;
+	readonly commandService: ICommandService;
+	readonly contextKeyService: IContextKeyService;
 	readonly executionHistoryService: IExecutionHistoryService;
 	readonly instantiationService: IInstantiationService;
 	readonly languageRuntimeService: ILanguageRuntimeService;
+	readonly layoutService: ILayoutService;
 	readonly runtimeSessionService: IRuntimeSessionService;
 	readonly runtimeStartupService: IRuntimeStartupService;
 	readonly languageService: ILanguageService;
@@ -46,9 +49,6 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly positronConsoleService: IPositronConsoleService;
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly viewsService: IViewsService;
-	readonly workbenchLayoutService: IWorkbenchLayoutService;
-	readonly contextKeyService: IContextKeyService;
-	readonly commandService: ICommandService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -32,7 +32,6 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { PositronViewPane } from '../../../browser/positronViewPane/positronViewPane.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { PositronConsole } from './positronConsole.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -42,6 +41,7 @@ import { IReactComponentContainer, ISize, PositronReactRenderer } from '../../..
 import { IExecutionHistoryService } from '../../executionHistory/common/executionHistoryService.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 
 /**
  * PositronConsoleViewPane class.
@@ -185,6 +185,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 	 * @param keybindingService The keybinding service.
 	 * @param languageRuntimeService The language runtime service.
 	 * @param languageService The language service.
+	 * @param layoutService The layout service.
 	 * @param logService The log service.
 	 * @param modelService The model service.
 	 * @param notificationService The notification service.
@@ -197,7 +198,6 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 	 * @param themeService The theme service.
 	 * @param viewDescriptorService The view descriptor service.
 	 * @param viewsService The views service.
-	 * @param workbenchLayoutService The workbench layout service.
 	 */
 	constructor(
 		options: IViewPaneOptions,
@@ -213,6 +213,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ILanguageRuntimeService private readonly languageRuntimeService: ILanguageRuntimeService,
 		@ILanguageService private readonly languageService: ILanguageService,
+		@ILayoutService private readonly layoutService: ILayoutService,
 		@ILogService private readonly logService: ILogService,
 		@IModelService private readonly modelService: IModelService,
 		@INotificationService private readonly notificationService: INotificationService,
@@ -225,7 +226,6 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
 		@IViewsService private readonly viewsService: IViewsService,
-		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService
 	) {
 		super(
 			options,
@@ -291,6 +291,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				keybindingService={this.keybindingService}
 				languageRuntimeService={this.languageRuntimeService}
 				languageService={this.languageService}
+				layoutService={this.layoutService}
 				logService={this.logService}
 				modelService={this.modelService}
 				notificationService={this.notificationService}
@@ -301,7 +302,6 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				runtimeSessionService={this.runtimeSessionService}
 				runtimeStartupService={this.runtimeStartupService}
 				viewsService={this.viewsService}
-				workbenchLayoutService={this.workbenchLayoutService}
 			/>
 		);
 


### PR DESCRIPTION
### Description

This PR addresses #6585 by fixing the cursor in the `CurrentWorkingDirectory` component.

Additional information:

- The `CurrentWorkingDirectory` component has been refactored to be in its own file.
- The user can copy the current working directory to the clipboard using a new right-click context menu in the `CurrentWorkingDirectory` component.

<img width="573" alt="image" src="https://github.com/user-attachments/assets/5de17aa9-5fd7-4bbb-8347-cef681d5bcc9" />

### Release Notes

#### New Features

- The user can copy the current working directory to the clipboard using a new right-click context menu in the `CurrentWorkingDirectory` component.

<img width="573" alt="image" src="https://github.com/user-attachments/assets/4d2fda43-1f1f-4fb8-9963-afd70753eafd" />

#### Bug Fixes

- #6585

### QA Notes

The new right-click context menu in the `CurrentWorkingDirectory` component is a custom context menu, so it can be tested.

Tests:
@:console