### PR TITLE
e2e-test: expand outline test to include reload with R foreground/Python background

### DIFF
--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -85,6 +85,7 @@ test.describe('Session: Outline', {
 		const { outline, editor } = app.workbench;
 
 		// Start sessions
+		await sessions.deleteAll();
 		const [, rSession] = await sessions.start(['python', 'r']);
 
 		// Verify outlines for both file types
@@ -105,6 +106,32 @@ test.describe('Session: Outline', {
 		await sessions.select(rSession.id); // Issue 7052 - we shouldn't have to click the tab
 		await verifyROutline(outline);
 	});
+
+	test('Verify outline after reload with Python in foreground and R in background',
+		async function ({ app, runCommand, sessions }) {
+			const { outline, editor } = app.workbench;
+
+			// Start sessions
+			await sessions.deleteAll();
+			await sessions.start(['r', 'python']);
+
+			// Verify outlines for both file types
+			await editor.selectTab(R_FILE);
+			await verifyROutline(outline);
+
+			await editor.selectTab(PY_FILE);
+			await verifyPythonOutline(outline);
+
+			// Reload window
+			await runCommand('workbench.action.reloadWindow');
+
+			// Verify outlines for both file types
+			await editor.selectTab(R_FILE);
+			await verifyROutline(outline);
+
+			await editor.selectTab(PY_FILE);
+			await verifyPythonOutline(outline);
+		});
 });
 
 async function verifyPythonOutline(outline: Outline) {

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -79,7 +79,7 @@ test.describe('Session: Outline', {
 		await verifyPythonOutline(outline);
 	});
 
-	test('Verify outline after reload with R in foreground and Python in background', {
+	test('Verify outline after reload with Python in foreground and R in background', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7052' }],
 	}, async function ({ app, runCommand, sessions }) {
 		const { outline, editor } = app.workbench;
@@ -107,7 +107,7 @@ test.describe('Session: Outline', {
 		await verifyROutline(outline);
 	});
 
-	test('Verify outline after reload with Python in foreground and R in background',
+	test('Verify outline after reload with R in foreground and Python in background',
 		async function ({ app, runCommand, sessions }) {
 			const { outline, editor } = app.workbench;
 


### PR DESCRIPTION
### Summary

Expanding outline test coverage to include scenario of R session in background on reload.


### QA Notes

@:sessions