### PR TITLE
update isGlobalPython to consider Pyenv interpreters as global pythons

### DIFF
--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -92,8 +92,23 @@ export async function isGlobalPython(interpreterPath: string): Promise<boolean |
     }
     const extensionApi: PythonExtension = extension.exports as PythonExtension;
     const interpreterDetails = await extensionApi.environments.resolveEnvironment(interpreterPath);
-    const isGlobal = interpreterDetails?.environment === undefined;
-    return isGlobal;
+
+    // If we can't resolve the interpreter details, we can't determine if it's a global python installation
+    if (!interpreterDetails) {
+        return undefined;
+    }
+
+    // If the interpreter is not in a virtual environment, it is a global python installation
+    if (interpreterDetails.environment === undefined) {
+        return true;
+    }
+
+    // If the interpreter is in a virtual environment, but was installed via Pyenv, it is a global python installation
+    if (interpreterDetails.tools.includes('Pyenv')) {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
### Summary

- addresses #7027

#### JS Locator

<img width="954" alt="fixed_jslocator_projwiz" src="https://github.com/user-attachments/assets/fbf87ecc-a15a-43ed-917a-52cafbf8f802" />

#### Native Locator

<img width="966" alt="fixed_nativelocator_projwiz" src="https://github.com/user-attachments/assets/1ef96490-0e72-4ba9-81ad-1b9744edbfd7" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Pyenv interpreters are now available in the Project Wizard when using the Native Python Locator (#7027)


### QA Notes

See steps in #7027!