### PR TITLE
Fix variables sending update event on empty cell execution

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/conftest.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/conftest.py
@@ -134,8 +134,7 @@ def shell(kernel) -> Iterable[PositronShell]:
     new_user_ns_keys = set(shell.user_ns.keys()) - user_ns_keys
     for key in new_user_ns_keys:
         del shell.user_ns[key]
-    if "_" in shell.user_ns:
-        del shell.user_ns["_"]
+    shell.user_ns["_"] = ""
 
 
 @pytest.fixture
@@ -212,6 +211,9 @@ def variables_comm(variables_service: VariablesService) -> DummyComm:
 
     # Clear messages due to the comm_open
     variables_comm.messages.clear()
+
+    # Clear the snapshot
+    variables_service._snapshot = None  # noqa: SLF001
 
     return variables_comm
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,6 @@ import pytest
 
 from positron import variables as variables_module
 from positron.access_keys import encode_access_key
-from positron.inspectors import get_inspector
 from positron.positron_comm import JsonRpcErrorCode
 from positron.utils import JsonData, JsonRecord, not_none
 from positron.variables import VariablesService, _summarize_variable


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4277.

The problem is that IPython runs `post_run_cell` hooks but not `pre_run_cell` hooks when executing an empty cell. The fix is to exit early in both cases if the cell was empty.

I also made a couple test changes:

1. Separated the change detection tests such that we don't need the complicated logic to determine whether it's `assigned` or `unevaluated`.
2. Wrapped a bunch of test cases in `pytest.param` which makes it easier to browse in the test explorer UI.
3. Reset the `_` variable to `''` instead of deleting it after each test, which more closely matches real behavior. That seemed to affect the ordering of variables in certain tests which I updated too.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed Python Variables flashing to signify an update when running an empty code cell (#4277).