### PR TITLE
Anthropic model config

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -304,7 +304,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			'positron.assistant.models',
 			existingConfigs
 		);
-		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, error.message));
+		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
+		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, err.message));
 	}
 }
 

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -304,7 +304,7 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			'positron.assistant.models',
 			existingConfigs
 		);
-		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, JSON.stringify(error)));
+		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, error.message));
 	}
 }
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -51,10 +51,7 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 		const error = await languageModel.resolveConnection(new vscode.CancellationTokenSource().token);
 
 		if (error) {
-			vscode.window.showErrorMessage(
-				vscode.l10n.t(`Positron Assistant: Failed to register model configuration. ${error.message}`)
-			);
-			throw new Error(vscode.l10n.t('Failed to register model configuration. {0}', [error.message]));
+			throw new Error(error.message);
 		}
 
 		registerModelWithAPI(languageModel, modelConfig, context);
@@ -62,7 +59,7 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 		vscode.window.showErrorMessage(
 			vscode.l10n.t('Positron Assistant: Failed to register model configuration. {0}', [e])
 		);
-		throw new Error(vscode.l10n.t('Failed to register model configuration. {0}', [e]));
+		throw e;
 	}
 }
 

--- a/extensions/positron-assistant/src/md/welcomeready.md
+++ b/extensions/positron-assistant/src/md/welcomeready.md
@@ -4,7 +4,7 @@ Click on or type $(mention) to work with Chat Participants in Positron Assistant
 
 Click on $(attach) or type `#` to add context, such as files to your Positron Assistant chat.
 
-Type / to use predefined quick commands such as `/help` or `/quatro`.
+Type / to use predefined quick commands such as `/help` or `/quarto`.
 
 The {guide-link} explains the possibilities and capabilities of Positron Assistant.
 

--- a/extensions/positron-assistant/src/md/welcomeready.md
+++ b/extensions/positron-assistant/src/md/welcomeready.md
@@ -4,7 +4,7 @@ Click on or type $(mention) to work with Chat Participants in Positron Assistant
 
 Click on $(attach) or type `#` to add context, such as files to your Positron Assistant chat.
 
-Type / to use predefined quick commands such as `/help` or `/quarto`.
+Type `/` to use predefined quick commands such as `/help` or `/quarto`.
 
 The {guide-link} explains the possibilities and capabilities of Positron Assistant.
 

--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './embeddedLink.css';
+
 import React from 'react';
 
 /**

--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import React from 'react';
+
+/**
+ * A component that displays a string and converts any markdown links in the string to a href links.
+ *
+ * @param props the string to display containing markdown links to convert to a link
+ */
+export const EmbeddedLink = (props: React.PropsWithChildren) => {
+	// capture markdown links in the format [text](url)
+	const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
+	const text = props.children as string;
+
+	// Splits the text into tuples of [text, linkText, linkUrl]
+	// e.g. "This is a [link](https://example.com)" becomes ["This is a ", "link", "https://example.com"]
+	// If a markdown link has no plain text before it, it will be split into ["", "link", "https://example.com"]
+	const parts = text.split(regex);
+
+	return (
+		<span className='embedded-link'>
+			{parts.map((part, index) => {
+				// This is the first part of the markdown link
+				if (index % 3 === 1) {
+					// The second part of the markdown link
+					const link = parts[index + 1];
+					return (
+						<a key={index} href={link} rel='noreferrer' target='_blank'>
+							{part}
+						</a>
+					);
+				} else if (index % 3 === 0) {
+					// This is plain text
+					return part;
+				}
+				return null;
+			})}
+		</span>
+	);
+}

--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.embedded-link > a {
+	color: var(--vscode-textLink-foreground);
+}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioButton.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioButton.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // CSS.
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import './radioButton.css';
 
 // React.
@@ -15,6 +16,7 @@ import React from 'react';
 interface RadioButtonItemOptions {
 	identifier: string;
 	title: string;
+	disabled?: boolean;
 }
 
 /**
@@ -34,6 +36,7 @@ export class RadioButtonItem {
 interface RadioButtonProps extends RadioButtonItemOptions {
 	selected: boolean;
 	groupName: string;
+	disabled?: boolean;
 	onSelected: () => void;
 }
 
@@ -45,10 +48,11 @@ interface RadioButtonProps extends RadioButtonItemOptions {
 export const RadioButton = (props: RadioButtonProps) => {
 	// Render.
 	return (
-		<div className='radio-button'>
+		<div className={positronClassNames('radio-button', { disabled: props.disabled })}>
 			<input
 				checked={props.selected}
 				className='radio-button-input'
+				disabled={props.disabled}
 				id={props.identifier}
 				name={props.groupName}
 				tabIndex={props.selected ? 0 : -1}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
@@ -52,6 +52,7 @@ export const RadioGroup = (props: PropsWithChildren<RadioGroupProps>) => {
 				return (
 					<RadioButton
 						key={index}
+						disabled={entry.options.disabled}
 						groupName={props.name}
 						identifier={entry.options.identifier}
 						selected={entry.options.identifier === currentSelection}

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1511,17 +1511,17 @@ export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BORDER_SELECTED = registerColor(
 
 // < --- Positron Icon Button --- >
 export const POSITRON_ICON_BUTTON_BORDER = registerColor('positronIconButton.border', {
-	dark: '#999999',
-	light: '#3a78b1',
-	hcDark: '#ff0000',
-	hcLight: '#ff0000'
+	dark: focusBorder,
+	light: focusBorder,
+	hcDark: focusBorder,
+	hcLight: focusBorder
 }, localize('positronIconButton.border', "Positron icon button border color."));
 
 export const POSITRON_ICON_BUTTON_BACKGROUND = registerColor('positronIconButton.background', {
-	dark: '#37373d',
-	light: '#e4e6f1',
-	hcDark: '#ff0000',
-	hcLight: '#ff0000'
+	dark: listInactiveSelectionBackground,
+	light: listInactiveSelectionBackground,
+	hcDark: listHoverBackground,
+	hcLight: listHoverBackground
 }, localize('positronIconButton.background', "Positron icon button background color."));
 
 // < --- Positron Drop Down --- >

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from 'react'
+import { IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js'
+import { localize } from '../../../../../nls.js'
+import { LabeledTextInput } from '../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js'
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js'
+import { LanguageModelUIConfiguration } from '../languageModelModalDialog.js'
+
+interface LanguageModelConfigComponentProps {
+	provider: LanguageModelUIConfiguration,
+	source: IPositronLanguageModelSource,
+	onChange: (config: IPositronLanguageModelConfig) => void,
+	onSignIn: () => void,
+}
+
+export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
+	function getTos(provider: string) {
+		switch (provider) {
+			case 'anthropic':
+				return localize('positron.newConnectionModalDialog.anthropicTos',
+					"By using Anthropic, you agree to abide by their Consumer or Commercial terms of service.");
+			default:
+				return '';
+		}
+	}
+
+	return (<>
+		{props.source.supportedOptions.includes('apiKey') && (
+			<ApiKey apiKey={props.provider.apiKey} signedIn={props.source.signedIn} onChange={(newApiKey) => {
+				props.onChange({ ...props.provider, apiKey: newApiKey });
+			}} onSignIn={props.onSignIn} />
+		)}
+		{(!props.source.supportedOptions.includes('apiKey')) &&
+			<SignInButton signedIn={props.source.signedIn} onSignIn={props.onSignIn} />
+		}
+		<div className='language-model-dialog-tos' id='model-tos'>
+			{getTos(props.provider.provider)}
+		</div>
+	</>)
+}
+
+// Language config parts
+const ApiKey = (props: { apiKey?: string, signedIn?: boolean, onChange: (newApiKey: string) => void, onSignIn: () => void }) => {
+	return (<>
+		<div className='language-model-authentication-container' id='api-key-input'>
+			<LabeledTextInput
+				disabled={props.signedIn}
+				label={(() => localize('positron.newConnectionModalDialog.apiKey', "API Key"))()}
+				type='password'
+				value={props.apiKey ?? ''}
+				onChange={e => { props.onChange(e.currentTarget.value) }} />
+			<SignInButton signedIn={props.signedIn} onSignIn={props.onSignIn} />
+		</div>
+	</>)
+}
+
+const SignInButton = (props: { signedIn?: boolean, onSignIn: () => void }) => {
+	return <Button className='language-model button sign-in' onPressed={props.onSignIn}>
+		{(() => {
+			if (props.signedIn) {
+				return localize('positron.newConnectionModalDialog.signOut', "Sign out");
+			} else {
+				return localize('positron.newConnectionModalDialog.signIn', "Sign in");
+			}
+		})()}
+	</Button>
+}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -9,6 +9,7 @@ import { localize } from '../../../../../nls.js'
 import { LabeledTextInput } from '../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js'
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js'
 import { LanguageModelUIConfiguration } from '../languageModelModalDialog.js'
+import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.js'
 
 interface LanguageModelConfigComponentProps {
 	provider: LanguageModelUIConfiguration,
@@ -22,23 +23,26 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 		switch (provider) {
 			case 'anthropic':
 				return localize('positron.newConnectionModalDialog.anthropicTos',
-					"By using Anthropic, you agree to abide by their Consumer or Commercial terms of service.");
+					"By using Anthropic, you agree to abide by their [Consumer](https://www.anthropic.com/legal/consumer-terms) or [Commercial](https://www.anthropic.com/legal/commercial-terms) terms of service.");
+			case 'google':
+				return localize('positron.newConnectionModalDialog.googleTos',
+					"By using Gemini, you agree to abide by their [Terms of Service](https://gemini.google/policy-guidelines).");
 			default:
 				return '';
 		}
 	}
 
 	return (<>
-		{props.source.supportedOptions.includes('apiKey') && (
-			<ApiKey apiKey={props.provider.apiKey} signedIn={props.source.signedIn} onChange={(newApiKey) => {
-				props.onChange({ ...props.provider, apiKey: newApiKey });
-			}} onSignIn={props.onSignIn} />
-		)}
-		{(!props.source.supportedOptions.includes('apiKey')) &&
+		<div className='language-model-container input'>
+			{props.source.supportedOptions.includes('apiKey') && !props.source.signedIn && (
+				<ApiKey apiKey={props.provider.apiKey} signedIn={props.source.signedIn} onChange={(newApiKey) => {
+					props.onChange({ ...props.provider, apiKey: newApiKey });
+				}} onSignIn={props.onSignIn} />
+			)}
 			<SignInButton signedIn={props.source.signedIn} onSignIn={props.onSignIn} />
-		}
+		</div>
 		<div className='language-model-dialog-tos' id='model-tos'>
-			{getTos(props.provider.provider)}
+			<EmbeddedLink>{getTos(props.provider.provider)}</EmbeddedLink>
 		</div>
 	</>)
 }
@@ -53,7 +57,6 @@ const ApiKey = (props: { apiKey?: string, signedIn?: boolean, onChange: (newApiK
 				type='password'
 				value={props.apiKey ?? ''}
 				onChange={e => { props.onChange(e.currentTarget.value) }} />
-			<SignInButton signedIn={props.signedIn} onSignIn={props.onSignIn} />
 		</div>
 	</>)
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -21,7 +21,7 @@
 }
 
 .language-model.button-container .language-model.button {
-	width: 170px;
+	width: 110px;
 }
 
 .language-model.button .vertical-stack {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -20,9 +20,18 @@
 	scrollbar-width: thin;
 }
 
+.language-model.button-container .language-model.button {
+	width: 170px;
+}
+
+.language-model.button .vertical-stack {
+	text-align: center;
+}
+
 .language-model.icon {
 	height: 3rem;
 	width: 3rem;
+	margin: 0 15px;
 	align-self: center;
 }
 
@@ -44,10 +53,7 @@
 	border: 1px solid var(--vscode-positronModalDialog-background);
 }
 
-.language-model.button.selected {
-	background: var(--vscode-positronIconButton-background);
-}
-
+.language-model.button.selected,
 .language-model.button:hover {
 	border: 1px solid var(--vscode-positronIconButton-border);
 	background: var(--vscode-positronIconButton-background);
@@ -58,11 +64,30 @@
 }
 
 .language-model.button.sign-in {
-	align-self: center;
+	align-self: end;
 	font-weight: 600;
 	text-wrap: nowrap;
 	height: 2rem;
 	border-radius: 5px;
 	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
 	background: var(--vscode-positronModalDialog-buttonBackground);
+}
+
+/** layout the children of this container horizontally */
+.language-model-authentication-method-container .radio-group {
+	display: flex;
+	flex-direction: row;
+	column-gap: 10px;
+}
+
+.language-model-modal-dialog .content-area > .vertical-stack {
+	row-gap: 2px;
+}
+
+.language-model-authentication-method-container div.radio-button.disabled {
+	color: var(--vscode-disabledForeground);
+}
+
+#model-tos {
+	font-size: 0.7rem;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -59,8 +59,14 @@
 	background: var(--vscode-positronIconButton-background);
 }
 
+.language-model-container {
+	display: flex;
+	height: 3rem;
+}
+
 .language-model-authentication-container {
 	display: flex;
+	width: 100%;
 }
 
 .language-model.button.sign-in {
@@ -89,5 +95,10 @@
 }
 
 #model-tos {
+	margin-top: 1rem;
 	font-size: 0.7rem;
+}
+
+.language-model-modal-dialog .ok-action-bar.top-separator {
+	border-top: none;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -103,7 +103,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	})!;
 
 	const [source, setSource] = React.useState<IPositronLanguageModelSource>(defaultSource);
-	const [providerConfig, setProviderConfig] = React.useState<LanguageModelUIConfiguration>({ ...defaultSource.defaults, provider: defaultSource.provider.id, type: defaultSource.type });
+	const [providerConfig, setProviderConfig] = React.useState<LanguageModelUIConfiguration>({ ...defaultSource.defaults, name: defaultSource.provider.displayName, provider: defaultSource.provider.id, type: defaultSource.type });
 	const [apiKey, setApiKey] = React.useState<string>();
 	const [baseUrl, setBaseUrl] = React.useState<string | undefined>(defaultSource.defaults.baseUrl);
 	const [resourceName, setResourceName] = React.useState<string | undefined>(defaultSource.defaults.resourceName);

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -166,12 +166,6 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const providers = props.sources
 		.filter(source => source.type === 'chat')
 		.sort((a, b) => {
-			// sort test models to the end
-			// if (a.isTest && !b.isTest) {
-			// 	return 1;
-			// } else if (!a.isTest && b.isTest) {
-			// 	return -1;
-			// }
 			return a.provider.displayName.localeCompare(b.provider.displayName);
 		})
 		.map(source => new DropDownListBoxItem({
@@ -396,7 +390,6 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 						name='authMethod'
 						onSelectionChanged={(authMethod) => {
 							// setAuthMethod(authMethod);
-							console.log(authMethod);
 						}}
 					/>
 				</div>

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -82,7 +82,7 @@ export interface LanguageModelUIConfiguration extends IPositronLanguageModelConf
 const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModelConfigurationProps>) => {
 	const [type, setType] = React.useState<PositronLanguageModelType>(PositronLanguageModelType.Chat);
 
-	const useNewConfig = props.configurationService.getValue<boolean>('positron.assistant.newModelConfiguration');
+	const useNewConfig = props.configurationService.getValue<boolean>('positron.assistant.newModelConfiguration') ?? true;
 	const enabledProviders = props.sources.map(source => source.provider.id);
 	const hasAnthropic = enabledProviders.includes('anthropic');
 	const hasMistral = enabledProviders.includes('mistral');

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -22,9 +22,11 @@ import { localize } from '../../../../nls.js';
 import { ProgressBar } from '../../../../base/browser/ui/positronComponents/progressBar.js';
 import { LanguageModelButton } from './components/languageModelButton.js';
 import { DropDownListBox } from '../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
-import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { OKModalDialog } from '../../../browser/positronComponents/positronModalDialog/positronOKModalDialog.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { LanguageModelConfigComponent } from './components/languageModelConfigComponent.js';
+import { RadioButtonItem } from '../../../browser/positronComponents/positronModalDialog/components/radioButton.js';
+import { RadioGroup } from '../../../browser/positronComponents/positronModalDialog/components/radioGroup.js';
 
 export const showLanguageModelModalDialog = (
 	keybindingService: IKeybindingService,
@@ -71,6 +73,12 @@ interface LanguageModelConfigurationProps {
 	onClose: () => void;
 }
 
+export interface LanguageModelUIConfiguration extends IPositronLanguageModelConfig {
+	signedIn?: boolean;
+	isTest?: boolean;
+	apiKey?: string;
+}
+
 const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModelConfigurationProps>) => {
 	const [type, setType] = React.useState<PositronLanguageModelType>(PositronLanguageModelType.Chat);
 
@@ -80,12 +88,12 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const hasMistral = enabledProviders.includes('mistral');
 	const defaultSource = props.sources.find(source => {
 		// If Anthropic is available, prefer it for chat models
-		if (source.type === type) {
-			if (type === 'chat' && hasAnthropic) {
+		if (type === 'chat') {
+			if (hasAnthropic) {
 				return source.provider.id === 'anthropic';
 			}
 			// If Mistral is available, prefer it for completion models
-			if (type === 'completion' && hasMistral) {
+			if (hasMistral) {
 				return source.provider.id === 'mistral';
 			}
 			// In all other cases, prefer the first available provider
@@ -95,6 +103,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	})!;
 
 	const [source, setSource] = React.useState<IPositronLanguageModelSource>(defaultSource);
+	const [providerConfig, setProviderConfig] = React.useState<LanguageModelUIConfiguration>({ ...defaultSource.defaults, provider: defaultSource.provider.id, type: defaultSource.type });
 	const [apiKey, setApiKey] = React.useState<string>();
 	const [baseUrl, setBaseUrl] = React.useState<string | undefined>(defaultSource.defaults.baseUrl);
 	const [resourceName, setResourceName] = React.useState<string | undefined>(defaultSource.defaults.resourceName);
@@ -115,17 +124,18 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		props.positronAssistantService.onChangeLanguageModelConfig((newSource) => {
 			// find newSource in props.sources and update it
 			const index = props.sources.findIndex(source => source.provider.id === newSource.provider.id);
+			const mergedSource = { ...source, ...newSource, supportedOptions: source.supportedOptions };
 			if (index >= 0) {
-				props.sources[index] = newSource;
+				props.sources[index] = mergedSource;
 			}
 
 			// if newSource matches source, update source
 			if (source.provider.id === newSource.provider.id) {
-				setSource(newSource);
+				setSource(mergedSource);
 			}
 
 		});
-	}, [props.positronAssistantService, props.sources, source.provider.id]);
+	}, [props.positronAssistantService, props.sources, source]);
 
 	useEffect(() => {
 		setModel(source.defaults.model);
@@ -137,11 +147,33 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		setLocation(source.defaults.location);
 		setToolCalls(source.defaults.toolCalls);
 		setNumCtx(source.defaults.numCtx);
+
 	}, [source]);
 
+	const authMethodRadioButtons: RadioButtonItem[] = [
+		new RadioButtonItem({
+			identifier: 'oauth',
+			title: localize('positron.newConnectionModalDialog.oauth', "OAuth"),
+			disabled: true,
+		}),
+		new RadioButtonItem({
+			identifier: 'apiKey',
+			title: localize('positron.newConnectionModalDialog.apiKey', "API Key"),
+			disabled: false,
+		}),
+	];
+
 	const providers = props.sources
-		.filter(source => source.type === type)
-		.sort((a, b) => a.provider.displayName.localeCompare(b.provider.displayName))
+		.filter(source => source.type === 'chat')
+		.sort((a, b) => {
+			// sort test models to the end
+			// if (a.isTest && !b.isTest) {
+			// 	return 1;
+			// } else if (!a.isTest && b.isTest) {
+			// 	return -1;
+			// }
+			return a.provider.displayName.localeCompare(b.provider.displayName);
+		})
 		.map(source => new DropDownListBoxItem({
 			identifier: source.provider.id,
 			title: source.provider.displayName,
@@ -159,41 +191,23 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		}
 		setShowProgress(true);
 		setError(undefined);
-		props.onAction({
-			type: type,
-			provider: source.provider.id,
-			model: model,
-			name: name,
-			apiKey: apiKey,
-			baseUrl: baseUrl,
-			resourceName: resourceName,
-			project: project,
-			location: location,
-			toolCalls: toolCalls,
-			numCtx: numCtx,
-		}, source.signedIn ? 'delete' : 'save').then(() => {
-			source.signedIn = !source.signedIn;
-		}).catch((e) => {
-			setError(e.message);
-		}).finally(() => {
+		if (providerConfig) {
+			props.onAction(
+				providerConfig,
+				source.signedIn ? 'delete' : 'save')
+				.catch((e) => {
+					setError(e.message);
+				}).finally(() => {
+					setShowProgress(false);
+				});
+		} else {
 			setShowProgress(false);
-		});
+			setError(localize('positron.newConnectionModalDialog.incompleteConfig', 'The configuration is incomplete.'));
+		}
 	}
 	const onCancel = async () => {
 		props.onCancel();
 		props.renderer.dispose();
-	}
-
-	function signInButton() {
-		return <Button className='language-model button sign-in' onPressed={onSignIn}>
-			{(() => {
-				if (source.signedIn) {
-					return localize('positron.newConnectionModalDialog.signOut', "Sign out");
-				} else {
-					return localize('positron.newConnectionModalDialog.signIn', "Sign in");
-				}
-			})()}
-		</Button>
 	}
 
 	function oldDialog() {
@@ -338,7 +352,11 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 								displayName={provider.options.title ?? provider.options.identifier}
 								identifier={provider.options.identifier}
 								selected={provider.options.identifier === source.provider.id}
-								onClick={() => setSource(provider.options.value)}
+								onClick={() => {
+									setSource(provider.options.value);
+									setProviderConfig({ ...provider.options.value, ...provider.options.value.defaults, provider: provider.options.identifier });
+									setError(undefined);
+								}}
 							/>
 						})
 					}
@@ -346,30 +364,30 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				<label className='language-model-section'>
 					{(() => localize('positron.newConnectionModalDialog.authentication', "Authentication"))()}
 				</label>
-				{source?.supportedOptions.includes('apiKey') &&
-					(
-						<div className='language-model-authentication-container' id='api-key-input'>
-							<LabeledTextInput
-								label={(() => localize('positron.newConnectionModalDialog.apiKey', "API Key"))()}
-								type='password'
-								validator={(value) => {
-									if (errorMessage) {
-										return errorMessage;
-									}
-									return value ? undefined : localize('positron.newConnectionModalDialog.missingApiKey', 'An API key is required')
-								}}
-								value={apiKey ?? ''}
-								onChange={e => { setApiKey(e.currentTarget.value) }}
-							/>
-							{signInButton()}
-						</div>
-					)
-				}
-				{!source?.supportedOptions.includes('apiKey') &&
-					signInButton()
-				}
+				<div className='language-model-authentication-method-container'>
+					<RadioGroup
+						entries={authMethodRadioButtons}
+						initialSelectionId='apiKey'
+						name='authMethod'
+						onSelectionChanged={(authMethod) => {
+							// setAuthMethod(authMethod);
+							console.log(authMethod);
+						}}
+					/>
+				</div>
+				<LanguageModelConfigComponent
+					provider={providerConfig}
+					source={source}
+					onChange={(config) => {
+						setProviderConfig(config);
+					}}
+					onSignIn={onSignIn}
+				/>
 				{showProgress &&
 					<ProgressBar />
+				}
+				{errorMessage &&
+					<div className='language-model-error error error-msg'>{errorMessage}</div>
 				}
 			</VerticalStack>
 		</OKModalDialog>;

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -181,8 +181,33 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		}))
 
 	const onAccept = () => {
-		props.onClose();
-		props.renderer.dispose();
+		if (useNewConfig) {
+			props.onClose();
+			props.renderer.dispose();
+		} else {
+			setShowProgress(true);
+			setError(undefined);
+			props.onAction({
+				type: type,
+				provider: source.provider.id,
+				model: model,
+				name: name,
+				apiKey: apiKey,
+				baseUrl: baseUrl,
+				resourceName: resourceName,
+				project: project,
+				location: location,
+				toolCalls: toolCalls,
+				numCtx: numCtx,
+			}, 'save')
+				.catch((e) => {
+					setError(e.message);
+				}).finally(() => {
+					setShowProgress(false);
+					props.onClose();
+					props.renderer.dispose();
+				});
+		}
 	}
 
 	const onSignIn = async () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -15,9 +15,7 @@ import { IChatRequestData, IPositronAssistantService, IPositronChatContext, IPos
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { showLanguageModelModalDialog } from './languageModelModalDialog.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { Emitter } from '../../../../base/common/event.js';
 
 /**
@@ -42,7 +40,6 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@ILayoutService private readonly _layoutService: ILayoutService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
@@ -110,11 +107,11 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 	}
 
 	getSupportedProviders(): string[] {
-		const providers = ['anthropic', 'google', 'copilot'];
+		const providers = ['anthropic'];
 		const useTestModels = this._configurationService.getValue<boolean>('positron.assistant.testModels');
 
-		if (IsDevelopmentContext.getValue(this._contextKeyService) || useTestModels) {
-			providers.push('bedrock', 'error', 'echo');
+		if (useTestModels) {
+			providers.push('bedrock', 'error', 'echo', 'google', 'copilot');
 		}
 		return providers;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->
Address #6613 
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Switches to new dialog for managing language models by default. The old one is still available by setting `positron.assistant.enable: false` in the `settings.json`.

There were some changes to the styling to match the colours and fix the high contrast setting. The dialog shows authentication options for OAuth and API key but only API key will be selectable until OAuth is implemented.

The TOS is displayed for the selected provider at the bottom if available. A new React component was created to allow the embedded links. The string can set the link by using markdown and the component will convert it into a link.

Without test models:
![image](https://github.com/user-attachments/assets/1525fbe1-a219-4fe3-8191-812f49179b94)

With test models
![image](https://github.com/user-attachments/assets/7f784b15-a22d-434a-ac98-cc6d648adade)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add new UI for adding Anthropic Claude using API key #6613 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
