### PR TITLE
e2e Test: Basic Positron Asisstant 

### DIFF
--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -19,6 +19,7 @@
 export enum TestTags {
 	// feature tags
 	APPS = '@:apps',
+	ASSISTANT = '@:assistant',
 	CONNECTIONS = '@:connections',
 	CONSOLE = '@:console',
 	CRITICAL = '@:critical',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -38,6 +38,7 @@ import { References } from '../pages/references';
 import { SCM } from '../pages/scm';
 import { Sessions } from '../pages/sessions';
 import { Search } from '../pages/search.js';
+import { Assistant } from '../pages/positronAssistant.js';
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -79,6 +80,7 @@ export class Workbench {
 	readonly scm: SCM;
 	readonly sessions: Sessions;
 	readonly search: Search;
+	readonly assistant: Assistant;
 
 	constructor(code: Code) {
 
@@ -116,5 +118,6 @@ export class Workbench {
 		this.scm = new SCM(code, this.layouts);
 		this.sessions = new Sessions(code, this.console, this.quickaccess, this.quickInput);
 		this.search = new Search(code);
+		this.assistant = new Assistant(code);
 	}
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -33,10 +33,8 @@ export class Assistant {
 	async openPositronAssistantChat() {
 		await test.step('Verify Assistant is enabled and Open it.', async () => {
 			await this.verifyChatButtonVisible();
-			try {
-				await this.verifyAddModelLinkVisible();
-			}
-			catch (e) {
+			const addModelLinkIsVisible = await this.code.driver.page.locator(ADD_MODEL_LINK).isVisible();
+			if (!addModelLinkIsVisible) {
 				await this.code.driver.page.locator(CHATBUTTON).click();
 			}
 		});

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -9,6 +9,7 @@ import { Code } from '../infra/code';
 
 const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label="Chat (Ctrl+Alt+I)"]';
 const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
+const ADD_MODEL_BUTTON = 'a.action-label[aria-label="Add Language Model"]';
 const APIKEY_INPUT = 'input.text-input[type="password"]';
 const DONE_BUTTON = 'button.positron-button.action-bar-button.default';
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
@@ -18,7 +19,7 @@ const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(svg
 const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(.codicon-info)';
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(.codicon-error)';
 const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(svg path[fill="url(#gemini-color_svg__a)"])';
-
+const CHAT_PANEL = '#workbench\\.panel\\.chat';
 /*
  *  Reuseable Positron Assistant functionality for tests to leverage.
  */
@@ -33,7 +34,7 @@ export class Assistant {
 	async openPositronAssistantChat() {
 		await test.step('Verify Assistant is enabled and Open it.', async () => {
 			await this.verifyChatButtonVisible();
-			const addModelLinkIsVisible = await this.code.driver.page.locator(ADD_MODEL_LINK).isVisible();
+			const addModelLinkIsVisible = await this.code.driver.page.locator(CHAT_PANEL).isVisible();
 			if (!addModelLinkIsVisible) {
 				await this.code.driver.page.locator(CHATBUTTON).click();
 			}
@@ -44,9 +45,18 @@ export class Assistant {
 		await this.code.driver.page.locator(ADD_MODEL_LINK).click();
 	}
 
+	async clickAddModelButton() {
+		await this.code.driver.page.locator(ADD_MODEL_BUTTON).click();
+	}
+
 	async verifyAddModelLinkVisible() {
 		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toBeVisible();
 		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toHaveText('Add a Language Model.');
+	}
+
+	async verifyAddModelButtonVisible() {
+		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toBeVisible();
+		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toHaveText('Add Language Model');
 	}
 
 	async selectModelProvider(provider: string) {

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect, test } from '@playwright/test';
+import { Code } from '../infra/code';
+
+const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label="Chat (Ctrl+Alt+I)"]';
+const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
+const APIKEY_INPUT = 'input.text-input[type="password"]';
+const DONE_BUTTON = 'button.positron-button.action-bar-button.default';
+const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
+const SIGN_OUT_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign out")';
+const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(svg path[fill="#D97757"])';
+const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(svg[id*="bedrock"])';
+const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(.codicon-info)';
+const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(.codicon-error)';
+const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(svg path[fill="url(#gemini-color_svg__a)"])';
+
+/*
+ *  Reuseable Positron Assistant functionality for tests to leverage.
+ */
+export class Assistant {
+
+	constructor(private code: Code) { }
+
+	async verifyChatButtonVisible() {
+		await expect(this.code.driver.page.locator(CHATBUTTON)).toBeVisible();
+	}
+
+	async openPositronAssistantChat() {
+		await test.step('Verify Assistant is enabled and Open it.', async () => {
+			await this.verifyChatButtonVisible();
+			try {
+				await this.verifyAddModelLinkVisible();
+			}
+			catch (e) {
+				await this.code.driver.page.locator(CHATBUTTON).click();
+			}
+		});
+	}
+
+	async clickAddModelLink() {
+		await this.code.driver.page.locator(ADD_MODEL_LINK).click();
+	}
+
+	async verifyAddModelLinkVisible() {
+		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toBeVisible();
+		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toHaveText('Add a Language Model.');
+	}
+
+	async selectModelProvider(provider: string) {
+		switch (provider.toLowerCase()) {
+			case 'anthropic':
+				await this.code.driver.page.locator(ANTHROPIC_BUTTON).click();
+				break;
+			case 'aws':
+			case 'bedrock':
+			case 'aws bedrock':
+				await this.code.driver.page.locator(AWS_BEDROCK_BUTTON).click();
+				break;
+			case 'echo':
+				await this.code.driver.page.locator(ECHO_MODEL_BUTTON).click();
+				break;
+			case 'error':
+				await this.code.driver.page.locator(ERROR_MODEL_BUTTON).click();
+				break;
+			case 'gemini':
+				await this.code.driver.page.locator(GEMINI_BUTTON).click();
+				break;
+			default:
+				throw new Error(`Unsupported model provider: ${provider}`);
+		}
+	}
+
+	async enterApiKey(apiKey: string) {
+		const apiKeyInput = this.code.driver.page.locator(APIKEY_INPUT);
+		await apiKeyInput.fill(apiKey);
+	}
+
+	async clickSignInButton() {
+		await this.code.driver.page.locator(SIGN_IN_BUTTON).click();
+	}
+
+	async clickDoneButton() {
+		await this.code.driver.page.locator(DONE_BUTTON).click();
+	}
+
+	async clickSignOutButton() {
+		await this.code.driver.page.locator(SIGN_OUT_BUTTON).click();
+	}
+
+	async verifySignOutButtonVisible(timeout: number = 15000) {
+		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toBeVisible({ timeout });
+		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toHaveText('Sign out', { timeout });
+	}
+
+	async verifySignInButtonVisible(timeout: number = 15000) {
+		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toBeVisible({ timeout });
+		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toHaveText('Sign in', { timeout });
+	}
+}

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+	test.beforeAll('How to set User Settings', async function ({ userSettings }) {
+		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
+		await userSettings.set([['positron.assistant.enable', 'true'],
+		['positron.assistant.newModelConfiguration', 'true'],
+		['positron.assistant.testModels', 'true']], true);
+	});
+
+	test('Verify Positron Assistant enabled', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await expect(app.code.driver.page.locator('.chat-welcome-view-title')).toBeVisible();
+		await app.workbench.assistant.verifyAddModelLinkVisible();
+	});
+
+	test('Antropic: Verfy Bad API key results in error', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.clickAddModelLink();
+		await app.workbench.assistant.selectModelProvider('Anthropic');
+		await app.workbench.assistant.enterApiKey('1234');
+		await app.workbench.assistant.clickSignInButton();
+		await expect(app.workbench.assistant.verifySignOutButtonVisible(5000)).rejects.toThrow();
+		await app.workbench.assistant.clickDoneButton();
+	});
+
+	test('Echo: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.clickAddModelLink();
+		await app.workbench.assistant.selectModelProvider('echo');
+		await app.workbench.assistant.clickSignInButton();
+		await app.workbench.assistant.verifySignOutButtonVisible();
+		await app.workbench.assistant.clickSignOutButton();
+		await app.workbench.assistant.verifySignInButtonVisible();
+		await app.workbench.assistant.clickDoneButton();
+	});
+
+});
+

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -19,13 +19,12 @@ test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] 
 
 	test('Verify Positron Assistant enabled', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await expect(app.code.driver.page.locator('.chat-welcome-view-title')).toBeVisible();
-		await app.workbench.assistant.verifyAddModelLinkVisible();
+		await app.workbench.assistant.verifyAddModelButtonVisible();
 	});
 
 	test('Antropic: Verfy Bad API key results in error', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.clickAddModelLink();
+		await app.workbench.assistant.clickAddModelButton();
 		await app.workbench.assistant.selectModelProvider('Anthropic');
 		await app.workbench.assistant.enterApiKey('1234');
 		await app.workbench.assistant.clickSignInButton();
@@ -35,7 +34,7 @@ test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] 
 
 	test('Echo: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.clickAddModelLink();
+		await app.workbench.assistant.clickAddModelButton();
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignInButton();
 		await app.workbench.assistant.verifySignOutButtonVisible();


### PR DESCRIPTION
### Intent

Added a couple of basic positron assitant tests.
* The feature is hidden behind several hidden settings
* The UI will be in flux for awhile, so these test will be changing, hence some of the verifications are simple, etc. 

### QA Notes
All tests should pass.

@:assistant @:web @:win
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
