### PR TITLE
Update foreground session when interpreter changes

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -353,12 +353,16 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 *
 	 * If `console.multipleConsoleSessions` is enabled this function works as decribed below:
 	 *
-	 * Select a session for the provided runtime. If there is an active console session for the runtime,
-	 * set it as the foreground session and return. If there is no active console session for the runtime,
-	 * start a new session for the runtime.
+	 * Select a session for the provided runtime.
 	 *
-	 * If there are multiple sessions for the runtime, the most recently created session is set as the
-	 * foreground session.
+	 * For console sessions, if there is an active console session for the runtime, set it as
+	 *  the foreground session and return. If there is no active console session for the runtime,
+	 * start a new session for the runtime. If there are multiple sessions for the runtime,
+	 * the most recently created session is set as the foreground session.
+	 *
+	 * For notebooks, only one runtime session for a notebook URI is allowed. Starts a session for the
+	 * new runtime after shutting down the session for the previous runtime. Do nothing if the runtime
+	 * matches the active runtime for the notebook session.
 	 *
 	 * @param runtimeId The ID of the runtime to select
 	 * @param source The source of the selection

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -289,17 +289,16 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	/**
-	 * Gets the console session for a runtime, if one exists. Used by the top
-	 * bar interpreter drop-down to associated a session with a runtime.
+	 * Gets the console session for a runtime, if one exists.
+	 * Used to associated a session with a runtime.
 	 *
 	 * @param runtimeId The runtime identifier of the session to retrieve.
 	 * @returns The console session with the given runtime identifier, or undefined if
 	 *  no console session with the given runtime identifier exists.
 	 */
 	getConsoleSessionForRuntime(runtimeId: string): ILanguageRuntimeSession | undefined {
-		// It's possible that there are multiple consoles for the same runtime,
-		// for example, if one failed to start and is uninitialized. In that case,
-		// we return the most recently created.
+		// It's possible that there are multiple consoles for the same runtime.
+		// In that case, we return the most recently created.
 		return Array.from(this._activeSessionsBySessionId.values())
 			.map((info, index) => ({ info, index }))
 			.sort((a, b) =>
@@ -354,17 +353,12 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 *
 	 * If `console.multipleConsoleSessions` is enabled this function works as decribed below:
 	 *
-	 * Starts a runtime session for the provided runtime if there isn't one.
+	 * Select a session for the provided runtime. If there is an active console session for the runtime,
+	 * set it as the foreground session and return. If there is no active console session for the runtime,
+	 * start a new session for the runtime.
 	 *
-	 * For notebooks, only one runtime session for a notebook URI is allowed. Starts a session for the
-	 * new runtime after shutting down the session for the previous runtime. Do nothing if the runtime
-	 * matches the active runtime for the notebook session.
-	 *
-	 * For consoles, we can have multiple sessions for a given runtime. Starts a session for the new
-	 * runtime if there isn't one. Do nothing if there is an active console session for the runtime.
-	 *
-	 * This should not be used to create new console sessions unless the goal is to limit session
-	 * creation to one per runtime.
+	 * If there are multiple sessions for the runtime, the most recently created session is set as the
+	 * foreground session.
 	 *
 	 * @param runtimeId The ID of the runtime to select
 	 * @param source The source of the selection
@@ -423,6 +417,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				// Check if there is a console session for this runtime already
 				const activeSession = this.getConsoleSessionForRuntime(runtimeId);
 				if (activeSession) {
+					// Set it as the foreground session and return.
+					this.foregroundSession = activeSession;
 					return;
 				}
 			} else {


### PR DESCRIPTION
Addresses #6719 

This fixes a regression introduced to `$selectLanguageRuntime` when multiple console sessions is enabled. 

The `$selectLanguageRuntime` function exposed to the extension host by Positron is meant to be used by a language pack to signal to Positron that the interpreter/runtime has changed on their end and that Positron should take appropriate action. Right now that means Positron should change the foreground session to a session for that runtime.

The foreground session is not updated by Positron when `$selectLanguageRuntime` is being called which is causing the user to see mismatched information in the UI.

The fix is to update the foreground session in Positron when `$selectLanguageRuntime` is called.

Note: This doesn't address the inverse path. When the foreground session changes, the Python extension does not currently change the active interpreter. That can be handled after https://github.com/posit-dev/positron/pull/6714 which provides a way for extensions to be notified the foreground session has changed.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:sessions @:console @:web

### Screenshots

https://github.com/user-attachments/assets/59b878a1-87e1-48d7-9307-b8a1ce7421e2


