### PR TITLE
Data Explorer: Show tooltips for table data cell values that are truncated

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -171,10 +171,10 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			this._configurationService,
 			this._keybindingService,
 			this._layoutService,
+			this._hoverService,
 			this._dataExplorerClientInstance,
 			this._tableDataCache
 		));
-
 		// Add the onDidClose event handler.
 		this._register(this._dataExplorerClientInstance.onDidClose(() => {
 			this._onDidCloseEmitter.fire();

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -61,15 +61,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @param _configurationService The configuration service.
 	 * @param _keybindingService The keybinding service.
 	 * @param _layoutService The layout service.
+	 * @param _hoverService The hover service.
 	 * @param _dataExplorerClientInstance The data explorer client instance.
 	 * @param _tableDataCache The table data cache.
 	 */
 	constructor(
 		private readonly _commandService: ICommandService,
 		private readonly _configurationService: IConfigurationService,
+		private readonly _hoverService: IHoverService,
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
-		private readonly _hoverService: IHoverService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _tableDataCache: TableDataCache,
 	) {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -98,9 +98,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			cursorOffset: 0.5,
 		});
 
-		// Create the cell hover manager with a shorter delay (500ms) for testing
 		this._cellHoverManager = this._register(new PositronActionBarHoverManager(false, this._configurationService, this._hoverService));
-		this._cellHoverManager.setCustomHoverDelay(500);
 
 		/**
 		 * Updates the layout entries.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -59,18 +59,18 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Constructor.
 	 * @param _commandService The command service.
 	 * @param _configurationService The configuration service.
+	 * @param _hoverService The hover service.
 	 * @param _keybindingService The keybinding service.
 	 * @param _layoutService The layout service.
-	 * @param _hoverService The hover service.
 	 * @param _dataExplorerClientInstance The data explorer client instance.
 	 * @param _tableDataCache The table data cache.
 	 */
 	constructor(
 		private readonly _commandService: ICommandService,
 		private readonly _configurationService: IConfigurationService,
-		private readonly _hoverService: IHoverService,
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
+		private readonly _hoverService: IHoverService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _tableDataCache: TableDataCache,
 	) {
@@ -100,6 +100,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		});
 
 		this._cellHoverManager = this._register(new PositronActionBarHoverManager(false, this._configurationService, this._hoverService));
+		this._cellHoverManager.setCustomHoverDelay(500);
 
 		/**
 		 * Updates the layout entries.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -13,6 +13,8 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 import { IColumnSortKey } from '../../../browser/positronDataGrid/interfaces/columnSortKey.js';
 import { TableDataCell } from './components/tableDataCell.js';
 import { AnchorPoint } from '../../../browser/positronComponents/positronModalPopup/positronModalPopup.js';
@@ -44,6 +46,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _onAddFilterEmitter = this._register(new Emitter<ColumnSchema>);
 
+	/**
+	 * The cell hover manager with longer delay for data cell tooltips.
+	 */
+	private readonly _cellHoverManager: PositronActionBarHoverManager;
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -62,6 +69,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		private readonly _configurationService: IConfigurationService,
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
+		private readonly _hoverService: IHoverService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _tableDataCache: TableDataCache,
 	) {
@@ -89,6 +97,10 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			internalCursor: true,
 			cursorOffset: 0.5,
 		});
+
+		// Create the cell hover manager with a shorter delay (500ms) for testing
+		this._cellHoverManager = this._register(new PositronActionBarHoverManager(false, this._configurationService, this._hoverService));
+		this._cellHoverManager.setCustomHoverDelay(500);
 
 		/**
 		 * Updates the layout entries.
@@ -294,6 +306,20 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @param rowIndex The row index.
 	 * @returns The cell value.
 	 */
+	/**
+	 * Gets the cell hover manager.
+	 * @returns The cell hover manager.
+	 */
+	get cellHoverManager(): PositronActionBarHoverManager {
+		return this._cellHoverManager;
+	}
+
+	/**
+	 * Gets a data cell.
+	 * @param columnIndex The column index.
+	 * @param rowIndex The row index.
+	 * @returns The cell value.
+	 */
 	cell(columnIndex: number, rowIndex: number): JSX.Element | undefined {
 		// Get the column.
 		const column = this.column(columnIndex);
@@ -312,6 +338,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			<TableDataCell
 				column={column}
 				dataCell={dataCell}
+				hoverManager={this._cellHoverManager}
 			/>
 		);
 	}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -144,14 +144,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		));
 
 		// Create the hover manager.
-		this._hoverManager = new PositronActionBarHoverManager(
+		this._hoverManager = this._register(new PositronActionBarHoverManager(
 			true,
 			this._configurationService,
 			this._hoverService
-		);
+		));
 		// Show tooltip hovers right away
 		this._hoverManager.setCustomHoverDelay(0);
-		this._register(this._hoverManager);
 	}
 
 	//#endregion Constructor


### PR DESCRIPTION
Addresses #3658 by adding tooltips for values that are truncated in the data grid. RStudio shows tooltips after a delay whether the values are truncated or not, so we could also always show tooltips even for small values.

https://github.com/user-attachments/assets/31455635-efa3-407d-acc6-39d7c836dd38

e2e: @:data-explorer

### Release Notes

#### New Features

- Display tooltips for truncated data when hovering over a data cell in the data explorer.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
