### PR TITLE
Data Explorer: Regularize datetime64 summary statistic formatting with units other than nanoseconds

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1888,29 +1888,10 @@ class PandasView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount,
+                    profile_type=profile_type,
                     support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SummaryStats,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SmallHistogram,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.LargeHistogram,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SmallFrequencyTable,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.LargeFrequencyTable,
-                    support_status=SupportStatus.Supported,
-                ),
+                )
+                for profile_type in ColumnProfileType
             ],
         ),
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
@@ -2748,29 +2729,10 @@ class PolarsView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount,
+                    profile_type=profile_type,
                     support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SummaryStats,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SmallHistogram,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.LargeHistogram,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.SmallFrequencyTable,
-                    support_status=SupportStatus.Supported,
-                ),
-                ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.LargeFrequencyTable,
-                    support_status=SupportStatus.Supported,
-                ),
+                )
+                for profile_type in ColumnProfileType
             ],
         ),
         export_data_selection=ExportDataSelectionFeatures(

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -101,7 +101,6 @@ if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
 
-    # import pyarrow as pa
 
 logger = logging.getLogger(__name__)
 
@@ -1515,7 +1514,6 @@ class PandasView(DataExplorerTableView):
         return {"row_labels": row_labels}
 
     def _format_values(self, values, options: FormatOptions) -> list[ColumnValue]:
-        import numpy as np
         import pandas as pd
 
         float_format = _get_float_formatter(options)
@@ -1992,7 +1990,7 @@ def _date_median(x):
     import pandas as pd
 
     # the np.array calls are required to please pyright
-    median_value = int(np.median(pd.to_numeric(x).to_numpy()))
+    median_value = int(np.median(pd.to_numeric(x).to_numpy()))  # type: ignore
     return pd.Series([median_value], dtype=x.dtype)[0]
 
 
@@ -2128,7 +2126,13 @@ def _polars_summarize_datetime(col: pl.Series, _):
     timezone = str(getattr(col.dtype, "time_zone", None))
 
     return _box_datetime_stats(
-        col.dtype.time_unit, col.n_unique(), col.min(), mean_date, median_date, col.max(), timezone
+        getattr(col.dtype, "time_unit", None),
+        col.n_unique(),
+        col.min(),
+        mean_date,
+        median_date,
+        col.max(),
+        timezone,
     )
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -10,6 +10,7 @@ import inspect
 import math
 import pprint
 from decimal import Decimal
+from importlib.metadata import version
 from io import StringIO
 from typing import Any, Dict, List, Optional, Type, cast
 
@@ -18,6 +19,7 @@ import pandas as pd
 import polars as pl
 import pytest
 import pytz
+from packaging import version as pkg_version
 
 from .._vendor.pydantic import BaseModel
 from ..access_keys import encode_access_key
@@ -60,6 +62,16 @@ TARGET_NAME = "positron.dataExplorer"
 def supports_keyword(func, keyword):
     signature = inspect.signature(func)
     return keyword in signature.parameters
+
+
+def is_pandas_2_or_higher():
+    """Check if the installed pandas version is 2.0.0 or higher."""
+    try:
+        pandas_version = version("pandas")
+        return pkg_version.parse(pandas_version) >= pkg_version.parse("2.0.0")
+    except ImportError:
+        # Handle case where pandas is not installed
+        return False
 
 
 # ----------------------------------------------------------------------
@@ -2759,91 +2771,16 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "median": _format_float(f12_f64.median()),
             },
         ),
-        # datetime64[us]
-        (
-            "df1",
-            13,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00",
-                "mean_date": "2000-01-01 00:00:00.000495",
-                "median_date": "2000-01-01 00:00:00.000495",
-                "max_date": "2000-01-01 00:00:00.000990",
-                "timezone": "None",
-            },
-        ),
-        (
-            "df1",
-            14,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00-05:00",
-                "mean_date": "2000-01-01 00:00:00.000495-05:00",
-                "median_date": "2000-01-01 00:00:00.000495-05:00",
-                "max_date": "2000-01-01 00:00:00.000990-05:00",
-                "timezone": "US/Eastern",
-            },
-        ),
-        # datetime64[ms]
-        (
-            "df1",
-            15,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00",
-                "mean_date": "2000-01-01 00:00:00.495",
-                "median_date": "2000-01-01 00:00:00.495",
-                "max_date": "2000-01-01 00:00:00.990",
-                "timezone": "None",
-            },
-        ),
-        (
-            "df1",
-            16,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00-05:00",
-                "mean_date": "2000-01-01 00:00:00.495-05:00",
-                "median_date": "2000-01-01 00:00:00.495-05:00",
-                "max_date": "2000-01-01 00:00:00.990-05:00",
-                "timezone": "US/Eastern",
-            },
-        ),
-        # datetime64[s]
-        (
-            "df1",
-            17,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00",
-                "mean_date": "2000-01-01 00:08:15",
-                "median_date": "2000-01-01 00:08:15",
-                "max_date": "2000-01-01 00:16:30",
-                "timezone": "None",
-            },
-        ),
-        (
-            "df1",
-            18,
-            {
-                "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00-05:00",
-                "mean_date": "2000-01-01 00:08:15-05:00",
-                "median_date": "2000-01-01 00:08:15-05:00",
-                "max_date": "2000-01-01 00:16:30-05:00",
-                "timezone": "US/Eastern",
-            },
-        ),
         # mixed types
         (
             "df_mixed_tz1",
             0,
             {
                 "num_unique": 150,
-                "min_date": "None",
-                "mean_date": "None",
-                "median_date": "None",
-                "max_date": "None",
+                "min_date": None,
+                "mean_date": None,
+                "median_date": None,
+                "max_date": None,
                 "timezone": "None, US/Eastern, ... (1 more)",
             },
         ),
@@ -2853,13 +2790,95 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             {
                 "num_unique": 100,
                 "min_date": "2000-01-01 00:00:00+08:00",
-                "mean_date": "None",
-                "median_date": "None",
+                "mean_date": None,
+                "median_date": None,
                 "max_date": "2000-01-05 02:00:00-05:00",
                 "timezone": "US/Eastern, Asia/Hong_Kong",
             },
         ),
     ]
+
+    # Test cases that only work for pandas >= 2.0
+    if is_pandas_2_or_higher():
+        cases.extend(
+            [
+                # datetime64[us]
+                (
+                    "df1",
+                    13,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00",
+                        "mean_date": "2000-01-01 00:00:00.000495",
+                        "median_date": "2000-01-01 00:00:00.000495",
+                        "max_date": "2000-01-01 00:00:00.000990",
+                        "timezone": "None",
+                    },
+                ),
+                (
+                    "df1",
+                    14,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00-05:00",
+                        "mean_date": "2000-01-01 00:00:00.000495-05:00",
+                        "median_date": "2000-01-01 00:00:00.000495-05:00",
+                        "max_date": "2000-01-01 00:00:00.000990-05:00",
+                        "timezone": "US/Eastern",
+                    },
+                ),
+                # datetime64[ms]
+                (
+                    "df1",
+                    15,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00",
+                        "mean_date": "2000-01-01 00:00:00.495",
+                        "median_date": "2000-01-01 00:00:00.495",
+                        "max_date": "2000-01-01 00:00:00.990",
+                        "timezone": "None",
+                    },
+                ),
+                (
+                    "df1",
+                    16,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00-05:00",
+                        "mean_date": "2000-01-01 00:00:00.495-05:00",
+                        "median_date": "2000-01-01 00:00:00.495-05:00",
+                        "max_date": "2000-01-01 00:00:00.990-05:00",
+                        "timezone": "US/Eastern",
+                    },
+                ),
+                # datetime64[s]
+                (
+                    "df1",
+                    17,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00",
+                        "mean_date": "2000-01-01 00:08:15",
+                        "median_date": "2000-01-01 00:08:15",
+                        "max_date": "2000-01-01 00:16:30",
+                        "timezone": "None",
+                    },
+                ),
+                (
+                    "df1",
+                    18,
+                    {
+                        "num_unique": 100,
+                        "min_date": "2000-01-01 00:00:00-05:00",
+                        "mean_date": "2000-01-01 00:08:15-05:00",
+                        "median_date": "2000-01-01 00:08:15-05:00",
+                        "max_date": "2000-01-01 00:16:30-05:00",
+                        "timezone": "US/Eastern",
+                    },
+                ),
+            ]
+        )
 
     for table_name, col_index, ex_result in cases:
         profiles = [_get_summary_stats(col_index)]

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2577,11 +2577,23 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             * 20,
             # datetime64[us] with 10us increments
             "f13": pd.date_range("2000-01-01", freq="10us", periods=100).astype("datetime64[us]"),
+            "f14": (
+                pd.date_range("2000-01-01", freq="10us", periods=100)
+                .astype("datetime64[us]")
+                .tz_localize("US/Eastern")
+            ),
             # datetime64[ms] with 10ms increments
-            "f14": pd.date_range("2000-01-01", freq="10ms", periods=100).astype("datetime64[ms]"),
-            "f15": (
+            "f15": pd.date_range("2000-01-01", freq="10ms", periods=100).astype("datetime64[ms]"),
+            "f16": (
                 pd.date_range("2000-01-01", freq="10ms", periods=100)
                 .astype("datetime64[ms]")
+                .tz_localize("US/Eastern")
+            ),
+            # datetime64[s] for 10s increments
+            "f17": pd.date_range("2000-01-01", freq="10s", periods=100).astype("datetime64[s]"),
+            "f18": (
+                pd.date_range("2000-01-01", freq="10s", periods=100)
+                .astype("datetime64[s]")
                 .tz_localize("US/Eastern")
             ),
         }
@@ -2760,10 +2772,22 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "timezone": "None",
             },
         ),
-        # datetime64[ms]
         (
             "df1",
             14,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00-05:00",
+                "mean_date": "2000-01-01 00:00:00.000495-05:00",
+                "median_date": "2000-01-01 00:00:00.000495-05:00",
+                "max_date": "2000-01-01 00:00:00.000990-05:00",
+                "timezone": "US/Eastern",
+            },
+        ),
+        # datetime64[ms]
+        (
+            "df1",
+            15,
             {
                 "num_unique": 100,
                 "min_date": "2000-01-01 00:00:00",
@@ -2775,13 +2799,38 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
         ),
         (
             "df1",
-            15,
+            16,
             {
                 "num_unique": 100,
                 "min_date": "2000-01-01 00:00:00-05:00",
                 "mean_date": "2000-01-01 00:00:00.495-05:00",
                 "median_date": "2000-01-01 00:00:00.495-05:00",
                 "max_date": "2000-01-01 00:00:00.990-05:00",
+                "timezone": "US/Eastern",
+            },
+        ),
+        # datetime64[s]
+        (
+            "df1",
+            17,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00",
+                "mean_date": "2000-01-01 00:08:15",
+                "median_date": "2000-01-01 00:08:15",
+                "max_date": "2000-01-01 00:16:30",
+                "timezone": "None",
+            },
+        ),
+        (
+            "df1",
+            18,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00-05:00",
+                "mean_date": "2000-01-01 00:08:15-05:00",
+                "median_date": "2000-01-01 00:08:15-05:00",
+                "max_date": "2000-01-01 00:16:30-05:00",
                 "timezone": "US/Eastern",
             },
         ),

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2575,6 +2575,15 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 Decimal("3.5"),
             ]
             * 20,
+            # datetime64[us] with 10us increments
+            "f13": pd.date_range("2000-01-01", freq="10us", periods=100).astype("datetime64[us]"),
+            # datetime64[ms] with 10ms increments
+            "f14": pd.date_range("2000-01-01", freq="10ms", periods=100).astype("datetime64[ms]"),
+            "f15": (
+                pd.date_range("2000-01-01", freq="10ms", periods=100)
+                .astype("datetime64[ms]")
+                .tz_localize("US/Eastern")
+            ),
         }
     )
 
@@ -2736,6 +2745,44 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "mean": _format_float(f12_f64.mean()),
                 "stdev": _format_float(f12_f64.std()),
                 "median": _format_float(f12_f64.median()),
+            },
+        ),
+        # datetime64[us]
+        (
+            "df1",
+            13,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00",
+                "mean_date": "2000-01-01 00:00:00.000495",
+                "median_date": "2000-01-01 00:00:00.000495",
+                "max_date": "2000-01-01 00:00:00.000990",
+                "timezone": "None",
+            },
+        ),
+        # datetime64[ms]
+        (
+            "df1",
+            14,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00",
+                "mean_date": "2000-01-01 00:00:00.495",
+                "median_date": "2000-01-01 00:00:00.495",
+                "max_date": "2000-01-01 00:00:00.990",
+                "timezone": "None",
+            },
+        ),
+        (
+            "df1",
+            15,
+            {
+                "num_unique": 100,
+                "min_date": "2000-01-01 00:00:00-05:00",
+                "mean_date": "2000-01-01 00:00:00.495-05:00",
+                "median_date": "2000-01-01 00:00:00.495-05:00",
+                "max_date": "2000-01-01 00:00:00.990-05:00",
+                "timezone": "US/Eastern",
             },
         ),
         # mixed types

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -42,12 +42,14 @@ from ..data_explorer import (
 from ..data_explorer_comm import (
     ColumnDisplayType,
     ColumnProfileResult,
+    ColumnProfileType,
     ColumnProfileTypeSupportStatus,
     ColumnSchema,
     ColumnSortKey,
     FilterResult,
     FormatOptions,
     RowFilter,
+    RowFilterType,
     RowFilterTypeSupportStatus,
     SupportStatus,
 )
@@ -628,19 +630,7 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     assert row_filters["support_status"] == SupportStatus.Supported
     assert row_filters["supports_conditions"] == SupportStatus.Unsupported
 
-    row_filter_types = [
-        "between",
-        "compare",
-        "is_empty",
-        "is_false",
-        "is_null",
-        "is_true",
-        "not_between",
-        "not_empty",
-        "not_null",
-        "search",
-        "set_membership",
-    ]
+    row_filter_types = list(RowFilterType)
     for tp in row_filter_types:
         assert (
             RowFilterTypeSupportStatus(row_filter_type=tp, support_status=SupportStatus.Supported)
@@ -651,30 +641,10 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     assert column_profiles["support_status"] == SupportStatus.Supported
 
     profile_types = [
-        ColumnProfileTypeSupportStatus(
-            profile_type="null_count", support_status=SupportStatus.Supported
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="small_histogram",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="large_histogram",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="small_frequency_table",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="large_frequency_table",
-            support_status=SupportStatus.Supported,
-        ),
+        ColumnProfileTypeSupportStatus(profile_type=pt, support_status=SupportStatus.Supported)
+        for pt in list(ColumnProfileType)
     ]
+
     for tp in profile_types:
         assert tp in column_profiles["supported_types"]
 
@@ -2592,21 +2562,21 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f14": (
                 pd.date_range("2000-01-01", freq="10us", periods=100)
                 .astype("datetime64[us]")
-                .tz_localize("US/Eastern")
+                .tz_localize("US/Eastern")  # type: ignore
             ),
             # datetime64[ms] with 10ms increments
             "f15": pd.date_range("2000-01-01", freq="10ms", periods=100).astype("datetime64[ms]"),
             "f16": (
                 pd.date_range("2000-01-01", freq="10ms", periods=100)
                 .astype("datetime64[ms]")
-                .tz_localize("US/Eastern")
+                .tz_localize("US/Eastern")  # type: ignore
             ),
             # datetime64[s] for 10s increments
             "f17": pd.date_range("2000-01-01", freq="10s", periods=100).astype("datetime64[s]"),
             "f18": (
                 pd.date_range("2000-01-01", freq="10s", periods=100)
                 .astype("datetime64[s]")
-                .tz_localize("US/Eastern")
+                .tz_localize("US/Eastern")  # type: ignore
             ),
         }
     )
@@ -3296,29 +3266,8 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     assert export_data["support_status"] == SupportStatus.Supported
     assert export_data["supported_formats"] == ["csv", "tsv"]
     assert features["get_column_profiles"]["supported_types"] == [
-        ColumnProfileTypeSupportStatus(
-            profile_type="null_count", support_status=SupportStatus.Supported
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="small_histogram",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="large_histogram",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="small_frequency_table",
-            support_status=SupportStatus.Supported,
-        ),
-        ColumnProfileTypeSupportStatus(
-            profile_type="large_frequency_table",
-            support_status=SupportStatus.Supported,
-        ),
+        ColumnProfileTypeSupportStatus(profile_type=pt, support_status=SupportStatus.Supported)
+        for pt in list(ColumnProfileType)
     ]
 
 


### PR DESCRIPTION
Addresses #4343. The median values were being formatted with nanoseconds always, even when the datetime64 unit is seconds, milliseconds, or microseconds. This regularizes things. The only exception is when the microsecond/nanosecond value is zero in which case the sub-second precision data is not rendered.

<img width="353" alt="image" src="https://github.com/user-attachments/assets/c9f6b953-6331-44ba-a1c6-87b49e1c93be" />

@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Timestamps with second, millisecond, or microsecond unit are rendered consistently in the data explorer summary statistics pane.

### QA Notes

You can use the 100x100 all types Parquet data in qa-example-content to verify the behavior.