### PR TITLE
python ci: use `/dailies/` instead of `/preleases`

### DIFF
--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -276,7 +276,7 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     switch (platform) {
         case 'darwin':
             fileName = `Positron-${version}${suffix}`;
-            url = new URL(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
+            url = new URL(`https://cdn.posit.co/positron/dailies/mac/universal/${fileName}`);
             break;
         default:
             throw new Error(`Unsupported platform: ${platform}`);


### PR DESCRIPTION
Updating relevant paths to new release location. Note: we are only running the debugger tests on macos, so this is the sole relevant location.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- `Positron Python CI / Test TypeScript (macos-latest, 3.x, debugger)` tests are currently failing 


### QA Notes

should pass CI