### PR TITLE
ci: bump playwright to v1.51.0, currents to v1.11.2

### DIFF
--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -53,10 +53,10 @@ jobs:
           npm install typescript
 
           # Install required dependencies - must keep in sync with root package.json
-          npm install @playwright/test@^1.49.1
+          npm install @playwright/test@^1.51.0
           npx playwright install
           npx playwright install-deps
-          npm install @currents/playwright@^1.8.0
+          npm install @currents/playwright@^1.11.2
           npm install @midleman/github-actions-reporter@^1.9.5
           npm install @vscode/v8-heap-parser@^0.1.0
           npm install fs-extra

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
-      enable_currents_reporter: true
+      enable_currents_reporter: false
       install_undetectable_interpreters: true
     secrets: inherit
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
-      enable_currents_reporter: false
+      enable_currents_reporter: true
       install_undetectable_interpreters: true
     secrets: inherit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "yazl": "^2.4.3"
       },
       "devDependencies": {
-        "@currents/playwright": "^1.9.4",
+        "@currents/playwright": "^1.11.2",
         "@midleman/github-actions-reporter": "^1.9.5",
         "@playwright/test": "^1.51.0",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
@@ -1199,16 +1199,17 @@
       }
     },
     "node_modules/@currents/playwright": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.9.4.tgz",
-      "integrity": "sha512-PC+rz0vLDcMD/eOzeVIQrXhowEGXlds5LIhuVcfKDH2j4AcE5XwBrUOBEI1duOZq5dDK5ii7G3LZ6vN4RtM64A==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.11.2.tgz",
+      "integrity": "sha512-9QMObMqin80Cubw0N2DUMrHbqUvcDni3ujLW5UhNBR1gQlObqdA8dr2GJVpTScwoYg3xMvmLp19D8tpS78tNcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@commander-js/extra-typings": "^12.1.0",
         "@currents/commit-info": "1.0.1-beta.0",
         "async-retry": "^1.3.3",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "axios-retry": "^4.5.0",
         "c12": "^1.11.2",
         "chalk": "^4.1.2",
@@ -1226,6 +1227,7 @@
         "nanoid": "^3.3.8",
         "object-sizeof": "^2.6.5",
         "p-debounce": "^2.1.0",
+        "p-map": "^4.0.0",
         "p-queue": "6.6.2",
         "pino": "^9.6.0",
         "pluralize": "^8.0.0",
@@ -1236,7 +1238,7 @@
         "tmp": "^0.2.3",
         "tmp-promise": "^3.0.3",
         "ts-pattern": "^5.6.0",
-        "ws": "^8.18.0"
+        "ws": "^8.18.1"
       },
       "bin": {
         "pwc": "dist/bin/pwc.js",
@@ -1294,6 +1296,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@currents/playwright/node_modules/source-map-support": {
@@ -3963,6 +3981,20 @@
         "node": ">= 14"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4657,9 +4689,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5434,6 +5466,16 @@
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cli-cursor": {
@@ -10917,6 +10959,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       "devDependencies": {
         "@currents/playwright": "^1.9.4",
         "@midleman/github-actions-reporter": "^1.9.5",
-        "@playwright/test": "^1.50.1",
+        "@playwright/test": "^1.51.0",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
         "@swc/core": "1.3.62",
         "@types/cookie": "^0.3.3",
@@ -2147,13 +2147,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+      "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14999,13 +14999,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15031,9 +15031,9 @@
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   "devDependencies": {
     "@currents/playwright": "^1.9.4",
     "@midleman/github-actions-reporter": "^1.9.5",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.51.0",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@swc/core": "1.3.62",
     "@types/cookie": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "yazl": "^2.4.3"
   },
   "devDependencies": {
-    "@currents/playwright": "^1.9.4",
+    "@currents/playwright": "^1.11.2",
     "@midleman/github-actions-reporter": "^1.9.5",
     "@playwright/test": "^1.51.0",
     "@stylistic/eslint-plugin-ts": "^2.8.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,7 @@ process.env.PW_TEST = '1';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig<CustomTestOptions>({
+	captureGitInfo: { commit: true, diff: true },
 	globalSetup: './test/e2e/tests/_global.setup.ts',
 	testDir: './test/e2e',
 	testIgnore: '**/example.test.ts',


### PR DESCRIPTION
### Summary
* Bump Playwright to `v1.51.0`
* Bump Currents to `v1.11.2`

### QA Notes

✅  Tested by enabling Currents on this PR to confirm all is well.
👁️  Check out the metadata and prompt (on flaky/failed tests) info that is now avail in our [reports](https://d38p2avprg8il3.cloudfront.net/playwright-report-13765881826-8415/index.html).