### PR TITLE
Fix `positron-r` LSP race conditions

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -699,11 +699,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		if (state === positron.RuntimeState.Ready) {
 			// Start the LSP and DAP servers
 			this._queue.add(async () => {
-				const lsp = this.startLsp();
-				this._lspStarting = lsp;
-
 				const dap = this.startDap();
-				await Promise.all([lsp, dap]);
+				await dap;
 			});
 
 			this._queue.add(async () => {
@@ -739,23 +736,31 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 	public async activateLsp() {
 		// Start LSP for the foreground session only if its been previously stopped
-		if (this._lsp.state === LspState.stopped) {
-			this._queue.add(async () => {
-				const port = await this.adapterApi!.findAvailablePort([], 25);
-				if (this._kernel) {
-					this._kernel.emitJupyterLog(`Starting Positron LSP server on port ${port}`);
-					await this._kernel.startPositronLsp(`127.0.0.1:${port}`);
-				}
-				this._lsp.activate(port, this.context);
+		if (this._lsp.state === LspState.stopped ||
+			this._lsp.state === LspState.uninitialized) {
+			// Use this promise to await this function until
+			// the LSP call has been popped off the queue & executed
+			await new Promise<void>((resolve) => {
+				this._queue.add(async () => {
+					this._lspStarting = this.startLsp();
+					this._lspStarting.then(() => {
+						resolve();
+					});
+				});
 			});
 		}
 	}
 
-	public deactivateLsp() {
+	public async deactivateLsp() {
 		// Stop LSP if it's running
 		if (this._lsp.state === LspState.running) {
-			this._queue.add(async () => {
-				await this._lsp.deactivate(true);
+			// Use this promise to await this function until
+			// the LSP call has been popped off the queue & executed
+			await new Promise<void>((resolve) => {
+				this._queue.add(async () => {
+					await this._lsp.deactivate(true);
+					resolve();
+				});
 			});
 		}
 	}


### PR DESCRIPTION
When session changes, positron-r waits for all LSPs to shut down before starting the new session's.

Defer LSP from starting on session start, instead awaiting for it to become the foreground session.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Duplicate outlines no longer shown for R runtimes when starting or switching sessions


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:console @:sessions
