### PR TITLE
Restore inline chat feature

### DIFF
--- a/extensions/positron-assistant/src/commands/default.ts
+++ b/extensions/positron-assistant/src/commands/default.ts
@@ -117,10 +117,22 @@ export async function defaultHandler(
 		const document = request.location2.document;
 		const selection = request.location2.selection;
 		const selectedText = document.getText(selection);
-		messages.push(...[
-			vscode.LanguageModelChatMessage.User(`The user has selected the following text: ${selectedText}`),
-			vscode.LanguageModelChatMessage.Assistant('Acknowledged.'),
-		]);
+		const documentText = document.getText();
+		const ref = {
+			id: document.uri.toString(),
+			documentText,
+			selectedText,
+			line: selection.active.line + 1, // 1-based line numbering for the model
+			column: selection.active.character,
+			documentOffset: document.offsetAt(selection.active)
+		};
+		const textParts: vscode.LanguageModelTextPart[] = [
+			new vscode.LanguageModelTextPart(`\n\n${JSON.stringify(ref)}`)
+		];
+		messages.push(vscode.LanguageModelChatMessage.User(textParts));
+		messages.push(
+			vscode.LanguageModelChatMessage.Assistant('Acknowledged.')
+		);
 
 		// Add tool to output text edits
 		tools.push(textEditToolAdapter.toolData);

--- a/extensions/positron-assistant/src/md/prompts/chat/editor.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/editor.md
@@ -1,4 +1,12 @@
 The user has invoked you from the text editor.
 
 When you have finished responding, you can choose to output a revised version of the selection provided by the user if required.
+
 Never mention the name of the function, just use it.
+
+If there is selected text, assume the user has a question about it or wants to
+replace it with something else.
+
+Use the line and column provided to provide the user with response appropriate
+to the current cursor location, but don't mention the line and column numbers
+in your response unless needed for clarification.

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -37,6 +37,7 @@ class PositronAssistantParticipant implements positron.ai.ChatParticipant {
 			positron.PositronChatAgentLocation.Terminal,
 			positron.PositronChatAgentLocation.Editor,
 			positron.PositronChatAgentLocation.Notebook,
+			positron.PositronChatAgentLocation.EditingSession,
 		],
 		disambiguation: []
 	};


### PR DESCRIPTION
This change restores the inline chat feature for Assistant and provides it with additional context. 

Addresses #6769
Addresses #6667 