### PR TITLE
Fix the CodeEditorWidget context menu so it shows up

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -699,6 +699,13 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			}
 		);
 
+		// This fixes https://github.com/posit-dev/positron/issues/2281 by stopping mouse down
+		// events from propagating to the ConsoleInstance, which has its own context menu that was
+		// showing instead of the CodeEditorWidget's context menu.
+		codeEditorWidget.onMouseDown(e => {
+			e.event.stopPropagation();
+		});
+
 		// Add the code editor widget to the disposables store.
 		disposableStore.add(codeEditorWidget);
 		setCodeEditorWidget(codeEditorWidget);
@@ -953,8 +960,11 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	 * @param e A FocusEvent<HTMLDivElement, Element> that contains the event data.
 	 */
 	const focusHandler = (e: FocusEvent<HTMLDivElement, Element>) => {
-		// Drive focus into the code editor widget.
-		if (codeEditorWidgetRef.current) {
+		// Drive focus into the code editor widget, if it doesn't already have it. Checking for
+		// hasTextFocus is part of the fix for https://github.com/posit-dev/positron/issues/2281.
+		// Without this check, the CodeEditorWidget's context menu is shown and immediately hidden
+		// by the unnecessary call to focus.
+		if (codeEditorWidgetRef.current && !codeEditorWidgetRef.current.hasTextFocus) {
 			codeEditorWidgetRef.current.focus();
 		}
 	};


### PR DESCRIPTION
### Description

This PR addresses #1916 and #2281. With these changes, the `CodeEditorWidget` context menu is now available via a right click and it works.

Here's a screen shot:

<img width="258" alt="image" src="https://github.com/user-attachments/assets/e0bb0a8c-20b7-472a-bfd4-069d2d778a80" />

The fix was twofold:

1. Stop mouse down events in the `CodeEditorWidget` component from propagating to the the `ConsoleInstance` component because it has its own context menu.
2. Don't `focus` the `CodeEditorWidget` component when it already has focus. This was causing the `CodeEditorWidget` context menu to be shown and immediately hidden.

Tests:
@:console

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #1916
- #2281

### QA Notes

None