### PR TITLE
e2e Test: fix flakey connections test on windows

### DIFF
--- a/test/e2e/tests/connections/connections-db.test.ts
+++ b/test/e2e/tests/connections/connections-db.test.ts
@@ -38,10 +38,11 @@ test.describe('SQLite DB Connection', {
 				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 				await app.workbench.connections.connectIcon.click();
 			} catch (error) {
+				// For some reasonm, on the retry, the pane opes directly to this connection
+				// and the connectIcon.click() is not needed.
 				await app.workbench.sideBar.openSession();
 				await app.code.driver.page.waitForTimeout(2000);
 				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
-				await app.workbench.connections.connectIcon.click();
 			}
 		});
 

--- a/test/e2e/tests/connections/connections-db.test.ts
+++ b/test/e2e/tests/connections/connections-db.test.ts
@@ -38,7 +38,7 @@ test.describe('SQLite DB Connection', {
 				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 				await app.workbench.connections.connectIcon.click();
 			} catch (error) {
-				// For some reasonm, on the retry, the pane opes directly to this connection
+				// For some reasonm, on the retry, the pane opens directly to this connection
 				// and the connectIcon.click() is not needed.
 				await app.workbench.sideBar.openSession();
 				await app.code.driver.page.waitForTimeout(2000);


### PR DESCRIPTION
### Intent

Occasionally on windows the connection pane doesn't correctly open in the test.  I previuosly added a try/catch retry. but it appears when it does this retry, it opens the connection directly and the extran `connectIcon.click()` isn't needed.

### QA Notes
All tests pass.. part of criitcal already.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
