### PR TITLE
Fix Python shutdown hangs

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -459,7 +459,15 @@ class PositronJediLanguageServer(JediLanguageServer):
         # Start Jedi LSP as an asyncio TCP server in a separate thread.
         logger.info("Starting LSP server thread")
         self._server_thread = threading.Thread(
-            target=self.start_tcp, args=(lsp_host,), name="LSPServerThread"
+            target=self.start_tcp,
+            args=(lsp_host,),
+            name="LSPServerThread",
+            # Allow the kernel process to exit while this thread is still running.
+            # We already try to exit the language server cleanly in both the kernel
+            # and the client. If that fails unexpectedly, we don't want the process
+            # to hang.
+            # See: https://github.com/posit-dev/positron/issues/7083.
+            daemon=True,
         )
         self._server_thread.start()
 


### PR DESCRIPTION
Addresses #7083.

### QA Notes

e2e: @:sessions @:console