### PR TITLE
Better session switcher ranking

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -78,6 +78,11 @@
 	margin-right: 6px;
 }
 
+.action-bar-button.border .action-bar-button-face {
+	padding: 0 5px;
+	max-height: 100%;
+}
+
 .disabled .action-bar-button-text {
 	color: var(--positronActionBar-disabledForeground);
 }

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -413,7 +413,7 @@ const selectNewLanguageRuntime = async (
 		// Add a separator for active sessions.
 		runtimeItems.push({
 			type: 'separator',
-			label: localize('positron.languageRuntime.currentSession', 'Active Sessions')
+			label: localize('positron.languageRuntime.projectRuntimes', 'Project')
 		});
 		// Add active runtimes first and foremost.
 		activeRuntimes.forEach(runtime => {


### PR DESCRIPTION
Improves session switcher/creator ranking. Current session runtime appears first, allowing for "plus" + enter to clone the session. Other active session runtimes appear directly below that, sorted descending by most recently used. Remaining, inactive runtimes are listed last.

https://github.com/user-attachments/assets/4e51bdf8-7397-4f45-bac8-6a7ed2adc664

Addresses #6795 & #6800

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Improves order of runtimes in session switcher quickpick

#### Bug Fixes

- Adjusts session switcher padding to match project switcher


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:console @:session
