### PR TITLE
e2e-test: fix typo in problems test

### DIFF
--- a/test/e2e/tests/problems/problems.test.ts
+++ b/test/e2e/tests/problems/problems.test.ts
@@ -50,7 +50,7 @@ test.describe('Problems', {
 		await keyboard.hotKeys.undo();
 
 		// Verify the error is no longer present in Editor and Problems view
-		await problems.expectSquigglyCountToBe('error', 1);
+		await problems.expectSquigglyCountToBe('error', 0);
 		await problems.expectProblemsCountToBe(0);
 	});
 });


### PR DESCRIPTION
### Summary
The assertion is incorrect, just fixing it.

### QA Notes

@:problems