### PR TITLE
Bump ark to 0.1.177

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -766,7 +766,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.176"
+      "ark": "0.1.177"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/745

- https://github.com/posit-dev/positron/issues/4158

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- duckplyr data frames are no longer immediately materialized by the variables pane. This also requires the [development version of duckplyr](https://github.com/tidyverse/duckplyr/pull/661). https://github.com/posit-dev/positron/issues/4158


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
