### PR TITLE
Make content emitted from `.Rprofile` display more reliably

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -136,7 +136,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.35"
+      "kallichore": "0.1.36"
     }
   },
   "extensionDependencies": [

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1590,6 +1590,10 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			}
 		}
 
+		// Ensure the kernel is ready; otherwise messages will be emitted to the
+		// frontend before the kernel is "started"
+		this._ready.wait();
+
 		// Translate the Jupyter message to a LanguageRuntimeMessage and emit it
 		this._messages.emitJupyter(msg);
 	}

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -38,7 +38,7 @@ test.describe('Console Pane: R', {
 			await app.workbench.console.barClearButton.click();
 			await app.workbench.console.barRestartButton.click();
 			await app.workbench.console.waitForReady('>');
-			// await app.workbench.console.waitForConsoleContents('cat from .Rprofile'); // add back when Davis gives the go ahead
+			await app.workbench.console.waitForConsoleContents('cat from .Rprofile');
 		}).toPass();
 	});
 


### PR DESCRIPTION
This change is (another) attempt to address https://github.com/posit-dev/positron/issues/6344.

The main body of the fix is in the kernel supervisor (https://github.com/posit-dev/kallichore/pull/30). It was dropping iopub messages while waiting for a `kernel_info_reply`; these messages are now saved and sent to the client after the reply has been processed.

Getting this content more reliably introduced a new problem: because websockets are so fast, it's easy for statements emitted from `.Rprofile` to reach the client _before_ the kernel info! So you can wind up in a situation wherein you see your Rprofile's output in the Console _above_ the startup banner. To help guard against this, I've added a guard to prevent Jupyter messages from getting streamed until the kernel is marked ready. There's some risk this could cause other issues, so we may need to consider a different (read: more complicated) approach to this problem.

Test tags: `@:console`