### PR TITLE
python: re-enable PET unit tests

### DIFF
--- a/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinder.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinder.unit.test.ts
@@ -16,9 +16,8 @@ import { MockOutputChannel } from '../mockClasses';
 import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
 
 // --- Start Positron ---
-// re-enable when Native Finder is used for discovery
 // TODO: add test for python.interpreters.include here once we switch to Native Finder
-suite.skip('Native Python Finder', () => {
+suite('Native Python Finder', () => {
     // --- Find Positron ---
     let finder: NativePythonFinder;
     let createLogOutputChannelStub: sinon.SinonStub;


### PR DESCRIPTION
Turning on unit tests that were turned off pre-PET support. I've decided against turning on the [Rust tests](https://github.com/microsoft/vscode-python/blob/725d5395664f7130bd81ccdbce925f2944a713de/.github/workflows/pr-check.yml#L417-L420), since we have not forked the PET repo and manually upgrade released versions of PET during upstream merges.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #6432 Turns on Python Environment Tools unit tests

#### Bug Fixes

- N/A


### QA Notes

CI should be green
