### PR TITLE
Make connection icons slightly smaller

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.css
@@ -69,12 +69,16 @@
 }
 
 .connections-list-item .col-icon {
+	padding-left: 5px;
 	width: 26px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .connections-list-item .col-icon > img {
-	width: 26px;
-	height: 26px;
+	width: 19px;
+	height: 19px;
 }
 
 .connections-list-container .col-language {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -103,10 +103,13 @@
 }
 
 .connections-instance-details .connection-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	flex-grow: 0;
 	flex-shrink: 0;
-	width: 26px;
-	height: 26px;
+	width: 19px;
+	height: 19px;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
This a tiny visual change. I think the connection icons a little too large currently. See the screenshots below.

Old:
![CleanShot 2025-03-12 at 17 47 31@2x](https://github.com/user-attachments/assets/aceaa845-c239-4ce1-93d8-5503cb1d93a3)

New:
![CleanShot 2025-03-12 at 17 46 44@2x](https://github.com/user-attachments/assets/d8c85b05-7654-477d-955e-ff94b117718e)



Old:
![CleanShot 2025-03-12 at 17 47 26@2x](https://github.com/user-attachments/assets/c0222460-6e3e-4737-9ae7-c93937db4ef2)

New:
![CleanShot 2025-03-12 at 17 46 36@2x](https://github.com/user-attachments/assets/f157deee-4488-4622-b8dc-a88b9967e220)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
