### PR TITLE
Update `getPlot` to use the plot image directly instead of a summary

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -71,7 +71,18 @@
             }
           }
         },
-        "tags": ["positron-assistant"]
+        "tags": [
+          "positron-assistant"
+        ]
+      },
+      {
+        "name": "getPlot",
+        "displayName": "Get active plot",
+        "modelDescription": "Get the current active plot that is visible to the user.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ]
       }
     ]
   },

--- a/extensions/positron-assistant/src/commands/default.ts
+++ b/extensions/positron-assistant/src/commands/default.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 
 import { EXTENSION_ROOT_DIR } from '../constants';
 import { arrayBufferToBase64, BinaryMessageReferences, toLanguageModelChatMessage } from '../utils';
-import { documentEditToolAdapter, getPlotToolAdapter, selectionEditToolAdapter } from '../tools';
+import { documentEditToolAdapter, selectionEditToolAdapter } from '../tools';
 
 const mdDir = `${EXTENSION_ROOT_DIR}/src/md/`;
 
@@ -46,7 +46,6 @@ export async function defaultHandler(
 			}
 			return true;
 		}),
-		getPlotToolAdapter.toolData,
 	];
 
 	// Binary references for use by the Language Model
@@ -230,7 +229,7 @@ export async function defaultHandler(
 
 			const newHistory = [
 				...messages,
-				vscode.LanguageModelChatMessage.User(textResponses),
+				vscode.LanguageModelChatMessage.Assistant(textResponses),
 				vscode.LanguageModelChatMessage.Assistant(toolRequests),
 				vscode.LanguageModelChatMessage.User(
 					Object.entries(toolResponses).map(([id, resp]) => {

--- a/extensions/positron-assistant/src/languageModelParts.ts
+++ b/extensions/positron-assistant/src/languageModelParts.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * This module defines a custom language model image part, allowing tools to
+ * return images to language models. Ideally this would be implemented directly
+ * in the VSCode API.
+ *
+ * Tools can return a {@link vscode.LanguageModelPromptTsxPart} with `value`
+ * set to the result of {@link LanguageModelImage.toJSON}. For example, see
+ * the `getPlot` tool implementation. Note that this does not seem to be the
+ * intended use of prompt TSX parts, but works for now.
+ *
+ * Models can check whether a part is an image using {@link isLanguageModelImagePart},
+ * and handle the part accordingly.
+ */
+
+enum CustomLanguageModelPartType {
+	Image = 'image',
+}
+
+export interface LanguageModelImagePart {
+	readonly value: LanguageModelImage;
+}
+
+export class LanguageModelImage {
+	readonly mimeType: string;
+	readonly base64: string;
+
+	constructor(mimeType: string, base64: string) {
+		this.mimeType = mimeType;
+		this.base64 = base64;
+	}
+
+	toJSON(): any {
+		return {
+			$positronType: CustomLanguageModelPartType.Image,
+			mimeType: this.mimeType,
+			base64: this.base64,
+		};
+	}
+}
+
+export function isLanguageModelImagePart(part: unknown): part is LanguageModelImagePart {
+	return part instanceof vscode.LanguageModelPromptTsxPart &&
+		part.value !== null &&
+		typeof part.value === 'object' &&
+		'$positronType' in part.value &&
+		part.value.$positronType === CustomLanguageModelPartType.Image;
+}


### PR DESCRIPTION
Address #7085. This PR updates the `getPlot` tool to use the plot image directly instead of a summary.

I ended up using `vscode.LanguageModelPromptTsxPart` as a way to send the image data as a tool result. We could also update the VSCode API adding a `LanguageModelImagePart` but I suspect upstream will do similar at some point. The prompt TSX hack also lets us send arbitrary JSON serializable interfaces to the language model in case it needs to inspect/modify the result.

The main reason for this work is actually to implement `getPlot` for non-Vercel models e.g. one using the Anthropic SDK.

### QA Notes

Ask the model a question about the current active plot. Nothing else should have broken, in particular all other tools should still be good.