### PR TITLE
e2e-test: focus console on enter key

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -138,6 +138,7 @@ export class Console {
 	}
 
 	async sendEnterKey() {
+		await this.focus();
 		await this.code.driver.page.waitForTimeout(500);
 		await this.code.driver.page.keyboard.press('Enter');
 	}


### PR DESCRIPTION
### Summary
Focus console before hitting enter key.

### QA Notes

@:sessions
