### PR TITLE
Bump ark to 0.1.172

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -708,7 +708,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.170"
+      "ark": "0.1.171"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -708,7 +708,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.171"
+      "ark": "0.1.172"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/736
- https://github.com/posit-dev/ark/pull/735
- https://github.com/posit-dev/ark/pull/732
    - https://github.com/posit-dev/ark/pull/741


### Release Notes

#### New Features

- Plots in R have been significantly reworked. This has fixed a number of bugs regarding creating multiple plots in one call and issues related to `par()`. Specifically, plots with [sf](https://github.com/posit-dev/positron/issues/5046), [ggExtra](https://github.com/posit-dev/positron/issues/5346), [biplot](https://github.com/posit-dev/positron/issues/4549), [patchwork](https://github.com/posit-dev/positron/issues/4593), [`ggsave()`](https://github.com/posit-dev/positron/issues/3915), [stars](https://github.com/posit-dev/positron/issues/3834), and [tinyplot](https://github.com/posit-dev/positron/issues/3667) should now work as intended. Our [Epic](https://github.com/posit-dev/positron/issues/4734) contains the full list of resolved issues, along with some remaining issues.

#### Bug Fixes

- Older versions of renv (1.0.1 and earlier) are now supported, but we recommend that you update to the latest renv with `renv::upgrade()` for the best experience (https://github.com/posit-dev/ark/pull/736).
- Completions now work for the latest version of R6 (https://github.com/posit-dev/ark/pull/735).


### QA Notes

I'll ping y'all directly.

`@:plots`