### PR TITLE
Data Explorer: Add basic tooltips to sparkline column summary plots

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -587,6 +587,7 @@
 		"--vscode-positronDataExplorer-invalidFilterBackground",
 		"--vscode-positronDataExplorer-sparklineAxis",
 		"--vscode-positronDataExplorer-sparklineFill",
+		"--vscode-positronDataExplorer-sparklineHover",
 		"--vscode-positronDataExplorer-sparklineStroke",
 		"--vscode-positronDataExplorer-statusIndicatorComputing",
 		"--vscode-positronDataExplorer-statusIndicatorDisconnected",

--- a/src/vs/platform/positronActionBar/browser/positronActionBarHoverManager.ts
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarHoverManager.ts
@@ -164,6 +164,13 @@ export class PositronActionBarHoverManager extends Disposable implements IHoverM
 	}
 
 	/**
+	 * Set the hover delay to the specified value.
+	 */
+	public setHoverDelay(hoverDelay: number): void {
+		this._hoverDelay = hoverDelay;
+	}
+
+	/**
 	 * Hides the hover.
 	 */
 	public hideHover(): void {

--- a/src/vs/platform/positronActionBar/browser/positronActionBarHoverManager.ts
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarHoverManager.ts
@@ -27,6 +27,11 @@ export class PositronActionBarHoverManager extends Disposable implements IHoverM
 	private _hoverDelay: number;
 
 	/**
+	 * A custom hover delay to override the one from the configuration service.
+	 */
+	private _customHoverDelay: number | undefined;
+
+	/**
 	 * Gets or sets the hover leave time.
 	 */
 	private _hoverLeaveTime: number = 0;
@@ -70,7 +75,7 @@ export class PositronActionBarHoverManager extends Disposable implements IHoverM
 		// Initialize and track changes to the hover delay configuration.
 		this._hoverDelay = this._configurationService.getValue<number>('workbench.hover.delay');
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('workbench.hover.delay')) {
+			if (e.affectsConfiguration('workbench.hover.delay') && !this._customHoverDelay) {
 				this._hoverDelay = this._configurationService.getValue<number>('workbench.hover.delay');
 			}
 		}));
@@ -166,7 +171,8 @@ export class PositronActionBarHoverManager extends Disposable implements IHoverM
 	/**
 	 * Set the hover delay to the specified value.
 	 */
-	public setHoverDelay(hoverDelay: number): void {
+	public setCustomHoverDelay(hoverDelay: number): void {
+		this._customHoverDelay = hoverDelay;
 		this._hoverDelay = hoverDelay;
 	}
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1937,6 +1937,14 @@ export const POSITRON_DATA_EXPLORER_SPARKLINE_FILL_COLOR = registerColor('positr
 	hcLight: '#56a2dd',
 }, localize('positronDataExplorer.sparklineFill', "Positron data explorer sparkline fill color."));
 
+// Positron data explorer sparkline hover color.
+export const POSITRON_DATA_EXPLORER_SPARKLINE_HOVER_COLOR = registerColor('positronDataExplorer.sparklineHover', {
+	dark: '#ff8c69',
+	light: '#ff8c69',
+	hcDark: '#ff8c69',
+	hcLight: '#ff8c69',
+}, localize('positronDataExplorer.sparklineHover', "Positron data explorer sparkline hover color."));
+
 // Positron data explorer sparkline stroke color.
 export const POSITRON_DATA_EXPLORER_SPARKLINE_STROKE_COLOR = registerColor('positronDataExplorer.sparklineStroke', {
 	dark: '#0066b6',

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
@@ -15,6 +15,7 @@ import { positronFalse, positronMissing, positronTrue } from '../../common/const
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 /**
  * Constants.
@@ -27,6 +28,7 @@ export const COLUMN_PROFILE_BOOLEAN_LINE_COUNT = 3;
 interface ColumnProfileBooleanProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
+	hoverService?: IHoverService;
 }
 
 /**
@@ -41,7 +43,10 @@ export const ColumnProfileBoolean = (props: ColumnProfileBooleanProps) => {
 	return (
 		<div className='column-profile-info'>
 			{columnFrequencyTable &&
-				<ColumnProfileSparklineFrequencyTable columnFrequencyTable={columnFrequencyTable} />
+				<ColumnProfileSparklineFrequencyTable
+					columnFrequencyTable={columnFrequencyTable}
+					hoverService={props.hoverService}
+				/>
 			}
 			<div className='tabular-info'>
 				<div className='labels'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
@@ -15,7 +15,7 @@ import { positronFalse, positronMissing, positronTrue } from '../../common/const
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +28,7 @@ export const COLUMN_PROFILE_BOOLEAN_LINE_COUNT = 3;
 interface ColumnProfileBooleanProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +45,7 @@ export const ColumnProfileBoolean = (props: ColumnProfileBooleanProps) => {
 			{columnFrequencyTable &&
 				<ColumnProfileSparklineFrequencyTable
 					columnFrequencyTable={columnFrequencyTable}
-					hoverService={props.hoverService}
+					hoverManager={props.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileBoolean.tsx
@@ -15,7 +15,6 @@ import { positronFalse, positronMissing, positronTrue } from '../../common/const
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
-import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +27,6 @@ export const COLUMN_PROFILE_BOOLEAN_LINE_COUNT = 3;
 interface ColumnProfileBooleanProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +43,7 @@ export const ColumnProfileBoolean = (props: ColumnProfileBooleanProps) => {
 			{columnFrequencyTable &&
 				<ColumnProfileSparklineFrequencyTable
 					columnFrequencyTable={columnFrequencyTable}
-					hoverManager={props.hoverManager}
+					hoverManager={props.instance.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
@@ -15,7 +15,7 @@ import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineHistogram } from './columnProfileSparklines.js';
 import { positronMax, positronMean, positronMedian, positronMin, positronMissing, positronSD } from '../../common/constants.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +28,7 @@ export const COLUMN_PROFILE_NUMBER_LINE_COUNT = 6;
 interface ColumnProfileNumberProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +45,7 @@ export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
 			{columnHistogram &&
 				<ColumnProfileSparklineHistogram
 					columnHistogram={columnHistogram}
-					hoverService={props.hoverService}
+					hoverManager={props.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
@@ -15,6 +15,7 @@ import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineHistogram } from './columnProfileSparklines.js';
 import { positronMax, positronMean, positronMedian, positronMin, positronMissing, positronSD } from '../../common/constants.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 /**
  * Constants.
@@ -27,6 +28,7 @@ export const COLUMN_PROFILE_NUMBER_LINE_COUNT = 6;
 interface ColumnProfileNumberProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
+	hoverService?: IHoverService;
 }
 
 /**
@@ -41,7 +43,10 @@ export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
 	return (
 		<div className='column-profile-info'>
 			{columnHistogram &&
-				<ColumnProfileSparklineHistogram columnHistogram={columnHistogram} />
+				<ColumnProfileSparklineHistogram
+					columnHistogram={columnHistogram}
+					hoverService={props.hoverService}
+				/>
 			}
 			<div className='tabular-info'>
 				<div className='labels'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
@@ -15,7 +15,6 @@ import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineHistogram } from './columnProfileSparklines.js';
 import { positronMax, positronMean, positronMedian, positronMin, positronMissing, positronSD } from '../../common/constants.js';
-import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +27,6 @@ export const COLUMN_PROFILE_NUMBER_LINE_COUNT = 6;
 interface ColumnProfileNumberProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +43,7 @@ export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
 			{columnHistogram &&
 				<ColumnProfileSparklineHistogram
 					columnHistogram={columnHistogram}
-					hoverManager={props.hoverManager}
+					hoverManager={props.instance.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { VectorHistogram } from './vectorHistogram.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
 import { ColumnFrequencyTable, ColumnHistogram } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -27,7 +27,7 @@ const X_AXIS_HEIGHT = 0.5;
  */
 interface ColumnProfileSparklineHistogramProps {
 	readonly columnHistogram: ColumnHistogram;
-	readonly hoverService?: IHoverService;
+	readonly hoverManager: IHoverManager;
 }
 
 /**
@@ -37,7 +37,7 @@ interface ColumnProfileSparklineHistogramProps {
  */
 export const ColumnProfileSparklineHistogram = ({
 	columnHistogram,
-	hoverService
+	hoverManager
 }: ColumnProfileSparklineHistogramProps) => {
 	// Render.
 	return (
@@ -52,7 +52,7 @@ export const ColumnProfileSparklineHistogram = ({
 				columnHistogram={columnHistogram}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
-				hoverService={hoverService}
+				hoverManager={hoverManager}
 				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >
@@ -64,7 +64,7 @@ export const ColumnProfileSparklineHistogram = ({
  */
 interface ColumnProfileSparklineFrequencyTableProps {
 	readonly columnFrequencyTable: ColumnFrequencyTable;
-	readonly hoverService?: IHoverService;
+	readonly hoverManager: IHoverManager;
 }
 
 /**
@@ -74,7 +74,7 @@ interface ColumnProfileSparklineFrequencyTableProps {
  */
 export const ColumnProfileSparklineFrequencyTable = ({
 	columnFrequencyTable,
-	hoverService
+	hoverManager
 }: ColumnProfileSparklineFrequencyTableProps) => {
 	// Render.
 	return (
@@ -89,7 +89,7 @@ export const ColumnProfileSparklineFrequencyTable = ({
 				columnFrequencyTable={columnFrequencyTable}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
-				hoverService={hoverService}
+				hoverManager={hoverManager}
 				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { VectorHistogram } from './vectorHistogram.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
 import { ColumnFrequencyTable, ColumnHistogram } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 /**
  * Constants.
@@ -26,6 +27,7 @@ const X_AXIS_HEIGHT = 0.5;
  */
 interface ColumnProfileSparklineHistogramProps {
 	readonly columnHistogram: ColumnHistogram;
+	readonly hoverService?: IHoverService;
 }
 
 /**
@@ -34,7 +36,8 @@ interface ColumnProfileSparklineHistogramProps {
  * @returns The rendered component.
  */
 export const ColumnProfileSparklineHistogram = ({
-	columnHistogram
+	columnHistogram,
+	hoverService
 }: ColumnProfileSparklineHistogramProps) => {
 	// Render.
 	return (
@@ -49,6 +52,7 @@ export const ColumnProfileSparklineHistogram = ({
 				columnHistogram={columnHistogram}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
+				hoverService={hoverService}
 				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >
@@ -60,6 +64,7 @@ export const ColumnProfileSparklineHistogram = ({
  */
 interface ColumnProfileSparklineFrequencyTableProps {
 	readonly columnFrequencyTable: ColumnFrequencyTable;
+	readonly hoverService?: IHoverService;
 }
 
 /**
@@ -68,7 +73,8 @@ interface ColumnProfileSparklineFrequencyTableProps {
  * @returns The rendered component.
  */
 export const ColumnProfileSparklineFrequencyTable = ({
-	columnFrequencyTable
+	columnFrequencyTable,
+	hoverService
 }: ColumnProfileSparklineFrequencyTableProps) => {
 	// Render.
 	return (
@@ -83,6 +89,7 @@ export const ColumnProfileSparklineFrequencyTable = ({
 				columnFrequencyTable={columnFrequencyTable}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
+				hoverService={hoverService}
 				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
@@ -15,7 +15,7 @@ import { positronEmpty, positronMissing, positronUnique } from '../../common/con
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +28,7 @@ export const COLUMN_PROFILE_STRING_LINE_COUNT = 3;
 interface ColumnProfileStringProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +45,7 @@ export const ColumnProfileString = (props: ColumnProfileStringProps) => {
 			{columnFrequencyTable &&
 				<ColumnProfileSparklineFrequencyTable
 					columnFrequencyTable={columnFrequencyTable}
-					hoverService={props.hoverService}
+					hoverManager={props.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
@@ -15,7 +15,6 @@ import { positronEmpty, positronMissing, positronUnique } from '../../common/con
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
-import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -28,7 +27,6 @@ export const COLUMN_PROFILE_STRING_LINE_COUNT = 3;
 interface ColumnProfileStringProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
-	hoverManager: IHoverManager;
 }
 
 /**
@@ -45,7 +43,7 @@ export const ColumnProfileString = (props: ColumnProfileStringProps) => {
 			{columnFrequencyTable &&
 				<ColumnProfileSparklineFrequencyTable
 					columnFrequencyTable={columnFrequencyTable}
-					hoverManager={props.hoverManager}
+					hoverManager={props.instance.hoverManager}
 				/>
 			}
 			<div className='tabular-info'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileString.tsx
@@ -15,6 +15,7 @@ import { positronEmpty, positronMissing, positronUnique } from '../../common/con
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineFrequencyTable } from './columnProfileSparklines.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 /**
  * Constants.
@@ -27,6 +28,7 @@ export const COLUMN_PROFILE_STRING_LINE_COUNT = 3;
 interface ColumnProfileStringProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
+	hoverService?: IHoverService;
 }
 
 /**
@@ -41,7 +43,10 @@ export const ColumnProfileString = (props: ColumnProfileStringProps) => {
 	return (
 		<div className='column-profile-info'>
 			{columnFrequencyTable &&
-				<ColumnProfileSparklineFrequencyTable columnFrequencyTable={columnFrequencyTable} />
+				<ColumnProfileSparklineFrequencyTable
+					columnFrequencyTable={columnFrequencyTable}
+					hoverService={props.hoverService}
+				/>
 			}
 			<div className='tabular-info'>
 				<div className='labels'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -108,6 +108,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnHistogram={columnHistogram}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
+							hoverService={props.hoverService}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -136,6 +137,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnFrequencyTable={columnFrequencyTable}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
+							hoverService={props.hoverService}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -245,15 +247,15 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		switch (props.columnSchema.type_display) {
 			// Number.
 			case ColumnDisplayType.Number:
-				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
+				return <ColumnProfileNumber columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
 
 			// Boolean.
 			case ColumnDisplayType.Boolean:
-				return <ColumnProfileBoolean columnIndex={props.columnIndex} instance={props.instance} />;
+				return <ColumnProfileBoolean columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
 
 			// String.
 			case ColumnDisplayType.String:
-				return <ColumnProfileString columnIndex={props.columnIndex} instance={props.instance} />;
+				return <ColumnProfileString columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
 
 			// Date.
 			case ColumnDisplayType.Date:

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -10,8 +10,6 @@ import './columnSummaryCell.css';
 import React, { useRef } from 'react';
 
 // Other dependencies.
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { usePositronDataGridContext } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
 import { VectorHistogram } from './vectorHistogram.js';
@@ -26,6 +24,7 @@ import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../common/positronDataExplorerExperimentalConfig.js';
 import { renderLeadingTrailingWhitespace } from './tableDataCell.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -38,7 +37,7 @@ const SPARKLINE_X_AXIS_HEIGHT = 0.5;
  * ColumnSummaryCellProps interface.
  */
 interface ColumnSummaryCellProps {
-	hoverService: IHoverService;
+	hoverManager: IHoverManager;
 	instance: TableSummaryDataGridInstance;
 	columnSchema: ColumnSchema;
 	columnIndex: number;
@@ -108,7 +107,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnHistogram={columnHistogram}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
-							hoverService={props.hoverService}
+							hoverManager={props.hoverManager}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -137,7 +136,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnFrequencyTable={columnFrequencyTable}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
-							hoverService={props.hoverService}
+							hoverManager={props.hoverManager}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -247,15 +246,15 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		switch (props.columnSchema.type_display) {
 			// Number.
 			case ColumnDisplayType.Number:
-				return <ColumnProfileNumber columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
+				return <ColumnProfileNumber columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
 
 			// Boolean.
 			case ColumnDisplayType.Boolean:
-				return <ColumnProfileBoolean columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
+				return <ColumnProfileBoolean columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
 
 			// String.
 			case ColumnDisplayType.String:
-				return <ColumnProfileString columnIndex={props.columnIndex} hoverService={props.hoverService} instance={props.instance} />;
+				return <ColumnProfileString columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
 
 			// Date.
 			case ColumnDisplayType.Date:
@@ -409,22 +408,9 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div
 					ref={dataTypeRef}
 					className={`data-type-icon codicon ${dataTypeIcon}`}
-					onMouseLeave={() => props.hoverService.hideHover()}
+					onMouseLeave={() => props.hoverManager.hideHover()}
 					onMouseOver={() =>
-						props.hoverService.showHover({
-							content: `${props.columnSchema.type_name}`,
-							target: dataTypeRef.current,
-							position: {
-								hoverPosition: HoverPosition.ABOVE,
-							},
-							persistence: {
-								hideOnHover: false
-							},
-							appearance: {
-								showHoverHint: true,
-								showPointer: true
-							}
-						}, false)
+						props.hoverManager.showHover(dataTypeRef.current, `${props.columnSchema.type_name}`)
 					}
 				/>
 				<div className='column-name'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -24,7 +24,6 @@ import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../common/positronDataExplorerExperimentalConfig.js';
 import { renderLeadingTrailingWhitespace } from './tableDataCell.js';
-import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Constants.
@@ -37,7 +36,6 @@ const SPARKLINE_X_AXIS_HEIGHT = 0.5;
  * ColumnSummaryCellProps interface.
  */
 interface ColumnSummaryCellProps {
-	hoverManager: IHoverManager;
 	instance: TableSummaryDataGridInstance;
 	columnSchema: ColumnSchema;
 	columnIndex: number;
@@ -107,7 +105,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnHistogram={columnHistogram}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
-							hoverManager={props.hoverManager}
+							hoverManager={props.instance.hoverManager}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -136,7 +134,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							columnFrequencyTable={columnFrequencyTable}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
-							hoverManager={props.hoverManager}
+							hoverManager={props.instance.hoverManager}
 							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
@@ -246,15 +244,15 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		switch (props.columnSchema.type_display) {
 			// Number.
 			case ColumnDisplayType.Number:
-				return <ColumnProfileNumber columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
+				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Boolean.
 			case ColumnDisplayType.Boolean:
-				return <ColumnProfileBoolean columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
+				return <ColumnProfileBoolean columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// String.
 			case ColumnDisplayType.String:
-				return <ColumnProfileString columnIndex={props.columnIndex} hoverManager={props.hoverManager} instance={props.instance} />;
+				return <ColumnProfileString columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Date.
 			case ColumnDisplayType.Date:
@@ -408,9 +406,12 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div
 					ref={dataTypeRef}
 					className={`data-type-icon codicon ${dataTypeIcon}`}
-					onMouseLeave={() => props.hoverManager.hideHover()}
+					onMouseLeave={() => props.instance.hoverManager.hideHover()}
 					onMouseOver={() =>
-						props.hoverManager.showHover(dataTypeRef.current, `${props.columnSchema.type_name}`)
+						props.instance.hoverManager.showHover(
+							dataTypeRef.current,
+							`${props.columnSchema.type_name}`
+						)
 					}
 				/>
 				<div className='column-name'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.css
@@ -11,6 +11,19 @@
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
 }
 
+.vector-frequency-table .count-hover {
+	fill: var(--vscode-positronDataExplorer-sparklineHover);
+}
+
 .vector-frequency-table .count.other {
 	opacity: 0.65;
+}
+
+/* Tooltip styles */
+.tooltip-container div {
+	background-color: transparent !important;
+	cursor: default;
+	pointer-events: all;
+	position: relative;
+	z-index: 100;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
@@ -7,10 +7,12 @@
 import './vectorFrequencyTable.css';
 
 // React.
-import React, { useState } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 
 // Other dependencies.
 import { ColumnFrequencyTable } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 
 /**
  * VectorFrequencyTableProps interface.
@@ -20,7 +22,182 @@ interface VectorFrequencyTableProps {
 	readonly graphHeight: number;
 	readonly xAxisHeight: number;
 	readonly columnFrequencyTable: ColumnFrequencyTable;
+	readonly hoverService?: IHoverService;
 }
+
+/**
+ * FrequencyCount component to render a single bar with tooltip
+ */
+const FrequencyCount = React.memo(({
+	count,
+	countIndex,
+	value,
+	countWidth,
+	countHeight,
+	graphHeight,
+	xAxisHeight,
+	countPercent,
+	xPosition,
+	hoverService
+}: {
+	count: number;
+	countIndex: number;
+	value: string | number;
+	countWidth: number;
+	countHeight: number;
+	graphHeight: number;
+	xAxisHeight: number;
+	countPercent: string;
+	xPosition: number;
+	hoverService?: IHoverService;
+}) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isHovered, setIsHovered] = useState(false);
+
+	// Format numeric values with 4 significant digits if they're numbers
+	const formatValue = (val: string | number): string | number => {
+		if (typeof val === 'number') {
+			return val.toPrecision(4);
+		}
+		const num = parseFloat(String(val));
+		return !isNaN(num) ? num.toPrecision(4) : val;
+	};
+
+	const formattedValue = formatValue(value);
+
+	return (
+		<foreignObject
+			key={`count-${countIndex}`}
+			className='tooltip-container'
+			height={graphHeight}
+			width={countWidth}
+			x={xPosition}
+			y={0}
+		>
+			<div
+				ref={containerRef}
+				style={{
+					height: '100%',
+					width: '100%',
+					position: 'relative',
+				}}
+				onMouseLeave={() => {
+					hoverService?.hideHover();
+					setIsHovered(false);
+				}}
+				onMouseOver={() => {
+					setIsHovered(true);
+					if (hoverService && containerRef.current) {
+						hoverService.showHover({
+							content: `Value: ${formattedValue}\nCount: ${count} (${countPercent}%)`,
+							target: containerRef.current,
+							position: {
+								hoverPosition: HoverPosition.ABOVE,
+							},
+							persistence: {
+								hideOnHover: false
+							},
+							appearance: {
+								showHoverHint: false,
+								showPointer: false
+							}
+						}, false);
+					}
+				}}
+			>
+				<svg height='100%' width='100%'>
+					<rect
+						className={isHovered ? 'count-hover' : 'count'}
+						height={countHeight}
+						width='100%'
+						x={0}
+						y={graphHeight - xAxisHeight - countHeight}
+					/>
+				</svg>
+			</div>
+		</foreignObject>
+	);
+});
+
+/**
+ * OtherCount component to render the "other" bar with tooltip
+ */
+const OtherCount = React.memo(({
+	otherCount,
+	maxCount,
+	totalCount,
+	graphHeight,
+	graphWidth,
+	xAxisHeight,
+	xPosition,
+	hoverService
+}: {
+	otherCount: number;
+	maxCount: number;
+	totalCount: number;
+	graphHeight: number;
+	graphWidth: number;
+	xAxisHeight: number;
+	xPosition: number;
+	hoverService?: IHoverService;
+}) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isHovered, setIsHovered] = useState(false);
+	const countHeight = (otherCount / maxCount) * graphHeight;
+	const otherCountPercent = totalCount > 0 ? ((otherCount / totalCount) * 100).toFixed(1) : '0.0';
+
+	return (
+		<foreignObject
+			className='tooltip-container'
+			height={graphHeight}
+			width={graphWidth - xPosition}
+			x={xPosition}
+			y={0}
+		>
+			<div
+				ref={containerRef}
+				style={{
+					height: '100%',
+					width: '100%',
+					position: 'relative',
+				}}
+				onMouseLeave={() => {
+					hoverService?.hideHover();
+					setIsHovered(false);
+				}}
+				onMouseOver={() => {
+					setIsHovered(true);
+					if (hoverService && containerRef.current) {
+						hoverService.showHover({
+							content: `Other values\nCount: ${otherCount} (${otherCountPercent}%)`,
+							target: containerRef.current,
+							position: {
+								hoverPosition: HoverPosition.ABOVE,
+							},
+							persistence: {
+								hideOnHover: false
+							},
+							appearance: {
+								showHoverHint: false,
+								showPointer: false
+							}
+						}, false);
+					}
+				}}
+			>
+				<svg height='100%' width='100%'>
+					<rect
+						className={isHovered ? 'count-hover other' : 'count other'}
+						height={countHeight}
+						width='100%'
+						x={0}
+						y={graphHeight - xAxisHeight - countHeight}
+					/>
+				</svg>
+			</div>
+		</foreignObject>
+	);
+});
 
 /**
  * VectorFrequencyTable component.
@@ -64,32 +241,24 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 		return maxCount;
 	});
 
-	/**
-	 * OtherCount component.
-	 * @param x The X offset.
-	 * @returns The rendered component.
-	 */
-	const OtherCount = ({ x }: { x: number }) => {
-		// Safety check.
-		if (!props.columnFrequencyTable.other_count) {
-			return null;
-		}
+	// Calculate total count for percentages
+	const totalCount = useMemo(() => {
+		return props.columnFrequencyTable.counts.reduce((sum, count) => sum + count, 0) +
+			(props.columnFrequencyTable.other_count || 0);
+	}, [props.columnFrequencyTable.counts, props.columnFrequencyTable.other_count]);
 
-		// Render.
-		const countHeight = (props.columnFrequencyTable.other_count / maxCount) * props.graphHeight;
-		return (
-			<rect
-				className='count other'
-				height={countHeight}
-				width={props.graphWidth - x}
-				x={x}
-				y={props.graphHeight - props.xAxisHeight - countHeight}
-			/>
-		);
-	};
+	// Calculate the positions of each frequency bar
+	const positions = useMemo(() => {
+		const posArray: number[] = [];
+		let x = 0;
+		for (let i = 0; i < props.columnFrequencyTable.counts.length; i++) {
+			posArray.push(x);
+			x += countWidth + 1;
+		}
+		return posArray;
+	}, [props.columnFrequencyTable.counts.length, countWidth]);
 
 	// Render.
-	let x = 0;
 	return (
 		<svg
 			className='vector-frequency-table'
@@ -105,22 +274,37 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 				/>
 				{props.columnFrequencyTable.counts.map((count, countIndex) => {
 					const countHeight = Math.max(1, (count / maxCount) * props.graphHeight);
-					try {
-						return (
-							<rect
-								key={`count-${countIndex}`}
-								className='count'
-								height={countHeight}
-								width={countWidth}
-								x={x}
-								y={props.graphHeight - props.xAxisHeight - countHeight}
-							/>
-						);
-					} finally {
-						x += countWidth + 1;
-					}
+					const value = props.columnFrequencyTable.values[countIndex];
+					const countPercent = totalCount > 0 ? ((count / totalCount) * 100).toFixed(1) : '0.0';
+
+					return (
+						<FrequencyCount
+							key={`frequency-count-${countIndex}`}
+							count={count}
+							countHeight={countHeight}
+							countIndex={countIndex}
+							countPercent={countPercent}
+							countWidth={countWidth}
+							graphHeight={props.graphHeight}
+							hoverService={props.hoverService}
+							value={value}
+							xAxisHeight={props.xAxisHeight}
+							xPosition={positions[countIndex]}
+						/>
+					);
 				})}
-				{props.columnFrequencyTable.other_count && <OtherCount x={x} />}
+				{props.columnFrequencyTable.other_count && (
+					<OtherCount
+						graphHeight={props.graphHeight}
+						graphWidth={props.graphWidth}
+						hoverService={props.hoverService}
+						maxCount={maxCount}
+						otherCount={props.columnFrequencyTable.other_count}
+						totalCount={totalCount}
+						xAxisHeight={props.xAxisHeight}
+						xPosition={positions[positions.length - 1] + countWidth + 1}
+					/>
+				)}
 			</g>
 		</svg>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
@@ -11,8 +11,7 @@ import React, { useState, useRef, useMemo } from 'react';
 
 // Other dependencies.
 import { ColumnFrequencyTable } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * VectorFrequencyTableProps interface.
@@ -22,7 +21,7 @@ interface VectorFrequencyTableProps {
 	readonly graphHeight: number;
 	readonly xAxisHeight: number;
 	readonly columnFrequencyTable: ColumnFrequencyTable;
-	readonly hoverService?: IHoverService;
+	readonly hoverManager: IHoverManager;
 }
 
 /**
@@ -38,7 +37,7 @@ const FrequencyCount = React.memo(({
 	xAxisHeight,
 	countPercent,
 	xPosition,
-	hoverService
+	hoverManager
 }: {
 	count: number;
 	countIndex: number;
@@ -49,7 +48,7 @@ const FrequencyCount = React.memo(({
 	xAxisHeight: number;
 	countPercent: string;
 	xPosition: number;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isHovered, setIsHovered] = useState(false);
@@ -82,26 +81,16 @@ const FrequencyCount = React.memo(({
 					position: 'relative',
 				}}
 				onMouseLeave={() => {
-					hoverService?.hideHover();
+					hoverManager?.hideHover();
 					setIsHovered(false);
 				}}
 				onMouseOver={() => {
 					setIsHovered(true);
-					if (hoverService && containerRef.current) {
-						hoverService.showHover({
-							content: `Value: ${formattedValue}\nCount: ${count} (${countPercent}%)`,
-							target: containerRef.current,
-							position: {
-								hoverPosition: HoverPosition.ABOVE,
-							},
-							persistence: {
-								hideOnHover: false
-							},
-							appearance: {
-								showHoverHint: false,
-								showPointer: false
-							}
-						}, false);
+					if (containerRef.current) {
+						hoverManager.showHover(
+							containerRef.current,
+							`Value: ${formattedValue}\nCount: ${count} (${countPercent}%)`
+						);
 					}
 				}}
 			>
@@ -115,7 +104,7 @@ const FrequencyCount = React.memo(({
 					/>
 				</svg>
 			</div>
-		</foreignObject>
+		</foreignObject >
 	);
 });
 
@@ -130,7 +119,7 @@ const OtherCount = React.memo(({
 	graphWidth,
 	xAxisHeight,
 	xPosition,
-	hoverService
+	hoverManager
 }: {
 	otherCount: number;
 	maxCount: number;
@@ -139,7 +128,7 @@ const OtherCount = React.memo(({
 	graphWidth: number;
 	xAxisHeight: number;
 	xPosition: number;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isHovered, setIsHovered] = useState(false);
@@ -162,26 +151,13 @@ const OtherCount = React.memo(({
 					position: 'relative',
 				}}
 				onMouseLeave={() => {
-					hoverService?.hideHover();
+					hoverManager.hideHover();
 					setIsHovered(false);
 				}}
 				onMouseOver={() => {
 					setIsHovered(true);
-					if (hoverService && containerRef.current) {
-						hoverService.showHover({
-							content: `Other values\nCount: ${otherCount} (${otherCountPercent}%)`,
-							target: containerRef.current,
-							position: {
-								hoverPosition: HoverPosition.ABOVE,
-							},
-							persistence: {
-								hideOnHover: false
-							},
-							appearance: {
-								showHoverHint: false,
-								showPointer: false
-							}
-						}, false);
+					if (containerRef.current) {
+						hoverManager.showHover(containerRef.current, `Other values\nCount: ${otherCount} (${otherCountPercent}%)`);
 					}
 				}}
 			>
@@ -195,7 +171,7 @@ const OtherCount = React.memo(({
 					/>
 				</svg>
 			</div>
-		</foreignObject>
+		</foreignObject >
 	);
 });
 
@@ -286,7 +262,7 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 							countPercent={countPercent}
 							countWidth={countWidth}
 							graphHeight={props.graphHeight}
-							hoverService={props.hoverService}
+							hoverManager={props.hoverManager}
 							value={value}
 							xAxisHeight={props.xAxisHeight}
 							xPosition={positions[countIndex]}
@@ -297,7 +273,7 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 					<OtherCount
 						graphHeight={props.graphHeight}
 						graphWidth={props.graphWidth}
-						hoverService={props.hoverService}
+						hoverManager={props.hoverManager}
 						maxCount={maxCount}
 						otherCount={props.columnFrequencyTable.other_count}
 						totalCount={totalCount}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.css
@@ -10,3 +10,16 @@
 .vector-histogram .bin-count {
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
 }
+
+.vector-histogram .bin-count-hover {
+	fill: var(--vscode-positronDataExplorer-sparklineHover);
+}
+
+/* Tooltip styles */
+.tooltip-container div {
+	background-color: transparent !important;
+	cursor: default;
+	pointer-events: all;
+	position: relative;
+	z-index: 100;
+}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -11,8 +11,7 @@ import React, { useState, useRef, useMemo } from 'react';
 
 // Other dependencies.
 import { ColumnHistogram } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * VectorHistogramProps interface.
@@ -22,7 +21,7 @@ interface VectorHistogramProps {
 	readonly graphHeight: number;
 	readonly xAxisHeight: number;
 	readonly columnHistogram: ColumnHistogram;
-	readonly hoverService?: IHoverService;
+	readonly hoverManager: IHoverManager;
 }
 
 /**
@@ -38,7 +37,7 @@ const BinItem = React.memo(({
 	graphHeight,
 	xAxisHeight,
 	binCountPercent,
-	hoverService
+	hoverManager
 }: {
 	binCount: number;
 	binCountIndex: number;
@@ -49,7 +48,7 @@ const BinItem = React.memo(({
 	graphHeight: number;
 	xAxisHeight: number;
 	binCountPercent: string;
-	hoverService?: IHoverService;
+	hoverManager: IHoverManager;
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isHovered, setIsHovered] = useState(false);
@@ -81,26 +80,16 @@ const BinItem = React.memo(({
 					width: '100%'
 				}}
 				onMouseLeave={() => {
-					hoverService?.hideHover();
+					hoverManager.hideHover();
 					setIsHovered(false);
 				}}
 				onMouseOver={() => {
 					setIsHovered(true);
-					if (hoverService && containerRef.current) {
-						hoverService.showHover({
-							content: `Range: ${formattedMin} to ${formattedMax}\nCount: ${binCount} (${binCountPercent}%)`,
-							target: containerRef.current,
-							position: {
-								hoverPosition: HoverPosition.ABOVE,
-							},
-							persistence: {
-								hideOnHover: false
-							},
-							appearance: {
-								showHoverHint: false,
-								showPointer: false
-							}
-						}, false);
+					if (containerRef.current) {
+						hoverManager.showHover(
+							containerRef.current,
+							`Range: ${formattedMin} to ${formattedMax}\nCount: ${binCount} (${binCountPercent}%)`
+						);
 					}
 				}}
 			>
@@ -188,7 +177,7 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 							binMin={binMin}
 							binWidth={binWidth}
 							graphHeight={props.graphHeight}
-							hoverService={props.hoverService}
+							hoverManager={props.hoverManager}
 							xAxisHeight={props.xAxisHeight}
 						/>
 					);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -7,10 +7,12 @@
 import './vectorHistogram.css';
 
 // React.
-import React, { useState } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 
 // Other dependencies.
 import { ColumnHistogram } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 
 /**
  * VectorHistogramProps interface.
@@ -20,7 +22,101 @@ interface VectorHistogramProps {
 	readonly graphHeight: number;
 	readonly xAxisHeight: number;
 	readonly columnHistogram: ColumnHistogram;
+	readonly hoverService?: IHoverService;
 }
+
+/**
+ * BinItem component to render a single histogram bin with tooltip
+ */
+const BinItem = React.memo(({
+	binCount,
+	binCountIndex,
+	binMin,
+	binMax,
+	binWidth,
+	binCountHeight,
+	graphHeight,
+	xAxisHeight,
+	binCountPercent,
+	hoverService
+}: {
+	binCount: number;
+	binCountIndex: number;
+	binMin: string;
+	binMax: string;
+	binWidth: number;
+	binCountHeight: number;
+	graphHeight: number;
+	xAxisHeight: number;
+	binCountPercent: string;
+	hoverService?: IHoverService;
+}) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isHovered, setIsHovered] = useState(false);
+
+	// Format numeric values with 4 significant digits if they're numbers
+	const formatValue = (value: string): string => {
+		const num = parseFloat(value);
+		return !isNaN(num) ? num.toPrecision(4) : value;
+	};
+
+	const formattedMin = formatValue(binMin);
+	const formattedMax = formatValue(binMax);
+
+	return (
+		<foreignObject
+			key={`bin-count-container-${binCountIndex}`}
+			className='tooltip-container'
+			height={graphHeight}
+			width={binWidth}
+			x={binCountIndex * binWidth}
+			y={0}
+		>
+			<div
+				ref={containerRef}
+				style={{
+					cursor: 'default',
+					height: '100%',
+					position: 'relative',
+					width: '100%'
+				}}
+				onMouseLeave={() => {
+					hoverService?.hideHover();
+					setIsHovered(false);
+				}}
+				onMouseOver={() => {
+					setIsHovered(true);
+					if (hoverService && containerRef.current) {
+						hoverService.showHover({
+							content: `Range: ${formattedMin} to ${formattedMax}\nCount: ${binCount} (${binCountPercent}%)`,
+							target: containerRef.current,
+							position: {
+								hoverPosition: HoverPosition.ABOVE,
+							},
+							persistence: {
+								hideOnHover: false
+							},
+							appearance: {
+								showHoverHint: false,
+								showPointer: false
+							}
+						}, false);
+					}
+				}}
+			>
+				<svg height='100%' width='100%'>
+					<rect
+						className={isHovered ? 'bin-count-hover' : 'bin-count'}
+						height={binCountHeight}
+						width={binWidth}
+						x={0}
+						y={graphHeight - xAxisHeight - binCountHeight}
+					/>
+				</svg>
+			</div>
+		</foreignObject>
+	);
+});
 
 /**
  * VectorHistogram component.
@@ -55,6 +151,11 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 		return maxBinCount;
 	});
 
+	// Calculate the total bin count once for percentage calculations
+	const totalBinCount = useMemo(() => {
+		return props.columnHistogram.bin_counts.reduce((sum, count) => sum + count, 0);
+	}, [props.columnHistogram.bin_counts]);
+
 	// Render.
 	return (
 		<svg
@@ -71,14 +172,24 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 				/>
 				{props.columnHistogram.bin_counts.map((binCount, binCountIndex) => {
 					const binCountHeight = (binCount / maxBinCount) * props.graphHeight;
+					const binMin = props.columnHistogram.bin_edges[binCountIndex];
+					const binMax = props.columnHistogram.bin_edges[binCountIndex + 1];
+					// Calculate percentage of the total
+					const binCountPercent = totalBinCount > 0 ? ((binCount / totalBinCount) * 100).toFixed(1) : '0.0';
+
 					return (
-						<rect
-							key={`bin-count-${binCountIndex}`}
-							className='bin-count'
-							height={binCountHeight}
-							width={binWidth}
-							x={binCountIndex * binWidth}
-							y={props.graphHeight - props.xAxisHeight - binCountHeight}
+						<BinItem
+							key={`bin-item-${binCountIndex}`}
+							binCount={binCount}
+							binCountHeight={binCountHeight}
+							binCountIndex={binCountIndex}
+							binCountPercent={binCountPercent}
+							binMax={binMax}
+							binMin={binMin}
+							binWidth={binWidth}
+							graphHeight={props.graphHeight}
+							hoverService={props.hoverService}
+							xAxisHeight={props.xAxisHeight}
 						/>
 					);
 				})}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -150,7 +150,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			this._hoverService
 		);
 		// Show tooltip hovers right away
-		this._hoverManager.setHoverDelay(100);
+		this._hoverManager.setCustomHoverDelay(0);
 		this._register(this._hoverManager);
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -40,7 +40,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _onDidSelectColumnEmitter = this._register(new Emitter<number>);
 
-	private readonly _hoverManager: PositronActionBarHoverManager;
+	public readonly _hoverManager: PositronActionBarHoverManager;
 
 	//#endregion Private Properties
 
@@ -240,7 +240,6 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			<ColumnSummaryCell
 				columnIndex={rowIndex}
 				columnSchema={columnSchema}
-				hoverManager={this._hoverManager}
 				instance={this}
 				onDoubleClick={() => this._onDidSelectColumnEmitter.fire(rowIndex)}
 			/>
@@ -265,6 +264,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 */
 	get configurationService() {
 		return this._configurationService;
+	}
+
+	/**
+	 * Gets the hover manager.
+	 */
+	get hoverManager() {
+		return this._hoverManager;
 	}
 
 	//#endregion Public Properties

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -21,6 +21,7 @@ import { COLUMN_PROFILE_OBJECT_LINE_COUNT } from './components/columnProfileObje
 import { COLUMN_PROFILE_STRING_LINE_COUNT } from './components/columnProfileString.js';
 import { COLUMN_PROFILE_BOOLEAN_LINE_COUNT } from './components/columnProfileBoolean.js';
 import { COLUMN_PROFILE_DATE_TIME_LINE_COUNT } from './components/columnProfileDatetime.js';
+import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 
 /**
  * Constants.
@@ -38,6 +39,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * The onDidSelectColumn event emitter.
 	 */
 	private readonly _onDidSelectColumnEmitter = this._register(new Emitter<number>);
+
+	private readonly _hoverManager: PositronActionBarHoverManager;
 
 	//#endregion Private Properties
 
@@ -74,6 +77,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			internalCursor: false,
 			selection: false
 		});
+
+
 
 		// Set the column layout entries. There is always one column.
 		this._columnLayoutManager.setLayoutEntries(1);
@@ -137,6 +142,16 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire()
 		));
+
+		// Create the hover manager.
+		this._hoverManager = new PositronActionBarHoverManager(
+			true,
+			this._configurationService,
+			this._hoverService
+		);
+		// Show tooltip hovers right away
+		this._hoverManager.setHoverDelay(100);
+		this._register(this._hoverManager);
 	}
 
 	//#endregion Constructor
@@ -225,7 +240,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			<ColumnSummaryCell
 				columnIndex={rowIndex}
 				columnSchema={columnSchema}
-				hoverService={this._hoverService}
+				hoverManager={this._hoverManager}
 				instance={this}
 				onDoubleClick={() => this._onDidSelectColumnEmitter.fire(rowIndex)}
 			/>


### PR DESCRIPTION
Addresses #5846. 

I used Claude Code to try to implement tooltips in the data explorer and the results aren't half bad. Someone who is better at frontend should take a look at this work (98% AI-generated -- I added a hover color after it was done) and see if we should do things a different way.

https://github.com/user-attachments/assets/22a8c979-e1d7-4857-8f01-a43e5ff4910b

e2e: @:data-explorer

### Release Notes

#### New Features

- Tooltips are displayed when hovering over the summary plots in the data explorer.

#### Bug Fixes

- N/A