### PR TITLE
Activate LSP for notebooks immediately

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -700,7 +700,17 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			// Start the LSP and DAP servers
 			this._queue.add(async () => {
 				const dap = this.startDap();
-				await dap;
+
+				if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
+					// For consoles, the LSP is activated when the console becomes the foreground session
+					await dap;
+				} else {
+					// For background / notebook, the LSP is activated on startup
+					// (these never become foreground sessions)
+					const lsp = this.startLsp();
+					this._lspStarting = lsp;
+					await Promise.all([lsp, dap]);
+				}
 			});
 
 			this._queue.add(async () => {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -734,33 +734,31 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	public async activateLsp() {
-		// Start LSP for the foreground session only if its been previously stopped
+	/**
+	 * Start the LSP
+	 *
+	 * Returns a promise that resolves when the LSP has been activated.
+	 */
+	public async activateLsp(): Promise<void> {
 		if (this._lsp.state === LspState.stopped ||
 			this._lsp.state === LspState.uninitialized) {
-			// Use this promise to await this function until
-			// the LSP call has been popped off the queue & executed
-			await new Promise<void>((resolve) => {
-				this._queue.add(async () => {
-					this._lspStarting = this.startLsp();
-					this._lspStarting.then(() => {
-						resolve();
-					});
-				});
+			return this._queue.add(async () => {
+				const lsp = this.startLsp();
+				this._lspStarting = lsp;
+				await lsp;
 			});
 		}
 	}
 
-	public async deactivateLsp() {
-		// Stop LSP if it's running
+	/**
+	 * Stops the LSP if it is running
+	 *
+	 * Returns a promise that resolves when the LSP has been deactivated.
+	 */
+	public async deactivateLsp(): Promise<void> {
 		if (this._lsp.state === LspState.running) {
-			// Use this promise to await this function until
-			// the LSP call has been popped off the queue & executed
-			await new Promise<void>((resolve) => {
-				this._queue.add(async () => {
-					await this._lsp.deactivate(true);
-					resolve();
-				});
+			return this._queue.add(async () => {
+				await this._lsp.deactivate(true);
 			});
 		}
 	}


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/positron/pull/6844, joint work with @samclark2015 (we talked about these changes together so I'll go ahead and merge)

Addresses https://github.com/posit-dev/positron/issues/6864

Notebook sessions are never made foreground sessions, so our delayed activation never fires for them. I think there is really some better solution for this that would move LSP activation/deactivation fully into the session manager, but this fixes it for the moment. It doesn't seem right for the session to special case behavior like this based on whether it is a notebook or not.

Also simplifies some promise handling in the activate/deactivate methods.

`@:console` `@:sessions` `@:web`