### PR TITLE
Track restarting R sessions to reactivate their LSP when they come back online

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -169,12 +169,9 @@ export class ArkLsp implements vscode.Disposable {
 	/**
 	 * Stops the client instance.
 	 *
-	 * @param awaitStop If true, waits for the client to stop before returning.
-	 *   This should be set to `true` if the server process is still running, and
-	 *   `false` if the server process has already exited.
 	 * @returns A promise that resolves when the client has been stopped.
 	 */
-	public async deactivate(awaitStop: boolean) {
+	public async deactivate() {
 		if (!this._client) {
 			// No client to stop, so just resolve
 			return;
@@ -190,25 +187,24 @@ export class ArkLsp implements vscode.Disposable {
 		// partially initialized client.
 		await this._initializing;
 
-		const promise = awaitStop ?
-			// If the kernel hasn't exited, we can just await the promise directly
-			this._client!.stop() :
-			// The promise returned by `stop()` never resolves if the server
-			// side is disconnected, so rather than awaiting it when the runtime
-			// has exited, we wait for the client to change state to `stopped`,
-			// which does happen reliably.
-			new Promise<void>((resolve) => {
-				const disposable = this._client!.onDidChangeState((event) => {
-					if (event.newState === State.Stopped) {
-						resolve();
-						disposable.dispose();
-					}
-				});
-				this._client!.stop();
+		// Ideally we'd just wait for `this._client!.stop()`. In practice, the
+		// promise returned by `stop()` never resolves if the server side is
+		// disconnected, so rather than awaiting it when the runtime has exited,
+		// we wait for the client to change state to `stopped`, which does
+		// happen reliably.
+		const stopped = new Promise<void>((resolve) => {
+			const disposable = this._client!.onDidChangeState((event) => {
+				if (event.newState === State.Stopped) {
+					resolve();
+					disposable.dispose();
+				}
 			});
+		});
+
+		this._client!.stop();
 
 		// Don't wait more than a couple of seconds for the client to stop
-		await Promise.race([promise, timeout(2000, 'waiting for client to stop')]);
+		await Promise.race([stopped, timeout(2000, 'waiting for client to stop')]);
 	}
 
 	/**
@@ -295,7 +291,7 @@ export class ArkLsp implements vscode.Disposable {
 	 */
 	async dispose() {
 		this.activationDisposables.forEach(d => d.dispose());
-		await this.deactivate(false);
+		await this.deactivate();
 	}
 
 	public showOutput() {

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -90,13 +90,10 @@ export class RSessionManager {
 			// sessions that permanently go into `Exited` and never come back
 			// online will never be removed from `_restartingConsoleSessionIds`,
 			// but we don't think that would get too out of control.
-			//
-			// On exit, we also double check that we are fully deactivated
 			case positron.RuntimeState.Exited: {
 				if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
 					this._restartingConsoleSessionIds.add(session.metadata.sessionId);
 				}
-				await this.deactivateSession(session);
 			}
 
 			default:

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -155,7 +155,7 @@ export class RSessionManager {
 	}
 
 	private async deactivateSession(session: RSession): Promise<void> {
-		await session.deactivateLsp(true);
+		await session.deactivateLsp();
 	}
 
 	/**

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -22,7 +22,7 @@ export class RSessionManager {
 	private _lastForegroundSessionId: string | null = null;
 
 	/// The set of sessions actively restarting
-	private _restartingConsoleSessions: Set<string> = new Set();
+	private _restartingConsoleSessionIds: Set<string> = new Set();
 
 	/// The last binpath that was used
 	private _lastBinpath = '';
@@ -71,8 +71,8 @@ export class RSessionManager {
 			// - Non-console sessions are activated immediately.
 			case positron.RuntimeState.Ready: {
 				if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
-					if (this._restartingConsoleSessions.has(session.metadata.sessionId)) {
-						this._restartingConsoleSessions.delete(session.metadata.sessionId);
+					if (this._restartingConsoleSessionIds.has(session.metadata.sessionId)) {
+						this._restartingConsoleSessionIds.delete(session.metadata.sessionId);
 						if (this._lastForegroundSessionId === session.metadata.sessionId) {
 							await this.activateConsoleSession(session);
 						}
@@ -88,13 +88,13 @@ export class RSessionManager {
 			// to only track truly restarting sessions, but kallichore doesn't
 			// emit that right now. The practical downside of this is that
 			// sessions that permanently go into `Exited` and never come back
-			// online will never be removed from `_restartingConsoleSessions`,
+			// online will never be removed from `_restartingConsoleSessionIds`,
 			// but we don't think that would get too out of control.
 			//
 			// On exit, we also double check that we are fully deactivated
 			case positron.RuntimeState.Exited: {
 				if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
-					this._restartingConsoleSessions.add(session.metadata.sessionId);
+					this._restartingConsoleSessionIds.add(session.metadata.sessionId);
 				}
 				await this.deactivateSession(session);
 			}

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -60,20 +60,6 @@ export class RSessionManager {
 	}
 
 	/**
-	 * Gets the runtime with the given ID, if it's registered.
-	 *
-	 * @param id The ID of the runtime to get
-	 * @returns The runtime. Throws an error if the runtime doesn't exist.
-	 */
-	getSession(sessionId: string): RSession {
-		const session = this._sessions.get(sessionId);
-		if (!session) {
-			throw new Error(`Session ${sessionId} not found.`);
-		}
-		return session;
-	}
-
-	/**
 	 * Registers a runtime with the manager. Throws an error if a runtime with
 	 * the same ID is already registered.
 	 *
@@ -118,16 +104,6 @@ export class RSessionManager {
 		}
 
 		return consoleSessions[0];
-	}
-
-	/**
-	 * Checks to see whether a session with the given ID is registered.
-	 *
-	 * @param id The ID of the session to check
-	 * @returns Whether the session with the given ID is registered.
-	 */
-	hasSession(sessionId: string): boolean {
-		return this._sessions.has(sessionId);
 	}
 
 	/**

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -78,7 +78,7 @@ export class RSessionManager implements vscode.Disposable {
 			// - Restarted console sessions are activated here if they were previously the
 			//   foreground session before their restart, as we won't get a foreground session
 			//   notification for them otherwise.
-			// - Non-console sessions are activated immediately.
+			// - Notebook sessions are activated immediately (Background sessions never have their LSP activated).
 			case positron.RuntimeState.Ready: {
 				if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
 					if (this._restartingConsoleSessionIds.has(session.metadata.sessionId)) {
@@ -87,7 +87,7 @@ export class RSessionManager implements vscode.Disposable {
 							await this.activateConsoleSession(session);
 						}
 					}
-				} else {
+				} else if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Notebook) {
 					await this.activateSession(session);
 				}
 				break;

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -675,12 +675,12 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 * should call this.
 	 */
 	public async activateLsp(): Promise<void> {
-		if (this._lsp.state !== LspState.stopped && this._lsp.state !== LspState.uninitialized) {
-			// Already activated
-			return undefined;
-		}
-
 		return this._queue.add(async () => {
+			if (this._lsp.state !== LspState.stopped && this._lsp.state !== LspState.uninitialized) {
+				// Already activated
+				return;
+			}
+
 			if (this._kernel) {
 				this._kernel.emitJupyterLog('Starting Positron LSP server');
 
@@ -711,15 +711,16 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 * to ensure that other LSPs are deactivated first.
 	 */
 	public async deactivateLsp(): Promise<void> {
-		if (this._lsp.state !== LspState.running) {
-			// Nothing to deactivate
-			return undefined;
-		}
-
 		return this._queue.add(async () => {
+			if (this._lsp.state !== LspState.running) {
+				// Nothing to deactivate
+				return;
+			}
+
 			if (this._kernel) {
 				this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
 			}
+
 			await this._lsp.deactivate();
 		});
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -681,21 +681,25 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 				return;
 			}
 
-			if (this._kernel) {
-				this._kernel.emitJupyterLog('Starting Positron LSP server');
-
-				// Create the LSP comm, which also starts the LSP server.
-				// We await the server selected port (the server selects the
-				// port since it is in charge of binding to it, which avoids
-				// race conditions). We also use this promise to avoid restarting
-				// in the middle of initialization.
-				this._lspStarting = this._kernel.startPositronLsp('127.0.0.1');
-				const port = await this._lspStarting;
-
-				this._kernel.emitJupyterLog(`Starting Positron LSP client on port ${port}`);
-
-				await this._lsp.activate(port);
+			if (!this._kernel) {
+				// TODO: Can we log this somewhere?
+				// Cannot start LSP, kernel not started
+				return;
 			}
+
+			this._kernel.emitJupyterLog('Starting Positron LSP server');
+
+			// Create the LSP comm, which also starts the LSP server.
+			// We await the server selected port (the server selects the
+			// port since it is in charge of binding to it, which avoids
+			// race conditions). We also use this promise to avoid restarting
+			// in the middle of initialization.
+			this._lspStarting = this._kernel.startPositronLsp('127.0.0.1');
+			const port = await this._lspStarting;
+
+			this._kernel.emitJupyterLog(`Starting Positron LSP client on port ${port}`);
+
+			await this._lsp.activate(port);
 		});
 	}
 
@@ -719,11 +723,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 				// Nothing to deactivate
 				return;
 			}
-
-			if (this._kernel) {
-				this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
-			}
-
+			this._kernel?.emitJupyterLog(`Stopping Positron LSP server`);
 			await this._lsp.deactivate();
 		});
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -15,6 +15,7 @@ import { RHtmlWidget, getResourceRoots } from './htmlwidgets';
 import { randomUUID } from 'crypto';
 import { handleRCode } from './hyperlink';
 import { RSessionManager } from './session-manager';
+import { LOGGER } from './extension.js';
 
 interface RPackageInstallation {
 	packageName: string;
@@ -676,14 +677,13 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 */
 	public async activateLsp(): Promise<void> {
 		return this._lspQueue.add(async () => {
-			if (this._lsp.state !== LspState.stopped && this._lsp.state !== LspState.uninitialized) {
-				// Already activated
+			if (!this._kernel) {
+				LOGGER.warn('Cannot activate LSP; kernel not started');
 				return;
 			}
 
-			if (!this._kernel) {
-				// TODO: Can we log this somewhere?
-				// Cannot start LSP, kernel not started
+			if (this._lsp.state !== LspState.stopped && this._lsp.state !== LspState.uninitialized) {
+				// Already activated
 				return;
 			}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -317,7 +317,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 					this._kernel!.emitJupyterLog('LSP startup timed out during interpreter restart');
 				})
 			]);
-			await this._lsp.deactivate(true);
+			await this._lsp.deactivate();
 			return this._kernel.restart(workingDirectory);
 		} else {
 			throw new Error('Cannot restart; kernel not started');
@@ -327,7 +327,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	async shutdown(exitReason = positron.RuntimeExitReason.Shutdown): Promise<void> {
 		if (this._kernel) {
 			// Stop the LSP client before shutting down the kernel
-			await this._lsp.deactivate(true);
+			await this._lsp.deactivate();
 			return this._kernel.shutdown(exitReason);
 		} else {
 			throw new Error('Cannot shutdown; kernel not started');
@@ -343,7 +343,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			// messages if we yank the kernel out from beneath it without
 			// warning.
 			await Promise.race([
-				this._lsp.deactivate(true),
+				this._lsp.deactivate(),
 				delay(250)
 			]);
 			return this._kernel.forceQuit();
@@ -710,7 +710,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 * thing is that an LSP should only ever be started up by a session manager
 	 * to ensure that other LSPs are deactivated first.
 	 */
-	public async deactivateLsp(awaitStop: boolean): Promise<void> {
+	public async deactivateLsp(): Promise<void> {
 		if (this._lsp.state !== LspState.running) {
 			// Nothing to deactivate
 			return undefined;
@@ -720,7 +720,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			if (this._kernel) {
 				this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
 			}
-			await this._lsp.deactivate(awaitStop);
+			await this._lsp.deactivate();
 		});
 	}
 

--- a/extensions/positron-r/src/test/session-manager.unit.test.ts
+++ b/extensions/positron-r/src/test/session-manager.unit.test.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { createUniqueId, mock } from './utils';
+import * as util from '../util';
+import { RSession } from '../session.js';
+
+function mockSession(sessionMode = positron.LanguageRuntimeSessionMode.Console): RSession {
+	return new RSession(
+		mock<positron.LanguageRuntimeMetadata>({
+		}),
+		mock<positron.RuntimeSessionMetadata>({
+			sessionId: createUniqueId(),
+			sessionMode,
+		}),
+	);
+}
+
+suite('Session manager', () => {
+	let suiteDisposables: vscode.Disposable[] = [];
+
+	let onDidChangeForegroundSession: vscode.EventEmitter<string | undefined>;
+
+	let foregroundSession: RSession;
+	let foregroundSessionSpy: sinon.SinonSpiedInstance<RSession>;
+
+	let nonForegroundSession: RSession;
+	let nonForegroundSessionSpy: sinon.SinonSpiedInstance<RSession>;
+
+	let notebookSession: RSession;
+	let notebookSessionSpy: sinon.SinonSpiedInstance<RSession>;
+
+	suiteSetup(() => {
+		// Needs to be done once per suite not once per test because of how `RSessionManager` is a singleton.
+		// If we did it once per test then instantiating `RSessionManager` would capture the first test's stubbed
+		// version of `onDidChangeForegroundSession`.
+		onDidChangeForegroundSession = new vscode.EventEmitter();
+		suiteDisposables.push(onDidChangeForegroundSession);
+		sinon.stub(positron.runtime, 'onDidChangeForegroundSession').get(() => onDidChangeForegroundSession.event);
+	})
+
+	suiteTeardown(() => {
+		sinon.restore();
+		suiteDisposables.forEach((d) => d.dispose());
+	})
+
+	setup(() => {
+		foregroundSession = mockSession();
+		foregroundSessionSpy = sinon.spy(foregroundSession);
+
+		nonForegroundSession = mockSession();
+		nonForegroundSessionSpy = sinon.spy(nonForegroundSession);
+
+		notebookSession = mockSession(positron.LanguageRuntimeSessionMode.Notebook);
+		notebookSessionSpy = sinon.spy(notebookSession);
+	});
+
+	test('should deactivate non-foreground session before activating foreground session', async () => {
+		// Change the foreground session.
+		onDidChangeForegroundSession.fire(foregroundSession.metadata.sessionId);
+
+		// Wait for the event loop to run.
+		await util.delay(0);
+
+		// The foreground session should be activated.
+		sinon.assert.calledOnce(foregroundSessionSpy.activateLsp);
+		sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+
+		// The non-foreground session should be deactivated, and it should happen first.
+		sinon.assert.calledOnce(nonForegroundSessionSpy.deactivateLsp);
+		sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+		sinon.assert.callOrder(nonForegroundSessionSpy.deactivateLsp, foregroundSessionSpy.activateLsp);
+
+		// The notebook session should not be deactivated.
+		sinon.assert.notCalled(notebookSessionSpy.activateLsp);
+		sinon.assert.notCalled(notebookSessionSpy.deactivateLsp);
+	});
+
+	test('should do nothing when foreground console is unset', async () => {
+		// Change the foreground session.
+		onDidChangeForegroundSession.fire(undefined);
+
+		// Wait for the event loop to run.
+		await util.delay(0);
+
+		sinon.assert.notCalled(foregroundSessionSpy.activateLsp);
+		sinon.assert.notCalled(foregroundSessionSpy.deactivateLsp);
+		sinon.assert.notCalled(nonForegroundSessionSpy.activateLsp);
+		sinon.assert.notCalled(nonForegroundSessionSpy.deactivateLsp);
+		sinon.assert.notCalled(notebookSessionSpy.activateLsp);
+		sinon.assert.notCalled(notebookSessionSpy.deactivateLsp);
+	});
+});

--- a/extensions/positron-r/src/test/utils.ts
+++ b/extensions/positron-r/src/test/utils.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function mock<T>(obj: Partial<T>): T {
+	return obj as T;
+}
+
+export function createUniqueId(): string {
+	return Math.floor(Math.random() * 0x100000000).toString(16);
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6902, joint work with @seeM 
Attempt 2 replacing https://github.com/posit-dev/positron/pull/6924 
Joint PR with #6947 

As noted in https://github.com/posit-dev/positron/pull/6924, restarting sessions won't have `onDidChangeForegroundSession` events fired for them, because the foreground session isn't changing. And we think this is correct because many things rely on the foreground session event not firing unnecessarily.

Instead, it seems like it is up to the language extension to track when the LSP needs to come online. This isn't super easy, but I've come up with:

- When a session becomes the R foreground session through `onDidChangeForegroundSession`, activate the LSP and deactivate all others.

- When a session restarts AND reenters the `Ready` state AND was previously the R foreground session, activate the LSP and deactivate all others. We are not going to get a `onDidChangeForegroundSession` notification here, so it is up to us to handle this case.

Implementing the 2nd bullet was a bit gross. I've chosen to do it in `RSessionManager` for now, but I think that is going to eventually get absorbed into `RRuntimeManager` (that's not that important to the PR, just a note).

---

An important note about this PR is that it fully transitions ownership over _starting_ the LSP from `RSession` itself up into `RSessionManager`. In a multi console world, it is impossible for `RSession` itself to correctly start its own LSP because it has to wait for all other LSPs to shut down first - something only a session manager can do.

@:web @:sessions @:notebooks