### PR TITLE
Data Explorer: Allow DuckDB CSV sniffer to detect non-comma delimiters in .csv files

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1531,11 +1531,9 @@ export class DataExplorerRpcHandler {
 			// TODO: Will need to be able to pass CSV / TSV options from the
 			// UI at some point.
 			const options: Array<string> = [];
-			if (fileExt === '.csv') {
-				options.push('delim=\',\'');
-			} else if (fileExt === '.tsv') {
+			if (fileExt === '.tsv') {
 				options.push('delim=\'\t\'');
-			} else {
+			} else if (fileExt !== '.csv' && fileExt !== '.tsv') {
 				throw new Error(`Unsupported file extension: ${fileExt}`);
 			}
 


### PR DESCRIPTION
Addresses #6733, which allows the DuckDB backend to open well-behaved .csv files that use a non-comma delimiter (even though CSV stands for "comma-separated values"!). It works for the pipe- and tab-separated files in the issue.

e2e: @:data-explorer

### Release Notes

#### New Features

- Opening a CSV file which uses a non-comma delimiter from the explorer pane will now work in most cases.

#### Bug Fixes

- N/A


### QA Notes

You can find some example files for e2e testing in #6733.