### PR TITLE
Remove Positron workaround for not caching resources to fix CSS reloading

### DIFF
--- a/src/vs/platform/protocol/electron-main/protocolMainService.ts
+++ b/src/vs/platform/protocol/electron-main/protocolMainService.ts
@@ -104,14 +104,6 @@ export class ProtocolMainService extends Disposable implements IProtocolMainServ
 			}
 		}
 
-		// --- Start Positron ---
-		// In development, disable caching of resources so that every resource is reloaded when the
-		// window is reloaded.
-		if (!this.environmentService.isBuilt) {
-			headers = { ...headers, 'Cache-Control': 'no-store' };
-		}
-		// --- End Positron ---
-
 		// In OSS, evict resources from the memory cache in the renderer process
 		// Refs https://github.com/microsoft/vscode/issues/148541#issuecomment-2670891511
 		if (!this.environmentService.isBuilt) {


### PR DESCRIPTION
## Description

This PR fixes a problem in development that's been happening since the 1.98.0 merge. CSS files were not reloading when Positron was reloaded (e.g. with ⌘-R). The fix was to remove Positron's fix for this problem and use the official fix from 1.98.0.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A