### PR TITLE
e2e-test: unskip session-state test

### DIFF
--- a/test/e2e/pages/editor.ts
+++ b/test/e2e/pages/editor.ts
@@ -41,7 +41,9 @@ export class Editor {
 	 * @param filename the name of the tab to select
 	 */
 	async selectTab(filename: string): Promise<void> {
-		await this.code.driver.page.getByRole('tab', { name: filename }).click();
+		await test.step(`Select tab ${filename}`, async () => {
+			await this.code.driver.page.getByRole('tab', { name: filename }).click();
+		});
 	}
 
 	/**

--- a/test/e2e/pages/outline.ts
+++ b/test/e2e/pages/outline.ts
@@ -7,7 +7,7 @@
 import { fail } from 'assert';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
-import { expect } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 
 const HORIZONTAL_SASH = '.explorer-viewlet .monaco-sash.horizontal';
 const FOCUS_OUTLINE_COMMAND = 'outline.focus';
@@ -65,20 +65,26 @@ export class Outline {
 	}
 
 	async expectOutlineElementToBeVisible(text: string, visible = true): Promise<void> {
-		visible
-			? await expect(this.outlineElement.filter({ hasText: text })).toBeVisible()
-			: await expect(this.outlineElement.filter({ hasText: text })).not.toBeVisible();
+		await test.step(`Expect outline element to be ${visible ? 'visible' : 'not visible'}: ${text}`, async () => {
+			visible
+				? await expect(this.outlineElement.filter({ hasText: text })).toBeVisible()
+				: await expect(this.outlineElement.filter({ hasText: text })).not.toBeVisible();
+		});
 	}
 
 	async expectOutlineToBeEmpty(): Promise<void> {
-		await expect(this.code.driver.page.getByText(/^No symbols found in document/)).toBeVisible();
+		await test.step('Expect outline to be empty', async () => {
+			await expect(this.code.driver.page.getByText(/^No symbols found in document/)).toBeVisible();
+		});
 	}
 
 	async expectOutlineElementCountToBe(count: number): Promise<void> {
-		if (count === 0) {
-			await expect(this.outlineElement).not.toBeVisible();
-		}
-		await expect(this.outlineElement).toHaveCount(count);
+		await test.step(`Expect outline element count to be ${count}`, async () => {
+			if (count === 0) {
+				await expect(this.outlineElement).not.toBeVisible();
+			}
+			await expect(this.outlineElement).toHaveCount(count);
+		});
 	}
 
 	async expectOutlineToContain(expected: string[]): Promise<void> {

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1080,7 +1080,3 @@ export const availableRuntimes: { [key: string]: SessionInfo } = {
 	pythonAlt: { ...pythonSessionAlt },
 	pythonHidden: { ...pythonSessionHidden },
 };
-
-const availableRuntimesNameToKeyMap = new Map(
-	Object.entries(availableRuntimes).map(([key, runtime]) => [runtime.name, key])
-);

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -442,8 +442,6 @@ export class Sessions {
 			if (waitForReady) {
 				await expect(this.page.getByText(/starting/)).toBeVisible();
 				await expect(this.page.getByText(/starting/)).not.toBeVisible({ timeout: 90000 });
-				// const sessionId = await this.getCurrentSessionId();
-				// await this.expectStatusToBe(sessionId, 'idle');
 			}
 			return this.getCurrentSessionId();
 		});

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -568,8 +568,6 @@ export class Sessions {
 
 			if (infoButtonCount === 0) {
 				throw new Error('No active session');
-			} else if (infoButtonCount > 1) {
-				throw new Error('Multiple info buttons found');
 			}
 
 			const testId = await infoButton.getAttribute('data-testid');

--- a/test/e2e/tests/sessions/session-delete.test.ts
+++ b/test/e2e/tests/sessions/session-delete.test.ts
@@ -31,8 +31,7 @@ test.describe('Sessions: Delete', {
 		await sessions.expectSessionCountToBe(0);
 	});
 
-	test.skip('Validate session picker and variables after delete', {
-		annotation: [{ type: 'issue', description: 'the variables dropdown does not match session name' }],
+	test('Validate session picker and variables after delete', {
 		tag: [tags.VARIABLES]
 	}, async function ({ app, sessions }) {
 		const { variables } = app.workbench;

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -79,14 +79,14 @@ test.describe('Session: Outline', {
 		await verifyPythonOutline(outline);
 	});
 
-	test('Verify outline after reload with Python in foreground and R in background', {
+	test.skip('Verify outline after reload with Python in foreground and R in background', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7052' }],
 	}, async function ({ app, runCommand, sessions }) {
 		const { outline, editor } = app.workbench;
 
 		// Start sessions
 		await sessions.deleteAll();
-		const [, rSession] = await sessions.start(['python', 'r']);
+		await sessions.start(['python', 'r']);
 
 		// Verify outlines for both file types
 		await editor.selectTab(PY_FILE);
@@ -103,7 +103,6 @@ test.describe('Session: Outline', {
 		await verifyPythonOutline(outline);
 
 		await editor.selectTab(R_FILE);
-		await sessions.select(rSession.id); // Issue 7052 - we shouldn't have to click the tab
 		await verifyROutline(outline);
 	});
 

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -96,7 +96,9 @@ test.describe('Session: Outline', {
 		await verifyROutline(outline);
 
 		// Reload window
+		await sessions.expectSessionCountToBe(2);
 		await runCommand('workbench.action.reloadWindow');
+		await sessions.expectSessionCountToBe(2);
 
 		// Verify outlines for both file types
 		await editor.selectTab(PY_FILE);

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -31,7 +31,7 @@ test.describe('Session: Outline', {
 		await outline.focus();
 	});
 
-	test('Verify outline is based on editor and per session', async function ({ app, openFile, sessions }) {
+	test('Verify outline is based on editor and per session', async function ({ app, sessions }) {
 		const { outline, console, editor } = app.workbench;
 
 		// No active session - verify no outlines
@@ -79,14 +79,14 @@ test.describe('Session: Outline', {
 		await verifyPythonOutline(outline);
 	});
 
-	test.skip('Verify outline after reload with Python in foreground and R in background', {
+	test('Verify outline after reload with Python in foreground and R in background', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7052' }],
 	}, async function ({ app, runCommand, sessions }) {
 		const { outline, editor } = app.workbench;
 
 		// Start sessions
 		await sessions.deleteAll();
-		await sessions.start(['python', 'r']);
+		const [, rSession] = await sessions.start(['python', 'r']);
 
 		// Verify outlines for both file types
 		await editor.selectTab(PY_FILE);
@@ -105,6 +105,7 @@ test.describe('Session: Outline', {
 		await verifyPythonOutline(outline);
 
 		await editor.selectTab(R_FILE);
+		await sessions.select(rSession.id); // Issue 7052 - we shouldn't have to click the tab
 		await verifyROutline(outline);
 	});
 


### PR DESCRIPTION
### Summary
A handful of session test updates:
* fixed bug in session create logic, in which sessions were created out of order
* improved metadata verifications
* fixed and unskipped `session-state.test.ts`
* unskipped variables mismatch test in `session-delete.test.ts` as this was just fixed

### QA Notes

@:sessions @:web
