### PR TITLE
e2e-test: session outline test updates

### DIFF
--- a/test/e2e/pages/editor.ts
+++ b/test/e2e/pages/editor.ts
@@ -37,6 +37,13 @@ export class Editor {
 		await this.editorPane.pressSequentially(text);
 	}
 
+	/** Action: Select tab by name
+	 * @param filename the name of the tab to select
+	 */
+	async selectTab(filename: string): Promise<void> {
+		await this.code.driver.page.getByRole('tab', { name: filename }).click();
+	}
+
 	/**
 	 * Action: Select a file in the editor and enter text
 	 * @param filename the name of the file to select
@@ -44,7 +51,7 @@ export class Editor {
 	 */
 	async selectTabAndType(filename: string, text: string): Promise<void> {
 		await test.step(`Select tab ${filename} and type text`, async () => {
-			await this.code.driver.page.getByRole('tab', { name: filename }).click();
+			await this.selectTab(filename);
 			await this.type(text);
 		});
 	}

--- a/test/e2e/pages/outline.ts
+++ b/test/e2e/pages/outline.ts
@@ -70,7 +70,14 @@ export class Outline {
 			: await expect(this.outlineElement.filter({ hasText: text })).not.toBeVisible();
 	}
 
+	async expectOutlineToBeEmpty(): Promise<void> {
+		await expect(this.code.driver.page.getByText(/^No symbols found in document/)).toBeVisible();
+	}
+
 	async expectOutlineElementCountToBe(count: number): Promise<void> {
+		if (count === 0) {
+			await expect(this.outlineElement).not.toBeVisible();
+		}
 		await expect(this.outlineElement).toHaveCount(count);
 	}
 

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -17,63 +17,55 @@ test.describe('Session: Outline', {
 		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
 	});
 
-	test('Python - Verify outline is per session', async function ({ app, openFile, sessions }) {
-		const { variables, outline, console } = app.workbench;
-
-		const [pySession, pyAltSession] = await sessions.start(['python', 'pythonAlt']);
-
-		// Focus outline view and open Python file
+	test('Verify outline is based on editor and per session', async function ({ app, openFile, sessions }) {
+		const { variables, outline, console, editor } = app.workbench;
 		await variables.togglePane('hide');
 		await outline.focus();
-		await openFile('workspaces/outline/basic-outline-with-vars.py');
 
-		// Session 1 - verify only expected outline elements
-		await sessions.select(pySession.id);
+		await openFile('workspaces/outline/basic-outline-with-vars.py');
+		await openFile('workspaces/outline/basic-outline-with-vars.r');
+
+		// No Session - verify no outline elements
+		await outline.expectOutlineToBeEmpty();
+
+		// Start sessions
+		const [pySession1, pySession2, rSession1, rSession2] = await sessions.start(['python', 'pythonAlt', 'r', 'rAlt']);
+
+		// Select Python file
+		await editor.selectTab('basic-outline-with-vars.py');
+
+		// Python Session 1 - verify only expected outline elements
+		await sessions.select(pySession1.id);
 		await console.typeToConsole('global_variable="goodbye"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
 
-		// Python Alt Session - verify only expected outline elements
-		await sessions.select(pyAltSession.id);
+		// Select R file
+		await editor.selectTab('basic-outline-with-vars.r');
+
+		// R Session 1 - verify only expected outline elements
+		await sessions.select(rSession1.id);
+		await outline.expectOutlineElementCountToBe(3);
+		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
+		await outline.expectOutlineElementToBeVisible('global_variable');
+		await outline.expectOutlineElementToBeVisible('local_variable');
+
+		// R Session 2 - verify only expected outline elements
+		await sessions.select(rSession2.id);
+		await outline.expectOutlineElementCountToBe(3);
+		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
+		await outline.expectOutlineElementToBeVisible('global_variable');
+		await outline.expectOutlineElementToBeVisible('local_variable');
+
+		// Select Python file
+		await editor.selectTab('basic-outline-with-vars.py');
+
+		// Python Session 2 - verify only expected outline elements
+		await sessions.select(pySession2.id);
 		await console.typeToConsole('global_variable="goodbye2"', true);
 		await outline.expectOutlineElementCountToBe(2);
 		await outline.expectOutlineElementToBeVisible('global_variable = "hello"');
 		await outline.expectOutlineElementToBeVisible('def demonstrate_scope');
-	});
-
-	test('R - Verify outline is per session', async function ({ app, openFile, sessions }) {
-		const { variables, outline, console } = app.workbench;
-
-		const [rSession1, rSession2, rSessionAlt] = await sessions.start(['r', 'r', 'rAlt'], { reuse: false });
-
-		// Focus outline view and open Python file
-		await variables.togglePane('hide');
-		await outline.focus();
-		await openFile('workspaces/outline/basic-outline-with-vars.r');
-
-		// Session 1 - verify only expected outline elements
-		await sessions.select(rSession1.id);
-		await console.typeToConsole('x<-"goodbye"', true);
-		await outline.expectOutlineElementCountToBe(3);
-		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
-		await outline.expectOutlineElementToBeVisible('global_variable');
-		await outline.expectOutlineElementToBeVisible('local_variable');
-
-		// Session 2 - verify only expected outline elements
-		await sessions.select(rSession2.id);
-		await console.typeToConsole('x<-"goodbye2"', true);
-		await outline.expectOutlineElementCountToBe(3);
-		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
-		await outline.expectOutlineElementToBeVisible('global_variable');
-		await outline.expectOutlineElementToBeVisible('local_variable');
-
-		// Session 3 (Alt) - verify only expected outline elements
-		await sessions.select(rSessionAlt.id);
-		await console.typeToConsole('x<-"goodbye3"', true);
-		await outline.expectOutlineElementCountToBe(3);
-		await outline.expectOutlineElementToBeVisible('demonstrate_scope');
-		await outline.expectOutlineElementToBeVisible('global_variable');
-		await outline.expectOutlineElementToBeVisible('local_variable');
 	});
 });


### PR DESCRIPTION
### Summary 

Updated the session outline test toggle between files (in addition to between sessions) to verify outline displays as expected. And to ensure proper behavior when foreground session doesn't match editor.

### QA Notes

@:sessions