### PR TITLE
Bugfix/multiple console sessions variables pane

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
@@ -8,7 +8,7 @@ import './consoleInstanceItems.css';
 
 // React.
 import { flushSync } from 'react-dom';
-import React, { useReducer } from 'react';
+import React, { Component } from 'react';
 
 // Other dependencies.
 import { FontInfo } from '../../../../../editor/common/config/fontInfo.js';
@@ -36,8 +36,6 @@ import { RuntimeItemRestartButton } from '../../../../services/positronConsole/b
 import { IPositronConsoleInstance } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { RuntimeItemStartupFailure } from '../../../../services/positronConsole/browser/classes/runtimeItemStartupFailure.js';
 import { localize } from '../../../../../nls.js';
-import { multipleConsoleSessionsFeatureEnabled } from '../../../../services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.js';
-import { usePositronConsoleContext } from '../positronConsoleContext.js';
 
 /**
  * ConsoleInstanceItemsProps interface.
@@ -53,69 +51,82 @@ interface ConsoleInstanceItemsProps {
 /**
  * ConsoleInstanceItems component.
  */
-export const ConsoleInstanceItems = (props: ConsoleInstanceItemsProps) => {
-	const context = usePositronConsoleContext();
-	const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(context.configurationService);
+export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
+	/**
+	 * Constructor.
+	 * @param props
+	 */
+	constructor(props: ConsoleInstanceItemsProps) {
+		super(props);
+	}
 
-	let extensionHostDisconnected = false;
+	/**
+	 * Renders the component.
+	 * @returns The rendered component.
+	 */
+	override render() {
 
-	const [, forceUpdate] = useReducer(x => x + 1, 0);
+		let extensionHostDisconnected = false;
 
-	return (
-		<>
-			<div className='top-spacer' />
-			{props.positronConsoleInstance.runtimeItems.map(runtimeItem => {
-				if (runtimeItem instanceof RuntimeItemActivity) {
-					return <RuntimeActivity key={runtimeItem.id} fontInfo={props.editorFontInfo} positronConsoleInstance={props.positronConsoleInstance} runtimeItemActivity={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemPendingInput) {
-					return <RuntimePendingInput key={runtimeItem.id} fontInfo={props.editorFontInfo} runtimeItemPendingInput={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemStartup) {
-					extensionHostDisconnected = false;
-					return <RuntimeStartup key={runtimeItem.id} runtimeItemStartup={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemReconnected) {
-					extensionHostDisconnected = false;
-					return null;
-				} else if (runtimeItem instanceof RuntimeItemStarting) {
-					return <RuntimeStarting key={runtimeItem.id} runtimeItemStarting={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemStarted) {
-					return <RuntimeStarted key={runtimeItem.id} runtimeItemStarted={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemOffline) {
-					return <RuntimeOffline key={runtimeItem.id} runtimeItemOffline={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemExited) {
-					if (runtimeItem.reason === 'extensionHost') {
-						extensionHostDisconnected = true;
+		return (
+			<>
+				<div className='top-spacer' />
+				{this.props.positronConsoleInstance.runtimeItems.map(runtimeItem => {
+					if (runtimeItem instanceof RuntimeItemActivity) {
+						return <RuntimeActivity key={runtimeItem.id} fontInfo={this.props.editorFontInfo} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemActivity={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemPendingInput) {
+						return <RuntimePendingInput key={runtimeItem.id} fontInfo={this.props.editorFontInfo} runtimeItemPendingInput={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemStartup) {
+						extensionHostDisconnected = false;
+						return <RuntimeStartup key={runtimeItem.id} runtimeItemStartup={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemReconnected) {
+						extensionHostDisconnected = false;
+						return null;
+					} else if (runtimeItem instanceof RuntimeItemStarting) {
+						return <RuntimeStarting key={runtimeItem.id} runtimeItemStarting={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemStarted) {
+						return <RuntimeStarted key={runtimeItem.id} runtimeItemStarted={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemOffline) {
+						return <RuntimeOffline key={runtimeItem.id} runtimeItemOffline={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemExited) {
+						if (runtimeItem.reason === 'extensionHost') {
+							extensionHostDisconnected = true;
+							return null;
+						}
+						return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemRestartButton) {
+						return <RuntimeRestartButton key={runtimeItem.id} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemRestartButton={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
+						return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
+					} else if (runtimeItem instanceof RuntimeItemTrace) {
+						return this.props.trace && <RuntimeTrace key={runtimeItem.id} runtimeItemTrace={runtimeItem} />;
+					} else {
+						// This indicates a bug.
 						return null;
 					}
-					return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemRestartButton && !multiSessionsEnabled) {
-					return <RuntimeRestartButton key={runtimeItem.id} positronConsoleInstance={props.positronConsoleInstance} runtimeItemRestartButton={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
-					return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
-				} else if (runtimeItem instanceof RuntimeItemTrace) {
-					return props.trace && <RuntimeTrace key={runtimeItem.id} runtimeItemTrace={runtimeItem} />;
-				} else {
-					// This indicates a bug.
-					return null;
+				})}
+				{extensionHostDisconnected ?
+					(<div className='console-item-reconnecting'>
+						<span className='codicon codicon-loading codicon-modifier-spin'></span>
+						<span>{localize(
+							"positron.console.extensionsRestarting",
+							"Extensions restarting..."
+						)}</span>
+					</div>) :
+					null
 				}
-			})}
-			{extensionHostDisconnected ?
-				(<div className='console-item-reconnecting'>
-					<span className='codicon codicon-loading codicon-modifier-spin'></span>
-					<span>{localize(
-						"positron.console.extensionsRestarting",
-						"Extensions restarting..."
-					)}</span>
-				</div>) :
-				null
-			}
 
-			<ConsoleInput
-				hidden={props.positronConsoleInstance.promptActive || !props.runtimeAttached}
-				positronConsoleInstance={props.positronConsoleInstance}
-				width={props.consoleInputWidth}
-				onCodeExecuted={() => flushSync(() => forceUpdate())} // Update the component to eliminate flickering.
-				onSelectAll={props.onSelectAll}
-			/>
-		</>
-	);
+				<ConsoleInput
+					hidden={this.props.positronConsoleInstance.promptActive || !this.props.runtimeAttached}
+					positronConsoleInstance={this.props.positronConsoleInstance}
+					width={this.props.consoleInputWidth}
+					onCodeExecuted={() =>
+						// Update the component to eliminate flickering.
+						flushSync(() => this.forceUpdate()
+						)}
+					onSelectAll={this.props.onSelectAll}
+				/>
+			</>
+		);
+	}
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
@@ -50,6 +50,17 @@ interface ConsoleInstanceItemsProps {
 }
 /**
  * ConsoleInstanceItems component.
+ *
+ * PLEASE READ:
+ * This component is a class component ON PURPOSE!
+ * This needs to be a class component to fix https://github.com/posit-dev/positron/issues/705.
+ * Without `forceUpdate()`, there will be a regression for issue #705.
+ *
+ * This is the only class component in Positron Core for this reason.
+ * Other workarounds do not work, including the offical suggestion in the React FAQ:
+ * https://legacy.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+ *
+ * See commit: https://github.com/posit-dev/positron/commit/1e125e96bdc128a5c2dc2a9df7cdb52ba9ea5aaf
  */
 export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.css
@@ -7,6 +7,7 @@
 	border-left: 1px solid var(--vscode-terminal-border);
 	background-color: var(--vscode-tab-inactiveBackground);
 	flex-grow: 1;
+	overflow-y: auto;
 }
 
 .tabs-container .tab-button {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 
 // Other dependencies.
 import { IAction } from '../../../../../base/common/actions.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
@@ -32,21 +31,6 @@ export const VariablesInstanceMenuButton = () => {
 		}
 		return 'None';
 	};
-
-	// State.
-	const [activeRuntimeLabel, setActiveRuntimeLabel] =
-		React.useState(labelForRuntime(
-			positronVariablesContext.activePositronVariablesInstance?.session));
-
-	// useEffect hook to update the runtime label.
-	React.useEffect(() => {
-		const disposables = new DisposableStore();
-		const variablesService = positronVariablesContext.positronVariablesService;
-		disposables.add(variablesService.onDidChangeActivePositronVariablesInstance(e => {
-			setActiveRuntimeLabel(labelForRuntime(e?.session));
-		}));
-		return () => disposables.dispose();
-	}, [positronVariablesContext.activePositronVariablesInstance, positronVariablesContext.positronVariablesService]);
 
 	// Builds the actions.
 	const actions = () => {
@@ -83,7 +67,7 @@ export const VariablesInstanceMenuButton = () => {
 	return (
 		<ActionBarMenuButton
 			actions={actions}
-			text={activeRuntimeLabel}
+			text={labelForRuntime(positronVariablesContext.activePositronVariablesInstance?.session)}
 		/>
 	);
 };

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1848,6 +1848,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		}));
 
 		this._runtimeDisposableStore.add(this._session.onDidEndSession((exit) => {
+			const multiSessionsEnabled =
+				multipleConsoleSessionsFeatureEnabled(this._configurationService);
+
 			// If trace is enabled, add a trace runtime item.
 			if (this._trace) {
 				this.addRuntimeItemTrace(`onDidEndSession (code ${exit.exit_code}, reason '${exit.reason}')`);
@@ -1871,10 +1874,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// code was `0`, we don't attempt to automatically start the runtime again. In this
 			// case, we add an activity item that shows a button the user can use to start the
 			// runtime manually.
-			if (exit.reason === RuntimeExitReason.ForcedQuit ||
+			const showRestartButton = exit.reason === RuntimeExitReason.ForcedQuit ||
 				exit.reason === RuntimeExitReason.Shutdown ||
 				exit.reason === RuntimeExitReason.Unknown ||
-				crashedAndNeedRestartButton) {
+				crashedAndNeedRestartButton;
+
+			if (!multiSessionsEnabled && showRestartButton) {
 				const restartButton = new RuntimeItemRestartButton(generateUuid(),
 					this._session.runtimeMetadata.languageName,
 					() => {

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -246,7 +246,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			this._setActivePositronVariablesBySession(this._runtimeSessionService.foregroundSession);
 		} else {
 			// All else fails, just reset to the default
-			this._setActivePositronVariablesInstance()
+			this._setActivePositronVariablesInstance();
 		}
 	}
 

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -19,9 +19,9 @@ import { IAccessibilityService } from '../../../../platform/accessibility/common
 import { IEditorService } from '../../editor/common/editorService.js';
 import { NotebookEditorInput } from '../../../contrib/notebook/common/notebookEditorInput.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IPositronConsoleService } from '../../positronConsole/browser/interfaces/positronConsoleService.js';
+import { IPositronConsoleInstance, IPositronConsoleService } from '../../positronConsole/browser/interfaces/positronConsoleService.js';
 import { PositronNotebookEditorInput } from '../../../contrib/positronNotebook/browser/PositronNotebookEditorInput.js';
-import { IPositronConsoleInstance } from '../../positronConsole/browser/interfaces/positronConsoleService.js';
+import { multipleConsoleSessionsFeatureEnabled } from '../../runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.js';
 
 /**
  * PositronVariablesService class.
@@ -274,6 +274,8 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 	private createOrAssignPositronVariablesInstance(
 		session: ILanguageRuntimeSession,
 		activate: boolean) {
+		const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(this._configurationService);
+
 		// Ignore background sessions
 		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Background) {
 			return;
@@ -285,48 +287,74 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 		);
 
 		if (positronVariablesInstance) {
-
 			const state = positronVariablesInstance.state;
-
 			if (state === RuntimeClientState.Closed || state === RuntimeClientState.Uninitialized) {
 				// The Positron variables instance has exited, so attach it to
-				// this new session instance. (This is most likely a restart of
+				// this session instance. (This is most likely a restart of
 				// the runtime session.)
 				positronVariablesInstance.setRuntimeSession(session);
-				return;
-
-			} else {
-				// The Positron variables instance is still running, so we don't
-				// need to do anything.
-				return;
 			}
+			// The Positron variables instance is still running,
+			// so we don't need to do anything else.
+			return;
 		}
 
-		// Look for an old variables instance that has the same runtime ID and
-		// notebook URI (can be empty) as the one we're starting. We recycle the
-		// old instance, if we have one, instead of creating a new one.
-		const allInstances = Array.from(this._positronVariablesInstancesBySessionId.values());
-		const existingInstance = allInstances.find(
-			positronVariablesInstance => {
-				// Check the runtime ID and notebook URI for a match.
-				return positronVariablesInstance.session.runtimeMetadata.runtimeId ===
-					session.runtimeMetadata.runtimeId &&
-					isEqual(positronVariablesInstance.session.metadata.notebookUri, session.metadata.notebookUri);
-			});
+		if (multiSessionsEnabled) {
+			// Reuse variable instances for notebook sessions ONLY instead of creating new ones
+			// by finding old instances for the same runtime ID and notebook URI.
+			if (session.metadata.notebookUri) {
+				const allInstances = Array.from(this._positronVariablesInstancesBySessionId.values());
+				const existingInstance = allInstances.find(variableInstance => {
+					// Check the runtime ID and notebook URI for a match.
+					return variableInstance.session.runtimeMetadata.runtimeId ===
+						session.runtimeMetadata.runtimeId &&
+						isEqual(variableInstance.session.metadata.notebookUri, session.metadata.notebookUri);
+				});
 
-		if (existingInstance) {
-			// Clean up the old session ID mapping
-			this._positronVariablesInstancesBySessionId.deleteAndDispose(existingInstance.session.sessionId);
+				if (existingInstance) {
+					// Clean up the old session ID mapping
+					this._positronVariablesInstancesBySessionId.deleteAndDispose(
+						existingInstance.session.sessionId
+					);
 
-			// Update the map of Positron variables instances by session ID.
-			this._positronVariablesInstancesBySessionId.set(
-				session.sessionId,
-				existingInstance
-			);
+					// Update the map of Positron variables instances by session ID.
+					this._positronVariablesInstancesBySessionId.set(
+						session.sessionId,
+						existingInstance
+					);
 
-			// Attach the new session to the existing instance.
-			existingInstance.setRuntimeSession(session);
-			return;
+					// Attach the new session to the existing instance.
+					existingInstance.setRuntimeSession(session);
+					return;
+				}
+			}
+		} else {
+			// Look for an old variables instance that has the same runtime ID and
+			// notebook URI (can be empty) as the one we're starting. We recycle the
+			// old instance, if we have one, instead of creating a new one.
+			const allInstances = Array.from(this._positronVariablesInstancesBySessionId.values());
+			const existingInstance = allInstances.find(
+				positronVariablesInstance => {
+					// Check the runtime ID and notebook URI for a match.
+					return positronVariablesInstance.session.runtimeMetadata.runtimeId ===
+						session.runtimeMetadata.runtimeId &&
+						isEqual(positronVariablesInstance.session.metadata.notebookUri, session.metadata.notebookUri);
+				});
+
+			if (existingInstance) {
+				// Clean up the old session ID mapping
+				this._positronVariablesInstancesBySessionId.deleteAndDispose(existingInstance.session.sessionId);
+
+				// Update the map of Positron variables instances by session ID.
+				this._positronVariablesInstancesBySessionId.set(
+					session.sessionId,
+					existingInstance
+				);
+
+				// Attach the new session to the existing instance.
+				existingInstance.setRuntimeSession(session);
+				return;
+			}
 		}
 
 		// If we got here, we need to start a new Positron variables instance.


### PR DESCRIPTION
### Description

Addresses #6590

This change includes:
* the bare minimum to get each session to have its own variables instance in the UI
* Adds the ability to scroll the console tab list
* Hides the restart session button within the console that appears when the console is shutdown via `q()`/`exit()`

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:sessions @:web @:variables

### Screenshots

**Variables Pane**

https://github.com/user-attachments/assets/d20c3762-a9ee-4acd-baa7-a50ebabf498a

**Console Tab List Scrollbar**

https://github.com/user-attachments/assets/cc94885f-9ed2-4228-8df0-a1829ffd5744


