### PR TITLE
Pin ruff to 0.9.10 temporarily to fix CI

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Lint and Check Formatting with Ruff
         run: |
-          python -m pip install -U ruff
+          python -m pip install -U ruff==0.9.10
           python -m ruff check .
           python -m ruff format --check
         working-directory: ${{ env.PYTHON_SRC_DIR }}


### PR DESCRIPTION
Temporarily pin ruff to the previous version to unblock CI. We can investigate issues with our Python CI when upgrading to ruff 0.10.