### PR TITLE
Improves the implementation of ActivityItemStream for code clarity

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorStream.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorStream.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,11 +11,11 @@ import React from 'react';
 
 // Other dependencies.
 import { OutputLines } from './outputLines.js';
-import { ActivityItemErrorStream } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
+import { ActivityItemStream } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
 
 // ActivityErrorStreamProps interface.
 export interface ActivityErrorStreamProps {
-	activityItemErrorStream: ActivityItemErrorStream;
+	activityItemStream: ActivityItemStream;
 }
 
 /**
@@ -27,7 +27,7 @@ export const ActivityErrorStream = (props: ActivityErrorStreamProps) => {
 	// Render.
 	return (
 		<div className='activity-error-stream'>
-			<OutputLines outputLines={props.activityItemErrorStream.outputLines} />
+			<OutputLines outputLines={props.activityItemStream.outputLines} />
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputStream.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputStream.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,11 +11,11 @@ import React from 'react';
 
 // Other dependencies.
 import { OutputLines } from './outputLines.js';
-import { ActivityItemOutputStream } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
+import { ActivityItemStream } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
 
 // ActivityOutputStreamProps interface.
 export interface ActivityOutputStreamProps {
-	activityItemOutputStream: ActivityItemOutputStream;
+	activityItemStream: ActivityItemStream;
 }
 
 /**
@@ -26,6 +26,6 @@ export interface ActivityOutputStreamProps {
 export const ActivityOutputStream = (props: ActivityOutputStreamProps) => {
 	// Render.
 	return (
-		<OutputLines outputLines={props.activityItemOutputStream.outputLines} />
+		<OutputLines outputLines={props.activityItemStream.outputLines} />
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
@@ -27,7 +27,7 @@ import { ActivityOutputMessage } from './activityOutputMessage.js';
 import { ActivityItemErrorMessage } from '../../../../services/positronConsole/browser/classes/activityItemErrorMessage.js';
 import { IPositronConsoleInstance } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { ActivityItemOutputMessage } from '../../../../services/positronConsole/browser/classes/activityItemOutputMessage.js';
-import { ActivityItemErrorStream, ActivityItemOutputStream } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
+import { ActivityItemStream, ActivityItemStreamType } from '../../../../services/positronConsole/browser/classes/activityItemStream.js';
 
 // RuntimeActivityProps interface.
 export interface RuntimeActivityProps {
@@ -48,10 +48,15 @@ export const RuntimeActivity = (props: RuntimeActivityProps) => {
 			{props.runtimeItemActivity.activityItems.map(activityItem => {
 				if (activityItem instanceof ActivityItemInput) {
 					return <ActivityInput key={activityItem.id} activityItemInput={activityItem} fontInfo={props.fontInfo} positronConsoleInstance={props.positronConsoleInstance} />;
-				} else if (activityItem instanceof ActivityItemOutputStream) {
-					return <ActivityOutputStream key={activityItem.id} activityItemOutputStream={activityItem} />;
-				} else if (activityItem instanceof ActivityItemErrorStream) {
-					return <ActivityErrorStream key={activityItem.id} activityItemErrorStream={activityItem} />;
+				} else if (activityItem instanceof ActivityItemStream) {
+					if (activityItem.type === ActivityItemStreamType.OUTPUT) {
+						return <ActivityOutputStream key={activityItem.id} activityItemStream={activityItem} />;
+					} else if (activityItem.type === ActivityItemStreamType.ERROR) {
+						return <ActivityErrorStream key={activityItem.id} activityItemStream={activityItem} />;
+					} else {
+						// This indicates a bug. A new stream type was added but not handled here.
+						return null;
+					}
 				} else if (activityItem instanceof ActivityItemPrompt) {
 					return <ActivityPrompt key={activityItem.id} activityItemPrompt={activityItem} positronConsoleInstance={props.positronConsoleInstance} />;
 				} else if (activityItem instanceof ActivityItemOutputHtml) {
@@ -63,7 +68,7 @@ export const RuntimeActivity = (props: RuntimeActivityProps) => {
 				} else if (activityItem instanceof ActivityItemErrorMessage) {
 					return <ActivityErrorMessage key={activityItem.id} activityItemErrorMessage={activityItem} />;
 				} else {
-					// This indicates a bug.
+					// This indicates a bug. A new activity item was added but not handled here.
 					return null;
 				}
 			})}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -4,25 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RuntimeItem } from './runtimeItem.js';
+import { ActivityItemStream } from './activityItemStream.js';
 import { ActivityItemPrompt } from './activityItemPrompt.js';
 import { ActivityItemOutputHtml } from './activityItemOutputHtml.js';
 import { ActivityItemOutputPlot } from './activityItemOutputPlot.js';
 import { ActivityItemErrorMessage } from './activityItemErrorMessage.js';
 import { ActivityItemOutputMessage } from './activityItemOutputMessage.js';
 import { ActivityItemInput, ActivityItemInputState } from './activityItemInput.js';
-import { ActivityItemErrorStream, ActivityItemOutputStream, ActivityItemStream } from './activityItemStream.js';
 
 /**
  * The ActivityItem type alias.
  */
 export type ActivityItem =
+	ActivityItemStream |
 	ActivityItemErrorMessage |
-	ActivityItemErrorStream |
 	ActivityItemInput |
 	ActivityItemOutputHtml |
 	ActivityItemOutputMessage |
 	ActivityItemOutputPlot |
-	ActivityItemOutputStream |
 	ActivityItemPrompt;
 
 /**
@@ -35,12 +34,8 @@ const isSameActivityItemStream = (
 	activityItemStream1: ActivityItemStream,
 	activityItemStream2: ActivityItemStream
 ) =>
-	(
-		(activityItemStream1 instanceof ActivityItemOutputStream &&
-			activityItemStream2 instanceof ActivityItemOutputStream) ||
-		(activityItemStream1 instanceof ActivityItemErrorStream &&
-			activityItemStream2 instanceof ActivityItemErrorStream)
-	) && activityItemStream1.parentId === activityItemStream2.parentId;
+	activityItemStream1.type === activityItemStream2.type &&
+	activityItemStream1.parentId === activityItemStream2.parentId;
 
 /**
  * RuntimeItemActivity class.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -34,7 +34,7 @@ import { ActivityItemOutputMessage } from './classes/activityItemOutputMessage.j
 import { RuntimeItemStartupFailure } from './classes/runtimeItemStartupFailure.js';
 import { ActivityItem, RuntimeItemActivity } from './classes/runtimeItemActivity.js';
 import { ActivityItemInput, ActivityItemInputState } from './classes/activityItemInput.js';
-import { ActivityItemErrorStream, ActivityItemOutputStream } from './classes/activityItemStream.js';
+import { ActivityItemStream, ActivityItemStreamType } from './classes/activityItemStream.js';
 import { ILanguageRuntimeCodeExecutedEvent, IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
 import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeStartMode } from '../../runtimeSession/common/runtimeSessionService.js';
@@ -1750,7 +1750,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				if (languageRuntimeMessageStream.name === 'stdout') {
 					this.addOrUpdateUpdateRuntimeItemActivity(
 						languageRuntimeMessageStream.parent_id,
-						new ActivityItemOutputStream(
+						new ActivityItemStream(
+							ActivityItemStreamType.OUTPUT,
 							languageRuntimeMessageStream.id,
 							languageRuntimeMessageStream.parent_id,
 							new Date(languageRuntimeMessageStream.when),
@@ -1760,7 +1761,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				} else if (languageRuntimeMessageStream.name === 'stderr') {
 					this.addOrUpdateUpdateRuntimeItemActivity(
 						languageRuntimeMessageStream.parent_id,
-						new ActivityItemErrorStream(
+						new ActivityItemStream(
+							ActivityItemStreamType.ERROR,
 							languageRuntimeMessageStream.id,
 							languageRuntimeMessageStream.parent_id,
 							new Date(languageRuntimeMessageStream.when),


### PR DESCRIPTION
### Description

When the Positron Console was implemented, a decision was made to create two types of activity item streams, `ActivityItemOutputStream` for the `stdout` stream and `ActivityItemErrorStream` for the `stderr` stream. At the time, this seemed like the best implementation and it resulted in three classes:

`ActivityItemStream` base class which contains all the logic for an activity item stream.
`ActivityItemOutputStream` subclass.
`ActivityItemErrorStream` subclass.

Basically, this meant that we were using the type system to keep track of the type of an activity item stream.

After reviewing https://github.com/posit-dev/positron/pull/4848 and https://github.com/posit-dev/positron/issues/4519, and thinking about the problem and the implementation more deeply, this PR makes the following adjustments:

1. Adds a new `ActivityItemStreamType` enumeration and adds a `type` property to the `ActivityItemStream` class.
2. Improves how new `ActivityItemStream` objects are created by adding a `clone` method.
3. Removes `ActivityItemOutputStream` subclass.
4. Removes `ActivityItemErrorStream` subclass.
5. Simplifies impacted code.

Tests:
@:console

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A