### PR TITLE
python: show interpreter path when python files opened

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -647,7 +647,7 @@
                     "type": "string"
                 },
                 "python.interpreter.infoVisibility": {
-                    "default": "never",
+                    "default": "onPythonRelated",
                     "description": "%python.interpreter.infoVisibility.description%",
                     "enum": [
                         "never",

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -133,8 +133,8 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
         if (this.statusBar) {
             if (interpreter) {
                 this.statusBar.color = '';
-                // --- Start Positron --
-                this.statusBar.tooltip = 'Select Interpreter';
+                // --- Start Positron ---
+                this.statusBar.tooltip = InterpreterQuickPickList.browsePath.title;
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -134,8 +134,8 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             if (interpreter) {
                 this.statusBar.color = '';
                 // --- Start Positron --
-                // disable tooltip that displays path
-                // this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
+                // tooltip is full interpreter path
+                this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path);
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(
@@ -147,7 +147,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
                     this.currentlySelectedInterpreterPath = interpreter.path;
                 }
                 // --- Start Positron --
-                // status bar text should be interpreter path
+                // status bar text should be interpreter path, relative to workspace
                 let text = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
                 // --- End Positron ---
                 text = text?.startsWith('Python') ? text?.substring('Python'.length)?.trim() : text;

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -134,8 +134,8 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             if (interpreter) {
                 this.statusBar.color = '';
                 // --- Start Positron --
-                // tooltip is full interpreter path
-                this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path);
+                // remove tooltip
+                // this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path);
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -134,8 +134,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             if (interpreter) {
                 this.statusBar.color = '';
                 // --- Start Positron --
-                // remove tooltip
-                // this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path);
+                this.statusBar.tooltip = 'Select Interpreter';
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -134,7 +134,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             if (interpreter) {
                 this.statusBar.color = '';
                 // --- Start Positron ---
-                this.statusBar.tooltip = InterpreterQuickPickList.browsePath.title;
+                this.statusBar.tooltip = InterpreterQuickPickList.browsePath.openButtonLabel;
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -133,7 +133,10 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
         if (this.statusBar) {
             if (interpreter) {
                 this.statusBar.color = '';
-                this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
+                // --- Start Positron --
+                // disable tooltip that displays path
+                // this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
+                // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(
                         l10n.t(
@@ -143,7 +146,10 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
                     );
                     this.currentlySelectedInterpreterPath = interpreter.path;
                 }
-                let text = interpreter.detailedDisplayName;
+                // --- Start Positron --
+                // status bar text should be interpreter path
+                let text = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
+                // --- End Positron ---
                 text = text?.startsWith('Python') ? text?.substring('Python'.length)?.trim() : text;
                 this.statusBar.text = text ?? '';
                 this.statusBar.backgroundColor = undefined;

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -185,10 +185,10 @@ suite('Interpreters Display', () => {
                 if (useLanguageStatus) {
                     // --- Start Positron ---
                     // Status bar value should be the path, not the display name
-                    // languageStatusItem.verify(
-                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                    //     TypeMoq.Times.once(),
-                    // );
+                    languageStatusItem.verify(
+                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
+                        TypeMoq.Times.once(),
+                    );
                     // --- End Positron ---
                     languageStatusItem.verify(
                         (s) => (s.detail = TypeMoq.It.isValue(activeInterpreter.path)!),

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -183,19 +183,25 @@ suite('Interpreters Display', () => {
                 await interpreterDisplay.refresh(resource);
 
                 if (useLanguageStatus) {
-                    languageStatusItem.verify(
-                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                        TypeMoq.Times.once(),
-                    );
+                    // --- Start Positron ---
+                    // Status bar value should be the path, not the display name
+                    // languageStatusItem.verify(
+                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
+                    //     TypeMoq.Times.once(),
+                    // );
+                    // --- End Positron ---
                     languageStatusItem.verify(
                         (s) => (s.detail = TypeMoq.It.isValue(activeInterpreter.path)!),
                         TypeMoq.Times.atLeastOnce(),
                     );
                 } else {
-                    statusBar.verify(
-                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                        TypeMoq.Times.once(),
-                    );
+                    // --- Start Positron ---
+                    // Status bar value should be the path, not the display name
+                    // statusBar.verify(
+                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
+                    //     TypeMoq.Times.once(),
+                    // );
+                    // --- End Positron ---
                     statusBar.verify(
                         (s) => (s.tooltip = TypeMoq.It.isValue(activeInterpreter.path)!),
                         TypeMoq.Times.atLeastOnce(),
@@ -233,7 +239,10 @@ suite('Interpreters Display', () => {
                 const pythonPath = path.join('user', 'development', 'env', 'bin', 'python');
                 const workspaceFolder = Uri.file('workspace');
                 const displayName = 'Python 3.10.1';
-                const expectedDisplayName = '3.10.1';
+                // --- Start Positron ---
+                // Status bar value should be the path, not the display name
+                const expectedDisplayName = path.join('user', 'development', 'env', 'bin', 'python');
+                // --- End Positron ---
 
                 setupWorkspaceFolder(resource, workspaceFolder);
                 const pythonInterpreter: PythonEnvironment = ({
@@ -329,19 +338,25 @@ suite('Interpreters Display', () => {
                 interpreterHelper.verifyAll();
                 interpreterService.verifyAll();
                 if (useLanguageStatus) {
-                    languageStatusItem.verify(
-                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                        TypeMoq.Times.once(),
-                    );
+                    // --- Start Positron ---
+                    // Status bar should display path, not interpreter name
+                    // languageStatusItem.verify(
+                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
+                    //     TypeMoq.Times.once(),
+                    // );
+                    // --- End Positron ---
                     languageStatusItem.verify(
                         (s) => (s.detail = TypeMoq.It.isValue(pythonPath)!),
                         TypeMoq.Times.atLeastOnce(),
                     );
                 } else {
-                    statusBar.verify(
-                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                        TypeMoq.Times.once(),
-                    );
+                    // --- Start Positron ---
+                    // Status bar should display path, not display name
+                    // statusBar.verify(
+                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
+                    //     TypeMoq.Times.once(),
+                    // );
+                    // --- End Positron ---
                     statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)!), TypeMoq.Times.atLeastOnce());
                 }
             });

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -236,7 +236,7 @@ suite('Interpreters Display', () => {
             });
             // --- Start Positron ---
             // rename test to reflect reality
-            test('Tooltip should point Select Interpreter', async () => {
+            test('Tooltip should be "Select Interpreter"', async () => {
                 // --- End Positron ---
                 const resource = Uri.file('x');
                 const pythonPath = path.join('user', 'development', 'env', 'bin', 'python');
@@ -268,7 +268,7 @@ suite('Interpreters Display', () => {
                     );
                 } else {
                     // --- Start Positron ---
-                    // No tooltip
+                    // Tooltip should be "Select Interpreter"
                     statusBar.verify(
                         (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')),
                         TypeMoq.Times.atLeastOnce(),

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -197,15 +197,15 @@ suite('Interpreters Display', () => {
                 } else {
                     // --- Start Positron ---
                     // Status bar value should be the path, not the display name
+                    statusBar.verify(
+                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
+                        TypeMoq.Times.once(),
+                    );
                     // statusBar.verify(
-                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                    //     TypeMoq.Times.once(),
+                    //     (s) => (s.tooltip = TypeMoq.It.isValue(activeInterpreter.path)!),
+                    //     TypeMoq.Times.atLeastOnce(),
                     // );
                     // --- End Positron ---
-                    statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue(activeInterpreter.path)!),
-                        TypeMoq.Times.atLeastOnce(),
-                    );
                 }
             });
             test('Log the output channel if displayed needs to be updated with a new interpreter', async () => {
@@ -264,7 +264,10 @@ suite('Interpreters Display', () => {
                         TypeMoq.Times.once(),
                     );
                 } else {
-                    statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)), TypeMoq.Times.atLeastOnce());
+                    // --- Start Positron ---
+                    // No tooltip
+                    //statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)), TypeMoq.Times.atLeastOnce());
+                    // --- End Positron ---
                     statusBar.verify((s) => (s.text = TypeMoq.It.isValue(expectedDisplayName)), TypeMoq.Times.once());
                 }
             });
@@ -351,13 +354,13 @@ suite('Interpreters Display', () => {
                     );
                 } else {
                     // --- Start Positron ---
-                    // Status bar should display path, not display name
-                    // statusBar.verify(
-                    //     (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.detailedDisplayName)!),
-                    //     TypeMoq.Times.once(),
-                    // );
+                    // Status bar should display path without any tooltip
+                    statusBar.verify(
+                        (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
+                        TypeMoq.Times.once(),
+                    );
+                    // statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)!), TypeMoq.Times.atLeastOnce());
                     // --- End Positron ---
-                    statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)!), TypeMoq.Times.atLeastOnce());
                 }
             });
             suite('Visibility', () => {

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -201,10 +201,10 @@ suite('Interpreters Display', () => {
                         (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
                         TypeMoq.Times.once(),
                     );
-                    // statusBar.verify(
-                    //     (s) => (s.tooltip = TypeMoq.It.isValue(activeInterpreter.path)!),
-                    //     TypeMoq.Times.atLeastOnce(),
-                    // );
+                    statusBar.verify(
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')!),
+                        TypeMoq.Times.atLeastOnce(),
+                    );
                     // --- End Positron ---
                 }
             });
@@ -234,7 +234,10 @@ suite('Interpreters Display', () => {
                     activeInterpreter.path,
                 );
             });
-            test('If interpreter is not identified then tooltip should point to python Path', async () => {
+            // --- Start Positron ---
+            // rename test to reflect reality
+            test('Tooltip should point Select Interpreter', async () => {
+                // --- End Positron ---
                 const resource = Uri.file('x');
                 const pythonPath = path.join('user', 'development', 'env', 'bin', 'python');
                 const workspaceFolder = Uri.file('workspace');
@@ -266,7 +269,10 @@ suite('Interpreters Display', () => {
                 } else {
                     // --- Start Positron ---
                     // No tooltip
-                    //statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)), TypeMoq.Times.atLeastOnce());
+                    statusBar.verify(
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')),
+                        TypeMoq.Times.atLeastOnce(),
+                    );
                     // --- End Positron ---
                     statusBar.verify((s) => (s.text = TypeMoq.It.isValue(expectedDisplayName)), TypeMoq.Times.once());
                 }
@@ -354,12 +360,15 @@ suite('Interpreters Display', () => {
                     );
                 } else {
                     // --- Start Positron ---
-                    // Status bar should display path without any tooltip
+                    // Status bar should display path, tooltip should say Select Interpreter
                     statusBar.verify(
                         (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
                         TypeMoq.Times.once(),
                     );
-                    // statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)!), TypeMoq.Times.atLeastOnce());
+                    statusBar.verify(
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')!),
+                        TypeMoq.Times.atLeastOnce(),
+                    );
                     // --- End Positron ---
                 }
             });


### PR DESCRIPTION
User feedback was that it can be difficult to see the full path of the active interpreter. This is partially fixed with the new multiconsole work, which has a much wider display to see the full path on interpreter selection. We still want a zero-click way to see the interpreter path though, so I've reused the capability that is already available in the Python extension.

Since we already have the interpreter name displayed in numerous locations, I feel okay removing it here.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #3033 

#### Bug Fixes

- N/A


### QA Notes

![Screenshot 2025-03-05 at 12 38 53 PM](https://github.com/user-attachments/assets/e341cb45-bc49-4d8e-9d93-26f49a8a36e3)

With a Python file open, the path to the active interpreter should show in the bottom right of the status bar
