### PR TITLE
Set typescript.preferences.importModuleSpecifierEnding to .js in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -175,4 +175,5 @@
 	"eslint.useFlatConfig": true,
 	"editor.occurrencesHighlightDelay": 0,
 	"typescript.experimental.expandableHover": true,
+	"typescript.preferences.importModuleSpecifierEnding": "js",
 }


### PR DESCRIPTION
### Description

This PR adds the `"typescript.preferences.importModuleSpecifierEnding": ".js"` setting to `settings.json` so that using the add import Quick Fix will automatically append `.js` to the newly-added `import` statement.

<img width="725" alt="image" src="https://github.com/user-attachments/assets/d06b74e9-2dd7-42e9-9c27-5ea1d8619583" />


Result:

<img width="982" alt="image" src="https://github.com/user-attachments/assets/8f2c296a-9837-4f0f-9df7-81f914a05236" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A
