### PR TITLE
e2e-test: add session scroll test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -31,6 +31,7 @@ export class Sessions {
 	sessionTabs: Locator;
 	currentSessionTab: Locator;
 	consoleInstance: (sessionId: string) => Locator;
+	outputChannel: Locator;
 
 	constructor(private code: Code, private console: Console, private quickaccess: QuickAccess, private quickinput: QuickInput) {
 		this.page = this.code.driver.page;
@@ -49,6 +50,7 @@ export class Sessions {
 		this.sessionTabs = this.page.getByTestId(/console-tab/);
 		this.currentSessionTab = this.sessionTabs.filter({ has: this.page.locator('.tab-button--active') });
 		this.consoleInstance = (sessionId: string) => this.page.getByTestId(`console-${sessionId}`);
+		this.outputChannel = this.page.getByRole('combobox');
 	}
 
 
@@ -543,17 +545,19 @@ export class Sessions {
 
 			// Verify Language Console
 			await this.selectMetadataOption('Show Console Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}`));
-			await expect(this.page.getByRole('combobox')).toHaveValue(/Console$/);
+			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(/Console$/);
 
 			// Verify Output Channel
 			await this.selectMetadataOption('Show Kernel Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}`));
-			await expect(this.page.getByRole('combobox')).toHaveValue(/Kernel$/);
+			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(/Kernel$/);
 
 			// Verify LSP Output Channel
 			await this.selectMetadataOption('Show LSP Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(/Language Server \(Console\)$/);
+			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(/Language Server \(Console\)$/);
+
 
 			// Go back to console when done
 			await this.console.clickConsoleTab();

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -238,7 +238,7 @@ export class Sessions {
 			// Collect all disconnected session IDs
 			for (const sessionId of sessionIds) {
 				const status = await this.getIconStatus(sessionId);
-				if (status === 'disconnected' || 'exited') {
+				if (status === 'disconnected' || status === 'exited') {
 					disconnectedSessions.push(sessionId);
 				}
 			}
@@ -481,7 +481,7 @@ export class Sessions {
 	 * @param sessionIdOrName A string representing the session name or id.
 	 * @returns 'active', 'idle', 'disconnected', or 'unknown'
 	 */
-	async getIconStatus(sessionIdOrName: string): Promise<'active' | 'idle' | 'disconnected' | 'unknown'> {
+	async getIconStatus(sessionIdOrName: string): Promise<'active' | 'idle' | 'disconnected' | 'exited' | 'unknown'> {
 		const session = this.getSessionTab(sessionIdOrName);
 
 		if (await this.activeStatus(session).isVisible()) { return 'active'; }

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -543,7 +543,7 @@ export class Sessions {
 
 			// Verify Language Console
 			await this.selectMetadataOption('Show Console Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}.*: Console$`));
+			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}.*Console$`, 's'));
 
 			// Verify Output Channel
 			await this.selectMetadataOption('Show Kernel Output Channel');

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -41,7 +41,7 @@ export class Sessions {
 		this.metadataButton = this.page.getByRole('button', { name: 'Console information' });
 		this.metadataDialog = this.page.getByRole('dialog');
 		this.quickPick = new SessionQuickPick(this.code, this);
-		this.activeSessionPicker = this.page.getByRole('button', { name: 'Open Active Session Picker' });
+		this.activeSessionPicker = this.page.locator('[id="workbench.parts.positron-top-action-bar"]').getByRole('button', { name: /(Start a New Session)|(Open Active Session Picker)/ });
 		this.trashButton = (sessionId: string) => this.getSessionTab(sessionId).getByTestId('trash-session');
 		this.newConsoleButton = this.page.getByRole('button', { name: 'Open Start Session Picker', exact: true });
 		this.restartButton = this.page.getByLabel('Restart console', { exact: true });
@@ -639,7 +639,6 @@ export class Sessions {
  */
 export class SessionQuickPick {
 	private sessionQuickMenu = this.code.driver.page.getByText(/(Select a Session)|(Start a New Session)/);
-	private newSessionQuickOption = this.code.driver.page.getByText(/New Session.../);
 
 	constructor(private code: Code, private sessions: Sessions) { }
 
@@ -654,7 +653,8 @@ export class SessionQuickPick {
 		}
 
 		if (viewAllRuntimes) {
-			await this.newSessionQuickOption.click();
+			await this.code.driver.page.getByRole('combobox', { name: 'input' }).fill('New Session');
+			await this.code.driver.page.keyboard.press('Enter');
 			await expect(this.code.driver.page.getByText(/Start a New Session/)).toBeVisible();
 		} else {
 			await expect(this.code.driver.page.getByText(/Select a Session/)).toBeVisible();

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -541,20 +541,20 @@ export class Sessions {
 			await this.page.keyboard.press('Escape');
 
 			// Verify Language Console
+			const escapedSessionName = new RegExp(session.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
 			await this.selectMetadataOption('Show Console Output Channel');
-			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(escapedSessionName);
 			await expect(this.outputChannel).toHaveValue(/Console$/);
 
 			// Verify Output Channel
 			await this.selectMetadataOption('Show Kernel Output Channel');
-			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(escapedSessionName);
 			await expect(this.outputChannel).toHaveValue(/Kernel$/);
 
 			// Verify LSP Output Channel
 			await this.selectMetadataOption('Show LSP Output Channel');
-			await expect(this.outputChannel).toHaveValue(new RegExp(session.name));
+			await expect(this.outputChannel).toHaveValue(escapedSessionName);
 			await expect(this.outputChannel).toHaveValue(/Language Server \(Console\)$/);
-
 
 			// Go back to console when done
 			await this.console.clickConsoleTab();

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -543,11 +543,13 @@ export class Sessions {
 
 			// Verify Language Console
 			await this.selectMetadataOption('Show Console Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}.*Console$`, 's'));
+			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}`));
+			await expect(this.page.getByRole('combobox')).toHaveValue(/Console$/);
 
 			// Verify Output Channel
 			await this.selectMetadataOption('Show Kernel Output Channel');
-			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}.*: Kernel$`));
+			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${session.language} ${session.version}`));
+			await expect(this.page.getByRole('combobox')).toHaveValue(/Kernel$/);
 
 			// Verify LSP Output Channel
 			await this.selectMetadataOption('Show LSP Output Channel');

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { pythonSession, rSession, SessionInfo } from '../../infra';
+import { pythonSession, pythonSessionAlt, rSession, SessionInfo } from '../../infra';
 import { expect } from '@playwright/test';
 
 const pythonSession1: SessionInfo = { ...pythonSession };
+const pythonSession2: SessionInfo = { ...pythonSessionAlt };
 const rSession1: SessionInfo = { ...rSession };
 
 test.use({
@@ -30,32 +31,6 @@ test.describe('Sessions: Management', {
 		await app.workbench.sessions.deleteDisconnectedSessions();
 	});
 
-	test('Validate metadata between sessions', {
-		annotation: [
-			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6389' }]
-	}, async function ({ app }) {
-		const sessions = app.workbench.sessions;
-		const console = app.workbench.console;
-
-		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
-
-		// Verify Python session metadata
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'idle' });
-
-		// Shutdown Python session and verify metadata
-		await sessions.select(pythonSession1.name);
-		await console.typeToConsole('exit()', true);
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
-
-		// Shutdown R session and verify metadata
-		await sessions.select(rSession1.name);
-		await console.typeToConsole('q()', true);
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'exited' });
-	});
-
 	test('Validate variables between sessions', {
 		tag: [tags.VARIABLES]
 	}, async function ({ app }) {
@@ -65,18 +40,27 @@ test.describe('Sessions: Management', {
 
 		// Ensure sessions exist and are idle
 		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
 		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
-		// Set and verify variables in Python
-		await sessions.select(pythonSession1.name);
+		// Set and verify variables in Python Session 1
+		await sessions.select(pythonSession1.id);
 		await console.typeToConsole('x = 1', true);
 		await console.typeToConsole('y = 2', true);
 		await variables.expectRuntimeToBe('visible', pythonSession1.name);
 		await variables.expectVariableToBe('x', '1');
 		await variables.expectVariableToBe('y', '2');
 
+		// Set and verify variables in Python Session 2
+		await sessions.select(pythonSession2.id);
+		await console.typeToConsole('x = 11', true);
+		await console.typeToConsole('y = 22', true);
+		await variables.expectRuntimeToBe('visible', pythonSession2.name);
+		await variables.expectVariableToBe('x', '11');
+		await variables.expectVariableToBe('y', '22');
+
 		// Set and verify variables in R
-		await sessions.select(rSession1.name);
+		await sessions.select(rSession1.id);
 		await console.typeToConsole('x <- 3', true);
 		await console.typeToConsole('z <- 4', true);
 		await variables.expectRuntimeToBe('visible', rSession1.name);
@@ -84,17 +68,31 @@ test.describe('Sessions: Management', {
 		await variables.expectVariableToBe('z', '4');
 
 		// Switch back to Python, update variables, and verify
-		await sessions.select(pythonSession1.name);
+		await sessions.select(pythonSession1.id);
 		await console.typeToConsole('x = 0', true);
 		await variables.expectRuntimeToBe('visible', pythonSession1.name);
 		await variables.expectVariableToBe('x', '0');
 		await variables.expectVariableToBe('y', '2');
 
 		// Switch back to R, verify variables remain unchanged
-		await sessions.select(rSession1.name);
+		await sessions.select(rSession1.id);
 		await variables.expectRuntimeToBe('visible', rSession1.name);
 		await variables.expectVariableToBe('x', '3');
 		await variables.expectVariableToBe('z', '4');
+	});
+
+	test('Validate session list is scrollable', async function ({ app }) {
+		const sessions = app.workbench.sessions;
+
+		// Ensure sessions exist and are idle
+		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
+		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
+		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+
+		// Resize window to force scrolling
+		await sessions.resizeSessionList({ y: 250 });
+		await sessions.expectSessionListToBeScrollable({ horizontal: false, vertical: true });
+		await sessions.resizeSessionList({ y: -250 });
 	});
 
 	test('Validate active session list in console matches active session list in session picker', async function ({ app }) {

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -93,6 +93,9 @@ test.describe('Sessions: Management', {
 		await sessions.resizeSessionList({ y: 250 });
 		await sessions.expectSessionListToBeScrollable({ horizontal: false, vertical: true });
 		await sessions.resizeSessionList({ y: -250 });
+
+		// Cleaning up since next test only needs 2 sessions
+		await sessions.delete(pythonSession2.id);
 	});
 
 	test('Validate active session list in console matches active session list in session picker', async function ({ app }) {

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -90,9 +90,9 @@ test.describe('Sessions: Management', {
 		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Resize window to force scrolling
-		await sessions.resizeSessionList({ y: 250 });
+		await sessions.resizeSessionList({ y: 350 });
 		await sessions.expectSessionListToBeScrollable({ horizontal: false, vertical: true });
-		await sessions.resizeSessionList({ y: -250 });
+		await sessions.resizeSessionList({ y: -350 });
 
 		// Cleaning up since next test only needs 2 sessions
 		await sessions.delete(pythonSession2.id);

--- a/test/e2e/tests/sessions/session-picker.test.ts
+++ b/test/e2e/tests/sessions/session-picker.test.ts
@@ -49,7 +49,7 @@ test.describe('Sessions: Session Picker', {
 		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
 
 		// Widen session tab list to view full runtime names
-		await sessions.widenSessionTabList();
+		await sessions.resizeSessionList({ x: -100 });
 
 		// Verify Active Session Picker is accurate when selecting different sessions
 		pythonSession2.id = await sessions.launch(pythonSession2);

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -59,7 +59,7 @@ test.describe('Sessions: State', {
 		// Restart Python session, verify Python transitions to active --> idle and R remains idle
 		await sessions.restart(pythonSession1.id, false);
 		await sessions.expectStatusToBe(pythonSession1.id, 'active');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
 		await sessions.expectStatusToBe(rSession1.id, 'idle');
 
 		// Shutdown Python session, verify Python transitions to disconnected while R remains idle
@@ -71,7 +71,7 @@ test.describe('Sessions: State', {
 		// Restart R session, verify R to returns to active --> idle and Python remains disconnected
 		await sessions.restart(rSession1.id, false);
 		await sessions.expectStatusToBe(rSession1.id, 'active');
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
 		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
 
 		// Shutdown R, verify both Python and R in disconnected state


### PR DESCRIPTION
### Summary
This PR makes updates and improvements to session tests:
* moved session metadata test from `session-mgmt.test.ts` -> `session-state.ts`
* added scrolling test to `session-mgmt.test.ts`
   * added helpers for resizing window and asserting scrollability 
* updated session variable test to now have 3 sessions (2 python, 1 R)

### QA Notes

@:sessions @:web @:win
