### PR TITLE
Fix bokeh test not running because code was never executing

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -221,12 +221,11 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 
 		});
 
-		test.skip('Python - Verify bokeh Python widget', {
+		test('Python - Verify bokeh Python widget', {
 			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6045' }],
 			tag: [tags.WEB, tags.WIN]
 		}, async function ({ app }) {
-			await app.workbench.console.pasteCodeToConsole(bokeh);
-			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.executeCode('Python', bokeh);
 
 			// selector not factored out as it is unique to bokeh
 			const bokehCanvas = '.bk-Canvas';

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -632,7 +632,9 @@ const ipywidgetOutput = `import ipywidgets
 output = ipywidgets.Output()
 output`;
 
-const bokeh = `from bokeh.plotting import figure, output_file, show
+const bokeh = `from bokeh.plotting import figure, output_file, show, reset_output
+# Proactively reset output in case hvplot has changed anything
+reset_output()
 
 # instantiating the figure object
 graph = figure(title = "Bokeh Line Graph")


### PR DESCRIPTION
Addresses #6045.

The bokeh test was using a different method of running code in the console. Combining `app.workbench.console.pasteCodeToConsole()` followed by `app.workbench.console.sendEnterKey()`. 
This left the code sitting in the console unrun for some reason. 

This PR replaces that code with `app.workbench.console.executeCode()` to ensure the bokeh code is run. 
