### PR TITLE
Ensure no overlapping Python console language servers

### DIFF
--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// eslint-disable-next-line import/no-unresolved
-import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { ProgressLocation, ProgressOptions } from 'vscode';
 import * as fs from 'fs';
@@ -21,42 +19,11 @@ import { IApplicationShell } from '../common/application/types';
 import { activateAppDetection as activateWebAppDetection } from './webAppContexts';
 import { activateWebAppCommands } from './webAppCommands';
 import { printInterpreterDebugInfo } from './interpreterSettings';
-import { getActivePythonSessions } from './util';
+import { registerLanguageServerManager } from './languageServerManager';
 
 export async function activatePositron(serviceContainer: IServiceContainer): Promise<void> {
     try {
         const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
-        // Manage language servers when the foreground session changes.
-        disposables.push(
-            positron.runtime.onDidChangeForegroundSession(async (sessionId) => {
-                if (!sessionId) {
-                    // There is no foreground session, nothing to do.
-                    return;
-                }
-
-                const sessions = await getActivePythonSessions();
-
-                const foregroundSession = sessions.find((session) => session.metadata.sessionId === sessionId);
-                if (!foregroundSession) {
-                    // The foreground session is for another language.
-                    return;
-                }
-
-                // Deactivate non-foreground console session language servers.
-                await Promise.all(
-                    sessions
-                        .filter(
-                            (session) =>
-                                session.metadata.sessionId !== sessionId &&
-                                session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console,
-                        )
-                        .map((session) => session.deactivateLsp()),
-                );
-
-                // Activate the foreground session language server.
-                await foregroundSession.activateLsp();
-            }),
-        );
         // Register a command to check if ipykernel is installed for a given interpreter.
         disposables.push(
             vscode.commands.registerCommand('python.isIpykernelInstalled', async (pythonPath: string) => {
@@ -126,6 +93,9 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
 
         // Activate web application commands.
         activateWebAppCommands(serviceContainer, disposables);
+
+        // Register the language server manager to support multiple console sessions.
+        registerLanguageServerManager(disposables);
 
         traceInfo('activatePositron: done!');
     } catch (ex) {

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -5,7 +5,7 @@
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { getActivePythonSessions } from './util';
+import { getActivePythonSessions } from './session';
 
 export function registerLanguageServerManager(disposables: vscode.Disposable[]): void {
     disposables.push(

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -33,7 +33,7 @@ export function registerLanguageServerManager(disposables: vscode.Disposable[]):
                             session.metadata.sessionId !== sessionId &&
                             session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console,
                     )
-                    .map((session) => session.deactivateLsp()),
+                    .map((session) => session.deactivateLsp(true)),
             );
 
             // Activate the foreground session language server.

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { getActivePythonSessions } from './util';
+
+export function registerLanguageServerManager(disposables: vscode.Disposable[]): void {
+    disposables.push(
+        // When the foreground session changes:
+        // 1. Deactivate non-foreground session language servers.
+        // 2. Activate the foreground session language server.
+        positron.runtime.onDidChangeForegroundSession(async (sessionId) => {
+            if (!sessionId) {
+                // There is no foreground session, nothing to do.
+                return;
+            }
+
+            const sessions = await getActivePythonSessions();
+            const foregroundSession = sessions.find((session) => session.metadata.sessionId === sessionId);
+            if (!foregroundSession) {
+                // The foreground session is for another language.
+                return;
+            }
+
+            // Deactivate non-foreground console session language servers.
+            await Promise.all(
+                sessions
+                    .filter(
+                        (session) =>
+                            session.metadata.sessionId !== sessionId &&
+                            session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console,
+                    )
+                    .map((session) => session.deactivateLsp()),
+            );
+
+            // Activate the foreground session language server.
+            await foregroundSession.activateLsp();
+        }),
+    );
+}

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -793,3 +793,9 @@ export function createJupyterKernelExtra(): undefined {
     // };
     return undefined;
 }
+
+/** Get the active Python language runtime sessions. */
+export async function getActivePythonSessions(): Promise<PythonRuntimeSession[]> {
+    const sessions = await positron.runtime.getActiveSessions();
+    return sessions.filter((session) => session instanceof PythonRuntimeSession) as PythonRuntimeSession[];
+}

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -114,18 +114,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this.onDidChangeRuntimeState = this._stateEmitter.event;
         this.onDidEndSession = this._exitEmitter.event;
 
-        positron.runtime.onDidChangeForegroundSession(async (sessionId) => {
-            if (sessionId) {
-                if (sessionId === metadata.sessionId) {
-                    // Start LSP for the foreground session only if its been previously stopped
-                    await this.activateLsp();
-                } else if (metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
-                    // Stop LSP for other console sessions if they are running
-                    await this.deactivateLsp(true);
-                }
-            }
-        });
-
         // Extract the extra data from the runtime metadata; it contains the
         // Python path that was saved when the metadata was created.
         const extraData: PythonRuntimeExtraData = runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData;

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -47,20 +47,8 @@ export async function hasFiles(includes: string[]): Promise<boolean> {
     return files.length > 0;
 }
 
+/** Get the active Python language runtime sessions. */
 export async function getActivePythonSessions(): Promise<PythonRuntimeSession[]> {
     const sessions = await positron.runtime.getActiveSessions();
     return sessions.filter((session) => session instanceof PythonRuntimeSession) as PythonRuntimeSession[];
-}
-
-export abstract class Disposable {
-    protected _disposables: vscode.Disposable[] = [];
-
-    public dispose(): void {
-        this._disposables.forEach((disposable) => disposable.dispose());
-    }
-
-    protected _register<T extends vscode.Disposable>(value: T): T {
-        this._disposables.push(value);
-        return value;
-    }
 }

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -4,11 +4,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// eslint-disable-next-line import/no-unresolved
-import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { traceVerbose } from '../logging';
-import { PythonRuntimeSession } from './session';
 
 export class PromiseHandles<T> {
     resolve!: (value: T | Promise<T>) => void;
@@ -45,10 +42,4 @@ export async function hasFiles(includes: string[]): Promise<boolean> {
     traceVerbose(`Found _files_: ${files.map((file) => file.fsPath)}`);
 
     return files.length > 0;
-}
-
-/** Get the active Python language runtime sessions. */
-export async function getActivePythonSessions(): Promise<PythonRuntimeSession[]> {
-    const sessions = await positron.runtime.getActiveSessions();
-    return sessions.filter((session) => session instanceof PythonRuntimeSession) as PythonRuntimeSession[];
 }

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -49,7 +49,7 @@ export async function hasFiles(includes: string[]): Promise<boolean> {
 
 export async function getActivePythonSessions(): Promise<PythonRuntimeSession[]> {
     const sessions = await positron.runtime.getActiveSessions();
-    return sessions.filter((session) => session instanceof PythonRuntimeSession);
+    return sessions.filter((session) => session instanceof PythonRuntimeSession) as PythonRuntimeSession[];
 }
 
 export abstract class Disposable {

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -1,10 +1,14 @@
+/* eslint-disable max-classes-per-file */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { traceVerbose } from '../logging';
+import { PythonRuntimeSession } from './session';
 
 export class PromiseHandles<T> {
     resolve!: (value: T | Promise<T>) => void;
@@ -41,4 +45,22 @@ export async function hasFiles(includes: string[]): Promise<boolean> {
     traceVerbose(`Found _files_: ${files.map((file) => file.fsPath)}`);
 
     return files.length > 0;
+}
+
+export async function getActivePythonSessions(): Promise<PythonRuntimeSession[]> {
+    const sessions = await positron.runtime.getActiveSessions();
+    return sessions.filter((session) => session instanceof PythonRuntimeSession);
+}
+
+export abstract class Disposable {
+    protected _disposables: vscode.Disposable[] = [];
+
+    public dispose(): void {
+        this._disposables.forEach((disposable) => disposable.dispose());
+    }
+
+    protected _register<T extends vscode.Disposable>(value: T): T {
+        this._disposables.push(value);
+        return value;
+    }
 }

--- a/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { interfaces } from 'inversify';
+import { registerLanguageServerManager } from '../../client/positron/languageServerManager';
+import { mock } from './utils';
+import { createUniqueId, PythonRuntimeSession } from '../../client/positron/session';
+import * as util from '../../client/positron/util';
+import { IServiceContainer } from '../../client/ioc/types';
+
+function mockSession(sessionMode = positron.LanguageRuntimeSessionMode.Console): PythonRuntimeSession {
+    return new PythonRuntimeSession(
+        mock<positron.LanguageRuntimeMetadata>({
+            extraRuntimeData: {
+                pythonPath: 'python',
+            },
+        }),
+        mock<positron.RuntimeSessionMetadata>({
+            sessionId: createUniqueId(),
+            sessionMode,
+        }),
+        mock<IServiceContainer>({
+            get: <T>(_: interfaces.ServiceIdentifier<T>) => undefined as T,
+        }),
+    );
+}
+
+suite('Language server manager', () => {
+    let disposables: vscode.Disposable[];
+    let onDidChangeForegroundSession: vscode.EventEmitter<string | undefined>;
+    let foregroundSession: PythonRuntimeSession;
+    let nonForegroundSession: PythonRuntimeSession;
+    let foregroundSessionSpy: sinon.SinonSpiedInstance<PythonRuntimeSession>;
+    let nonForegroundSessionSpy: sinon.SinonSpiedInstance<PythonRuntimeSession>;
+
+    setup(() => {
+        disposables = [];
+        onDidChangeForegroundSession = new vscode.EventEmitter();
+
+        foregroundSession = mockSession();
+        nonForegroundSession = mockSession();
+        foregroundSessionSpy = sinon.spy(foregroundSession);
+        nonForegroundSessionSpy = sinon.spy(nonForegroundSession);
+
+        // Stub the runtime API. Use Object.assign since positron.runtime doesn't exist
+        // in the unit test environment, but TypeScript doesn't know that.
+        Object.assign(positron.runtime, {
+            onDidChangeForegroundSession: onDidChangeForegroundSession.event,
+            getActiveSessions: async () => [foregroundSession, nonForegroundSession],
+        });
+
+        registerLanguageServerManager(disposables);
+    });
+
+    teardown(() => {
+        sinon.restore();
+        disposables.forEach((d) => d.dispose());
+        onDidChangeForegroundSession.dispose();
+    });
+
+    test('should deactivate non-foreground session before activating foreground session', async () => {
+        // Change the foreground session.
+        onDidChangeForegroundSession.fire(foregroundSession.metadata.sessionId);
+
+        // Wait for the event loop to run.
+        await util.delay(0);
+
+        sinon.assert.calledOnce(foregroundSessionSpy.activateLsp);
+        sinon.assert.calledOnce(nonForegroundSessionSpy.deactivateLsp);
+        sinon.assert.callOrder(nonForegroundSessionSpy.deactivateLsp, foregroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+    });
+
+    test('should do nothing if there is no foreground session', async () => {
+        // Change the foreground session.
+        onDidChangeForegroundSession.fire(undefined);
+
+        // Wait for the event loop to run.
+        await util.delay(0);
+
+        sinon.assert.notCalled(foregroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
+    });
+
+    test('should do nothing for unknown foreground session', async () => {
+        // Create a session unknown to positron.runtime.getActiveSessions.
+        const unknownSession = mockSession();
+        const unknownSessionSpy = sinon.spy(unknownSession);
+
+        // Change the foreground session.
+        onDidChangeForegroundSession.fire(unknownSession.metadata.sessionId);
+
+        // Wait for the event loop to run.
+        await util.delay(0);
+
+        sinon.assert.notCalled(foregroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
+        sinon.assert.notCalled(unknownSessionSpy.activateLsp);
+        sinon.assert.notCalled(unknownSessionSpy.deactivateLsp);
+    });
+
+    test('should not deactivate non-console sessions', async () => {
+        sinon.stub(nonForegroundSession.metadata, 'sessionMode').value(positron.LanguageRuntimeSessionMode.Notebook);
+
+        onDidChangeForegroundSession.fire(foregroundSession.metadata.sessionId);
+
+        // Wait for the event loop to run.
+        await util.delay(0);
+
+        // The foreground session should still be activated.
+        sinon.assert.calledOnce(foregroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+
+        // The non-foreground session should not be deactivated.
+        sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+        sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
+    });
+});

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1431,6 +1431,11 @@ declare module 'positron' {
 		export function getPreferredRuntime(languageId: string): Thenable<LanguageRuntimeMetadata>;
 
 		/**
+		 * List all active sessions.
+		 */
+		export function getActiveSessions(): Thenable<LanguageRuntimeSession[]>;
+
+		/**
 		 * Get the active foreground session, if any.
 		 */
 		export function getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1280,6 +1280,12 @@ export class MainThreadLanguageRuntime
 		return Promise.resolve(this._runtimeStartupService.getPreferredRuntime(languageId));
 	}
 
+	$getActiveSessions(): Promise<IRuntimeSessionMetadata[]> {
+		return Promise.resolve(
+			this._runtimeSessionService.getActiveSessions().map(
+				activeSession => activeSession.session.metadata));
+	}
+
 	$getForegroundSession(): Promise<string | undefined> {
 		return Promise.resolve(this._runtimeSessionService.foregroundSession?.sessionId);
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -97,6 +97,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			getPreferredRuntime(languageId: string): Thenable<positron.LanguageRuntimeMetadata> {
 				return extHostLanguageRuntime.getPreferredRuntime(languageId);
 			},
+			getActiveSessions(): Thenable<positron.LanguageRuntimeSession[]> {
+				return extHostLanguageRuntime.getActiveSessions();
+			},
 			getForegroundSession(): Thenable<positron.LanguageRuntimeSession | undefined> {
 				return extHostLanguageRuntime.getForegroundSession();
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -42,6 +42,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$unregisterLanguageRuntime(handle: number): void;
 	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
+	$getActiveSessions(): Promise<RuntimeSessionMetadata[]>;
 	$getForegroundSession(): Promise<string | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;
 	$restartSession(handle: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -736,6 +736,19 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		}, 2000, 5);
 	}
 
+	public async getActiveSessions(): Promise<positron.LanguageRuntimeSession[]> {
+		const sessionMetadatas = await this._proxy.$getActiveSessions();
+		const sessions: positron.LanguageRuntimeSession[] = [];
+		for (const sessionMetadata of sessionMetadatas) {
+			const session = this._runtimeSessions.find(session => session.metadata.sessionId === sessionMetadata.sessionId);
+			if (!session) {
+				throw new Error(`Session ID '${sessionMetadata.sessionId}' was returned as an active session, but is not known to the extension host.`);
+			}
+			sessions.push(session);
+		}
+		return sessions;
+	}
+
 	public async getForegroundSession(): Promise<positron.LanguageRuntimeSession | undefined> {
 		const sessionId = await this._proxy.$getForegroundSession();
 		if (!sessionId) {

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -22,6 +22,7 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ActiveRuntimeSession } from '../../../runtimeSession/common/activeRuntimeSession.js';
 
 class TestWorkspaceContextService implements IWorkspaceContextService {
 	private readonly _onWillChangeWorkspaceFolders = new Emitter<IWorkspaceFoldersWillChangeEvent>();
@@ -148,6 +149,10 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 	}
 
 	getNotebookSessionForNotebookUri(_notebookUri: any): ILanguageRuntimeSession | undefined {
+		throw new Error('Method not implemented.');
+	}
+
+	getActiveSessions(): ActiveRuntimeSession[] {
 		throw new Error('Method not implemented.');
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -354,6 +354,15 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	/**
+	 * List all active runtime sessions.
+	 *
+	 * @returns The active sessions.
+	 */
+	getActiveSessions(): ActiveRuntimeSession[] {
+		return Array.from(this._activeSessionsBySessionId.values());
+	}
+
+	/**
 	 * Selects and starts a new runtime session, after shutting down any currently active
 	 * sessions for the console or notebook.
 	 *

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -374,6 +374,11 @@ export interface IRuntimeSessionService {
 	getNotebookSessionForNotebookUri(notebookUri: URI): ILanguageRuntimeSession | undefined;
 
 	/**
+	 * List all active runtime sessions.
+	 */
+	getActiveSessions(): ActiveRuntimeSession[];
+
+	/**
 	 * Checks for a starting or running console for the given language ID.
 	 *
 	 * @param languageId The language ID to check for; if undefined, checks for


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6533 and https://github.com/posit-dev/positron/issues/2620.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

You should be able to switch Python console sessions and never see a duplicated Outline or diagnostics.