### PR TITLE
E2E test: notebook cross cell LSP test

### DIFF
--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -102,6 +102,17 @@ export class Notebooks {
 		});
 	}
 
+	async hoverCellText(cellIndex: number, text: string) {
+		await test.step(`Hover cell ${cellIndex} text: "${text}"`, async () => {
+
+			const cellText = this.code.driver.page.locator(CELL_LINE).nth(cellIndex).locator('span').locator('span').filter(
+				{ hasText: text }
+			);
+			await cellText.click();
+			await cellText.hover();
+		});
+	}
+
 	async executeCodeInCell() {
 		await test.step('Execute code in cell', async () => {
 			await this.quickaccess.runCommand(EXECUTE_CELL_COMMAND);

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -102,14 +102,17 @@ test.describe('Notebooks', {
 
 			await app.workbench.notebooks.addCodeToCellAtIndex('torch.rand(10)', 1);
 
-			await app.workbench.notebooks.hoverCellText(1, 'torch');
+			// toPass block seems to be needed on Ubuntu
+			await expect(async () => {
+				await app.workbench.notebooks.hoverCellText(1, 'torch');
 
-			const hoverTooltip = app.code.driver.page.getByRole('tooltip', {
-				name: /module torch/,
-			});
+				const hoverTooltip = app.code.driver.page.getByRole('tooltip', {
+					name: /module torch/,
+				});
 
-			await expect(hoverTooltip).toBeVisible();
-			await expect(hoverTooltip).toContainText('The torch package contains');
+				await expect(hoverTooltip).toBeVisible();
+				await expect(hoverTooltip).toContainText('The torch package contains');
+			}).toPass({ timeout: 60000 });
 		});
 	});
 

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -91,6 +91,26 @@ test.describe('Notebooks', {
 			// Verify the variable is in the variables pane
 			await app.workbench.variables.expectVariableToBe('baz', "'baz'");
 		});
+
+		test('Python - Ensure LSP works across cells', async function ({ app }) {
+
+			await app.workbench.notebooks.insertNotebookCell('code');
+
+			await app.workbench.notebooks.addCodeToCellAtIndex('import torch');
+
+			await app.workbench.notebooks.insertNotebookCell('code');
+
+			await app.workbench.notebooks.addCodeToCellAtIndex('torch.rand(10)', 1);
+
+			await app.workbench.notebooks.hoverCellText(1, 'torch');
+
+			const hoverTooltip = app.code.driver.page.getByRole('tooltip', {
+				name: /module torch/,
+			});
+
+			await expect(hoverTooltip).toBeVisible();
+			await expect(hoverTooltip).toContainText('The torch package contains');
+		});
 	});
 
 	test.describe('R Notebooks', () => {


### PR DESCRIPTION
Check hover text from LSP for Python notebook where `import torch` is in cell one and `torch.rand(10)` is in cell two.  Hover text for `torch` in cell two is checked.

### QA Notes

@:web @:win @:notebooks
