### PR TITLE
e2e-test: gracefully handle repo cloning when offline

### DIFF
--- a/test/e2e/infra/test-runner/test-setup.ts
+++ b/test/e2e/infra/test-runner/test-setup.ts
@@ -28,7 +28,7 @@ export function prepareTestEnv(rootPath = process.env.ROOT_PATH || 'ROOT_PATH no
 
 	try {
 		initializeTestEnvironment(rootPath, logger);
-		console.log('Test environment ready.');
+		console.log('✓ Test environment ready');
 
 		// Disabling this section of code for now. It's used to download a stable version of VSCode
 		// Maybe we would want to update this to download a stable version of Positron some day?

--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -67,11 +67,11 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 	copyRepo(cacheDir, workspacePath);
 }
 
-// Helper function to copy the repo
 function copyRepo(source: string, destination: string): void {
-	rimraf.sync(destination);
-	fs.mkdirSync(destination, { recursive: true });
-	const cmd = process.platform === 'win32' ? `xcopy /E /H /K /Y "${source}\\*" "${destination}\\*"` : `cp -R "${source}/." "${destination}"`;
-	cp.execSync(cmd);
+	if (process.platform === 'win32') {
+		cp.execSync(`xcopy /E /H /K /Y "${source}\\*" "${destination}\\*"`);
+	} else {
+		cp.execSync(`cp -R "${source}/." "${destination}"`);
+	}
 	console.log(`✓ Workspace: ${destination}`);
 }

--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -10,57 +10,68 @@ import rimraf from 'rimraf';
 import * as os from 'os';
 
 export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WORKSPACE_PATH is not set in cloneTestRepo'): void {
+	// Prevent Git warnings about missing templates.
+	process.env.GIT_TEMPLATE_DIR = '';
+
 	const testRepoUrl = 'https://github.com/posit-dev/qa-example-content.git';
 	const cacheDir = path.join(os.tmpdir(), 'qa-example-content-cache');
 	const cachedCommitFile = path.join(cacheDir, '.cached-commit');
 	const branch = 'main';
 
-	if (process.env.FORCE_CLONE === 'true') {
-		console.log('FORCE_CLONE is set.');
-		rimraf.sync(cacheDir);
-	}
-
+	// Check if the machine is online by attempting to fetch the latest commit hash.
+	let remoteCommitHash: string | null = null;
 	try {
-		console.log(`Preparing workspace at: ${workspacePath}`);
-
-		// Get the latest commit hash from the remote repo
-		const remoteCommitHash = cp.execSync(`git ls-remote ${testRepoUrl} refs/heads/${branch}`).toString().split('\t')[0].trim();
-
-		// Check if cache exists and matches the latest commit hash
-		if (fs.existsSync(cacheDir) && fs.existsSync(cachedCommitFile)) {
-			const cachedCommitHash = fs.readFileSync(cachedCommitFile, 'utf-8').trim();
-			if (remoteCommitHash === cachedCommitHash) {
-				rimraf.sync(workspacePath);
-				fs.mkdirSync(workspacePath, { recursive: true });
-				copyDirectory(cacheDir, workspacePath);
-				console.log('Workspace updated from cache.');
-				return;
-			}
-		}
-
-		// If cache is missing or outdated, download a fresh copy
-		console.log('Cache outdated or missing. Cloning fresh repo.');
-		rimraf.sync(cacheDir);
-		cp.spawnSync('git', ['clone', '--depth=1', '--branch', branch, testRepoUrl, cacheDir], { stdio: 'inherit' });
-
-		// Store the latest commit hash in the cache
-		fs.writeFileSync(cachedCommitFile, remoteCommitHash);
-
-		// Copy fresh repo to the workspace
-		rimraf.sync(workspacePath);
-		fs.mkdirSync(workspacePath, { recursive: true });
-		copyDirectory(cacheDir, workspacePath);
-	} catch (error) {
-		console.error(`Error while cloning/updating repository: ${(error as Error).message}`);
-		throw error;
+		remoteCommitHash = cp.execSync(`git ls-remote ${testRepoUrl} refs/heads/${branch}`, { stdio: 'pipe' })
+			.toString()
+			.split('\t')[0]
+			.trim();
+	} catch {
+		console.warn('! Warning: No internet connection detected.');
 	}
+
+	// Prevent force cloning if offline
+	if (process.env.FORCE_CLONE === 'true') {
+		if (!remoteCommitHash) {
+			console.error('✗ FORCE_CLONE is set, but the machine is offline. Skipping repository clone');
+		} else {
+			console.log('i FORCE_CLONE is set, forcing a fresh clone');
+			rimraf.sync(cacheDir);
+		}
+	}
+
+	// Check if cache exists and is valid
+	const hasCachedRepo = fs.existsSync(cacheDir) && fs.existsSync(cachedCommitFile);
+	const cachedCommitHash = hasCachedRepo ? fs.readFileSync(cachedCommitFile, 'utf-8').trim() : null;
+
+	// Use cache if available and up-to-date OR if offline
+	if (hasCachedRepo && (remoteCommitHash === cachedCommitHash || !remoteCommitHash)) {
+		console.log('✓ Using cached repository');
+		copyRepo(cacheDir, workspacePath);
+		return;
+	}
+
+	if (!remoteCommitHash) {
+		console.error('✗ No internet connection and no valid cache found.');
+		return;
+	}
+
+	// Clone fresh repo
+	console.log('✓ Cloning fresh repository...');
+	rimraf.sync(cacheDir);
+	if (cp.spawnSync('git', ['clone', '--depth=1', '--branch', branch, testRepoUrl, cacheDir, '-q'], { stdio: 'inherit' }).status !== 0) {
+		console.error('✗ Failed to clone repository.');
+		return;
+	}
+
+	fs.writeFileSync(cachedCommitFile, remoteCommitHash);
+	copyRepo(cacheDir, workspacePath);
 }
 
-function copyDirectory(source: string, destination: string): void {
-	// copy contents of source to destination
-	if (process.platform === 'win32') {
-		cp.execSync(`xcopy /E /H /K /Y "${source}\\*" "${destination}\\*"`);
-	} else {
-		cp.execSync(`cp -R "${source}/." "${destination}"`);
-	}
+// Helper function to copy the repo
+function copyRepo(source: string, destination: string): void {
+	rimraf.sync(destination);
+	fs.mkdirSync(destination, { recursive: true });
+	const cmd = process.platform === 'win32' ? `xcopy /E /H /K /Y "${source}\\*" "${destination}\\*"` : `cp -R "${source}/." "${destination}"`;
+	cp.execSync(cmd);
+	console.log(`✓ Workspace: ${destination}`);
 }

--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -26,7 +26,7 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 			.split('\t')[0]
 			.trim();
 	} catch {
-		console.warn('! Warning: No internet connection detected.');
+		console.warn('! Warning: No internet connection detected');
 	}
 
 	// Prevent force cloning if offline
@@ -51,7 +51,7 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 	}
 
 	if (!remoteCommitHash) {
-		console.error('✗ No internet connection and no valid cache found.');
+		console.error('✗ No internet connection and no valid cache found');
 		return;
 	}
 
@@ -59,7 +59,7 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 	console.log('✓ Cloning fresh repository...');
 	rimraf.sync(cacheDir);
 	if (cp.spawnSync('git', ['clone', '--depth=1', '--branch', branch, testRepoUrl, cacheDir, '-q'], { stdio: 'inherit' }).status !== 0) {
-		console.error('✗ Failed to clone repository.');
+		console.error('✗ Failed to clone repository');
 		return;
 	}
 


### PR DESCRIPTION
### Summary
- Updated the script in our e2e tests that clones `qa-example-content` to gracefully handle the scenario when user is offline (for example, on a plane headed to/from work week). Previously user was unable to launch playwright due to cloning error.

### QA Notes

Feel free to test it out locally with by toggling WIFI on and off and running either of these commands:
* `FORCE_CLONE=true npx playwright test fast-execution --project e2e-electron`
* `FORCE_CLONE=false npx playwright test fast-execution --project e2e-electron`
