### PR TITLE
Add Conda R interpreter discovery

### DIFF
--- a/extensions/positron-r/src/provider-conda.ts
+++ b/extensions/positron-r/src/provider-conda.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as util from "util";
-import { LOGGER } from './extension';
+import { LOGGER } from "./extension";
 import { exec } from "child_process";
 
 const execPromise = util.promisify(exec);
@@ -35,12 +35,16 @@ export async function getCondaEnvironments(): Promise<string[]> {
  * Discover R binaries inside Conda environments
  */
 
-
 /**
  * Get expected R binary path inside a Conda environment
  */
-export function getCondaRPath(envPath: string): string {
-	return path.join(envPath, "bin", "R");
-	// path.join(envPath, "Lib", "R", "bin", "x64", "R.exe") // for future Windows support
-	// ? path.join(envPath, "Lib", "R", "bin", "R.exe")
+export function getCondaRPaths(envPath: string): string[] {
+	const paths: string[] = [];
+	if (process.platform !== "win32") {
+		paths.push(path.join(envPath, "bin", "R"));
+	} else {
+		paths.push(path.join(envPath, "Lib", "R", "bin", "x64", "R.exe")); // Prioritise x64 binaries
+		paths.push(path.join(envPath, "Lib", "R", "bin", "R.exe"));
+	}
+	return paths;
 }

--- a/extensions/positron-r/src/provider-conda.ts
+++ b/extensions/positron-r/src/provider-conda.ts
@@ -1,0 +1,46 @@
+import * as path from "path";
+import * as util from "util";
+import { LOGGER } from './extension';
+import { exec } from "child_process";
+
+const execPromise = util.promisify(exec);
+
+/**
+ * Check if Conda is installed by running `conda --version`
+ */
+export async function isCondaAvailable(): Promise<boolean> {
+	try {
+		await execPromise("conda --version");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Retrieve Conda environment paths using `conda env list --json`
+ */
+export async function getCondaEnvironments(): Promise<string[]> {
+	try {
+		const { stdout } = await execPromise("conda env list --json");
+		const envs = JSON.parse(stdout).envs as string[];
+		return envs;
+	} catch (error) {
+		LOGGER.error("Failed to retrieve Conda environments:", error);
+		return [];
+	}
+}
+
+/**
+ * Discover R binaries inside Conda environments
+ */
+
+
+/**
+ * Get expected R binary path inside a Conda environment
+ */
+export function getCondaRPath(envPath: string): string {
+	return path.join(envPath, "bin", "R");
+	// path.join(envPath, "Lib", "R", "bin", "x64", "R.exe") // for future Windows support
+	// ? path.join(envPath, "Lib", "R", "bin", "R.exe")
+}

--- a/extensions/positron-r/src/provider-conda.ts
+++ b/extensions/positron-r/src/provider-conda.ts
@@ -48,3 +48,17 @@ export function getCondaRPaths(envPath: string): string[] {
 	}
 	return paths;
 }
+
+export function getCondaName(homePath: string): string {
+	const parts = homePath.split(path.sep); // Split path into components
+	let targetIndex = -1;
+
+	targetIndex = parts.lastIndexOf("Lib");
+
+	// The Conda env name should be the directory before "Lib" or "bin"
+	if (targetIndex > 0) {
+		return parts[targetIndex - 1]; // Get the folder before "Lib" or "bin"
+	}
+
+	return ""; // Return empty if no valid Conda env name is found
+}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -17,7 +17,7 @@ import { LOGGER } from './extension';
 import { EXTENSION_ROOT_DIR, MINIMUM_R_VERSION } from './constants';
 import { getInterpreterOverridePaths, printInterpreterSettingsInfo, userRBinaries, userRHeadquarters } from './interpreter-settings.js';
 import { isDirectory, isFile } from './path-utils.js';
-import { isCondaAvailable, getCondaEnvironments, getCondaRPaths } from './provider-conda.js';
+import { isCondaAvailable, getCondaEnvironments, getCondaRPaths, getCondaName } from './provider-conda.js';
 
 // We don't give this a type so it's compatible with both the VS Code
 // and the LSP types
@@ -238,8 +238,17 @@ export async function makeMetadata(
 		isUserInstallation ?
 			RRuntimeSource.user : RRuntimeSource.system;
 
+	let runtimeShortName: string;
+	runtimeShortName = includeArch ? `${rInst.version} (${rInst.arch})` : rInst.version;
 	// Short name shown to users (when disambiguating within a language)
-	const runtimeShortName = includeArch ? `${rInst.version} (${rInst.arch})` : rInst.version;
+	if (rInst.reasonDiscovered && rInst.reasonDiscovered.includes(ReasonDiscovered.CONDA)) {
+		const condaName = getCondaName(rInst.homepath);
+		if (condaName === "") {
+			runtimeShortName = `${runtimeShortName} (Conda)`; // in case no conda name is detected
+		} else {
+			runtimeShortName = `${runtimeShortName} (Conda: ${condaName})`;
+		}
+	}
 
 	// Full name shown to users
 	const runtimeName = `R ${runtimeShortName}`;

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -621,7 +621,7 @@ async function discoverCondaBinaries(): Promise<RBinary[]> {
 		for (const rPath of rPaths) {
 			if (fs.existsSync(rPath)) { // return the first existing R
 				LOGGER.info(`Detected R in Conda environment: ${rPath}`);
-				rBinaries.push({ path: rPath, reasons: [ReasonDiscovered.HQ] });
+				rBinaries.push({ path: rPath, reasons: [ReasonDiscovered.CONDA] });
 				break;
 			}
 		}

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -51,6 +51,7 @@ export enum ReasonDiscovered {
 	/* eslint-disable @typescript-eslint/naming-convention */
 	PATH = "PATH",
 	HQ = "HQ",
+	CONDA = "CONDA",
 	/* eslint-enable @typescript-eslint/naming-convention */
 	adHoc = "adHoc",
 	userSetting = "userSetting",
@@ -78,6 +79,8 @@ export function friendlyReason(reason: ReasonDiscovered | ReasonRejected | null)
 				return 'Found in PATH, via the `which` command';
 			case ReasonDiscovered.HQ:
 				return 'Found in the primary location for R versions on this operating system';
+			case ReasonDiscovered.CONDA:
+				return 'Found in a Conda environment';
 			case ReasonDiscovered.adHoc:
 				return 'Found in a conventional location for symlinked R binaries';
 			case ReasonDiscovered.userSetting:


### PR DESCRIPTION
#### New Features

- Adds conda R interpreter discovery.
- Displays the Conda environment name in R interpreter selector (just like for Python).
- Addresses #6600 , and fixes #4398 .

![image](https://github.com/user-attachments/assets/26336deb-0ecf-47f1-8d03-3f4fc87fe9ee)


#### Bug Fixes

- N/A


### QA Notes

 - Tested it on Windows. 
 - Didn't test on Linux/WSL, but my WSL works with my conda R installation once I manually add it to the list - so in theory my PR should work for Linux. 
 - I haven't tried with OSX at all I would assume it behaves similar to Linux.
 - Note using the interpreter does not involve activating the Conda environment