### PR TITLE
Allow users to specify a bootstrap extensions directory on server startup

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -968,7 +968,7 @@
         "filename": "src/vs/server/node/webClientServer.ts",
         "hashed_secret": "66e26ed510af41f1d322d1ebda4389302f4a03c7",
         "is_verified": false,
-        "line_number": 504,
+        "line_number": 505,
         "is_secret": false
       },
       {
@@ -976,7 +976,7 @@
         "filename": "src/vs/server/node/webClientServer.ts",
         "hashed_secret": "93f2efffc36c6e096cdb21d6aadb7087dc0d7478",
         "is_verified": false,
-        "line_number": 510,
+        "line_number": 511,
         "is_secret": false
       }
     ],
@@ -1975,5 +1975,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-17T13:57:33Z"
+  "generated_at": "2025-03-17T15:54:45Z"
 }

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -59,6 +59,9 @@ export interface NativeParsedArgs {
 	'extensions-dir'?: string;
 	'extensions-download-dir'?: string;
 	'builtin-extensions-dir'?: string;
+	// --- Start Positron ---
+	'bootstrap-extensions-dir'?: string;
+	// --- End Positron ---
 	extensionDevelopmentPath?: string[]; // undefined or array of 1 or more local paths or URIs
 	extensionTestsPath?: string; // either a local path or a URI
 	extensionDevelopmentKind?: string[];

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -140,6 +140,9 @@ export interface INativeEnvironmentService extends IEnvironmentService {
 	extensionsPath: string;
 	extensionsDownloadLocation: URI;
 	builtinExtensionsPath: string;
+	// --- Start Positron ---
+	bootstrapExtensionsPath?: string;
+	// --- End Positron ---
 
 	// --- use in-memory Secret Storage
 	useInMemorySecretStorage?: boolean;

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -184,6 +184,11 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 		return undefined;
 	}
 
+	// --- Start Positron ---
+	get bootstrapExtensionsPath(): string | undefined {
+		return this.args['bootstrap-extensions-dir'];
+	}
+	// --- End Positron ---
 	get disableExtensions(): boolean | string[] {
 		if (this.args['disable-extensions']) {
 			return true;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -95,6 +95,9 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
 	'extensions-download-dir': { type: 'string' },
 	'builtin-extensions-dir': { type: 'string' },
+	// --- Start Positron ---
+	'bootstrap-extensions-dir': { type: 'string' },
+	// --- End Positron ---
 	'list-extensions': { type: 'boolean', cat: 'e', description: localize('listExtensions', "List the installed extensions.") },
 	'show-versions': { type: 'boolean', cat: 'e', description: localize('showVersions', "Show versions of installed extensions, when using --list-extensions.") },
 	'category': { type: 'string', allowEmptyValue: true, cat: 'e', description: localize('category', "Filters installed extensions by provided category, when using --list-extensions."), args: 'category' },

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -57,6 +57,9 @@ const isSupportedForCmd = (optionId: keyof RemoteParsedArgs) => {
 		case 'enable-smoke-test-driver':
 		case 'extensions-download-dir':
 		case 'builtin-extensions-dir':
+		// --- Start Positron ---
+		case 'bootstrap-extensions-dir':
+		// --- End Positron ---
 		case 'telemetry':
 			return false;
 		default:

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -74,6 +74,7 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 	// --- Start Positron ---
 	// Allow disabling extensions in server mode.
 	'disable-extension': OPTIONS['disable-extension'],
+	'bootstrap-extensions-dir': { type: 'string', description: nls.localize('bootstrap-extensions-dir', "The directory to look for extensions to install on launch.") },
 	// --- End Positron ---
 
 	'show-versions': OPTIONS['show-versions'],
@@ -116,6 +117,9 @@ export interface ServerParsedArgs {
 	'disable-file-downloads'?: boolean;
 	'disable-file-uploads'?: boolean;
 	// --- End PWB ---
+	// --- Start Positron ---
+	'bootstrap-extensions-dir'?: string;
+	// --- End Positron ---
 
 	/* ----- server setup ----- */
 

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -443,6 +443,7 @@ export class WebClientServer {
 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
 			// --- Start Positron ---
 			disableExtension: this._environmentService.args['disable-extension'],
+			bootstrapExtensionsDir: this._environmentService.args['bootstrap-extensions-dir'],
 			// --- End Positron ---
 			productConfiguration,
 			callbackRoute: callbackRoute


### PR DESCRIPTION
Addresses #6304 


Allow users to specify an `--bootstrap-extensions-dir` on server startup and install all VSIX files from this folder on launch. Like bootstrap extensions, this will only happen after a version upgrade so that users ultimately control their own extensions.

This feature is primarily for Workbench so release notes will be documented as part of Workbench.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:web-only
