### PR TITLE
e2e-test: sessions restart and confirm lsp active

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -102,7 +102,7 @@ export class Workbench {
 		this.connections = new Connections(code, this.quickaccess);
 		this.newProjectWizard = new NewProjectWizard(code, this.quickaccess);
 		this.output = new Output(code, this.quickaccess, this.quickInput);
-		this.console = new Console(code, this.quickaccess, this.quickInput);
+		this.console = new Console(code, this.quickaccess, this.quickInput, this.hotKeys);
 		this.interpreter = new Interpreter(code, this.console);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess);
 		this.welcome = new Welcome(code);

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -8,6 +8,7 @@ import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 import { QuickInput } from './quickInput';
 import { InterpreterType } from '../infra/fixtures/interpreter.js';
+import { HotKeys } from './hotKeys.js';
 
 const CONSOLE_INPUT = '.console-input';
 const ACTIVE_CONSOLE_INSTANCE = '.console-instance[style*="z-index: auto"]';
@@ -37,7 +38,7 @@ export class Console {
 		return this.code.driver.page.locator(EMPTY_CONSOLE).getByText('There is no interpreter running');
 	}
 
-	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput) {
+	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput, private hotKeys: HotKeys) {
 		this.barPowerButton = this.code.driver.page.getByLabel('Shutdown console');
 		this.barRestartButton = this.code.driver.page.getByLabel('Restart console');
 		this.barClearButton = this.code.driver.page.getByLabel('Clear console');
@@ -134,6 +135,14 @@ export class Console {
 			if (pressEnter) {
 				await this.code.driver.page.keyboard.press('Enter', { delay: 1000 });
 			}
+		});
+	}
+
+	async clearInput() {
+		await test.step('Clear console input', async () => {
+			await this.focus();
+			await this.hotKeys.selectAll();
+			await this.code.driver.page.keyboard.press('Backspace');
 		});
 	}
 
@@ -310,8 +319,7 @@ export class Console {
 	}
 
 	async focus() {
-		await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? `Meta+K` : `Control+K`);
-		await this.code.driver.page.keyboard.press('F');
+		await this.hotKeys.focusConsole();
 	}
 
 	async clickConsoleTab() {
@@ -332,6 +340,8 @@ export class Console {
 	}
 
 	async expectSuggestionListCount(count: number): Promise<void> {
-		await expect(this.suggestionList).toHaveCount(count);
+		await test.step(`Expect console suggestion list count to be ${count}`, async () => {
+			await expect(this.suggestionList).toHaveCount(count);
+		});
 	}
 }

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -344,4 +344,10 @@ export class Console {
 			await expect(this.suggestionList).toHaveCount(count);
 		});
 	}
+
+	async expectSuggestionListToContain(label: string): Promise<void> {
+		await test.step(`Expect console suggestion list to contain: ${label}`, async () => {
+			await this.code.driver.page.locator('.suggest-widget').getByLabel(label).isVisible();
+		});
+	}
 }

--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { Code } from '../infra/code';
 
 
@@ -79,6 +79,8 @@ export class Editors {
 	}
 
 	async expectSuggestionListCount(count: number): Promise<void> {
-		await expect(this.suggestionList).toHaveCount(count);
+		await test.step(`Expect editor suggestion list to have ${count} items`, async () => {
+			await expect(this.suggestionList).toHaveCount(count);
+		});
 	}
 }

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -158,7 +158,8 @@ export class Sessions {
 			await this.page.mouse.move(0, 0);
 
 			if (waitForIdle) {
-				await expect(this.page.getByText(/restarting/)).not.toBeVisible({ timeout: 90000 });
+				await expect(this.page.getByText('Restarting')).not.toBeVisible({ timeout: 90000 });
+				await expect(this.page.getByText('restarted')).toBeVisible();
 				await this.expectStatusToBe(sessionIdOrName, 'idle');
 			}
 		});

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -159,7 +159,7 @@ export class Sessions {
 
 			if (waitForIdle) {
 				await expect(this.page.getByText('Restarting')).not.toBeVisible({ timeout: 90000 });
-				await expect(this.page.getByText('restarted')).toBeVisible();
+				await expect(this.page.locator('.console-instance[style*="z-index: auto"]').getByText('restarted.')).toBeVisible();
 				await this.expectStatusToBe(sessionIdOrName, 'idle');
 			}
 		});

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -70,27 +70,25 @@ test.describe('Session: Autocomplete', {
 		// Session 1 - verify console autocomplete
 		await sessions.select(pySession.id);
 		await console.typeToConsole('import os', true, 0);
-		await console.typeToConsole('os.path', false, 250);
-		await console.expectSuggestionListCount(6);
+		await console.typeToConsole('os.path.', false, 250);
+		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 		await console.clearInput();
 
 		// Session 2 - verify console autocomplete
 		await sessions.select(pyAltSession.id);
 		await console.typeToConsole('import os', true, 0);
-		await console.typeToConsole('os.path', false, 250);
-		await console.expectSuggestionListCount(6);
+		await console.typeToConsole('os.path.', false, 250);
+		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 		await console.clearInput();
 
 		// Session 1 - restart and verify console autocomplete
 		await sessions.restart(pySession.id);
 		await console.typeToConsole('import os', true, 0);
-		await console.typeToConsole('os.path', false, 250);
-		await console.expectSuggestionListCount(6);
+		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 
 		// Session 2 - verify console autocomplete
 		await sessions.select(pyAltSession.id);
-		await console.typeToConsole('os.path', false, 250);
-		await console.expectSuggestionListCount(6);
+		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 	});
 
 	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
@@ -140,25 +138,25 @@ test.describe('Session: Autocomplete', {
 
 		// Session 1 - verify console autocomplete
 		await sessions.select(rSession.id);
-		await console.typeToConsole('base::');
-		await console.expectSuggestionListCount(12);
+		await console.typeToConsole('base::abb');
+		await console.expectSuggestionListToContain('abbreviate, {base}');
 
 		// Session 2 - verify console autocomplete
 		await sessions.select(rSessionAlt.id);
-		await console.typeToConsole('base::');
-		await console.expectSuggestionListCount(12);
+		await console.typeToConsole('base::abb');
+		await console.expectSuggestionListToContain('abbreviate, {base}');
 
 		// Session 1 - restart and verify console autocomplete
 		await sessions.restart(rSession.id);
-		await app.code.driver.page.keyboard.press('Backspace');
-		await console.typeToConsole(':');
-		await console.expectSuggestionListCount(12);
+		await console.clearInput();
+		await console.typeToConsole('base::abb');
+		await console.expectSuggestionListToContain('abbreviate, {base}');
 
 		// Session 2 - verify console autocomplete
 		await sessions.select(rSessionAlt.id);
-		await app.code.driver.page.keyboard.press('Backspace');
-		await console.typeToConsole(':');
-		await console.expectSuggestionListCount(12);
+		await console.clearInput();
+		await console.typeToConsole('base::abb');
+		await console.expectSuggestionListToContain('abbreviate, {base}');
 	});
 });
 

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -18,6 +18,10 @@ test.describe('Session: Autocomplete', {
 		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
 	});
 
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
 	test('Python - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
 		const { variables, editors, console } = app.workbench;
 
@@ -53,6 +57,40 @@ test.describe('Session: Autocomplete', {
 		// Alt Session 1 - retrigger and verify no editor autocomplete
 		await triggerAutocompleteInEditor({ app, session: pyAltSession, retrigger: true });
 		await editors.expectSuggestionListCount(0);
+
+		await sessions.deleteAll();
+	});
+
+	test('Python - Verify autocomplete suggestions (LSP is alive) after restart', async function ({ app, hotKeys, sessions }) {
+		const { variables, console } = app.workbench;
+
+		const [pySession, pyAltSession] = await sessions.start(['python', 'pythonAlt']);
+		await variables.togglePane('hide');
+
+		// Session 1 - verify console autocomplete
+		await sessions.select(pySession.id);
+		await console.typeToConsole('import os', true, 0);
+		await console.typeToConsole('os.path', false, 250);
+		await console.expectSuggestionListCount(6);
+		await console.clearInput();
+
+		// Session 2 - verify console autocomplete
+		await sessions.select(pyAltSession.id);
+		await console.typeToConsole('import os', true, 0);
+		await console.typeToConsole('os.path', false, 250);
+		await console.expectSuggestionListCount(6);
+		await console.clearInput();
+
+		// Session 1 - restart and verify console autocomplete
+		await sessions.restart(pySession.id);
+		await console.typeToConsole('import os', true, 0);
+		await console.typeToConsole('os.path', false, 250);
+		await console.expectSuggestionListCount(6);
+
+		// Session 2 - verify console autocomplete
+		await sessions.select(pyAltSession.id);
+		await console.typeToConsole('os.path', false, 250);
+		await console.expectSuggestionListCount(6);
 	});
 
 	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
@@ -90,6 +128,37 @@ test.describe('Session: Autocomplete', {
 		// Alt Session 1 - retrigger verify no editor autocomplete
 		await triggerAutocompleteInEditor({ app, session: rSessionAlt, retrigger: true });
 		await editors.expectSuggestionListCount(0);
+
+		await sessions.deleteAll();
+	});
+
+	test('R - Verify autocomplete suggestions (LSP is alive) after restart', async function ({ app, runCommand, sessions }) {
+		const { variables, console } = app.workbench;
+
+		const [rSession, rSessionAlt] = await sessions.start(['r', 'rAlt'], { reuse: false });
+		await variables.togglePane('hide');
+
+		// Session 1 - verify console autocomplete
+		await sessions.select(rSession.id);
+		await console.typeToConsole('base::');
+		await console.expectSuggestionListCount(12);
+
+		// Session 2 - verify console autocomplete
+		await sessions.select(rSessionAlt.id);
+		await console.typeToConsole('base::');
+		await console.expectSuggestionListCount(12);
+
+		// Session 1 - restart and verify console autocomplete
+		await sessions.restart(rSession.id);
+		await app.code.driver.page.keyboard.press('Backspace');
+		await console.typeToConsole(':');
+		await console.expectSuggestionListCount(12);
+
+		// Session 2 - verify console autocomplete
+		await sessions.select(rSessionAlt.id);
+		await app.code.driver.page.keyboard.press('Backspace');
+		await console.typeToConsole(':');
+		await console.expectSuggestionListCount(12);
 	});
 });
 


### PR DESCRIPTION
### Summary

Adding e2e test coverage to verify that LSP functionality (via autocomplete suggestions) works as expected for both R and Python sessions after a restart.

### QA Notes

@:sessions