### PR TITLE
Fix display and discovery for interpreters included via settings or found in `/opt/python`

### DIFF
--- a/extensions/positron-python/src/client/common/stringUtils.ts
+++ b/extensions/positron-python/src/client/common/stringUtils.ts
@@ -44,3 +44,14 @@ export function replaceAll(source: string, substr: string, newSubstr: string): s
 
     return source.replace(new RegExp(escapeRegExp(substr), 'g'), newSubstr);
 }
+
+// --- Start Positron ---
+/**
+ * Returns the shortest string from an array of strings.
+ * @param strings - The strings to compare.
+ * @returns The shortest string.
+ */
+export function getShortestString(strings: string[]): string {
+    return strings.reduce((a, b) => (a.length <= b.length ? a : b));
+}
+// --- End Positron ---

--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -331,6 +331,9 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         EnvironmentType.MicrosoftStore,
         EnvironmentType.Global,
         EnvironmentType.System,
+        // --- Start Positron ---
+        EnvironmentType.Custom,
+        // --- End Positron ---
         EnvironmentType.Unknown,
     ];
 }

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -696,6 +696,18 @@ function getGroupedQuickPickItems(
         updatedItems.push({ label: EnvGroups.Recommended, kind: QuickPickItemKind.Separator }, recommended);
     }
     let previousGroup = EnvGroups.Recommended;
+    // --- Start Positron ---
+    // Move the Custom group to the top of the list
+    const customItems = items.filter((item) => item.interpreter.envType === EnvironmentType.Custom);
+    if (customItems.length) {
+        for (const item of customItems) {
+            previousGroup = addSeparatorIfApplicable(updatedItems, item, workspacePath, previousGroup);
+            updatedItems.push(item);
+        }
+        // Remove Custom env items from the original list so they aren't duplicated
+        items = items.filter((item) => item.interpreter.envType !== EnvironmentType.Custom);
+    }
+    // --- End Positron ---
     for (const item of items) {
         previousGroup = addSeparatorIfApplicable(updatedItems, item, workspacePath, previousGroup);
         updatedItems.push(item);

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -95,7 +95,6 @@ export namespace EnvGroups {
     export const Pixi = 'Pixi';
     // --- Start Positron ---
     export const Uv = 'Uv';
-    export const Custom = 'Custom';
     // --- End Positron ---
     export const VirtualEnvWrapper = 'VirtualEnvWrapper';
     export const ActiveState = 'ActiveState';
@@ -696,18 +695,6 @@ function getGroupedQuickPickItems(
         updatedItems.push({ label: EnvGroups.Recommended, kind: QuickPickItemKind.Separator }, recommended);
     }
     let previousGroup = EnvGroups.Recommended;
-    // --- Start Positron ---
-    // Move the Custom group to the top of the list
-    const customItems = items.filter((item) => item.interpreter.envType === EnvironmentType.Custom);
-    if (customItems.length) {
-        for (const item of customItems) {
-            previousGroup = addSeparatorIfApplicable(updatedItems, item, workspacePath, previousGroup);
-            updatedItems.push(item);
-        }
-        // Remove Custom env items from the original list so they aren't duplicated
-        items = items.filter((item) => item.interpreter.envType !== EnvironmentType.Custom);
-    }
-    // --- End Positron ---
     for (const item of items) {
         previousGroup = addSeparatorIfApplicable(updatedItems, item, workspacePath, previousGroup);
         updatedItems.push(item);
@@ -740,6 +727,10 @@ function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
         return EnvGroups.Workspace;
     }
     switch (item.interpreter.envType) {
+        // --- Start Positron ---
+        case EnvironmentType.Custom:
+            return EnvGroups.Global;
+        // --- End Positron ---
         case EnvironmentType.Global:
         case EnvironmentType.System:
         case EnvironmentType.Unknown:

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -95,6 +95,7 @@ export namespace EnvGroups {
     export const Pixi = 'Pixi';
     // --- Start Positron ---
     export const Uv = 'Uv';
+    export const Custom = 'Custom';
     // --- End Positron ---
     export const VirtualEnvWrapper = 'VirtualEnvWrapper';
     export const ActiveState = 'ActiveState';

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -155,7 +155,7 @@ export function shouldIncludeInterpreter(interpreterPath: string): boolean {
  * @param interpreterPath The interpreter path to check
  * @returns Whether the interpreter is a custom environment.
  */
-export function isCustomEnvironment(interpreterPath: string): boolean {
+export async function isCustomEnvironment(interpreterPath: string): Promise<boolean> {
     return !!isIncludedInterpreter(interpreterPath) || !!isOverrideInterpreter(interpreterPath);
 }
 

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -156,7 +156,7 @@ export function shouldIncludeInterpreter(interpreterPath: string): boolean {
  * @returns Whether the interpreter is a custom environment.
  */
 export function isCustomEnvironment(interpreterPath: string): boolean {
-    return isOverrideInterpreter(interpreterPath) || !!isIncludedInterpreter(interpreterPath);
+    return !!isIncludedInterpreter(interpreterPath) || !!isOverrideInterpreter(interpreterPath);
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -90,14 +90,14 @@ function getOverrideInterpreters(): string[] {
  * @returns List of custom environment directories to look for environments.
  */
 export function getCustomEnvDirs(): string[] {
-    const overrideDirs = getOverrideInterpreters();
-    if (overrideDirs.length > 0) {
-        return mapInterpretersToInstallDirs(overrideDirs);
+    const overrideInterpreters = getOverrideInterpreters();
+    if (overrideInterpreters.length > 0) {
+        return mapInterpretersToInstallDirs(overrideInterpreters);
     }
 
-    const includeDirs = getIncludedInterpreters();
-    if (includeDirs.length > 0) {
-        return mapInterpretersToInstallDirs(includeDirs);
+    const includedInterpreters = getIncludedInterpreters();
+    if (includedInterpreters.length > 0) {
+        return mapInterpretersToInstallDirs(includedInterpreters);
     }
 
     return [];
@@ -150,13 +150,16 @@ export function shouldIncludeInterpreter(interpreterPath: string): boolean {
 }
 
 /**
- * Check if an interpreter path is a custom environment. An interpreter is a custom environment if it is
- * included in the settings or specified to override the discovered interpreters.
+ * Check if an interpreter path is a custom environment.
+ * An interpreter is a custom environment if it exists in any of the custom search directories.
  * @param interpreterPath The interpreter path to check
  * @returns Whether the interpreter is a custom environment.
  */
 export async function isCustomEnvironment(interpreterPath: string): Promise<boolean> {
-    return !!isIncludedInterpreter(interpreterPath) || !!isOverrideInterpreter(interpreterPath);
+    const overrideInterpreters = getOverrideInterpreters();
+    const includeInterpreters = getIncludedInterpreters();
+    const customDirs = mapInterpretersToInstallDirs([...overrideInterpreters, ...includeInterpreters]);
+    return customDirs.some((dir) => isParentPath(interpreterPath, dir));
 }
 
 /**
@@ -297,54 +300,52 @@ export function printInterpreterDebugInfo(interpreters: PythonEnvironment[]): vo
 /**
  * Maps a list of interpreter paths to their installation directories.
  * @param interpreterPaths List of interpreter paths to map to their installation directories.
- * @returns
+ * @returns List of unique installation directories.
  */
 function mapInterpretersToInstallDirs(interpreterPaths: string[]): string[] {
-    return interpreterPaths.map((interpreterPath) => {
-        // If it's already a directory, return it as-is.
-        if (isDirectorySync(interpreterPath)) {
-            return interpreterPath;
-        }
+    return Array.from(
+        new Set(
+            interpreterPaths.map((interpreterPath) => {
+                // If it's already a directory, return it as-is.
+                if (isDirectorySync(interpreterPath)) {
+                    return interpreterPath;
+                }
 
-        // If it's a file, we need to return the installation directory so that the Python locators can find it.
-        // e.g. ~/scratch/3.10.4/bin/python -> ~/scratch/3.10.4
-        // The locators expect a list of environment directories and don't seem to handle individual interpreter files.
-        // The installation directory is the grandparent directory, which upholds the JS locator's DEFAULT_SEARCH_DEPTH of 2
-        // see extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
-        // The Native Python Locator seems to use the same search depth of 2, although not explicitly documented in the python extension.
-        let parentDir: string | undefined;
-        let installDir: string | undefined;
-        try {
-            // parentDir tends to be the bin directory, which is the parent of the interpreter file.
-            parentDir = path.dirname(interpreterPath);
-            // installDir tends to be the python version directory, AKA the installation directory, which is the parent of the bin directory.
-            installDir = path.dirname(parentDir);
-        } catch (error) {
-            traceError(
-                `[mapInterpretersToInterpreterDirs]: Failed to get install directory for Python interpreter ${interpreterPath}`,
-                error,
-            );
-        }
+                // If it's a file, we need to return the installation directory so that the Python locators can find it.
+                // e.g. ~/scratch/3.10.4/bin/python -> ~/scratch/3.10.4
+                let parentDir: string | undefined;
+                let installDir: string | undefined;
+                try {
+                    parentDir = path.dirname(interpreterPath);
+                    installDir = path.dirname(parentDir);
+                } catch (error) {
+                    traceError(
+                        `[mapInterpretersToInterpreterDirs]: Failed to get install directory for Python interpreter ${interpreterPath}`,
+                        error,
+                    );
+                }
 
-        if (installDir) {
-            traceVerbose(
-                `[mapInterpretersToInterpreterDirs]: Mapped ${interpreterPath} to installation directory ${installDir}`,
-            );
-            return installDir;
-        }
+                if (installDir) {
+                    traceVerbose(
+                        `[mapInterpretersToInterpreterDirs]: Mapped ${interpreterPath} to installation directory ${installDir}`,
+                    );
+                    return installDir;
+                }
 
-        if (parentDir) {
-            traceInfo(
-                `[mapInterpretersToInterpreterDirs]: Expected ${interpreterPath} to be located in a Python installation directory. It may not be discoverable.`,
-            );
-            return parentDir;
-        }
+                if (parentDir) {
+                    traceInfo(
+                        `[mapInterpretersToInterpreterDirs]: Expected ${interpreterPath} to be located in a Python installation directory. It may not be discoverable.`,
+                    );
+                    return parentDir;
+                }
 
-        traceInfo(
-            `[mapInterpretersToInterpreterDirs]: Unable to map ${interpreterPath} to an installation directory. It may not be discoverable.`,
-        );
-        return interpreterPath;
-    });
+                traceInfo(
+                    `[mapInterpretersToInterpreterDirs]: Unable to map ${interpreterPath} to an installation directory. It may not be discoverable.`,
+                );
+                return interpreterPath;
+            }),
+        ),
+    );
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -150,6 +150,16 @@ export function shouldIncludeInterpreter(interpreterPath: string): boolean {
 }
 
 /**
+ * Check if an interpreter path is a custom environment. An interpreter is a custom environment if it is
+ * included in the settings or specified to override the discovered interpreters.
+ * @param interpreterPath The interpreter path to check
+ * @returns Whether the interpreter is a custom environment.
+ */
+export async function isCustomEnvironment(interpreterPath: string): Promise<boolean> {
+    return shouldIncludeInterpreter(interpreterPath);
+}
+
+/**
  * Checks if an interpreter path is included in the settings.
  * @param interpreterPath The interpreter path to check
  * @returns True if the interpreter is included in the settings, false if it is not included

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -155,8 +155,8 @@ export function shouldIncludeInterpreter(interpreterPath: string): boolean {
  * @param interpreterPath The interpreter path to check
  * @returns Whether the interpreter is a custom environment.
  */
-export async function isCustomEnvironment(interpreterPath: string): Promise<boolean> {
-    return shouldIncludeInterpreter(interpreterPath);
+export function isCustomEnvironment(interpreterPath: string): boolean {
+    return isOverrideInterpreter(interpreterPath) || !!isIncludedInterpreter(interpreterPath);
 }
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/env.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/env.ts
@@ -199,6 +199,13 @@ function buildEnvDisplayString(env: PythonEnvInfo, getAllDetails = false): strin
             envSuffixParts.push(kindName);
         }
     }
+    // --- Start Positron ---
+    // For any environments added via user settings, tag them as "custom". Custom environments
+    // will already include "custom" as part of the name, so we don't need to duplicate the info.
+    if (env.source.includes(PythonEnvSource.UserSettings) && env.kind !== PythonEnvKind.Custom) {
+        envSuffixParts.push('custom');
+    }
+    // --- End Positron ---
     const envSuffix = envSuffixParts.length === 0 ? '' : `(${envSuffixParts.join(': ')})`;
 
     // Pull it all together.

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/env.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/env.ts
@@ -199,13 +199,6 @@ function buildEnvDisplayString(env: PythonEnvInfo, getAllDetails = false): strin
             envSuffixParts.push(kindName);
         }
     }
-    // --- Start Positron ---
-    // For any environments added via user settings, tag them as "custom". Custom environments
-    // will already include "custom" as part of the name, so we don't need to duplicate the info.
-    if (env.source.includes(PythonEnvSource.UserSettings) && env.kind !== PythonEnvKind.Custom) {
-        envSuffixParts.push('custom');
-    }
-    // --- End Positron ---
     const envSuffix = envSuffixParts.length === 0 ? '' : `(${envSuffixParts.join(': ')})`;
 
     // Pull it all together.

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
@@ -102,6 +102,12 @@ export enum PythonEnvSource {
      */
     WindowsRegistry = 'windows registry',
     // If source turns out to be useful we will expand this enum to contain more details sources.
+    // --- Start Positron ---
+    /**
+     * Environment was found via user settings
+     */
+    UserSettings = 'user settings',
+    // --- End Positron ---
 }
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -31,6 +31,7 @@ import { traceError } from '../../../../logging';
 import { getCustomEnvDirs } from '../../../../positron/interpreterSettings';
 import { traceVerbose } from '../../../../logging';
 import { ADDITIONAL_POSIX_BIN_PATHS } from '../../../common/posixUtils';
+import { PythonEnvSource } from '../../info/index';
 // --- End Positron ---
 
 const PYTHON_ENV_TOOLS_PATH = isWindows()
@@ -54,6 +55,9 @@ export interface NativeEnvInfo {
     project?: string;
     arch?: 'x64' | 'x86';
     symlinks?: string[];
+    // --- Start Positron ---
+    source?: PythonEnvSource[];
+    // --- End Positron ---
 }
 
 export interface NativeEnvManagerInfo {

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -30,6 +30,7 @@ import { traceError } from '../../../../logging';
 // --- Start Positron ---
 import { getCustomEnvDirs } from '../../../../positron/interpreterSettings';
 import { traceVerbose } from '../../../../logging';
+import { ADDITIONAL_POSIX_BIN_PATHS } from '../../../common/posixUtils';
 // --- End Positron ---
 
 const PYTHON_ENV_TOOLS_PATH = isWindows()
@@ -467,13 +468,13 @@ function getAdditionalEnvDirs(): string[] {
     const additionalDirs: string[] = [];
 
     // Add additional dirs to search for Python environments on non-Windows platforms.
+    // See JS locator equivalent `getAdditionalPosixBinaries` in extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
     if (!isWindows()) {
-        // /opt/python is a recommended Python installation location on Posit Workbench.
-        // see: https://docs.posit.co/ide/server-pro/python/installing_python.html
-        additionalDirs.push('/opt/python');
+        additionalDirs.push(...ADDITIONAL_POSIX_BIN_PATHS);
     }
 
     // Add user-specified Python search directories.
+    // See JS locator equivalent in extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
     const customEnvDirs = getCustomEnvDirs();
     additionalDirs.push(...customEnvDirs);
 

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -468,7 +468,7 @@ function getEnvironmentDirs(): string[] {
  * Gets the list of additional directories to add to environment directories.
  * @returns List of directories to add to environment directories.
  */
-function getAdditionalEnvDirs(): string[] {
+export function getAdditionalEnvDirs(): string[] {
     const additionalDirs: string[] = [];
 
     // Add additional dirs to search for Python environments on non-Windows platforms.

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -16,6 +16,7 @@ export enum NativePythonEnvironmentKind {
     Poetry = 'Poetry',
     // --- Start Positron ---
     Uv = 'Uv',
+    Custom = 'Custom',
     // --- End Positron ---
     MacPythonOrg = 'MacPythonOrg',
     MacCommandLineTools = 'MacCommandLineTools',
@@ -47,6 +48,9 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.MacCommandLineTools, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacPythonOrg, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacXCode, PythonEnvKind.System],
+    // --- Start Positron ---
+    [NativePythonEnvironmentKind.Custom, PythonEnvKind.Custom],
+    // --- End Positron ---
 ]);
 
 export function categoryToKind(category?: NativePythonEnvironmentKind, logger?: LogOutputChannel): PythonEnvKind {

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { gte } from 'semver';
 import { PythonEnvKind, PythonEnvSource } from '../../info';
 import { BasicEnvInfo, IPythonEnvsIterator, Locator } from '../../locator';
-import { commonPosixBinPaths, getPythonBinFromPosixPaths } from '../../../common/posixUtils';
+import { ADDITIONAL_POSIX_BIN_PATHS, commonPosixBinPaths, getPythonBinFromPosixPaths } from '../../../common/posixUtils';
 import { isPyenvShimDir } from '../../../common/environmentManagers/pyenv';
 import { getOSType, OSType } from '../../../../common/utils/platform';
 import { isMacDefaultPythonPath } from '../../../common/environmentManagers/macDefault';
@@ -92,12 +92,7 @@ export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {
  * @returns Paths to Python binaries found in additional locations for Posix systems.
  */
 export async function* getAdditionalPosixBinaries(searchDepth = 2): AsyncGenerator<string> {
-    const additionalLocations = [
-        // /opt/python is a recommended Python installation location on Posit Workbench.
-        // see: https://docs.posit.co/ide/server-pro/python/installing_python.html
-        '/opt/python',
-    ];
-    for (const location of additionalLocations) {
+    for (const location of ADDITIONAL_POSIX_BIN_PATHS) {
         const executables = findInterpretersInDir(location, searchDepth);
         for await (const entry of executables) {
             const { filename } = entry;

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
@@ -53,7 +53,9 @@ export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {
                 traceVerbose(`Found ${pythonBinaries.length} python binaries in posix paths`);
 
                 // --- Start Positron ---
-                traceVerbose(`[PosixKnownPathsLocator] Python binaries found in posix paths: ${pythonBinaries.join(', ')}`);
+                traceVerbose(
+                    `[PosixKnownPathsLocator] Python binaries found in posix paths: ${pythonBinaries.join(', ')}`,
+                );
                 // --- End Positron ---
 
                 // Filter out MacOS system installs of Python 2 if necessary.

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
@@ -5,7 +5,8 @@ import * as os from 'os';
 import { gte } from 'semver';
 import { PythonEnvKind, PythonEnvSource } from '../../info';
 import { BasicEnvInfo, IPythonEnvsIterator, Locator } from '../../locator';
-import { ADDITIONAL_POSIX_BIN_PATHS, commonPosixBinPaths, getPythonBinFromPosixPaths } from '../../../common/posixUtils';
+// eslint-disable-next-line import/no-duplicates
+import { commonPosixBinPaths, getPythonBinFromPosixPaths } from '../../../common/posixUtils';
 import { isPyenvShimDir } from '../../../common/environmentManagers/pyenv';
 import { getOSType, OSType } from '../../../../common/utils/platform';
 import { isMacDefaultPythonPath } from '../../../common/environmentManagers/macDefault';
@@ -14,6 +15,8 @@ import { StopWatch } from '../../../../common/utils/stopWatch';
 
 // --- Start Positron ---
 import { findInterpretersInDir, looksLikeBasicGlobalPython } from '../../../common/commonUtils';
+// eslint-disable-next-line import/no-duplicates
+import { ADDITIONAL_POSIX_BIN_PATHS } from '../../../common/posixUtils';
 // --- End Positron ---
 
 export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
@@ -16,7 +16,7 @@
 import { toLower, uniq, uniqBy } from 'lodash';
 import { chain, iterable } from '../../../../common/utils/async';
 import { getOSType, OSType } from '../../../../common/utils/platform';
-import { PythonEnvKind } from '../../info';
+import { PythonEnvKind, PythonEnvSource } from '../../info';
 import { BasicEnvInfo, IPythonEnvsIterator } from '../../locator';
 import { FSWatchingLocator } from './fsWatchingLocator';
 import { findInterpretersInDir, looksLikeBasicVirtualPython } from '../../../common/commonUtils';
@@ -94,7 +94,7 @@ export class UserSpecifiedEnvironmentLocator extends FSWatchingLocator {
                             const kind = await getVirtualEnvKind(filename);
                             try {
                                 foundPythons.push(filename);
-                                yield { kind, executablePath: filename, searchLocation: undefined };
+                                yield { kind, executablePath: filename, source: [PythonEnvSource.UserSettings], searchLocation: undefined };
                                 traceVerbose(
                                     `[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`,
                                 );

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
@@ -94,7 +94,12 @@ export class UserSpecifiedEnvironmentLocator extends FSWatchingLocator {
                             const kind = await getVirtualEnvKind(filename);
                             try {
                                 foundPythons.push(filename);
-                                yield { kind, executablePath: filename, source: [PythonEnvSource.UserSettings], searchLocation: undefined };
+                                yield {
+                                    kind,
+                                    executablePath: filename,
+                                    source: [PythonEnvSource.UserSettings],
+                                    searchLocation: undefined,
+                                };
                                 traceVerbose(
                                     `[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`,
                                 );

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
@@ -108,10 +108,14 @@ export class UserSpecifiedEnvironmentLocator extends FSWatchingLocator {
                             source: [PythonEnvSource.UserSettings],
                             searchLocation: undefined,
                         };
-                        traceVerbose(`[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`);
+                        traceVerbose(
+                            `[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`,
+                        );
                         const skippedEnvs = filenames.filter((f) => f !== filename);
                         skippedEnvs.forEach((f) => {
-                            traceVerbose(`[UserSpecifiedEnvironmentLocator] User-specified Environment: [skipped] ${f}`);
+                            traceVerbose(
+                                `[UserSpecifiedEnvironmentLocator] User-specified Environment: [skipped] ${f}`,
+                            );
                         });
                     }
                 }

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
@@ -86,7 +86,7 @@ export class UserSpecifiedEnvironmentLocator extends FSWatchingLocator {
                     }
                     traceVerbose(
                         `[UserSpecifiedEnvironmentLocator] Found ${filenames.length} user-specified envs in: ${envRootDir}`,
-                    )
+                    );
 
                     // No environments found in the directory, log a warning.
                     if (filenames.length === 0) {
@@ -108,14 +108,10 @@ export class UserSpecifiedEnvironmentLocator extends FSWatchingLocator {
                         source: [PythonEnvSource.UserSettings],
                         searchLocation: undefined,
                     };
-                    traceVerbose(
-                        `[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`,
-                    );
+                    traceVerbose(`[UserSpecifiedEnvironmentLocator] User-specified Environment: [added] ${filename}`);
                     const skippedEnvs = filenames.filter((f) => f !== filename);
                     skippedEnvs.forEach((f) => {
-                        traceVerbose(
-                            `[UserSpecifiedEnvironmentLocator] User-specified Environment: [skipped] ${f}`,
-                        );
+                        traceVerbose(`[UserSpecifiedEnvironmentLocator] User-specified Environment: [skipped] ${f}`);
                     });
                 }
                 return generator();

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -43,10 +43,10 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.ActiveState, isActiveStateEnvironment);
     // --- Start Positron ---
     identifier.set(PythonEnvKind.Uv, isUvEnvironment);
-    identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
     identifier.set(PythonEnvKind.Custom, async (path: string) => isCustomEnvironment(path));
-    identifier.set(PythonEnvKind.Unknown, defaultTrue);
     // --- End Positron ---
+    identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
+    identifier.set(PythonEnvKind.Unknown, defaultTrue);
     return identifier;
 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -45,8 +45,8 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.Uv, isUvEnvironment);
     identifier.set(PythonEnvKind.Custom, async (path: string) => isCustomEnvironment(path));
     // --- End Positron ---
-    identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
     identifier.set(PythonEnvKind.Unknown, defaultTrue);
+    identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
     return identifier;
 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -44,7 +44,7 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     // --- Start Positron ---
     identifier.set(PythonEnvKind.Uv, isUvEnvironment);
     identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
-    identifier.set(PythonEnvKind.Custom, isCustomEnvironment);
+    identifier.set(PythonEnvKind.Custom, async (path: string) => isCustomEnvironment(path));
     identifier.set(PythonEnvKind.Unknown, defaultTrue);
     // --- End Positron ---
     return identifier;

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -19,6 +19,7 @@ import { isActiveStateEnvironment } from './environmentManagers/activestate';
 import { isPixiEnvironment } from './environmentManagers/pixi';
 // --- Start Positron ---
 import { isUvEnvironment } from './environmentManagers/uv';
+import { isCustomEnvironment } from '../../positron/interpreterSettings';
 // --- End Positron ---
 
 const notImplemented = () => Promise.resolve(false);
@@ -42,9 +43,10 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.ActiveState, isActiveStateEnvironment);
     // --- Start Positron ---
     identifier.set(PythonEnvKind.Uv, isUvEnvironment);
-    // --- End Positron ---
-    identifier.set(PythonEnvKind.Unknown, defaultTrue);
     identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
+    identifier.set(PythonEnvKind.Custom, isCustomEnvironment);
+    identifier.set(PythonEnvKind.Unknown, defaultTrue);
+    // --- End Positron ---
     return identifier;
 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -43,7 +43,7 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.ActiveState, isActiveStateEnvironment);
     // --- Start Positron ---
     identifier.set(PythonEnvKind.Uv, isUvEnvironment);
-    identifier.set(PythonEnvKind.Custom, async (path: string) => isCustomEnvironment(path));
+    identifier.set(PythonEnvKind.Custom, isCustomEnvironment);
     // --- End Positron ---
     identifier.set(PythonEnvKind.Unknown, defaultTrue);
     identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
@@ -4,8 +4,14 @@
 import { getSearchPathEntries } from '../../../common/utils/exec';
 import { getOSType, OSType } from '../../../common/utils/platform';
 import { isParentPath } from '../externalDependencies';
+// eslint-disable-next-line import/no-duplicates
 import { commonPosixBinPaths } from '../posixUtils';
 import { isPyenvShimDir } from './pyenv';
+
+// --- Start Positron ---
+// eslint-disable-next-line import/no-duplicates
+import { ADDITIONAL_POSIX_BIN_PATHS } from '../posixUtils';
+// --- End Positron ---
 
 /**
  * Checks if the given interpreter belongs to known globally installed types. If an global
@@ -32,6 +38,9 @@ async function isFoundInPathEnvVar(executablePath: string): Promise<boolean> {
         searchPathEntries = getSearchPathEntries();
     } else {
         searchPathEntries = await commonPosixBinPaths();
+        // --- Start Positron ---
+        searchPathEntries.concat(ADDITIONAL_POSIX_BIN_PATHS);
+        // --- End Positron ---
     }
     // Filter out pyenv shims. They are not actual python binaries, they are used to launch
     // the binaries specified in .python-version file in the cwd. We should not be reporting

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
@@ -39,7 +39,7 @@ async function isFoundInPathEnvVar(executablePath: string): Promise<boolean> {
     } else {
         searchPathEntries = await commonPosixBinPaths();
         // --- Start Positron ---
-        searchPathEntries.concat(ADDITIONAL_POSIX_BIN_PATHS);
+        searchPathEntries.push(...ADDITIONAL_POSIX_BIN_PATHS);
         // --- End Positron ---
     }
     // Filter out pyenv shims. They are not actual python binaries, they are used to launch

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
@@ -30,7 +30,7 @@ export async function isGloballyInstalledEnv(executablePath: string): Promise<bo
     //     }
     // }
     // --- Start Positron ---
-    return await isFoundInPathEnvVar(executablePath) || isAdditionalGlobalBinPath(executablePath);
+    return (await isFoundInPathEnvVar(executablePath)) || isAdditionalGlobalBinPath(executablePath);
     // --- End Positron ---
 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -139,6 +139,27 @@ export async function resolveSymbolicLink(absPath: string, stats?: fsapi.Stats, 
     return absPath;
 }
 
+// --- Start Positron ---
+export function resolveSymbolicLinkSync(absPath: string, stats?: fsapi.Stats, count?: number): string {
+    stats = stats ?? fsapi.statSync(absPath);
+    if (stats.isSymbolicLink()) {
+        if (count && count > 5) {
+            traceError(`Detected a potential symbolic link loop at ${absPath}, terminating resolution.`);
+            return absPath;
+        }
+        const link = fs.readlinkSync(absPath);
+        // Result from readlink is not guaranteed to be an absolute path. For eg. on Mac it resolves
+        // /usr/local/bin/python3.9 -> ../../../Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9
+        //
+        // The resultant path is reported relative to the symlink directory we resolve. Convert that to absolute path.
+        const absLinkPath = path.isAbsolute(link) ? link : path.resolve(path.dirname(absPath), link);
+        count = count ? count + 1 : 1;
+        return resolveSymbolicLinkSync(absLinkPath, undefined, count);
+    }
+    return absPath;
+}
+// --- End Positron ---
+
 export async function getFileInfo(filePath: string): Promise<{ ctime: number; mtime: number }> {
     try {
         const data = await fsapi.lstat(filePath);

--- a/extensions/positron-python/src/client/pythonEnvironments/common/posixUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/posixUtils.ts
@@ -71,6 +71,14 @@ export async function commonPosixBinPaths(): Promise<string[]> {
     return paths.filter((_, index) => exists[index]);
 }
 
+// --- Start Positron ---
+export const ADDITIONAL_POSIX_BIN_PATHS = [
+    // /opt/python is a recommended Python installation location on Posit Workbench.
+    // see: https://docs.posit.co/ide/server-pro/python/installing_python.html
+    '/opt/python',
+];
+// --- End Positron ---
+
 /**
  * Finds python interpreter binaries or symlinks in a given directory.
  * @param searchDir : Directory to search in

--- a/extensions/positron-python/src/client/pythonEnvironments/common/posixUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/posixUtils.ts
@@ -119,6 +119,10 @@ function pickShortestPath(pythonPaths: string[]) {
  * Finds python binaries in given directories. This function additionally reduces the
  * found binaries to unique set be resolving symlinks, and returns the shortest paths
  * to the said unique binaries.
+ * --- Start Positron ---
+ * Please update the implementation in extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.ts
+ * if you change the logic here.
+ * --- End Positron ---
  * @param searchDirs : Directories to search for python binaries
  * @returns : Unique paths to python interpreters found in the search dirs.
  */

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -230,6 +230,9 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                         EnvironmentType.MicrosoftStore,
                                         EnvironmentType.Global,
                                         EnvironmentType.Pyenv,
+                                        // --- Start Positron ---
+                                        EnvironmentType.Custom,
+                                        // --- End Positron ---
                                     ].includes(i.envType) && i.type === undefined, // only global intepreters
                                 {
                                     skipRecommended: true,

--- a/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
@@ -23,6 +23,7 @@ export enum EnvironmentType {
     Pixi = 'Pixi',
     // --- Start Positron ---
     Uv = 'Uv',
+    Custom = 'Custom',
     // --- End Positron ---
     VirtualEnvWrapper = 'VirtualEnvWrapper',
     ActiveState = 'ActiveState',

--- a/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
@@ -42,6 +42,7 @@ const convertedKinds = new Map(
         [PythonEnvKind.Pixi]: EnvironmentType.Pixi,
         // --- Start Positron ---
         [PythonEnvKind.Uv]: EnvironmentType.Uv,
+        [PythonEnvKind.Custom]: EnvironmentType.Custom,
         // --- End Positron ---
         [PythonEnvKind.Venv]: EnvironmentType.Venv,
         [PythonEnvKind.VirtualEnvWrapper]: EnvironmentType.VirtualEnvWrapper,

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -3,7 +3,8 @@
 
 import * as path from 'path';
 import { Disposable, Event, EventEmitter, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
-import { PythonEnvInfo, PythonEnvKind, PythonEnvSource, PythonEnvType, PythonVersion } from './base/info';
+// eslint-disable-next-line import/no-duplicates
+import { PythonEnvInfo, PythonEnvKind, PythonEnvType, PythonVersion } from './base/info';
 import {
     GetRefreshEnvironmentsOptions,
     IDiscoveryAPI,
@@ -40,6 +41,8 @@ import { getWorkspaceFolders, onDidChangeWorkspaceFolders } from '../common/vsco
 import { isUvEnvironment } from './common/environmentManagers/uv';
 import { isCustomEnvironment } from '../positron/interpreterSettings';
 import { isAdditionalGlobalBinPath } from './common/environmentManagers/globalInstalledEnvs';
+// eslint-disable-next-line import/no-duplicates
+import { PythonEnvSource } from './base/info';
 // --- End Positron ---
 
 function makeExecutablePath(prefix?: string): string {
@@ -235,6 +238,7 @@ function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[]): Pyth
         }
     }
     // --- End Positron ---
+
     const arch = toArch(nativeEnv.arch);
     const version: PythonVersion = parseVersion(nativeEnv.version ?? '');
     const name = getName(nativeEnv, kind, condaEnvDirs);

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -594,10 +594,12 @@ export function createNativeEnvironmentsApi(finder: NativePythonFinder): IDiscov
 }
 
 // --- Start Positron ---
-type DuplicateEnvResult = {
-    duplicateEnv: PythonEnvInfo | undefined;
-    skipAddEnv: boolean;
-} | undefined;
+type DuplicateEnvResult =
+    | {
+          duplicateEnv: PythonEnvInfo | undefined;
+          skipAddEnv: boolean;
+      }
+    | undefined;
 
 /**
  * Handles duplicate environments in additional environment directories.
@@ -616,7 +618,9 @@ function handleDuplicateEnvInAdditionalDirs(envs: PythonEnvInfo[], info: PythonE
 
     // Look for an existing environment in the same additional environment directory
     const resolvedEnv = resolveSymbolicLinkSync(info.executable.filename);
-    const duplicateEnv = envs.find((item) => arePathsSame(resolvedEnv, resolveSymbolicLinkSync(item.executable.filename)));
+    const duplicateEnv = envs.find((item) =>
+        arePathsSame(resolvedEnv, resolveSymbolicLinkSync(item.executable.filename)),
+    );
     if (!duplicateEnv) {
         return undefined;
     }
@@ -640,9 +644,7 @@ function handleDuplicateEnvInAdditionalDirs(envs: PythonEnvInfo[], info: PythonE
     // If the environment being added is the shortest, replace the duplicate
     // e.g. we are trying to add ~/scratch/3.10.4/bin/python, and we already added ~/scratch/3.10.4/bin/python3.10, so
     // we should replace ~/scratch/3.10.4/bin/python3.10 with ~/scratch/3.10.4/bin/python.
-    traceVerbose(
-        `[addEnv] Replacing ${duplicateEnv.executable.filename} with ${info.executable.filename}`,
-    );
+    traceVerbose(`[addEnv] Replacing ${duplicateEnv.executable.filename} with ${info.executable.filename}`);
     return { duplicateEnv, skipAddEnv: false };
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -303,17 +303,17 @@ enum ExistingEnvAction {
 
 type ExistingEnvResult =
     | {
-        reason: ExistingEnvAction.KeepExistingEnv;
-        existingEnv: PythonEnvInfo;
-    }
+          reason: ExistingEnvAction.KeepExistingEnv;
+          existingEnv: PythonEnvInfo;
+      }
     | {
-        reason: ExistingEnvAction.AddNewEnv;
-        existingEnv: undefined;
-    }
+          reason: ExistingEnvAction.AddNewEnv;
+          existingEnv: undefined;
+      }
     | {
-        reason: ExistingEnvAction.ReplaceExistingEnv;
-        existingEnv: PythonEnvInfo;
-    };
+          reason: ExistingEnvAction.ReplaceExistingEnv;
+          existingEnv: PythonEnvInfo;
+      };
 // --- End Positron ---
 
 class NativePythonEnvironments implements IDiscoveryAPI, Disposable {

--- a/extensions/positron-python/src/test/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator.unit.test.ts
@@ -11,7 +11,7 @@ import * as TypeMoq from 'typemoq';
 import { WorkspaceConfiguration } from 'vscode';
 import * as fs from '../../../../../client/common/platform/fs-paths';
 import * as workspaceApis from '../../../../../client/common/vscodeApis/workspaceApis';
-import { PythonEnvKind } from '../../../../../client/pythonEnvironments/base/info';
+import { PythonEnvKind, PythonEnvSource } from '../../../../../client/pythonEnvironments/base/info';
 import { getEnvs } from '../../../../../client/pythonEnvironments/base/locatorUtils';
 import { UserSpecifiedEnvironmentLocator } from '../../../../../client/pythonEnvironments/base/locators/lowLevel/userSpecifiedEnvLocator';
 import { createBasicEnv } from '../../common';
@@ -127,7 +127,9 @@ suite('UserSpecifiedEnvironment Locator', () => {
             ]);
 
         // These are the expected environments that should be located
-        const expectedEnvs = userSpecifiedEnvs.executables.map((e: string) => createBasicEnv(PythonEnvKind.Custom, e));
+        const expectedEnvs = userSpecifiedEnvs.executables.map((e: string) =>
+            createBasicEnv(PythonEnvKind.Custom, e, [PythonEnvSource.UserSettings]),
+        );
 
         // Locate the environments and compare them to the expected environments
         const iterator = locator.iterEnvs();
@@ -150,7 +152,9 @@ suite('UserSpecifiedEnvironment Locator', () => {
             ]);
 
         // These are the expected environments that should be located
-        const expectedEnvs = userSpecifiedEnvs.executables.map((e: string) => createBasicEnv(PythonEnvKind.Custom, e));
+        const expectedEnvs = userSpecifiedEnvs.executables.map((e: string) =>
+            createBasicEnv(PythonEnvKind.Custom, e, [PythonEnvSource.UserSettings]),
+        );
 
         // Locate the environments and compare them to the expected environments
         const iterator = locator.iterEnvs();


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/6270
- addresses https://github.com/posit-dev/positron/issues/7058

#### Implementation

- set the environment `source` to `PythonEnvSource.UserSettings` for interpreters specified via `python.interpreters.include`/`python.interpreters.override` for both the JS and Native locators
- ensure user settings-specified interpreters are tagged as Custom instead of Unknown
    - if an interpreter was added via the settings, but is a Venv, it will show as a Venv instead of Custom; same goes for Uv/Conda/etc.
- ensure `/opt/python`-installed interpreters tagged as Global instead of Unknown

#### Known Issues
See screenshots in the QA Notes section below for examples
- when using the Native locator, the Python: Select Interpreter quickpick does not display as much information as when the JS locator is used. In particular, text like "custom" is not included 

### Release Notes

#### New Features

- Python interpreters installed at `/opt/python` or included via interpreter settings are no longer tagged as "Unknown" (#6270)

#### Bug Fixes

- Fixed issue with missing or duplicated Python interpreters when installed in `opt/python` or included via interpreter settings (#7058)


### QA Notes

@:interpreters

#### Setup
- ensure at least one python installation exists at `/opt/python`,
    - e.g. `/opt/python/3.10.4/bin/python`
- ensure at least one python installation is specified in `python.interpreters.include`
    - e.g. `~/scratch/3.10.4/bin/python` exists and the following is set:
    ```
    "python.interpreters.include": [
            "~/scratch"
    ],
    ```

#### Settings+UI Combinations

1. "python.locator": "js" and "console.multipleConsoleSessions": false

    ##### Interpreter Dropdown

    <img width="386" alt="jslocator+nomulticonsole+interpreterdropdown" src="https://github.com/user-attachments/assets/7b941ea0-1308-4012-8b81-64ac4003203f" />

    ##### Python: Select Interpreter Quickpick (`console.multipleConsoleSessions` can be true or false)

    <img width="607" alt="jslocator+pythonquickpick" src="https://github.com/user-attachments/assets/27a74920-e6ff-4cc7-a54a-0d70815b9c4e" />

2. "python.locator": "js" and "console.multipleConsoleSessions": true

    ##### Multi Console Start Session Quickpick

    <img width="612" alt="jslocator+multiconsole+startsessionquickpick" src="https://github.com/user-attachments/assets/1bbc9f68-e2a5-4f21-a46b-6c796d5e6a6f" />

3. "python.locator": "native" and "console.multipleConsoleSessions": false

    ##### Interpreter Dropdown

    <img width="383" alt="locatornative_muticonsolefalse_interpreterdropdown" src="https://github.com/user-attachments/assets/c7626328-ce33-43d4-8129-63db24ceef46" />

    ##### Python: Select Interpreter Quickpick (`console.multipleConsoleSessions` can be true or false)

    <img width="609" alt="locatornative_quickpick" src="https://github.com/user-attachments/assets/eb676ba6-9a15-4792-9382-e426c07207ab" />

4. "python.locator": "native" and "console.multipleConsoleSessions": true

    ##### Multi Console Start Session Quickpick

    <img width="610" alt="locatornative_muticonsoletrue" src="https://github.com/user-attachments/assets/70aad74d-f4c9-47fe-a8ea-8a2ad437e8f9" />

This change is also reflected in the dropdown in the Project Wizard, which retrieves the same information as the Interpreter Dropdown / Start Session Quickpick:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/686ee754-0e53-4505-b586-fa6672a2e053" />