### PR TITLE
use distinct CSS class name for `runtime-startup-progress`

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupProgress.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupProgress.css
@@ -3,26 +3,26 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.runtime-starting {
+.runtime-startup-progress {
 	display: flex;
 	flex-direction: column;
 }
 
-.runtime-starting .action,
-.runtime-starting .runtime-name {
+.runtime-startup-progress .action,
+.runtime-startup-progress .runtime-name {
 	margin: 2px;
 	text-transform: uppercase;
 	text-align: center;
 }
 
-.runtime-starting .action {
+.runtime-startup-progress .action {
 	font-size: 11px;
 }
 
-.runtime-starting .runtime-name {
+.runtime-startup-progress .runtime-name {
 	font-weight: bold;
 }
 
-.runtime-starting-icon {
+.runtime-startup-progress-icon {
 	height: 50px;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupProgress.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupProgress.tsx
@@ -35,8 +35,8 @@ const reconnecting = localize('positron.runtimeStartup.existingSession', "Reconn
 export const RuntimeStartupProgress = (props: RuntimeStartupProgressProps) => {
 	// Render.
 	return (
-		<div className='runtime-starting'>
-			<img className='runtime-starting-icon' src={`data:image/svg+xml;base64,${props.evt.runtime.base64EncodedIconSvg}`} />
+		<div className='runtime-startup-progress'>
+			<img className='runtime-startup-progress-icon' src={`data:image/svg+xml;base64,${props.evt.runtime.base64EncodedIconSvg}`} />
 			<div className='runtime-name'>{props.evt.runtime.runtimeName}</div>
 			<div className='action'>{props.evt.newSession ? preparing : reconnecting}</div>
 		</div>


### PR DESCRIPTION
## Summary

- addresses https://github.com/posit-dev/positron/issues/6798

### Implementation
- the `runtime-starting` CSS class is used in both https://github.com/posit-dev/positron/blob/main/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarting.css and https://github.com/posit-dev/positron/blob/main/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupProgress.css
- it seemed like the CSS classes were colliding in Web mode, causing the startup progress layout to render in an unexpected way
- renaming the CSS class for the runtime startup progress to a distinct CSS class name resolves the issue

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed runtime startup progress layout in Positron Server Web (#6798)

### QA Notes

The "Preparing" state in Console should now render without overlapping or odd alignment in Positron Server Web. The "Preparing" state in Console should look identical in Web and Desktop now.
