### PR TITLE
Use VSCode Color Theme for code cells and add option for border

### DIFF
--- a/extensions/positron-code-cells/package.json
+++ b/extensions/positron-code-cells/package.json
@@ -183,6 +183,26 @@
           "when": "positron.supportsCodeCells"
         }
       ]
+    },
+    "configuration": {
+      "title": "Positron Code Cells",
+      "properties": {
+        "positronCodeCells.cellStyle": {
+          "type": "string",
+          "default": "background",
+          "enum": [
+            "border",
+            "background",
+            "both"
+          ],
+          "enumDescriptions": [
+            "Show only cell borders",
+            "Show only cell backgrounds",
+            "Show both cell borders and backgrounds"
+          ],
+          "description": "Controls the style of code cell decorations. Colors are configurable with `notebook.selectedCellBackground` and `interactive.activeCodeBorder`. See https://code.visualstudio.com/api/references/theme-color"
+        }
+      }
     }
   },
   "main": "./out/extension.js",

--- a/extensions/positron-code-cells/src/test/decorations.test.ts
+++ b/extensions/positron-code-cells/src/test/decorations.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { closeAllEditors, delay, disposeAll } from './utils';
-import { SetDecorations, activateDecorations, cellDecorationType } from '../decorations';
+import { SetDecorations, activateDecorations, focusedCellBackgroundDecorationType, focusedCellBottomDecorationType, focusedCellTopDecorationType } from '../decorations';
 
 suite('Decorations', () => {
 	const disposables: vscode.Disposable[] = [];
@@ -23,73 +23,98 @@ suite('Decorations', () => {
 		await closeAllEditors();
 	});
 
-	function assertCellDecorationRangesEqual(expected: vscode.Range[]): void {
-		assert.deepStrictEqual(decorations.get(cellDecorationType), expected, 'Cell decoration ranges are not equal');
+	function assertCellDecorationRangesEqual(type: vscode.TextEditorDecorationType, expected: vscode.Range[]): void {
+		assert.deepStrictEqual(
+			decorations.get(type), expected, 'Cell decoration ranges are not equal'
+		);
 	}
 
 	test('Opening an empty Python document', async () => {
-		await showTextDocument();
-		assertCellDecorationRangesEqual([]);
+		switchCellStyle('background');
+		await showTextDocument('');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
 	});
 
 	test('Opening a Python document with code cells', async () => {
-		await showTextDocument('#%%');
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		await showTextDocument('# %%');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 	});
 
 	test('Adding a code cell to an empty Python document', async () => {
 		const editor = await showTextDocument();
-		assertCellDecorationRangesEqual([]);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
 
 		const result = await editor.edit((editBuilder) => {
-			editBuilder.insert(new vscode.Position(0, 0), '#%%');
+			editBuilder.insert(new vscode.Position(0, 0), '# %%');
 		});
 		assert.ok(result);
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 	});
 
 	test('Changing the selected code cell in a Python document', async () => {
-		const editor = await showTextDocument('#%%\n#%%');
-		editor.selection = new vscode.Selection(1, 0, 1, 0);
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		const editor = await showTextDocument('# %%\n# %%');
+		editor.selection = new vscode.Selection(0, 0, 1, 0);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		// Move the selection to the second cell
 		editor.selection = new vscode.Selection(1, 0, 1, 0);
-
-		// Decorations do not update immediately
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
 
 		// Decorations update after a delay
 		// --- Start Positron ---
 		await delay(400);
 		// --- End Positron ---
-		assertCellDecorationRangesEqual([new vscode.Range(1, 0, 1, 3)]);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(1, 0, 1, 4)]);
 	});
 
 	test('Removing all code cells from a Python document', async () => {
-		const editor = await showTextDocument('#%%');
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		const editor = await showTextDocument('# %%');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		await editor.edit((editBuilder) => {
 			editBuilder.delete(new vscode.Range(0, 0, 1, 0));
 		});
 
 		// Decorations do not update immediately
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		// Decorations update after a delay
 		// --- Start Positron ---
 		await delay(400);
 		// --- End Positron ---
-		assertCellDecorationRangesEqual([]);
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
 	});
 
 	test('Changing the active editor', async () => {
-		await showTextDocument('#%%');
-		assertCellDecorationRangesEqual([new vscode.Range(0, 0, 0, 3)]);
+		await showTextDocument('# %%');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		await showTextDocument('');
-		assertCellDecorationRangesEqual([]);
+		// --- Start Positron ---
+		await delay(400);
+		// --- End Positron ---
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
+	});
+
+	test('Changing the cell style option', async () => {
+		await switchCellStyle('background');
+		await showTextDocument('# %%\n');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 1, 0)]);
+		assertCellDecorationRangesEqual(focusedCellTopDecorationType, []);
+		assertCellDecorationRangesEqual(focusedCellBottomDecorationType, []);
+
+		// Need to open a new document since changing setting does not retrigger setDecorations
+		await switchCellStyle('border');
+		await showTextDocument('# %%\n');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
+		assertCellDecorationRangesEqual(focusedCellTopDecorationType, [new vscode.Range(0, 0, 0, 0)]);
+		assertCellDecorationRangesEqual(focusedCellBottomDecorationType, [new vscode.Range(1, 0, 1, 0)]);
+
+		// Need to open a new document since changing setting does not retrigger setDecorations
+		await switchCellStyle('both');
+		await showTextDocument('# %%\n');
+		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 1, 0)]);
+		assertCellDecorationRangesEqual(focusedCellTopDecorationType, [new vscode.Range(0, 0, 0, 0)]);
+		assertCellDecorationRangesEqual(focusedCellBottomDecorationType, [new vscode.Range(1, 0, 1, 0)]);
 	});
 });
 
@@ -97,4 +122,9 @@ async function showTextDocument(content?: string): Promise<vscode.TextEditor> {
 	const document = await vscode.workspace.openTextDocument({ language: 'python', content });
 	const editor = await vscode.window.showTextDocument(document);
 	return editor;
+}
+
+async function switchCellStyle(cellStyle: string) {
+	const configuration = vscode.workspace.getConfiguration();
+	await configuration.update("positronCodeCells.cellStyle", cellStyle, vscode.ConfigurationTarget.Global);
 }


### PR DESCRIPTION
Fixes #6579 following the discussion there. 

Uses `notebook.selectedCellBackground` color theme (which should always be defined). Also, adds option to use cell borders (using `interactive.activeCodeBorder` matching `vscode-jupyter` extension), or both borders and background.

Here's an example with Positron Light and Gruvbox Dark Medium and `"cellStyle": "both"` setting. I think both looks really good
![CleanShot 2025-03-04 at 10 28 54@2x](https://github.com/user-attachments/assets/3bc09792-2290-4162-a176-4e9bc0a27149)

![CleanShot 2025-03-04 at 10 28 11@2x](https://github.com/user-attachments/assets/d7d87e71-6f0f-48e9-bd7e-03d5dcbe1d08)




### Release Notes

#### New Features

- Positron code cells extension now allows customization of the active code cell decoration. As a default it uses `notebook.selectedCellBackground` for background color and/or `interactive.activeCodeBorder` for borders. See https://code.visualstudio.com/api/references/theme-color for customization. An option `cellStyle` lets you select between background, border, or both

#### Bug Fixes

- N/A


### QA Notes

- Added tests for `cellStyle` setting
- Opened debug and toggled between themes and settings to make sure things looked good across a range of downloaded themes.