### PR TITLE
E2E test: exclude interpreters tests

### DIFF
--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -47,15 +47,15 @@ test.describe('Interpreter Includes/Excludes', {
 		if (alternatePython) {
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
 
+			const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
 			await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
 			try {
 				await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
-				fail('selectInterpreter was supposed to fail as ~/.pyenv was excluded');
+				fail(failMessage);
 			} catch (e) {
-				if (!(e instanceof Error)) {
-					throw e; // Fail the test if an unexpected error type occurs
+				if (e instanceof Error && e.message.includes(failMessage)) {
+					fail(failMessage);
 				}
-				logger.log('Expected failure: Interpreter selection failed as ~/.pyenv was excluded');
 			}
 		} else {
 			fail('Alternate Python version not set');
@@ -69,18 +69,19 @@ test.describe('Interpreter Includes/Excludes', {
 		if (alternateR) {
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
 
+			const failMessage = 'selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded';
 			await userSettings.set([['positron.r.interpreters.exclude', '["/opt/R/4.4.2"]']], true);
 			try {
 				await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
-				fail('selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded');
+				fail(failMessage);
 			} catch (e) {
-				if (!(e instanceof Error)) {
-					throw e; // Fail the test if an unexpected error type occurs
+				if (e instanceof Error && e.message.includes(failMessage)) {
+					fail(failMessage);
 				}
-				logger.log('Expected failure: Interpreter selection failed as /opt/R/4.4.2 was excluded');
 			}
 		} else {
 			fail('Alternate R version not set');
 		}
 	});
+
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -57,6 +57,8 @@ test.describe('Interpreter Includes/Excludes', {
 					fail(failMessage);
 				}
 			}
+
+			await app.code.driver.page.keyboard.press('Escape');
 		} else {
 			fail('Alternate R version not set');
 		}

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -62,8 +62,6 @@ test.describe('Interpreter Includes/Excludes', {
 		} else {
 			fail('Alternate R version not set');
 		}
-
-		await app.code.driver.page.keyboard.press('Escape');
 	});
 
 	test('Python - Can Exclude an Interpreter', async function ({ app, python, userSettings, logger }) {

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -40,28 +40,6 @@ test.describe('Interpreter Includes/Excludes', {
 		}
 	});
 
-	test('Python - Can Exclude an Interpreter', async function ({ app, python, userSettings, logger }) {
-
-		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
-
-		if (alternatePython) {
-			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
-
-			const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
-			await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
-			try {
-				await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
-				fail(failMessage);
-			} catch (e) {
-				if (e instanceof Error && e.message.includes(failMessage)) {
-					fail(failMessage);
-				}
-			}
-		} else {
-			fail('Alternate Python version not set');
-		}
-	});
-
 	test('R - Can Exclude an Interpreter', async function ({ app, r, userSettings, logger }) {
 
 		const alternateR = process.env.POSITRON_R_ALT_VER_SEL;
@@ -81,6 +59,32 @@ test.describe('Interpreter Includes/Excludes', {
 			}
 		} else {
 			fail('Alternate R version not set');
+		}
+
+		await app.code.driver.page.keyboard.press('Escape');
+	});
+
+	test('Python - Can Exclude an Interpreter', async function ({ app, python, userSettings, logger }) {
+
+		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
+
+		if (alternatePython) {
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
+
+			const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
+			await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
+			try {
+				await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
+				fail(failMessage);
+			} catch (e) {
+				if (e instanceof Error && e.message.includes(failMessage)) {
+					fail(failMessage);
+				}
+			}
+
+			await app.code.driver.page.keyboard.press('Escape');
+		} else {
+			fail('Alternate Python version not set');
 		}
 	});
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { fail } from 'assert';
 import { InterpreterType } from '../../infra/fixtures/interpreter';
 import { test, tags } from '../_test.setup';
 
@@ -36,6 +37,44 @@ test.describe('Interpreter Includes/Excludes', {
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, hiddenR, true);
 		} else {
 			logger.log('Hidden R version not set'); // use this for now so release test can essentially skip this case
+		}
+	});
+
+	test('Python - Can Exclude an Interpreter', async function ({ app, python, userSettings, logger }) {
+
+		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
+
+		if (alternatePython) {
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
+
+			await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
+			try {
+				await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
+				fail('selectInterpreter was supposed to fail as ~/.pyenv was excluded');
+			} catch (e) {
+				// expected
+			}
+		} else {
+			fail('Alternate Python version not set');
+		}
+	});
+
+	test('R - Can Exclude an Interpreter', async function ({ app, r, userSettings, logger }) {
+
+		const alternateR = process.env.POSITRON_R_ALT_VER_SEL;
+
+		if (alternateR) {
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
+
+			await userSettings.set([['positron.r.interpreters.exclud', '["/opt/R/4.4.2"]']], true);
+			try {
+				await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
+				fail('selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded');
+			} catch (e) {
+				// expected
+			}
+		} else {
+			fail('Alternate R version not set');
 		}
 	});
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -52,7 +52,10 @@ test.describe('Interpreter Includes/Excludes', {
 				await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, alternatePython, true);
 				fail('selectInterpreter was supposed to fail as ~/.pyenv was excluded');
 			} catch (e) {
-				// expected
+				if (!(e instanceof Error)) {
+					throw e; // Fail the test if an unexpected error type occurs
+				}
+				logger.log('Expected failure: Interpreter selection failed as ~/.pyenv was excluded');
 			}
 		} else {
 			fail('Alternate Python version not set');
@@ -71,7 +74,10 @@ test.describe('Interpreter Includes/Excludes', {
 				await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
 				fail('selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded');
 			} catch (e) {
-				// expected
+				if (!(e instanceof Error)) {
+					throw e; // Fail the test if an unexpected error type occurs
+				}
+				logger.log('Expected failure: Interpreter selection failed as /opt/R/4.4.2 was excluded');
 			}
 		} else {
 			fail('Alternate R version not set');

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -66,7 +66,7 @@ test.describe('Interpreter Includes/Excludes', {
 		if (alternateR) {
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
 
-			await userSettings.set([['positron.r.interpreters.exclud', '["/opt/R/4.4.2"]']], true);
+			await userSettings.set([['positron.r.interpreters.exclude', '["/opt/R/4.4.2"]']], true);
 			try {
 				await app.workbench.interpreter.selectInterpreter(InterpreterType.R, alternateR, true);
 				fail('selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded');


### PR DESCRIPTION
Exclude interpreter tests for Python and R.

### QA Notes

Interpreter tests should pass on ubuntu

@:interpreter