### PR TITLE
e2e connections test flake fix by adding retry

### DIFF
--- a/test/e2e/pages/sideBar.ts
+++ b/test/e2e/pages/sideBar.ts
@@ -7,6 +7,7 @@
 import { Code } from '../infra/code';
 
 const HIDE_SECONDARY_SIDE_BAR = '[aria-label="Hide Secondary Side Bar"]';
+const SESSION_BUTTON = '[aria-label="Session"]:has-text("Session")';
 
 /*
  *  Reuseable Positron sidebar functionality for tests to leverage.
@@ -18,5 +19,10 @@ export class SideBar {
 	async closeSecondarySideBar() {
 		this.code.logger.log('Hiding secondary side bar');
 		await this.code.driver.page.locator(HIDE_SECONDARY_SIDE_BAR).click();
+	}
+
+	async openSession() {
+		this.code.logger.log('Opening session');
+		await this.code.driver.page.locator(SESSION_BUTTON).click();
 	}
 }

--- a/test/e2e/tests/connections/connections-db.test.ts
+++ b/test/e2e/tests/connections/connections-db.test.ts
@@ -30,12 +30,19 @@ test.describe('SQLite DB Connection', {
 		});
 
 		await test.step('Open connections pane', async () => {
-			await app.workbench.layouts.enterLayout('fullSizedAuxBar');
-			// there is a flake of the db connection not displaying in the connections pane after
-			// clicking the db icon. i want to see if waiting for a second will help
-			await app.code.driver.page.waitForTimeout(2000);
-			await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
-			await app.workbench.connections.connectIcon.click();
+			try {
+				await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+				// there is a flake of the db connection not displaying in the connections pane after
+				// clicking the db icon. To work around, both a wait and a retry are added.
+				await app.code.driver.page.waitForTimeout(2000);
+				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
+				await app.workbench.connections.connectIcon.click();
+			} catch (error) {
+				await app.workbench.variables.togglePane('show');
+				await app.code.driver.page.waitForTimeout(2000);
+				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
+				await app.workbench.connections.connectIcon.click();
+			}
 		});
 
 		await test.step('Verify connection nodes', async () => {

--- a/test/e2e/tests/connections/connections-db.test.ts
+++ b/test/e2e/tests/connections/connections-db.test.ts
@@ -38,7 +38,7 @@ test.describe('SQLite DB Connection', {
 				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 				await app.workbench.connections.connectIcon.click();
 			} catch (error) {
-				await app.workbench.variables.togglePane('show');
+				await app.workbench.sideBar.openSession();
 				await app.code.driver.page.waitForTimeout(2000);
 				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 				await app.workbench.connections.connectIcon.click();


### PR DESCRIPTION
### Intent

The connections test continues to have a flake on windows where clicking the connection doesn't open the connections pane.  I can't get this to repro locally. In addition to the wait already in place, I added a single retry.


### QA Notes
All connections tests should pass (already part of PR test workflow)
@:win
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
