### PR TITLE
Fix ipykernel bundling not disabling via the setting

### DIFF
--- a/extensions/positron-python/src/client/positron/ipykernel.ts
+++ b/extensions/positron-python/src/client/positron/ipykernel.ts
@@ -14,8 +14,8 @@ import { IPythonExecutionFactory } from '../common/process/types';
 import { traceWarn } from '../logging';
 import { EXTENSION_ROOT_DIR } from '../constants';
 
-/** IPyKernel bundle information. */
-export interface IPykernelBundle {
+/** Ipykernel bundle information. */
+export interface IpykernelBundle {
     /** If bundling is disabled, the reason for it. */
     disabledReason?: string;
 
@@ -24,7 +24,7 @@ export interface IPykernelBundle {
 }
 
 /**
- * Get the IPyKernel bundle for a given interpreter.
+ * Get the Ipykernel bundle for a given interpreter.
  *
  * @param interpreter The interpreter to check.
  * @param serviceContainer The service container to use for dependency injection.
@@ -34,7 +34,7 @@ export async function getIpykernelBundle(
     interpreter: PythonEnvironment,
     serviceContainer: IServiceContainer,
     resource?: vscode.Uri,
-): Promise<IPykernelBundle> {
+): Promise<IpykernelBundle> {
     // Get the required services.
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     const pythonExecutionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -18,11 +18,11 @@ import { IInstaller, Product, ProductInstallStatus } from '../common/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
 import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE } from '../common/constants';
 import { EnvLocationHeuristic, getEnvLocationHeuristic } from '../interpreter/configuration/environmentTypeComparer';
-import { getIpykernelBundle, IPykernelBundle } from './ipykernel';
+import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
 
 export interface PythonRuntimeExtraData {
     pythonPath: string;
-    ipykernelBundle?: IPykernelBundle;
+    ipykernelBundle?: IpykernelBundle;
 }
 
 export async function createPythonRuntimeMetadata(

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -49,8 +49,8 @@ export async function createPythonRuntimeMetadata(
     let hasCompatibleKernel: boolean;
     if (ipykernelBundle.disabledReason) {
         traceInfo(
-            `createPythonRuntime: ipykernel bundling is disabled, ` +
-                `reason: ${ipykernelBundle.disabledReason}. ` +
+            `createPythonRuntime: ipykernel bundling is disabled ` +
+                `(reason: ${ipykernelBundle.disabledReason}). ` +
                 `Checking if ipykernel is installed`,
         );
         const productInstallStatus = await installer.isProductVersionCompatible(
@@ -59,6 +59,11 @@ export async function createPythonRuntimeMetadata(
             interpreter,
         );
         hasCompatibleKernel = productInstallStatus === ProductInstallStatus.Installed;
+        if (hasCompatibleKernel) {
+            traceInfo(`createPythonRuntime: ipykernel installed`);
+        } else {
+            traceInfo('createPythonRuntime: ipykernel not installed');
+        }
     } else {
         hasCompatibleKernel = true;
     }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -36,7 +36,7 @@ import { IWorkspaceService } from '../common/application/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { showErrorMessage } from '../common/vscodeApis/windowApis';
 import { Console } from '../common/utils/localize';
-import { IPykernelBundle } from './ipykernel';
+import { IpykernelBundle } from './ipykernel';
 import { whenTimeout } from './util';
 
 /** Regex for commands to uninstall packages using supported Python package managers. */
@@ -100,7 +100,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     private _pythonPath: string;
 
     /** The IPykernel bundle paths */
-    private _ipykernelBundle: IPykernelBundle;
+    private _ipykernelBundle: IpykernelBundle;
 
     dynState: positron.LanguageRuntimeDynState;
 

--- a/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { interfaces } from 'inversify';
+import { EXTENSION_ROOT_DIR } from '../../client/constants';
+import * as fs from '../../client/common/platform/fs-paths';
+import { getIpykernelBundle } from '../../client/positron/ipykernel';
+import { IPythonExecutionFactory, IPythonExecutionService } from '../../client/common/process/types';
+import { InterpreterInformation, PythonEnvironment } from '../../client/pythonEnvironments/info';
+import { IServiceContainer } from '../../client/ioc/types';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { PythonVersion } from '../../client/pythonEnvironments/info/pythonVersion';
+import { mock } from './utils';
+
+suite('Ipykernel', () => {
+    let interpreter: PythonEnvironment;
+    let pythonExecutionService: IPythonExecutionService;
+    let workspaceConfiguration: vscode.WorkspaceConfiguration;
+    let serviceContainer: IServiceContainer;
+
+    setup(() => {
+        interpreter = mock<PythonEnvironment>({
+            id: 'pythonEnvironmentId',
+            path: '/path/to/python',
+            version: mock<PythonVersion>({ major: 3, minor: 9 }),
+        });
+
+        pythonExecutionService = mock<IPythonExecutionService>({
+            getInterpreterInformation: () =>
+                Promise.resolve(
+                    mock<InterpreterInformation>({ implementation: 'cpython', version: interpreter.version }),
+                ),
+        });
+
+        const pythonExecutionFactory = mock<IPythonExecutionFactory>({
+            create: () => Promise.resolve(pythonExecutionService),
+        });
+
+        workspaceConfiguration = mock<vscode.WorkspaceConfiguration>({
+            get: (section: string) => (section === 'useBundledIpykernel' ? true : undefined),
+        });
+        const workspaceService = mock<IWorkspaceService>({
+            workspaceFolders: undefined,
+            getWorkspaceFolder: () => undefined,
+            getConfiguration: () => workspaceConfiguration,
+        });
+
+        serviceContainer = mock<IServiceContainer>({
+            get: <T>(serviceIdentifier: interfaces.ServiceIdentifier<T>) => {
+                switch (serviceIdentifier) {
+                    case IPythonExecutionFactory:
+                        return pythonExecutionFactory as T;
+                    case IWorkspaceService:
+                        return workspaceService as T;
+                    default:
+                        return undefined as T;
+                }
+            },
+        });
+    });
+
+    test('should bundle ipykernel for supported implementation and version', async () => {
+        // Start a console session with ipykernel bundle paths.
+        const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
+
+        // Ipykernel bundles should be added to the PYTHONPATH.
+        const arch = os.arch();
+        assert.deepStrictEqual(ipykernelBundle.paths, [
+            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp39'),
+            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp3'),
+            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'py3'),
+        ]);
+    });
+
+    test('should not bundle ipykernel if setting is disabled', async () => {
+        // Disable ipykernel bundling.
+        sinon.stub(workspaceConfiguration, 'get').withArgs('useBundledIpykernel').returns(false);
+
+        const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
+
+        assert.strictEqual(ipykernelBundle.paths, undefined);
+        assert.ok(ipykernelBundle.disabledReason);
+    });
+
+    test('should not bundle ipykernel if version is incompatible', async () => {
+        // Stub the interpreter version to be incompatible.
+        sinon.stub(interpreter, 'version').get(() => mock<PythonVersion>({ major: 2, minor: 7 }));
+
+        const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
+
+        assert.strictEqual(ipykernelBundle.paths, undefined);
+        assert.ok(ipykernelBundle.disabledReason);
+    });
+
+    test('should not bundle ipykernel if implementation is incompatible', async () => {
+        // Stub the interpreter implementation to be incompatible.
+        sinon.stub(pythonExecutionService, 'getInterpreterInformation').resolves(
+            mock<InterpreterInformation>({ implementation: 'not_cpython', version: interpreter.version }),
+        );
+
+        const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
+
+        assert.strictEqual(ipykernelBundle.paths, undefined);
+        assert.ok(ipykernelBundle.disabledReason);
+    });
+
+    test('should not bundle ipykernel if bundle path does not exist', async () => {
+        // Simulate the bundle paths not existing.
+        sinon.stub(fs, 'pathExists').resolves(false);
+
+        const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
+
+        assert.strictEqual(ipykernelBundle.paths, undefined);
+        assert.ok(ipykernelBundle.disabledReason);
+    });
+});

--- a/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/languageServerManager.unit.test.ts
@@ -105,6 +105,7 @@ suite('Language server manager', () => {
             mock<positron.LanguageRuntimeMetadata>({
                 extraRuntimeData: {
                     pythonPath: 'python',
+                    ipykernelBundle: {},
                 },
             }),
             mock<positron.RuntimeSessionMetadata>({

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -7,13 +7,10 @@
 
 import * as assert from 'assert';
 import { interfaces } from 'inversify';
-import * as os from 'os';
-import * as path from 'path';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import * as fs from '../../client/common/platform/fs-paths';
 import { ILanguageServerOutputChannel } from '../../client/activation/types';
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import {
@@ -33,27 +30,21 @@ import {
     JupyterLanguageRuntimeSession,
 } from '../../client/positron-supervisor.d';
 import { PythonRuntimeSession } from '../../client/positron/session';
-import { InterpreterInformation, PythonEnvironment } from '../../client/pythonEnvironments/info';
-import { IPythonExecutionFactory, IPythonExecutionService } from '../../client/common/process/types';
+import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { PythonVersion } from '../../client/pythonEnvironments/info/pythonVersion';
 import { mock } from './utils';
-import { EXTENSION_ROOT_DIR } from '../../client/constants';
+import { IpykernelBundle } from '../../client/positron/ipykernel';
 
 suite('Python Runtime Session', () => {
     let disposables: vscode.Disposable[];
     let applicationShell: IApplicationShell;
-    let runtimeMetadata: positron.LanguageRuntimeMetadata;
     let installerSpy: sinon.SinonSpiedInstance<IInstaller>;
     let interpreterPathService: IInterpreterPathService;
-    let workspaceConfiguration: vscode.WorkspaceConfiguration;
     let envVarsServiceSpy: sinon.SinonSpiedInstance<IEnvironmentVariablesService>;
-    let pythonExecutionService: IPythonExecutionService;
     let interpreter: PythonEnvironment;
     let serviceContainer: IServiceContainer;
     let kernelSpec: JupyterKernelSpec;
     let kernel: JupyterLanguageRuntimeSession;
-    let consoleSession: positron.LanguageRuntimeSession;
-    let notebookSession: positron.LanguageRuntimeSession;
 
     setup(() => {
         disposables = [];
@@ -72,10 +63,6 @@ suite('Python Runtime Session', () => {
             version: mock<PythonVersion>({ major: 3, minor: 9 }),
         });
 
-        runtimeMetadata = mock<positron.LanguageRuntimeMetadata>({
-            extraRuntimeData: { pythonPath: interpreter.path },
-        });
-
         const interpreterService = mock<IInterpreterService>({
             getInterpreterDetails: (_pythonPath, _resource) => Promise.resolve(interpreter),
         });
@@ -89,13 +76,9 @@ suite('Python Runtime Session', () => {
 
         const outputChannel = mock<ILanguageServerOutputChannel>({});
 
-        workspaceConfiguration = mock<vscode.WorkspaceConfiguration>({
-            get: (section) => (section === 'useBundledIpykernel' ? true : undefined),
-        });
         const workspaceService = mock<IWorkspaceService>({
             workspaceFolders: undefined,
             getWorkspaceFolder: () => undefined,
-            getConfiguration: () => workspaceConfiguration,
         });
 
         const pythonSettings = mock<IPythonSettings>({
@@ -114,17 +97,6 @@ suite('Python Runtime Session', () => {
             appendPythonPath: () => Promise.resolve(),
         });
         envVarsServiceSpy = sinon.spy(envVarsService);
-
-        pythonExecutionService = mock<IPythonExecutionService>({
-            getInterpreterInformation: () =>
-                Promise.resolve(
-                    mock<InterpreterInformation>({ implementation: 'cpython', version: interpreter.version }),
-                ),
-        });
-
-        const pythonExecutionFactory = mock<IPythonExecutionFactory>({
-            create: () => Promise.resolve(pythonExecutionService),
-        });
 
         serviceContainer = mock<IServiceContainer>({
             get: <T>(serviceIdentifier: interfaces.ServiceIdentifier<T>) => {
@@ -145,8 +117,6 @@ suite('Python Runtime Session', () => {
                         return interpreterService as T;
                     case ILanguageServerOutputChannel:
                         return outputChannel as T;
-                    case IPythonExecutionFactory:
-                        return pythonExecutionFactory as T;
                     case IWorkspaceService:
                         return workspaceService as T;
                     default:
@@ -189,17 +159,18 @@ suite('Python Runtime Session', () => {
             get: () => undefined,
         });
         vscode.workspace.getConfiguration = () => nullConfig;
-
-        const consoleMetadata = mock<positron.RuntimeSessionMetadata>({
-            sessionMode: positron.LanguageRuntimeSessionMode.Console,
-        });
-        consoleSession = new PythonRuntimeSession(runtimeMetadata, consoleMetadata, serviceContainer, kernelSpec);
-
-        const notebookMetadata = mock<positron.RuntimeSessionMetadata>({
-            sessionMode: positron.LanguageRuntimeSessionMode.Notebook,
-        });
-        notebookSession = new PythonRuntimeSession(runtimeMetadata, notebookMetadata, serviceContainer, kernelSpec);
     });
+
+    function createSession(
+        sessionMode: positron.LanguageRuntimeSessionMode,
+        ipykernelBundle: IpykernelBundle = {},
+    ): PythonRuntimeSession {
+        const runtimeMetadata = mock<positron.LanguageRuntimeMetadata>({
+            extraRuntimeData: { pythonPath: interpreter.path, ipykernelBundle },
+        });
+        const metadata = mock<positron.RuntimeSessionMetadata>({ sessionMode });
+        return new PythonRuntimeSession(runtimeMetadata, metadata, serviceContainer, kernelSpec);
+    }
 
     teardown(() => {
         disposables.forEach((disposable) => disposable.dispose());
@@ -209,7 +180,8 @@ suite('Python Runtime Session', () => {
     test('Start: updates the active interpreter for console sessions', async () => {
         const target = sinon.spy(interpreterPathService, 'update');
 
-        await consoleSession.start();
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        await session.start();
 
         sinon.assert.calledOnceWithExactly(
             target,
@@ -222,85 +194,34 @@ suite('Python Runtime Session', () => {
     test('Start: does not update the active interpreter for notebook sessions', async () => {
         const target = sinon.spy(interpreterPathService, 'update');
 
-        await notebookSession.start();
+        const session = createSession(positron.LanguageRuntimeSessionMode.Notebook);
+        await session.start();
 
         sinon.assert.notCalled(target);
     });
 
-    test('Start: bundle ipykernel', async () => {
-        // Start a console session.
-        await consoleSession.start();
+    test('Start: bundle ipykernel if enabled', async () => {
+        // Start a console session with ipykernel bundle paths.
+        const paths = ['path1', 'path2', 'path3'];
+        const ipykernelBundle: IpykernelBundle = { paths };
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console, ipykernelBundle);
+        await session.start();
 
         // Should not try to use ipykernel from the environment.
         sinon.assert.notCalled(installerSpy.isProductVersionCompatible);
 
         // Ipykernel bundles should be added to the PYTHONPATH.
         sinon.assert.callCount(envVarsServiceSpy.appendPythonPath, 3);
-        const arch = os.arch();
-        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[0], [
-            kernelSpec.env,
-            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp39'),
-        ]);
-        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[1], [
-            kernelSpec.env,
-            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp3'),
-        ]);
-        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[2], [
-            kernelSpec.env,
-            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'py3'),
-        ]);
+        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[0], [kernelSpec.env, paths[0]]);
+        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[1], [kernelSpec.env, paths[1]]);
+        assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[2], [kernelSpec.env, paths[2]]);
     });
 
-    test('Start: dont bundle ipykernel if setting is disabled', async () => {
-        // Disable ipykernel bundling.
-        sinon.stub(workspaceConfiguration, 'get').withArgs('useBundledIpykernel').returns(false);
-
-        // Start a console session.
-        await consoleSession.start();
-
-        // PYTHONPATH should be unchanged.
-        sinon.assert.notCalled(envVarsServiceSpy.appendPythonPath);
-
-        // Should try to use ipykernel from the environment.
-        sinon.assert.called(installerSpy.isProductVersionCompatible);
-    });
-
-    test('Start: dont bundle ipykernel if version is incompatible', async () => {
-        // Stub the interpreter version to be incompatible.
-        sinon.stub(interpreter, 'version').get(() => mock<PythonVersion>({ major: 2, minor: 7 }));
-
-        // Start a console session.
-        await consoleSession.start();
-
-        // PYTHONPATH should be unchanged.
-        sinon.assert.notCalled(envVarsServiceSpy.appendPythonPath);
-
-        // Should try to use ipykernel from the environment.
-        sinon.assert.called(installerSpy.isProductVersionCompatible);
-    });
-
-    test('Start: dont bundle ipykernel if implementation is incompatible', async () => {
-        // Stub the interpreter implementation to be incompatible.
-        sinon.stub(pythonExecutionService, 'getInterpreterInformation').resolves(
-            mock<InterpreterInformation>({ implementation: 'not_cpython', version: interpreter.version }),
-        );
-
-        // Start a console session.
-        await consoleSession.start();
-
-        // PYTHONPATH should be unchanged.
-        sinon.assert.notCalled(envVarsServiceSpy.appendPythonPath);
-
-        // Should try to use ipykernel from the environment.
-        sinon.assert.called(installerSpy.isProductVersionCompatible);
-    });
-
-    test('Start: dont bundle if bundle path does not exist', async () => {
-        // Simulate the bundle paths not existing.
-        sinon.stub(fs, 'pathExists').resolves(false);
-
-        // Start a console session.
-        await consoleSession.start();
+    test('Start: dont bundle ipykernel if disabled', async () => {
+        // Start a console session with ipykernel bunding disabled.
+        const ipykernelBundle: IpykernelBundle = { disabledReason: 'disabled' };
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console, ipykernelBundle);
+        await session.start();
 
         // PYTHONPATH should be unchanged.
         sinon.assert.notCalled(envVarsServiceSpy.appendPythonPath);
@@ -311,18 +232,19 @@ suite('Python Runtime Session', () => {
 
     test('Execute: dont uninstall bundled packages', async () => {
         // Start a console session.
-        await consoleSession.start();
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        await session.start();
 
         // Spy on the kernel execute method.
         const executeSpy = sinon.spy(kernel, 'execute');
 
         // Record emitted runtime messages.
         const messages: positron.LanguageRuntimeMessage[] = [];
-        disposables.push(consoleSession.onDidReceiveRuntimeMessage((message) => messages.push(message)));
+        disposables.push(session.onDidReceiveRuntimeMessage((message) => messages.push(message)));
 
         // Execute a command that tries to uninstall a bundled package.
         const id = 'execute-id';
-        consoleSession.execute(
+        session.execute(
             'pip uninstall ipykernel',
             id,
             positron.RuntimeCodeExecutionMode.Interactive,

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -812,6 +812,9 @@ async function getRSession_(progress: vscode.Progress<{ message?: string; increm
 class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	extraRuntimeData: any = {
 		pythonPath: 'Managed by the reticulate package',
+		ipykernelBundle: {
+			disabledReason: 'Cannot bundle ipkernel for reticulate sessions',
+		},
 	};
 	base64EncodedIconSvg: string | undefined;
 	constructor() {

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -813,7 +813,7 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	extraRuntimeData: any = {
 		pythonPath: 'Managed by the reticulate package',
 		ipykernelBundle: {
-			disabledReason: 'Cannot bundle ipkernel for reticulate sessions',
+			disabledReason: 'Cannot bundle ipykernel for reticulate sessions',
 		},
 	};
 	base64EncodedIconSvg: string | undefined;


### PR DESCRIPTION
Address #6636. Also simplified the reticulate case by supplying a "disabled" ipykernel bundle value.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- [#6636] Fix ipykernel bundling not disabling via the setting.

### QA Notes

I wasn't actually able to repro this bug so really just hoping that being a bit more careful with our checks will do the job. Also added logging in case it doesn't fix it.

@:reticulate