### PR TITLE
Data Explorer: Add tooltip explaining null percent indicator graphic in summary pane

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -121,7 +121,6 @@
 	display: grid;
 	grid-gap: 5px;
 	align-items: center;
-	pointer-events: none;
 	grid-column: missing-values / right-gutter;
 	grid-template-columns: [percent] 35px [graph] 25px [end];
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -239,13 +239,13 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			const nullCount = props.instance.getColumnProfileNullCount(props.columnIndex);
 
 			if (nullPercent === undefined || nullCount === undefined) {
-				return 'Null Values\nCalculating...';
+				return 'Missing Values\nCalculating...';
 			} else if (nullPercent === 0) {
-				return `Null Values\nNo null values`;
+				return `Missing Values\nNo missing values`;
 			} else if (nullPercent === 100) {
-				return `Null Values\nAll values are null (${nullCount.toLocaleString()} values)`;
+				return `Missing Values\nAll values are missing (${nullCount.toLocaleString()} values)`;
 			} else {
-				return `Null Values\n${nullPercent}% of values are null (${nullCount.toLocaleString()} values)`;
+				return `Missing Values\n${nullPercent}% of values are missing (${nullCount.toLocaleString()} values)`;
 			}
 		};
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -10,6 +10,7 @@ import './columnSummaryCell.css';
 import React, { useRef, useEffect } from 'react';
 
 // Other dependencies.
+import * as nls from '../../../../../nls.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { usePositronDataGridContext } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
 import { VectorHistogram } from './vectorHistogram.js';
@@ -239,13 +240,27 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			const nullCount = props.instance.getColumnProfileNullCount(props.columnIndex);
 
 			if (nullPercent === undefined || nullCount === undefined) {
-				return 'Missing Values\nCalculating...';
+				return nls.localize(
+					'positron.missingValues.calculating',
+					'Missing Values\nCalculating...'
+				);
 			} else if (nullPercent === 0) {
-				return `Missing Values\nNo missing values`;
+				return nls.localize(
+					'positron.missingValues.none',
+					'Missing Values\nNo missing values'
+				);
 			} else if (nullPercent === 100) {
-				return `Missing Values\nAll values are missing (${nullCount.toLocaleString()} values)`;
+				return nls.localize(
+					'positron.missingValues.all',
+					'Missing Values\nAll values are missing ({0} values)', nullCount.toLocaleString()
+				);
 			} else {
-				return `Missing Values\n${nullPercent}% of values are missing (${nullCount.toLocaleString()} values)`;
+				return nls.localize(
+					'positron.missingValues.some',
+					'Missing Values\n{0}% of values are missing ({1} values)',
+					nullPercent,
+					nullCount.toLocaleString()
+				);
 			}
 		};
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -7,7 +7,7 @@
 import './columnSummaryCell.css';
 
 // React.
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 // Other dependencies.
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
@@ -212,7 +212,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 	/**
 	 * ColumnNullPercent component.
-	 * @param props A ColumnNullPercentProps that contains the component properties.
 	 * @returns The rendered component.
 	 */
 	const ColumnNullPercent = () => {
@@ -231,9 +230,55 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			}
 		}
 
+		// Create a reference to the container div
+		const containerRef = useRef<HTMLDivElement>(null);
+
+		// Create tooltip text based on nullPercent
+		const getTooltipText = () => {
+			// Get the null count for this column
+			const nullCount = props.instance.getColumnProfileNullCount(props.columnIndex);
+
+			if (nullPercent === undefined || nullCount === undefined) {
+				return 'Null Values\nCalculating...';
+			} else if (nullPercent === 0) {
+				return `Null Values\nNo null values`;
+			} else if (nullPercent === 100) {
+				return `Null Values\nAll values are null (${nullCount.toLocaleString()} values)`;
+			} else {
+				return `Null Values\n${nullPercent}% of values are null (${nullCount.toLocaleString()} values)`;
+			}
+		};
+
+		// Show tooltip when mouse enters
+		const showTooltip = () => {
+			if (containerRef.current) {
+				props.instance.hoverManager.showHover(
+					containerRef.current,
+					getTooltipText()
+				);
+			}
+		};
+
+		// Hide tooltip when mouse leaves
+		const hideTooltip = () => {
+			props.instance.hoverManager.hideHover();
+		};
+
+		// Cleanup when component unmounts
+		useEffect(() => {
+			return () => {
+				props.instance.hoverManager.hideHover();
+			};
+		}, []);
+
 		// Render.
 		return (
-			<div className='column-null-percent'>
+			<div
+				ref={containerRef}
+				className='column-null-percent'
+				onMouseEnter={showTooltip}
+				onMouseLeave={hideTooltip}
+			>
 				{nullPercent !== undefined &&
 					<div className={positronClassNames('text-percent', { 'zero': nullPercent === 0 })}>
 						{nullPercent}%


### PR DESCRIPTION
Addresses #5849. The tooltip text probably needs to be localized, but I wanted to get feedback on the details before doing that. 

https://github.com/user-attachments/assets/3d013d6f-961c-4bcc-a38b-0daff0ed3f31


The text that is displayed varies based on whether the null percent is computing, 0, 100, or something in between:

```typescript
// Create tooltip text based on nullPercent
const getTooltipText = () => {
  // Get the null count for this column
  const nullCount = props.instance.getColumnProfileNullCount(props.columnIndex);

  if (nullPercent === undefined || nullCount === undefined) {
    return 'Null Values\nCalculating...';
  } else if (nullPercent === 0) {
    return `Null Values\nNo null values`;
  } else if (nullPercent === 100) {
    return `Null Values\nAll values are null (${nullCount.toLocaleString()} values)`;
  } else {
    return `Null Values\n${nullPercent}% of values are null (${nullCount.toLocaleString()} values)`;
  }
};
```

e2e: @:data-explorer

### Release Notes

#### New Features

- An explanatory tooltip is now shown when hovering over the null percentage graphic in the summary pane of the data explorer.

#### Bug Fixes

- N/A