### PR TITLE
Updates console to run input when runtime starts

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -89,6 +89,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		useStateRef<HistoryNavigator2<IInputHistoryEntry> | undefined>(undefined);
 	const [, setCurrentCodeFragment, currentCodeFragmentRef] =
 		useStateRef<string | undefined>(undefined);
+	const [, setShouldExecuteOnStart, shouldExecuteOnStartRef] = useStateRef(false);
 
 	/**
 	 * Determines whether it is OK to take focus.
@@ -620,6 +621,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 				// If the console instance isn't ready, ignore the event.
 				if (props.positronConsoleInstance.state !== PositronConsoleState.Ready) {
+					if (!shouldExecuteOnStartRef.current) {
+						setShouldExecuteOnStart(true);
+					}
 					break;
 				}
 
@@ -884,6 +888,10 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		disposableStore.add(props.positronConsoleInstance.onDidChangeState(state => {
 			// Update just the line number options.
 			codeEditorWidget.updateOptions(createLineNumbersOptions());
+			if (state === PositronConsoleState.Ready && shouldExecuteOnStartRef.current) {
+				shouldExecuteOnStartRef.current = false;
+				executeCodeEditorWidgetCodeIfPossible();
+			}
 		}));
 
 		// Add the onDidPasteText event handler.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -889,7 +889,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// Update just the line number options.
 			codeEditorWidget.updateOptions(createLineNumbersOptions());
 			if (state === PositronConsoleState.Ready && shouldExecuteOnStartRef.current) {
-				shouldExecuteOnStartRef.current = false;
+				setShouldExecuteOnStart(false);
 				executeCodeEditorWidgetCodeIfPossible();
 			}
 		}));


### PR DESCRIPTION
This updates the console to attempt to run code entered during runtime startup. When the runtime actually starts, code is checked for completeness (i.e., that it is not a fragment) and run if that passes. 


https://github.com/user-attachments/assets/6ec784e5-2600-438d-a593-83e9f1a493b3


Addresses #3085

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Console executes code entered before start


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:console
