### PR TITLE
Only render Console instances when the `consolePaneWidth` is greater than 0

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -136,18 +136,21 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 							style={{ height: props.height, width: consolePaneWidth }}
 						>
 							<ActionBar {...props} showDeleteButton={positronConsoleContext.consoleSessionListCollapsed} />
-							<div className='console-instances-container'>
-								{positronConsoleContext.positronConsoleInstances.map(positronConsoleInstance =>
-									<ConsoleInstance
-										key={positronConsoleInstance.sessionId}
-										active={positronConsoleInstance.sessionId === positronConsoleContext.activePositronConsoleInstance?.sessionId}
-										height={adjustedHeight}
-										positronConsoleInstance={positronConsoleInstance}
-										reactComponentContainer={props.reactComponentContainer}
-										width={consolePaneWidth}
-									/>
-								)}
-							</div>
+							{/* #6845 - Only render console instances when the console pane width is greater than 0. */}
+							{consolePaneWidth > 0 &&
+								<div className='console-instances-container'>
+									{positronConsoleContext.positronConsoleInstances.map(positronConsoleInstance =>
+										<ConsoleInstance
+											key={positronConsoleInstance.sessionId}
+											active={positronConsoleInstance.sessionId === positronConsoleContext.activePositronConsoleInstance?.sessionId}
+											height={adjustedHeight}
+											positronConsoleInstance={positronConsoleInstance}
+											reactComponentContainer={props.reactComponentContainer}
+											width={consolePaneWidth}
+										/>
+									)}
+								</div>
+							}
 						</div>
 						<VerticalSplitter
 							configurationService={positronConsoleContext.configurationService}


### PR DESCRIPTION
### Description

This PR addresses #6845 by only rendering `ConsoleInstance` components when the `consolePaneWidth` is greater than 0. (There's no need to render a zero-width component since it will render nothing.) This prevents the `ConsoleInput` component from setting the `CodeEditorWidget` component's width to something that's too small, which causes it to behave badly. (Ultimately, this is a `CodeEditorWidget` bug that does not have an easy or straightforward fix.)



### Release Notes

#### New Features

- N/A

#### Bug Fixes

- [#6845] Only render Console instances when the `consolePaneWidth` is greater than 0.

### QA Notes

Tests:
@:console

To test this fix, you must have the **Console: Multiple Console Sessions** setting enabled. Steps to test:

1. Open Positron.

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/b116d417-cfff-4284-8f64-92aab0fda10f" />

2. Drag the console to a new location (the Secondary Sidebar is a good spot):

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/379cba2e-4001-4687-86f1-617aa05262fe" />

3. Reset the Console location (the right-click context menu is a good way to do this):

<img width="333" alt="image" src="https://github.com/user-attachments/assets/ab4c55ce-f180-427a-8472-618e5488e840" />

If the ConsoleInput component appears normally, not like this:

![image](https://github.com/user-attachments/assets/aad8cf4b-511f-4278-a9bb-1aa6f5ed4962)

The fix has been verified.