### PR TITLE
Updates to fix modal popups in Safari

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -123,6 +123,18 @@ body.web {
 	font-size: 100%;
 }
 
+/* --- Start Positron --- */
+/*
+ * On Safari, we need to override the User Agent Style Sheet for buttons
+ * elements just like .monaco-workbench input does above for input elements.
+ */
+.monaco-workbench button {
+	color: inherit;
+	font-family: inherit;
+	font-size: 100%;
+}
+/* --- End Positron --- */
+
 .monaco-workbench table {
 	/*
 	 * Somehow this is required when tables show in floating windows

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
@@ -47,13 +47,13 @@ export const CustomFolderModalPopup = (props: CustomFolderModalPopupProps) => {
 	return (
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
-			height={'min-content'}
+			height={'auto'}
 			keyboardNavigationStyle='menu'
 			minWidth={275}
 			popupAlignment='right'
 			popupPosition='bottom'
 			renderer={props.renderer}
-			width={'max-content'}
+			width={'auto'}
 		>
 			<CustomFolderMenuItems
 				commandService={props.commandService}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
@@ -44,7 +44,7 @@ export const InterpretersManagerModalPopup = (props: InterpretersManagerModalPop
 	return (
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
-			height={'min-content'}
+			height={'auto'}
 			keyboardNavigationStyle='menu'
 			popupAlignment='right'
 			popupPosition='bottom'

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -38,7 +38,7 @@ export interface CustomContextMenuProps {
 	readonly anchorPoint?: AnchorPoint;
 	readonly popupPosition: PopupPosition;
 	readonly popupAlignment: PopupAlignment;
-	readonly width?: number | 'max-content' | 'auto';
+	readonly width?: number | 'auto';
 	readonly minWidth?: number | 'auto';
 	readonly entries: CustomContextMenuEntry[];
 }
@@ -78,7 +78,7 @@ export const showCustomContextMenu = async ({
 
 	// Supply the default width.
 	if (!width) {
-		width = 'max-content';
+		width = 'auto';
 	}
 
 	// Supply the default min width.
@@ -114,7 +114,7 @@ interface CustomContextMenuModalPopupProps {
 	readonly anchorPoint?: AnchorPoint;
 	readonly popupPosition: PopupPosition;
 	readonly popupAlignment: PopupAlignment;
-	readonly width: number | 'max-content' | 'auto';
+	readonly width: number | 'auto';
 	readonly minWidth: number | 'auto';
 	readonly entries: CustomContextMenuEntry[];
 }
@@ -217,7 +217,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
 			anchorPoint={props.anchorPoint}
-			height={'min-content'}
+			height={'auto'}
 			keyboardNavigationStyle='menu'
 			minWidth={props.minWidth}
 			popupAlignment={props.popupAlignment}

--- a/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
+++ b/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
@@ -177,7 +177,7 @@ const DropDownListBoxModalPopup = <T, V,>(props: DropDownListBoxModalPopupProps<
 	return (
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
-			height={'min-content'}
+			height={'auto'}
 			keyboardNavigationStyle='menu'
 			minWidth={props.anchorElement.offsetWidth}
 			popupAlignment='left'

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -42,8 +42,8 @@ class PopupLayout {
 	right: number | 'auto' = 'auto';
 	bottom: number | 'auto' = 'auto';
 	left: number | 'auto' = 'auto';
-	width: number | 'min-content' = 'min-content';
-	height: number | 'min-content' = 'min-content';
+	width: number | 'auto' = 'auto';
+	height: number | 'auto' = 'auto';
 	maxWidth: number | 'none' = 'none';
 	maxHeight: number | 'none' = 'none';
 	shadow: 'top' | 'bottom' = 'bottom';
@@ -81,9 +81,9 @@ export interface PositronModalPopupProps {
 	readonly anchorPoint?: AnchorPoint;
 	readonly popupPosition: PopupPosition;
 	readonly popupAlignment: PopupAlignment;
-	readonly width: number | 'max-content' | 'auto';
+	readonly width: number | 'auto';
 	readonly minWidth?: number | 'auto';
-	readonly height: number | 'min-content';
+	readonly height: number | 'auto';
 	readonly minHeight?: number | 'auto';
 	readonly maxHeight?: number | 'none';
 	readonly fixedHeight?: boolean;
@@ -184,7 +184,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			(anchorY + anchorHeight + LAYOUT_OFFSET + LAYOUT_MARGIN);
 
 		// Perform vertical popup layout.
-		if (props.height === 'min-content') {
+		if (props.height === 'auto') {
 			// Set the popup layout height.
 			popupLayout.height = props.height;
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -754,7 +754,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
 			fixedHeight={true}
-			height={'min-content'}
+			height={'auto'}
 			keyboardNavigationStyle='dialog'
 			popupAlignment='auto'
 			popupPosition='auto'

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -112,7 +112,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
 			fixedHeight={true}
-			height='min-content'
+			height='auto'
 			keyboardNavigationStyle='menu'
 			popupAlignment='auto'
 			popupPosition='auto'

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
@@ -89,7 +89,7 @@ export const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => 
 				},
 				popupPosition: 'auto',
 				popupAlignment: 'auto',
-				width: 'max-content',
+				width: 'auto',
 				entries
 			});
 		}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
@@ -69,7 +69,7 @@ export function WelcomeConsoleButton(props: WelcomeConsoleButtonProps) {
 		renderer.render(
 			<PositronModalPopup
 				anchorElement={ref.current}
-				height={'min-content'}
+				height={'auto'}
 				keyboardNavigationStyle='menu'
 				popupAlignment='left'
 				popupPosition='bottom'

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeMenuButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeMenuButton.tsx
@@ -49,7 +49,7 @@ export function WelcomeMenuButton(props: WelcomeMenuButtonProps) {
 		renderer.render(
 			<PositronModalPopup
 				anchorElement={ref.current}
-				height={'min-content'}
+				height={'auto'}
 				keyboardNavigationStyle='menu'
 				popupAlignment='left'
 				popupPosition='bottom'


### PR DESCRIPTION
### Description

This PR addresses #6524 by changing how Positron modal popups automatically size themselves. Now, we use `auto` for automatic layout. Prior to this PR, we used `max-content` (for width) or `min-content` (for height), which worked on Chrome and Electron, but did not work on Safari.

Tests:
@:console
@:data-explorer
@:modal
@:new-project-wizard
@:top-action-bar
@:variables
@:web

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6524


### QA Notes

This PR touches the core of how Positron modal popups are laid out. As such, we need to manually test each modal popup in Safari, Chrome, and Electron. I have done this, and everything appears to be functioning well.