### PR TITLE
Update Assistant configuration

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -354,7 +354,6 @@ const excludedExtensions = [
     // --- Start Positron ---
     'positron-zed',
     'positron-javascript',
-    'positron-assistant',
     // --- End Positron ---
 ];
 const marketplaceWebExtensionsExclude = new Set([

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -390,7 +390,6 @@ const excludedExtensions = [
 	// --- Start Positron ---
 	'positron-zed',
 	'positron-javascript',
-	'positron-assistant',
 	// --- End Positron ---
 ];
 

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -37,29 +37,21 @@
       {
         "command": "positron-assistant.addModelConfiguration",
         "title": "%commands.addModelConfiguration.title%",
-        "category": "%commands.category%"
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
       },
       {
         "command": "positron-assistant.configureModels",
         "title": "%commands.configureModels.title%",
-        "category": "%commands.category%"
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
       }
     ],
     "languageModels": [
       {
         "vendor": "positron"
       }
-    ],
-    "configuration": {
-      "title": "Positron Assistant",
-      "properties": {
-        "positron.assistant.enable": {
-          "type": "boolean",
-          "default": false,
-          "description": "%configuration.enable.description%"
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -3,6 +3,5 @@
 	"description": "Provides default assistant and language models for Positron.",
 	"commands.addModelConfiguration.title": "Add Language Model",
 	"commands.configureModels.title": "Configure Language Models",
-	"commands.category": "Positron Assistant",
-	"configuration.enable.description": "Enable Positron Assistant (experimental)"
+	"commands.category": "Positron Assistant"
 }


### PR DESCRIPTION
This change makes the Positron Assistant available in release builds; to enable it, an undocumented configuration option is required.

> [!NOTE]
> Positron Assistant is an internal, experimental project. We cannot yet provide support for it nor answer questions about its future scope.