### PR TITLE
Reticulate restarts

### DIFF
--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -645,9 +645,9 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		});
 
 		await this.shutdown(positron.RuntimeExitReason.Shutdown);
-		// If the `restart` is not handled finished, positron won't allow another session
-		// to start. To fix that we need to throw an error (that's silently ignroed by Positron)
-		// and then start a new session.
+		// If the `restart` is not finished, positron won't allow another session
+		// to start. To fix that we need to throw an error (that's silently ignored
+		// by Positron) and then start a new session.
 		throw new Error('Restarting the reticulate session');
 	}
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -782,7 +782,6 @@ export class ReticulateProvider {
 		if (this._client) {
 			this._client.dispose();
 		}
-		console.log("Registering reticulate client!")
 
 		this._client = client;
 		// We'll force the registration when the user calls `reticulate::repl_python()`
@@ -797,12 +796,10 @@ export class ReticulateProvider {
 		this.manager._session?.onDidEndSession(() => {
 			this._client?.dispose();
 			this._client = undefined;
-			console.log("Reticulate session ended");
 		});
 
 		this._client.onDidSendEvent(async (e) => {
 			const event = e.data as any;
-			console.log("Helloo reticulate:", event);
 			if (event.method === 'focus') {
 				let input;
 				if (event.params && event.params.input) {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -830,7 +830,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 					session.metadata.sessionMode, session.runtimeMetadata, session.metadata.notebookUri);
 				startPromise.complete(session.sessionId);
 			})
-			.catch((err) => startPromise.error(err));
+			.catch((err) => {
+				startPromise.error(err);
+				this.clearStartingSessionMaps(
+					session.metadata.sessionMode, session.runtimeMetadata, session.metadata.notebookUri);
+			});
 
 		// Ask the runtime to restart.
 		try {

--- a/test/e2e/infra/fixtures/interpreter.ts
+++ b/test/e2e/infra/fixtures/interpreter.ts
@@ -111,6 +111,13 @@ export class Interpreter {
 				.getByTitle('Restart the interpreter')
 				.click();
 
+			// Some interpreters (in special the Reticulate interpreter) will use a modal
+			// dialog before restarting.
+			const hasModal = await this.code.driver.page.locator('.positron-modal-dialog-box').isVisible({ timeout: 5000 });
+			if (hasModal) {
+				await this.code.driver.page.keyboard.press('Enter');
+			}
+
 			await this.closeInterpreterDropdown();
 		});
 	}

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -92,6 +92,16 @@ test.describe('Reticulate', {
 		await verifyReticulateFunctionality(app, interpreter, sequential);
 
 	});
+
+	test('R - Verify Reticulate Restart', {
+		tag: [tags.RETICULATE, tags.CONSOLE]
+	}, async function ({ app, interpreter }) {
+		await app.workbench.interpreter.selectInterpreter('Python', 'Python (reticulate)', true);
+		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+
+		await app.workbench.interpreter.restartPrimaryInterpreter('Python (reticulate)');
+		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+	});
 });
 
 async function verifyReticulateFunctionality(app, interpreter, sequential) {

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -96,11 +96,12 @@ test.describe('Reticulate', {
 	test('R - Verify Reticulate Restart', {
 		tag: [tags.RETICULATE, tags.CONSOLE]
 	}, async function ({ app, interpreter }) {
-		await app.workbench.interpreter.selectInterpreter('Python', 'Python (reticulate)', true);
-		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+		const interpreterDesc = 'Python (reticulate)';
+		await app.workbench.interpreter.selectInterpreter('Python', interpreterDesc, true);
+		await app.workbench.interpreter.verifyInterpreterIsRunning(interpreterDesc);
 
-		await app.workbench.interpreter.restartPrimaryInterpreter('Python (reticulate)');
-		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+		await app.workbench.interpreter.restartPrimaryInterpreter(interpreterDesc);
+		await app.workbench.interpreter.verifyInterpreterIsRunning(interpreterDesc);
 	});
 });
 


### PR DESCRIPTION
Addesses https://github.com/posit-dev/positron/issues/5952

When Restarting reticulate we also need to restart the R session, otherwise the reticulate session is not completely restarted. Thus, restart in reticulate is implemented by:

1. Shutting down the Python Kernel
2. Restarting the R session
3. Starting a new reticulate session

This used to work, but I think https://github.com/posit-dev/positron/pull/5926 made Positron more restrictive and doesn't allow two sessions with the same runtimeId to be in the 'starting' mode. Currently what happens when you 'restart', is that the session is added to:

https://github.com/posit-dev/positron/blob/ba48b51c525b9a8d4a29c8506781dda7ad62706a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts#L822-L824

and then being on that set, doesn't allow a session with the same runtimeId to be started again.
To fix that, we now throw from the reticulate session 'restart', so the startingSessions map is cleared allowing
the new session to be started. 

This is not ideal, but a full fix would require some larger refactor in the runtimeSession code. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed a bug when restarting Reticulate Python sessions (https://github.com/posit-dev/positron/issues/5952)

### QA Notes

Added a regression test to make sure we correctly restart the reticulate session

@:reticulate
