### PR TITLE
E2E test: verify disconnect behavior with data explorer

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -205,7 +205,7 @@ Data_Frame = pd.DataFrame({
 		await app.workbench.variables.focusVariablesView();
 	});
 
-	test('Python Pandas - Verify blank spaces in data explorer', async function ({ app, python }) {
+	test('Python Pandas - Verify blank spaces in data explorer and disconnect behavior', async function ({ app, python }) {
 
 		const script = `import pandas as pd
 df = pd.DataFrame({'x': ["a ", "a", "   ", ""]})`;
@@ -222,6 +222,14 @@ df = pd.DataFrame({'x': ["a ", "a", "   ", ""]})`;
 			expect(tableData[3]).toStrictEqual({ 'x': '<empty>' });
 			expect(tableData.length).toBe(4);
 		}).toPass({ timeout: 60000 });
+
+		if (app.web) {
+			await test.step('Verify disconnect dialog', async () => {
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.console.barPowerButton.click();
+				await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
+			});
+		}
 
 		await app.workbench.dataExplorer.closeDataExplorer();
 	});

--- a/test/e2e/tests/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-r.test.ts
@@ -45,6 +45,7 @@ test.describe('Data Explorer - R ', {
 			const clipboardText = await app.workbench.clipboard.getClipboardText();
 			expect(clipboardText).toBe('Strength');
 		});
+
 	});
 
 	test('R - Verify opening Data Explorer for the second time brings focus back', {
@@ -70,7 +71,7 @@ test.describe('Data Explorer - R ', {
 		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });
 	});
 
-	test('R - Verify blank spaces in data explorer', async function ({ app, r, executeCode }) {
+	test('R - Verify blank spaces in data explorer and disconnect behavior', async function ({ app, r, executeCode }) {
 		// Execute code to generate data frames
 		await executeCode('R', `df = data.frame(x = c("a ", "a", "   ", ""))`);
 
@@ -92,6 +93,14 @@ test.describe('Data Explorer - R ', {
 			expect(tableData).toStrictEqual(expectedData);
 			expect(tableData).toHaveLength(4);
 		}).toPass({ timeout: 60000 });
+
+		if (app.web) {
+			await test.step('Verify disconnect dialog', async () => {
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.console.barPowerButton.click();
+				await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
+			});
+		}
 	});
 });
 


### PR DESCRIPTION
We had a recent regression regarding the disconnect dialog.  This is to check for future regressions of the same type.

### QA Notes

All tests should pass

@:web @:data-explorer