### PR TITLE
ci: bump Playwright back to 1.51

### DIFF
--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -53,7 +53,7 @@ jobs:
           npm install typescript
 
           # Install required dependencies - must keep in sync with root package.json
-          npm install @playwright/test@^1.51.0
+          npm install @playwright/test@^1.51.1
           npx playwright install
           npx playwright install-deps
           npm install @currents/playwright@^1.11.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
         "yazl": "^2.4.3"
       },
       "devDependencies": {
-        "@currents/playwright": "^1.11.2",
+        "@currents/playwright": "^1.11.7",
         "@midleman/github-actions-reporter": "^1.9.5",
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.51.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
         "@swc/core": "1.3.62",
         "@types/cookie": "^0.3.3",
@@ -1233,17 +1233,16 @@
       }
     },
     "node_modules/@currents/playwright": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.11.4.tgz",
-      "integrity": "sha512-f1gcxXA5wNoPYci7ccayYEUq4N+QkiPbiRE4hasUbF75EWqHFlTFCLtEOQUXoVPz5mJLp48F1ZeDPnJiqADf6g==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.11.7.tgz",
+      "integrity": "sha512-2KO8n6QwmJjHa5gT1JFYsYc43E9KTg1W2L6KsT5wmlgVctl4isFrIAhVEracCvcuhRS4+523yWA/D8+o4iWzjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@commander-js/extra-typings": "^12.1.0",
         "@currents/commit-info": "1.0.1-beta.0",
         "async-retry": "^1.3.3",
-        "axios": "^1.8.2",
+        "axios": "^1.8.3",
         "axios-retry": "^4.5.0",
         "c12": "^1.11.2",
         "chalk": "^4.1.2",
@@ -1271,7 +1270,7 @@
         "stack-utils": "^2.0.6",
         "tmp": "^0.2.3",
         "tmp-promise": "^3.0.3",
-        "ts-pattern": "^5.6.0",
+        "ts-pattern": "^5.6.2",
         "ws": "^8.18.1"
       },
       "bin": {
@@ -2362,13 +2361,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15151,13 +15149,12 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15183,11 +15180,10 @@
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -134,9 +134,9 @@
     "http-proxy": "^1.18.1"
   },
   "devDependencies": {
-    "@currents/playwright": "^1.11.2",
+    "@currents/playwright": "^1.11.7",
     "@midleman/github-actions-reporter": "^1.9.5",
-    "@playwright/test": "^1.50.0",
+    "@playwright/test": "^1.51.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@swc/core": "1.3.62",
     "@types/cookie": "^0.3.3",


### PR DESCRIPTION
### QA Notes
Looks like during our latest upstream merge our Playwright version got downgraded. I noticed this because the metadata was missing from our trace reports.

### QA Notes

n/a
