### PR TITLE
e2e test: includes-excludes use fail instead of log warning

### DIFF
--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -24,7 +24,7 @@ test.describe('Interpreter Includes/Excludes', {
 			await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]']], true);
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, hiddenPython, true);
 		} else {
-			logger.log('Hidden Python version not set'); // use this for now so release test can essentially skip this case
+			fail('Hidden Python version not set');
 		}
 	});
 
@@ -36,7 +36,7 @@ test.describe('Interpreter Includes/Excludes', {
 			await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, hiddenR, true);
 		} else {
-			logger.log('Hidden R version not set'); // use this for now so release test can essentially skip this case
+			fail('Hidden R version not set');
 		}
 	});
 


### PR DESCRIPTION
### Intent

Now that https://github.com/posit-dev/positron/issues/6651 is done, we can make these tests fail instead of just warn when the hidden interpreter is not installed

### QA Notes
@:interpreter

All tests should pass.  We won't see the release tests pass until tonight's test run.