### PR TITLE
Add new OpenRPC method to ask for a password

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,14 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "build/secrets/.secrets.baseline"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1926,6 +1918,15 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 96
+      }
+    ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
@@ -1934,6 +1935,15 @@
         "is_verified": false,
         "line_number": 8,
         "is_secret": false
+      }
+    ],
+    "src/vs/workbench/services/languageRuntime/common/positronUiComm.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/workbench/services/languageRuntime/common/positronUiComm.ts",
+        "hashed_secret": "659b2a0d48dff4354af7e730d2138e52d57f5a6b",
+        "is_verified": false,
+        "line_number": 785
       }
     ],
     "src/vs/workbench/test/browser/webview.test.ts": [
@@ -1965,5 +1975,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-12T15:39:35Z"
+  "generated_at": "2025-03-17T13:57:33Z"
 }

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -311,6 +311,16 @@ class ShowDialogParams(BaseModel):
     )
 
 
+class AskForPasswordParams(BaseModel):
+    """
+    Ask the user for a password
+    """
+
+    prompt: StrictStr = Field(
+        description="The prompt, such as 'Please enter your password'",
+    )
+
+
 class PromptStateParams(BaseModel):
     """
     New state of the primary and secondary prompts
@@ -482,6 +492,8 @@ ShowMessageParams.update_forward_refs()
 ShowQuestionParams.update_forward_refs()
 
 ShowDialogParams.update_forward_refs()
+
+AskForPasswordParams.update_forward_refs()
 
 PromptStateParams.update_forward_refs()
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -722,7 +722,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.172"
+      "ark": "0.1.173"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -153,26 +153,26 @@
 			"result": {}
 		},
 		{
-            "name": "ask_for_password",
-            "summary": "Ask the user for a password",
-            "description": "Use this for an input box where the user can input a password",
-            "params": [
-                {
-                    "name": "prompt",
-                    "description": "The prompt, such as 'Please enter your password'",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ],
-            "result": {
+			"name": "ask_for_password",
+			"summary": "Ask the user for a password",
+			"description": "Use this for an input box where the user can input a password",
+			"params": [
+				{
+					"name": "prompt",
+					"description": "The prompt, such as 'Please enter your password'",
+					"schema": {
+						"type": "string"
+					}
+				}
+			],
+			"result": {
 				"required": false,
-                "schema": {
-                    "type": "string",
-                    "description": "The input from the user"
-                }
-            }
-        },
+				"schema": {
+					"type": "string",
+					"description": "The input from the user"
+				}
+			}
+		},
 		{
 			"name": "prompt_state",
 			"summary": "New state of the primary and secondary prompts",

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -153,6 +153,27 @@
 			"result": {}
 		},
 		{
+            "name": "ask_for_password",
+            "summary": "Ask the user for a password",
+            "description": "Use this for an input box where the user can input a password",
+            "params": [
+                {
+                    "name": "prompt",
+                    "description": "The prompt, such as 'Please enter your password'",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "result": {
+				"required": false,
+                "schema": {
+                    "type": "string",
+                    "description": "The input from the user"
+                }
+            }
+        },
+		{
 			"name": "prompt_state",
 			"summary": "New state of the primary and secondary prompts",
 			"description": "Languages like R allow users to change the way their prompts look. This event signals a change in the prompt configuration.",

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -24,6 +24,7 @@ import { IExtHostWorkspace } from '../extHostWorkspace.js';
 import { IExtHostCommands } from '../extHostCommands.js';
 import { ExtHostWebviews } from '../extHostWebview.js';
 import { ExtHostLanguageFeatures } from '../extHostLanguageFeatures.js';
+import { createExtHostQuickOpen } from '../extHostQuickOpen.js';
 import { ExtHostOutputService } from '../extHostOutput.js';
 import { ExtHostConsoleService } from './extHostConsoleService.js';
 import { ExtHostMethods } from './extHostMethods.js';
@@ -66,6 +67,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 		rpcProtocol.getRaw(ExtHostContext.ExtHostLanguageFeatures);
 	const extHostEditors: ExtHostEditors = rpcProtocol.getRaw(ExtHostContext.ExtHostEditors);
 	const extHostDocuments: ExtHostDocuments = rpcProtocol.getRaw(ExtHostContext.ExtHostDocuments);
+	const extHostQuickOpen = rpcProtocol.set(ExtHostPositronContext.ExtHostQuickOpen, createExtHostQuickOpen(rpcProtocol, extHostWorkspace, extHostCommands));
 	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, extHostLogService));
 	const extHostAiFeatures = rpcProtocol.set(ExtHostPositronContext.ExtHostAiFeatures, new ExtHostAiFeatures(rpcProtocol, extHostCommands));
 	const extHostPreviewPanels = rpcProtocol.set(ExtHostPositronContext.ExtHostPreviewPanel, new ExtHostPreviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
@@ -74,7 +76,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 	const extHostConsoleService = rpcProtocol.set(ExtHostPositronContext.ExtHostConsoleService, new ExtHostConsoleService(rpcProtocol, extHostLogService));
 	const extHostMethods = rpcProtocol.set(ExtHostPositronContext.ExtHostMethods,
 		new ExtHostMethods(rpcProtocol, extHostEditors, extHostDocuments, extHostModalDialogs,
-			extHostLanguageRuntime, extHostWorkspace, extHostCommands, extHostContextKeyService));
+			extHostLanguageRuntime, extHostWorkspace, extHostQuickOpen, extHostCommands, extHostContextKeyService));
 	const extHostConnections = rpcProtocol.set(ExtHostPositronContext.ExtHostConnections, new ExtHostConnections(rpcProtocol));
 
 	return function (extension: IExtensionDescription, extensionInfo: IExtensionRegistries, configProvider: ExtHostConfigProvider): typeof positron {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -6,7 +6,7 @@
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeExit, RuntimeExitReason, LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { createProxyIdentifier, IRPCProtocol, SerializableObjectWithBuffers } from '../../../services/extensions/common/proxyIdentifier.js';
-import { MainContext, IWebviewPortMapping, WebviewExtensionDescription, IChatProgressDto } from '../extHost.protocol.js';
+import { MainContext, IWebviewPortMapping, WebviewExtensionDescription, IChatProgressDto, ExtHostQuickOpenShape } from '../extHost.protocol.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IEditorContext } from '../../../services/frontendMethods/common/editorContext.js';
 import { RuntimeClientType, LanguageRuntimeSessionChannel } from './extHostTypes.positron.js';
@@ -213,6 +213,7 @@ export const ExtHostPositronContext = {
 	ExtHostMethods: createProxyIdentifier<ExtHostMethodsShape>('ExtHostMethods'),
 	ExtHostConnections: createProxyIdentifier<ExtHostConnectionsShape>('ExtHostConnections'),
 	ExtHostAiFeatures: createProxyIdentifier<ExtHostAiFeaturesShape>('ExtHostAiFeatures'),
+	ExtHostQuickOpen: createProxyIdentifier<ExtHostQuickOpenShape>('ExtHostQuickOpen'),
 };
 
 export const MainPositronContext = {

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -266,6 +266,16 @@ export interface ShowDialogParams {
 }
 
 /**
+ * Parameters for the AskForPassword method.
+ */
+export interface AskForPasswordParams {
+	/**
+	 * The prompt, such as 'Please enter your password'
+	 */
+	prompt: string;
+}
+
+/**
  * Parameters for the PromptState method.
  */
 export interface PromptStateParams {
@@ -638,6 +648,19 @@ export interface ShowDialogRequest {
 }
 
 /**
+ * Request: Ask the user for a password
+ *
+ * Use this for an input box where the user can input a password
+ */
+export interface AskForPasswordRequest {
+	/**
+	 * The prompt, such as 'Please enter your password'
+	 */
+	prompt: string;
+
+}
+
+/**
  * Request: Sleep for n seconds
  *
  * Useful for testing in the backend a long running frontend method
@@ -759,6 +782,7 @@ export enum UiFrontendRequest {
 	NewDocument = 'new_document',
 	ShowQuestion = 'show_question',
 	ShowDialog = 'show_dialog',
+	AskForPassword = 'ask_for_password',
 	DebugSleep = 'debug_sleep',
 	ExecuteCommand = 'execute_command',
 	EvaluateWhenClause = 'evaluate_when_clause',


### PR DESCRIPTION
Addresses #2890

This PR uses the existing password obfuscation functionality in the "quick open" `showInput()` to prompt a user for a password:

![Screenshot 2025-03-16 at 4 20 51 PM](https://github.com/user-attachments/assets/81317281-41ab-4cd4-9c6e-626778d82362)

### TODO

- [x] Bump ark with https://github.com/posit-dev/ark/pull/747

### Release Notes

#### New Features

- Now support `rstudioapi::askForPassword()`

#### Bug Fixes

- N/A


### QA Notes

Once this is used together with https://github.com/posit-dev/ark/pull/747, you can bring up the prompt via `rstudioapi::askForPassword("Tell me your most important password OR ELSE")` or your prompt of choice.

- You can assign the output like `out <- rstudioapi::askForPassword()`
- If you type some text and then hit <kbd>Enter</kbd>, you will then have the string stored in R in `out`
- If you hit <kbd>Esc</kbd>, then input box will dismiss with no errors
