### PR TITLE
Add positron.d.ts to eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1051,6 +1051,9 @@ export default tseslint.config(
 				{
 					'target': 'src/vs/workbench/api/~',
 					'restrictions': [
+						// --- Start Positron ---
+						'positron',
+						// --- End Positron ---
 						'vscode',
 						'vs/base/~',
 						'vs/base/parts/*/~',
@@ -1291,6 +1294,12 @@ export default tseslint.config(
 					'target': 'src/vscode-dts/**',
 					'restrictions': []
 				},
+				// --- Start Positron ---
+				{
+					'target': 'src/positron-dts/**',
+					'restrictions': ['vscode']
+				},
+				// --- End Positron ---
 				{
 					'target': 'src/bootstrap-window.ts',
 					'restrictions': []


### PR DESCRIPTION
Updating the eslint rule for local code imports. This allows `positron` to be imported with the same restrictions as importing `vscode`. It also fixes the import warning for `positron.d.ts` since it imports `vscode`.


No warnings!
![image](https://github.com/user-attachments/assets/76ce6752-c937-4b63-a4fc-75cf685f9bfe)
