### PR TITLE
E2E test: missing await breaking test

### DIFF
--- a/test/e2e/infra/fixtures/interpreter.ts
+++ b/test/e2e/infra/fixtures/interpreter.ts
@@ -81,7 +81,7 @@ export class Interpreter {
 			if (await selectedPrimaryInterpreter.count() === 1) {
 				await selectedPrimaryInterpreter.click();
 			} else {
-				primaryInterpreterByType.getByRole('button', { name: '' }).click();
+				await primaryInterpreterByType.getByRole('button', { name: '' }).click();
 				// first() here is a workaround because we are detecting the same interpreter twice
 				await secondaryInterpreterOption.first().click();
 			}


### PR DESCRIPTION
Seeing a test fail for no reason.  Noted that an await was missing at the suspect line.

### QA Notes

Just a missing await.  May as well allow test on merge
