### PR TITLE
Data Explorer: Add Interval ColumnDisplayType, classify pandas timedelta64 and polars Duration as interval

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -185,6 +185,7 @@ const SCHEMA_TYPE_MAPPING = new Map<string, ColumnDisplayType>([
 	['TIMESTAMP WITH TIME ZONE', ColumnDisplayType.Datetime],
 	['TIMESTAMP_NS WITH TIME ZONE', ColumnDisplayType.Datetime],
 	['TIME', ColumnDisplayType.Time],
+	['INTERVAL', ColumnDisplayType.Interval],
 	['DECIMAL', ColumnDisplayType.Number]
 ]);
 

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Interfaces copied from main UI data explorer codebase. Do not manually edit.
-
 /**
  * Descriptor for backend method invocation in via extension command.
  */
@@ -55,8 +53,8 @@ export interface DataExplorerResponse {
 	error_message?: string;
 }
 
-// AUTO-GENERATED from data_explorer.json; do not edit.
-//
+// AUTO-GENERATED from data_explorer.json; do not edit. Copy from
+// positronDataExplorerComm.ts instead.
 
 
 /**
@@ -607,6 +605,11 @@ export interface ColumnSummaryStats {
 	 */
 	datetime_stats?: SummaryStatsDatetime;
 
+	/**
+	 * Summary statistics for any other data types
+	 */
+	other_stats?: SummaryStatsOther;
+
 }
 
 /**
@@ -653,6 +656,17 @@ export interface SummaryStatsBoolean {
 	 * The number of non-null false values
 	 */
 	false_count: number;
+
+}
+
+/**
+ * SummaryStatsOther in Schemas
+ */
+export interface SummaryStatsOther {
+	/**
+	 * The number of unique values
+	 */
+	num_unique?: number;
 
 }
 
@@ -1116,6 +1130,7 @@ export enum ColumnDisplayType {
 	Date = 'date',
 	Datetime = 'datetime',
 	Time = 'time',
+	Interval = 'interval',
 	Object = 'object',
 	Array = 'array',
 	Struct = 'struct',
@@ -1385,7 +1400,6 @@ export interface ReturnColumnProfilesParams {
 	 * Optional error message if something failed to compute
 	 */
 	error_message?: string;
-
 }
 
 /**

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -2271,12 +2271,12 @@ class PolarsView(DataExplorerTableView):
             "Date": "date",
             "Datetime": "datetime",
             "Time": "time",
+            "Duration": "interval",
             "Decimal": "number",
             "Object": "object",
             "List": "array",
             "Struct": "struct",
             "Categorical": "categorical",
-            "Duration": "unknown",  # See #3418
             "Enum": "unknown",
             "Null": "unknown",  # Not yet implemented
             "Unknown": "unknown",

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1303,7 +1303,7 @@ class PandasView(DataExplorerTableView):
             column_name=str(column_name),
             column_index=column_index,
             type_name=type_name,
-            type_display=type_display,
+            type_display=ColumnDisplayType(type_display),
         )
 
     @classmethod
@@ -1782,8 +1782,11 @@ class PandasView(DataExplorerTableView):
 
         formatted_edges = self._format_values(bin_edges, format_options)
 
+        # TODO: formatted_edges should not contain any special values, but we should
+        # probably check more carefully.
+
         return ColumnHistogram(
-            bin_edges=formatted_edges,
+            bin_edges=[str(x) for x in formatted_edges],
             bin_counts=[int(x) for x in bin_counts],
             quantiles=[],
         )
@@ -1965,7 +1968,7 @@ def _date_median(x):
 
     # if any datetime64 or datetimetz type in pandas
     if x.dtype == "timedelta64[ns]":
-        return pd.to_timedelta(median_value)
+        return pd.to_timedelta(np.array(int(median_value)))
     else:
         # Date or datetime
         out = pd.to_datetime(np.array(median_value), utc=True)
@@ -2250,7 +2253,7 @@ class PolarsView(DataExplorerTableView):
             column_name=column_name,
             column_index=column_index,
             type_name=type_name,
-            type_display=type_display,
+            type_display=ColumnDisplayType(type_display),
         )
 
     TYPE_DISPLAY_MAPPING = MappingProxyType(
@@ -2655,8 +2658,10 @@ class PolarsView(DataExplorerTableView):
 
         formatted_edges = self._format_values(bin_edges, format_options)
 
+        # TODO: make sure that formatted_edges has no special values
+
         return ColumnHistogram(
-            bin_edges=formatted_edges,
+            bin_edges=[str(x) for x in formatted_edges],
             bin_counts=[int(x) for x in bin_counts],
             quantiles=[],
         )

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -978,8 +978,7 @@ def _pandas_temporal_mapper(type_name):
     if "datetime64" in type_name:
         return "datetime"
     elif "timedelta64" in type_name:
-        # We don't have a separate display type for timedelta yet
-        return "datetime"
+        return "interval"
     return None
 
 
@@ -1375,9 +1374,8 @@ class PandasView(DataExplorerTableView):
             "datetime64": "datetime",
             "datetime64[ns]": "datetime",
             "datetime": "datetime",
-            # Perhaps we will want to add a display type for timedelta
-            "timedelta64[ns]": "datetime",
-            "timedelta": "datetime",
+            "timedelta64[ns]": "interval",
+            "timedelta": "interval",
             "date": "date",
             "time": "time",
             "bytes": "string",
@@ -1963,16 +1961,15 @@ def _date_median(x):
     import pandas as pd
 
     # the np.array calls are required to please pyright
-    median_date = np.median(np.array(pd.to_numeric(x)))
+    median_value = np.median(np.array(pd.to_numeric(x)))
 
     # if any datetime64 or datetimetz type in pandas
-    if isinstance(x.dtype, pd.DatetimeTZDtype) or x.dtype == "datetime64":
-        out = pd.to_datetime(np.array(median_date), utc=True)
-        return out.tz_convert(x[0].tz)
-    elif x.dtype == "timedelta64[ns]":
-        return pd.to_timedelta(median_date)
+    if x.dtype == "timedelta64[ns]":
+        return pd.to_timedelta(median_value)
     else:
-        raise ValueError(x)
+        # Date or datetime
+        out = pd.to_datetime(np.array(median_value), utc=True)
+        return out.tz_convert(x[0].tz)
 
 
 def _possibly(f, otherwise=None):

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -897,7 +897,7 @@ class ColumnFrequencyTable(BaseModel):
     Result from a frequency_table profile request
     """
 
-    values: List[StrictStr] = Field(
+    values: List[ColumnValue] = Field(
         description="The formatted top values",
     )
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -36,6 +36,8 @@ class ColumnDisplayType(str, enum.Enum):
 
     Time = "time"
 
+    Interval = "interval"
+
     Object = "object"
 
     Array = "array"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -735,7 +735,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
                 dtype="timedelta64[ns]",
             ),
             "timedelta64[ns]",
-            "datetime",
+            "interval",
         ),
         # datetimetz
         (

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -742,7 +742,15 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
                 ["NaT", 3600, -3600, 0, 0],
                 dtype="timedelta64[s]",
             ),
-            "timedelta64[s]",
+            # Older versions of pandas upcast seconds to nanoseconds
+            str(
+                pd.Series(
+                    np.array(
+                        ["NaT", 3600, -3600, 0, 0],
+                        dtype="timedelta64[s]",
+                    )
+                ).dtype
+            ),
             "interval",
         ),
         # datetimetz

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -737,6 +737,14 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
             "timedelta64[ns]",
             "interval",
         ),
+        (
+            np.array(
+                ["NaT", 3600, -3600, 0, 0],
+                dtype="timedelta64[s]",
+            ),
+            "timedelta64[s]",
+            "interval",
+        ),
         # datetimetz
         (
             pd.Series(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -3060,7 +3060,7 @@ POLARS_TYPE_EXAMPLES = [
         pl.Duration("ms"),
         [0, 1000, 2000, None],
         "Duration(time_unit='ms')",
-        "unknown",
+        "interval",
     ),
     (
         pl.Decimal(12, 4),

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -729,6 +729,14 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
             "string",
             "string",
         ),
+        (
+            np.array(
+                ["NaT", 3600000000000, -3600000000000, 0, 0],
+                dtype="timedelta64[ns]",
+            ),
+            "timedelta64[ns]",
+            "datetime",
+        ),
         # datetimetz
         (
             pd.Series(

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -414,6 +414,7 @@
 					"date",
 					"datetime",
 					"time",
+					"interval",
 					"object",
 					"array",
 					"struct",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1236,7 +1236,7 @@
 						"type": "array",
 						"description": "The formatted top values",
 						"items": {
-							"type": "string"
+							"$ref": "#/components/schemas/column_value"
 						}
 					},
 					"counts": {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
@@ -35,6 +35,10 @@ export const columnSchemaDataTypeIcon = (columnSchema?: ColumnSchema) => {
 		case ColumnDisplayType.Time:
 			return 'codicon-positron-data-type-time';
 
+		// Reuse datetime icon for interval for now.
+		case ColumnDisplayType.Interval:
+			return 'codicon-positron-data-type-date-time';
+
 		case ColumnDisplayType.Object:
 			return 'codicon-positron-data-type-object';
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1084,6 +1084,7 @@ export enum ColumnDisplayType {
 	Date = 'date',
 	Datetime = 'datetime',
 	Time = 'time',
+	Interval = 'interval',
 	Object = 'object',
 	Array = 'array',
 	Struct = 'struct',

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -769,7 +769,7 @@ export interface ColumnFrequencyTable {
 	/**
 	 * The formatted top values
 	 */
-	values: Array<string>;
+	values: Array<ColumnValue>;
 
 	/**
 	 * Counts of top values

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -146,6 +146,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			case ColumnDisplayType.Date:
 			case ColumnDisplayType.Datetime:
 			case ColumnDisplayType.Time:
+			case ColumnDisplayType.Interval:
 			case ColumnDisplayType.Object:
 			case ColumnDisplayType.Array:
 			case ColumnDisplayType.Struct:
@@ -268,6 +269,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 			// Column display types that do not render a profile.
 			case ColumnDisplayType.Time:
+			case ColumnDisplayType.Interval:
 			case ColumnDisplayType.Array:
 			case ColumnDisplayType.Struct:
 			case ColumnDisplayType.Unknown:
@@ -309,6 +311,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			case ColumnDisplayType.Time:
 				return 'codicon-positron-data-type-time';
 
+			// Time.
+			case ColumnDisplayType.Interval:
+				return 'codicon-positron-data-type-time';
+
 			// Object.
 			case ColumnDisplayType.Object:
 				return 'codicon-positron-data-type-object';
@@ -346,6 +352,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			summaryStatsSupported = isSummaryStatsSupported();
 			break;
 		case ColumnDisplayType.Time:
+		case ColumnDisplayType.Interval:
 		case ColumnDisplayType.Array:
 		case ColumnDisplayType.Struct:
 		case ColumnDisplayType.Unknown:

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -313,7 +313,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 			// Time.
 			case ColumnDisplayType.Interval:
-				return 'codicon-positron-data-type-time';
+				return 'codicon-positron-data-type-date-time';
 
 			// Object.
 			case ColumnDisplayType.Object:

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -84,6 +84,9 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 			case ColumnDisplayType.Time:
 				return DataColumnAlignment.Right;
 
+			case ColumnDisplayType.Interval:
+				return DataColumnAlignment.Right;
+
 			case ColumnDisplayType.Object:
 				return DataColumnAlignment.Left;
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -435,6 +435,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 			// Column display types that do not render a profile.
 			case ColumnDisplayType.Time:
+			case ColumnDisplayType.Interval:
 			case ColumnDisplayType.Array:
 			case ColumnDisplayType.Struct:
 			case ColumnDisplayType.Unknown: {


### PR DESCRIPTION
Addresses #3418. The codicon for datetime is reused for interval, but at least this data does not show up as a question mark for now. We can look at adding sparklines, summary stats, and other functionality as follow up work. 

e2e: @:data-explorer

### QA Notes

Here's an example to create some datasets containing data like this:

```
import polars as pl
import pandas as pd
from datetime import timedelta

durations = [
    timedelta(hours=2, minutes=30),
    timedelta(hours=1, minutes=45),
    timedelta(hours=3, minutes=15),
    timedelta(hours=0, minutes=50)
]

# Polars DataFrame with Duration type
polars_df = pl.DataFrame({
    "duration": pl.Series(durations, dtype=pl.Duration)
})

# Pandas DataFrame with timedelta64 type
pandas_df = pd.DataFrame({
    "duration": pd.Series(durations, dtype='timedelta64[ns]')
})
```