### PR TITLE
Add new `positron.reopenWith` command to replace an editor

### DIFF
--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -68,6 +68,21 @@
           "description": "Automatically start Zed in new workspaces"
         }
       }
+    },
+    "commands": [
+      {
+        "command": "zed.quartoVisualMode",
+        "category": "Zed",
+        "title": "Edit Quarto File in Visual Mode"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "category": "Zed",
+          "command": "zed.quartoVisualMode"
+        }
+      ]
     }
   },
   "scripts": {

--- a/extensions/positron-zed/src/commands.ts
+++ b/extensions/positron-zed/src/commands.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export async function registerCommands(context: vscode.ExtensionContext) {
+	context.subscriptions.push(
+
+		vscode.commands.registerCommand('zed.quartoVisualMode', () => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor) {
+				return;
+			}
+			vscode.commands.executeCommand('positron.reopenWith', editor.document.uri, 'quarto.visualEditor');
+		}),
+
+	);
+}

--- a/extensions/positron-zed/src/extension.ts
+++ b/extensions/positron-zed/src/extension.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { ZedRuntimeManager } from './manager';
+import { registerCommands } from './commands';
 
 /**
  * Activates the extension.
@@ -14,4 +15,7 @@ import { ZedRuntimeManager } from './manager';
 export function activate(context: vscode.ExtensionContext) {
 	// Register the Zed runtime manager with the Positron runtime.
 	positron.runtime.registerLanguageRuntimeManager('zed', new ZedRuntimeManager(context));
+
+	// Register some dummy commands.
+	registerCommands(context);
 }

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -452,6 +452,16 @@ const newCommands: ApiCommand[] = [
 		],
 		ApiCommandResult.Void
 	),
+	// --- Start Positron ---
+	new ApiCommand(
+		'positron.reopenWith', '_workbench.reopenWith', 'Replace the provided resource with the same resource opened in a specific editor.',
+		[
+			ApiCommandArgument.Uri.with('resource', 'Resource to reopen'),
+			ApiCommandArgument.String.with('viewId', 'Custom editor view id. This should be the viewType string for custom editors or the notebookType string for notebooks. Use \'default\' to use VS Code\'s default text editor'),
+		],
+		ApiCommandResult.Void
+	),
+	// --- End Positron ---
 	new ApiCommand(
 		'vscode.diff', '_workbench.diff', 'Opens the provided resources in the diff editor to compare their contents.',
 		[

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -99,6 +99,9 @@ export const NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID = 'workbench.action.newEmptyEdit
 export const API_OPEN_EDITOR_COMMAND_ID = '_workbench.open';
 export const API_OPEN_DIFF_EDITOR_COMMAND_ID = '_workbench.diff';
 export const API_OPEN_WITH_EDITOR_COMMAND_ID = '_workbench.openWith';
+// --- Start Positron ---
+export const API_REOPEN_WITH_EDITOR_COMMAND_ID = '_workbench.reopenWith';
+// --- End Positron ---
 
 export const EDITOR_CORE_NAVIGATION_COMMANDS = [
 	SPLIT_EDITOR,
@@ -496,6 +499,29 @@ function registerOpenEditorAPICommands(): void {
 
 		await editorService.openEditor({ resource: URI.from(resource, true), options: { ...optionsArg, pinned: true, override: id } }, columnToEditorGroup(editorGroupsService, configurationService, columnArg));
 	});
+
+	// --- Start Positron ---
+	CommandsRegistry.registerCommand(API_REOPEN_WITH_EDITOR_COMMAND_ID, async (accessor: ServicesAccessor, resource: UriComponents, id: string) => {
+		const editorService = accessor.get(IEditorService);
+		const activeEditorPane = editorService.activeEditorPane;
+		if (!activeEditorPane) {
+			return;
+		}
+
+		await editorService.replaceEditors([
+			{
+				editor: activeEditorPane.input,
+				replacement: {
+					resource: activeEditorPane.input.resource,
+					options: {
+						override: id
+					}
+				}
+			}
+		], activeEditorPane.group);
+
+	});
+	// --- End Positron ---
 
 	// partial, renderer-side API command to open diff editor
 	// complements https://github.com/microsoft/vscode/blob/2b164efb0e6a5de3826bff62683eaeafe032284f/src/vs/workbench/api/common/extHostApiCommands.ts#L397


### PR DESCRIPTION
Addresses #6230

### Release Notes

#### New Features

- Add new API for extensions to reopen an editor in a new, different editor

#### Bug Fixes

- N/A


### QA Notes

In a dev build, you can test out the new demo command in the Zed extension "Zed: Edit Quarto File in Visual Mode". We don't currently have a way to directly test out new extension API functionality within Positron itself, however.