### PR TITLE
Reticulate: Multiple fixes to better support multi-console

### DIFF
--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -286,7 +286,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		progress.report({ increment: 10, message: vscode.l10n.t('Waiting for the R session to be ready') });
 		const reticulateId = await (async () => {
 			// We need to wait for the R session to be fully started.
-			// We might need to make some attemps.
+			// We might need to make some attempts.
 			for (let attempt = 1; attempt <= 20; attempt++) {
 				try {
 					return await rSession.callMethod?.('reticulate_id') as string;

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -841,8 +841,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 	public async shutdown(exitReason: positron.RuntimeExitReason) {
 		await this.pythonSession.shutdown(exitReason);
-		// TODO: Ideally we'd return focus to the parent R session, but currently there's
-		// no API for this.
+		positron.runtime.focusSession(this.rSession.metadata.sessionId);
 		return;
 	}
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -125,7 +125,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 				// Wait for the session to start (or fail to start) before
 				// returning from this callback, so that the progress bar stays up
 				// while we wait.
-				progress.report({ increment: 10, message: 'Waiting to connect' });
+				progress.report({ increment: 10, message: vscode.l10n.t('Waiting to connect') });
 				await session.started.wait();
 			}
 		});
@@ -134,7 +134,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 
 	async createSession_(runtimeMetadata: positron.LanguageRuntimeMetadata, sessionMetadata: positron.RuntimeSessionMetadata, progress: vscode.Progress<{ message?: string; increment: number }>): Promise<ReticulateRuntimeSession> {
 		try {
-			progress.report({ increment: 10, message: 'Finding the host the R session' });
+			progress.report({ increment: 10, message: vscode.l10n.t('Finding the host the R session') });
 			const sessions = await positron.runtime.getActiveSessions();
 			const usedRSessions = this.getSessions().map((pair) => pair.hostRSessionId);
 
@@ -150,14 +150,14 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 					// TODO: maybe show a quick menu so the user can select the session they want to attach to?
 					return freeRSessions[0];
 				} else {
-					progress.report({ increment: 2, message: 'Starting a new R session' });
+					progress.report({ increment: 2, message: vscode.l10n.t('Starting a new R session') });
 					// We need to create a new R session.
 					const rRuntime = await positron.runtime.getPreferredRuntime('r');
 					return await positron.runtime.startLanguageRuntime(rRuntime.runtimeId, rRuntime.runtimeName);
 				}
 			})();
 
-			progress.report({ increment: 5, message: 'Waiting for the R session to be ready' });
+			progress.report({ increment: 5, message: vscode.l10n.t('Waiting for the R session to be ready') });
 			const reticulateId = await (async () => {
 				// We need to wait for the R session to be fully started.
 				// We might need to make some attemps.
@@ -169,7 +169,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 						await new Promise(resolve => setTimeout(resolve, 100));
 					}
 				}
-				throw new InitializationError('Failed to get the reticulate ID');
+				throw new InitializationError(vscode.l10n.t('Failed to get the reticulate ID'));
 			})();
 			const session = await ReticulateRuntimeSession.create(runtimeMetadata, sessionMetadata, rSession, progress);
 			// Attach the reticulate session to the R session if the reticulate session was successfully created.
@@ -224,7 +224,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		const sessionPromise = new PromiseHandles<positron.LanguageRuntimeSession>();
 		vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
-			title: 'Restoring the Reticulate Python session',
+			title: vscode.l10n.t('Restoring the Reticulate Python session'),
 			cancellable: false
 		}, async (progress, _token) => {
 			let session: ReticulateRuntimeSession | undefined;
@@ -238,7 +238,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 				// Wait for the session to start (or fail to start) before
 				// returning from this callback, so that the progress bar stays up
 				// while we wait.
-				progress.report({ increment: 10, message: 'Waiting to connect' });
+				progress.report({ increment: 10, message: vscode.l10n.t('Waiting to connect') });
 				await session.started.wait();
 			}
 		});
@@ -258,12 +258,12 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 			// before moving on.
 			const hostRSessionId = sessionsMap.find((pair) => pair.reticulateSessionId === sessionMetadata.sessionId)?.hostRSessionId;
 			if (!hostRSessionId) {
-				throw new InitializationError('Failed to find the host R session for this reticulate session');
+				throw new InitializationError(vscode.l10n.t('Failed to find the host R session for this reticulate session'));
 			}
 
 			// Now wait for the host R session to be active.
 			// We might need to make some attemps.
-			progress.report({ increment: 10, message: 'Finding the host R session' });
+			progress.report({ increment: 10, message: vscode.l10n.t('Finding the host R session') });
 			const rSession = await (async () => {
 				for (let attempt = 1; attempt <= 5; attempt++) {
 					const sessions = await positron.runtime.getActiveSessions();
@@ -274,11 +274,11 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 					// Wait a bit before trying again.
 					await new Promise(resolve => setTimeout(resolve, 500));
 				}
-				throw new InitializationError('Failed to find the host R session for this reticulate session');
+				throw new InitializationError(vscode.l10n.t('Failed to find the host R session for this reticulate session'));
 			})();
 
 			// Wait and get the reticulateId.
-			progress.report({ increment: 10, message: 'Waiting for the R session to be ready' });
+			progress.report({ increment: 10, message: vscode.l10n.t('Waiting for the R session to be ready') });
 			const reticulateId = await (async () => {
 				// We need to wait for the R session to be fully started.
 				// We might need to make some attemps.
@@ -290,7 +290,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 						await new Promise(resolve => setTimeout(resolve, 100));
 					}
 				}
-				throw new InitializationError('Failed to get the reticulate ID');
+				throw new InitializationError(vscode.l10n.t('Failed to get the reticulate ID'));
 			})();
 
 			const session = await ReticulateRuntimeSession.restore(runtimeMetadata, sessionMetadata, rSession, progress);
@@ -370,7 +370,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		rSession: positron.LanguageRuntimeSession,
 		progress: vscode.Progress<{ message?: string; increment?: number }>,
 	): Promise<ReticulateRuntimeSession> {
-		progress.report({ increment: 10, message: 'Checking prerequisites' });
+		progress.report({ increment: 10, message: vscode.l10n.t('Checking prerequisites') });
 		const has_uv_support = await rSession.callMethod?.('is_installed', 'reticulate', '1.40.0.9000');
 		const config = ReticulateRuntimeSession.checkRSession(rSession);
 
@@ -380,7 +380,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		if (has_uv_support) {
 			const timeout = setTimeout(
 				() => {
-					progress.report({ increment: 2, message: 'Installing dependencies. This may take a while.' });
+					progress.report({ increment: 2, message: vscode.l10n.t('Installing dependencies. This may take a while.') });
 				},
 				5000
 			);
@@ -408,7 +408,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		progress: vscode.Progress<{ message?: string; increment?: number }>,
 	): Promise<ReticulateRuntimeSession> {
 		// Make sure the R session has the necessary packages installed.
-		progress.report({ increment: 10, message: 'Checking prerequisites' });
+		progress.report({ increment: 10, message: vscode.l10n.t('Checking prerequisites') });
 		const config = await ReticulateRuntimeSession.checkRSession(rSession);
 		const metadata = await ReticulateRuntimeSession.fixInterpreterPath(runtimeMetadata, config.python);
 
@@ -429,8 +429,8 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		if (!await rSession.callMethod?.('is_installed', 'reticulate', '1.39')) {
 			// Offer to install reticulate
 			const install_reticulate = await positron.window.showSimpleModalDialogPrompt(
-				'Missing reticulate',
-				'Reticulate >= 1.39 is required. Do you want to install reticulate?',
+				vscode.l10n.t('Missing reticulate'),
+				vscode.l10n.t('Reticulate >= 1.39 is required. Do you want to install reticulate?'),
 				'Yes',
 				'No'
 			);
@@ -439,13 +439,13 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 				try {
 					await rSession.callMethod?.('install_packages', 'reticulate');
 				} catch (err: any) {
-					throw new InitializationError(`Failed to install/update the reticulate package: ${err}`);
+					throw new InitializationError(vscode.l10n.t('Failed to install/update the reticulate package: {0}', err));
 				}
 			}
 
 			// Make a new check for reticulate
 			if (!await rSession.callMethod?.('is_installed', 'reticulate', '1.39')) {
-				throw new InitializationError('Reticulate >= 1.39 is required');
+				throw new InitializationError(vscode.l10n.t('Reticulate >= 1.39 is required'));
 			}
 		}
 
@@ -482,7 +482,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 		// An error happened, raise it
 		if (config.error) {
-			throw new InitializationError(`Failed checking for a suitable Python: ${config.error}`);
+			throw new InitializationError(vscode.l10n.t('Failed checking for a suitable Python: {0}', config.error));
 		}
 
 		// No error, but also no Python:
@@ -609,7 +609,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
 		this.onDidEndSession = this._exitEmitter.event;
 
-		this.progress.report({ increment: 10, message: 'Creating the Python session' });
+		this.progress.report({ increment: 10, message: vscode.l10n.t('Creating the Python session') });
 
 		this.pythonSession = this.createPythonRuntimeSession(
 			runtimeMetadata,
@@ -621,7 +621,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 	createPythonRuntimeSession(runtimeMetadata: positron.LanguageRuntimeMetadata, sessionMetadata: positron.RuntimeSessionMetadata, kernelSpec?: JupyterKernelSpec): positron.LanguageRuntimeSession {
 		const api = vscode.extensions.getExtension('ms-python.python');
 		if (!api) {
-			throw new Error('Failed to find the Positron Python extension API.');
+			throw new Error(vscode.l10n.t('Failed to find the Positron Python extension API.'));
 		}
 
 		const pythonSession: positron.LanguageRuntimeSession = api.exports.positron.createPythonRuntimeSession(
@@ -654,7 +654,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 	// A function that starts a kernel and then connects to it.
 	async startKernel(session: JupyterSession, kernel: JupyterKernel) {
 		kernel.log('Starting the Reticulate session!');
-		this.progress.report({ increment: 10, message: 'Starting the Reticulate session in R' });
+		this.progress.report({ increment: 10, message: vscode.l10n.t('Starting the Reticulate session in R') });
 
 		// Store a reference to the kernel, so the session can log, reconnect, etc.
 		this.kernel = kernel;
@@ -668,11 +668,11 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 		if (!this.rSession) {
 			kernel.log('No R session :(');
-			throw new Error('No R session to attach the Reticulate Python kernel');
+			throw new Error(vscode.l10n.t('No R session to attach the Reticulate Python kernel'));
 		}
 
 		if (!this.rSession.callMethod) {
-			throw new Error('No `callMethod` method in the RSession. This is not expected.');
+			throw new Error(vscode.l10n.t('No `callMethod` method in the RSession. This is not expected.'));
 		}
 
 		const init_err = await this.rSession.callMethod(
@@ -685,10 +685,10 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 		// An empty result means that the initialization went fine.
 		if (init_err !== '') {
-			throw new Error(`Reticulate initialization failed: ${init_err}`);
+			throw new Error(vscode.l10n.t(`Reticulate initialization failed: ${init_err}`));
 		}
 
-		this.progress.report({ increment: 10, message: 'Connecting to the Reticulate session' });
+		this.progress.report({ increment: 10, message: vscode.l10n.t('Connecting to the Reticulate session') });
 
 		try {
 			await kernel.connectToSession(session);
@@ -812,7 +812,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 					title: 'Creating the Reticulate Python session',
 					cancellable: false
 				}, async (progress, _token) => {
-					this.progress.report({ increment: 10, message: 'Creating the Python session' });
+					this.progress.report({ increment: 10, message: vscode.l10n.t('Creating the Python session') });
 					const metadata: positron.RuntimeSessionMetadata = { ...this.sessionMetadata, sessionId: `reticulate-python-${uuid.v4()}` };
 
 					// When the R session is ready, we can start a new Reticulate session.
@@ -822,7 +822,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 						kernelSpec
 					);
 
-					this.progress.report({ increment: 50, message: 'Initializing the Python session' });
+					this.progress.report({ increment: 50, message: vscode.l10n.t('Initializing the Python session') });
 
 					try {
 						await this.pythonSession.start();

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -114,7 +114,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 			let session: ReticulateRuntimeSession | undefined;
 			try {
 				session = await this.createSession_(runtimeMetadata, sessionMetadata, progress);
-				sessionPromise.resolve(session as positron.LanguageRuntimeSession);
+				sessionPromise.resolve(session);
 			} catch (err) {
 				sessionPromise.reject(err);
 			}
@@ -171,7 +171,6 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 				}
 				throw new InitializationError('Failed to get the reticulate ID');
 			})();
-
 			const session = await ReticulateRuntimeSession.create(runtimeMetadata, sessionMetadata, rSession, progress);
 			// Attach the reticulate session to the R session if the reticulate session was successfully created.
 			this.setSessions(rSession.metadata.sessionId, reticulateId, session);

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -11,6 +11,12 @@ import { JupyterKernelSpec, JupyterSession, JupyterKernel } from './positron-sup
 import { Barrier, PromiseHandles, withTimeout } from './async';
 import uuid = require('uuid');
 
+interface ReticulateSessionInfo {
+	reticulateSessionId: string;
+	hostRSessionId: string;
+	reticulateId: string;
+}
+
 export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager {
 
 	_sessions: Map<string, positron.LanguageRuntimeSession> = new Map();
@@ -183,7 +189,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 	}
 
 	setSessions(hostRSessionId: string, reticulateId: string, session: positron.LanguageRuntimeSession) {
-		let sessionsMap: { reticulateSessionId: string; hostRSessionId: string; reticulateId: string }[] =
+		let sessionsMap: ReticulateSessionInfo[] =
 			CONTEXT.workspaceState.get('reticulate-sessions-map', []);
 
 		session.onDidEndSession(() => {
@@ -208,9 +214,9 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		CONTEXT.workspaceState.update('reticulate-sessions-map', sessionsMap);
 	}
 
-	getSessions(): Array<{ reticulateSessionId: string; hostRSessionId: string; reticulateId: string }> {
+	getSessions(): Array<ReticulateSessionInfo> {
 		const sessionsMap = CONTEXT.workspaceState.get('reticulate-sessions-map', []);
-		return sessionsMap as Array<{ reticulateSessionId: string; hostRSessionId: string; reticulateId: string }>;
+		return sessionsMap as Array<ReticulateSessionInfo>;
 	}
 
 	async restoreSession(runtimeMetadata: positron.LanguageRuntimeMetadata, sessionMetadata: positron.RuntimeSessionMetadata): Promise<positron.LanguageRuntimeSession> {

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -951,7 +951,6 @@ export class ReticulateProvider {
 			if (event.method === 'focus') {
 				if (event.params && event.params.input) {
 					session.execute(
-						// If no input is provided, we execute dummy code to bring focus to the console
 						event.params.input,
 						'reticulate-input',
 						positron.RuntimeCodeExecutionMode.Interactive,
@@ -974,7 +973,6 @@ export class ReticulateProvider {
 
 		if (params.input) {
 			session.execute(
-				// If no input is provided, we execute dummy code to bring focus to the console
 				params.input,
 				'reticulate-input',
 				positron.RuntimeCodeExecutionMode.Interactive,

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -738,6 +738,14 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		return this.pythonSession.forceQuit();
 	}
 
+	public listOutputChannels(): positron.LanguageRuntimeSessionChannel[] {
+		return this.pythonSession.listOutputChannels?.() ?? [];
+	}
+
+	public showOutput(channel?: positron.LanguageRuntimeSessionChannel): void {
+		this.pythonSession.showOutput?.(channel);
+	}
+
 	public dispose() {
 		return this.pythonSession.dispose();
 	}

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -91,6 +91,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 	}
 
 	registerReticulateRuntime() {
+		LOGGER.info('Registering the reticulate runtime');
 		this._metadata = new ReticulateRuntimeMetadata();
 		this.onDidDiscoverRuntimeEmmiter?.fire(this._metadata);
 
@@ -111,6 +112,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 	}
 
 	async createSession(runtimeMetadata: positron.LanguageRuntimeMetadata, sessionMetadata: positron.RuntimeSessionMetadata): Promise<positron.LanguageRuntimeSession> {
+		LOGGER.info(`Creating Reticulate session. sessionId: ${sessionMetadata.sessionId}`);
 		const sessionPromise = new PromiseHandles<positron.LanguageRuntimeSession>();
 		vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
@@ -220,6 +222,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 	}
 
 	async restoreSession(runtimeMetadata: positron.LanguageRuntimeMetadata, sessionMetadata: positron.RuntimeSessionMetadata): Promise<positron.LanguageRuntimeSession> {
+		LOGGER.info(`Restoring Reticulate session. sessionId: ${sessionMetadata.sessionId}`);
 		const sessionPromise = new PromiseHandles<positron.LanguageRuntimeSession>();
 		vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
@@ -915,6 +918,7 @@ export class ReticulateProvider {
 
 	async registerClient(client: positron.RuntimeClientInstance, params: { input?: string; reticulate_id: string }) {
 		// We get to this codepath when a user calls `reticulate::repl_python()` from the R session.
+		LOGGER.info(`Registering reticulate client. reticulateId: ${params.reticulate_id}`,);
 
 		// We'll force the registration when the user calls `reticulate::repl_python()`
 		// even if the flag is not enabled.
@@ -963,7 +967,7 @@ export class ReticulateProvider {
 		client.onDidChangeClientState(
 			(state: positron.RuntimeClientState) => {
 				if (state === positron.RuntimeClientState.Closed) {
-					console.warn('Reticulate client closed by the back-end.');
+					LOGGER.error('Reticulate client closed by the back-end.');
 				}
 			}
 		);
@@ -989,6 +993,7 @@ export class ReticulateProvider {
 
 
 let CONTEXT: vscode.ExtensionContext;
+const LOGGER = vscode.window.createOutputChannel('Reticulate Extension', { log: true });
 
 /**
  * Activates the extension.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1565,6 +1565,11 @@ declare module 'positron' {
 		export function restartSession(sessionId: string): Thenable<void>;
 
 		/**
+		 * Focus a running session
+		 */
+		export function focusSession(sessionId: string): void;
+
+		/**
 		 * Register a handler for runtime client instances. This handler will be called
 		 * whenever a new client instance is created by a language runtime of the given
 		 * type.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1341,6 +1341,12 @@ export class MainThreadLanguageRuntime
 			this.findSession(handle).sessionId);
 	}
 
+	$focusSession(handle: number): void {
+		return this._runtimeSessionService.focusSession(
+			this.findSession(handle).sessionId
+		);
+	}
+
 	// Signals that language runtime discovery is complete.
 	$completeLanguageRuntimeDiscovery(): void {
 		this._runtimeStartupService.completeDiscovery(this._id);

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -130,6 +130,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			restartSession(sessionId: string): Thenable<void> {
 				return extHostLanguageRuntime.restartSession(sessionId);
 			},
+			focusSession(sessionId: string): void {
+				return extHostLanguageRuntime.focusSession(sessionId);
+			},
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -47,6 +47,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;
 	$restartSession(handle: number): Promise<void>;
 	$interruptSession(handle: number): Promise<void>;
+	$focusSession(handle: number): void;
 	$emitLanguageRuntimeMessage(handle: number, handled: boolean, message: SerializableObjectWithBuffers<ILanguageRuntimeMessage>): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;
 	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1180,6 +1180,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 				`it can be restarted.`));
 	}
 
+	public focusSession(sessionId: string): void {
+		for (let i = 0; i < this._runtimeSessions.length; i++) {
+			if (this._runtimeSessions[i].metadata.sessionId === sessionId) {
+				return this._proxy.$focusSession(i);
+			}
+		}
+		throw new Error(`Session with ID '${sessionId}' must be started before ` +
+			`it can be focused.`);
+	}
+
 	/**
 	 * Interrupts an active session.
 	 *

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -56,8 +56,13 @@ export const ConsoleInstanceInfoButton = () => {
 		}
 
 		// Get the channels from the session.
-		const channels =
-			intersectionOutputChannels(await session.listOutputChannels());
+		let channels: LanguageRuntimeSessionChannel[] = []
+		try {
+			channels = intersectionOutputChannels(await session.listOutputChannels());
+		} catch (err) {
+			// If we fail to get the channels we can just ignore it
+			console.warn('Failed to get output channels', err);
+		}
 
 		// Create the renderer.
 		const renderer = new PositronModalReactRenderer({

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -184,6 +184,10 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		throw new Error('Method not implemented.');
 	}
 
+	focusSession(_sessionId: string): void {
+		throw new Error('Method not implemented.');
+	}
+
 	restartSession(_sessionId: string, _source: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -481,15 +481,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	focusSession(sessionId: string): void {
 		const session = this.getSession(sessionId);
 		if (!session) {
-			this._logService.error(`Could not find session with id {sessionId}.`);
-			return;
+			throw new Error(`Could not find session with id {sessionId}.`);
 		}
 
 		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 			this.foregroundSession = session;
 		} else {
 			// TODO: we could potentially focus the notebook editor in this case.
-			this._logService.error(`Cannot focus a notebook session.`);
+			throw new Error(`Cannot focus a notebook session.`);
 		}
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -476,6 +476,24 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	/**
+	 * Focus a runtime session by setting it as the foreground session.
+	 */
+	focusSession(sessionId: string): void {
+		const session = this.getSession(sessionId);
+		if (!session) {
+			this._logService.error(`Could not find session with id {sessionId}.`);
+			return;
+		}
+
+		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
+			this.foregroundSession = session;
+		} else {
+			// TODO: we could potentially focus the notebook editor in this case.
+			this._logService.error(`Cannot focus a notebook session.`);
+		}
+	}
+
+	/**
 	 * Shutdown a runtime session.
 	 *
 	 * @param session The session to shutdown.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -464,6 +464,14 @@ export interface IRuntimeSessionService {
 	deleteSession(sessionId: string): Promise<void>;
 
 	/**
+	 * Focus the runtime session by making it the foreground session if it's
+	 * console session.
+	 *
+	 * @param sessionId The identifier of the session to focus.
+	 */
+	focusSession(sessionId: string): void;
+
+	/**
 	 * Restart a runtime session.
 	 *
 	 * @param sessionId The identifier of the session to restart.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -465,7 +465,7 @@ export interface IRuntimeSessionService {
 
 	/**
 	 * Focus the runtime session by making it the foreground session if it's
-	 * console session.
+	 * a console session.
 	 *
 	 * @param sessionId The identifier of the session to focus.
 	 */

--- a/test/e2e/pages/popups.ts
+++ b/test/e2e/pages/popups.ts
@@ -32,6 +32,17 @@ export class Popups {
 		}
 	}
 
+	async acceptModalDialog() {
+		try {
+			this.code.logger.log('Checking for modal dialog box');
+			// fail fast if the modal is not present
+			await expect(this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX)).toBeVisible();
+			await this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX_OK).click();
+		} catch {
+			this.code.logger.log('Did not find modal dialog box');
+		}
+	}
+
 	async installIPyKernel() {
 
 		try {

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1060,6 +1060,16 @@ const pythonSessionHidden: SessionInfo = {
 	waitForReady: true
 };
 
+// Use this session object to manage reticulate sessions.
+const pythonReticulate: SessionInfo = {
+	name: `Python (reticulate)`,
+	language: 'Python',
+	version: '',
+	triggerMode: 'session-picker',
+	id: '',
+	waitForReady: true
+};
+
 // Use this session object to manage default R env in the test
 const rSession: SessionInfo = {
 	name: `R ${DESIRED_R}`,
@@ -1090,7 +1100,7 @@ const rSessionHidden: SessionInfo = {
 	waitForReady: true
 };
 
-type SessionRuntimes = 'python' | 'pythonAlt' | 'pythonHidden' | 'r' | 'rAlt' | 'rHidden';
+type SessionRuntimes = 'python' | 'pythonAlt' | 'pythonHidden' | 'pythonReticulate' | 'r' | 'rAlt' | 'rHidden';
 
 export const availableRuntimes: { [key: string]: SessionInfo } = {
 	r: { ...rSession },
@@ -1099,4 +1109,5 @@ export const availableRuntimes: { [key: string]: SessionInfo } = {
 	python: { ...pythonSession },
 	pythonAlt: { ...pythonSessionAlt },
 	pythonHidden: { ...pythonSessionHidden },
+	pythonReticulate: { ...pythonReticulate },
 };

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -228,6 +228,7 @@ test.describe('Reticulate - multi console sessions', {
 				await app.workbench.console.sendEnterKey();
 
 				await app.workbench.console.waitForConsoleContents(`${val}`);
+				await sessions.expectAllSessionsToBeReady();
 			}
 		}
 
@@ -235,6 +236,7 @@ test.describe('Reticulate - multi console sessions', {
 		const restart = sessions.restart(reticulateSession.id, { waitForIdle: false });
 		await app.workbench.popups.acceptModalDialog();
 		await restart;
+		await sessions.expectAllSessionsToBeReady();
 		await sessions.expectStatusToBe(reticulateSession.id, 'idle', { timeout: 60000 });
 
 		// The other reticulate session should still print something from `x`

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -189,14 +189,14 @@ test.describe('Reticulate - multi console sessions', {
 	test('Can initialize multiple reticulate sessions', async function ({ app, sessions }) {
 
 		// This should start both an R session and the reticulate session
-		await sessions.start('pythonReticulate', { waitForReady: true });
+		await sessions.start('pythonReticulate', { reuse: false });
 		await sessions.expectSessionCountToBe(2); // because it also starts an R session
 		await sessions.expectAllSessionsToBeReady();
 
 
 		// Now launch a new reticulate session. This should start another R session
 		// and another python session.
-		await sessions.start('pythonReticulate', { waitForReady: true, reuse: false });
+		await sessions.start('pythonReticulate', { reuse: false });
 		await sessions.expectSessionCountToBe(4);
 		await sessions.expectAllSessionsToBeReady();
 

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { InterpreterType } from '../../infra/fixtures/interpreter.js';
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
@@ -105,6 +106,129 @@ test.describe('Reticulate', {
 		await app.workbench.interpreter.restartPrimaryInterpreter(interpreterDesc);
 		await app.workbench.interpreter.verifyInterpreterIsRunning(interpreterDesc);
 	});
+});
+
+test.describe('Reticulate - console interaction', {
+	tag: [tags.RETICULATE, tags.WEB]
+}, () => {
+	test.beforeAll(async function ({ app, userSettings }) {
+		try {
+			await userSettings.set([
+				['positron.reticulate.enabled', 'true']
+			]);
+
+		} catch (e) {
+			await app.code.driver.takeScreenshot('reticulateSetup');
+			throw e;
+		}
+	});
+
+	test('R - Reticulate can be started with reticulate::repl_python()', async function ({ app, interpreter }) {
+		// Start R console
+		await app.workbench.interpreter.selectInterpreter(InterpreterType.R, process.env.POSITRON_R_VER_SEL!);
+
+		// Now execute reticulate::repl_python()
+		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
+		await app.workbench.console.sendEnterKey();
+
+		// Wait for the reticulate interpreter to be running
+		// There's a small bug such that the button is green button is updated when
+		// the session starts. So we need to wait until reticulate starts to see the
+		// interpreter running
+		await app.workbench.console.waitForReadyAndStarted('>>>', 30000);
+		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+
+		// Create a variable in Python, we'll check we can access it from R.
+		await app.workbench.console.pasteCodeToConsole('x=100');
+		await app.workbench.console.sendEnterKey();
+
+		// Now go back to the R interprerter
+		await app.workbench.interpreter.selectInterpreter(InterpreterType.R, process.env.POSITRON_R_VER_SEL!);
+		await app.workbench.console.pasteCodeToConsole('print(reticulate::py$x)');
+		await app.workbench.console.sendEnterKey();
+		await app.workbench.console.waitForConsoleContents('[1] 100');
+
+		// Create a variable in R and expect to be able to access it from Python
+		await app.workbench.console.pasteCodeToConsole('y <- 200L');
+		await app.workbench.console.sendEnterKey();
+
+		// Executing reticulate::repl_python() should not start a new interpreter
+		// but should move focus to the reticulate interpreter
+		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
+		await app.workbench.console.sendEnterKey();
+
+		// Expect that focus changed to the reticulate console
+		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
+		await app.workbench.console.pasteCodeToConsole('print(r.y)');
+		await app.workbench.console.sendEnterKey();
+		await app.workbench.console.waitForConsoleContents('200');
+	});
+});
+
+test.describe('Reticulate - multi console sessions', {
+	tag: [tags.RETICULATE, tags.WEB, tags.SESSIONS]
+}, () => {
+
+	test.beforeAll(async function ({ userSettings }) {
+		await userSettings.set([
+			['console.multipleConsoleSessions', 'true'],
+			['positron.reticulate.enabled', 'true']
+		], true);
+	});
+
+	test.beforeEach(async function ({ app, sessions }) {
+		await app.workbench.variables.togglePane('hide');
+		await sessions.deleteDisconnectedSessions();
+		await sessions.clearConsoleAllSessions();
+	});
+
+	test('Can initialize multiple reticulate sessions', async function ({ app, sessions }) {
+
+		// This should start both an R session and the reticulate session
+		const reticulateSession = await sessions.start('pythonReticulate', { waitForReady: true });
+		await sessions.expectStatusToBe(reticulateSession.id, 'idle', { timeout: 60000 });
+		await sessions.expectSessionCountToBe(2);
+		await sessions.expectAllSessionsToBeIdle();
+
+
+		// Now launch a new reticulate session. This should start another R session
+		// and another python session.
+		const reticulateSession2 = await sessions.start('pythonReticulate', { waitForReady: true, reuse: false });
+		await sessions.expectStatusToBe(reticulateSession2.id, 'idle', { timeout: 60000 });
+		await sessions.expectSessionCountToBe(4);
+		await sessions.expectAllSessionsToBeIdle();
+
+		const sessionIds = await sessions.getAllSessionIds();
+		for (const id of sessionIds) {
+			await sessions.select(id);
+			let info;
+			try {
+				info = await sessions.getSelectedSessionInfo();
+			} catch (e) {
+				// getSelectSessionInfo works by parsing the name of the session
+				// but reticulate doesn't follow the same convention, we just skip
+				// for reticulate sessions
+			}
+
+			if (info && info.language === 'R') {
+				const val = Math.floor(Math.random() * 100);
+				await app.workbench.console.pasteCodeToConsole(`x <- ${val}L`);
+				await app.workbench.console.sendEnterKey();
+
+				await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
+				await app.workbench.console.sendEnterKey();
+
+				await app.workbench.console.waitForReadyAndStarted('>>>', 30000);
+
+				await app.workbench.console.pasteCodeToConsole('print(r.x)');
+				await app.workbench.console.sendEnterKey();
+
+				await app.workbench.console.waitForConsoleContents(`${val}`);
+			}
+		}
+
+	});
+
 });
 
 async function verifyReticulateFunctionality(app, interpreter, sequential) {

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -202,7 +202,6 @@ test.describe('Reticulate - multi console sessions', {
 
 		const sessionInfo = await sessions.getAllSessionIdsAndNames();
 		for (const { id, name } of sessionInfo) {
-			console.log(id, name);
 			if (name.startsWith('R ')) {
 
 				await sessions.select(id);
@@ -236,7 +235,7 @@ test.describe('Reticulate - multi console sessions', {
 		await sessions.select(reticulateIds[1], true);
 		await app.workbench.console.pasteCodeToConsole('print(type(r.x))');
 		await app.workbench.console.sendEnterKey();
-		await app.workbench.console.waitForConsoleContents('int');
+		await app.workbench.console.waitForConsoleContents(`<class 'int'>`, { exact: true });
 	});
 
 });

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -192,7 +192,7 @@ test.describe('Reticulate - multi console sessions', {
 		const reticulateSession = await sessions.start('pythonReticulate', { waitForReady: true });
 		await sessions.expectStatusToBe(reticulateSession.id, 'idle', { timeout: 60000 });
 		await sessions.expectSessionCountToBe(2);
-		await sessions.expectAllSessionsToBeIdle();
+		await sessions.expectAllSessionsToBeReady();
 
 
 		// Now launch a new reticulate session. This should start another R session
@@ -200,7 +200,7 @@ test.describe('Reticulate - multi console sessions', {
 		const reticulateSession2 = await sessions.start('pythonReticulate', { waitForReady: true, reuse: false });
 		await sessions.expectStatusToBe(reticulateSession2.id, 'idle', { timeout: 60000 });
 		await sessions.expectSessionCountToBe(4);
-		await sessions.expectAllSessionsToBeIdle();
+		await sessions.expectAllSessionsToBeReady();
 
 		const sessionIds = await sessions.getAllSessionIds();
 		for (const id of sessionIds) {
@@ -232,7 +232,7 @@ test.describe('Reticulate - multi console sessions', {
 		}
 
 		// Now test restarts
-		let restart = sessions.restart(reticulateSession.id, { waitForIdle: false });
+		const restart = sessions.restart(reticulateSession.id, { waitForIdle: false });
 		await app.workbench.popups.acceptModalDialog();
 		await restart;
 		await sessions.expectStatusToBe(reticulateSession.id, 'idle', { timeout: 60000 });

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -154,12 +154,16 @@ test.describe('Reticulate - console interaction', {
 
 		// Executing reticulate::repl_python() should not start a new interpreter
 		// but should move focus to the reticulate interpreter
-		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
+		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python(input = "z = 3")');
 		await app.workbench.console.sendEnterKey();
 
 		// Expect that focus changed to the reticulate console
 		await app.workbench.interpreter.verifyInterpreterIsRunning('Python (reticulate)');
 		await app.workbench.console.pasteCodeToConsole('print(r.y)');
+		await app.workbench.console.sendEnterKey();
+		await app.workbench.console.waitForConsoleContents('200');
+
+		await app.workbench.console.pasteCodeToConsole('print(z)');
 		await app.workbench.console.sendEnterKey();
 		await app.workbench.console.waitForConsoleContents('200');
 	});

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -231,6 +231,18 @@ test.describe('Reticulate - multi console sessions', {
 			}
 		}
 
+		// Now test restarts
+		let restart = sessions.restart(reticulateSession.id, { waitForIdle: false });
+		await app.workbench.popups.acceptModalDialog();
+		await restart;
+		await sessions.expectStatusToBe(reticulateSession.id, 'idle', { timeout: 60000 });
+
+		// The other reticulate session should still print something from `x`
+		await sessions.select(reticulateSession2.id);
+		await app.workbench.console.pasteCodeToConsole('print(type(r.x))');
+		await app.workbench.console.sendEnterKey();
+		await app.workbench.console.waitForConsoleContents('int');
+
 	});
 
 });


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6790
Also addesses https://github.com/posit-dev/positron/issues/6789

Sorry for the large diff. Most of the extension code had expectations that a single R and Python session were possible, so this turned out to be a largish refactor.

- Fixed retillculate infos displayed in the 'Runtime Info' button
- Improved how reticulate finds a host R session using the new `positron.runtime.getActiveSessions()`
- Tie reticulate sessions to the host R session, so we can correctly `restore` in the multi-console world.
- Added a positron API entrypoint to change the `foregroundSession`.
- Made sure that even when interacting with Positron from the console (ie creating a session with `reticulate::repl_python()`), we correctly send commands to the correctly embbeded python session.
- Added test cases for multi-console support.

Here's a small screencast showing the functionality:

https://github.com/user-attachments/assets/7ed710fe-1a63-4d27-b60b-76de47b065c2

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:reticulate
