### PR TITLE
Python LSP port selection

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/lsp.py
@@ -34,13 +34,13 @@ class LSPService:
 
         # Parse the host and port from the comm open message
         data = msg["content"]["data"]
-        client_address = data.get("ip_address", None)
-        if client_address is None:
+        ip_address = data.get("ip_address", None)
+        if ip_address is None:
             logger.warning(f"No ip_address in LSP comm open message: {msg}")
             return
 
         # Start the language server thread
-        POSITRON.start(lsp_host=client_address, lsp_port=0, shell=self._kernel.shell, comm=comm)
+        POSITRON.start(lsp_host=ip_address, shell=self._kernel.shell, comm=comm)
 
     def _receive_message(self, msg: Dict[str, Any]) -> None:
         """Handle messages received from the client via the positron.lsp comm."""

--- a/extensions/positron-python/python_files/posit/positron/lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/lsp.py
@@ -5,8 +5,7 @@
 
 import contextlib
 import logging
-import urllib.parse
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from comm.base_comm import BaseComm
 
@@ -35,18 +34,13 @@ class LSPService:
 
         # Parse the host and port from the comm open message
         data = msg["content"]["data"]
-        client_address = data.get("client_address", None)
+        client_address = data.get("ip_address", None)
         if client_address is None:
-            logger.warning(f"No client_address in LSP comm open message: {msg}")
-            return
-
-        host, port = self._split_address(client_address)
-        if host is None or port is None:
-            logger.warning(f"Could not parse host and port from client address: {client_address}")
+            logger.warning(f"No ip_address in LSP comm open message: {msg}")
             return
 
         # Start the language server thread
-        POSITRON.start(lsp_host=host, lsp_port=port, shell=self._kernel.shell, comm=comm)
+        POSITRON.start(lsp_host=client_address, lsp_port=0, shell=self._kernel.shell, comm=comm)
 
     def _receive_message(self, msg: Dict[str, Any]) -> None:
         """Handle messages received from the client via the positron.lsp comm."""
@@ -58,8 +52,3 @@ class LSPService:
         if self._comm is not None:
             with contextlib.suppress(Exception):
                 self._comm.close()
-
-    def _split_address(self, client_address: str) -> Tuple[Optional[str], Optional[int]]:
-        """Split an address of the form "host:port" into a tuple of (host, port)."""
-        result = urllib.parse.urlsplit("//" + client_address)
-        return (result.hostname, result.port)

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -322,6 +322,8 @@ class PositronJediLanguageServer(JediLanguageServer):
         asyncio.set_event_loop(self.loop)
 
         self._stop_event = threading.Event()
+        # Using the default `port` of `None` to allow the OS to pick a port for us, which
+        # we extract and send back below
         self._server = self.loop.run_until_complete(self.loop.create_server(self.lsp, host))
 
         listeners = self._server.sockets


### PR DESCRIPTION
Python LSP now provides its own port, and returns to client in `server_started` message. This prevents possible race conditions.

Supports #6846

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Python LSP now selects own port, preventing race conditions

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
