### PR TITLE
Data Explorer: Set summary pane width in absolute pixels instead of proportional to whole window

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -27,6 +27,7 @@ import { PositronDataExplorerLayout } from '../../../../../services/positronData
  * Constants.
  */
 const MIN_COLUMN_WIDTH = 300;
+const DEFAULT_SUMMARY_WIDTH = 400;
 
 /**
  * DataExplorer component.
@@ -230,11 +231,13 @@ export const DataExplorer = () => {
 		// Set the initial width.
 		setWidth(dataExplorerRef.current.offsetWidth);
 
-		// Set the initial columns width.
-		setColumnsWidth(Math.max(
-			Math.trunc(context.instance.columnsWidthPercent * dataExplorerRef.current.offsetWidth),
-			MIN_COLUMN_WIDTH
-		));
+		// Set the initial columns width - use stored width or default
+		const savedWidth = context.instance.summaryWidth;
+		setColumnsWidth(
+			savedWidth > 0 ?
+				Math.max(savedWidth, MIN_COLUMN_WIDTH) :
+				DEFAULT_SUMMARY_WIDTH
+		);
 
 		// Allocate and initialize the data explorer resize observer.
 		const resizeObserver = new ResizeObserver(entries => {
@@ -246,7 +249,7 @@ export const DataExplorer = () => {
 
 		// Return the cleanup function that will disconnect the resize observer.
 		return () => resizeObserver.disconnect();
-	}, [context.instance.columnsWidthPercent]);
+	}, [context.instance.summaryWidth]);
 
 	// ColumnsWidth Layout useEffect.
 	useLayoutEffect(() => {
@@ -300,7 +303,7 @@ export const DataExplorer = () => {
 	 */
 	const resizeHandler = (newColumnsWidth: number) => {
 		setColumnsWidth(newColumnsWidth);
-		context.instance.columnsWidthPercent = newColumnsWidth / width;
+		context.instance.summaryWidth = newColumnsWidth;
 	};
 
 	// Render.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -35,9 +35,9 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	isSummaryCollapsed: boolean;
 
 	/**
-	 * Gets or sets the columns width percent.
+	 * Gets or sets the summary width in pixels.
 	 */
-	columnsWidthPercent: number;
+	summaryWidth: number;
 
 	/**
 	 * Gets the TableSchemaDataGridInstance.
@@ -65,9 +65,9 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	readonly onDidChangeLayout: Event<PositronDataExplorerLayout>;
 
 	/**
-	 * The onDidChangeColumnsWidthPercent event.
+	 * The onDidChangeSummaryWidth event.
 	 */
-	readonly onDidChangeColumnsWidthPercent: Event<number>;
+	readonly onDidChangeSummaryWidth: Event<number>;
 
 	/**
 	 * The onDidRequestFocus event.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -57,9 +57,9 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	private _isSummaryCollapsed = DataExplorerSummaryCollapseEnabled(this._configurationService);
 
 	/**
-	 * Gets or sets the columns width percent.
+	 * Gets or sets the summary width in pixels.
 	 */
-	private _columnsWidthPercent = 0.25;
+	private _summaryWidth = 0;
 
 	/**
 	 * Gets the TableSchemaDataGridInstance.
@@ -84,9 +84,9 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	);
 
 	/**
-	 * The onDidChangeColumnsWidthPercent event emitter.
+	 * The onDidChangeSummaryWidth event emitter.
 	 */
-	private readonly _onDidChangeColumnsWidthPercentEmitter = this._register(new Emitter<number>);
+	private readonly _onDidChangeSummaryWidthEmitter = this._register(new Emitter<number>);
 
 	/**
 	 * The onDidChangeColumnsScrollOffset event emitter.
@@ -252,18 +252,18 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	}
 
 	/**
-	 * Gets the columns width percent.
+	 * Gets the summary width in pixels.
 	 */
-	get columnsWidthPercent() {
-		return this._columnsWidthPercent;
+	get summaryWidth() {
+		return this._summaryWidth;
 	}
 
 	/**
-	 * Sets the columns width percent.
+	 * Sets the summary width in pixels.
 	 */
-	set columnsWidthPercent(columnsWidthPercent: number) {
-		this._columnsWidthPercent = columnsWidthPercent;
-		this._onDidChangeColumnsWidthPercentEmitter.fire(this._columnsWidthPercent);
+	set summaryWidth(summaryWidth: number) {
+		this._summaryWidth = summaryWidth;
+		this._onDidChangeSummaryWidthEmitter.fire(this._summaryWidth);
 	}
 
 	/**
@@ -441,9 +441,9 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	readonly onDidChangeLayout = this._onDidChangeLayoutEmitter.event;
 
 	/**
-	 * onDidChangeColumnsWidthPercent event.
+	 * onDidChangeSummaryWidth event.
 	 */
-	readonly onDidChangeColumnsWidthPercent = this._onDidChangeColumnsWidthPercentEmitter.event;
+	readonly onDidChangeSummaryWidth = this._onDidChangeSummaryWidthEmitter.event;
 
 	/**
 	 * onDidChangeColumnsScrollOffset event.


### PR DESCRIPTION
Addresses #4977. Proportional sizing results in a lot of wasted space / bad appearance on ultrawide monitors. This refactors the summary pane size to be based on an absolute width vs. proportional.

Before (default):

<img width="2276" alt="image" src="https://github.com/user-attachments/assets/9eac7b33-b28e-47a4-bb8c-9f59a059e5d7" />

After (default):

<img width="2261" alt="image" src="https://github.com/user-attachments/assets/ed385d77-958e-408c-b3d0-2bb964232612" />

e2e: @:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Improve default width of data explorer summary pane on wide displays.