### PR TITLE
Fix Reticulate web tests

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
@@ -16,6 +16,7 @@ import { IReactComponentContainer } from '../../../../../base/browser/positronRe
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { IRuntimeSessionMetadata } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
+import { IPositronConsoleInstance } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 
 // ConsoleInstanceMenuButtonProps interface.
 interface ConsoleInstanceMenuButtonProps {
@@ -54,6 +55,21 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 		return () => disposables.dispose();
 	}, [positronConsoleContext.activePositronConsoleInstance, positronConsoleContext.positronConsoleService]);
 
+	// Switch to the given console.
+	const switchToConsole = (positronConsoleInstance: IPositronConsoleInstance) => {
+		const session = positronConsoleInstance.attachedRuntimeSession;
+		if (session) {
+			// For attached sessions, we need to set the foreground session.
+			positronConsoleContext.runtimeSessionService.foregroundSession = session;
+		} else {
+			// For detached sessions, set the session in just the console service.
+			positronConsoleContext.positronConsoleService.setActivePositronConsoleSession(positronConsoleInstance.sessionId);
+		}
+		setTimeout(() => {
+			props.reactComponentContainer.takeFocus();
+		}, 0);
+	}
+
 	// Builds the actions.
 	const actions = () => {
 		// Build the actions for the available console repl instances.
@@ -66,11 +82,7 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 				class: undefined,
 				enabled: true,
 				run: () => {
-					positronConsoleContext.runtimeSessionService.foregroundSession =
-						positronConsoleInstance.attachedRuntimeSession
-					setTimeout(() => {
-						props.reactComponentContainer.takeFocus();
-					}, 0);
+					switchToConsole(positronConsoleInstance);
 				}
 			});
 		});

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -319,10 +319,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 				 * a new one. This is problematic because the user's intention was to creat a new console
 				 * instance for the new session.
 				 */
-				const positronConsoleInstances = this._positronConsoleInstancesByRuntimeId.get(e.session.runtimeMetadata.runtimeId);
-
-				const positronConsoleInstance = positronConsoleInstances?.find(
-					console => console.sessionId === e.session.sessionId);
+				const positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(e.session.sessionId);
 
 				if (positronConsoleInstance) {
 					this._positronConsoleInstancesBySessionId.delete(positronConsoleInstance.sessionId);
@@ -337,14 +334,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 
 		// Register the onDidStartRuntime event handler so we activate the new Positron console instance when the runtime starts up.
 		this._register(this._runtimeSessionService.onDidStartRuntime(session => {
-			const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(this._configurationService);
-
-			let positronConsoleInstance: PositronConsoleInstance | undefined;
-			if (!multiSessionsEnabled) {
-				positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.runtimeMetadata.runtimeId);
-			} else {
-				positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.sessionId);
-			}
+			const positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.sessionId);
 
 			if (positronConsoleInstance) {
 				positronConsoleInstance.setState(PositronConsoleState.Ready);
@@ -353,15 +343,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 
 		// Register the onDidFailStartRuntime event handler so we activate the new Positron console instance when the runtime starts up.
 		this._register(this._runtimeSessionService.onDidFailStartRuntime(session => {
-			const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(this._configurationService);
-
-			let positronConsoleInstance: PositronConsoleInstance | undefined;
-			if (!multiSessionsEnabled) {
-				positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.runtimeMetadata.runtimeId);
-
-			} else {
-				positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.sessionId);
-			}
+			const positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(session.sessionId);
 
 			if (positronConsoleInstance) {
 				positronConsoleInstance.setState(PositronConsoleState.Exited);

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -140,11 +140,6 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	private readonly _positronConsoleInstancesByLanguageId = new Map<string, PositronConsoleInstance>();
 
 	/**
-	 * A map of the Positron console instances by runtime ID.
-	 */
-	private readonly _positronConsoleInstancesByRuntimeId = new Map<string, PositronConsoleInstance[]>();
-
-	/**
 	 * A map of the Positron console instances by session ID.
 	 */
 	private readonly _positronConsoleInstancesBySessionId = new Map<string, PositronConsoleInstance>();
@@ -628,16 +623,8 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 				runtimeMetadata.languageId,
 				positronConsoleInstance
 			);
-		} else {
-			// Add the Positron console instance.
-			const positronConsoleInstancesForRuntime =
-				this._positronConsoleInstancesByRuntimeId.get(runtimeMetadata.runtimeId) || [];
-			positronConsoleInstancesForRuntime.push(positronConsoleInstance);
-			this._positronConsoleInstancesByRuntimeId.set(
-				runtimeMetadata.runtimeId,
-				positronConsoleInstancesForRuntime
-			);
 		}
+
 		this._positronConsoleInstancesBySessionId.set(
 			sessionMetadata.sessionId,
 			positronConsoleInstance


### PR DESCRIPTION
This change attempts to fix the Reticulate web tests, which were recently broken by #6741. 

test: `@:web`, `@:console`, `@:reticulate`