### PR TITLE
Data Explorer: Fix bin edge computation bug in DuckDB backend

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -541,7 +541,7 @@ class ColumnProfileEvaluator {
 			result.toArray().map(entry => [entry.bin_id, entry.bin_count])
 		);
 		for (let i = 0; i < numBins; ++i) {
-			output.bin_edges.push((binWidth * i).toString());
+			output.bin_edges.push((minValue + binWidth * i).toString());
 			output.bin_counts.push(Number(histEntries.get(i) ?? 0));
 		}
 
@@ -549,7 +549,7 @@ class ColumnProfileEvaluator {
 		output.bin_counts[numBins - 1] += Number(histEntries.get(numBins) ?? 0);
 
 		// Compute the push the last bin
-		output.bin_edges.push((binWidth * numBins).toString());
+		output.bin_edges.push((minValue + binWidth * numBins).toString());
 		return output;
 	}
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -311,6 +311,7 @@ class ColumnProfileEvaluator {
 					break;
 				case ColumnProfileType.LargeHistogram:
 				case ColumnProfileType.SmallHistogram:
+					this.addNullCount(fieldName);
 					this.addHistogramStats(fieldName, spec.params as ColumnHistogramParams);
 					break;
 				case ColumnProfileType.LargeFrequencyTable:


### PR DESCRIPTION
Addresses #6885. The new tooltips in the data explorer revealed that the bin edges were being computed incorrectly with the DuckDB backend by not adding the minimum value to the multiple of the bin width. I also added some AI-assisted unit tests to verify the histogram -- in doing so I found another bug related to the handling of all-null columns in the histogram calculation, so this has now been fixed:

![image](https://github.com/user-attachments/assets/79c2bcdc-5d5d-4d20-bfcb-31dc89f96b93)

e2e: @:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Check the tooltips for numeric columns that the bin edges shown in the tooltip match the minimum value in the summary statistics.