### PR TITLE
Data Explorer: Reduce default summary panel width from 400 to 350 pixels

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -27,7 +27,7 @@ import { PositronDataExplorerLayout } from '../../../../../services/positronData
  * Constants.
  */
 const MIN_COLUMN_WIDTH = 300;
-const DEFAULT_SUMMARY_WIDTH = 400;
+const DEFAULT_SUMMARY_WIDTH = 350;
 
 /**
  * DataExplorer component.


### PR DESCRIPTION
Addresses #6952. I tried 300 pixels but it seemed too cramped, so hopefully this is a reasonable compromise and the e2e tests can be adjusted to this new default:

400 pixels:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d762a6a2-ecb0-4242-9c36-a986c302822b" />

350:

<img width="346" alt="image" src="https://github.com/user-attachments/assets/3969fcb2-8e75-4fd1-aace-3105b71d4034" />

e2e: @:data-explorer