### PR TITLE
e2e-test: longer sleep in session test

### DIFF
--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -92,7 +92,7 @@ test.describe('Sessions: State', {
 		// Verify Python session transitions to active when executing code
 		await sessions.select(pythonSession1.name);
 		await console.typeToConsole('import time', true);
-		await console.typeToConsole('time.sleep(3)', true);
+		await console.typeToConsole('time.sleep(5)', true);
 		await sessions.expectStatusToBe(pythonSession1.name, 'active');
 
 		// Verify R session transitions to active when executing code


### PR DESCRIPTION
### Summary

Allowing a longer tolerance between the 2 sleep commands to ensure we catch the state transitions in the session test.


### QA Notes

@:sessions @:win