### PR TITLE
Improve error handling for downloads

### DIFF
--- a/extensions/positron-supervisor/scripts/install-kallichore-server.ts
+++ b/extensions/positron-supervisor/scripts/install-kallichore-server.ts
@@ -179,11 +179,25 @@ async function downloadAndReplaceKallichore(version: string,
 			}
 			let binaryData = Buffer.alloc(0);
 
+			// Ensure we got a 200 response on the final request.
+			if (dlResponse.statusCode !== 200) {
+				throw new Error(`Failed to download Kallichore: HTTP ${dlResponse.statusCode}`);
+			}
+
 			dlResponse.on('data', (chunk: any) => {
 				binaryData = Buffer.concat([binaryData, chunk]);
 			});
 			dlResponse.on('end', async () => {
 				const kallichoreDir = path.join('resources', 'kallichore');
+
+				// Ensure we got some bytes. Less than 1024 bytes is probably
+				// an error; none of our assets are under 1mb
+				if (binaryData.length < 1024) {
+					// Log the data we did get
+					console.error(binaryData.toString('utf-8'));
+					throw new Error(
+						`Binary data is too small (${binaryData.length} bytes); download probably failed.`);
+				}
 
 				// Create the resources/kallichore directory if it doesn't exist.
 				if (!await existsAsync(kallichoreDir)) {


### PR DESCRIPTION
This change addresses an issue observed in builds in which problems downloading our binary dependencies do not necessarily cause the build to fail. Instead, the build "succeeds" but the product is broken because the dependencies are missing.

The fix is to add more error handling to the download scripts:

- make sure we got a 200 status code on our final request for the binary data (after following 302 redirects)
- make sure we got a reasonable-looking amount of data for the asset

Addresses https://github.com/posit-dev/positron/issues/6672