### PR TITLE
Always show interactive plots in the Viewer in server mode

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -21,6 +21,7 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { PositronOpenUrlInViewerAction } from './positronPreviewActions.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope, } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { POSITRON_PREVIEW_PLOTS_IN_VIEWER } from '../../../services/languageRuntime/common/languageRuntimeUiClient.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 // The Positron preview view icon.
 const positronPreviewViewIcon = registerIcon('positron-preview-view-icon', Codicon.positronPreviewView, nls.localize('positronPreviewViewIcon', 'View icon of the Positron preview view.'));
@@ -73,19 +74,26 @@ class PositronPreviewContribution extends Disposable implements IWorkbenchContri
 	}
 }
 
-// Register configuration options for the preview service
-const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-configurationRegistry.registerConfiguration({
-	id: 'positron',
-	properties: {
-		[POSITRON_PREVIEW_PLOTS_IN_VIEWER]: {
-			scope: ConfigurationScope.MACHINE,
-			type: 'boolean',
-			default: false,
-			description: nls.localize('positron.viewer.interactivePlotsInViewer', "When enabled, interactive HTML plots are shown in the Viewer pane rather than in the Plots pane.")
-		},
-	}
-});
-
+if (!isWeb) {
+	// In desktop mode, we can optionally show interactive plots in the Plots
+	// pane. This maneuver requires Electron to generate screen captures to use
+	// as thumbnails.
+	//
+	// In web mode, we can't do this, so we always show interactive plots in
+	// the Viewer pane (i.e. we behave as though this option is always set to
+	// true)
+	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+	configurationRegistry.registerConfiguration({
+		id: 'positron',
+		properties: {
+			[POSITRON_PREVIEW_PLOTS_IN_VIEWER]: {
+				scope: ConfigurationScope.MACHINE,
+				type: 'boolean',
+				default: false,
+				description: nls.localize('positron.viewer.interactivePlotsInViewer', "When enabled, interactive HTML plots are shown in the Viewer pane rather than in the Plots pane.")
+			},
+		}
+	});
+}
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(PositronPreviewContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -13,6 +13,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 export const POSITRON_PREVIEW_PLOTS_IN_VIEWER = 'positron.viewer.interactivePlotsInViewer';
 
@@ -165,7 +166,11 @@ export class UiClientInstance extends Disposable {
 				// Start an HTML proxy server for the file
 				const uri = await this.startHtmlProxyServer(e.path);
 
-				if (e.is_plot) {
+				if (isWeb) {
+					// In Web mode, we can't show interactive plots in the Plots
+					// pane.
+					e.is_plot = false;
+				} else if (e.is_plot) {
 					// Check the configuration to see if we should open the plot
 					// in the Viewer tab. If so, clear the `is_plot` flag so that
 					// we open the file in the Viewer.


### PR DESCRIPTION
This change causes all interactive plots to go to the Viewer pane in server mode. This sidesteps an issue in which thumbnails for interactive plots don't render in server mode. 

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/30b5a462-da71-4407-858f-4bee26ffb0c7" />

Addresses https://github.com/posit-dev/positron/issues/4278.

We've discussed a few more aggressive fixes (enumerated in the issue above) but I think this is the simplest approach.

### QA Notes

Note that there is a setting that lets you get this behavior in Desktop mode, too.

<img width="694" alt="image" src="https://github.com/user-attachments/assets/4d32262d-f911-483e-ad14-f6b1597789e3" />

This change works by removing the setting in server mode and acting as though it were always on.

So, worth checking:

- the setting still shows up in desktop mode
- the setting still works in desktop mode
- the setting does not show up in server mode

Tests: `@:plots`
