### PR TITLE
Fix references in Python notebooks

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -836,8 +836,8 @@ def positron_hover(
     return None
 
 
-@notebook_utils.supports_notebooks
 @POSITRON.feature(TEXT_DOCUMENT_REFERENCES)
+@notebook_utils.supports_notebooks
 def positron_references(
     server: PositronJediLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[List[Location]]:


### PR DESCRIPTION
Noticed this one during my demo today 😄

#### New Features

- N/A

#### Bug Fixes

- Fix "Go to References" in Python notebooks.