### PR TITLE
E2E tests: basic search tests

### DIFF
--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -46,6 +46,7 @@ export enum TestTags {
 	R_PKG_DEVELOPMENT = '@:r-pkg-development',
 	RETICULATE = '@:reticulate',
 	SCM = '@:scm',
+	SEARCH = '@:search',
 	SESSIONS = '@:sessions',
 	TASKS = '@:tasks',
 	TEST_EXPLORER = '@:test-explorer',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -37,6 +37,7 @@ import { Problems } from '../pages/problems';
 import { References } from '../pages/references';
 import { SCM } from '../pages/scm';
 import { Sessions } from '../pages/sessions';
+import { Search } from '../pages/search.js';
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -77,6 +78,7 @@ export class Workbench {
 	readonly references: References;
 	readonly scm: SCM;
 	readonly sessions: Sessions;
+	readonly search: Search;
 
 	constructor(code: Code) {
 
@@ -113,5 +115,6 @@ export class Workbench {
 		this.references = new References(code);
 		this.scm = new SCM(code, this.layouts);
 		this.sessions = new Sessions(code, this.console, this.quickaccess, this.quickInput);
+		this.search = new Search(code);
 	}
 }

--- a/test/e2e/pages/search.ts
+++ b/test/e2e/pages/search.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect } from '@playwright/test';
+import { Code } from '../infra/code';
+
+const VIEWLET = '.search-view';
+const INPUT = `${VIEWLET} .search-widget .search-container .monaco-inputbox textarea`;
+const INCLUDE_INPUT = `${VIEWLET} .query-details .file-types.includes .monaco-inputbox input`;
+const FILE_MATCH = (filename: string) => `${VIEWLET} .results .filematch[data-resource$="${filename}"]`;
+
+/*
+ *  Reuseable Positron search functionality for tests to leverage.
+ */
+export class Search {
+
+	constructor(private code: Code) { }
+
+	async openSearchViewlet(): Promise<any> {
+		if (process.platform === 'darwin') {
+			await this.code.driver.page.keyboard.press('Meta+Shift+F');
+		} else {
+			await this.code.driver.page.keyboard.press('Control+Shift+F');
+		}
+		await expect(this.code.driver.page.locator(INPUT)).toBeFocused();
+	}
+
+	async clearSearchResults(): Promise<void> {
+		await this.code.driver.page.locator(`.sidebar .title-actions .codicon-search-clear-results`).click({ force: true });
+		await this.waitForNoResultText();
+	}
+
+	async waitForNoResultText(): Promise<void> {
+
+		await expect(async () => {
+			const textContent = await this.code.driver.page.locator(`${VIEWLET} .messages`).textContent();
+
+			expect(textContent === '' || textContent === 'Search was canceled before any results could be found').toBe(true);
+		}).toPass({ timeout: 20000 });
+	}
+
+	async searchFor(value: string): Promise<any> {
+		await this.clearSearchResults();
+		await this.code.driver.page.locator(INPUT).fill(value);
+		await this.code.driver.page.keyboard.press('Enter');
+	}
+
+	async waitForResultText(text: string): Promise<void> {
+		await expect(async () => {
+			const message = await this.code.driver.page.locator(`${VIEWLET} .messages .message`).textContent();
+			expect(message).toContain(text);
+		}).toPass({ timeout: 20000 });
+	}
+
+	async setFilesToIncludeText(text: string): Promise<void> {
+		await this.code.driver.page.locator(INCLUDE_INPUT).fill(text || '');
+	}
+
+	async showQueryDetails(): Promise<void> {
+		await this.code.driver.page.locator(`${VIEWLET} .query-details .more`).click();
+	}
+
+	async hideQueryDetails(): Promise<void> {
+		await this.code.driver.page.locator(`${VIEWLET} .query-details.more .more`).click();
+	}
+
+	async removeFileMatch(filename: string): Promise<void> {
+		const fileMatch = FILE_MATCH(filename);
+		await this.code.driver.page.locator(fileMatch).click();
+		await this.code.driver.page.locator(`${fileMatch} .action-label.codicon-search-remove`).click();
+	}
+}

--- a/test/e2e/tests/search/search.test.ts
+++ b/test/e2e/tests/search/search.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Search', {
+	tag: [tags.SEARCH, tags.WEB, tags.WIN]
+}, () => {
+
+	test.afterEach(async function ({ app }) {
+		await app.workbench.search.searchFor('');
+	});
+
+	test('Verify Basic Search for Unique Strings', async function ({ app }) {
+		await app.workbench.search.openSearchViewlet();
+		await app.workbench.search.searchFor('unique-string');
+		await app.workbench.search.waitForResultText('8 results in 2 files');
+	});
+
+
+	test('Verify Basic Search for Unique Strings with Extension Filter', async function ({ app }) {
+		await app.workbench.search.openSearchViewlet();
+		await app.workbench.search.showQueryDetails();
+		await app.workbench.search.setFilesToIncludeText('*.js');
+		await app.workbench.search.searchFor('unique-string');
+		await app.workbench.search.waitForResultText('4 results in 1 file');
+		await app.workbench.search.setFilesToIncludeText('');
+		await app.workbench.search.hideQueryDetails();
+	});
+
+	test('Verify Basic Search for Unique Strings with File Removal', async function ({ app }) {
+		await app.workbench.search.openSearchViewlet();
+		await app.workbench.search.searchFor('unique-string');
+		await app.workbench.search.waitForResultText('8 results in 2 files');
+		await app.workbench.search.removeFileMatch('search-matches.txt');
+		await app.workbench.search.waitForResultText('4 results in 1 file');
+	});
+
+});


### PR DESCRIPTION
Simple replacement for search tests that were deleted when we migrated away from Mocha.

### QA Notes

@:search @:web @:win
