### PR TITLE
e2e-tests: unskip problems test

### DIFF
--- a/test/e2e/tests/problems/problems.test.ts
+++ b/test/e2e/tests/problems/problems.test.ts
@@ -11,9 +11,9 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('Problems', {
+test.describe('Problems', {
 	tag: [tags.PROBLEMS, tags.WEB, tags.WIN],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6535 or https://github.com/posit-dev/positron/issues/6536' }], // fixing either would allow us to fix
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6536' }], // fixing either would allow us to fix
 }, () => {
 
 	test('Python - Verify problems are highlighted in editor and count is accurate in Problems pane', async function ({ app, python, openFile }) {


### PR DESCRIPTION
### Summary

Turning the e2e problems tests back on.

### QA Notes

@:web @:win @:problems
