### PR TITLE
Assistant: Support inline editing

### DIFF
--- a/extensions/positron-assistant/src/commands/default.ts
+++ b/extensions/positron-assistant/src/commands/default.ts
@@ -29,7 +29,23 @@ export async function defaultHandler(
 	// List of tools for use by the Language Model
 	const toolOptions: Record<string, any> = {};
 	const tools: vscode.LanguageModelChatTool[] = [
-		...vscode.lm.tools.filter(tool => tool.tags.includes('positron-assistant')),
+		...vscode.lm.tools.filter(tool => {
+			// Ignore tools that are not applicable for the Positron Assistant
+			if (!tool.tags.includes('positron-assistant')) {
+				return false;
+			}
+			// Do not offer to execute code when the request isn't coming from
+			// the Chat pane; the other panes do not have an affordance for
+			// confirming executions.
+			//
+			// CONSIDER: It would be better for us to introspect the tool itself
+			// to see if it requires confirmation, but that information isn't
+			// currently exposed in `vscode.LanguageModelChatTool`.
+			if (tool.name === 'executeCode' && request.location2) {
+				return false;
+			}
+			return true;
+		}),
 		getPlotToolAdapter.toolData,
 	];
 

--- a/extensions/positron-assistant/src/md/prompts/chat/editor.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/editor.md
@@ -1,12 +1,9 @@
-The user has invoked you from the text editor.
+The user has invoked you from the text editor. They want to change something in
+the provided document. Your goal is to generate a set of edits to the document
+that represent the requested change.
 
-When you have finished responding, you can choose to output a revised version of the selection provided by the user if required.
+Use the line and column provided to provide the user with a response appropriate
+to the current cursor location. Unless otherwise directed, focus on the text
+near and below the cursor.
 
-Never mention the name of the function, just use it.
-
-If there is selected text, assume the user has a question about it or wants to
-replace it with something else.
-
-Use the line and column provided to provide the user with response appropriate
-to the current cursor location, but don't mention the line and column numbers
-in your response unless needed for clarification.
+When you are done, use the provided tool to apply your edits.

--- a/extensions/positron-assistant/src/md/prompts/chat/selection.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/selection.md
@@ -1,0 +1,12 @@
+The user has invoked you from the text editor.
+
+When you have finished responding, you can choose to output a revised version of the selection provided by the user if required.
+
+Never mention the name of the function, just use it.
+
+If there is selected text, assume the user has a question about it or wants to
+replace it with something else.
+
+Use the line and column provided to provide the user with response appropriate
+to the current cursor location, but don't mention the line and column numbers
+in your response unless needed for clarification.

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -712,25 +712,6 @@
           }
         },
         "tags": ["positron-assistant"]
-      },
-      {
-        "name": "installRPackage",
-        "displayName": "Install R package",
-        "modelDescription": "Given the names of one or more R packages, installs the packages in the current R environment.",
-        "canBeReferencedInPrompt": false,
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "packageNames": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "The list of R packages to install."
-            }
-          }
-        },
-        "tags": ["positron-assistant"]
       }
     ]
   },

--- a/extensions/positron-r/src/llm-tools.ts
+++ b/extensions/positron-r/src/llm-tools.ts
@@ -64,46 +64,4 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 	});
 
 	context.subscriptions.push(rPackageVersionTool);
-
-	const rPackageInstallTool = vscode.lm.registerTool<{ packageNames: string[] }>('installRPackage', {
-		prepareInvocation: async (options, token) => {
-			if (!options.input.packageNames || options.input.packageNames.length === 0) {
-				throw new Error('Supply one or more package names to install');
-			}
-
-			// Ask user for confirmation before proceeding
-			const packageList = options.input.packageNames.join(', ');
-			const result: vscode.PreparedToolInvocation = {
-				invocationMessage: 'Installing R packages: ' + packageList + '...',
-				confirmationMessages: {
-					title: 'Install',
-					message: 'Install the following R packages?\n' + packageList,
-				}
-				,
-			}
-			return result;
-		},
-		invoke: async (options, token) => {
-			const manager = RSessionManager.instance;
-			const session = manager.getConsoleSession();
-			if (!session) {
-				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart('No active R session'),
-				]);
-			}
-
-			if (!options.input.packageNames || options.input.packageNames.length === 0) {
-				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart('Supply one or more package names to install'),
-				]);
-			}
-
-			await session.callMethod('install_packages', options.input.packageNames);
-			return new vscode.LanguageModelToolResult([
-				new vscode.LanguageModelTextPart('Installed packages: ' + options.input.packageNames.join(', ')),
-			]);
-		}
-	});
-
-	context.subscriptions.push(rPackageInstallTool);
 }


### PR DESCRIPTION
This contains the minimal changes required to support inline editing in Positron Assistant. The most important part of the change is supplying a tool to the model that can perform text edits on any part of the document; formerly we only had one  that could replace the active selection. We use this new mode when there is no text selected; it has its own prompt and tool call. 

Other notes:

- The system doesn't seem smart enough to avoid using tools that prompt the user while generating edits. If it tries to use one of these, it hangs since the model output is not visible during edit generation. Easy enough to workaround for now but we may need a better approach to this problem.
- I have removed the R "install packages" tool because it is worse in every way than just letting the model create an "install.packages()" call on its own; it was intended to provide a proof of concept as a state-altering tool with confirmation, but we don't need it any more.

Addresses https://github.com/posit-dev/positron/issues/6959.

## QA Notes

Right now, asking a question in inline chat always dismisses the inline chat widget. If you asked a question ("explain this") rather than asked for an edit, it should pop the widget back up to show the answer.