### PR TITLE
Add supervisor version check

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -400,6 +400,17 @@ export class KCApi implements PositronSupervisorApi {
 			try {
 				const status = await this._api.serverStatus();
 				this._log.appendLine(`Kallichore ${status.body.version} server online with ${status.body.sessions} sessions`);
+
+				// Make sure the version is the one expected in package.json.
+				const version = this._context.extension.packageJSON.positron.binaryDependencies.kallichore;
+				if (status.body.version !== version) {
+					vscode.window.showWarningMessage(vscode.l10n.t(
+						'Positron Supervisor version {0} is unsupported (expected {1}). ' +
+						'This may result in unexpected behavior or errors.',
+						status.body.version,
+						version)
+					);
+				}
 				break;
 			} catch (err) {
 				const elapsed = Date.now() - startTime;


### PR DESCRIPTION
Adds a warning toast if you're using a version of the supervisor that doesn't match the one Positron wants.

<img width="506" alt="image" src="https://github.com/user-attachments/assets/98eb5526-7729-4f61-b479-260f79b3554d" />

Addresses https://github.com/posit-dev/positron/issues/7091.
