### PR TITLE
e2e-test: add session outline restart test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -159,7 +159,7 @@ export class Sessions {
 
 			if (waitForIdle) {
 				await expect(this.page.getByText('Restarting')).not.toBeVisible({ timeout: 90000 });
-				await expect(this.page.locator('.console-instance[style*="z-index: auto"]').getByText('restarted.')).toBeVisible();
+				await expect(this.page.locator('.console-instance[style*="z-index: auto"]').getByText('restarted.')).toBeVisible({ timeout: 90000 });
 				await this.expectStatusToBe(sessionIdOrName, 'idle');
 			}
 		});

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -97,7 +97,6 @@ test.describe('Sessions: Diagnostics', {
 
 		// Session 1 - restart session and verify only syntax error is present
 		await sessions.restart(rSession.id);
-		await sessions.select(rSession.id); // I prob shouldn't need to select...
 		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});

--- a/test/e2e/tests/sessions/session-diagnostics.test.ts
+++ b/test/e2e/tests/sessions/session-diagnostics.test.ts
@@ -95,9 +95,10 @@ test.describe('Sessions: Diagnostics', {
 		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
-		// Session 1 - restart session and verify only syntax error is present
+		// Session 1 - restart session and verify both problems (circos and syntax) are present
+		// Diagnostics engine is not aware of the circlize package, this is expected
 		await sessions.restart(rSession.id);
-		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 3, warningCount: 2, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});
 });

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -17,17 +17,22 @@ test.describe('Session: Outline', {
 	tag: [tags.WEB, tags.WIN, tags.SESSIONS, tags.OUTLINE]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings, openFile }) {
+	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
+	});
+
+	test.beforeAll(async function ({ app, openFile }) {
+		const { variables, outline } = app.workbench;
 
 		await openFile(`workspaces/outline/${PY_FILE}`);
 		await openFile(`workspaces/outline/${R_FILE}`);
+
+		await variables.togglePane('hide');
+		await outline.focus();
 	});
 
 	test('Verify outline is based on editor and per session', async function ({ app, openFile, sessions }) {
-		const { variables, outline, console, editor } = app.workbench;
-		await variables.togglePane('hide');
-		await outline.focus();
+		const { outline, console, editor } = app.workbench;
 
 		// No active session - verify no outlines
 		await editor.selectTab(PY_FILE);
@@ -75,9 +80,7 @@ test.describe('Session: Outline', {
 	});
 
 	test('Verify outline after reload with R in foreground and Python in background', async function ({ app, runCommand, sessions }) {
-		const { outline, editor, variables } = app.workbench;
-		await variables.togglePane('hide');
-		await outline.focus();
+		const { outline, editor } = app.workbench;
 
 		// Start sessions
 		const [, rSession] = await sessions.start(['python', 'r']);


### PR DESCRIPTION
Ya know, just updating session tests. 

Adding coverage for outline test after restart.

### QA Notes

@:sessions