### PR TITLE
e2e-test: session diagnostic test updates

### DIFF
--- a/test/e2e/pages/problems.ts
+++ b/test/e2e/pages/problems.ts
@@ -53,23 +53,23 @@ export class Problems {
 	 * @param warningCount - The expected warning count shown in the Problems view
 	 */
 	async expectDiagnosticsToBe({
-		problemCount,
+		badgeCount,
 		errorCount,
 		warningCount
 	}: {
-		problemCount?: number;
+		badgeCount?: number;
 		errorCount?: number;
 		warningCount?: number;
 	}): Promise<void> {
-		await test.step(`Expect diagnostics - Problems: ${problemCount ?? 'N/A'}, Errors: ${errorCount ?? 'N/A'}, Warnings: ${warningCount ?? 'N/A'}`, async () => {
+		await test.step(`Expect diagnostics - Problems: ${badgeCount ?? 'N/A'}, Errors: ${errorCount ?? 'N/A'}, Warnings: ${warningCount ?? 'N/A'}`, async () => {
 			// Waiting for debounce to complete, ensuring counts reflect the final state
 			await this.code.driver.page.waitForTimeout(1500);
 			await this.showProblemsView();
 
-			if (problemCount !== undefined) {
-				problemCount === 0
+			if (badgeCount !== undefined) {
+				badgeCount === 0
 					? await expect(this.problemsCount).not.toBeVisible()
-					: await expect(this.problemsCount).toHaveText(problemCount.toString());
+					: await expect(this.problemsCount).toHaveText(badgeCount.toString());
 			}
 
 			if (errorCount !== undefined) {

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Sessions: Diagnostics', {
+test.describe.skip('Sessions: Diagnostics', {
 	tag: [tags.SESSIONS, tags.PROBLEMS, tags.WEB, tags.WIN],
 	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6970' }]
 }, () => {
@@ -38,7 +38,7 @@ test.describe('Sessions: Diagnostics', {
 		await console.executeCode('Python', 'pip install termcolor', { maximizeConsole: false });
 		await console.executeCode('Python', 'import termcolor', { maximizeConsole: false });
 
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 }); // bug: this should be 0
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 1, errorCount: 0 }); // bug: this should be 0
 		await problems.expectSquigglyCountToBe('warning', 1); // bug this should be 0
 
 		// // Python Session 2 - verify only syntax error for variable x
@@ -49,7 +49,7 @@ test.describe('Sessions: Diagnostics', {
 
 		// Python Alt Session - verify warning since pkg was not installed in that runtime
 		await sessions.select(pyAltSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 2, errorCount: 0 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 2, errorCount: 0 });
 		await problems.expectWarningText('"x" is not defined');
 		await problems.expectWarningText('Import "termcolor" could not be resolved');
 		await problems.expectSquigglyCountToBe('warning', 2);
@@ -58,7 +58,7 @@ test.describe('Sessions: Diagnostics', {
 		await sessions.select(pySession.id); // select the session with no errors, so this should be the one that is running
 		const rSession = await sessions.start('r');
 		await sessions.select(rSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 }); // same bug: this should be 0
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 1, errorCount: 0 }); // same bug: this should be 0
 		await problems.expectSquigglyCountToBe('warning', 1);	// same bug: this should be 0
 	});
 
@@ -73,20 +73,20 @@ test.describe('Sessions: Diagnostics', {
 
 		// Session 1 - before installing/importing pkg the circos warning should be present
 		await sessions.select(rSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
 		await problems.expectSquigglyCountToBe('warning', 1);
 
 		// Session 1 - install & import circlize and verify no problems
 		await console.executeCode('R', "install.packages('circlize')", { maximizeConsole: false });
 		await console.executeCode('R', 'library(circlize)', { maximizeConsole: false });
-		await problems.expectDiagnosticsToBe({ problemCount: 0, warningCount: 0, errorCount: 0 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
 		await problems.expectSquigglyCountToBe('warning', 0);
 
 		// Session 2 - verify warning since circlize is not installed
 		await sessions.select(rSessionAlt.id);
 		await problems.expectSquigglyCountToBe('warning', 1);
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 1, errorCount: 0 });
 		await problems.expectWarningText('No symbol named \'circos.');
 
 		// Introduce a syntax error
@@ -94,12 +94,12 @@ test.describe('Sessions: Diagnostics', {
 
 		// Session 2 - verify both problems (circos and syntax) are present
 		await sessions.select(rSessionAlt.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify only syntax error is present
 		await sessions.select(rSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});
 });

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -11,7 +11,7 @@ test.use({
 
 test.describe('Sessions: Diagnostics', {
 	tag: [tags.SESSIONS, tags.PROBLEMS, tags.WEB, tags.WIN],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6872' }]
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6970' }]
 }, () => {
 
 	test.beforeAll(async function ({ userSettings }) {
@@ -22,46 +22,44 @@ test.describe('Sessions: Diagnostics', {
 		await runCommand('workbench.action.closeAllEditors');
 	});
 
-	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
+	test('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
 		const { problems, editor, console } = app.workbench;
 
-		const [pySession, pyAltSession] = await sessions.start(['python', 'pythonAlt']);
+		// @ts-ignore - need pySession2 once the bug is fixed
+		const [pySession, pySession2, pyAltSession] = await sessions.start(['python', 'python', 'pythonAlt']);
 
 		// Open new Python file
 		await runCommand('Python: New File');
-		await editor.type('import requests\nrequests.get("https://example.com")\n');
+		await editor.type('import termcolor\ntermcolor.COLORS.copy()\nprint(x)\n');
 
-		// Session 1 - before installing/importing package, the requests warning should be present
+		// Python Session 1 - install & import 'termcolor', assign variable x, and verify no problems
 		await sessions.select(pySession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
-		await problems.expectWarningText('Import "requests" could not be resolved from source');
-		await problems.expectSquigglyCountToBe('warning', 1);
+		await console.executeCode('Python', 'x=123', { maximizeConsole: false });
+		await console.executeCode('Python', 'pip install termcolor', { maximizeConsole: false });
+		await console.executeCode('Python', 'import termcolor', { maximizeConsole: false });
 
-		// Session 1 - install & import 'requests' and verify no problems
-		await console.executeCode('Python', 'pip install requests', { maximizeConsole: false });
-		await console.executeCode('Python', 'import requests', { maximizeConsole: false });
-		await problems.expectDiagnosticsToBe({ problemCount: 0, warningCount: 0, errorCount: 0 });
-		await problems.expectSquigglyCountToBe('warning', 0);
+		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 }); // bug: this should be 0
+		await problems.expectSquigglyCountToBe('warning', 1); // bug this should be 0
 
-		// Session 2 - verify warning since requests was not installed in that session
+		// // Python Session 2 - verify only syntax error for variable x
+		// await sessions.select(pySession2.id);
+		// await problems.expectDiagnosticsToBe({ problemCount: 0, warningCount: 1, errorCount: 1 });
+		// await problems.expectWarningText('"x" is not defined');
+		// await problems.expectSquigglyCountToBe('warning', 1);
+
+		// Python Alt Session - verify warning since pkg was not installed in that runtime
 		await sessions.select(pyAltSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 });
-		await problems.expectWarningText('Import "requests" could not be resolved from source');
-		await problems.expectSquigglyCountToBe('warning', 1);
+		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 2, errorCount: 0 });
+		await problems.expectWarningText('"x" is not defined');
+		await problems.expectWarningText('Import "termcolor" could not be resolved');
+		await problems.expectSquigglyCountToBe('warning', 2);
 
-		// Introduce a syntax error
-		await editor.selectTabAndType('Untitled-1', 'x =');
-
-		// Session 2 - verify both errors (import and syntax) are present
-		await sessions.select(pyAltSession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 3, warningCount: 2, errorCount: 1 });
-		await problems.expectSquigglyCountToBe('error', 1);
-
-		// Session 1 - verify 1 error (syntax) is present
-		await sessions.select(pySession.id);
-		await problems.expectDiagnosticsToBe({ problemCount: 2, warningCount: 1, errorCount: 1 });
-		await problems.expectSquigglyCountToBe('error', 1);
-
+		// Start R Session - Verify python diagnostics are still running even if foreground session is R
+		await sessions.select(pySession.id); // select the session with no errors, so this should be the one that is running
+		const rSession = await sessions.start('r');
+		await sessions.select(rSession.id);
+		await problems.expectDiagnosticsToBe({ problemCount: 1, warningCount: 1, errorCount: 0 }); // same bug: this should be 0
+		await problems.expectSquigglyCountToBe('warning', 1);	// same bug: this should be 0
 	});
 
 	test('R - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {


### PR DESCRIPTION
### Summary
Updated diagnostic tests to handle checking diagnostics when foreground session doesn't match the editor.
Also while the original issue has been solved, a new one relating to variable diagnostics has been opened and is referenced in the test.

Note: this test is still being skipped until remaining issues are resolved.

### QA Notes

@:sessions