### PR TITLE
E2E test: don't install undetectable interpreters for PR & merge

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -16,7 +16,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: "merge,electron/ubuntu"
       report_testrail: false
-      install_undetectable_interpreters: true
+      install_undetectable_interpreters: false
       install_license: false
       skip_tags: "@:nightly-only"
     secrets: inherit
@@ -40,7 +40,7 @@ jobs:
       project: "e2e-browser"
       currents_tags: "merge,browser/ubuntu"
       report_testrail: false
-      install_undetectable_interpreters: true
+      install_undetectable_interpreters: false
       install_license: true
       skip_tags: "@:nightly-only"
     secrets: inherit

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: true
+      install_undetectable_interpreters: false
       install_license: false
       skip_tags: "@:nightly-only"
     secrets: inherit
@@ -69,7 +69,7 @@ jobs:
       currents_tags: "pull-request,browser/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
-      install_undetectable_interpreters: true
+      install_undetectable_interpreters: false
       install_license: true
       skip_tags: "@:nightly-only"
     secrets: inherit


### PR DESCRIPTION
Now that test case excludes are working, we can skip unnecessary setup steps.

### QA Notes

All tests should pass
