### PR TITLE
python: deprioritize magics in autocompletion

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -631,7 +631,7 @@ def positron_completion(
 
                 # If Jedi knows how to complete the expression, use its suggestion.
                 new_text = completion.complete
-                if new_text is not None:
+                if completion.type == "path":
                     # Using the text_edit attribute (instead of insert_text used in
                     # lsp_completion_item) notifies the client to use the text as is,
                     # which is required to complete paths across `-` symbols,

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -631,7 +631,7 @@ def positron_completion(
 
                 # If Jedi knows how to complete the expression, use its suggestion.
                 new_text = completion.complete
-                if completion.type == "path":
+                if completion.type == "path" and new_text is not None:
                     # Using the text_edit attribute (instead of insert_text used in
                     # lsp_completion_item) notifies the client to use the text as is,
                     # which is required to complete paths across `-` symbols,


### PR DESCRIPTION
So, Python was actually always sending things in the right order 🎉 . The issue here is with the completion model on the front end; when we're scoring items to be sorted/filtered, it is based the end of the line where things are either edited or overwritten by the autocomplete. For example, if you do:

```
import positron
pos # wait for autocomplete
```
You'll get the completions `%psource`, `%precision`, and `positron`. For non-magics, we're using [InsertReplaceEdit](https://github.com/posit-dev/positron/blob/cca8855ce30bde389de22b45afa6241b86f322a5/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py#L658), the completion stays at the end of `pos` and adds the completion `itron`. There's no "remainder of the line" to score against, so it gets the worst possible score. Versus for the magics, we replace everything starting from the beginning of the line via [insert_text](https://github.com/posit-dev/positron/blob/cca8855ce30bde389de22b45afa6241b86f322a5/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py#L757). The completion replaces starting at the beginning of the line, so the "end" of the line would be `pos`.

All that being said, we only need the `InsertReplaceEdit` for paths, so we'll just scope it for that; all other completions will be scored as normal.



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #6289 Python autocomplete will not prioritize magics.


### QA Notes

There's a good example in the linked issue, or try

```
import positron
pos # wait for completion
```

and completion suggestions should be ordered `positron`, `%psource`, `%precision`. Additionally, path completions should still act as normal, eg, 

```
import pandas as pd
pd.read_csv("qa") # type this, assuming you have a qa-example-content/ dir 
```

the `pd.read_csv("qa")` should correctly autocomplete to `pd.read_csv("qa-example-content/")`