### PR TITLE
Data Explorer: Fix UI rendering bugs with DuckDB backend when a table has zero rows after filtering, other zero-row bugs

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -447,14 +447,7 @@ class ColumnProfileEvaluator {
 		// potentially better performance
 		const numRows = Number(stats.get('num_rows'));
 
-		// Handle numRows == 0 special case
-		if (numRows === 0) {
-			return {
-				bin_edges: [],
-				bin_counts: [],
-				quantiles: []
-			};
-		}
+		// If numRows is 0, this is handled earlier
 
 		// TODO: This may be lossy for very large INT64 values
 		// We used strings here to temporarily support decimal type data that fits in float64.
@@ -1161,24 +1154,108 @@ END`;
 		this._evaluateColumnProfiles(params);
 	}
 
+	/**
+	 * Creates empty summary statistics for a column when there are zero rows
+	 * @param columnSchema Column schema information
+	 * @returns Empty summary stats appropriate for the column type
+	 */
+	private createEmptySummaryStats(columnSchema: SchemaEntry): ColumnSummaryStats {
+		if (isNumeric(columnSchema.column_type) || columnSchema.column_type.startsWith('DECIMAL')) {
+			return {
+				type_display: ColumnDisplayType.Number,
+				number_stats: {}
+			};
+		} else if (columnSchema.column_type === 'VARCHAR') {
+			return {
+				type_display: ColumnDisplayType.String,
+				string_stats: {
+					num_unique: 0,
+					num_empty: 0
+				}
+			};
+		} else if (columnSchema.column_type === 'BOOLEAN') {
+			return {
+				type_display: ColumnDisplayType.Boolean,
+				boolean_stats: {
+					true_count: 0,
+					false_count: 0
+				}
+			};
+		} else if (columnSchema.column_type === 'TIMESTAMP') {
+			return {
+				type_display: ColumnDisplayType.Datetime,
+				datetime_stats: {
+					num_unique: 0
+				}
+			};
+		} else {
+			return {
+				type_display: ColumnDisplayType.Unknown
+			};
+		}
+	}
+
 	private async _evaluateColumnProfiles(params: GetColumnProfilesParams) {
-		const evaluator = new ColumnProfileEvaluator(this.db,
-			this.fullSchema,
-			this.tableName,
-			this._whereClause,
-			params
-		);
+		// Check if there are any rows in the filtered data
+		const [filteredRowCount, _] = await this._filteredShape;
 
 		const outParams: ReturnColumnProfilesEvent = {
 			callback_id: params.callback_id,
 			profiles: []
 		};
-		try {
-			outParams.profiles = await evaluator.evaluate();
-		} catch (error) {
-			// TODO: Add error message to ReturnColumnProfilesEvent and display in UI
-			const errorMessage = error instanceof Error ? error.message : 'unknown error';
-			console.log(`Failed to compute column profiles: ${errorMessage}`);
+
+		if (filteredRowCount === 0) {
+			// Handle the zero-row case - return empty/null profiles
+			outParams.profiles = params.profiles.map(request => {
+				// Create an empty result with appropriate null values
+				const result: ColumnProfileResult = {};
+
+				for (const spec of request.profiles) {
+					switch (spec.profile_type) {
+						case ColumnProfileType.NullCount:
+							result.null_count = 0;
+							break;
+						case ColumnProfileType.LargeHistogram:
+						case ColumnProfileType.SmallHistogram:
+							result[spec.profile_type] = {
+								bin_edges: ['NULL', 'NULL'],
+								bin_counts: [0],
+								quantiles: []
+							};
+							break;
+						case ColumnProfileType.LargeFrequencyTable:
+						case ColumnProfileType.SmallFrequencyTable:
+							result[spec.profile_type] = {
+								values: [],
+								counts: [],
+								other_count: 0
+							};
+							break;
+						case ColumnProfileType.SummaryStats:
+							// Create null summary stats appropriate for the column type
+							const columnSchema = this.fullSchema[request.column_index];
+							result.summary_stats = this.createEmptySummaryStats(columnSchema);
+							break;
+					}
+				}
+				return result;
+			});
+		} else {
+			// Normal case - compute stats using evaluator
+			const evaluator = new ColumnProfileEvaluator(this.db,
+				this.fullSchema,
+				this.tableName,
+				this._whereClause,
+				params
+			);
+
+			try {
+				outParams.profiles = await evaluator.evaluate();
+			} catch (error) {
+				// TODO: Add error message to ReturnColumnProfilesEvent and display in UI
+				const errorMessage = error instanceof Error ? error.message : 'unknown error';
+				console.log(`Failed to compute column profiles: ${errorMessage}`);
+			}
 		}
 
 		await vscode.commands.executeCommand(

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -114,18 +114,27 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				state.table_shape.num_rows
 			);
 
-			// Adjust the vertical scroll offset, if needed.
-			if (!this.firstRow) {
+			// For zero-row case (e.g., after filtering), ensure a full reset of scroll positions
+			if (state.table_shape.num_rows === 0) {
 				this._verticalScrollOffset = 0;
-			} else if (this._verticalScrollOffset > this.maximumVerticalScrollOffset) {
-				this._verticalScrollOffset = this.maximumVerticalScrollOffset;
-			}
-
-			// Adjust the horizontal scroll offset, if needed.
-			if (!this.firstColumn) {
 				this._horizontalScrollOffset = 0;
-			} else if (this._horizontalScrollOffset > this.maximumHorizontalScrollOffset) {
-				this._horizontalScrollOffset = this.maximumHorizontalScrollOffset;
+				// Force a layout recomputation and repaint
+				this.softReset();
+				this._onDidUpdateEmitter.fire();
+			} else {
+				// Adjust the vertical scroll offset, if needed.
+				if (!this.firstRow) {
+					this._verticalScrollOffset = 0;
+				} else if (this._verticalScrollOffset > this.maximumVerticalScrollOffset) {
+					this._verticalScrollOffset = this.maximumVerticalScrollOffset;
+				}
+
+				// Adjust the horizontal scroll offset, if needed.
+				if (!this.firstColumn) {
+					this._horizontalScrollOffset = 0;
+				} else if (this._horizontalScrollOffset > this.maximumHorizontalScrollOffset) {
+					this._horizontalScrollOffset = this.maximumHorizontalScrollOffset;
+				}
 			}
 		};
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -383,6 +383,17 @@ export class TableDataCache extends Disposable {
 		this._rows = tableState.table_shape.num_rows;
 		this._hasRowLabels = tableState.has_row_labels;
 
+		// If there are no rows (e.g., due to filtering), immediately fire an update and return
+		if (this._rows === 0) {
+			// Clear existing caches for a clean display
+			this._rowLabelCache.clear();
+			this._dataColumnCache.clear();
+			// Fire the update event before returning to ensure UI updates even with zero rows
+			this._onDidUpdateEmitter.fire();
+			this._updating = false;
+			return;
+		}
+
 		// Set the start column index and the end column index of the columns to cache.
 		const overscanColumns = screenColumns * OVERSCAN_FACTOR;
 		const startColumnIndex = Math.max(


### PR DESCRIPTION
Addresses #6531. This changes the DuckDB backend to bail out early of querying for data values or computing summary stats when the filtered table has zero rows. I used Claude Code to tweak the UI rendering logic which added some special cases when the table shape has zero rows, so this will need to be reviewed carefully.

e2e: @:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
