### PR TITLE
Remove unused extension context

### DIFF
--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(LOGGER.onDidChangeLogLevel(onDidChangeLogLevel));
 	onDidChangeLogLevel(LOGGER.logLevel);
 
-	const rRuntimeManager = new RRuntimeManager(context);
+	const rRuntimeManager = new RRuntimeManager();
 	positron.runtime.registerLanguageRuntimeManager('r', rRuntimeManager);
 
 	// Set contexts.

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -18,7 +18,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 
 	private readonly onDidDiscoverRuntimeEmitter = new vscode.EventEmitter<positron.LanguageRuntimeMetadata>();
 
-	constructor(private readonly _context: vscode.ExtensionContext) {
+	constructor() {
 		this.onDidDiscoverRuntime = this.onDidDiscoverRuntimeEmitter.event;
 	}
 
@@ -67,7 +67,6 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 			sessionMetadata.sessionMode);
 		const session = new RSession(runtimeMetadata,
 			sessionMetadata,
-			this._context,
 			kernelSpec,
 			kernelExtra);
 
@@ -146,9 +145,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		sessionMetadata: positron.RuntimeSessionMetadata): Thenable<positron.LanguageRuntimeSession> {
 
 		// When restoring an existing session, the kernelspec is stored.
-		const session = new RSession(runtimeMetadata,
-			sessionMetadata,
-			this._context);
+		const session = new RSession(runtimeMetadata, sessionMetadata);
 
 		return Promise.resolve(session);
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -84,7 +84,6 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	constructor(
 		readonly runtimeMetadata: positron.LanguageRuntimeMetadata,
 		readonly metadata: positron.RuntimeSessionMetadata,
-		readonly context: vscode.ExtensionContext,
 		readonly kernelSpec?: JupyterKernelSpec,
 		readonly extra?: JupyterKernelExtra,
 	) {

--- a/extensions/positron-r/src/test/README.md
+++ b/extensions/positron-r/src/test/README.md
@@ -1,5 +1,6 @@
 Launch tests by running this from the repository root:
 
 ```sh
-yarn test-extension -l positron-r
+nvm use
+npm run test-extension -- -l positron-r
 ```


### PR DESCRIPTION
Nothing much to see here, just removing an unused field from `RSession` that was getting in the way for something else