### PR TITLE
E2E test: skip "cat from .Rprofile" test step for now

### DIFF
--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -38,7 +38,7 @@ test.describe('Console Pane: R', {
 			await app.workbench.console.barClearButton.click();
 			await app.workbench.console.barRestartButton.click();
 			await app.workbench.console.waitForReady('>');
-			await app.workbench.console.waitForConsoleContents('cat from .Rprofile'); // 6344 validation
+			// await app.workbench.console.waitForConsoleContents('cat from .Rprofile'); // add back when Davis gives the go ahead
 		}).toPass();
 	});
 


### PR DESCRIPTION
Skipping check that can result in flakes at the moment.

### QA Notes
