### PR TITLE
Fix restart hangs

### DIFF
--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -87,7 +87,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * @param ipAddress The address of the client that will connect to the
      *  language server.
      */
-    startPositronLsp(ipAddress: string): Thenable<number>;
+    startPositronLsp(ipAddress: string): Promise<number>;
 
     /**
      * Convenience method for starting the Positron DAP server, if the
@@ -96,7 +96,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * @param debugType Passed as `vscode.DebugConfiguration.type`.
      * @param debugName Passed as `vscode.DebugConfiguration.name`.
      */
-    startPositronDap(debugType: string, debugName: string): Thenable<void>;
+    startPositronDap(debugType: string, debugName: string): Promise<void>;
 
     /**
      * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -86,7 +86,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(ipAddress: string): Thenable<number>;
+	startPositronLsp(ipAddress: string): Promise<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the
@@ -95,7 +95,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(debugType: string, debugName: string): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Promise<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -87,7 +87,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(ipAddress: string): Thenable<number>;
+	startPositronLsp(ipAddress: string): Promise<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the
@@ -96,7 +96,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(debugType: string, debugName: string): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Promise<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1361,6 +1361,12 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// All comms are now closed
 		this._comms.clear();
 
+		// Clear any starting comms
+		this._startingComms.forEach((promise) => {
+			promise.reject(new Error('Kernel exited'));
+		});
+		this._startingComms.clear();
+
 		// Clear any pending requests
 		this._pendingRequests.clear();
 		this._pendingUiCommRequests.forEach((req) => {

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -87,7 +87,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(ipAddress: string): Thenable<number>;
+	startPositronLsp(ipAddress: string): Promise<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the
@@ -96,7 +96,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(debugType: string, debugName: string): Thenable<void>;
+	startPositronDap(debugType: string, debugName: string): Promise<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -83,6 +83,7 @@ export const ConsoleInstanceInfoButton = () => {
 			ref={ref}
 			align='right'
 			ariaLabel={positronConsoleInfo}
+			dataTestId={`info-${positronConsoleContext.activePositronConsoleInstance?.sessionId ?? 'unknown'}`}
 			iconId='info'
 			tooltip={positronConsoleInfo}
 			onPressed={handlePressed}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -159,7 +159,7 @@ export class Sessions {
 
 			if (waitForIdle) {
 				await expect(this.page.getByText('Restarting')).not.toBeVisible({ timeout: 90000 });
-				await expect(this.page.locator('.console-instance[style*="z-index: auto"]').getByText('restarted.')).toBeVisible();
+				await expect(this.page.locator('.console-instance[style*="z-index: auto"]').getByText('restarted.')).toBeVisible({ timeout: 60000 });
 				await this.expectStatusToBe(sessionIdOrName, 'idle');
 			}
 		});
@@ -547,7 +547,13 @@ export class Sessions {
 	 * @returns the session ID or undefined if no session is selected
 	 */
 	async getCurrentSessionId(): Promise<string> {
-		return (await this.getMetadata()).id;
+		const testId = await this.page.getByTestId(/info-(python|r)-[a-z0-9]+/i).getAttribute('data-testid');
+
+		if (!testId || !/^info-((python|r)-[a-z0-9]+)$/i.test(testId)) {
+			throw new Error('No active session or unexpected session ID format');
+		}
+
+		return testId.replace(/^info-/, '');
 	}
 
 	/**

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -23,9 +23,7 @@ test.describe('Sessions: State', {
 		await sessions.clearConsoleAllSessions();
 	});
 
-	test('Validate state between sessions (active, idle, disconnect)', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7005' },]
-	}, async function ({ app, sessions }) {
+	test('Validate state between sessions (active, idle, disconnect)', async function ({ app, sessions }) {
 
 		const { console } = app.workbench;
 

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -23,7 +23,10 @@ test.describe('Sessions: State', {
 		await sessions.clearConsoleAllSessions();
 	});
 
-	test.skip('Validate state between sessions (active, idle, disconnect)', async function ({ app, sessions }) {
+	test('Validate state between sessions (active, idle, disconnect)', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7005' },]
+	}, async function ({ app, sessions }) {
+
 		const { console } = app.workbench;
 
 		// Start Python session


### PR DESCRIPTION
Fixes restart hangs. This happened when the kernel exits _after_ it creates the LSP comm and _before_ it receives a server started message. The solution is to reject the starting comm promises on kernel exit, like we do with other pending requests.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

e2e: @:sessions @:console