### PR TITLE
Fixes inability to restore duplicate console session

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -610,6 +610,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		runtimeMetadata: ILanguageRuntimeMetadata,
 		sessionMetadata: IRuntimeSessionMetadata,
 		activate: boolean): Promise<void> {
+		const multisessionEnabled = multipleConsoleSessionsFeatureEnabled(this._configurationService);
 
 		// See if we are already starting the requested session. If we
 		// are, return the promise that resolves when the session is ready to
@@ -617,9 +618,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// session to be coalesced.
 		const sessionMapKey = getSessionMapKey(
 			sessionMetadata.sessionMode, runtimeMetadata.runtimeId, sessionMetadata.notebookUri);
-		const startingRuntimePromise = this._startingSessionsBySessionMapKey.get(sessionMapKey);
-		if (startingRuntimePromise && !startingRuntimePromise.isSettled) {
-			return startingRuntimePromise.p.then(() => { });
+		if (!multisessionEnabled) {
+			const startingRuntimePromise = this._startingSessionsBySessionMapKey.get(sessionMapKey);
+			if (startingRuntimePromise && !startingRuntimePromise.isSettled) {
+				return startingRuntimePromise.p.then(() => { });
+			}
 		}
 
 		// Ensure that the runtime is registered.
@@ -637,17 +640,18 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			return;
 		}
 
-		// Create a promise that resolves when the runtime is ready to use.
 		const startPromise = new DeferredPromise<string>();
-		this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
+		if (!multisessionEnabled) {
+			// Create a promise that resolves when the runtime is ready to use.
+			this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
-		// It's possible that startPromise is never awaited, so we log any errors here
-		// at the debug level since we still expect the error to be handled/logged elsewhere.
-		startPromise.p.catch((err) => this._logService.debug(`Error starting session: ${err}`));
+			// It's possible that startPromise is never awaited, so we log any errors here
+			// at the debug level since we still expect the error to be handled/logged elsewhere.
+			startPromise.p.catch((err) => this._logService.debug(`Error starting session: ${err}`));
 
-		this.setStartingSessionMaps(
-			sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
-
+			this.setStartingSessionMaps(
+				sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
+		}
 		// We should already have a session manager registered, since we can't
 		// get here until the extension host has been activated.
 		if (this._sessionManagers.length === 0) {
@@ -660,8 +664,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			sessionManager = await this.getManagerForRuntime(runtimeMetadata);
 		} catch (err) {
 			startPromise.error(err);
-			this.clearStartingSessionMaps(
-				sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
+			if (!multisessionEnabled) {
+				this.clearStartingSessionMaps(
+					sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
+			}
 			throw err;
 		}
 
@@ -676,8 +682,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				`Reconnecting to session '${sessionMetadata.sessionId}' for language runtime ` +
 				`${formatLanguageRuntimeMetadata(runtimeMetadata)} failed. Reason: ${err}`);
 			startPromise.error(err);
-			this.clearStartingSessionMaps(
-				sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
+			if (!multisessionEnabled) {
+				this.clearStartingSessionMaps(
+					sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
+			}
 			throw err;
 		}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -618,7 +618,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// session to be coalesced.
 		const sessionMapKey = getSessionMapKey(
 			sessionMetadata.sessionMode, runtimeMetadata.runtimeId, sessionMetadata.notebookUri);
-		if (!multisessionEnabled) {
+		if (!multisessionEnabled || sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
 			const startingRuntimePromise = this._startingSessionsBySessionMapKey.get(sessionMapKey);
 			if (startingRuntimePromise && !startingRuntimePromise.isSettled) {
 				return startingRuntimePromise.p.then(() => { });
@@ -641,7 +641,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		}
 
 		const startPromise = new DeferredPromise<string>();
-		if (!multisessionEnabled) {
+		if (!multisessionEnabled || sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
 			// Create a promise that resolves when the runtime is ready to use.
 			this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
@@ -664,7 +664,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			sessionManager = await this.getManagerForRuntime(runtimeMetadata);
 		} catch (err) {
 			startPromise.error(err);
-			if (!multisessionEnabled) {
+			if (!multisessionEnabled || sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
 				this.clearStartingSessionMaps(
 					sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
 			}
@@ -682,7 +682,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				`Reconnecting to session '${sessionMetadata.sessionId}' for language runtime ` +
 				`${formatLanguageRuntimeMetadata(runtimeMetadata)} failed. Reason: ${err}`);
 			startPromise.error(err);
-			if (!multisessionEnabled) {
+			if (!multisessionEnabled || sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
 				this.clearStartingSessionMaps(
 					sessionMetadata.sessionMode, runtimeMetadata, sessionMetadata.notebookUri);
 			}


### PR DESCRIPTION
Restoring console sessions now are tracked separately from starting console sessions. These are keyed on Session ID to allow the restoration of multiple sessions of the same runtime.

Addresses #6725 

https://github.com/user-attachments/assets/aacef758-d49c-4d0c-934c-42c525c448f3


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- All console sessions restored after 

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:console @:sessions