### PR TITLE
e32e Test: add decimal type to duckDB test

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -60,8 +60,8 @@ test.describe('Headless Data Explorer', {
 			await app.workbench.dataExplorer.clickLowerRightCorner();
 			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
 			const lastRow = tableData.at(-2);
-			const lastHour = lastRow!['decimal_high_precision'];
-			expect(lastHour).toBe(`5555555555.55555555`);
+			const lastHour = lastRow!['decimal_no_scale'];
+			expect(lastHour).toBe(`5555555555`);
 		}).toPass();
 	}
 	);


### PR DESCRIPTION
### Intent
In support of #5169, adding support for decimal types in duckdb

Had to add a new test in teh describe block as the current testscases assume it's using the flights data files.

### QA Notes
@:data-explorer

All Tests should pass
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
