### PR TITLE
Data Explorer: Add / test support for decimal types with DuckDB backend and Python

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -61,7 +61,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as zlib from 'zlib';
 import Worker from 'web-worker';
-import { Schema, StructRow, Table, Vector } from 'apache-arrow';
+import { Table, Vector } from 'apache-arrow';
 import { pathToFileURL } from 'url';
 
 // Set to true when doing development for better console logging
@@ -184,7 +184,8 @@ const SCHEMA_TYPE_MAPPING = new Map<string, ColumnDisplayType>([
 	['TIMESTAMP_NS', ColumnDisplayType.Datetime],
 	['TIMESTAMP WITH TIME ZONE', ColumnDisplayType.Datetime],
 	['TIMESTAMP_NS WITH TIME ZONE', ColumnDisplayType.Datetime],
-	['TIME', ColumnDisplayType.Time]
+	['TIME', ColumnDisplayType.Time],
+	['DECIMAL', ColumnDisplayType.Number]
 ]);
 
 function formatLiteral(value: string, schema: ColumnSchema) {
@@ -344,6 +345,7 @@ class ColumnProfileEvaluator {
 	}
 
 	private addIqr(fieldName: string) {
+		// TODO: This will be imprecise / lossy for out-of-range int64 or decimal values
 		this.statsExprs.add(
 			`APPROX_QUANTILE("${fieldName}", 0.75)::DOUBLE - APPROX_QUANTILE("${fieldName}", 0.25)::DOUBLE
 			AS "iqr_${fieldName}"`
@@ -351,7 +353,7 @@ class ColumnProfileEvaluator {
 	}
 
 	private addHistogramStats(fieldName: string, params: ColumnHistogramParams) {
-		this.addMinMax(fieldName);
+		this.addMinMaxStringified(fieldName);
 		switch (params.method) {
 			case ColumnHistogramParamsMethod.FreedmanDiaconis:
 				this.addIqr(fieldName);
@@ -370,6 +372,11 @@ class ColumnProfileEvaluator {
 			this.statsExprs.add(`AVG("${fieldName}") AS "mean_${fieldName}"`);
 			this.statsExprs.add(`STDDEV_SAMP("${fieldName}") AS "stdev_${fieldName}"`);
 			this.statsExprs.add(`MEDIAN("${fieldName}") AS "median_${fieldName}"`);
+		} else if (columnSchema.column_type.startsWith('DECIMAL')) {
+			this.addMinMaxStringified(fieldName);
+			this.statsExprs.add(`AVG("${fieldName}")::DOUBLE AS "f64_mean_${fieldName}"`);
+			this.statsExprs.add(`STDDEV_SAMP("${fieldName}"::DOUBLE) AS "f64_stdev_${fieldName}"`);
+			this.statsExprs.add(`MEDIAN("${fieldName}"::DOUBLE) AS "f64_median_${fieldName}"`);
 		} else if (columnSchema.column_type === 'VARCHAR') {
 			this.addNumUnique(fieldName);
 
@@ -440,9 +447,11 @@ class ColumnProfileEvaluator {
 		// potentially better performance
 		const numRows = Number(stats.get('num_rows'));
 
-		// This may be lossy for very large INT64 values
-		const minValue = Number(stats.get(`min_${field}`));
-		const maxValue = Number(stats.get(`max_${field}`));
+		// TODO: This may be lossy for very large INT64 values
+		// We used strings here to temporarily support decimal type data that fits in float64.
+		// We will need to return later to support broader-spectrum decimals
+		const minValue = Number(stats.get(`string_min_${field}`));
+		const maxValue = Number(stats.get(`string_max_${field}`));
 
 		// Exceptional cases to worry about
 		// - Inf/-Inf values in min/max/iqr
@@ -534,7 +543,7 @@ class ColumnProfileEvaluator {
 		}
 
 		// Since the last bin edge is exclusive, we need to add its count to the last bin
-		output.bin_counts[numBins - 1] += Number(histEntries.get(numBins)) ?? 0;
+		output.bin_counts[numBins - 1] += Number(histEntries.get(numBins) ?? 0);
 
 		// Compute the push the last bin
 		output.bin_edges.push((binWidth * numBins).toString());
@@ -567,6 +576,17 @@ class ColumnProfileEvaluator {
 					mean: formatNumber(stats.get(`mean_${columnSchema.column_name}`)),
 					stdev: formatNumber(stats.get(`stdev_${columnSchema.column_name}`)),
 					median: formatNumber(stats.get(`median_${columnSchema.column_name}`))
+				}
+			};
+		} else if (columnSchema.column_type.startsWith('DECIMAL')) {
+			return {
+				type_display: ColumnDisplayType.Number,
+				number_stats: {
+					min_value: formatNumber(Number(stats.get(`string_min_${columnSchema.column_name}`))),
+					max_value: formatNumber(Number(stats.get(`string_max_${columnSchema.column_name}`))),
+					mean: formatNumber(stats.get(`f64_mean_${columnSchema.column_name}`)),
+					stdev: formatNumber(stats.get(`f64_stdev_${columnSchema.column_name}`)),
+					median: formatNumber(stats.get(`f64_median_${columnSchema.column_name}`))
 				}
 			};
 		} else if (columnSchema.column_type === 'VARCHAR') {
@@ -627,7 +647,7 @@ class ColumnProfileEvaluator {
 			const columnSchema = this.fullSchema[request.column_index];
 			const field = columnSchema.column_name;
 
-			const numRows = Number(stats.get('num_rows'));
+			// const numRows = Number(stats.get('num_rows'));
 
 			const result: ColumnProfileResult = {};
 			for (const spec of request.profiles) {
@@ -674,7 +694,11 @@ function isInteger(duckdbName: string) {
 }
 
 function isNumeric(duckdbName: string) {
-	return isInteger(duckdbName) || duckdbName === 'FLOAT' || duckdbName === 'DOUBLE';
+	return (
+		isInteger(duckdbName) ||
+		duckdbName === 'FLOAT' ||
+		duckdbName === 'DOUBLE'
+	);
 }
 
 /**
@@ -740,6 +764,12 @@ export class DuckDBTableView {
 				if (type_display === undefined) {
 					type_display = ColumnDisplayType.Unknown;
 				}
+
+				// If entry.column_type is like DECIMAL($p,$s), set type_display to Number
+				if (entry.column_type.startsWith('DECIMAL')) {
+					type_display = ColumnDisplayType.Number;
+				}
+
 				return {
 					column_name: entry.column_name,
 					column_index: index,
@@ -1215,10 +1245,6 @@ END`;
 			};
 		};
 
-		const formatColumnNames = (columns: Array<SchemaEntry>) => {
-			return columns.map(s => quoteIdentifier(s.column_name)).join(', ');
-		}
-
 		const getColumnSelectors = (columns: Array<SchemaEntry>) => {
 			const columnSelectors = [];
 			for (const column of columns) {
@@ -1273,7 +1299,7 @@ END`;
 				return {
 					data: result.toArray()[0][result.schema.names[0]],
 					format: params.format
-				}
+				};
 			}
 			case TableSelectionKind.CellRange: {
 				const selection = params.selection.selection as DataSelectionCellRange;

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -73,7 +73,12 @@ function makeTempTableName(): string {
 	return `positron_${randomUUID().replace(/-/g, '')}`;
 }
 
-type InsertColumn = { name: string; type: string; values: Array<string> };
+type InsertColumn = {
+	name: string;
+	type: string;
+	display_type?: ColumnDisplayType;
+	values: Array<string>;
+};
 
 async function createTempTable(
 	tableName: string,
@@ -117,7 +122,7 @@ async function getState(uri: string): Promise<BackendState> {
 	});
 }
 
-async function getSchema(tableName: string, formatOptions?: FormatOptions) {
+async function getSchema(tableName: string) {
 	const uri = `duckdb://${tableName}`;
 	const state = await getState(uri);
 	const shape = state.table_shape;
@@ -230,6 +235,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			}
 		} satisfies BackendState);
 
+
 		result = await dxExec({
 			method: DataExplorerBackendRequest.GetSchema,
 			uri,
@@ -274,8 +280,9 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		} satisfies TableSchema);
 	});
 
+	type TestCaseType = [InsertColumn[] | undefined, ColumnValue[][], FormatOptions];
+
 	test('get_data_values formatting', async () => {
-		type TestCaseType = [InsertColumn[] | undefined, ColumnValue[][], FormatOptions];
 
 		const testCases: Array<TestCaseType> = [
 			// Boolean
@@ -284,6 +291,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'BOOLEAN',
+						display_type: ColumnDisplayType.Boolean,
 						values: [
 							'true', 'false', 'NULL'
 						]
@@ -300,21 +308,25 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'TINYINT',
+						display_type: ColumnDisplayType.Number,
 						values: ['127', '-128', '0', 'NULL']
 					},
 					{
 						name: 'b',
 						type: 'SMALLINT',
+						display_type: ColumnDisplayType.Number,
 						values: ['32767', '-32768', '0', 'NULL']
 					},
 					{
 						name: 'c',
 						type: 'INTEGER',
+						display_type: ColumnDisplayType.Number,
 						values: ['2147483647', '-2147483648', '0', 'NULL']
 					},
 					{
 						name: 'd',
 						type: 'BIGINT',
+						display_type: ColumnDisplayType.Number,
 						values: ['9223372036854775807', '-9223372036854775808', '0', 'NULL']
 					},
 				],
@@ -342,6 +354,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'DOUBLE',
+						display_type: ColumnDisplayType.Number,
 						values: [
 							'0', '1.125', '0.12345', 'NULL', '\'NaN\'',
 							'\'Infinity\'', '\'-Infinity\'',
@@ -350,6 +363,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'b',
 						type: 'FLOAT',
+						display_type: ColumnDisplayType.Number,
 						values: [
 							'0', '1.115', '0.12366', 'NULL', '\'NaN\'',
 							'\'Infinity\'', '\'-Infinity\'',
@@ -368,6 +382,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'DOUBLE',
+						display_type: ColumnDisplayType.Number,
 						values: [
 							'123456789.78', '456789.78'
 						]
@@ -391,6 +406,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'DOUBLE',
+						display_type: ColumnDisplayType.Number,
 						values: [
 							'155500', '150000', '15000'
 						]
@@ -407,6 +423,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'a',
 						type: 'VARCHAR',
+						display_type: ColumnDisplayType.String,
 						values: [
 							'\'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\'',
 							'\'aaaaaaaaaaaaaaaaaaaaaaaaa\'',
@@ -425,21 +442,25 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: 'date0',
 						type: 'DATE',
+						display_type: ColumnDisplayType.Date,
 						values: ['\'2023-10-20\'', '\'2024-01-01\'', 'NULL']
 					},
 					{
 						name: 'timestamp0',
 						type: 'TIMESTAMP',
+						display_type: ColumnDisplayType.Datetime,
 						values: ['\'2023-10-20 15:30:00\'', '\'2024-01-01 08:00:00\'', 'NULL']
 					},
 					{
 						name: 'timestamptz0',
 						type: 'TIMESTAMP WITH TIME ZONE',
+						display_type: ColumnDisplayType.Datetime,
 						values: ['\'2023-10-20 15:30:00+00\'', '\'2024-01-01 08:00:00-05\'', 'NULL']
 					},
 					{
 						name: 'time0',
 						type: 'TIME',
+						display_type: ColumnDisplayType.Time,
 						values: ['\'13:30:00\'', '\'07:12:34.567\'', 'NULL']
 					}
 				],
@@ -452,15 +473,56 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				],
 				DEFAULT_FORMAT_OPTIONS
 			],
+			// Decimal types
+			[
+				[
+					{
+						name: 'decimal_default',
+						type: 'DECIMAL',
+						display_type: ColumnDisplayType.Number,
+						values: ['1.23', '45.67', '89.01', 'NULL']
+					},
+					{
+						name: 'decimal_precision',
+						type: 'DECIMAL(10)', // same as DECIMAL(10,0)
+						display_type: ColumnDisplayType.Number,
+						values: ['123456', '987654', '555555', 'NULL']
+					},
+					{
+						name: 'decimal_precision_scale',
+						type: 'DECIMAL(10,2)',
+						display_type: ColumnDisplayType.Number,
+						values: ['123.456', '789.012', '345.678', 'NULL']
+					}
+				],
+				[
+					['1.230', '45.670', '89.010', 0],
+					['123456', '987654', '555555', 0],
+					['123.46', '789.01', '345.68', 0]
+				],
+				DEFAULT_FORMAT_OPTIONS
+			]
 		];
 
 		let tableName, testInput, testResults, formatOptions;
 		for ([testInput, testResults, formatOptions] of testCases) {
 			// If testInput is undefined, just reuse the table from the previous test case
-			if (testInput !== undefined) {
-				tableName = makeTempTableName();
-				await createTempTable(tableName, testInput);
+			if (testInput === undefined) {
+				continue;
 			}
+
+			tableName = makeTempTableName();
+			await createTempTable(tableName, testInput);
+
+			const fullSchema = await getSchema(tableName!);
+
+			// Check that returned schema matches display types in testInput
+			for (let i = 0; i < testInput.length; i++) {
+				const schema = fullSchema.columns[i];
+				assert.strictEqual(schema.column_name, testInput[i].name);
+				assert.strictEqual(schema.type_display, testInput[i].display_type);
+			}
+
 			const data = await getAllDataValues(tableName!, formatOptions);
 			assert.deepStrictEqual(data,
 				{
@@ -654,7 +716,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			},
 			'int_col\tstr_col\n1\ta\n2\tb',
 			ExportFormat.Tsv
-		)
+		);
 
 		// Test HTML format
 		await testSelection(TableSelectionKind.CellRange,

--- a/extensions/positron-python/python_files/posit/conda-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/conda-test-requirements.txt
@@ -1,0 +1,22 @@
+bokeh
+fastcore
+geopandas
+holoviews
+ibis-duckdb
+ipykernel
+ipywidgets
+lightning
+matplotlib
+numpy
+pandas
+plotly
+polars
+pyarrow
+pytest<8.1.1
+pytest-asyncio
+pytest-mock
+pytorch
+ruff
+sqlalchemy
+# see https://github.com/posit-dev/positron/issues/6604
+ipython<=8.31.0

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -11,6 +11,7 @@ import logging
 import math
 import operator
 from datetime import datetime
+from decimal import Decimal
 from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
@@ -891,9 +892,13 @@ class NumPyMathHelper:
         return isinstance(value, (float, self.np.floating))
 
     def isnan(self, value):
+        if isinstance(value, Decimal):
+            return False
         return self.np.isnan(value)
 
     def isinf(self, value):
+        if isinstance(value, Decimal):
+            return False
         return self.np.isinf(value)
 
 
@@ -1874,6 +1879,10 @@ def _get_histogram_numpy(data, num_bins, method="fd"):
 
     assert num_bins is not None
     hist_params = {"bins": num_bins} if method == "fixed" else {"bins": method}
+
+    if data.dtype == object:
+        # For decimals, we convert to float which is lossy but works for now
+        return _get_histogram_numpy(data.astype(float), num_bins, method=method)
 
     # We optimistically compute the histogram once, and then do extra
     # work in the special cases where the binning method produces a

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2531,8 +2531,19 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f10": ["str", 1, 2, None, False] * 20,
             # mixed-integer-float
             "f11": np.array([1.5, 2, 2, None, 3.5] * 20, dtype=object),
+            # decimal
+            "f12": [
+                Decimal("1.5"),
+                Decimal("2"),
+                Decimal("2"),
+                None,
+                Decimal("3.5"),
+            ]
+            * 20,
         }
     )
+
+    f12_f64 = df1["f12"].astype("float64")
 
     df_mixed_tz1 = pd.concat(
         [
@@ -2680,6 +2691,19 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             11,
             {"num_unique": 3},
         ),
+        # decimal
+        (
+            "df1",
+            12,
+            {
+                "min_value": _format_float(f12_f64.min()),
+                "max_value": _format_float(f12_f64.max()),
+                "mean": _format_float(f12_f64.mean()),
+                "stdev": _format_float(f12_f64.std()),
+                "median": _format_float(f12_f64.median()),
+            },
+        ),
+        # mixed types
         (
             "df_mixed_tz1",
             0,
@@ -2722,6 +2746,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         max_value_length=1000,
         thousands_sep="_",
     )
+
     _format_float = _get_float_formatter(format_options)
 
     test_df = pd.DataFrame(
@@ -2732,6 +2757,23 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             "d": [0, 0, 0, 0, 0, 10, 10, 10, 10, 10, 10],
             "e": [np.inf, -np.inf, 0, 1, 2, 3, 4, 5, 6, 7, 8],
             "f": np.ones(11),
+            # decimal test case
+            "g": np.array(
+                [
+                    Decimal("1.1"),
+                    Decimal("1.2"),
+                    Decimal("1.3"),
+                    Decimal("1.4"),
+                    Decimal("1.5"),
+                    Decimal("1.6"),
+                    Decimal("1.7"),
+                    Decimal("1.8"),
+                    Decimal("1.9"),
+                    Decimal("2.0"),
+                    None,
+                ],
+                dtype=object,
+            ),
         }
     )
     dfp = pl.DataFrame(
@@ -2742,6 +2784,23 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             "d": [0, 0, 0, 0, 0, 10, 10, 10, 10, 10, 10],
             "e": [np.inf, -np.inf, 0, 1, 2, 3, 4, 5, 6, 7, 8],
             "f": np.ones(11),
+            # decimal test case
+            "g": np.array(
+                [
+                    Decimal("1.1"),
+                    Decimal("1.2"),
+                    Decimal("1.3"),
+                    Decimal("1.4"),
+                    Decimal("1.5"),
+                    Decimal("1.6"),
+                    Decimal("1.7"),
+                    Decimal("1.8"),
+                    Decimal("1.9"),
+                    Decimal("2.0"),
+                    None,
+                ],
+                dtype=object,
+            ),
         }
     )
 
@@ -2830,6 +2889,15 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             {
                 "bin_edges": ["0.5000", "1.50"],
                 "bin_counts": [11],
+                "quantiles": [],
+            },
+        ),
+        # test decimal
+        (
+            _get_histogram(6, bins=4),
+            {
+                "bin_edges": ["1.10", "1.33", "1.55", "1.77", "2.00"],
+                "bin_counts": [3, 2, 2, 3],
                 "quantiles": [],
             },
         ),

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -90,7 +90,7 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 				'50.0',
 				'36.0',
 				'44.0',
-				'0.0',
+				'26.0',
 			]);
 
 			const col5ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(5);

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -107,7 +107,7 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 				'47.8',
 				'50.0',
 				'43.5',
-				'0.0',
+				'47.8',
 			]);
 		});
 	});


### PR DESCRIPTION
Addresses #5169. I also added a conda/mamba-compatible environment specification since mixing was making it more difficult for me to set up and tear down new environments that also include R (e.g. with `mamba install r-base r-arrow`). 

e2e: @:data-explorer

### Release Notes

#### New Features

- Decimal data types in Parquet files are better supported in the data explorer.

#### Bug Fixes

- N/A

### QA Notes

I will submit a PR to the QA example datasets with some decimal data for testing