### PR TITLE
Restore missing `hasInstallScript` flags in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,6 +2919,7 @@
     },
     "node_modules/@vscode/deviceid": {
       "version": "0.1.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.2.0",
@@ -3036,6 +3037,7 @@
     },
     "node_modules/@vscode/policy-watcher": {
       "version": "1.1.8",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
@@ -3098,6 +3100,7 @@
     },
     "node_modules/@vscode/spdlog": {
       "version": "0.15.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
@@ -3107,6 +3110,7 @@
     },
     "node_modules/@vscode/sqlite3": {
       "version": "5.1.8-vscode",
+      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "node-addon-api": "^8.2.0",
@@ -3402,6 +3406,7 @@
     },
     "node_modules/@vscode/windows-mutex": {
       "version": "0.5.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
@@ -3410,6 +3415,7 @@
     },
     "node_modules/@vscode/windows-process-tree": {
       "version": "0.6.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "7.1.0"
@@ -3417,6 +3423,7 @@
     },
     "node_modules/@vscode/windows-registry": {
       "version": "1.1.0",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -12358,14 +12365,17 @@
     },
     "node_modules/native-is-elevated": {
       "version": "0.7.0",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/native-keymap": {
       "version": "3.3.5",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/native-watchdog": {
       "version": "1.4.2",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -18365,6 +18375,7 @@
     },
     "node_modules/windows-foreground-love": {
       "version": "0.5.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true
     },


### PR DESCRIPTION
This change restores some flags in `package.json` that were omitted with the 1.97 merge.

