### PR TITLE
Implement JEP 66 to fix/mitigate socket allocation race condition

### DIFF
--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -61,6 +61,14 @@ export interface JupyterKernelSpec {
     /** Environment variables to set when starting the kernel */
     env?: NodeJS.ProcessEnv;
 
+    /**
+     * The Jupyter protocol version to use when connecting to the kernel.
+     *
+     * When protocol >= 5.5 is used, the supervisor will use a handshake
+     * to negotiate ports instead of picking them ahead of time (JEP 66)
+     */
+    protocol_version: string; // eslint-disable-line
+
     /** Function that starts the kernel given a JupyterSession object.
      *  This is used to start the kernel if it's provided. In this case `argv`
      *  is ignored.

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -67,7 +67,7 @@ export interface JupyterKernelSpec {
      * When protocol >= 5.5 is used, the supervisor will use a handshake
      * to negotiate ports instead of picking them ahead of time (JEP 66)
      */
-    protocol_version: string; // eslint-disable-line
+    kernel_protocol_version: string; // eslint-disable-line
 
     /** Function that starts the kernel given a JupyterSession object.
      *  This is used to start the kernel if it's provided. In this case `argv`

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -267,6 +267,10 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
             // On Windows, we need to use the 'signal' interrupt mode since 'message' is
             // not supported.
             interrupt_mode: os.platform() === 'win32' ? 'signal' : 'message',
+            // In the future this may need to be updated to reflect the exact version of
+            // the protocol supported by ipykernel. For now, use 5.3 as a lowest
+            // common denominator.
+            protocol_version: '5.3',
             env,
         };
 

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -270,7 +270,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
             // In the future this may need to be updated to reflect the exact version of
             // the protocol supported by ipykernel. For now, use 5.3 as a lowest
             // common denominator.
-            protocol_version: '5.3',
+            kernel_protocol_version: '5.3',
             env,
         };
 

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -128,7 +128,7 @@ export function createJupyterKernelSpec(
 		'language': 'R',
 		'env': env,
 		// Protocol version 5.5 signals support for JEP 66
-		'protocol_version': '5.5' // eslint-disable-line
+		'kernel_protocol_version': '5.5' // eslint-disable-line
 	};
 
 	// Unless the user has chosen to restore the workspace, pass the

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -127,6 +127,8 @@ export function createJupyterKernelSpec(
 		'display_name': runtimeName, // eslint-disable-line
 		'language': 'R',
 		'env': env,
+		// Protocol version 5.5 signals support for JEP 66
+		'protocol_version': '5.5' // eslint-disable-line
 	};
 
 	// Unless the user has chosen to restore the workspace, pass the

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -66,7 +66,7 @@ export interface JupyterKernelSpec {
 	 * When protocol >= 5.5 is used, the supervisor will use a handshake
 	 * to negotiate ports instead of picking them ahead of time (JEP 66)
 	 */
-	protocol_version: string; // eslint-disable-line
+	kernel_protocol_version: string; // eslint-disable-line
 
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -60,6 +60,14 @@ export interface JupyterKernelSpec {
 	/** Environment variables to set when starting the kernel */
 	env?: NodeJS.ProcessEnv;
 
+	/**
+	 * The Jupyter protocol version to use when connecting to the kernel.
+	 *
+	 * When protocol >= 5.5 is used, the supervisor will use a handshake
+	 * to negotiate ports instead of picking them ahead of time (JEP 66)
+	 */
+	protocol_version: string; // eslint-disable-line
+
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`
 	 *  is ignored.

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -459,7 +459,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 				'display_name': "Reticulate Python Session", // eslint-disable-line
 				'language': 'Python',
 				'env': {},
-				'protocol_version': '5.3',
+				'kernel_protocol_version': '5.3',
 				'startKernel': async (session, kernel) => {
 					try {
 						await this.startKernel(session, kernel);

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -459,6 +459,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 				'display_name': "Reticulate Python Session", // eslint-disable-line
 				'language': 'Python',
 				'env': {},
+				'protocol_version': '5.3',
 				'startKernel': async (session, kernel) => {
 					try {
 						await this.startKernel(session, kernel);

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -60,6 +60,14 @@ export interface JupyterKernelSpec {
 
 	/** Environment variables to set when starting the kernel */
 	env?: NodeJS.ProcessEnv;
+
+	/**
+	 * The Jupyter protocol version to use when connecting to the kernel.
+	 *
+	 * When protocol >= 5.5 is used, the supervisor will use a handshake
+	 * to negotiate ports instead of picking them ahead of time (JEP 66)
+	 */
+	protocol_version: string; // eslint-disable-line
 
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -67,7 +67,7 @@ export interface JupyterKernelSpec {
 	 * When protocol >= 5.5 is used, the supervisor will use a handshake
 	 * to negotiate ports instead of picking them ahead of time (JEP 66)
 	 */
-	protocol_version: string; // eslint-disable-line
+	kernel_protocol_version: string; // eslint-disable-line
 
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -136,7 +136,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.33"
+      "kallichore": "0.1.34"
     }
   },
   "dependencies": {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -283,6 +283,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			username: os.userInfo().username,
 			interruptMode,
 			connectionTimeout,
+			protocolVersion: kernelSpec.protocol_version
 		};
 		await this._api.newSession(session);
 		this.log(`${kernelSpec.display_name} session '${this.metadata.sessionId}' created in ${workingDir} with command:`, vscode.LogLevel.Info);

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -283,7 +283,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			username: os.userInfo().username,
 			interruptMode,
 			connectionTimeout,
-			protocolVersion: kernelSpec.protocol_version
+			protocolVersion: kernelSpec.kernel_protocol_version
 		};
 		await this._api.newSession(session);
 		this.log(`${kernelSpec.display_name} session '${this.metadata.sessionId}' created in ${workingDir} with command:`, vscode.LogLevel.Info);

--- a/extensions/positron-supervisor/src/kcclient/model/newSession.ts
+++ b/extensions/positron-supervisor/src/kcclient/model/newSession.ts
@@ -55,6 +55,10 @@ export class NewSession {
     */
     'connectionTimeout'?: number = 30;
     'interruptMode': InterruptMode;
+    /**
+    * The Jupyter protocol version supported by the underlying kernel
+    */
+    'protocolVersion'?: string = '5.3';
 
     static discriminator: string | undefined = undefined;
 
@@ -113,6 +117,11 @@ export class NewSession {
             "name": "interruptMode",
             "baseName": "interrupt_mode",
             "type": "InterruptMode"
+        },
+        {
+            "name": "protocolVersion",
+            "baseName": "protocol_version",
+            "type": "string"
         }    ];
 
     static getAttributeTypeMap() {

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -61,6 +61,14 @@ export interface JupyterKernelSpec {
 	/** Environment variables to set when starting the kernel */
 	env?: NodeJS.ProcessEnv;
 
+	/**
+	 * The Jupyter protocol version to use when connecting to the kernel.
+	 *
+	 * When protocol >= 5.5 is used, the supervisor will use a handshake
+	 * to negotiate ports instead of picking them ahead of time (JEP 66)
+	 */
+	protocol_version: string; // eslint-disable-line
+
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`
 	 *  is ignored.

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -67,7 +67,7 @@ export interface JupyterKernelSpec {
 	 * When protocol >= 5.5 is used, the supervisor will use a handshake
 	 * to negotiate ports instead of picking them ahead of time (JEP 66)
 	 */
-	protocol_version: string; // eslint-disable-line
+	kernel_protocol_version: string; // eslint-disable-line
 
 	/** Function that starts the kernel given a JupyterSession object.
 	 *  This is used to start the kernel if it's provided. In this case `argv`


### PR DESCRIPTION
This change brings in a new version of the kernel supervisor that implements [JEP 66](https://jupyter.org/enhancement-proposals/66-jupyter-handshaking/jupyter-handshaking.html). This should prevent the socket allocation race condition when using the Ark kernel, which [implements the other side](https://github.com/posit-dev/ark/pull/576) of JEP 66.

Unfortunately ipykernel does not appear to support this proposal yet. However, the supervisor also has an improvement for kernels that don't support JEP 66: before this change, sockets were allocated when a session was created, and then used when the session was started. Because these are two different API calls, there's some opportunity for the sockets to get bound by other software between the two calls. After the change, creating a session does not allocate sockets; they are allocated immediately before the session is started in the same API call.

Addresses https://github.com/posit-dev/positron/issues/5799.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Improve R and Python session startup reliability by changing the way ports are negotiated (https://github.com/posit-dev/positron/issues/5799)


### QA Notes

- Restarting is also affected by this code.
- You can check the Positron Supervisor logs to see if this change is working. You should see JEP 66 referenced when the an R session starts, but not when a Python session starts.
- After this change, R should not experience any more "address in use" errors. 
- This change should reduce (and maybe even eliminate) Python "address in use" errors, but it isn't guaranteed to do so since it only reduces rather than eliminates the window of time between socket allocation and socket binding.

Test tags `@:console`