### PR TITLE
python: show unsupported interpreters

### DIFF
--- a/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Similar to the macPythonInterpreter diagnostic.
+
+// eslint-disable-next-line max-classes-per-file
+import { inject, injectable } from 'inversify';
+import { DiagnosticSeverity, l10n } from 'vscode';
+import '../../../common/extensions';
+import {
+    IDisposableRegistry,
+    IInterpreterPathService,
+    InterpreterConfigurationScope,
+    Resource,
+} from '../../../common/types';
+import { IInterpreterService } from '../../../interpreter/contracts';
+import { isVersionSupported } from '../../../interpreter/configuration/environmentTypeComparer';
+import { IServiceContainer } from '../../../ioc/types';
+import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
+import { IDiagnosticsCommandFactory } from '../commands/types';
+import { DiagnosticCodes } from '../constants';
+import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
+import { DiagnosticScope, IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService } from '../types';
+import { Common } from '../../../common/utils/localize';
+
+const messages = {
+    [DiagnosticCodes.UnsupportedPythonVersion]: l10n.t(
+        'The selected Python interpreter version is not supported. Some functionality in the extension will be limited. [Install another version of Python](https://www.python.org/downloads) or select a different interpreter for the best experience.',
+    ),
+};
+
+export class UnsupportedPythonVersionDiagnostic extends BaseDiagnostic {
+    constructor(code: DiagnosticCodes.UnsupportedPythonVersion, resource: Resource) {
+        super(code, messages[code], DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder, resource);
+    }
+}
+
+export const UnsupportedPythonVersionServiceId = 'UnsupportedPythonVersionServiceId';
+
+@injectable()
+export class UnsupportedPythonVersionService extends BaseDiagnosticsService {
+    protected changeThrottleTimeout = 1000;
+
+    private timeOut?: NodeJS.Timeout | number;
+
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+    ) {
+        super([DiagnosticCodes.UnsupportedPythonVersion], serviceContainer, disposableRegistry, true);
+        this.addPythonPathChangedHandler();
+    }
+
+    public dispose(): void {
+        if (this.timeOut && typeof this.timeOut !== 'number') {
+            clearTimeout(this.timeOut);
+            this.timeOut = undefined;
+        }
+    }
+
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
+        const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
+        const interpreter = await interpreterService.getActiveInterpreter(resource);
+        if (isVersionSupported(interpreter?.version)) {
+            return [];
+        }
+        return [new UnsupportedPythonVersionDiagnostic(DiagnosticCodes.UnsupportedPythonVersion, resource)];
+    }
+
+    protected async onHandle(diagnostics: IDiagnostic[]): Promise<void> {
+        if (diagnostics.length === 0) {
+            return;
+        }
+        const messageService = this.serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(
+            IDiagnosticHandlerService,
+            DiagnosticCommandPromptHandlerServiceId,
+        );
+        await Promise.all(
+            diagnostics.map(async (diagnostic) => {
+                const canHandle = await this.canHandle(diagnostic);
+                const shouldIgnore = await this.filterService.shouldIgnoreDiagnostic(diagnostic.code);
+                if (!canHandle || shouldIgnore) {
+                    return;
+                }
+                const commandPrompts = this.getCommandPrompts(diagnostic);
+                await messageService.handle(diagnostic, { commandPrompts, message: diagnostic.message });
+            }),
+        );
+    }
+
+    protected addPythonPathChangedHandler(): void {
+        const disposables = this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
+        const interpreterPathService = this.serviceContainer.get<IInterpreterPathService>(IInterpreterPathService);
+        disposables.push(interpreterPathService.onDidChange((i) => this.onDidChangeConfiguration(i)));
+    }
+
+    protected async onDidChangeConfiguration(
+        interpreterConfigurationScope: InterpreterConfigurationScope,
+    ): Promise<void> {
+        const workspaceUri = interpreterConfigurationScope.uri;
+        if (this.timeOut && typeof this.timeOut !== 'number') {
+            clearTimeout(this.timeOut);
+            this.timeOut = undefined;
+        }
+        this.timeOut = setTimeout(() => {
+            this.timeOut = undefined;
+            this.diagnose(workspaceUri)
+                .then((diagnostics) => this.handle(diagnostics))
+                .ignoreErrors();
+        }, this.changeThrottleTimeout);
+    }
+
+    private getCommandPrompts(diagnostic: IDiagnostic): { prompt: string; command?: IDiagnosticCommand }[] {
+        const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
+        switch (diagnostic.code) {
+            case DiagnosticCodes.UnsupportedPythonVersion: {
+                return [
+                    {
+                        prompt: Common.selectPythonInterpreter,
+                        command: commandFactory.createCommand(diagnostic, {
+                            type: 'executeVSCCommand',
+                            options: 'python.setInterpreter',
+                        }),
+                    },
+                    {
+                        prompt: Common.doNotShowAgain,
+                        command: commandFactory.createCommand(diagnostic, {
+                            type: 'ignore',
+                            options: DiagnosticScope.Global,
+                        }),
+                    },
+                ];
+            }
+            default: {
+                throw new Error("Invalid diagnostic for 'UnsupportedPythonVersionService'");
+            }
+        }
+    }
+}

--- a/extensions/positron-python/src/client/application/diagnostics/constants.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/constants.ts
@@ -8,6 +8,7 @@ export enum DiagnosticCodes {
     InvalidDebuggerTypeDiagnostic = 'InvalidDebuggerTypeDiagnostic',
     NoPythonInterpretersDiagnostic = 'NoPythonInterpretersDiagnostic',
     MacInterpreterSelected = 'MacInterpreterSelected',
+    UnsupportedPythonVersion = 'UnsupportedPythonVersion',
     InvalidPythonPathInDebuggerSettingsDiagnostic = 'InvalidPythonPathInDebuggerSettingsDiagnostic',
     InvalidPythonPathInDebuggerLaunchDiagnostic = 'InvalidPythonPathInDebuggerLaunchDiagnostic',
     EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic = 'EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic',

--- a/extensions/positron-python/src/client/application/diagnostics/constants.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/constants.ts
@@ -8,7 +8,10 @@ export enum DiagnosticCodes {
     InvalidDebuggerTypeDiagnostic = 'InvalidDebuggerTypeDiagnostic',
     NoPythonInterpretersDiagnostic = 'NoPythonInterpretersDiagnostic',
     MacInterpreterSelected = 'MacInterpreterSelected',
+    // --- Start Positron ---
+    // Add a new diagnostic code for unsupported Python versions
     UnsupportedPythonVersion = 'UnsupportedPythonVersion',
+    // --- End Positron ---
     InvalidPythonPathInDebuggerSettingsDiagnostic = 'InvalidPythonPathInDebuggerSettingsDiagnostic',
     InvalidPythonPathInDebuggerLaunchDiagnostic = 'InvalidPythonPathInDebuggerLaunchDiagnostic',
     EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic = 'EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic',

--- a/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
@@ -23,6 +23,9 @@ import {
     InvalidMacPythonInterpreterService,
     InvalidMacPythonInterpreterServiceId,
 } from './checks/macPythonInterpreter';
+// --- Start Positron ---
+import { UnsupportedPythonVersionService, UnsupportedPythonVersionServiceId } from './checks/unsupportedPythonVersion';
+// --- End Positron ---
 import {
     PowerShellActivationHackDiagnosticsService,
     PowerShellActivationHackDiagnosticsServiceId,
@@ -79,6 +82,13 @@ export function registerTypes(serviceManager: IServiceManager): void {
         InvalidMacPythonInterpreterService,
         InvalidMacPythonInterpreterServiceId,
     );
+    // --- Start Positron ---
+    serviceManager.addSingleton<IDiagnosticsService>(
+        IDiagnosticsService,
+        UnsupportedPythonVersionService,
+        UnsupportedPythonVersionServiceId,
+    );
+    // --- End Positron ---
 
     serviceManager.addSingleton<IDiagnosticsService>(
         IDiagnosticsService,

--- a/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
@@ -83,6 +83,7 @@ export function registerTypes(serviceManager: IServiceManager): void {
         InvalidMacPythonInterpreterServiceId,
     );
     // --- Start Positron ---
+    // Add a new diagnostic service for unsupported Python versions
     serviceManager.addSingleton<IDiagnosticsService>(
         IDiagnosticsService,
         UnsupportedPythonVersionService,

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -43,6 +43,8 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [LSCommands.RestartLS]: [];
     // --- Start Positron ---
     [Commands.Show_Interpreter_Debug_Info]: [];
+    // New command that opens the multisession interpreter picker
+    ['workbench.action.language.runtime.openActivePicker']: [];
     // --- End Positron ---
 }
 

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -149,6 +149,7 @@ export const UseProposedApi = Symbol('USE_VSC_PROPOSED_API');
 
 // --- Start Positron ---
 export const IPYKERNEL_VERSION = '>=6.19.1';
+// We support versions where MINIMUM_PYTHON_VERSION <= version < MAXIMUM_PYTHON_VERSION_EXCLUSIVE.
 export const MINIMUM_PYTHON_VERSION = { major: 3, minor: 9, patch: 0, raw: '3.9.0' } as PythonVersion;
 export const MAXIMUM_PYTHON_VERSION_EXCLUSIVE = { major: 3, minor: 14, patch: 0, raw: '3.14.0' } as PythonVersion;
 export const INTERPRETERS_INCLUDE_SETTING_KEY = 'interpreters.include';

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -150,6 +150,7 @@ export const UseProposedApi = Symbol('USE_VSC_PROPOSED_API');
 // --- Start Positron ---
 export const IPYKERNEL_VERSION = '>=6.19.1';
 export const MINIMUM_PYTHON_VERSION = { major: 3, minor: 9, patch: 0, raw: '3.9.0' } as PythonVersion;
+export const MAXIMUM_PYTHON_VERSION_EXCLUSIVE = { major: 3, minor: 14, patch: 0, raw: '3.14.0' } as PythonVersion;
 export const INTERPRETERS_INCLUDE_SETTING_KEY = 'interpreters.include';
 export const INTERPRETERS_EXCLUDE_SETTING_KEY = 'interpreters.exclude';
 export const INTERPRETERS_OVERRIDE_SETTING_KEY = 'interpreters.override';

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -253,6 +253,7 @@ export namespace InterpreterQuickPickList {
         label: l10n.t('Create Virtual Environment...'),
     };
     // --- Start Positron ---
+    // Add a new tooltip text
     export const unsupportedVersionTooltip = l10n.t('This version of Python is not supported');
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -252,6 +252,9 @@ export namespace InterpreterQuickPickList {
     export const create = {
         label: l10n.t('Create Virtual Environment...'),
     };
+    // --- Start Positron ---
+    export const unsupportedVersionTooltip = l10n.t('This version of Python is not supported');
+    // --- End Positron ---
 }
 
 export namespace OutputChannelNames {

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -70,6 +70,10 @@ export namespace Common {
     export const alwaysIgnore = l10n.t('Always Ignore');
     export const ignore = l10n.t('Ignore');
     export const selectPythonInterpreter = l10n.t('Select Python Interpreter');
+    // --- Start Positron ---
+    // Add a new button text
+    export const selectNewSession = l10n.t('Select a new session');
+    // --- End Positron ---
     export const openLaunch = l10n.t('Open launch.json');
     export const useCommandPrompt = l10n.t('Use Command Prompt');
     export const download = l10n.t('Download');

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -487,6 +487,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
                         }
                     }
                     // --- Start Positron ---
+                    // Add warning label to unsupported interpreters
                     if (isInterpreterQuickPickItem(item) && !isVersionSupported(item.interpreter.version)) {
                         if (!items[i].label.includes(Octicons.Warning)) {
                             items[i].label = `${Octicons.Warning} ${items[i].label}`;
@@ -739,6 +740,7 @@ function addSeparatorIfApplicable(
 
 function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
     // --- Start Positron ---
+    // If the interpreter is not supported, group it in the "Unsupported" category
     if (!isVersionSupported(item.interpreter.version)) {
         return EnvGroups.Unsupported;
     }

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -14,8 +14,7 @@ import { traceError, traceInfo } from '../logging';
 import { PythonEnvironment } from '../pythonEnvironments/info';
 import { createPythonRuntimeMetadata } from './runtime';
 import { comparePythonVersionDescending } from '../interpreter/configuration/environmentTypeComparer';
-import { MINIMUM_PYTHON_VERSION } from '../common/constants';
-import { isVersionSupported, shouldIncludeInterpreter } from './interpreterSettings';
+import { shouldIncludeInterpreter } from './interpreterSettings';
 import { hasFiles } from './util';
 
 /**
@@ -109,19 +108,12 @@ export async function* pythonRuntimeDiscoverer(
 }
 
 /**
- * Returns a list of Python interpreters with unsupported and user-excluded interpreters removed.
+ * Returns a list of Python interpreters with user-excluded interpreters removed.
  * @param interpreters The list of Python interpreters to filter.
- * @returns A list of Python interpreters that are supported and not user-excluded.
+ * @returns A list of Python interpreters that are not user-excluded.
  */
 function filterInterpreters(interpreters: PythonEnvironment[]): PythonEnvironment[] {
     return interpreters.filter((interpreter) => {
-        // Check if the interpreter version is supported
-        const isSupported = isVersionSupported(interpreter.version, MINIMUM_PYTHON_VERSION);
-        if (!isSupported) {
-            traceInfo(`pythonRuntimeDiscoverer: filtering out unsupported interpreter ${interpreter.path}`);
-            return false;
-        }
-
         // Check if the interpreter is excluded by the user
         const shouldInclude = shouldIncludeInterpreter(interpreter.path);
         if (!shouldInclude) {

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -11,13 +11,14 @@ import {
     INTERPRETERS_EXCLUDE_SETTING_KEY,
     INTERPRETERS_INCLUDE_SETTING_KEY,
     INTERPRETERS_OVERRIDE_SETTING_KEY,
-    MINIMUM_PYTHON_VERSION,
 } from '../common/constants';
 import { untildify } from '../common/helpers';
 import { PythonEnvironment } from '../pythonEnvironments/info';
-import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
 import { Resource, InspectInterpreterSettingType } from '../common/types';
-import { comparePythonVersionDescending } from '../interpreter/configuration/environmentTypeComparer';
+import {
+    comparePythonVersionDescending,
+    isVersionSupported,
+} from '../interpreter/configuration/environmentTypeComparer';
 
 /**
  * Gets the list of interpreters included in the settings.
@@ -212,17 +213,6 @@ function isOverrideInterpreter(interpreterPath: string): boolean | undefined {
 }
 
 /**
- * Check if a version is supported (i.e. >= the minimum supported version).
- * Also returns true if the version could not be determined.
- */
-export function isVersionSupported(
-    version: PythonVersion | undefined,
-    minimumSupportedVersion: PythonVersion,
-): boolean {
-    return !version || comparePythonVersionDescending(minimumSupportedVersion, version) >= 0;
-}
-
-/**
  * Interface for debug information about a Python interpreter.
  */
 interface InterpreterDebugInfo {
@@ -272,7 +262,7 @@ export function printInterpreterDebugInfo(interpreters: PythonEnvironment[]): vo
                 path: interpreter.path,
                 versionInfo: {
                     version: interpreter.version?.raw ?? 'Unknown',
-                    supportedVersion: isVersionSupported(interpreter.version, MINIMUM_PYTHON_VERSION),
+                    supportedVersion: isVersionSupported(interpreter.version),
                 },
                 envInfo: {
                     envType: interpreter.envType,

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -21,12 +21,10 @@ import { traceError, traceInfo, traceLog } from '../logging';
 import { IConfigurationService, IDisposable, IInstaller, InstallerResponse, Product } from '../common/types';
 import { PythonRuntimeSession } from './session';
 import { createPythonRuntimeMetadata, PythonRuntimeExtraData } from './runtime';
-import { Commands, EXTENSION_ROOT_DIR, MINIMUM_PYTHON_VERSION } from '../common/constants';
+import { Commands, EXTENSION_ROOT_DIR } from '../common/constants';
 import { JupyterKernelSpec } from '../positron-supervisor.d';
 import { IEnvironmentVariablesProvider } from '../common/variables/types';
-import { shouldIncludeInterpreter, isVersionSupported, getUserDefaultInterpreter } from './interpreterSettings';
-import { parseVersion, toSemverLikeVersion } from '../pythonEnvironments/base/info/pythonVersion';
-import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
+import { shouldIncludeInterpreter, getUserDefaultInterpreter } from './interpreterSettings';
 import { hasFiles } from './util';
 import { isProblematicCondaEnvironment } from '../interpreter/configuration/environmentTypeComparer';
 import { EnvironmentType } from '../pythonEnvironments/info';
@@ -180,13 +178,6 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, vscode.Dispo
      */
     public registerLanguageRuntime(runtime: positron.LanguageRuntimeMetadata): void {
         const extraData = runtime.extraRuntimeData as PythonRuntimeExtraData;
-        const pythonVersion: PythonVersion = toSemverLikeVersion(parseVersion(runtime.languageVersion));
-
-        // Check if the interpreter should be included in the list of registered runtimes
-        if (!isVersionSupported(pythonVersion, MINIMUM_PYTHON_VERSION)) {
-            traceInfo(`Not registering runtime ${extraData.pythonPath} as it is not a supported version.`);
-            return;
-        }
 
         if (shouldIncludeInterpreter(extraData.pythonPath)) {
             // Save the runtime for later use

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -16,7 +16,7 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { traceInfo } from '../logging';
 import { IInstaller, Product, ProductInstallStatus } from '../common/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
-import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE, Octicons } from '../common/constants';
+import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE } from '../common/constants';
 import {
     EnvLocationHeuristic,
     getEnvLocationHeuristic,
@@ -112,7 +112,7 @@ export async function createPythonRuntimeMetadata(
 
     let supportedFlag = '';
     if (!isVersionSupported(interpreter.version)) {
-        supportedFlag = `${Octicons.Warning} (Unsupported) `;
+        supportedFlag = `(Unsupported) `;
     }
 
     const runtimeName = `${supportedFlag}Python ${runtimeShortName}`;

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -112,7 +112,7 @@ export async function createPythonRuntimeMetadata(
 
     let supportedFlag = '';
     if (!isVersionSupported(interpreter.version)) {
-        supportedFlag = `UNSUPPORTED: `;
+        supportedFlag = `Unsupported: `;
     }
 
     const runtimeName = `${supportedFlag}Python ${runtimeShortName}`;

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -112,7 +112,7 @@ export async function createPythonRuntimeMetadata(
 
     let supportedFlag = '';
     if (!isVersionSupported(interpreter.version)) {
-        supportedFlag = `(Unsupported) `;
+        supportedFlag = `UNSUPPORTED: `;
     }
 
     const runtimeName = `${supportedFlag}Python ${runtimeShortName}`;

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -16,8 +16,12 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { traceInfo } from '../logging';
 import { IInstaller, Product, ProductInstallStatus } from '../common/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
-import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE } from '../common/constants';
-import { EnvLocationHeuristic, getEnvLocationHeuristic } from '../interpreter/configuration/environmentTypeComparer';
+import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE, Octicons } from '../common/constants';
+import {
+    EnvLocationHeuristic,
+    getEnvLocationHeuristic,
+    isVersionSupported,
+} from '../interpreter/configuration/environmentTypeComparer';
 import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
 
 export interface PythonRuntimeExtraData {
@@ -105,7 +109,13 @@ export async function createPythonRuntimeMetadata(
         runtimeShortName += `: ${envName}`;
     }
     runtimeShortName += ')';
-    const runtimeName = `Python ${runtimeShortName}`;
+
+    let supportedFlag = '';
+    if (!isVersionSupported(interpreter.version)) {
+        supportedFlag = `${Octicons.Warning} (Unsupported) `;
+    }
+
+    const runtimeName = `${supportedFlag}Python ${runtimeShortName}`;
 
     // Create a stable ID for the runtime based on the interpreter path and version.
     const digest = crypto.createHash('sha256');

--- a/extensions/positron-python/src/test/configuration/environmentTypeComparer.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/environmentTypeComparer.unit.test.ts
@@ -197,7 +197,12 @@ suite('Environment sorting', () => {
             } as PythonEnvironment,
             envB: {
                 envType: EnvironmentType.Pyenv,
-                version: { major: 3, minor: 7, patch: 2 },
+                // --- Start Positron ---
+                // Positron puts unsupported Python versions at the end, so we need the Pyenv test
+                // version to be supported.
+                // version: { major: 3, minor: 7, patch: 2 },
+                version: { major: 3, minor: 9, patch: 2 },
+                // --- End Positron ---
                 path: path.join('path', 'to', 'normal', 'pyenv'),
             } as PythonEnvironment,
             expected: 1,

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
@@ -25,7 +25,11 @@ const info: PythonEnvironment = {
     envName: '',
     path: '',
     envType: EnvironmentType.Unknown,
-    version: new SemVer('1.0.0-alpha'),
+    // --- Start Positron ---
+    // Positron sorts unsupported versions differently, so we want these to be supported versions.
+    // version: new SemVer('1.0.0-alpha'),
+    version: new SemVer('3.13.0'),
+    // --- End Positron ---
     sysPrefix: '',
     sysVersion: '',
 };

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -17,6 +17,7 @@ import * as fs from '../../client/common/platform/fs-paths';
 import * as runtime from '../../client/positron/runtime';
 import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
 import * as interpreterSettings from '../../client/positron/interpreterSettings';
+import * as environmentTypeComparer from '../../client/interpreter/configuration/environmentTypeComparer';
 import * as util from '../../client/positron/util';
 import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
 import { IConfigurationService, IDisposable, InspectInterpreterSettingType } from '../../client/common/types';
@@ -72,7 +73,7 @@ suite('Python runtime manager', () => {
             return undefined;
         });
 
-        isVersionSupportedStub = sinon.stub(interpreterSettings, 'isVersionSupported');
+        isVersionSupportedStub = sinon.stub(environmentTypeComparer, 'isVersionSupported');
         isVersionSupportedStub.returns(true);
 
         pythonRuntimeManager = new PythonRuntimeManager(serviceContainer.object, interpreterService.object);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5166. This PR:

- stops hiding unsupported interpreters from dropdowns
- adds visually distinct ways of indicating when an interpreter has an unsupported version (too new or too old)
- adds a diagnostic that pops up when an unsupported python is selected anyway

Screenshots:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/1c8c9f7c-896b-4995-8a37-24c29fd3c00d" />
<img width="618" alt="image" src="https://github.com/user-attachments/assets/003bb74d-47d5-4a38-8b6b-232f7a7fbcff" />
<img width="463" alt="image" src="https://github.com/user-attachments/assets/772e6939-50ab-48f2-b842-789372c4f869" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #5166 Unsupported versions of Python are now selectable with a warning.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Install Python versions that are 3.8 or below, or 3.14 or above. They should show up in the multisession picker and be labeled `(Unsupported)`. They should also show up in the Python: Select Interpreter picker and be grouped into their own group at the bottom.

If clicked, most likely you will be prompted to install ipykernel. If ipykernel is already installed, you should get a diagnostic message that warns you it's unsupported.

@:console
@:interpreter
@:new-project-wizard
@:sessions
