### PR TITLE
Fix slow Python shutdowns

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -815,7 +815,6 @@ def positron_highlight(
     return highlight(server, params)
 
 
-@POSITRON.thread()
 @POSITRON.feature(TEXT_DOCUMENT_HOVER)
 def positron_hover(
     server: PositronJediLanguageServer, params: TextDocumentPositionParams


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6948.

The thread decorator creates a thread pool, which starts a resource tracker process that takes a while to exit and doesn't respond to SIGTERM ([source](https://github.com/python/cpython/blob/main/Lib/multiprocessing/resource_tracker.py)). The short-term fix is to revert this change which was previously added in an attempt to fix a performance issue with hovers (see https://github.com/openlawlibrary/pygls/issues/517#issue-2828099848).

A longer term fix would be to upgrade jedi-language-server to pygls v2 which uses the concurrent futures thread pool implementation that doesn't seem to have this problem and/or or to update jedi-language-server to offload slow tasks from the main thread so that it can respond to cancel requests.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- [#6948] Fixed slow Python shutdowns and restarts.