### PR TITLE
Data Explorer: Add simple loading indicator for column summary sparklines

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -102,6 +102,19 @@
 	grid-column: sparkline / missing-values;
 }
 
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline .loading-sparkline .loading-indicator {
+	fill: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundFill);
+	stroke: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke);
+	opacity: 0.5;
+	animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+	0% { opacity: 0.2; }
+	50% { opacity: 0.5; }
+	100% { opacity: 0.2; }
+}
+
 /* column-null-percent */
 
 .data-grid-row-cell .content .column-summary .basic-info .column-null-percent {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -121,10 +121,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							/>
 							<rect className='loading-indicator'
 								height={SPARKLINE_HEIGHT * 0.3}
+								rx={2}
 								width={SPARKLINE_WIDTH * 0.8}
 								x={SPARKLINE_WIDTH * 0.1}
 								y={SPARKLINE_HEIGHT * 0.5}
-								rx={2}
 							/>
 						</g>
 					</svg>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -82,6 +82,56 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	 * @returns The rendered component.
 	 */
 	const ColumnSparkline = () => {
+		// Determines whether a sparkline is expected for this column type
+		const shouldShowSparkline = () => {
+			switch (props.columnSchema.type_display) {
+				case ColumnDisplayType.Number:
+				case ColumnDisplayType.Boolean:
+				case ColumnDisplayType.String:
+					return true;
+				default:
+					return false;
+			}
+		};
+
+		/**
+		 * SparklineLoadingIndicator component.
+		 * Displays a subtle loading animation while data is being computed.
+		 */
+		const SparklineLoadingIndicator = () => {
+			return (
+				<div
+					className='column-sparkline'
+					style={{
+						width: SPARKLINE_WIDTH,
+						height: SPARKLINE_HEIGHT + SPARKLINE_X_AXIS_HEIGHT
+					}}
+				>
+					<svg
+						className='vector-histogram loading-sparkline'
+						shapeRendering='crispEdges'
+						viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT + SPARKLINE_X_AXIS_HEIGHT}`}
+					>
+						<g>
+							<rect className='x-axis'
+								height={SPARKLINE_X_AXIS_HEIGHT}
+								width={SPARKLINE_WIDTH}
+								x={0}
+								y={SPARKLINE_HEIGHT - SPARKLINE_X_AXIS_HEIGHT}
+							/>
+							<rect className='loading-indicator'
+								height={SPARKLINE_HEIGHT * 0.3}
+								width={SPARKLINE_WIDTH * 0.8}
+								x={SPARKLINE_WIDTH * 0.1}
+								y={SPARKLINE_HEIGHT * 0.5}
+								rx={2}
+							/>
+						</g>
+					</svg>
+				</div>
+			);
+		};
+
 		// Render.
 		switch (props.columnSchema.type_display) {
 			// Column display types that render a histogram sparkline.
@@ -89,7 +139,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				// Get the column histogram.
 				const columnHistogram = props.instance.getColumnProfileSmallHistogram(props.columnIndex);
 				if (!columnHistogram) {
-					return null;
+					return shouldShowSparkline() ? <SparklineLoadingIndicator /> : null;
 				}
 
 				// Render the column sparkline.
@@ -118,7 +168,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				// Get the column frequency table.
 				const columnFrequencyTable = props.instance.getColumnProfileSmallFrequencyTable(props.columnIndex);
 				if (!columnFrequencyTable) {
-					return null;
+					return shouldShowSparkline() ? <SparklineLoadingIndicator /> : null;
 				}
 
 				// Render the column sparkline.


### PR DESCRIPTION
Addresses #4630. The CSS/SVG is AI-generated, so we can easily do something different, but I think that users would appreciate to know that the results are pending especially with very large datasets:

https://github.com/user-attachments/assets/08f2ac5a-5e3b-47ba-86d6-7f70789edce3

e2e: @:data-explorer

### Release Notes

#### New Features

- We now display a loading indicator for the small histogram/frequency table sparkline plots in the data explorer. 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
