### PR TITLE
Assistant: Update to new code editing API

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -180,7 +180,7 @@ function registerConfigureModelsCommand(context: vscode.ExtensionContext, storag
 
 function registerMappedEditsProvider(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
-		vscode.chat.registerMappedEditsProvider({ pattern: '**/*' }, editsProvider)
+		vscode.chat.registerMappedEditsProvider2(editsProvider)
 	);
 }
 


### PR DESCRIPTION
The code editing provider API has changed to support mapped edits that span several documents, and to stream the results instead of waiting for them at the end.

This PR makes the minimal change necessary to restore the functionality Assistant had prior to the change by implementing the new API.

Addresses #6960. 

