### PR TITLE
e2e-test: wait for no startup messaging after reload due to user settings

### DIFF
--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -76,7 +76,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 	restartApp: [async ({ app }, use) => {
 		await app.restart();
-		await app.workbench.sessions.expectAllSessionsToBeReady();
+		await app.workbench.sessions.expectNoStartUpMessaging();
 
 		await use(app);
 	}, { scope: 'test', timeout: 60000 }],
@@ -86,7 +86,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 		try {
 			await app.start();
-			await app.workbench.sessions.expectAllSessionsToBeReady();
+			await app.workbench.sessions.expectNoStartUpMessaging();
 
 			await use(app);
 		} catch (error) {
@@ -227,6 +227,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 			restartApp = false
 		) => {
 			await userSettings.setUserSettings(settings, restartApp);
+			await app.workbench.sessions.expectNoStartUpMessaging();
 		};
 
 		await use({


### PR DESCRIPTION
### Summary
It's kind of odd (and predictable) that this didn't manifest in the PR runs, but I suspect all that's missing is the wait for no startup messaging when we reload per usage of custom user settings. I also updated so "app start" and "app restart" also are using the same method to confirm things have loaded.

### QA Notes

@:sessions
