### PR TITLE
don't show modal when no R installations installed

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -55,19 +55,10 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	// Discover R binaries on the system
 	const { binaries, currentBinary } = await getBinaries();
 
-	// If no R binaries are found, notify the user and end discovery.
+	// If no R binaries are found, log to output and end discovery.
 	if (binaries.length === 0) {
-		LOGGER.warn('Positron could not find any R installations. Please review any custom settings.');
+		LOGGER.warn('Positron could not find any R installations. Please verify that you have R installed and review any custom settings.');
 		printInterpreterSettingsInfo();
-		const showLog = await positron.window.showSimpleModalDialogPrompt(
-			vscode.l10n.t('No R installations discovered'),
-			vscode.l10n.t('Positron could not find any R installations. Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations">https://positron.posit.co/r-installations</a>'),
-			vscode.l10n.t('View logs'),
-			vscode.l10n.t('Dismiss')
-		);
-		if (showLog) {
-			LOGGER.show();
-		}
 		return;
 	}
 


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/6829

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### Bug Fixes

- A modal no longer shows when Positron is opened without R installed (#6829)


### QA Notes

Python-only users shouldn't be aggressively notified via modal when R isn't installed. We just log to the R Language Pack output.
