### PR TITLE
Let the Jupyter Kernel pick the DAP/LSP server port

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -310,10 +310,8 @@ class PositronJediLanguageServer(JediLanguageServer):
 
         return decorator
 
-    def start_tcp(self, host: str, port: int) -> None:
+    def start_tcp(self, host: str) -> None:
         """Starts TCP server."""
-        logger.info("Starting TCP server on %s:%s", host, port)
-
         # Create a new event loop for the LSP server thread.
         self.loop = asyncio.new_event_loop()
 
@@ -324,14 +322,25 @@ class PositronJediLanguageServer(JediLanguageServer):
         asyncio.set_event_loop(self.loop)
 
         self._stop_event = threading.Event()
-        self._server = self.loop.run_until_complete(self.loop.create_server(self.lsp, host, port))
+        # Using the default `port` of `None` to allow the OS to pick a port for us, which
+        # we extract and send back below
+        self._server = self.loop.run_until_complete(self.loop.create_server(self.lsp, host))
+
+        listeners = self._server.sockets
+        for socket in listeners:
+            addr, port = socket.getsockname()
+            if addr == host:
+                logger.info("LSP server is listening on %s:%d", host, port)
+                break
+        else:
+            raise AssertionError("Unable to determine LSP server port")
 
         # Notify the frontend that the LSP server is ready
         if self._comm is None:
             logger.warning("LSP comm was not set, could not send server_started message")
         else:
             logger.info("LSP server is ready, sending server_started message")
-            self._comm.send({"msg_type": "server_started", "content": {}})
+            self._comm.send({"msg_type": "server_started", "content": {"port": port}})
 
         # Run the event loop until the stop event is set.
         try:
@@ -342,7 +351,7 @@ class PositronJediLanguageServer(JediLanguageServer):
         finally:
             self.shutdown()
 
-    def start(self, lsp_host: str, lsp_port: int, shell: "PositronShell", comm: BaseComm) -> None:
+    def start(self, lsp_host: str, shell: "PositronShell", comm: BaseComm) -> None:
         """
         Start the LSP.
 
@@ -367,7 +376,7 @@ class PositronJediLanguageServer(JediLanguageServer):
         # Start Jedi LSP as an asyncio TCP server in a separate thread.
         logger.info("Starting LSP server thread")
         self._server_thread = threading.Thread(
-            target=self.start_tcp, args=(lsp_host, lsp_port), name="LSPServerThread"
+            target=self.start_tcp, args=(lsp_host,), name="LSPServerThread"
         )
         self._server_thread.start()
 

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -85,11 +85,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * Convenience method for starting the Positron DAP server, if the
      * language runtime supports it.
      *
-     * @param serverPort The port on which to bind locally.
      * @param debugType Passed as `vscode.DebugConfiguration.type`.
      * @param debugName Passed as `vscode.DebugConfiguration.name`.
      */
-    startPositronDap(serverPort: number, debugType: string, debugName: string): Thenable<void>;
+    startPositronDap(debugType: string, debugName: string): Thenable<void>;
 
     /**
      * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -170,15 +170,6 @@ export interface PositronSupervisorApi extends vscode.Disposable {
         runtimeMetadata: positron.LanguageRuntimeMetadata,
         sessionMetadata: positron.RuntimeSessionMetadata,
     ): Promise<JupyterLanguageRuntimeSession>;
-
-    /**
-     * Finds an available TCP port for a server
-     *
-     * @param excluding A list of ports to exclude from the search
-     * @param maxTries The maximum number of attempts
-     * @returns An available TCP port
-     */
-    findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -76,10 +76,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * Convenience method for starting the Positron LSP server, if the
      * language runtime supports it.
      *
-     * @param clientAddress The address of the client that will connect to the
+     * @param ipAddress The address of the client that will connect to the
      *  language server.
      */
-    startPositronLsp(clientAddress: string): Thenable<void>;
+    startPositronLsp(ipAddress: string): Thenable<number>;
 
     /**
      * Convenience method for starting the Positron DAP server, if the

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -545,6 +545,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             return this._queue.add(async () => {
                 await this.startLsp();
             });
+        } else {
+            return undefined;
         }
     }
 
@@ -556,6 +558,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
                 }
                 await this._lsp?.deactivate(awaitStop);
             });
+        } else {
+            return undefined;
         }
     }
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -741,7 +741,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.173"
+      "ark": "0.1.174"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -69,10 +69,7 @@ export class ArkLsp implements vscode.Disposable {
 	 * @param port The port on which the language server is listening.
 	 * @param context The VSCode extension context.
 	 */
-	public async activate(
-		port: number,
-		_context: vscode.ExtensionContext
-	): Promise<void> {
+	public async activate(port: number): Promise<void> {
 
 		// Clean up disposables from any previous activation
 		this.activationDisposables.forEach(d => d.dispose());

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -170,15 +170,6 @@ export interface PositronSupervisorApi extends vscode.Disposable {
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
 		sessionMetadata: positron.RuntimeSessionMetadata
 	): Promise<JupyterLanguageRuntimeSession>;
-
-	/**
-	 * Finds an available TCP port for a server
-	 *
-	 * @param excluding A list of ports to exclude from the search
-	 * @param maxTries The maximum number of attempts
-	 * @returns An available TCP port
-	 */
-	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -75,10 +75,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron LSP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param clientAddress The address of the client that will connect to the
+	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(clientAddress: string): Thenable<void>;
+	startPositronLsp(ipAddress: string): Thenable<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -84,15 +84,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron DAP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param serverPort The port on which to bind locally.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(
-		serverPort: number,
-		debugType: string,
-		debugName: string,
-	): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Thenable<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -33,7 +33,7 @@ export class RSessionManager {
 						.map(([, s]) => {
 							if (s.metadata.sessionId !== sessionId &&
 								s.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
-								return s.deactivateLsp();
+								return s.deactivateLsp(true);
 							}
 						})
 						// Remove undefined values
@@ -155,4 +155,3 @@ export class RSessionManager {
 		return this._lastBinpath;
 	}
 }
-

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -298,8 +298,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	// Keep track of LSP init to avoid stopping in the middle of startup
-	private _lspStarting: Promise<void> = Promise.resolve();
+	// Keep track of LSP init to avoid stopping in the middle of startup.
+	// Resolves to the port number used to connect on the client side.
+	private _lspStarting: Thenable<number> = Promise.resolve(0);
 
 	async restart(workingDirectory: string | undefined): Promise<void> {
 		if (this._kernel) {
@@ -666,15 +667,52 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	private async startLsp(): Promise<void> {
-		// The adapter API is guaranteed to exist at this point since the
-		// runtime cannot become Ready without it
-		const port = await this.adapterApi!.findAvailablePort([], 25);
-		if (this._kernel) {
-			this._kernel.emitJupyterLog(`Starting Positron LSP server on port ${port}`);
-			await this._kernel.startPositronLsp(`127.0.0.1:${port}`);
+	/**
+	 * Start the LSP
+	 *
+	 * Returns a promise that resolves when the LSP has been activated.
+	 */
+	public async activateLsp(): Promise<void> {
+		if (this._lsp.state === LspState.stopped ||
+			this._lsp.state === LspState.uninitialized) {
+			return this._queue.add(async () => {
+				await this.startLsp();
+			});
 		}
-		this._lsp.activate(port, this.context);
+	}
+
+	/**
+	 * Stops the LSP if it is running
+	 *
+	 * Returns a promise that resolves when the LSP has been deactivated.
+	 */
+	public async deactivateLsp(awaitStop: boolean): Promise<void> {
+		if (this._lsp.state === LspState.running) {
+			return this._queue.add(async () => {
+				if (this._kernel) {
+					this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
+				}
+				await this._lsp.deactivate(awaitStop);
+			});
+		}
+	}
+
+	private async startLsp(): Promise<void> {
+		if (this._kernel) {
+			this._kernel.emitJupyterLog('Starting Positron LSP server');
+
+			// Create the LSP comm, which also starts the LSP server.
+			// We await the server selected port (the server selects the
+			// port since it is in charge of binding to it, which avoids
+			// race conditions). We also use this promise to avoid restarting
+			// in the middle of initialization.
+			this._lspStarting = this._kernel.startPositronLsp('127.0.0.1');
+			const port = await this._lspStarting;
+
+			this._kernel.emitJupyterLog(`Starting Positron LSP client on port ${port}`);
+
+			await this._lsp.activate(port);
+		}
 	}
 
 	/**
@@ -708,7 +746,6 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 					// For background / notebook, the LSP is activated on startup
 					// (these never become foreground sessions)
 					const lsp = this.startLsp();
-					this._lspStarting = lsp;
 					await Promise.all([lsp, dap]);
 				}
 			});
@@ -733,43 +770,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			});
 
 		} else if (state === positron.RuntimeState.Exited) {
-			if (this._lsp.state === LspState.running) {
-				this._queue.add(async () => {
-					if (this._kernel) {
-						this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
-					}
-					await this._lsp.deactivate(false);
-				});
-			}
-		}
-	}
-
-	/**
-	 * Start the LSP
-	 *
-	 * Returns a promise that resolves when the LSP has been activated.
-	 */
-	public async activateLsp(): Promise<void> {
-		if (this._lsp.state === LspState.stopped ||
-			this._lsp.state === LspState.uninitialized) {
-			return this._queue.add(async () => {
-				const lsp = this.startLsp();
-				this._lspStarting = lsp;
-				await lsp;
-			});
-		}
-	}
-
-	/**
-	 * Stops the LSP if it is running
-	 *
-	 * Returns a promise that resolves when the LSP has been deactivated.
-	 */
-	public async deactivateLsp(): Promise<void> {
-		if (this._lsp.state === LspState.running) {
-			return this._queue.add(async () => {
-				await this._lsp.deactivate(true);
-			});
+			this.deactivateLsp(false);
 		}
 	}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -678,6 +678,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			return this._queue.add(async () => {
 				await this.startLsp();
 			});
+		} else {
+			return undefined;
 		}
 	}
 
@@ -694,6 +696,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 				}
 				await this._lsp.deactivate(awaitStop);
 			});
+		} else {
+			return undefined;
 		}
 	}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -727,8 +727,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 	private async startDap(): Promise<void> {
 		if (this._kernel) {
-			const port = await this.adapterApi!.findAvailablePort([], 25);
-			await this._kernel.startPositronDap(port, 'ark', 'Ark Positron R');
+			await this._kernel.startPositronDap('ark', 'Ark Positron R');
 		}
 	}
 

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -76,10 +76,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron LSP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param clientAddress The address of the client that will connect to the
+	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(clientAddress: string): Thenable<void>;
+	startPositronLsp(ipAddress: string): Thenable<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -157,15 +157,6 @@ export interface PositronSupervisorApi extends vscode.Disposable {
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
 		sessionMetadata: positron.RuntimeSessionMetadata
 	): Promise<JupyterLanguageRuntimeSession>;
-
-	/**
-	 * Finds an available TCP port for a server
-	 *
-	 * @param excluding A list of ports to exclude from the search
-	 * @param maxTries The maximum number of attempts
-	 * @returns An available TCP port
-	 */
-	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -85,15 +85,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron DAP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param serverPort The port on which to bind locally.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(
-		serverPort: number,
-		debugType: string,
-		debugName: string,
-	): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Thenable<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -833,10 +833,6 @@ export class KCApi implements PositronSupervisorApi {
 		this._disposables.forEach(disposable => disposable.dispose());
 	}
 
-	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number> {
-		return findAvailablePort(excluding, maxTries);
-	}
-
 	/**
 	 * Attempts to locate a copy of the Kallichore server binary.
 	 *

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -214,6 +214,13 @@ export class KCApi implements PositronSupervisorApi {
 		bearer.accessToken = bearerToken;
 
 		// Find a port for the server to listen on
+		// TODO: There is a race condition here because we picked a port but did
+		// not bind to it. In the time between when we pick the port and when
+		// the kallichore server binds to it, someone else could have bound to
+		// that port! Instead, we should do something similar to JEP 66 for
+		// kallichore's main port handling too
+		// (https://github.com/posit-dev/kallichore/issues/2).
+		// After we do that, remove `findAvailablePort()` entirely.
 		const port = await findAvailablePort([], 10);
 
 		// Start a timer so we can track server startup time

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -324,21 +324,16 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 	/**
 	 * Requests that the kernel start a Debug Adapter Protocol server, and
-	 * connect it to the client locally on the given TCP port.
+	 * connect it to the client locally on the given TCP address.
 	 *
-	 * @param serverPort The port on which to bind locally.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	async startPositronDap(
-		serverPort: number,
-		debugType: string,
-		debugName: string,
-	) {
+	async startPositronDap(debugType: string, debugName: string) {
 		// NOTE: Ideally we'd connect to any address but the
 		// `debugServer` property passed in the configuration below
-		// needs to be a port for localhost.
-		const serverAddress = `127.0.0.1:${serverPort}`;
+		// needs to be localhost.
+		const ipAddress = '127.0.0.1';
 
 		// TODO: Should we query the kernel to see if it can create a DAP
 		// (QueryInterface style) instead of just demanding it?
@@ -348,7 +343,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		// Create a unique client ID for this instance
 		const clientId = `positron-dap-${this.runtimeMetadata.languageId}-${createUniqueId()}`;
-		this.log(`Starting DAP server ${clientId} for ${serverAddress}`, vscode.LogLevel.Debug);
+		this.log(`Starting DAP server ${clientId} for ${ipAddress}`, vscode.LogLevel.Debug);
 
 		// Notify Positron that we're handling messages from this client
 		this._disposables.push(positron.runtime.registerClientInstance(clientId));
@@ -356,11 +351,21 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		await this.createClient(
 			clientId,
 			positron.RuntimeClientType.Dap,
-			{ client_address: serverAddress }
+			{ ip_address: ipAddress }
 		);
 
+		// Create a promise that will resolve when the DAP starts on the server
+		// side. When the promise resolves we obtain the port the client should
+		// connect on.
+		const startPromise = new PromiseHandles<number>();
+		this._startingComms.set(clientId, startPromise);
+
+		// Immediately await that promise because `startPositronDap()` handles the full
+		// DAP setup, unlike the LSP where the extension finishes the setup.
+		const port = await startPromise.promise;
+
 		// Create the DAP client message handler
-		this._dapClient = new DapClient(clientId, serverPort, debugType, debugName, this);
+		this._dapClient = new DapClient(clientId, port, debugType, debugName, this);
 	}
 
 	/**

--- a/extensions/positron-supervisor/src/PortFinder.ts
+++ b/extensions/positron-supervisor/src/PortFinder.ts
@@ -6,7 +6,7 @@
 import * as net from 'net';
 
 /**
- * Finds an available TCP port for a server
+ * Finds an available TCP port
  *
  * @param excluding A list of ports to exclude from the search
  * @param maxTries The maximum number of attempts

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -172,15 +172,6 @@ export interface PositronSupervisorApi extends vscode.Disposable {
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
 		sessionMetadata: positron.RuntimeSessionMetadata
 	): Promise<JupyterLanguageRuntimeSession>;
-
-	/**
-	 * Finds an available TCP port for a server
-	 *
-	 * @param excluding A list of ports to exclude from the search
-	 * @param maxTries The maximum number of attempts
-	 * @returns An available TCP port
-	 */
-	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -76,10 +76,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron LSP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param clientAddress The address of the client that will connect to the
+	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(clientAddress: string): Thenable<void>;
+	startPositronLsp(ipAddress: string): Thenable<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -85,15 +85,10 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron DAP server, if the
 	 * language runtime supports it.
 	 *
-	 * @param serverPort The port on which to bind locally.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(
-		serverPort: number,
-		debugType: string,
-		debugName: string,
-	): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Thenable<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output


### PR DESCRIPTION
Requires https://github.com/posit-dev/ark/pull/750

This PR is in the same realm as #6874 in that it remove the potential for a race condition in our TCP connection between the LSP client and server. #6874 is about removing the potential for a race condition in the core jupyter kernel sockets (iopub, heartbeat, etc). Remove this LSP related race condition is going to be important in multi-session world, because each time we switch to a new session we pick a new port, which otherwise would greatly increase the risk of port related race conditions.

There are now two messages used in the LSP/DAP Comm startup sequence. I'll use Rust to describe them:

```rust
/// Message sent from the frontend requesting a server to start
pub struct ServerStartMessage {
    /// The IP address on which the client is listening for server requests. The server is
    /// in charge of picking the exact port to communicate over, since the server is the
    /// one that binds to the port (to prevent race conditions).
    ip_address: String,
}

/// Message sent to the frontend to acknowledge that the corresponding server has started
pub struct ServerStartedMessage {
    /// The port that the frontend should connect to on the `ip_address` it sent over
    port: u16,
}
```

- Positron sends the kernel an `ip_address` (right now it is always `127.0.0.1`) and then waits to receive a `port`
- The kernel does whatever it needs to bind to a port on that ip address. For ark this looks like trying to connect to `127.0.0.1:0` and letting the OS assign us a port.
- The kernel sends back the `port` and the server side of the LSP/DAP starts listening for connections on that port.
- Positron gets the `port` and finishes out the handshake by setting up the LSP client and performing a `socket.connect(port)`, which also unblocks the server since it has been listening for that connection


https://github.com/user-attachments/assets/6bec3556-f95c-4da8-af0f-37a4c68013f7

`@:web` `@:console` `@:sessions` `@:notebooks`
