### PR TITLE
Python: Only start Console LSPs from the `onDidChangeForegroundSession` event

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -728,7 +728,12 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this._state = state;
         if (state === positron.RuntimeState.Ready) {
             this._queue.add(async () => {
-                await this.startLsp();
+                if (this.metadata.sessionMode !== positron.LanguageRuntimeSessionMode.Console) {
+                    // Start the language server for non-Console sessions immediately, because
+                    // they will never become foreground sessions. Otherwise we delay LSP activation
+                    // until the session becomes the foreground session.
+                    await this.startLsp();
+                }
             });
 
             this._queue.add(async () => {

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -527,9 +527,13 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         );
     }
 
+    /**
+     * Start the LSP
+     *
+     * Returns a promise that resolves when the LSP has been activated.
+     */
     async activateLsp(): Promise<void> {
-        // Start LSP for the foreground session only if its been previously stopped
-        if (this._lsp?.state === LspState.stopped) {
+        if (this._lsp?.state === LspState.stopped || this._lsp?.state === LspState.uninitialized) {
             return this._queue.add(async () => {
                 await this.startLsp();
             });
@@ -538,6 +542,11 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
     }
 
+    /**
+     * Stops the LSP if it is running
+     *
+     * Returns a promise that resolves when the LSP has been deactivated.
+     */
     async deactivateLsp(awaitStop: boolean): Promise<void> {
         if (this._lsp?.state === LspState.running) {
             return this._queue.add(async () => {


### PR DESCRIPTION
> [!WARNING]  
> Needs https://github.com/posit-dev/positron/pull/6938, as otherwise applying this fix means that Python LSPs won't reactivate on a session restart

This fixes the issue @seeM noted where you'd still temporarily have two 2 LSPs active when you start up a new Python session or switch between them. Starting the LSP in `session.ts` itself means you can't wait for other LSPs to stop first, this all has to happen in the "manager". Here we just apply the same fix as what we did on the R side.

For both R and Python, I still think an even better solution will be to lift the responsibility of starting/stopping any of the LSPs into the session manager (right now we still start non-Console LSPs from `session.ts` and that feels wrong to me).

Notice in the video that in the Outline you no longer get 2 sets of outlines, instead you just get a little flicker as one turns off and the other loads in

https://github.com/user-attachments/assets/90699cb0-01c9-4c2a-a184-0dd000480758

