### PR TITLE
expand scope of env/interpreter settings to "resource"

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -541,7 +541,7 @@
                         }
                     ],
                     "markdownDescription": "%python.environmentProviders.enable.markdownDescription%",
-                    "scope": "machine-overridable",
+                    "scope": "resource",
                     "type": "object",
                     "properties": {
                         "Venv": {
@@ -556,7 +556,7 @@
                 "python.defaultInterpreterPath": {
                     "default": "python",
                     "markdownDescription": "%python.defaultInterpreterPath.description%",
-                    "scope": "machine-overridable",
+                    "scope": "resource",
                     "type": "string",
                     "tags": [
                         "interpreterSettings"
@@ -565,7 +565,7 @@
                 "python.interpreters.include": {
                     "default": [],
                     "markdownDescription": "%python.interpreters.include.markdownDescription%",
-                    "scope": "machine",
+                    "scope": "resource",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -578,7 +578,7 @@
                 "python.interpreters.exclude": {
                     "default": [],
                     "markdownDescription": "%python.interpreters.exclude.markdownDescription%",
-                    "scope": "machine",
+                    "scope": "resource",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -591,7 +591,7 @@
                 "python.interpreters.override": {
                     "default": [],
                     "markdownDescription": "%python.interpreters.override.markdownDescription%",
-                    "scope": "machine",
+                    "scope": "resource",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -196,7 +196,7 @@
         "title": "%r.configuration.title-dev%",
         "properties": {
           "positron.r.customRootFolders": {
-            "scope": "machine",
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "string"
@@ -209,7 +209,7 @@
             "markdownDescription": "%r.configuration.customRootFolders.markdownDescription%"
           },
           "positron.r.customBinaries": {
-            "scope": "machine",
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "string"
@@ -222,7 +222,7 @@
             "markdownDescription": "%r.configuration.customBinaries.markdownDescription%"
           },
           "positron.r.interpreters.exclude": {
-            "scope": "machine",
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "string"
@@ -235,7 +235,7 @@
             "markdownDescription": "%r.configuration.interpreters.exclude.markdownDescription%"
           },
           "positron.r.interpreters.override": {
-            "scope": "machine",
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "string"
@@ -248,7 +248,7 @@
             "markdownDescription": "%r.configuration.interpreters.override.markdownDescription%"
           },
           "positron.r.interpreters.default": {
-            "scope": "machine",
+            "scope": "resource",
             "type": "string",
             "default": null,
             "tags": [


### PR DESCRIPTION
## Summary

- addresses: #6909
- Interpreter settings and Python Environment Provider settings are now configurable via User Settings in Positron on Workbench
- This change is needed because settings must be available via User Settings in order for Workbench admins to configure defaults for the settings via https://docs.posit.co/ide/server-pro/positron_sessions/configuration.html#positron-pro-user-settings. Prior to this change, many of the settings were only available via Remote Settings in Positron Server Web / Positron on Workbench.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Expand setting scope for interpreter settings to User Settings in Positron Server Web (#6909)


### QA Notes

In Positron Desktop, searching for `@tag:interpreterSettings` and `python.environmentProviders.enable` in the Settings UI results in the setting being available across the User and Workspace settings tabs. The settings can be modified in the settings.json file available via command `Preferences: Open User Settings (JSON)`.

In Positron Server Web / Positron on Workbench, searching for `@tag:interpreterSettings` and `python.environmentProviders.enable` in the Settings UI results in the setting being available across the User, Remote and Workspace settings tabs. The settings can be modified in the settings.json file available via command `Preferences: Open User Settings (JSON)`.
