### PR TITLE
Assistant: Add setting to control which provider(s) are enabled

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -172,8 +172,32 @@ async function confirmModelDeletion(context: vscode.ExtensionContext, storage: S
 }
 
 export async function showConfigurationDialog(context: vscode.ExtensionContext, storage: SecretStorage) {
+	// Get the configuration option listing enabled providers
+	let enabledProviders: string[] =
+		vscode.workspace.getConfiguration('positron.assistant').get('enabledProviders') || [];
+
+	// Ensure an array was specified; coerce other values
+	if (!Array.isArray(enabledProviders)) {
+		if (typeof enabledProviders === 'string') {
+			// Be nice and allow a single string to be used to enable a single provider
+			enabledProviders = [enabledProviders];
+		} else if (enabledProviders) {
+			// Log an error if the value is not a string or array
+			console.log('Invalid value for positron.assistant.enabledProviders, ignoring: ',
+				JSON.stringify(enabledProviders)
+			);
+			enabledProviders = [];
+		} else {
+			enabledProviders = [];
+		}
+	}
+
 	// Gather model sources
-	const sources = [...languageModels, ...completionModels].map((provider) => provider.source);
+	const sources = [...languageModels, ...completionModels]
+		.map((provider) => provider.source)
+		.filter((source) => {
+			enabledProviders.includes(source.provider.id);
+		});
 
 	// Show a modal asking user for configuration details
 	return positron.ai.showLanguageModelConfig(sources, async (userConfig) => {

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -171,7 +171,7 @@ async function confirmModelDeletion(context: vscode.ExtensionContext, storage: S
 	}
 }
 
-export async function showConfigurationDialog(context: vscode.ExtensionContext, storage: SecretStorage) {
+export function getEnabledProviders(): string[] {
 	// Get the configuration option listing enabled providers
 	let enabledProviders: string[] =
 		vscode.workspace.getConfiguration('positron.assistant').get('enabledProviders') || [];
@@ -192,11 +192,18 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 		}
 	}
 
-	// Gather model sources
+	return enabledProviders;
+}
+
+export async function showConfigurationDialog(context: vscode.ExtensionContext, storage: SecretStorage) {
+
+	// Gather model sources; ignore disabled providers
+	const enabledProviders = getEnabledProviders();
 	const sources = [...languageModels, ...completionModels]
 		.map((provider) => provider.source)
 		.filter((source) => {
-			enabledProviders.includes(source.provider.id);
+			// If no specific set of providers was specified, include all
+			return enabledProviders.length === 0 || enabledProviders.includes(source.provider.id);
 		});
 
 	// Show a modal asking user for configuration details

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -1,12 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { revive } from '../../../../base/common/marshalling.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { IChatAgentData, IChatAgentService } from '../../../contrib/chat/common/chatAgents.js';
 import { ChatModel } from '../../../contrib/chat/common/chatModel.js';
 import { IChatProgress, IChatService } from '../../../contrib/chat/common/chatService.js';
@@ -25,8 +23,7 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 		extHostContext: IExtHostContext,
 		@IPositronAssistantService private readonly _positronAssistantService: IPositronAssistantService,
 		@IChatService private readonly _chatService: IChatService,
-		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IChatAgentService private readonly _chatAgentService: IChatAgentService
 	) {
 		super();
 		// Create the proxy for the extension host.
@@ -37,12 +34,8 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	 * Register chat agent data from the extension host.
 	 */
 	async $registerChatAgent(agentData: IChatAgentData): Promise<void> {
-		// Only register chat agents in development mode, hiding the Chat panel in release builds
-		const isDevelopment = IsDevelopmentContext.getValue(this._contextKeyService);
-		if (isDevelopment) {
-			const agent = this._register(this._chatAgentService.registerAgent(agentData.id, agentData));
-			this._registrations.set(agentData.id, agent);
-		}
+		const agent = this._register(this._chatAgentService.registerAgent(agentData.id, agentData));
+		this._registrations.set(agentData.id, agent);
 	}
 
 	/*

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -60,9 +60,23 @@ interface LanguageModelConfigurationProps {
 const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModelConfigurationProps>) => {
 	const [type, setType] = React.useState<PositronLanguageModelType>(PositronLanguageModelType.Chat);
 
+	const enabledProviders = props.sources.map(source => source.provider.id);
+	const hasAnthropic = enabledProviders.includes('anthropic');
+	const hasMistral = enabledProviders.includes('mistral');
 	const defaultSource = props.sources.find(source => {
-		const defaultProvider = type === 'chat' ? 'anthropic' : 'mistral';
-		return source.provider.id === defaultProvider && source.type.includes(type);
+		// If Anthropic is available, prefer it for chat models
+		if (source.type === type) {
+			if (type === 'chat' && hasAnthropic) {
+				return source.provider.id === 'anthropic';
+			}
+			// If Mistral is available, prefer it for completion models
+			if (type === 'completion' && hasMistral) {
+				return source.provider.id === 'mistral';
+			}
+			// In all other cases, prefer the first available provider
+			return true;
+		}
+		return false;
 	})!;
 
 	const [source, setSource] = React.useState<IPositronLanguageModelSource>(defaultSource);


### PR DESCRIPTION
Creates a setting that can be used to control which model provider(s) are enabled. When not set, all providers are enabled; when set, only the listed providers are enabled.

Addresses https://github.com/posit-dev/positron/issues/6610.

<img width="783" alt="image" src="https://github.com/user-attachments/assets/0a897f1b-38f6-4f8c-86a1-25f51503345a" />


