### PR TITLE
python: status bar path should not be clickable

### DIFF
--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -83,9 +83,12 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             };
             this.disposableRegistry.push(this.languageStatus);
         } else {
-            const [alignment, priority] = [StatusBarAlignment.Right, STATUS_BAR_ITEM_PRIORITY];
+            // --- Start Positron ---
+            // remove command to open interpreter dropdown and move to left hand side
+            const [alignment, priority] = [StatusBarAlignment.Left, STATUS_BAR_ITEM_PRIORITY];
             this.statusBar = application.createStatusBarItem(alignment, priority, 'python.selectedInterpreterDisplay');
-            this.statusBar.command = Commands.Set_Interpreter;
+            // this.statusBar.command = Commands.Set_Interpreter;
+            // --- End Positron ---
             this.disposableRegistry.push(this.statusBar);
             this.statusBar.name = Interpreters.selectedPythonInterpreter;
         }

--- a/extensions/positron-python/src/client/interpreter/display/index.ts
+++ b/extensions/positron-python/src/client/interpreter/display/index.ts
@@ -137,7 +137,7 @@ export class InterpreterDisplay implements IInterpreterDisplay, IExtensionSingle
             if (interpreter) {
                 this.statusBar.color = '';
                 // --- Start Positron ---
-                this.statusBar.tooltip = InterpreterQuickPickList.browsePath.openButtonLabel;
+                this.statusBar.tooltip = l10n.t('Active Interpreter');
                 // --- End Positron ---
                 if (this.currentlySelectedInterpreterPath !== interpreter.path) {
                     traceLog(

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -105,9 +105,12 @@ suite('Interpreters Display', () => {
             applicationShell
                 .setup((a) =>
                     a.createStatusBarItem(
-                        TypeMoq.It.isValue(StatusBarAlignment.Right),
+                        // --- Start Positron ---
+                        // we moved status bar to the left
+                        TypeMoq.It.isValue(StatusBarAlignment.Left),
                         TypeMoq.It.isAny(),
-                        TypeMoq.It.isAny(),
+                        TypeMoq.It.isValue('python.selectedInterpreterDisplay'),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => statusBar.object);
@@ -154,11 +157,17 @@ suite('Interpreters Display', () => {
                                 title: InterpreterQuickPickList.browsePath.openButtonLabel,
                                 command: Commands.Set_Interpreter,
                             })),
-                        TypeMoq.Times.once(),
+                        // --- Start Positron ---
+                        // should not have any command set
+                        TypeMoq.Times.never(),
+                        // --- End Positron ---
                     );
                     expect(disposableRegistry).contain(languageStatusItem.object);
                 } else {
-                    statusBar.verify((s) => (s.command = TypeMoq.It.isAny()), TypeMoq.Times.once());
+                    // --- Start Positron ---
+                    // No command should be set for status bar
+                    statusBar.verify((s) => (s.command = TypeMoq.It.isAny()), TypeMoq.Times.never());
+                    // --- End Positron ---
                     expect(disposableRegistry).contain(statusBar.object);
                 }
                 expect(disposableRegistry).to.be.lengthOf.above(0);
@@ -202,7 +211,7 @@ suite('Interpreters Display', () => {
                         TypeMoq.Times.once(),
                     );
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')!),
+                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)!),
                         TypeMoq.Times.atLeastOnce(),
                     );
                     // --- End Positron ---
@@ -270,7 +279,7 @@ suite('Interpreters Display', () => {
                     // --- Start Positron ---
                     // Tooltip should be "Select Interpreter"
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')),
+                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)),
                         TypeMoq.Times.atLeastOnce(),
                     );
                     // --- End Positron ---
@@ -366,7 +375,7 @@ suite('Interpreters Display', () => {
                         TypeMoq.Times.once(),
                     );
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue('Select Interpreter')!),
+                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)!),
                         TypeMoq.Times.atLeastOnce(),
                     );
                     // --- End Positron ---

--- a/extensions/positron-python/src/test/interpreters/display.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/display.unit.test.ts
@@ -154,7 +154,7 @@ suite('Interpreters Display', () => {
                     languageStatusItem.verify(
                         (s) =>
                             (s.command = TypeMoq.It.isValue({
-                                title: InterpreterQuickPickList.browsePath.openButtonLabel,
+                                title: 'Active Interpreter',
                                 command: Commands.Set_Interpreter,
                             })),
                         // --- Start Positron ---
@@ -211,8 +211,11 @@ suite('Interpreters Display', () => {
                         TypeMoq.Times.once(),
                     );
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)!),
+                        // --- Start Positron ---
+                        // Tooltip should be "Active Interpreter"
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Active Interpreter')!),
                         TypeMoq.Times.atLeastOnce(),
+                        // --- End Positron ---
                     );
                     // --- End Positron ---
                 }
@@ -245,7 +248,7 @@ suite('Interpreters Display', () => {
             });
             // --- Start Positron ---
             // rename test to reflect reality
-            test('Tooltip should be "Select Interpreter"', async () => {
+            test('Tooltip should be "Active Interpreter"', async () => {
                 // --- End Positron ---
                 const resource = Uri.file('x');
                 const pythonPath = path.join('user', 'development', 'env', 'bin', 'python');
@@ -277,9 +280,9 @@ suite('Interpreters Display', () => {
                     );
                 } else {
                     // --- Start Positron ---
-                    // Tooltip should be "Select Interpreter"
+                    // Tooltip should be "Active Interpreter"
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)),
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Active Interpreter')),
                         TypeMoq.Times.atLeastOnce(),
                     );
                     // --- End Positron ---
@@ -369,13 +372,13 @@ suite('Interpreters Display', () => {
                     );
                 } else {
                     // --- Start Positron ---
-                    // Status bar should display path, tooltip should say Select Interpreter
+                    // Status bar should display path, tooltip should say Active Interpreter
                     statusBar.verify(
                         (s) => (s.text = TypeMoq.It.isValue(activeInterpreter.path)!),
                         TypeMoq.Times.once(),
                     );
                     statusBar.verify(
-                        (s) => (s.tooltip = TypeMoq.It.isValue(InterpreterQuickPickList.browsePath.openButtonLabel)!),
+                        (s) => (s.tooltip = TypeMoq.It.isValue('Active Interpreter')!),
                         TypeMoq.Times.atLeastOnce(),
                     );
                     // --- End Positron ---


### PR DESCRIPTION
After discussion, it was decided that the python interpreter path in the status bar should no longer be clickable. We should encourage users instead to go through the Positron interpreter selector as normal.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #7001 Python path on status bar no longer pulls up interpreter selection

#### Bug Fixes

- N/A


### QA Notes

Open Python file.
See interpreter path, click on it. 
Nothing should happen.