### PR TITLE
Python: Update diagnostics when switching console sessions

### DIFF
--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -95,7 +95,7 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
         activateWebAppCommands(serviceContainer, disposables);
 
         // Register the language server manager to support multiple console sessions.
-        registerLanguageServerManager(disposables);
+        registerLanguageServerManager(serviceContainer, disposables);
 
         traceInfo('activatePositron: done!');
     } catch (ex) {

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -10,8 +10,10 @@ import { IServiceContainer } from '../ioc/types';
 import { IPythonPathUpdaterServiceManager } from '../interpreter/configuration/types';
 import { IWorkspaceService } from '../common/application/types';
 
-
-export function registerLanguageServerManager(serviceContainer: IServiceContainer, disposables: vscode.Disposable[]): void {
+export function registerLanguageServerManager(
+    serviceContainer: IServiceContainer,
+    disposables: vscode.Disposable[],
+): void {
     disposables.push(
         // When the foreground session changes:
         // 1. Deactivate non-foreground session language servers.
@@ -22,8 +24,9 @@ export function registerLanguageServerManager(serviceContainer: IServiceContaine
                 return;
             }
 
-            const pythonPathUpdaterService: IPythonPathUpdaterServiceManager = serviceContainer.get<IPythonPathUpdaterServiceManager>(
-                IPythonPathUpdaterServiceManager);
+            const pythonPathUpdaterService: IPythonPathUpdaterServiceManager = serviceContainer.get<
+                IPythonPathUpdaterServiceManager
+            >(IPythonPathUpdaterServiceManager);
             const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
 
             const sessions = await getActivePythonSessions();
@@ -63,7 +66,12 @@ export function registerLanguageServerManager(serviceContainer: IServiceContaine
                 configTarget = vscode.ConfigurationTarget.WorkspaceFolder;
             }
 
-            await pythonPathUpdaterService.updatePythonPath(foregroundSession.runtimeMetadata.runtimePath, configTarget, 'ui', folderUri);
-        })
+            await pythonPathUpdaterService.updatePythonPath(
+                foregroundSession.runtimeMetadata.runtimePath,
+                configTarget,
+                'ui',
+                folderUri,
+            );
+        }),
     );
 }

--- a/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
@@ -14,6 +14,8 @@ import { mock } from './utils';
 import { createUniqueId, PythonRuntimeSession } from '../../client/positron/session';
 import * as util from '../../client/positron/util';
 import { IServiceContainer } from '../../client/ioc/types';
+import { IPythonPathUpdaterServiceManager } from '../../client/interpreter/configuration/types';
+import { IWorkspaceService } from '../../client/common/application/types';
 
 function mockSession(sessionMode = positron.LanguageRuntimeSessionMode.Console): PythonRuntimeSession {
     return new PythonRuntimeSession(
@@ -56,7 +58,26 @@ suite('Language server manager', () => {
             getActiveSessions: async () => [foregroundSession, nonForegroundSession],
         });
 
-        registerLanguageServerManager(disposables);
+        const pythonPathUpdaterService = mock<IPythonPathUpdaterServiceManager>({
+            updatePythonPath: sinon.stub(),
+        });
+
+        const workspaceService = mock<IWorkspaceService>({});
+
+        const serviceContainer = {
+            get(serviceIdentifier) {
+                switch (serviceIdentifier) {
+                    case IPythonPathUpdaterServiceManager:
+                        return pythonPathUpdaterService;
+                    case IWorkspaceService:
+                        return workspaceService;
+                    default:
+                        throw new Error('Unknown service');
+                }
+            },
+        } as IServiceContainer;
+
+        registerLanguageServerManager(serviceContainer, disposables);
     });
 
     teardown(() => {


### PR DESCRIPTION
Pyright requires the `pythonPath` setting to be updated to refresh squiggles. This now gets done in the `foregroundSession` listener in positron-python.

**Note:** This behavior only applies to workspaces; non-workspace editors do not update properly yet. Tracked in #6936.

https://github.com/user-attachments/assets/12113483-8628-452e-a2a0-ec375bbc2cbc

Addresses #6872

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Pyright diagnostics now follow console session


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:sessions