### PR TITLE
e2e-test: fix delete in session tests

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -384,7 +384,7 @@ export class Sessions {
 	 * @returns the metadata of the session
 	 */
 	async getMetadata(sessionId?: string): Promise<SessionMetaData> {
-		return await test.step(`Get metadata for session: ${sessionId ?? 'current tab'}`, async () => {
+		return await test.step(`Get metadata for: ${sessionId ?? 'current session'}`, async () => {
 			if (sessionId) {
 				await this.page.getByTestId(`console-tab-${sessionId}`).click();
 			}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -239,10 +239,7 @@ export class Sessions {
 			}
 
 			// Handle the last one separately because there is no tab list trash icon to click on
-			const { state } = await this.getMetadata();
-			if (state === 'disconnected' || state === 'exited') {
-				await this.console.barTrashButton.click();
-			}
+			await this.console.barTrashButton.click();
 		});
 	}
 

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -138,7 +138,7 @@ test.describe('Sessions: Management', {
 		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Delete 1st session and verify active sessions and runtime in session picker
-		await sessions.delete(pythonSession1.name);
+		await sessions.delete(pythonSession1.id);
 		await sessions.expectSessionCountToBe(1);
 		await sessions.expectActiveSessionListsToMatch();
 		await variables.expectRuntimeToBe('visible', rSession1.name);

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -30,29 +30,6 @@ test.describe('Sessions: Management', {
 		await app.workbench.sessions.deleteDisconnectedSessions();
 	});
 
-	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app }) {
-		const sessions = app.workbench.sessions;
-		const variables = app.workbench.variables;
-		const console = app.workbench.console;
-
-		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
-
-		// Delete 1st session and verify active sessions and runtime in session picker
-		await sessions.delete(pythonSession1.name);
-		await sessions.expectSessionCountToBe(1);
-		await sessions.expectSessionListsToMatch();
-		await variables.expectRuntimeToBe('visible', rSession1.name);
-
-		// Delete 2nd session and verify no active sessions or runtime in session picker
-		await console.barTrashButton.click();
-		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
-		await sessions.expectSessionCountToBe(0);
-		await sessions.expectSessionListsToMatch();
-		await variables.expectRuntimeToBe('not.visible', `${rSession1.name}|${pythonSession1.name}|None`);
-	});
-
 	test('Validate metadata between sessions', {
 		annotation: [
 			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6389' }]
@@ -61,8 +38,8 @@ test.describe('Sessions: Management', {
 		const console = app.workbench.console;
 
 		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Verify Python session metadata
 		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
@@ -87,8 +64,8 @@ test.describe('Sessions: Management', {
 		const variables = app.workbench.variables;
 
 		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Set and verify variables in Python
 		await sessions.select(pythonSession1.name);
@@ -125,32 +102,52 @@ test.describe('Sessions: Management', {
 		const console = app.workbench.console;
 
 		// Start sessions and verify active sessions: order matters!
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 		await sessions.expectSessionCountToBe(2, 'active');
-		await sessions.expectSessionListsToMatch();
+		await sessions.expectActiveSessionListsToMatch();
 
 		// Shutdown Python session and verify active sessions
 		await sessions.select(pythonSession1.name);
 		await console.typeToConsole('exit()', true);
 		await sessions.expectSessionCountToBe(1, 'active');
-		await sessions.expectSessionListsToMatch();
+		await sessions.expectActiveSessionListsToMatch();
 
 		// Shutdown R session and verify active sessions
 		await sessions.select(rSession1.name);
 		await console.typeToConsole('q()', true);
 		await sessions.expectSessionCountToBe(0, 'active');
-		await sessions.expectSessionListsToMatch();
+		await sessions.expectActiveSessionListsToMatch();
 
 		// Launch Python session (again) and verify active sessions
 		await sessions.deleteDisconnectedSessions();
 		await sessions.launch(pythonSession1);
 		await sessions.expectSessionCountToBe(1, 'active');
-		await sessions.expectSessionListsToMatch();
+		await sessions.expectActiveSessionListsToMatch();
+		await console.barTrashButton.click();
+		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
+	});
 
-		// Restart Python session and verify active sessions
-		await console.barClearButton.click();
-		await sessions.restartButton.click();
-		await sessions.expectSessionListsToMatch();
+	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app }) {
+		const sessions = app.workbench.sessions;
+		const variables = app.workbench.variables;
+		const console = app.workbench.console;
+
+		// Ensure sessions exist and are idle
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+
+		// Delete 1st session and verify active sessions and runtime in session picker
+		await sessions.delete(pythonSession1.name);
+		await sessions.expectSessionCountToBe(1);
+		await sessions.expectActiveSessionListsToMatch();
+		await variables.expectRuntimeToBe('visible', rSession1.name);
+
+		// Delete 2nd session and verify no active sessions or runtime in session picker
+		await console.barTrashButton.click();
+		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
+		await sessions.expectSessionCountToBe(0);
+		await sessions.expectActiveSessionListsToMatch();
+		await variables.expectRuntimeToBe('not.visible', `${rSession1.name}|${pythonSession1.name}|None`);
 	});
 });

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -124,8 +124,6 @@ test.describe('Sessions: Management', {
 		await sessions.launch(pythonSession1);
 		await sessions.expectSessionCountToBe(1, 'active');
 		await sessions.expectActiveSessionListsToMatch();
-		// await console.barTrashButton.click();
-		// await expect(sessions.activeSessionPicker).toHaveText('Start Session');
 	});
 
 	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app }) {

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -124,8 +124,8 @@ test.describe('Sessions: Management', {
 		await sessions.launch(pythonSession1);
 		await sessions.expectSessionCountToBe(1, 'active');
 		await sessions.expectActiveSessionListsToMatch();
-		await console.barTrashButton.click();
-		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
+		// await console.barTrashButton.click();
+		// await expect(sessions.activeSessionPicker).toHaveText('Start Session');
 	});
 
 	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app }) {

--- a/test/e2e/tests/sessions/session-picker.test.ts
+++ b/test/e2e/tests/sessions/session-picker.test.ts
@@ -45,8 +45,8 @@ test.describe('Sessions: Session Picker', {
 	test('Verify Session Picker updates correctly across multiple active sessions', async function ({ app }) {
 		const sessions = app.workbench.sessions;
 
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Widen session tab list to view full runtime names
 		await sessions.widenSessionTabList();

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -85,8 +85,8 @@ test.describe('Sessions: State', {
 		const console = app.workbench.console;
 
 		// Start Python and R sessions
-		pythonSession1.id = await sessions.reuseSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseSessionIfExists(rSession1);
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Verify Python session transitions to active when executing code
 		await sessions.select(pythonSession1.name);


### PR DESCRIPTION
### Summary
* Fixed the flake with deleting disconnected sessions by properly waiting for disconnection to finish.
* Moved "delete" test back in its original position to confirm it no longer flakes.
* Cleaned up some misc things. 🧹 

### QA Notes

@:sessions
