### PR TITLE
e2e-test: add session fixture and update tests

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -132,8 +132,7 @@ export class Console {
 			await this.code.driver.page.keyboard.type(text, { delay });
 
 			if (pressEnter) {
-				await this.code.driver.page.waitForTimeout(500);
-				await this.code.driver.page.keyboard.press('Enter');
+				await this.code.driver.page.keyboard.press('Enter', { delay: 1000 });
 			}
 		});
 	}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -47,7 +47,7 @@ export class Sessions {
 		this.quickPick = new SessionQuickPick(this.code, this);
 		this.activeSessionPicker = this.page.locator('[id="workbench.parts.positron-top-action-bar"]').getByRole('button', { name: /(Start a New Session)|(Open Active Session Picker)/ });
 		this.trashButton = (sessionId: string) => this.getSessionTab(sessionId).getByTestId('trash-session');
-		this.newConsoleButton = this.page.getByRole('button', { name: 'Open Start Session Picker', exact: true });
+		this.newConsoleButton = this.page.getByRole('toolbar', { name: 'Console actions' }).getByRole('button', { name: 'Start a New Session' });
 		this.restartButton = this.page.getByLabel('Restart console', { exact: true });
 		this.shutDownButton = this.page.getByLabel('Shutdown console', { exact: true });
 		this.sessions = this.page.getByTestId(/console-(?!tab-)[a-zA-Z0-9-]+/);
@@ -105,7 +105,6 @@ export class Sessions {
 			} else if (triggerMode === 'console') {
 				await this.console.focus();
 				await this.newConsoleButton.click();
-				await expect(this.code.driver.page.getByText(/Select a Session/)).toBeVisible();
 			} else {
 				await this.page.keyboard.press('Control+Shift+/');
 			}
@@ -266,13 +265,9 @@ export class Sessions {
 			if (disconnectedSessions.length === 0) { return; } // Nothing to delete
 
 			// Delete all but the last one
-			for (let i = 0; i < disconnectedSessions.length - 1; i++) {
+			for (let i = 0; i < disconnectedSessions.length; i++) {
 				await this.delete(disconnectedSessions[i]);
 			}
-
-			// Handle the last one separately because there may not be a tab list trash icon to click on
-			await this.console.barTrashButton.click();
-			await expect(this.page.getByText('Shutting down')).not.toBeVisible();
 		});
 	}
 
@@ -831,13 +826,14 @@ export type QuickPickSessionInfo = {
 	path: string;
 };
 
+export type SessionTrigger = 'session-picker' | 'quickaccess' | 'console' | 'hotkey';
 
 export type SessionInfo = {
 	name: string;
 	language: 'Python' | 'R';
 	version: string; // e.g. '3.10.15'
 	id: string;
-	triggerMode?: 'session-picker' | 'quickaccess' | 'console' | 'hotkey';
+	triggerMode?: SessionTrigger;
 	waitForReady?: boolean;
 };
 

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, Logger, UserSetting, UserSettingsFixtures, createLogger, createApp, TestTags, SessionInfo, pythonSession, rSession, rSessionAlt, pythonSessionAlt } from '../infra';
+import { Application, Logger, UserSetting, UserSettingsFixtures, createLogger, createApp, TestTags, Sessions } from '../infra';
 import { PackageManager } from '../pages/utils/packageManager';
 import { Keyboard } from '../infra/keyboard.js';
 
@@ -123,36 +123,12 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		await use({ set: setInterpreter });
 	}, { scope: 'test', timeout: 30000 }],
 
-	sessions: [async ({ app }, use) => {
-		const startSessions = async (sessions: SessionRuntimes[], options?: { waitForReady?: boolean; triggerMode?: 'session-picker' | 'quickaccess' | 'console' | 'hotkey'; reuse?: boolean; deleteAfterTest?: boolean }): Promise<SessionInfo[]> => {
-
-			const {
-				waitForReady = true,
-				triggerMode = 'console',
-				reuse = true,
-			} = options || {};
-
-			const availableRuntimes: { [key: string]: SessionInfo } = {
-				r: { ...rSession, triggerMode, waitForReady },
-				rAlt: { ...rSessionAlt, triggerMode, waitForReady },
-				python: { ...pythonSession, triggerMode, waitForReady },
-				pythonAlt: { ...pythonSessionAlt, triggerMode, waitForReady },
-			};
-
-			const sessionList: SessionInfo[] = [];
-
-			for (let i = 0; i < sessions.length; i++) {
-				const session = { ...availableRuntimes[sessions[i]] };
-				session.id = reuse
-					? await app.workbench.sessions.reuseIdleSessionIfExists(session)
-					: await app.workbench.sessions.launch(session);
-				sessionList.push(session);
-			}
-			return sessionList;
-		};
-		await use({ start: startSessions });
-
-	}, { scope: 'test', timeout: 90000 }],
+	sessions: [
+		async ({ app }, use) => {
+			await use(app.workbench.sessions);
+		},
+		{ scope: 'test' }
+	],
 
 	r: [
 		async ({ interpreter }, use) => {
@@ -432,8 +408,6 @@ async function moveAndOverwrite(sourcePath, destinationPath) {
 	} catch (err) { }
 }
 
-type SessionRuntimes = 'python' | 'pythonAlt' | 'r' | 'rAlt';
-
 interface TestFixtures {
 	restartApp: Application;
 	tracing: any;
@@ -441,14 +415,7 @@ interface TestFixtures {
 	attachScreenshotsToReport: any;
 	attachLogsToReport: any;
 	interpreter: { set: (interpreterName: 'Python' | 'R', waitFoReady?: boolean) => Promise<void> };
-	sessions: {
-		start: (sessions: SessionRuntimes[], options?: {
-			waitForReady?: boolean;
-			triggerMode?: 'session-picker' | 'quickaccess' | 'console' | 'hotkey';
-			reuse?: boolean;
-
-		}) => Promise<SessionInfo[]>;
-	};
+	sessions: Sessions;
 	r: void;
 	python: void;
 	packages: PackageManager;

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -3,15 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Application, pythonSession, pythonSessionAlt, rSession, rSessionAlt, SessionInfo } from '../../infra/index.js';
+import { Application, SessionInfo } from '../../infra/index.js';
 import { test, tags } from '../_test.setup';
-
-const pythonSession1a: SessionInfo = { ...pythonSession };
-const pythonSession1b: SessionInfo = { ...pythonSession, name: `Python ${process.env.POSITRON_PY_VER_SEL} - 2`, };
-const pythonSession2: SessionInfo = { ...pythonSessionAlt };
-const rSession1a: SessionInfo = { ...rSession };
-const rSession1b: SessionInfo = { ...rSession, name: `R ${process.env.POSITRON_R_VER_SEL} - 2`, };
-const rSession2: SessionInfo = { ...rSessionAlt };
 
 test.use({
 	suiteId: __filename
@@ -27,12 +20,10 @@ test.describe('Session: Autocomplete', {
 
 	test('Python - Verify autocomplete suggestions in Console and Editor',
 		{ annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6839' }] },
-		async function ({ app, runCommand }) {
-			const { sessions, variables, editors, console } = app.workbench;
+		async function ({ app, runCommand, sessions }) {
+			const { sessions: session, variables, editors, console } = app.workbench;
 
-			pythonSession1a.id = await sessions.launch(pythonSession1a);
-			pythonSession1b.id = await sessions.launch(pythonSession1b);
-			pythonSession2.id = await sessions.launch(pythonSession2);
+			const [pythonSession1a, pythonSession1b, pythonSession2] = await sessions.start(['python', 'python', 'pythonAlt']);
 			await variables.togglePane('hide');
 
 			// Session 1a - trigger and verify console autocomplete
@@ -44,7 +35,7 @@ test.describe('Session: Autocomplete', {
 			await console.expectSuggestionListCount(8);
 
 			// Session 2 - trigger and verify no console autocomplete
-			await sessions.select(pythonSession2.id);
+			await session.select(pythonSession2.id);
 			await console.typeToConsole('pd.Dat', false, 250);
 			await console.expectSuggestionListCount(0);
 
@@ -64,12 +55,10 @@ test.describe('Session: Autocomplete', {
 			await editors.expectSuggestionListCount(0);
 		});
 
-	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand }) {
-		const { sessions, variables, editors, console } = app.workbench;
+	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
+		const { sessions: session, variables, editors, console } = app.workbench;
 
-		rSession1a.id = await sessions.reuseIdleSessionIfExists(rSession1a);
-		rSession1b.id = await sessions.launch(rSession1b);
-		rSession2.id = await sessions.launch(rSession2);
+		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
 		await variables.togglePane('hide');
 
 		// Session 1a - verify console autocomplete
@@ -81,7 +70,7 @@ test.describe('Session: Autocomplete', {
 		await console.expectSuggestionListCount(4);
 
 		// Session 2 - verify no console autocomplete
-		await sessions.select(rSession2.id);
+		await session.select(rSession2.id);
 		await console.typeToConsole('read_p', false, 250);
 		await console.expectSuggestionListCount(0);
 

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -21,7 +21,7 @@ test.describe('Session: Autocomplete', {
 	test('Python - Verify autocomplete suggestions in Console and Editor',
 		{ annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6839' }] },
 		async function ({ app, runCommand, sessions }) {
-			const { sessions: session, variables, editors, console } = app.workbench;
+			const { variables, editors, console } = app.workbench;
 
 			const [pythonSession1a, pythonSession1b, pythonSession2] = await sessions.start(['python', 'python', 'pythonAlt']);
 			await variables.togglePane('hide');
@@ -35,7 +35,7 @@ test.describe('Session: Autocomplete', {
 			await console.expectSuggestionListCount(8);
 
 			// Session 2 - trigger and verify no console autocomplete
-			await session.select(pythonSession2.id);
+			await sessions.select(pythonSession2.id);
 			await console.typeToConsole('pd.Dat', false, 250);
 			await console.expectSuggestionListCount(0);
 
@@ -56,7 +56,7 @@ test.describe('Session: Autocomplete', {
 		});
 
 	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
-		const { sessions: session, variables, editors, console } = app.workbench;
+		const { variables, editors, console } = app.workbench;
 
 		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
 		await variables.togglePane('hide');
@@ -70,7 +70,7 @@ test.describe('Session: Autocomplete', {
 		await console.expectSuggestionListCount(4);
 
 		// Session 2 - verify no console autocomplete
-		await session.select(rSession2.id);
+		await sessions.select(rSession2.id);
 		await console.typeToConsole('read_p', false, 250);
 		await console.expectSuggestionListCount(0);
 

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -23,19 +23,19 @@ test.describe('Session: Autocomplete', {
 		async function ({ app, runCommand, sessions }) {
 			const { variables, editors, console } = app.workbench;
 
-			const [pythonSession1a, pythonSession1b, pythonSession2] = await sessions.start(['python', 'python', 'pythonAlt']);
+			const [pySession1, pySession2, pyAltSession] = await sessions.start(['python', 'python', 'pythonAlt']);
 			await variables.togglePane('hide');
 
 			// Session 1a - trigger and verify console autocomplete
-			await triggerAutocompleteInConsole(app, pythonSession1a);
+			await triggerAutocompleteInConsole(app, pySession1);
 			await console.expectSuggestionListCount(8);
 
 			// Session 1b - trigger and verify console autocomplete
-			await triggerAutocompleteInConsole(app, pythonSession1b);
+			await triggerAutocompleteInConsole(app, pySession2);
 			await console.expectSuggestionListCount(8);
 
 			// Session 2 - trigger and verify no console autocomplete
-			await sessions.select(pythonSession2.id);
+			await sessions.select(pyAltSession.id);
 			await console.typeToConsole('pd.Dat', false, 250);
 			await console.expectSuggestionListCount(0);
 
@@ -43,34 +43,34 @@ test.describe('Session: Autocomplete', {
 			await runCommand('Python: New Python File');
 
 			// Session 1a - trigger and verify editor autocomplete
-			await triggerAutocompleteInEditor({ app, session: pythonSession1a, retrigger: false });
+			await triggerAutocompleteInEditor({ app, session: pySession1, retrigger: false });
 			await editors.expectSuggestionListCount(5);  // issue 6839, should be 8
 
 			// Session 1b - retrigger and verify editor autocomplete
-			await triggerAutocompleteInEditor({ app, session: pythonSession1b, retrigger: true });
+			await triggerAutocompleteInEditor({ app, session: pySession2, retrigger: true });
 			await editors.expectSuggestionListCount(5); // issue 6839, should be 8
 
 			// Session 2 - retrigger and verify no editor autocomplete
-			await triggerAutocompleteInEditor({ app, session: pythonSession2, retrigger: true });
+			await triggerAutocompleteInEditor({ app, session: pyAltSession, retrigger: true });
 			await editors.expectSuggestionListCount(0);
 		});
 
 	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
 		const { variables, editors, console } = app.workbench;
 
-		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
+		const [rSession1, rSession2, rSessionAlt] = await sessions.start(['r', 'r', 'rAlt']);
 		await variables.togglePane('hide');
 
 		// Session 1a - verify console autocomplete
-		await triggerAutocompleteInConsole(app, rSession1a);
+		await triggerAutocompleteInConsole(app, rSession1);
 		await console.expectSuggestionListCount(4);
 
 		// Session 1b - verify console autocomplete
-		await triggerAutocompleteInConsole(app, rSession1b);
+		await triggerAutocompleteInConsole(app, rSession2);
 		await console.expectSuggestionListCount(4);
 
 		// Session 2 - verify no console autocomplete
-		await sessions.select(rSession2.id);
+		await sessions.select(rSessionAlt.id);
 		await console.typeToConsole('read_p', false, 250);
 		await console.expectSuggestionListCount(0);
 
@@ -78,15 +78,15 @@ test.describe('Session: Autocomplete', {
 		await runCommand('R: New R File');
 
 		// Session 1a - trigger and verify editor autocomplete
-		await triggerAutocompleteInEditor({ app, session: rSession1a, retrigger: false });
+		await triggerAutocompleteInEditor({ app, session: rSession1, retrigger: false });
 		await editors.expectSuggestionListCount(4);
 
 		// Session 1b - retrigger and verify editor autocomplete
-		await triggerAutocompleteInEditor({ app, session: rSession1b, retrigger: true });
+		await triggerAutocompleteInEditor({ app, session: rSession2, retrigger: true });
 		await editors.expectSuggestionListCount(4);
 
 		// Session 2 - retrigger verify no editor autocomplete
-		await triggerAutocompleteInEditor({ app, session: rSession2, retrigger: true });
+		await triggerAutocompleteInEditor({ app, session: rSessionAlt, retrigger: true });
 		await editors.expectSuggestionListCount(0);
 	});
 });

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -23,7 +23,7 @@ test.describe('Sessions: Diagnostics', {
 	});
 
 	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
-		const { sessions: session, problems, editor, console } = app.workbench;
+		const { problems, editor, console } = app.workbench;
 
 		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt']);
 
@@ -32,7 +32,7 @@ test.describe('Sessions: Diagnostics', {
 		await editor.type('import requests\nrequests.get("https://example.com")\n');
 
 		// Session 1 - before installing/importing package, the requests warning should be present
-		await session.select(pythonSession1.id);
+		await sessions.select(pythonSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -44,7 +44,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since requests was not installed in that session
-		await session.select(pythonSession2.id);
+		await sessions.select(pythonSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -53,19 +53,19 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x =');
 
 		// Session 2 - verify both errors (import and syntax) are present
-		await session.select(pythonSession2.id);
+		await sessions.select(pythonSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify 1 error (syntax) is present
-		await session.select(pythonSession1.id);
+		await sessions.select(pythonSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 	});
 
 	test('R - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
-		const { sessions: session, problems, editor, console } = app.workbench;
+		const { problems, editor, console } = app.workbench;
 
 		const [rSession1, rSession2] = await sessions.start(['r', 'rAlt']);
 
@@ -74,7 +74,7 @@ test.describe('Sessions: Diagnostics', {
 		await editor.type('circos.points()\n');
 
 		// Session 1 - before installing/importing pkg the circos warning should be present
-		await session.select(rSession1.id);
+		await sessions.select(rSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -86,7 +86,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since circlize is not installed
-		await session.select(rSession2.id);
+		await sessions.select(rSession2.id);
 		await problems.expectSquigglyCountToBe('warning', 1);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
@@ -95,12 +95,12 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x <-');
 
 		// Session 2 - verify both problems (circos and syntax) are present
-		await session.select(rSession2.id);
+		await sessions.select(rSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify only syntax error is present
-		await session.select(rSession1.id);
+		await sessions.select(rSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -25,14 +25,14 @@ test.describe('Sessions: Diagnostics', {
 	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
 		const { problems, editor, console } = app.workbench;
 
-		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt']);
+		const [pySession, pyAltSession] = await sessions.start(['python', 'pythonAlt']);
 
 		// Open new Python file
 		await runCommand('Python: New File');
 		await editor.type('import requests\nrequests.get("https://example.com")\n');
 
 		// Session 1 - before installing/importing package, the requests warning should be present
-		await sessions.select(pythonSession1.id);
+		await sessions.select(pySession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -44,7 +44,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since requests was not installed in that session
-		await sessions.select(pythonSession2.id);
+		await sessions.select(pyAltSession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -53,12 +53,12 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x =');
 
 		// Session 2 - verify both errors (import and syntax) are present
-		await sessions.select(pythonSession2.id);
+		await sessions.select(pyAltSession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify 1 error (syntax) is present
-		await sessions.select(pythonSession1.id);
+		await sessions.select(pySession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
@@ -67,14 +67,14 @@ test.describe('Sessions: Diagnostics', {
 	test('R - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
 		const { problems, editor, console } = app.workbench;
 
-		const [rSession1, rSession2] = await sessions.start(['r', 'rAlt']);
+		const [rSession, rSessionAlt] = await sessions.start(['r', 'rAlt']);
 
 		// Open new R file
 		await runCommand('R: New File');
 		await editor.type('circos.points()\n');
 
 		// Session 1 - before installing/importing pkg the circos warning should be present
-		await sessions.select(rSession1.id);
+		await sessions.select(rSession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -86,7 +86,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since circlize is not installed
-		await sessions.select(rSession2.id);
+		await sessions.select(rSessionAlt.id);
 		await problems.expectSquigglyCountToBe('warning', 1);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
@@ -95,12 +95,12 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x <-');
 
 		// Session 2 - verify both problems (circos and syntax) are present
-		await sessions.select(rSession2.id);
+		await sessions.select(rSessionAlt.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify only syntax error is present
-		await sessions.select(rSession1.id);
+		await sessions.select(rSession.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -3,13 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { pythonSession, pythonSessionAlt, rSession, rSessionAlt, SessionInfo } from '../../infra/index.js';
 import { test, tags } from '../_test.setup.js';
-
-const pythonSession1: SessionInfo = { ...pythonSession };
-const pythonSession2: SessionInfo = { ...pythonSessionAlt };
-const rSession1: SessionInfo = { ...rSession };
-const rSession2: SessionInfo = { ...rSessionAlt };
 
 test.use({
 	suiteId: __filename
@@ -28,18 +22,17 @@ test.describe('Sessions: Diagnostics', {
 		await runCommand('workbench.action.closeAllEditors');
 	});
 
-	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand }) {
-		const { sessions, problems, editor, console } = app.workbench;
+	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
+		const { sessions: session, problems, editor, console } = app.workbench;
 
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
+		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt']);
 
 		// Open new Python file
 		await runCommand('Python: New File');
 		await editor.type('import requests\nrequests.get("https://example.com")\n');
 
 		// Session 1 - before installing/importing package, the requests warning should be present
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -51,7 +44,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since requests was not installed in that session
-		await sessions.select(pythonSession2.id);
+		await session.select(pythonSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('Import "requests" could not be resolved from source');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -60,29 +53,28 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x =');
 
 		// Session 2 - verify both errors (import and syntax) are present
-		await sessions.select(pythonSession2.id);
+		await session.select(pythonSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify 1 error (syntax) is present
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 	});
 
-	test('R - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand }) {
-		const { sessions, problems, editor, console } = app.workbench;
+	test('R - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
+		const { sessions: session, problems, editor, console } = app.workbench;
 
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
-		rSession2.id = await sessions.reuseIdleSessionIfExists(rSession2);
+		const [rSession1, rSession2] = await sessions.start(['r', 'rAlt']);
 
 		// Open new R file
 		await runCommand('R: New File');
 		await editor.type('circos.points()\n');
 
 		// Session 1 - before installing/importing pkg the circos warning should be present
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
 		await problems.expectSquigglyCountToBe('warning', 1);
@@ -94,7 +86,7 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since circlize is not installed
-		await sessions.select(rSession2.id);
+		await session.select(rSession2.id);
 		await problems.expectSquigglyCountToBe('warning', 1);
 		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
@@ -103,12 +95,12 @@ test.describe('Sessions: Diagnostics', {
 		await editor.selectTabAndType('Untitled-1', 'x <-');
 
 		// Session 2 - verify both problems (circos and syntax) are present
-		await sessions.select(rSession2.id);
+		await session.select(rSession2.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify only syntax error is present
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -23,8 +23,8 @@ test.describe('Sessions: Management', {
 		await app.workbench.variables.togglePane('hide');
 	});
 
-	test.afterEach(async function ({ app }) {
-		await app.workbench.sessions.deleteDisconnectedSessions();
+	test.afterEach(async function ({ sessions }) {
+		await sessions.deleteDisconnectedSessions();
 	});
 
 	test('Validate variables between sessions', {
@@ -33,49 +33,49 @@ test.describe('Sessions: Management', {
 		const { console, variables } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'pythonAlt', 'r']);
+		const [pySession, pySessionAlt, rSession] = await sessions.start(['python', 'pythonAlt', 'r']);
 
 		// Set and verify variables in Python Session 1
-		await sessions.select(pythonSession1.id);
+		await sessions.select(pySession.id);
 		await console.typeToConsole('x = 1', true);
 		await console.typeToConsole('y = 2', true);
-		await variables.expectRuntimeToBe('visible', pythonSession1.name);
+		await variables.expectRuntimeToBe('visible', pySession.name);
 		await variables.expectVariableToBe('x', '1');
 		await variables.expectVariableToBe('y', '2');
 
 		// Set and verify variables in Python Session 2
-		await sessions.select(pythonSession2.id);
+		await sessions.select(pySessionAlt.id);
 		await console.typeToConsole('x = 11', true);
 		await console.typeToConsole('y = 22', true);
-		await variables.expectRuntimeToBe('visible', pythonSession2.name);
+		await variables.expectRuntimeToBe('visible', pySessionAlt.name);
 		await variables.expectVariableToBe('x', '11');
 		await variables.expectVariableToBe('y', '22');
 
 		// Set and verify variables in R
-		await sessions.select(rSession1.id);
+		await sessions.select(rSession.id);
 		await console.typeToConsole('x <- 3', true);
 		await console.typeToConsole('z <- 4', true);
-		await variables.expectRuntimeToBe('visible', rSession1.name);
+		await variables.expectRuntimeToBe('visible', rSession.name);
 		await variables.expectVariableToBe('x', '3');
 		await variables.expectVariableToBe('z', '4');
 
 		// Switch back to Python, update variables, and verify
-		await sessions.select(pythonSession1.id);
+		await sessions.select(pySession.id);
 		await console.typeToConsole('x = 0', true);
-		await variables.expectRuntimeToBe('visible', pythonSession1.name);
+		await variables.expectRuntimeToBe('visible', pySession.name);
 		await variables.expectVariableToBe('x', '0');
 		await variables.expectVariableToBe('y', '2');
 
 		// Switch back to R, verify variables remain unchanged
-		await sessions.select(rSession1.id);
-		await variables.expectRuntimeToBe('visible', rSession1.name);
+		await sessions.select(rSession.id);
+		await variables.expectRuntimeToBe('visible', rSession.name);
 		await variables.expectVariableToBe('x', '3');
 		await variables.expectVariableToBe('z', '4');
 	});
 
-	test('Validate session list is scrollable', async function ({ app, sessions }) {
+	test('Validate session list is scrollable', async function ({ sessions }) {
 		// @ts-ignore need a couple sessions for scrolling
-		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt', 'python']);
+		const [pySession, pySessionAlt] = await sessions.start(['python', 'pythonAlt']);
 
 		// Resize window to force scrolling
 		// Move the divider to be 100px above the bottom
@@ -84,25 +84,25 @@ test.describe('Sessions: Management', {
 		await sessions.setSessionDividerAboveBottom(500);
 
 		// Cleaning up since next test only needs 2 sessions
-		await sessions.delete(pythonSession2.id);
+		await sessions.delete(pySessionAlt.id);
 	});
 
 	test('Validate active session list in console matches active session list in session picker', async function ({ app, sessions }) {
 		const { console } = app.workbench;
 
 		// Start sessions and verify active sessions: order matters!
-		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+		const [pySession, rSession] = await sessions.start(['python', 'r']);
 		await sessions.expectSessionCountToBe(2, 'active');
 		await sessions.expectActiveSessionListsToMatch();
 
 		// Shutdown Python session and verify active sessions
-		await sessions.select(pythonSession1.name);
+		await sessions.select(pySession.name);
 		await console.typeToConsole('exit()', true);
 		await sessions.expectSessionCountToBe(1, 'active');
 		await sessions.expectActiveSessionListsToMatch();
 
 		// Shutdown R session and verify active sessions
-		await sessions.select(rSession1.name);
+		await sessions.select(rSession.name);
 		await console.typeToConsole('q()', true);
 		await sessions.expectSessionCountToBe(0, 'active');
 		await sessions.expectActiveSessionListsToMatch();
@@ -118,20 +118,20 @@ test.describe('Sessions: Management', {
 		const { console, variables } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+		const [pySession, rSession] = await sessions.start(['python', 'r']);
 
 		// Delete 1st session and verify active sessions and runtime in session picker
-		await sessions.delete(pythonSession1.id);
+		await sessions.delete(pySession.id);
 		await sessions.expectSessionCountToBe(1);
 		await sessions.expectActiveSessionListsToMatch();
-		await variables.expectRuntimeToBe('visible', rSession1.name);
+		await variables.expectRuntimeToBe('visible', rSession.name);
 
 		// Delete 2nd session and verify no active sessions or runtime in session picker
 		await console.barTrashButton.click();
 		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
 		await sessions.expectSessionCountToBe(0);
 		await sessions.expectActiveSessionListsToMatch();
-		await variables.expectRuntimeToBe('not.visible', `${rSession1.name}|${pythonSession1.name}|None`);
+		await variables.expectRuntimeToBe('not.visible', `${rSession.name}|${pySession.name}|None`);
 	});
 
 	test('Validate session, console, variables, and plots persist after reload',
@@ -144,20 +144,19 @@ test.describe('Sessions: Management', {
 			const { console, plots, variables } = app.workbench;
 
 			// Ensure sessions exist and are idle
-			const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+			const [pySession, rSession] = await sessions.start(['python', 'r']);
 
-			// pythonSession1b.id = await sessions.launch(pythonSession1b);
 			await sessions.expectSessionCountToBe(2);
 			await sessions.expectAllSessionsToBeIdle();
 
 			// Select R session and run script to generate plot and variable
-			await runCodeInSession(app, rSession1, 1,);
+			await runCodeInSession(app, rSession, 1,);
 			await plots.waitForCurrentPlot();
 			await console.waitForConsoleContents('[1] "this is console 1"');
 			await variables.expectVariableToBe('test', '1');
 
 			// Select Python session 1 and run script to generate plot and variable
-			await runCodeInSession(app, pythonSession1, 2);
+			await runCodeInSession(app, pySession, 2);
 			await plots.waitForCurrentPlot();
 			await plots.expectPlotThumbnailsCountToBe(2);
 			await console.waitForConsoleContents('this is console 2', { exact: true });
@@ -165,7 +164,7 @@ test.describe('Sessions: Management', {
 
 			// issue 6725: uncomment below lines after issue is fixed
 			// Select Python session 1b (same runtime) and run script to generate plot and variable
-			// await runCodeInSession(app, pythonSession1b, 3);
+			// await runCodeInSession(app, pySession2, 3);
 			// await plots.expectPlotThumbnailsCountToBe(3);
 			// await console.waitForConsoleContents('this is console 3', { exact: true });
 			// await variables.expectVariableToBe('test', '3');
@@ -178,21 +177,21 @@ test.describe('Sessions: Management', {
 			await sessions.expectAllSessionsToBeIdle();
 
 			// Verify sessions, plot, console history, and variables persist for R session
-			await sessions.select(rSession1.id);
+			await sessions.select(rSession.id);
 			await variables.expectVariableToBe('test', '1');
 			await console.waitForConsoleContents('[1] "this is console 1"');
 			await plots.waitForCurrentPlot();
 			await plots.expectPlotThumbnailsCountToBe(2);
 
 			// Verify sessions, plot, console history, and variables persist for Python session
-			await sessions.select(pythonSession1.id);
+			await sessions.select(pySession.id);
 			await variables.expectVariableToBe('test', '2');
 			await console.waitForConsoleContents('this is console 2', { exact: true });
 			await plots.waitForCurrentPlot();
 			await plots.expectPlotThumbnailsCountToBe(2);
 
 			// issue 6725: uncomment below lines after issue is fixed
-			// await sessions.select(pythonSession1b.id);
+			// await sessions.select(pySession2.id);
 			// await variables.expectVariableToBe('test', '3');
 			// await console.waitForConsoleContents('this is console 3', { exact: true });
 		});

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -4,13 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { Application, pythonSession, pythonSessionAlt, rSession, SessionInfo } from '../../infra';
+import { Application, SessionInfo } from '../../infra';
 import { expect } from '@playwright/test';
-
-const pythonSession1: SessionInfo = { ...pythonSession };
-// const pythonSession1b: SessionInfo = { ...pythonSession };
-const pythonSession2: SessionInfo = { ...pythonSessionAlt };
-const rSession1: SessionInfo = { ...rSession };
 
 test.use({
 	suiteId: __filename
@@ -34,16 +29,14 @@ test.describe('Sessions: Management', {
 
 	test('Validate variables between sessions', {
 		tag: [tags.VARIABLES]
-	}, async function ({ app }) {
-		const { sessions, console, variables } = app.workbench;
+	}, async function ({ app, sessions }) {
+		const { sessions: session, console, variables } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'pythonAlt', 'r']);
 
 		// Set and verify variables in Python Session 1
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await console.typeToConsole('x = 1', true);
 		await console.typeToConsole('y = 2', true);
 		await variables.expectRuntimeToBe('visible', pythonSession1.name);
@@ -51,7 +44,7 @@ test.describe('Sessions: Management', {
 		await variables.expectVariableToBe('y', '2');
 
 		// Set and verify variables in Python Session 2
-		await sessions.select(pythonSession2.id);
+		await session.select(pythonSession2.id);
 		await console.typeToConsole('x = 11', true);
 		await console.typeToConsole('y = 22', true);
 		await variables.expectRuntimeToBe('visible', pythonSession2.name);
@@ -59,7 +52,7 @@ test.describe('Sessions: Management', {
 		await variables.expectVariableToBe('y', '22');
 
 		// Set and verify variables in R
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await console.typeToConsole('x <- 3', true);
 		await console.typeToConsole('z <- 4', true);
 		await variables.expectRuntimeToBe('visible', rSession1.name);
@@ -67,83 +60,78 @@ test.describe('Sessions: Management', {
 		await variables.expectVariableToBe('z', '4');
 
 		// Switch back to Python, update variables, and verify
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await console.typeToConsole('x = 0', true);
 		await variables.expectRuntimeToBe('visible', pythonSession1.name);
 		await variables.expectVariableToBe('x', '0');
 		await variables.expectVariableToBe('y', '2');
 
 		// Switch back to R, verify variables remain unchanged
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await variables.expectRuntimeToBe('visible', rSession1.name);
 		await variables.expectVariableToBe('x', '3');
 		await variables.expectVariableToBe('z', '4');
 	});
 
-	test('Validate session list is scrollable', async function ({ app }) {
-		const sessions = app.workbench.sessions;
+	test('Validate session list is scrollable', async function ({ app, sessions }) {
+		const session = app.workbench.sessions;
 
-		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt']);
 
 		// Resize window to force scrolling
 		// Move the divider to be 100px above the bottom
-		await sessions.setSessionDividerAboveBottom(100);
-		await sessions.expectSessionListToBeScrollable({ horizontal: false, vertical: true });
-		await sessions.setSessionDividerAboveBottom(500);
+		await session.setSessionDividerAboveBottom(100);
+		await session.expectSessionListToBeScrollable({ horizontal: false, vertical: true });
+		await session.setSessionDividerAboveBottom(500);
 
 		// Cleaning up since next test only needs 2 sessions
-		await sessions.delete(pythonSession2.id);
+		await session.delete(pythonSession2.id);
 	});
 
-	test('Validate active session list in console matches active session list in session picker', async function ({ app }) {
-		const { sessions, console } = app.workbench;
+	test('Validate active session list in console matches active session list in session picker', async function ({ app, sessions }) {
+		const { sessions: session, console } = app.workbench;
 
 		// Start sessions and verify active sessions: order matters!
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
-		await sessions.expectSessionCountToBe(2, 'active');
-		await sessions.expectActiveSessionListsToMatch();
+		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+		await session.expectSessionCountToBe(2, 'active');
+		await session.expectActiveSessionListsToMatch();
 
 		// Shutdown Python session and verify active sessions
-		await sessions.select(pythonSession1.name);
+		await session.select(pythonSession1.name);
 		await console.typeToConsole('exit()', true);
-		await sessions.expectSessionCountToBe(1, 'active');
-		await sessions.expectActiveSessionListsToMatch();
+		await session.expectSessionCountToBe(1, 'active');
+		await session.expectActiveSessionListsToMatch();
 
 		// Shutdown R session and verify active sessions
-		await sessions.select(rSession1.name);
+		await session.select(rSession1.name);
 		await console.typeToConsole('q()', true);
-		await sessions.expectSessionCountToBe(0, 'active');
-		await sessions.expectActiveSessionListsToMatch();
+		await session.expectSessionCountToBe(0, 'active');
+		await session.expectActiveSessionListsToMatch();
 
 		// Launch Python session (again) and verify active sessions
-		await sessions.deleteDisconnectedSessions();
-		await sessions.launch(pythonSession1);
-		await sessions.expectSessionCountToBe(1, 'active');
-		await sessions.expectActiveSessionListsToMatch();
+		await session.deleteDisconnectedSessions();
+		await session.launch(pythonSession1);
+		await session.expectSessionCountToBe(1, 'active');
+		await session.expectActiveSessionListsToMatch();
 	});
 
-	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app }) {
-		const { sessions, console, variables } = app.workbench;
+	test('Validate can delete sessions', { tag: [tags.VARIABLES] }, async function ({ app, sessions }) {
+		const { sessions: session, console, variables } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
 
 		// Delete 1st session and verify active sessions and runtime in session picker
-		await sessions.delete(pythonSession1.id);
-		await sessions.expectSessionCountToBe(1);
-		await sessions.expectActiveSessionListsToMatch();
+		await session.delete(pythonSession1.id);
+		await session.expectSessionCountToBe(1);
+		await session.expectActiveSessionListsToMatch();
 		await variables.expectRuntimeToBe('visible', rSession1.name);
 
 		// Delete 2nd session and verify no active sessions or runtime in session picker
 		await console.barTrashButton.click();
-		await expect(sessions.activeSessionPicker).toHaveText('Start Session');
-		await sessions.expectSessionCountToBe(0);
-		await sessions.expectActiveSessionListsToMatch();
+		await expect(session.activeSessionPicker).toHaveText('Start Session');
+		await session.expectSessionCountToBe(0);
+		await session.expectActiveSessionListsToMatch();
 		await variables.expectRuntimeToBe('not.visible', `${rSession1.name}|${pythonSession1.name}|None`);
 	});
 
@@ -153,15 +141,15 @@ test.describe('Sessions: Management', {
 			annotation: [
 				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6036' },
 				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6725' }]
-		}, async function ({ app, runCommand }) {
-			const { sessions, console, plots, variables } = app.workbench;
+		}, async function ({ app, sessions, runCommand }) {
+			const { sessions: session, console, plots, variables } = app.workbench;
 
 			// Ensure sessions exist and are idle
-			pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-			rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+			const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+
 			// pythonSession1b.id = await sessions.launch(pythonSession1b);
-			await sessions.expectSessionCountToBe(2);
-			await sessions.expectAllSessionsToBeIdle();
+			await session.expectSessionCountToBe(2);
+			await session.expectAllSessionsToBeIdle();
 
 			// Select R session and run script to generate plot and variable
 			await runCodeInSession(app, rSession1, 1,);
@@ -187,25 +175,25 @@ test.describe('Sessions: Management', {
 			await runCommand('workbench.action.reloadWindow');
 
 			// Verify all sessions reload and are idle
-			await sessions.expectSessionCountToBe(2);
-			await sessions.expectAllSessionsToBeIdle();
+			await session.expectSessionCountToBe(2);
+			await session.expectAllSessionsToBeIdle();
 
 			// Verify sessions, plot, console history, and variables persist for R session
-			await sessions.select(rSession1.id);
+			await session.select(rSession1.id);
 			await variables.expectVariableToBe('test', '1');
 			await console.waitForConsoleContents('[1] "this is console 1"');
 			await plots.waitForCurrentPlot();
 			await plots.expectPlotThumbnailsCountToBe(2);
 
 			// Verify sessions, plot, console history, and variables persist for Python session
-			await sessions.select(pythonSession1.id);
+			await session.select(pythonSession1.id);
 			await variables.expectVariableToBe('test', '2');
 			await console.waitForConsoleContents('this is console 2', { exact: true });
 			await plots.waitForCurrentPlot();
 			await plots.expectPlotThumbnailsCountToBe(2);
 
 			// issue 6725: uncomment below lines after issue is fixed
-			// await sessions.select(pythonSession1b.id);
+			// await session.select(pythonSession1b.id);
 			// await variables.expectVariableToBe('test', '3');
 			// await console.waitForConsoleContents('this is console 3', { exact: true });
 		});

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -76,7 +76,8 @@ test.describe('Sessions: Management', {
 	test('Validate session list is scrollable', async function ({ app, sessions }) {
 		const session = app.workbench.sessions;
 
-		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt']);
+		// @ts-ignore need a couple sessions for scrolling
+		const [pythonSession1, pythonSession2] = await sessions.start(['python', 'pythonAlt', 'python']);
 
 		// Resize window to force scrolling
 		// Move the divider to be 100px above the bottom

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -50,7 +50,7 @@ test.describe('Session: Outline', {
 	});
 
 	test('R - Verify outline is per session', async function ({ app, openFile, sessions }) {
-		const { sessions: session, variables, outline, console } = app.workbench;
+		const { variables, outline, console } = app.workbench;
 
 		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
 
@@ -60,7 +60,7 @@ test.describe('Session: Outline', {
 		await openFile('workspaces/outline/basic-outline-with-vars.r');
 
 		// Session 1a - verify only expected outline elements
-		await session.select(rSession1a.id);
+		await sessions.select(rSession1a.id);
 		await console.typeToConsole('x<-"goodbye"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -68,7 +68,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 1b - verify only expected outline elements
-		await session.select(rSession1b.id);
+		await sessions.select(rSession1b.id);
 		await console.typeToConsole('x<-"goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -76,7 +76,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 2 - verify only expected outline elements
-		await session.select(rSession2.id);
+		await sessions.select(rSession2.id);
 		await console.typeToConsole('x<-"goodbye3"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -3,15 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { pythonSession, pythonSessionAlt, rSession, rSessionAlt, SessionInfo } from '../../infra/index.js';
 import { test, tags } from '../_test.setup';
-
-const pythonSession1a: SessionInfo = { ...pythonSession };
-const pythonSession1b: SessionInfo = { ...pythonSession, name: `Python ${process.env.POSITRON_PY_VER_SEL} - 2`, };
-const pythonSession2: SessionInfo = { ...pythonSessionAlt };
-const rSession1a: SessionInfo = { ...rSession };
-const rSession1b: SessionInfo = { ...rSession, name: `R ${process.env.POSITRON_R_VER_SEL} - 2`, };
-const rSession2: SessionInfo = { ...rSessionAlt };
 
 test.use({
 	suiteId: __filename
@@ -25,12 +17,10 @@ test.describe('Session: Outline', {
 		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
 	});
 
-	test('Python - Verify outline is per session', async function ({ app, openFile }) {
-		const { sessions, variables, outline, console } = app.workbench;
+	test('Python - Verify outline is per session', async function ({ app, openFile, sessions }) {
+		const { sessions: session, variables, outline, console } = app.workbench;
 
-		pythonSession1a.id = await sessions.launch(pythonSession1a);
-		pythonSession1b.id = await sessions.launch(pythonSession1b);
-		pythonSession2.id = await sessions.launch(pythonSession2);
+		const [pythonSession1a, pythonSession1b, pythonSession2] = await sessions.start(['python', 'python', 'pythonAlt']);
 
 		// Focus outline view and open Python file
 		await variables.togglePane('hide');
@@ -38,33 +28,31 @@ test.describe('Session: Outline', {
 		await openFile('workspaces/outline/basic-outline-with-vars.py');
 
 		// Session 1a - verify only expected outline elements
-		await sessions.select(pythonSession1a.id);
+		await session.select(pythonSession1a.id);
 		await console.typeToConsole('global_variable="goodbye"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 
 		// Session 1b - verify only expected outline elements
-		await sessions.select(pythonSession1b.id);
+		await session.select(pythonSession1b.id);
 		await console.typeToConsole('global_variable="goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 
 		// Session 2 - verify only expected outline elements
-		await sessions.select(pythonSession2.id);
+		await session.select(pythonSession2.id);
 		await console.typeToConsole('global_variable="goodbye3"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 	});
 
-	test('R - Verify outline is per session', async function ({ app, openFile }) {
-		const { sessions, variables, outline, console } = app.workbench;
+	test('R - Verify outline is per session', async function ({ app, openFile, sessions }) {
+		const { sessions: session, variables, outline, console } = app.workbench;
 
-		rSession1a.id = await sessions.launch(rSession1a);
-		rSession1b.id = await sessions.launch(rSession1b);
-		rSession2.id = await sessions.launch(rSession2);
+		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
 
 		// Focus outline view and open Python file
 		await variables.togglePane('hide');
@@ -72,7 +60,7 @@ test.describe('Session: Outline', {
 		await openFile('workspaces/outline/basic-outline-with-vars.r');
 
 		// Session 1a - verify only expected outline elements
-		await sessions.select(rSession1a.id);
+		await session.select(rSession1a.id);
 		await console.typeToConsole('x<-"goodbye"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -80,7 +68,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 1b - verify only expected outline elements
-		await sessions.select(rSession1b.id);
+		await session.select(rSession1b.id);
 		await console.typeToConsole('x<-"goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -88,7 +76,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 2 - verify only expected outline elements
-		await sessions.select(rSession2.id);
+		await session.select(rSession2.id);
 		await console.typeToConsole('x<-"goodbye3"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -18,9 +18,9 @@ test.describe('Session: Outline', {
 	});
 
 	test('Python - Verify outline is per session', async function ({ app, openFile, sessions }) {
-		const { sessions: session, variables, outline, console } = app.workbench;
+		const { variables, outline, console } = app.workbench;
 
-		const [pythonSession1a, pythonSession1b, pythonSession2] = await sessions.start(['python', 'python', 'pythonAlt']);
+		const [pySession1, pySession2, pyAltSession] = await sessions.start(['python', 'python', 'pythonAlt']);
 
 		// Focus outline view and open Python file
 		await variables.togglePane('hide');
@@ -28,21 +28,21 @@ test.describe('Session: Outline', {
 		await openFile('workspaces/outline/basic-outline-with-vars.py');
 
 		// Session 1a - verify only expected outline elements
-		await session.select(pythonSession1a.id);
+		await sessions.select(pySession1.id);
 		await console.typeToConsole('global_variable="goodbye"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 
 		// Session 1b - verify only expected outline elements
-		await session.select(pythonSession1b.id);
+		await sessions.select(pySession2.id);
 		await console.typeToConsole('global_variable="goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 
 		// Session 2 - verify only expected outline elements
-		await session.select(pythonSession2.id);
+		await sessions.select(pyAltSession.id);
 		await console.typeToConsole('global_variable="goodbye3"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
@@ -52,7 +52,7 @@ test.describe('Session: Outline', {
 	test('R - Verify outline is per session', async function ({ app, openFile, sessions }) {
 		const { variables, outline, console } = app.workbench;
 
-		const [rSession1a, rSession1b, rSession2] = await sessions.start(['r', 'r', 'rAlt']);
+		const [rSession1, rSession2, rSessionAlt] = await sessions.start(['r', 'r', 'rAlt']);
 
 		// Focus outline view and open Python file
 		await variables.togglePane('hide');
@@ -60,7 +60,7 @@ test.describe('Session: Outline', {
 		await openFile('workspaces/outline/basic-outline-with-vars.r');
 
 		// Session 1a - verify only expected outline elements
-		await sessions.select(rSession1a.id);
+		await sessions.select(rSession1.id);
 		await console.typeToConsole('x<-"goodbye"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -68,7 +68,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 1b - verify only expected outline elements
-		await sessions.select(rSession1b.id);
+		await sessions.select(rSession2.id);
 		await console.typeToConsole('x<-"goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
@@ -76,7 +76,7 @@ test.describe('Session: Outline', {
 		await outline.expectOutlineElementToBeVisible('local_variable');
 
 		// Session 2 - verify only expected outline elements
-		await sessions.select(rSession2.id);
+		await sessions.select(rSessionAlt.id);
 		await console.typeToConsole('x<-"goodbye3"', true);
 		await outline.expectOutlineElementCountToBe(3);
 		await outline.expectOutlineElementToBeVisible('demonstrate_scope');

--- a/test/e2e/tests/sessions/session-picker.test.ts
+++ b/test/e2e/tests/sessions/session-picker.test.ts
@@ -21,42 +21,39 @@ test.describe('Sessions: Session Picker', {
 	test('Python - Start and verify session via session picker', async function ({ app, sessions }) {
 		const session = app.workbench.sessions;
 
-		const [pythonSession] = await sessions.start(['python'], { triggerMode: 'session-picker' });
+		const pythonSession = await sessions.start('python', { triggerMode: 'session-picker' });
 		await session.expectSessionPickerToBe(pythonSession);
 		const { state } = await session.getMetadata();
 		expect(state).toBe('idle');
 	});
 
-	test('R - Start and verify session via session picker', async function ({ app, sessions }) {
-		const session = app.workbench.sessions;
+	test('R - Start and verify session via session picker', async function ({ sessions }) {
 
-		const [rSession] = await sessions.start(['r'], { triggerMode: 'session-picker' });
-		await session.expectSessionPickerToBe(rSession);
-		const { state } = await session.getMetadata();
+		const rSession = await sessions.start('r', { triggerMode: 'session-picker' });
+		await sessions.expectSessionPickerToBe(rSession);
+		const { state } = await sessions.getMetadata();
 		expect(state).toBe('idle');
 	});
 
-	test('Verify Session Picker updates correctly across multiple active sessions', async function ({ app, sessions }) {
-		const session = app.workbench.sessions;
-
+	test('Verify Session Picker updates correctly across multiple active sessions', async function ({ sessions }) {
 		// Start Python and R sessions
 		const [pythonSession1, rSession1] = await sessions.start(['python', 'r'], { triggerMode: 'session-picker' });
 
 		// Widen session tab list to view full runtime names
-		await session.resizeSessionList({ x: -100 });
+		await sessions.resizeSessionList({ x: -100 });
 
 		// Start another Python session and verify Active Session Picker updates
 		const [pythonSession2] = await sessions.start(['pythonAlt'], { triggerMode: 'session-picker' });
-		await expect(session.activeSessionPicker).toContainText(pythonSession2.name);
+		await expect(sessions.activeSessionPicker).toContainText(pythonSession2.name);
 
 		// Start another R session and verify Active Session Picker updates
 		const [rSession2] = await sessions.start(['rAlt'], { triggerMode: 'session-picker' });
-		await expect(session.activeSessionPicker).toContainText(rSession2.name);
+		await expect(sessions.activeSessionPicker).toContainText(rSession2.name);
 
-		await session.select(rSession1.id);
-		await expect(session.activeSessionPicker).toContainText(rSession1.name);
+		await sessions.select(rSession1.id);
+		await expect(sessions.activeSessionPicker).toContainText(rSession1.name);
 
-		await session.select(pythonSession1.id);
-		await expect(session.activeSessionPicker).toContainText(pythonSession1.name);
+		await sessions.select(pythonSession1.id);
+		await expect(sessions.activeSessionPicker).toContainText(pythonSession1.name);
 	});
 });

--- a/test/e2e/tests/sessions/session-picker.test.ts
+++ b/test/e2e/tests/sessions/session-picker.test.ts
@@ -18,42 +18,39 @@ test.describe('Sessions: Session Picker', {
 		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
 	});
 
-	test('Python - Start and verify session via session picker', async function ({ app, sessions }) {
-		const session = app.workbench.sessions;
-
+	test('Python - Start and verify session via session picker', async function ({ sessions }) {
 		const pythonSession = await sessions.start('python', { triggerMode: 'session-picker' });
-		await session.expectSessionPickerToBe(pythonSession);
-		const { state } = await session.getMetadata();
-		expect(state).toBe('idle');
+
+		await sessions.expectSessionPickerToBe(pythonSession);
+		await sessions.expectAllSessionsToBeIdle();
 	});
 
 	test('R - Start and verify session via session picker', async function ({ sessions }) {
-
 		const rSession = await sessions.start('r', { triggerMode: 'session-picker' });
+
 		await sessions.expectSessionPickerToBe(rSession);
-		const { state } = await sessions.getMetadata();
-		expect(state).toBe('idle');
+		await sessions.expectAllSessionsToBeIdle();
 	});
 
 	test('Verify Session Picker updates correctly across multiple active sessions', async function ({ sessions }) {
 		// Start Python and R sessions
-		const [pythonSession1, rSession1] = await sessions.start(['python', 'r'], { triggerMode: 'session-picker' });
+		const [pySession, rSession] = await sessions.start(['python', 'r'], { triggerMode: 'session-picker' });
 
 		// Widen session tab list to view full runtime names
 		await sessions.resizeSessionList({ x: -100 });
 
 		// Start another Python session and verify Active Session Picker updates
-		const [pythonSession2] = await sessions.start(['pythonAlt'], { triggerMode: 'session-picker' });
-		await expect(sessions.activeSessionPicker).toContainText(pythonSession2.name);
+		const pySessionAlt = await sessions.start('pythonAlt', { triggerMode: 'session-picker' });
+		await expect(sessions.activeSessionPicker).toContainText(pySessionAlt.name);
 
 		// Start another R session and verify Active Session Picker updates
-		const [rSession2] = await sessions.start(['rAlt'], { triggerMode: 'session-picker' });
-		await expect(sessions.activeSessionPicker).toContainText(rSession2.name);
+		const rSessionAlt = await sessions.start('rAlt', { triggerMode: 'session-picker' });
+		await expect(sessions.activeSessionPicker).toContainText(rSessionAlt.name);
 
-		await sessions.select(rSession1.id);
-		await expect(sessions.activeSessionPicker).toContainText(rSession1.name);
+		await sessions.select(rSession.id);
+		await expect(sessions.activeSessionPicker).toContainText(rSession.name);
 
-		await sessions.select(pythonSession1.id);
-		await expect(sessions.activeSessionPicker).toContainText(pythonSession1.name);
+		await sessions.select(pySession.id);
+		await expect(sessions.activeSessionPicker).toContainText(pySession.name);
 	});
 });

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -27,102 +27,102 @@ test.describe('Sessions: State', {
 
 	test('Validate state between sessions (active, idle, disconnect)', async function ({ app, sessions }) {
 
-		const { sessions: session, console } = app.workbench;
+		const { console } = app.workbench;
 
 		// Start Python session
-		const [pythonSession1] = await sessions.start(['python'], { waitForReady: false });
+		const pythonSession1 = await sessions.start('python', { waitForReady: false });
 
 		// Verify Python session is visible and transitions from starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
-		await session.expectStatusToBe(pythonSession1.id, 'starting');
-		await session.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
+		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Restart Python session and confirm state returns to starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
-		await session.restartButton.click();
-		await session.expectStatusToBe(pythonSession1.id, 'starting');
-		await session.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.restartButton.click();
+		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
+		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Start R session
 		const [rSession1] = await sessions.start(['r'], { waitForReady: false });
 
 		// Verify R session transitions from active --> idle while Python session remains idle
-		await session.expectStatusToBe(rSession1.id, 'active');
-		await session.expectStatusToBe(rSession1.id, 'idle');
-		await session.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(rSession1.id, 'active');
+		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Restart Python session, verify Python transitions to active --> idle and R remains idle
-		await session.restart(pythonSession1.id, false);
-		await session.expectStatusToBe(pythonSession1.id, 'active');
-		await session.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
-		await session.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.restart(pythonSession1.id, false);
+		await sessions.expectStatusToBe(pythonSession1.id, 'active');
+		await sessions.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
+		await sessions.expectStatusToBe(rSession1.id, 'idle');
 
 		// Shutdown Python session, verify Python transitions to disconnected while R remains idle
-		await session.select(pythonSession1.id);
+		await sessions.select(pythonSession1.id);
 		await console.typeToConsole('exit()', true);
-		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
-		await session.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await sessions.expectStatusToBe(rSession1.id, 'idle');
 
 		// Restart R session, verify R to returns to active --> idle and Python remains disconnected
-		await session.restart(rSession1.id, false);
-		await session.expectStatusToBe(rSession1.id, 'active');
-		await session.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
-		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await sessions.restart(rSession1.id, false);
+		await sessions.expectStatusToBe(rSession1.id, 'active');
+		await sessions.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
+		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
 
 		// Shutdown R, verify both Python and R in disconnected state
-		await session.select(rSession1.id);
+		await sessions.select(rSession1.id);
 		await console.typeToConsole('q()', true);
-		await session.expectStatusToBe(rSession1.id, 'disconnected');
-		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await sessions.expectStatusToBe(rSession1.id, 'disconnected');
+		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
 	});
 
 	test('Validate state displays as active when executing code', async function ({ app, sessions }) {
-		const { sessions: session, console } = app.workbench;
+		const { console } = app.workbench;
 
 		// Start Python and R sessions
-		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
+		const [pythonSession1, rSession1] = await sessions.start(['python', 'r',]);
 
 		// Verify Python session transitions to active when executing code
-		await session.select(pythonSession1.name);
+		await sessions.select(pythonSession1.name);
 		await console.typeToConsole('import time', true);
-		await console.typeToConsole('time.sleep(5)', true);
-		await session.expectStatusToBe(pythonSession1.name, 'active');
+		await console.typeToConsole('time.sleep(7)', true);
+		await sessions.expectStatusToBe(pythonSession1.name, 'active');
 
 		// Verify R session transitions to active when executing code
 		// Verify Python session continues to run and transitions to idle when finished
-		await session.select(rSession1.name);
-		await console.typeToConsole('Sys.sleep(1)', true);
-		await session.expectStatusToBe(rSession1.name, 'active');
-		await session.expectStatusToBe(rSession1.name, 'idle');
-		await session.expectStatusToBe(pythonSession1.name, 'active');
-		await session.expectStatusToBe(pythonSession1.name, 'idle');
+		await sessions.select(rSession1.name);
+		await console.typeToConsole('Sys.sleep(2)', true);
+		await sessions.expectStatusToBe(rSession1.name, 'active');
+		await sessions.expectStatusToBe(rSession1.name, 'idle');
+		await sessions.expectStatusToBe(pythonSession1.name, 'active');
+		await sessions.expectStatusToBe(pythonSession1.name, 'idle');
 	});
 
 	test('Validate metadata between sessions', async function ({ app, sessions }) {
-		const { sessions: session, console } = app.workbench;
+		const { console } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'python', 'r']);
+		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'pythonAlt', 'r']);
 
 		// Verify Python session metadata
-		await session.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
-		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
-		await session.expectMetaDataToBe({ ...rSession1, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...rSession1, state: 'idle' });
 
 		// Shutdown Python session 1 and verify metadata
-		await session.select(pythonSession1.id);
+		await sessions.select(pythonSession1.id);
 		await console.typeToConsole('exit()', true);
-		await session.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
-		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
 
 		// Shutdown R session and verify metadata
-		await session.select(rSession1.id);
+		await sessions.select(rSession1.id);
 		await console.typeToConsole('q()', true);
-		await session.expectMetaDataToBe({ ...rSession1, state: 'exited' });
-		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...rSession1, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
 
 		// Shutdown Python session 2 and verify metadata
 		await console.typeToConsole('exit()', true);
-		await session.expectMetaDataToBe({ ...pythonSession2, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'exited' });
 	});
 });

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -30,99 +30,99 @@ test.describe('Sessions: State', {
 		const { console } = app.workbench;
 
 		// Start Python session
-		const pythonSession1 = await sessions.start('python', { waitForReady: false });
+		const pySession = await sessions.start('python', { waitForReady: false });
 
 		// Verify Python session is visible and transitions from starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
-		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(pySession.id, 'starting');
+		await sessions.expectStatusToBe(pySession.id, 'idle');
 
 		// Restart Python session and confirm state returns to starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
 		await sessions.restartButton.click();
-		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(pySession.id, 'starting');
+		await sessions.expectStatusToBe(pySession.id, 'idle');
 
 		// Start R session
-		const [rSession1] = await sessions.start(['r'], { waitForReady: false });
+		const rSession = await sessions.start('r', { waitForReady: false });
 
 		// Verify R session transitions from active --> idle while Python session remains idle
-		await sessions.expectStatusToBe(rSession1.id, 'active');
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await sessions.expectStatusToBe(rSession.id, 'active');
+		await sessions.expectStatusToBe(rSession.id, 'idle');
+		await sessions.expectStatusToBe(pySession.id, 'idle');
 
 		// Restart Python session, verify Python transitions to active --> idle and R remains idle
-		await sessions.restart(pythonSession1.id, false);
-		await sessions.expectStatusToBe(pythonSession1.id, 'active');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.restart(pySession.id, false);
+		await sessions.expectStatusToBe(pySession.id, 'active');
+		await sessions.expectStatusToBe(pySession.id, 'idle', { timeout: 60000 });
+		await sessions.expectStatusToBe(rSession.id, 'idle');
 
 		// Shutdown Python session, verify Python transitions to disconnected while R remains idle
-		await sessions.select(pythonSession1.id);
+		await sessions.select(pySession.id);
 		await console.typeToConsole('exit()', true);
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await sessions.expectStatusToBe(pySession.id, 'disconnected');
+		await sessions.expectStatusToBe(rSession.id, 'idle');
 
 		// Restart R session, verify R to returns to active --> idle and Python remains disconnected
-		await sessions.restart(rSession1.id, false);
-		await sessions.expectStatusToBe(rSession1.id, 'active');
-		await sessions.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await sessions.restart(rSession.id, false);
+		await sessions.expectStatusToBe(rSession.id, 'active');
+		await sessions.expectStatusToBe(rSession.id, 'idle', { timeout: 60000 });
+		await sessions.expectStatusToBe(pySession.id, 'disconnected');
 
 		// Shutdown R, verify both Python and R in disconnected state
-		await sessions.select(rSession1.id);
+		await sessions.select(rSession.id);
 		await console.typeToConsole('q()', true);
-		await sessions.expectStatusToBe(rSession1.id, 'disconnected');
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await sessions.expectStatusToBe(rSession.id, 'disconnected');
+		await sessions.expectStatusToBe(pySession.id, 'disconnected');
 	});
 
 	test('Validate state displays as active when executing code', async function ({ app, sessions }) {
 		const { console } = app.workbench;
 
 		// Start Python and R sessions
-		const [pythonSession1, rSession1] = await sessions.start(['python', 'r',]);
+		const [pySession, rSession] = await sessions.start(['python', 'r',]);
 
 		// Verify Python session transitions to active when executing code
-		await sessions.select(pythonSession1.name);
+		await sessions.select(pySession.name);
 		await console.typeToConsole('import time', true);
 		await console.typeToConsole('time.sleep(7)', true);
-		await sessions.expectStatusToBe(pythonSession1.name, 'active');
+		await sessions.expectStatusToBe(pySession.name, 'active');
 
 		// Verify R session transitions to active when executing code
 		// Verify Python session continues to run and transitions to idle when finished
-		await sessions.select(rSession1.name);
+		await sessions.select(rSession.name);
 		await console.typeToConsole('Sys.sleep(2)', true);
-		await sessions.expectStatusToBe(rSession1.name, 'active');
-		await sessions.expectStatusToBe(rSession1.name, 'idle');
-		await sessions.expectStatusToBe(pythonSession1.name, 'active');
-		await sessions.expectStatusToBe(pythonSession1.name, 'idle');
+		await sessions.expectStatusToBe(rSession.name, 'active');
+		await sessions.expectStatusToBe(rSession.name, 'idle');
+		await sessions.expectStatusToBe(pySession.name, 'active');
+		await sessions.expectStatusToBe(pySession.name, 'idle');
 	});
 
 	test('Validate metadata between sessions', async function ({ app, sessions }) {
 		const { console } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'pythonAlt', 'r']);
+		const [pySession, pySessionAlt, rSession] = await sessions.start(['python', 'pythonAlt', 'r']);
 
 		// Verify Python session metadata
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pySession, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...rSession, state: 'idle' });
 
-		// Shutdown Python session 1 and verify metadata
-		await sessions.select(pythonSession1.id);
+		// Shutdown Python session and verify metadata
+		await sessions.select(pySession.id);
 		await console.typeToConsole('exit()', true);
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...pySession, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
 
 		// Shutdown R session and verify metadata
-		await sessions.select(rSession1.id);
+		await sessions.select(rSession.id);
 		await console.typeToConsole('q()', true);
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await sessions.expectMetaDataToBe({ ...rSession, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
 
-		// Shutdown Python session 2 and verify metadata
+		// Shutdown Alt Python session and verify metadata
 		await console.typeToConsole('exit()', true);
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'exited' });
+		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'exited' });
 	});
 });

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -4,11 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { pythonSession, pythonSessionAlt, rSession } from '../../infra';
-
-const pythonSession1 = { ...pythonSession };
-const pythonSession2 = { ...pythonSessionAlt };
-const rSession1 = { ...rSession };
 
 test.use({
 	suiteId: __filename
@@ -30,109 +25,104 @@ test.describe('Sessions: State', {
 		await app.workbench.sessions.deleteDisconnectedSessions();
 	});
 
-	test('Validate state between sessions (active, idle, disconnect)', async function ({ app }) {
-		const sessions = app.workbench.sessions;
-		const console = app.workbench.console;
+	test('Validate state between sessions (active, idle, disconnect)', async function ({ app, sessions }) {
+
+		const { sessions: session, console } = app.workbench;
 
 		// Start Python session
-		pythonSession1.id = await sessions.launch({ ...pythonSession1, waitForReady: false });
+		const [pythonSession1] = await sessions.start(['python'], { waitForReady: false });
 
 		// Verify Python session is visible and transitions from starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
-		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await session.expectStatusToBe(pythonSession1.id, 'starting');
+		await session.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Restart Python session and confirm state returns to starting --> idle
 		// Note displays as 'starting' in metadata dialog and as 'active' in session tab list
-		await sessions.restartButton.click();
-		await sessions.expectStatusToBe(pythonSession1.id, 'starting');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await session.restartButton.click();
+		await session.expectStatusToBe(pythonSession1.id, 'starting');
+		await session.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Start R session
-		rSession1.id = await sessions.launch({ ...rSession1, waitForReady: false });
+		const [rSession1] = await sessions.start(['r'], { waitForReady: false });
 
 		// Verify R session transitions from active --> idle while Python session remains idle
-		await sessions.expectStatusToBe(rSession1.id, 'active');
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle');
+		await session.expectStatusToBe(rSession1.id, 'active');
+		await session.expectStatusToBe(rSession1.id, 'idle');
+		await session.expectStatusToBe(pythonSession1.id, 'idle');
 
 		// Restart Python session, verify Python transitions to active --> idle and R remains idle
-		await sessions.restart(pythonSession1.id, false);
-		await sessions.expectStatusToBe(pythonSession1.id, 'active');
-		await sessions.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await session.restart(pythonSession1.id, false);
+		await session.expectStatusToBe(pythonSession1.id, 'active');
+		await session.expectStatusToBe(pythonSession1.id, 'idle', { timeout: 60000 });
+		await session.expectStatusToBe(rSession1.id, 'idle');
 
 		// Shutdown Python session, verify Python transitions to disconnected while R remains idle
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await console.typeToConsole('exit()', true);
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
-		await sessions.expectStatusToBe(rSession1.id, 'idle');
+		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await session.expectStatusToBe(rSession1.id, 'idle');
 
 		// Restart R session, verify R to returns to active --> idle and Python remains disconnected
-		await sessions.restart(rSession1.id, false);
-		await sessions.expectStatusToBe(rSession1.id, 'active');
-		await sessions.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await session.restart(rSession1.id, false);
+		await session.expectStatusToBe(rSession1.id, 'active');
+		await session.expectStatusToBe(rSession1.id, 'idle', { timeout: 60000 });
+		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
 
 		// Shutdown R, verify both Python and R in disconnected state
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await console.typeToConsole('q()', true);
-		await sessions.expectStatusToBe(rSession1.id, 'disconnected');
-		await sessions.expectStatusToBe(pythonSession1.id, 'disconnected');
+		await session.expectStatusToBe(rSession1.id, 'disconnected');
+		await session.expectStatusToBe(pythonSession1.id, 'disconnected');
 	});
 
-	test('Validate state displays as active when executing code', async function ({ app }) {
-		const sessions = app.workbench.sessions;
-		const console = app.workbench.console;
+	test('Validate state displays as active when executing code', async function ({ app, sessions }) {
+		const { sessions: session, console } = app.workbench;
 
 		// Start Python and R sessions
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+		const [pythonSession1, rSession1] = await sessions.start(['python', 'r']);
 
 		// Verify Python session transitions to active when executing code
-		await sessions.select(pythonSession1.name);
+		await session.select(pythonSession1.name);
 		await console.typeToConsole('import time', true);
 		await console.typeToConsole('time.sleep(5)', true);
-		await sessions.expectStatusToBe(pythonSession1.name, 'active');
+		await session.expectStatusToBe(pythonSession1.name, 'active');
 
 		// Verify R session transitions to active when executing code
 		// Verify Python session continues to run and transitions to idle when finished
-		await sessions.select(rSession1.name);
+		await session.select(rSession1.name);
 		await console.typeToConsole('Sys.sleep(1)', true);
-		await sessions.expectStatusToBe(rSession1.name, 'active');
-		await sessions.expectStatusToBe(rSession1.name, 'idle');
-		await sessions.expectStatusToBe(pythonSession1.name, 'active');
-		await sessions.expectStatusToBe(pythonSession1.name, 'idle');
+		await session.expectStatusToBe(rSession1.name, 'active');
+		await session.expectStatusToBe(rSession1.name, 'idle');
+		await session.expectStatusToBe(pythonSession1.name, 'active');
+		await session.expectStatusToBe(pythonSession1.name, 'idle');
 	});
 
-	test('Validate metadata between sessions', async function ({ app }) {
-		const sessions = app.workbench.sessions;
-		const console = app.workbench.console;
+	test('Validate metadata between sessions', async function ({ app, sessions }) {
+		const { sessions: session, console } = app.workbench;
 
 		// Ensure sessions exist and are idle
-		pythonSession1.id = await sessions.reuseIdleSessionIfExists(pythonSession1);
-		pythonSession2.id = await sessions.reuseIdleSessionIfExists(pythonSession2);
-		rSession1.id = await sessions.reuseIdleSessionIfExists(rSession1);
+		const [pythonSession1, pythonSession2, rSession1] = await sessions.start(['python', 'python', 'r']);
 
 		// Verify Python session metadata
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'idle' });
+		await session.expectMetaDataToBe({ ...pythonSession1, state: 'idle' });
+		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await session.expectMetaDataToBe({ ...rSession1, state: 'idle' });
 
 		// Shutdown Python session 1 and verify metadata
-		await sessions.select(pythonSession1.id);
+		await session.select(pythonSession1.id);
 		await console.typeToConsole('exit()', true);
-		await sessions.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await session.expectMetaDataToBe({ ...pythonSession1, state: 'exited' });
+		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
 
 		// Shutdown R session and verify metadata
-		await sessions.select(rSession1.id);
+		await session.select(rSession1.id);
 		await console.typeToConsole('q()', true);
-		await sessions.expectMetaDataToBe({ ...rSession1, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
+		await session.expectMetaDataToBe({ ...rSession1, state: 'exited' });
+		await session.expectMetaDataToBe({ ...pythonSession2, state: 'idle' });
 
 		// Shutdown Python session 2 and verify metadata
 		await console.typeToConsole('exit()', true);
-		await sessions.expectMetaDataToBe({ ...pythonSession2, state: 'exited' });
+		await session.expectMetaDataToBe({ ...pythonSession2, state: 'exited' });
 	});
 });


### PR DESCRIPTION
### Summary
* Updated `sessions` POM to simplify starting a session
* Exposing `sessions` as fixture (which will replace `interpreter` eventually).
* Updated session tests to levreage new fixture.

### QA Notes

@:sessions