### PR TITLE
bump wait for connection

### DIFF
--- a/test/e2e/tests/connections/connections-db.test.ts
+++ b/test/e2e/tests/connections/connections-db.test.ts
@@ -33,7 +33,7 @@ test.describe('SQLite DB Connection', {
 			await app.workbench.layouts.enterLayout('fullSizedAuxBar');
 			// there is a flake of the db connection not displaying in the connections pane after
 			// clicking the db icon. i want to see if waiting for a second will help
-			await app.code.driver.page.waitForTimeout(1000);
+			await app.code.driver.page.waitForTimeout(2000);
 			await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 			await app.workbench.connections.connectIcon.click();
 		});


### PR DESCRIPTION
This tests occaionally fails on windows, due to an empty connection pane.

We previously put in a very small wait, I'm bumped it by 1 second to see if this helps.

If this continues to be an issue, we could also wrap that click in a retry.

## QA Notes
All test should pass. The offending test is already marked "critical" so the PR run will pick it up.

@:win