### PR TITLE
e2e-test: extend timeout for session restart

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -180,7 +180,7 @@ export class Sessions {
 	 * @param waitForIdle wait for the session to display as "idle" (ready)
 	 */
 	async restart(sessionIdOrName: string, waitForIdle = true, clearConsole = true): Promise<void> {
-		await test.step(`Restart session:`, async () => {
+		await test.step(`Restart session: ${sessionIdOrName}`, async () => {
 			await this.getSessionTab(sessionIdOrName).click();
 
 			if (clearConsole) {
@@ -191,7 +191,7 @@ export class Sessions {
 			await this.page.mouse.move(0, 0);
 
 			if (waitForIdle) {
-				this.expectStatusToBe(sessionIdOrName, 'idle', { timeout: 60000 });
+				this.expectStatusToBe(sessionIdOrName, 'idle', { timeout: 90000 });
 			}
 		});
 	}

--- a/test/e2e/tests/variables/variables-pane.test.ts
+++ b/test/e2e/tests/variables/variables-pane.test.ts
@@ -40,7 +40,7 @@ test.describe('Variables Pane', {
 
 	test('Python - Verify only 1 entry per environment', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5887' }],
-	}, async function ({ app, logger, python }) {
+	}, async function ({ app, python }) {
 		await app.workbench.console.barClearButton.click();
 		await app.workbench.console.barRestartButton.click();
 		await app.workbench.console.waitForReady('>>>');
@@ -71,7 +71,7 @@ test.describe('Variables Pane', {
 
 	test('R - Verify only 1 entry per environment', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5887' }],
-	}, async function ({ app, logger, r }) {
+	}, async function ({ app, r }) {
 		await app.workbench.console.barClearButton.click();
 		await app.workbench.console.barRestartButton.click();
 		await app.workbench.console.waitForReady('>');


### PR DESCRIPTION
### Summary

Saw a test flake due to restart still occurring in test. Extending time to allow restart to finish.

### QA Notes

@:sessions