### PR TITLE
Updates variable pane switcher labelling

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -949,7 +949,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		if (this.dynState.currentNotebookUri) {
 			return basename(this.dynState.currentNotebookUri);
 		}
-		return this.runtimeMetadata.runtimeName;
+		return this.metadata.sessionName;
 	}
 	static clientCounter = 0;
 

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -28,7 +28,7 @@ export const VariablesInstanceMenuButton = () => {
 	// Helper method to calculate the label for a runtime.
 	const labelForRuntime = (session?: ILanguageRuntimeSession): string => {
 		if (session) {
-			return session.getLabel();
+			return session.metadata.sessionName;
 		}
 		return 'None';
 	};

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -28,7 +28,7 @@ export const VariablesInstanceMenuButton = () => {
 	// Helper method to calculate the label for a runtime.
 	const labelForRuntime = (session?: ILanguageRuntimeSession): string => {
 		if (session) {
-			return session.metadata.sessionName;
+			return session.getLabel();
 		}
 		return 'None';
 	};


### PR DESCRIPTION
Variables pane now keyed by session name instead of runtime name. 

<img width="806" alt="Screenshot 2025-04-02 at 9 27 48 AM" src="https://github.com/user-attachments/assets/ec30509e-aa4b-4cd1-b7e4-3770c5b7ec99" />


Addresses #7087

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Variables pane switcher matches other session switchers

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:sessions @:variables @:notebooks