### PR TITLE
Remove 100 character ruler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -168,9 +168,6 @@
 		"editor.wordWrap": "on"
 	},
 	"css.format.spaceAroundSelectorSeparator": true,
-	"editor.rulers": [
-		100
-	],
 	"typescript.enablePromptUseWorkspaceTsdk": true,
 	"eslint.useFlatConfig": true,
 	"editor.occurrencesHighlightDelay": 0,


### PR DESCRIPTION
### Description

This PR removes the 100-character ruler in `./vscode/settings.json`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A