### PR TITLE
e2e tests: increase run timeout

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   e2e-linux:
     name: ${{ inputs.display_name || 'e2e-linux' }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-latest-8x
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Intent

Increase the run timeout for linux, as it's been hitting the limit more lately as we add more tests, etc.  Windows already has a longer timeout[


### QA Notes
All runs finish

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
