### PR TITLE
Disable the Pyright pull diagnostics, for now

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -918,6 +918,7 @@
         "configurationDefaults": {
             "pyright.disableLanguageServices": true,
             "pyright.disableOrganizeImports": true,
+            "pyright.disablePullDiagnostics": true,
             "python.analysis.autoImportCompletions": false,
             "python.analysis.typeCheckingMode": "off"
         },


### PR DESCRIPTION
Addresses #6933 with a temporary fix for the time being

For this contributed default to do anything (and not be labeled as "not allowed"), Positron needs to have v1.1.397 of the Pyright extension. @melissa-barca is going to bump Pyright to 1.1.397 in #6919.