### PR TITLE
E2E tests: untag web for default interpreters

### DIFF
--- a/test/e2e/tests/interpreters/default-interpreters.test.ts
+++ b/test/e2e/tests/interpreters/default-interpreters.test.ts
@@ -13,7 +13,7 @@ test.use({
 });
 
 test.describe('Default Interpreters', {
-	tag: [tags.INTERPRETER, tags.WEB]
+	tag: [tags.INTERPRETER]
 }, () => {
 
 	const homeDir = process.env.HOME || '';


### PR DESCRIPTION
Untag web for new default interpreters test.

### QA Notes

All tests pass (aside possibly from reticulate which has other issues)
