### PR TITLE
python: changed order in test-requirements.txt

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -244,7 +244,8 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
     Running holoviews/holoviz code that sets an extension will trigger an event on the ui comm that
     can be used on the front end to react appropriately.
     """
-    shell.run_cell("import holoviews as hv; hv.extension('plotly')")
+    res = shell.run_cell("import holoviews as hv; hv.extension('plotly')")
+    res.raise_error()
 
     assert len(ui_comm.messages) == 1
     assert ui_comm.messages[0] == json_rpc_notification("clear_webview_preloads", {})

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -1,4 +1,3 @@
-bokeh
 fastcore
 geopandas
 holoviews
@@ -21,3 +20,6 @@ torch
 sqlalchemy
 # see https://github.com/posit-dev/positron/issues/6604
 ipython<=8.31.0
+# putting this last because holoviews is picky about dependency versions (including bokeh),
+# so uv's resolver needs to tackle holoviews first
+bokeh


### PR DESCRIPTION
Addresses #6890.

When we switched to installing dependencies with `uv`, the resolver logic slightly changed from the old pip logic, which ended up giving us different versions of various packages than before (see https://github.com/posit-dev/positron/issues/6890#issuecomment-2741080283). In particular, we landed in a state where the versions of `bokeh`, `holoviews`, and `panel` were incompatible in practice, despite their metadata saying that they _were_ compatible.

After some experimentation, I found that if we move `bokeh` to the end of the file, then the `uv` resolver will try to solve it last. This is good because by that point, the picky `holoviews` is already solved, and we can just install a compatible `bokeh` version.

Sorry I forgot to run the nightly tests before merging that PR! Will do before I merge this one 🙂 