### PR TITLE
E2E test: remove unnecessary web filter for disconnect test

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -223,13 +223,11 @@ df = pd.DataFrame({'x': ["a ", "a", "   ", ""]})`;
 			expect(tableData.length).toBe(4);
 		}).toPass({ timeout: 60000 });
 
-		if (app.web) {
-			await test.step('Verify disconnect dialog', async () => {
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.console.barPowerButton.click();
-				await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
-			});
-		}
+		await test.step('Verify disconnect dialog', async () => {
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			await app.workbench.console.barPowerButton.click();
+			await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
+		});
 
 		await app.workbench.dataExplorer.closeDataExplorer();
 	});

--- a/test/e2e/tests/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-r.test.ts
@@ -94,13 +94,11 @@ test.describe('Data Explorer - R ', {
 			expect(tableData).toHaveLength(4);
 		}).toPass({ timeout: 60000 });
 
-		if (app.web) {
-			await test.step('Verify disconnect dialog', async () => {
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.console.barPowerButton.click();
-				await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
-			});
-		}
+		await test.step('Verify disconnect dialog', async () => {
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			await app.workbench.console.barPowerButton.click();
+			await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
+		});
 	});
 });
 


### PR DESCRIPTION
Jon noticed that a dialog I thought was native actually wasn't.

### QA Notes

All data explorer tests should pass.

@:web @win @data-explorer
