### PR TITLE
Data Explorer: Fix 1-pixel gaps that appear between some sparkline histogram bins

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -64,7 +64,9 @@ const BinItem = React.memo(({
 
 	// Calculate exact bin position and width to avoid 1-pixel gaps between bins
 	const binPosition = Math.round(binCountIndex * binWidth);
-	binWidth = Math.round((binCountIndex + 1) * binWidth) - binPosition;
+
+	// Make sure bin width is at least 1
+	binWidth = Math.max(1, Math.round((binCountIndex + 1) * binWidth) - binPosition);
 
 	return (
 		<foreignObject

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -62,13 +62,17 @@ const BinItem = React.memo(({
 	const formattedMin = formatValue(binMin);
 	const formattedMax = formatValue(binMax);
 
+	// Calculate exact bin position and width to avoid 1-pixel gaps between bins
+	const binPosition = Math.round(binCountIndex * binWidth);
+	binWidth = Math.round((binCountIndex + 1) * binWidth) - binPosition;
+
 	return (
 		<foreignObject
 			key={`bin-count-container-${binCountIndex}`}
 			className='tooltip-container'
 			height={graphHeight}
 			width={binWidth}
-			x={binCountIndex * binWidth}
+			x={binPosition}
 			y={0}
 		>
 			<div


### PR DESCRIPTION
Addresses #6897.

Here are the sparklines from 

Before:

![image](https://github.com/user-attachments/assets/9d7db264-52b9-4e0f-b83e-cc30a74cd4a0)

After:

![image](https://github.com/user-attachments/assets/616758eb-d3d4-4f58-a5d2-40b5b01252b8)

e2e: @:data-explorer

### Release Notes



#### New Features

- N/A

#### Bug Fixes

- Fix occasional 1-pixel gaps in sparkline histograms in data explorer. 
