### PR TITLE
6612 model provider dialog improvements

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -334,7 +334,7 @@ export function expandConfigToSource(config: StoredModelConfig): positron.ai.Lan
 		...config,
 		provider: {
 			id: config.provider,
-			displayName: config.provider
+			displayName: config.name
 		},
 		supportedOptions: [],
 		defaults: {

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -293,6 +293,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 	try {
 		await registerModel(newConfig, context, storage);
 
+		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
+
 		vscode.window.showInformationMessage(
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
@@ -310,7 +312,8 @@ async function deleteConfigurationByProvider(context: vscode.ExtensionContext, s
 	const existingConfigs: Array<StoredModelConfig> = context.globalState.get('positron.assistant.models') || [];
 	const updatedConfigs = existingConfigs.filter(config => config.provider !== providerId);
 
-	if (existingConfigs.findIndex(config => config.provider === providerId) === -1) {
+	const targetConfig = existingConfigs.find(config => config.provider === providerId);
+	if (targetConfig === undefined) {
 		throw new Error(vscode.l10n.t('No configuration found for provider {0}', providerId));
 	}
 
@@ -322,6 +325,24 @@ async function deleteConfigurationByProvider(context: vscode.ExtensionContext, s
 	await storage.delete(`apiKey-${providerId}`);
 
 	await registerModels(context, storage);
+
+	positron.ai.removeLanguageModelConfig(expandConfigToSource(targetConfig));
+}
+
+export function expandConfigToSource(config: StoredModelConfig): positron.ai.LanguageModelSource {
+	return {
+		...config,
+		provider: {
+			id: config.provider,
+			displayName: config.provider
+		},
+		supportedOptions: [],
+		defaults: {
+			name: config.name,
+			model: config.model
+		},
+		type: config.type
+	};
 }
 
 export async function deleteConfiguration(context: vscode.ExtensionContext, storage: SecretStorage, id: string) {

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { EncryptedSecretStorage, getEnabledProviders, getModelConfiguration, getModelConfigurations, GlobalSecretStorage, ModelConfig, SecretStorage, showConfigurationDialog, showModelList, StoredModelConfig } from './config';
+import { EncryptedSecretStorage, expandConfigToSource, getEnabledProviders, getModelConfiguration, getModelConfigurations, getStoredModels, GlobalSecretStorage, ModelConfig, SecretStorage, showConfigurationDialog, showModelList, StoredModelConfig } from './config';
 import { newLanguageModel } from './models';
 import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { editsProvider } from './edits';
@@ -224,6 +224,12 @@ export function activate(context: vscode.ExtensionContext) {
 	const enabled = vscode.workspace.getConfiguration('positron.assistant').get('enable');
 	if (enabled) {
 		registerAssistant(context);
+		const storedModels = getStoredModels(context);
+		if (storedModels.length) {
+			storedModels.forEach(stored => {
+				positron.ai.addLanguageModelConfig(expandConfigToSource(stored));
+			});
+		}
 	} else {
 		// If the assistant is not enabled, listen for configuration changes so that we can
 		// enable it immediately if the user enables it in the settings.

--- a/extensions/positron-assistant/src/md/welcomeready.md
+++ b/extensions/positron-assistant/src/md/welcomeready.md
@@ -1,0 +1,11 @@
+Positron Assistant is an AI coding companion designed to accelerate and enhance your data science projects.
+
+Click on or type $(mention) to work with Chat Participants in Positron Assistant.
+
+Click on $(attach) or type `#` to add context, such as files to your Positron Assistant chat.
+
+Type / to use predefined quick commands such as `/help` or `/quatro`.
+
+The {guide-link} explains the possibilities and capabilities of Positron Assistant.
+
+Always verify results. AI assistants can sometimes produce incorrect code.

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -82,17 +82,22 @@ class PositronAssistantParticipant implements positron.ai.ChatParticipant {
 
 	readonly welcomeMessageProvider = {
 		provideWelcomeMessage: async (token: vscode.CancellationToken) => {
-			let welcomeText = await fs.promises.readFile(`${mdDir}/welcome.md`, 'utf8');
-
+			let welcomeText;
 			const addLanguageModelMessage = vscode.l10n.t('Add a Language Model.');
 
 			// Show an extra configuration link if there are no configured models yet
 			if (getStoredModels(this._context).length === 0) {
+				welcomeText = await fs.promises.readFile(`${mdDir}/welcome.md`, 'utf8');
 				const commandUri = vscode.Uri.parse('command:positron-assistant.addModelConfiguration');
 				welcomeText += `\n\n[${addLanguageModelMessage}](${commandUri})`;
+			} else {
+				welcomeText = await fs.promises.readFile(`${mdDir}/welcomeready.md`, 'utf8');
+				// TODO: Replace with guide link once it has been created
+				const guideLink = vscode.Uri.parse('https://positron.posit.co');
+				welcomeText = welcomeText.replace('{guide-link}', `[${vscode.l10n.t('Positron Assistant User Guide')}](${guideLink})`);
 			}
 
-			const message = new vscode.MarkdownString(welcomeText);
+			const message = new vscode.MarkdownString(welcomeText, true);
 			message.isTrusted = true;
 
 			return {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1720,6 +1720,23 @@ declare module 'positron' {
 		): Thenable<void>;
 
 		/**
+		 * Adds the model to the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 * @param config the model config
+		 */
+		export function addLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
+		 * Removes the model from the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 */
+		export function removeLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
 		 * The context in which a chat request is made.
 		 */
 		export interface ChatContext {

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -97,4 +97,14 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	async $getSupportedProviders(): Promise<string[]> {
 		return this._positronAssistantService.getSupportedProviders();
 	}
+
+	$addLanguageModelConfig(source: IPositronLanguageModelSource): void {
+		source.signedIn = true;
+		this._positronAssistantService.addLanguageModelConfig(source);
+	}
+
+	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
+		source.signedIn = false;
+		this._positronAssistantService.removeLanguageModelConfig(source);
+	}
 }

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -33,6 +33,7 @@ import { UiFrontendRequest } from '../../../services/languageRuntime/common/posi
 import { ExtHostConnections } from './extHostConnections.js';
 import { ExtHostAiFeatures } from './extHostAiFeatures.js';
 import { IToolInvocationContext } from '../../../contrib/chat/common/languageModelToolsService.js';
+import { IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -237,7 +238,13 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 			getSupportedProviders(): Thenable<string[]> {
 				return extHostAiFeatures.getSupportedProviders();
-			}
+			},
+			addLanguageModelConfig(source: IPositronLanguageModelSource): void {
+				return extHostAiFeatures.addLanguageModelConfig(source);
+			},
+			removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
+				return extHostAiFeatures.removeLanguageModelConfig(source);
+			},
 		};
 
 		// --- End Positron ---

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -136,6 +136,8 @@ export interface MainThreadAiFeaturesShape {
 	$responseProgress(sessionId: string, dto: IChatProgressDto): void;
 	$languageModelConfig(id: string, sources: IPositronLanguageModelSource[]): Thenable<void>;
 	$getSupportedProviders(): Thenable<string[]>;
+	$addLanguageModelConfig(source: IPositronLanguageModelSource): void;
+	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 }
 
 export interface ExtHostAiFeaturesShape {

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -12,7 +12,7 @@ import * as typeConvert from '../extHostTypeConverters.js';
 import { ExtHostCommands } from '../extHostCommands.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { isToolInvocationContext, IToolInvocationContext } from '../../../contrib/chat/common/languageModelToolsService.js';
-import { IChatRequestData, IPositronChatContext, IPositronLanguageModelConfig } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
+import { IChatRequestData, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { ChatAgentLocation } from '../../../contrib/chat/common/chatAgents.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -90,5 +90,13 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 
 	async getSupportedProviders(): Promise<string[]> {
 		return this._proxy.$getSupportedProviders();
+	}
+
+	addLanguageModelConfig(source: IPositronLanguageModelSource): void {
+		this._proxy.$addLanguageModelConfig(source);
+	}
+
+	removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
+		this._proxy.$removeLanguageModelConfig(source);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -11,7 +11,9 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';
-import { MarkdownString } from '../../../../base/common/htmlContent.js';
+// --- Start Positron ---
+// import { MarkdownString } from '../../../../base/common/htmlContent.js';
+// --- End Positron ---
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -630,17 +632,21 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		const welcomeContent = this.viewModel?.model.welcomeMessage ?? this.persistedWelcomeMessage;
 		if (welcomeContent && !numItems && (this.welcomeMessageContainer.children.length === 0 || this.location === ChatAgentLocation.EditingSession)) {
 			dom.clearNode(this.welcomeMessageContainer);
-			const tips = this.viewOptions.supportsAdditionalParticipants
-				? new MarkdownString(localize('chatWidget.tips', "{0} or type {1} to attach context\n\n{2} to chat with extensions\n\nType {3} to use commands", '$(attach)', '#', '$(mention)', '/'), { supportThemeIcons: true })
-				: new MarkdownString(localize('chatWidget.tips.withoutParticipants', "{0} or type {1} to attach context", '$(attach)', '#'), { supportThemeIcons: true });
+			// --- Start Positron ---
+			// Remove tips here since it is included in our own welcome message with our preferred formatting.
+
+			// const tips = this.viewOptions.supportsAdditionalParticipants
+			// 	? new MarkdownString(localize('chatWidget.tips', "{0} or type {1} to attach context\n\n{2} to chat with extensions\n\nType {3} to use commands", '$(attach)', '#', '$(mention)', '/'), { supportThemeIcons: true })
+			// 	: new MarkdownString(localize('chatWidget.tips.withoutParticipants', "{0} or type {1} to attach context", '$(attach)', '#'), { supportThemeIcons: true });
 			const welcomePart = this._register(this.instantiationService.createInstance(
 				ChatViewWelcomePart,
-				{ ...welcomeContent, tips, },
+				{ ...welcomeContent, },
 				{
 					location: this.location,
 					isWidgetWelcomeViewContent: true
 				}
 			));
+			// --- End Positron ---
 			dom.append(this.welcomeMessageContainer, welcomePart.element);
 		}
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -53,10 +53,12 @@ export const LanguageModelButton = (props: LanguageModelButtonProps) => {
 				{ 'selected': props.selected }
 			)}
 			onPressed={props.onClick}>
-			<VerticalStack>
-				{getIcon()}
-				{props.displayName}
-			</VerticalStack>
+			<div id={`${props.identifier}-provider-button`}>
+				<VerticalStack>
+					{getIcon()}
+					{props.displayName}
+				</VerticalStack>
+			</div>
 		</Button>
 	);
 };

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -17,7 +17,7 @@ import { OKCancelModalDialog } from '../../../browser/positronComponents/positro
 import { VerticalStack } from '../../../browser/positronComponents/positronModalDialog/components/verticalStack.js';
 import { DropDownListBoxItem } from '../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { LabeledTextInput } from '../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
-import { IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
+import { IPositronAssistantService, IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
 import { localize } from '../../../../nls.js';
 import { ProgressBar } from '../../../../base/browser/ui/positronComponents/progressBar.js';
 import { LanguageModelButton } from './components/languageModelButton.js';
@@ -30,6 +30,7 @@ export const showLanguageModelModalDialog = (
 	keybindingService: IKeybindingService,
 	layoutService: ILayoutService,
 	configurationService: IConfigurationService,
+	positronAssistantService: IPositronAssistantService,
 	sources: IPositronLanguageModelSource[],
 	onAction: (config: IPositronLanguageModelConfig, action: string) => Promise<void>,
 	onCancel: () => void,
@@ -47,6 +48,7 @@ export const showLanguageModelModalDialog = (
 				configurationService={configurationService}
 				keybindingService={keybindingService}
 				layoutService={layoutService}
+				positronAssistantService={positronAssistantService}
 				renderer={renderer}
 				sources={sources}
 				onAction={onAction}
@@ -60,6 +62,7 @@ export const showLanguageModelModalDialog = (
 interface LanguageModelConfigurationProps {
 	keybindingService: IKeybindingService;
 	layoutService: ILayoutService;
+	positronAssistantService: IPositronAssistantService;
 	sources: IPositronLanguageModelSource[];
 	configurationService: IConfigurationService;
 	renderer: PositronModalReactRenderer;
@@ -107,6 +110,22 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	useEffect(() => {
 		setSource(defaultSource);
 	}, [type, defaultSource]);
+
+	useEffect(() => {
+		props.positronAssistantService.onChangeLanguageModelConfig((newSource) => {
+			// find newSource in props.sources and update it
+			const index = props.sources.findIndex(source => source.provider.id === newSource.provider.id);
+			if (index >= 0) {
+				props.sources[index] = newSource;
+			}
+
+			// if newSource matches source, update source
+			if (source.provider.id === newSource.provider.id) {
+				setSource(newSource);
+			}
+
+		});
+	}, [props.positronAssistantService, props.sources, source.provider.id]);
 
 	useEffect(() => {
 		setModel(source.defaults.model);

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -329,7 +329,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				</label>
 				{source?.supportedOptions.includes('apiKey') &&
 					(
-						<div className='language-model-authentication-container'>
+						<div className='language-model-authentication-container' id='api-key-input'>
 							<LabeledTextInput
 								label={(() => localize('positron.newConnectionModalDialog.apiKey', "API Key"))()}
 								type='password'

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -5,6 +5,7 @@
 
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ChatAgentLocation } from '../../../chat/common/chatAgents.js';
+import { Event } from '../../../../../base/common/event.js';
 
 // Create the decorator for the Positron assistant service (used in dependency injection).
 export const IPositronAssistantService = createDecorator<IPositronAssistantService>('positronAssistantService');
@@ -75,6 +76,11 @@ export interface IPositronAssistantService {
 	readonly _serviceBrand: undefined;
 
 	/**
+	 * Event that fires when a language model configuration is added or deleted.
+	 */
+	readonly onChangeLanguageModelConfig: Event<IPositronLanguageModelSource>;
+
+	/**
 	 * Build positron specific context object to be attached to chat requests.
 	 */
 	getPositronChatContext(request: IChatRequestData): IPositronChatContext;
@@ -93,10 +99,22 @@ export interface IPositronAssistantService {
 		onCancel: () => void,
 		onClose: () => void,
 	): void;
+
 	/**
 	 * Get the supported providers for Positron Assistant.
 	 */
 	getSupportedProviders(): string[];
+
+	/**
+	 * Add a language model configuration.
+	 */
+	addLanguageModelConfig(source: IPositronLanguageModelSource): void;
+
+	/**
+	 * Remove a language model configuration.
+	 */
+	removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
+
 	/**
 	 * Placeholder that gets called to "initialize" the PositronAssistantService.
 	 */


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #6612 

Adds some element id's for automated tests.

Update the Chat view welcome message for when a model is available. I'll open an issue to address the problem of it not refreshing when a model is available/unavailable. It doesn't seem to refresh even with a UI reload.

Add event listener support for model configuration changes. This allows the UI to be notified that a model source has changed. This is important for knowing that the model is now signed in/out.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
The new UI is still hidden behind the secret preference. The Echo and Error models are the only ones that are ready to test with the simple sign in/out workflow.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
