### PR TITLE
Fire foreground session change on restarts

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1548,10 +1548,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			switch (state) {
 				case RuntimeState.Ready:
 					// If the session is a console session, make it the
-					// foreground session if it isn't already.
-					if (session !== this._foregroundSession &&
-						session.metadata.sessionMode === LanguageRuntimeSessionMode.Console &&
-						activate) {
+					// foreground session. We fire the setter even if
+					// this session was already the foreground session,
+					// because we need `onDidChangeForegroundSession()`
+					// to fire on restarts.
+					if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console && activate) {
 						this.foregroundSession = session;
 					}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6902, joint work with @seeM 

What was happening before was:
- R starts up in a new console, this fires `onDidChangeForegroundSession` and we activate the LSP
- R restarts, this did _not_ fire `onDidChangeForegroundSession`, so the LSP was never activated after the restart

@seeM and I debated what the right thing to do here is. Technically the foreground session hasn't changed - it's still the same console instance but the underlying "kernel session" is totally new with a new LSP. But since we rely on this event for starting and stopping the LSP for that new kernel session, firing `onDidChangeForegroundSession` on a restart seemed like the least worst option

`@:sessions`

I tried adding some tests on the R side like Wasim did for Python, but I had trouble because `positron.runtime` actually does exist for our unit tests, so we can't stub in our own version of `onDidChangeForegroundSession` and fire it at whim like he did on the Python side. I'm going to dump my partial test file below in case we come back to it.

<details>

```ts
/* eslint-disable @typescript-eslint/no-empty-function */
/*---------------------------------------------------------------------------------------------
 *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
 *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 *--------------------------------------------------------------------------------------------*/

import * as positron from 'positron';
import * as sinon from 'sinon';
import * as vscode from 'vscode';
import { createUniqueId, mock } from './utils';
import * as util from '../util';
import { RSession } from '../session.js';

function mockSession(sessionMode = positron.LanguageRuntimeSessionMode.Console): RSession {
	return new RSession(
		mock<positron.LanguageRuntimeMetadata>({
		}),
		mock<positron.RuntimeSessionMetadata>({
			sessionId: createUniqueId(),
			sessionMode,
		}),
	);
}

suite('Session manager', () => {
	let disposables: vscode.Disposable[];
	let onDidChangeForegroundSession: vscode.EventEmitter<string | undefined>;
	let foregroundSession: RSession;
	let nonForegroundSession: RSession;
	let foregroundSessionSpy: sinon.SinonSpiedInstance<RSession>;
	let nonForegroundSessionSpy: sinon.SinonSpiedInstance<RSession>;

	setup(() => {
		disposables = [];
		onDidChangeForegroundSession = new vscode.EventEmitter();

		foregroundSession = mockSession();
		nonForegroundSession = mockSession();
		foregroundSessionSpy = sinon.spy(foregroundSession);
		nonForegroundSessionSpy = sinon.spy(nonForegroundSession);
	});

	teardown(() => {
		sinon.restore();
		disposables.forEach((d) => d.dispose());
		onDidChangeForegroundSession.dispose();
	});

	test('should deactivate non-foreground session before activating foreground session', async () => {
		// Change the foreground session.
		onDidChangeForegroundSession.fire(foregroundSession.metadata.sessionId);

		// Wait for the event loop to run.
		await util.delay(0);

		sinon.assert.calledOnce(foregroundSessionSpy.activateLsp);
		sinon.assert.calledOnce(nonForegroundSessionSpy.deactivateLsp);
		sinon.assert.callOrder(nonForegroundSessionSpy.deactivateLsp, foregroundSessionSpy.activateLsp);
		sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
		sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
	});

	test('should do nothing if there is no foreground session', async () => {
		// Change the foreground session.
		onDidChangeForegroundSession.fire(undefined);

		// Wait for the event loop to run.
		await util.delay(0);

		sinon.assert.notCalled(foregroundSessionSpy.activateLsp);
		sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
		sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
		sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
	});

	test('should not deactivate non-console sessions', async () => {
		sinon.stub(nonForegroundSession.metadata, 'sessionMode').value(positron.LanguageRuntimeSessionMode.Notebook);

		onDidChangeForegroundSession.fire(foregroundSession.metadata.sessionId);

		// Wait for the event loop to run.
		await util.delay(0);

		// The foreground session should still be activated.
		sinon.assert.calledOnce(foregroundSessionSpy.activateLsp);
		sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);

		// The non-foreground session should not be deactivated.
		sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
		sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
	});
});

```

</details>