### PR TITLE
Propose using `--vscode-tab-activeBackground` for the action bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActionBar.css
+++ b/src/vs/workbench/browser/parts/editor/editorActionBar.css
@@ -7,7 +7,7 @@
 	height: 32px;
 	--positronActionBar-border: var(--vscode-positronSideActionBar-border);
 	--positronActionBar-separator: var(--vscode-positronSideActionBar-separator);
-	--positronActionBar-background: var(--vscode-positronDataExplorer-contrastBackground);
+	--positronActionBar-background: var(--vscode-tab-activeBackground);
 	--positronActionBar-foreground: var(--vscode-positronSideActionBar-foreground);
 	--positronActionBar-hoverBackground: var(--vscode-positronSideActionBar-hoverBackground);
 	--positronActionBar-disabledForeground: var(--vscode-positronSideActionBar-disabledForeground);


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/6527

**This may not be the right fix, I'm just proposing this as an alternative to think about**

In the current state of the Editor Action Bar, for basic text editors a _third_ background color is being introduced which makes it feel jarring (i.e. it doesn't use the active tab background color, nor does it use the overall UI background color). I think what I don't like about this is that it disconnects the editor file name from the editor contents, which feel like elements that should be tightly coupled.

![Screenshot 2025-03-07 at 11 30 38 AM](https://github.com/user-attachments/assets/7881bd00-9c3a-46fb-856c-9cd21bbdba43)

I'd like to propose using the active tab's background color for our editor action bar background color

This is what an editor looks like now with my change, I think the action bar "flows" out of the `settings.json` tab very nicely now, and avoids the jarring split between the editor file name and the editor contents:

<img width="1556" alt="Screenshot 2025-03-07 at 12 00 09 PM" src="https://github.com/user-attachments/assets/b988a501-f7de-4916-9424-d11def0158c8" />

I see that `var(--vscode-positronDataExplorer-contrastBackground)` was being used, and when I open a data explorer with `main` I see what the original intended goal was - the action bar flows nicely with the filter bar of the data explorer. 

<img width="1246" alt="Screenshot 2025-03-07 at 12 20 50 PM" src="https://github.com/user-attachments/assets/605dc22c-3dcb-455a-8a07-b5b1a5646bd6" />

And with my change it now looks like this, where the editor action bar still flows nicely with the file name, but is now a different color from the data explorer filter bar. I don't mind this too much, but if someone wants to do more work to keep the editor action bar the same color as the filter bar when the data explorer is open, I would not mind trying to keep the original coloring here too.

<img width="1118" alt="Screenshot 2025-03-07 at 12 19 55 PM" src="https://github.com/user-attachments/assets/e0c86b0c-ca99-48ca-aa63-638318e0ed03" />

