### PR TITLE
Update extension-related branding

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -902,6 +902,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 					notificationService.prompt(
 						Severity.Info,
 						// --- Start Positron ---
+						// localize('InstallVSIXAction.successReload', "Completed installing extension from VSIX. Please reload Visual Studio Code to enable it."),
 						localize('InstallVSIXAction.successReload', "Completed installing extension from VSIX. Please reload Positron to enable it."),
 						// --- End Positron ---
 						[{

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -901,7 +901,9 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 				if (requireReload) {
 					notificationService.prompt(
 						Severity.Info,
-						localize('InstallVSIXAction.successReload', "Completed installing extension from VSIX. Please reload Visual Studio Code to enable it."),
+						// --- Start Positron ---
+						localize('InstallVSIXAction.successReload', "Completed installing extension from VSIX. Please reload Positron to enable it."),
+						// --- End Positron ---
 						[{
 							label: localize('InstallVSIXAction.reloadNow', "Reload Now"),
 							run: () => hostService.reload()

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -901,6 +901,7 @@ export class UninstallAction extends ExtensionAction {
 		try {
 			await this.extensionsWorkbenchService.uninstall(this.extension);
 			// --- Start Positron ---
+			// alert(localize('uninstallExtensionComplete', "Please reload Visual Studio Code to complete the uninstallation of the extension {0}.", this.extension.displayName));
 			alert(localize('uninstallExtensionComplete', "Please reload Positron to complete the uninstallation of the extension {0}.", this.extension.displayName));
 			// --- End Positron ---
 		} catch (error) {
@@ -2894,9 +2895,9 @@ export class ReinstallAction extends Action {
 				return this.extensionsWorkbenchService.reinstall(extension)
 					.then(extension => {
 						const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
-						const message = requireReload ?
-							// --- Start Positron ---
-							localize('ReinstallAction.successReload', "Please reload Positron to complete reinstalling the extension {0}.", extension.identifier.id)
+						// --- Start Positron ---
+						// const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Visual Studio Code to complete reinstalling the extension {0}.", extension.identifier.id)
+						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Positron to complete reinstalling the extension {0}.", extension.identifier.id)
 							// --- End Positron ---
 							: localize('ReinstallAction.success', "Reinstalling the extension {0} is completed.", extension.identifier.id);
 						const actions = requireReload ? [{

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -900,7 +900,9 @@ export class UninstallAction extends ExtensionAction {
 
 		try {
 			await this.extensionsWorkbenchService.uninstall(this.extension);
-			alert(localize('uninstallExtensionComplete', "Please reload Visual Studio Code to complete the uninstallation of the extension {0}.", this.extension.displayName));
+			// --- Start Positron ---
+			alert(localize('uninstallExtensionComplete', "Please reload Positron to complete the uninstallation of the extension {0}.", this.extension.displayName));
+			// --- End Positron ---
 		} catch (error) {
 			if (!isCancellationError(error)) {
 				this.dialogService.error(getErrorMessage(error));
@@ -2892,7 +2894,10 @@ export class ReinstallAction extends Action {
 				return this.extensionsWorkbenchService.reinstall(extension)
 					.then(extension => {
 						const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
-						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Visual Studio Code to complete reinstalling the extension {0}.", extension.identifier.id)
+						const message = requireReload ?
+							// --- Start Positron ---
+							localize('ReinstallAction.successReload', "Please reload Positron to complete reinstalling the extension {0}.", extension.identifier.id)
+							// --- End Positron ---
 							: localize('ReinstallAction.success', "Reinstalling the extension {0} is completed.", extension.identifier.id);
 						const actions = requireReload ? [{
 							label: localize('InstallVSIXAction.reloadNow', "Reload Now"),

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -455,6 +455,11 @@ export class Extension implements IExtension {
 
 		if (this.type === ExtensionType.System) {
 			// --- Start Positron ---
+			// 			return Promise.resolve(`# ${this.displayName || this.name}
+			// **Notice:** This extension is bundled with Visual Studio Code. It can be disabled but not uninstalled.
+			// ## Features
+			// ${this.description}
+			// `);
 			return Promise.resolve(`# ${this.displayName || this.name}
 **Notice:** This extension is bundled with Positron. It can be disabled but not uninstalled.
 ## Features

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -454,11 +454,13 @@ export class Extension implements IExtension {
 		}
 
 		if (this.type === ExtensionType.System) {
+			// --- Start Positron ---
 			return Promise.resolve(`# ${this.displayName || this.name}
-**Notice:** This extension is bundled with Visual Studio Code. It can be disabled but not uninstalled.
+**Notice:** This extension is bundled with Positron. It can be disabled but not uninstalled.
 ## Features
 ${this.description}
 `);
+			// --- End Positron ---
 		}
 
 		if (this.resourceExtension?.readmeUri) {


### PR DESCRIPTION
Replaces "Visual Studio Code" with "Positron" in a handful of extension-related actions

Addresses #2104

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

Replaces "Visual Studio Code" with "Positron" in:
- "Install Extension VSIX" action, when a full reload is required
- "Developer: Reinstall Extension..."
- "Uninstall" action (though string is seemingly not displayed)
- Generated system extension README


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

#### Developer: Reinstall Extension
1. Invoke `workbench.extensions.action.reinstall` from command pallet.
2. Choose extension to reinstall
3. Validate that notification upon completion shows "Positron" and not "Visual Studio Code"
