### PR TITLE
Validate LLM API key before registering it

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -7,9 +7,9 @@ import * as positron from 'positron';
 import { randomUUID } from 'crypto';
 import { languageModels } from './models';
 import { completionModels } from './completion';
-import { registerModels } from './extension';
+import { registerModel, registerModels } from './extension';
 
-interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
+export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
 }
 
@@ -70,6 +70,21 @@ export interface ModelConfig extends StoredModelConfig {
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
 	return context.globalState.get('positron.assistant.models') || [];
+}
+
+export async function getModelConfiguration(id: string, context: vscode.ExtensionContext, storage: SecretStorage): Promise<ModelConfig | undefined> {
+	const storedConfigs = getStoredModels(context);
+	const config = storedConfigs.find((config) => config.id === id);
+
+	if (!config) {
+		return undefined;
+	}
+
+	const apiKey = await storage.get(`apiKey-${config.id}`);
+	return {
+		...config,
+		apiKey: apiKey || ''
+	};
 }
 
 export async function getModelConfigurations(context: vscode.ExtensionContext, storage: SecretStorage): Promise<ModelConfig[]> {
@@ -252,12 +267,20 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 			[...existingConfigs, newConfig]
 		);
 
-		vscode.window.showInformationMessage(
-			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
-		);
-
 		// Register the new model
-		await registerModels(context, storage, id);
+		const registered = await registerModel(newConfig, context, storage);
+
+		if (!registered) {
+			await storage.delete(`apiKey-${id}`);
+			await context.globalState.update(
+				'positron.assistant.models',
+				existingConfigs
+			);
+		} else {
+			vscode.window.showInformationMessage(
+				vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
+			);
+		}
 	});
 
 }

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -257,7 +257,7 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 		);
 
 		// Register the new model
-		await registerModels(context, storage);
+		await registerModels(context, storage, id);
 	});
 
 }

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -10,8 +10,6 @@ import { newLanguageModel } from './models';
 import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { editsProvider } from './edits';
 import { createParticipants } from './participants';
-import { register } from 'node:module';
-import { LanguageModel } from 'ai';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -50,11 +48,11 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 		}
 
 		const languageModel = newLanguageModel(modelConfig);
-		const resolved = await languageModel.resolveConnection(new vscode.CancellationTokenSource().token);
+		const error = await languageModel.resolveConnection(new vscode.CancellationTokenSource().token);
 
-		if (!resolved) {
+		if (error) {
 			vscode.window.showErrorMessage(
-				vscode.l10n.t('Positron Assistant: Failed to register model configuration. The model could not be connected.')
+				vscode.l10n.t(`Positron Assistant: Failed to register model configuration. ${error.message}`)
 			);
 			return false;
 		}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -11,6 +11,7 @@ import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { editsProvider } from './edits';
 import { createParticipants } from './participants';
 import { register } from 'node:module';
+import { LanguageModel } from 'ai';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -28,7 +29,7 @@ function disposeParticipants() {
 	participantDisposables = [];
 }
 
-export async function registerModels(context: vscode.ExtensionContext, storage: SecretStorage) {
+export async function registerModels(context: vscode.ExtensionContext, storage: SecretStorage, newConfigId?: string) {
 	// Dispose of existing models
 	disposeModels();
 
@@ -62,6 +63,16 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 				const isFirst = idx === 0;
 
 				const languageModel = newLanguageModel(config);
+
+				// If a new model was added, select it and send a test request
+				if (newConfigId === config.id) {
+					console.log('Sending test request for new model: ', languageModel.name);
+					const resolved = languageModel.resolveConnection(new vscode.CancellationTokenSource().token);
+					resolved.then((connectionResolved) => {
+						console.log('Resolved connection: ', connectionResolved, languageModel.name);
+					});
+				}
+
 				const modelDisp = vscode.lm.registerChatModelProvider(languageModel.identifier, languageModel, {
 					name: languageModel.name,
 					family: languageModel.provider,

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -107,16 +107,17 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 
 	async resolveConnection(token: vscode.CancellationToken): Promise<boolean> {
 		token.onCancellationRequested(() => {
-			// Cancel the connection
 			return false;
 		});
 
 		try {
-			const { response, text, finishReason } = await ai.generateText({
+			// send a test message to the model
+			await ai.generateText({
 				model: this.model,
 				prompt: 'Hello!',
 			});
 
+			// if the model responds, the config works
 			return true;
 		} catch (error) {
 			return false;

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -39,7 +39,7 @@ class ErrorLanguageModel implements positron.ai.LanguageModelChatProvider {
 		throw new Error(this._message);
 	}
 
-	resolveConnection(token: vscode.CancellationToken): Thenable<boolean> {
+	resolveConnection(token: vscode.CancellationToken): Thenable<Error | undefined> {
 		throw new Error(this._message);
 	}
 }
@@ -85,8 +85,8 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 		}
 	}
 
-	resolveConnection(token: vscode.CancellationToken): Thenable<boolean> {
-		return Promise.resolve(true);
+	resolveConnection(token: vscode.CancellationToken): Thenable<Error | undefined> {
+		return Promise.resolve(undefined);
 	}
 }
 
@@ -105,22 +105,27 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		this.provider = _config.provider;
 	}
 
-	async resolveConnection(token: vscode.CancellationToken): Promise<boolean> {
+	async resolveConnection(token: vscode.CancellationToken): Promise<Error | undefined> {
 		token.onCancellationRequested(() => {
 			return false;
 		});
 
 		try {
 			// send a test message to the model
-			await ai.generateText({
+			const result = await ai.generateText({
 				model: this.model,
-				prompt: 'Hello!',
+				prompt: 'I\'m checking to see if you\'re there. Response only with the word "hello".',
 			});
 
 			// if the model responds, the config works
-			return true;
+			return undefined;
 		} catch (error) {
-			return false;
+			if (ai.AISDKError.isInstance(error)) {
+				return new Error(error.message);
+			}
+			else {
+				return new Error(JSON.stringify(error));
+			}
 		}
 	}
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1600,8 +1600,10 @@ declare module 'positron' {
 
 			/**
 			 * Tests the connection to the language model provider.
+			 *
+			 * Returns an error if the connection fails.
 			 */
-			resolveConnection(token: vscode.CancellationToken): Thenable<boolean>;
+			resolveConnection(token: vscode.CancellationToken): Thenable<Error | undefined>;
 		}
 
 		/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1597,6 +1597,11 @@ declare module 'positron' {
 			 * Calculate the token count for a given string.
 			 */
 			provideTokenCount(text: string | vscode.LanguageModelChatMessage, token: vscode.CancellationToken): Thenable<number>;
+
+			/**
+			 * Tests the connection to the language model provider.
+			 */
+			resolveConnection(token: vscode.CancellationToken): Thenable<boolean>;
 		}
 
 		/**

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -20,6 +20,7 @@ import { DropDownListBoxItem } from '../../../browser/positronComponents/dropDow
 import { LabeledTextInput } from '../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
 import { IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
 import { localize } from '../../../../nls.js';
+import { ProgressBar } from '../../../../base/browser/ui/positronComponents/progressBar.js';
 
 export const showLanguageModelModalDialog = (
 	keybindingService: IKeybindingService,
@@ -89,6 +90,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const [numCtx, setNumCtx] = React.useState<number | undefined>(defaultSource.defaults.numCtx);
 	const [model, setModel] = React.useState<string>(defaultSource.defaults.model);
 	const [name, setName] = React.useState<string>(defaultSource.defaults.name);
+	const [showProgress, setShowProgress] = React.useState(false);
 
 	useEffect(() => {
 		setSource(defaultSource);
@@ -119,7 +121,8 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		if (!source) {
 			return;
 		}
-		await props.onSave({
+		setShowProgress(true);
+		props.onSave({
 			type: type,
 			provider: source.provider.id,
 			model: model,
@@ -131,8 +134,10 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			location: location,
 			toolCalls: toolCalls,
 			numCtx: numCtx,
-		})
-		props.renderer.dispose();
+		}).finally(() => {
+			setShowProgress(false);
+			props.renderer.dispose();
+		});
 	}
 	const onCancel = async () => {
 		props.onCancel();
@@ -250,6 +255,9 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 						{(() => localize('positron.newConnectionModalDialog.toolCalls', "Enable tool calling"))()}
 					</label>
 				</div>
+			}
+			{showProgress &&
+				<ProgressBar />
 			}
 		</VerticalStack>
 	</OKCancelModalDialog>


### PR DESCRIPTION
Address #6616

Adds some methods to be able to register one model at a time. It performs a request on the model and registers it with the language API if it succeeded.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Validates LLM API key before adding it to Positron Assistant #6616

#### Bug Fixes

- N/A


### QA Notes
There will be an error toast notification if the model was not added.


https://github.com/user-attachments/assets/17712e81-75ce-4be2-969f-9150bedef386



<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
