### PR TITLE
Multiple Console Sessions: quality of life changes

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -158,6 +158,14 @@ export const TopActionBarInterpretersManager_New = (props: TopActionBarInterpret
 
 	const labelText = activeSession?.runtimeMetadata?.runtimeName ?? startSession;
 
+	// Check if there are any active sessions to determine if the
+	// button should launch the active session picker command or
+	// the create session command.
+	const hasActiveSessions = context.runtimeSessionService.activeSessions.length > 0;
+	const command = hasActiveSessions
+		? 'workbench.action.language.runtime.openActivePicker'
+		: 'workbench.action.language.runtime.openStartPicker';
+
 	// Main useEffect.
 	useEffect(() => {
 		// Create the disposable store for cleanup.
@@ -181,9 +189,9 @@ export const TopActionBarInterpretersManager_New = (props: TopActionBarInterpret
 
 	return (
 		<ActionBarCommandButton
-			ariaLabel={CommandCenter.title('workbench.action.language.runtime.openActivePicker')}
+			ariaLabel={CommandCenter.title(command)}
 			border={true}
-			commandId={'workbench.action.language.runtime.openActivePicker'}
+			commandId={command}
 			text={labelText}
 			{
 			...(

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -158,11 +158,12 @@ export const TopActionBarInterpretersManager_New = (props: TopActionBarInterpret
 
 	const labelText = activeSession?.runtimeMetadata?.runtimeName ?? startSession;
 
-	// Check if there are any active sessions to determine if the
-	// button should launch the active session picker command or
-	// the create session command.
-	const hasActiveSessions = context.runtimeSessionService.activeSessions.length > 0;
-	const command = hasActiveSessions
+	// Check if there are any active console sessions to determine
+	// if the active session picker or the create session pikcer
+	// should be shown.
+	const hasActiveConsoleSessions = context.runtimeSessionService.activeSessions.find(
+		session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
+	const command = hasActiveConsoleSessions
 		? 'workbench.action.language.runtime.openActivePicker'
 		: 'workbench.action.language.runtime.openStartPicker';
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -756,8 +756,8 @@ export function registerLanguageRuntimeActions() {
 				},
 				category,
 				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Backquote,
-					mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Backquote },
+					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
+					mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Slash },
 					weight: KeybindingWeight.WorkbenchContrib
 				},
 				menu: [{

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -149,7 +149,7 @@ export const selectLanguageRuntimeSession = async (
 				session.sessionId === runtimeSessionService.foregroundSession?.sessionId;
 			return {
 				id: session.sessionId,
-				label: session.runtimeMetadata.runtimeName,
+				label: session.metadata.sessionName,
 				detail: session.runtimeMetadata.runtimePath,
 				description: isForegroundSession ? 'Currently Selected' : undefined,
 				iconPath: {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -111,7 +111,13 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 			role='tablist'
 			style={{ height: props.height, width: props.width }}
 		>
-			{consoleInstances.map((positronConsoleInstance) => <ConsoleTab key={positronConsoleInstance.session.sessionId} positronConsoleInstance={positronConsoleInstance} onClick={() => handleTabClick(positronConsoleInstance.session.sessionId)} />)}
+			{consoleInstances.map((positronConsoleInstance) =>
+				<ConsoleTab
+					key={positronConsoleInstance.session.sessionId}
+					positronConsoleInstance={positronConsoleInstance}
+					onClick={() => handleTabClick(positronConsoleInstance.session.sessionId)}
+				/>
+			)}
 		</div>
 	)
 }

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1301,6 +1301,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		startMode: RuntimeStartMode,
 		activate: boolean,
 		notebookUri?: URI): Promise<string> {
+		const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(this._configurationService);
+
 		this.setStartingSessionMaps(sessionMode, runtimeMetadata, notebookUri);
 
 		// Create a promise that resolves when the runtime is ready to use, if there isn't already one.
@@ -1336,11 +1338,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// The first session for a runtime does not append this count to the session name.
 			this._sessionsByRuntimeIdCounter.set(runtimeMetadata.runtimeId, 1);
 		}
-
 		const sessionId = this.generateNewSessionId(runtimeMetadata);
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId,
-			sessionName: sessionCount ? `${sessionName} - ${sessionCount}` : sessionName,
+			sessionName: sessionCount && multiSessionsEnabled ? `${sessionName} - ${sessionCount}` : sessionName,
 			sessionMode,
 			notebookUri,
 			createdTimestamp: Date.now(),

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -112,8 +112,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	private readonly _consoleSessionsByRuntimeId = new Map<string, ILanguageRuntimeSession[]>();
 
 	// A map of the number of sessions created per runtime ID. This is used to
-	// make each session name per runtime unique.
-	private readonly _sessionsByRuntimeIdCounter = new Map<string, number>();
+	// make each session name unique.
+	private readonly _consoleSessionCounterByRuntimeId = new Map<string, number>();
 
 	// A map of the last active console session per langauge.
 	// We can have multiple console sessions per language,
@@ -1327,21 +1327,26 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			throw err;
 		}
 
-		// Determine if the session name should be appended with a session count to make it unique.
-		let sessionCount = this._sessionsByRuntimeIdCounter.get(runtimeMetadata.runtimeId);
-		if (sessionCount) {
-			// Increment the session count for the runtime and append it to the session name.
-			sessionCount++;
-			this._sessionsByRuntimeIdCounter.set(runtimeMetadata.runtimeId, sessionCount);
-		} else {
-			// Initialize the session count for the runtime.
-			// The first session for a runtime does not append this count to the session name.
-			this._sessionsByRuntimeIdCounter.set(runtimeMetadata.runtimeId, 1);
+		// Determine if the console session name should be appended with a session count to make it unique.
+		let updatedSessionName = sessionName;
+		if (sessionMode === LanguageRuntimeSessionMode.Console && multiSessionsEnabled) {
+			let sessionCount = this._consoleSessionCounterByRuntimeId.get(runtimeMetadata.runtimeId);
+			if (sessionCount) {
+				// Increment the session count for the runtime and append it to the session name.
+				sessionCount++;
+				this._consoleSessionCounterByRuntimeId.set(runtimeMetadata.runtimeId, sessionCount);
+				updatedSessionName = `${sessionName} - ${sessionCount}`;
+			} else {
+				// Initialize the session count for the runtime.
+				// The first session for a runtime does not append this count to the session name.
+				this._consoleSessionCounterByRuntimeId.set(runtimeMetadata.runtimeId, 1);
+			}
 		}
+
 		const sessionId = this.generateNewSessionId(runtimeMetadata);
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId,
-			sessionName: sessionCount && multiSessionsEnabled ? `${sessionName} - ${sessionCount}` : sessionName,
+			sessionName: updatedSessionName,
 			sessionMode,
 			notebookUri,
 			createdTimestamp: Date.now(),

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -67,7 +67,7 @@ export class Sessions {
 	async launch(options: {
 		language: 'Python' | 'R';
 		version?: string;
-		triggerMode?: 'session-picker' | 'quickaccess' | 'console';
+		triggerMode?: 'session-picker' | 'quickaccess' | 'console' | 'hotkey';
 		waitForReady?: boolean;
 	}): Promise<string> {
 
@@ -79,7 +79,7 @@ export class Sessions {
 			language,
 			version = language === 'Python' ? DESIRED_PYTHON : DESIRED_R,
 			waitForReady = true,
-			triggerMode = 'quickaccess',
+			triggerMode = 'hotkey',
 		} = options;
 
 		await test.step(`Start session via ${triggerMode}: ${language} ${version}`, async () => {
@@ -93,8 +93,10 @@ export class Sessions {
 				await this.quickaccess.runCommand(command, { keepOpen: true });
 			} else if (triggerMode === 'session-picker') {
 				await this.quickPick.openSessionQuickPickMenu();
-			} else {
+			} else if (triggerMode === 'console') {
 				await this.newConsoleButton.click();
+			} else {
+				await this.page.keyboard.press('Control+Shift+/');
 			}
 
 			await this.quickinput.type(`${language} ${version}`);
@@ -766,7 +768,7 @@ export type SessionInfo = {
 	language: 'Python' | 'R';
 	version: string; // e.g. '3.10.15'
 	id: string;
-	triggerMode?: 'session-picker' | 'quickaccess' | 'console';
+	triggerMode?: 'session-picker' | 'quickaccess' | 'console' | 'hotkey';
 	waitForReady?: boolean;
 };
 
@@ -788,7 +790,7 @@ export const pythonSession: SessionInfo = {
 	name: `Python ${process.env.POSITRON_PY_VER_SEL || ''}`,
 	language: 'Python',
 	version: process.env.POSITRON_PY_VER_SEL || '',
-	triggerMode: 'session-picker',
+	triggerMode: 'hotkey',
 	id: '',
 	waitForReady: true
 };
@@ -798,7 +800,7 @@ export const pythonSessionAlt: SessionInfo = {
 	name: `Python ${process.env.POSITRON_PY_ALT_VER_SEL || ''}`,
 	language: 'Python',
 	version: process.env.POSITRON_PY_ALT_VER_SEL || '',
-	triggerMode: 'session-picker',
+	triggerMode: 'hotkey',
 	id: '',
 	waitForReady: true
 };
@@ -808,7 +810,7 @@ export const rSession: SessionInfo = {
 	name: `R ${process.env.POSITRON_R_VER_SEL || ''}`,
 	language: 'R',
 	version: process.env.POSITRON_R_VER_SEL || '',
-	triggerMode: 'session-picker',
+	triggerMode: 'hotkey',
 	id: '',
 	waitForReady: true
 };
@@ -818,7 +820,7 @@ export const rSessionAlt: SessionInfo = {
 	name: `R ${process.env.POSITRON_R_ALT_VER_SEL || ''}`,
 	language: 'R',
 	version: process.env.POSITRON_R_ALT_VER_SEL || '',
-	triggerMode: 'session-picker',
+	triggerMode: 'hotkey',
 	id: '',
 	waitForReady: true
 };


### PR DESCRIPTION
Addresses #6683, #6625, #6654

This PR addresses a few polish items for multiple console sessions:
* Each session (sans notebook sessions) will now have a unique name per runtime to help users differentiate between sessions.
* The command to create a new console session is launched directly from the session switcher if there are no active console sessions. This reduces the extra click users were required to make in the empty console state from the session switcher.
* Update the keybinding for the start new session command to `ctrl+shift+/`

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:sessions @:console @:web @:win

### Screenshots

**Launch "Start A New Session" Command When No Active Console Sessions**

https://github.com/user-attachments/assets/4190bf63-b174-4a14-a7c6-cb67a071a57d

**Unique Session Names**

https://github.com/user-attachments/assets/f33a1f49-bd00-4e63-8e47-faeb96d743ab


