### PR TITLE
E2E test: temporary debugging change for --grep-invert

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -191,6 +191,9 @@ jobs:
           # Log the final grep-invert argument for debugging
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
+          # Log the command to be run for debugging purposes
+          echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep \"${{ env.PW_TAGS }}\" $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
+
           # Run Playwright tests
           DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -16,7 +16,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: "merge,electron/ubuntu"
       report_testrail: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
       install_license: false
       skip_tags: "@:nightly-only"
     secrets: inherit
@@ -40,7 +40,7 @@ jobs:
       project: "e2e-browser"
       currents_tags: "merge,browser/ubuntu"
       report_testrail: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
       install_license: true
       skip_tags: "@:nightly-only"
     secrets: inherit

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
       install_license: false
       skip_tags: "@:nightly-only"
     secrets: inherit
@@ -69,7 +69,7 @@ jobs:
       currents_tags: "pull-request,browser/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
       install_license: true
       skip_tags: "@:nightly-only"
     secrets: inherit


### PR DESCRIPTION
Temporarily install hidden interpreters always while tagging issue is debugged

### QA Notes

All tests should pass
