### PR TITLE
ci: disable currents report on full test suite

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -33,7 +33,7 @@ on:
         description: "Whether or not to report results to TestRail."
         default: false
         type: boolean
-      enable_currents_reporter:
+      report_currents:
         required: false
         description: "Whether or not to report results to Currents."
         type: boolean
@@ -165,7 +165,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/ubuntu' }}
-          ENABLE_CURRENTS_REPORTER: ${{ inputs.enable_currents_reporter }}
+          ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
         run: |
           echo "Processing skip_tags input: '${{ inputs.skip_tags }}'"

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -27,7 +27,7 @@ on:
         description: "Whether or not to report results to TestRail."
         default: false
         type: boolean
-      enable_currents_reporter:
+      report_currents:
         required: false
         description: "Whether or not to report results to Currents."
         type: boolean
@@ -187,7 +187,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }} # only works on push events
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
-          ENABLE_CURRENTS_REPORTER: ${{ inputs.enable_currents_reporter }}
+          ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
         run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -55,6 +55,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: ${{ github.event_name == 'schedule' && 'nightly,electron/ubuntu' || 'electron/ubuntu' }}
       report_testrail: false
+      report_currents: false
       install_undetectable_interpreters: true
       install_license: false
 
@@ -68,6 +69,7 @@ jobs:
       display_name: "electron (win)"
       currents_tags: ${{ github.event_name == 'schedule' && 'nightly,electron/win' || 'electron/win' }}
       report_testrail: false
+      report_currents: false
 
   e2e-browser:
     name: e2e
@@ -80,6 +82,7 @@ jobs:
       display_name: "browser (ubuntu)"
       currents_tags: ${{ github.event_name == 'schedule' && 'nightly,browser/ubuntu' || 'browser/ubuntu' }}
       report_testrail: false
+      report_currents: false
       install_undetectable_interpreters: true
       install_license: true
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
       display_name: "electron (ubuntu)"
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
-      enable_currents_reporter: false
+      report_currents: false
       install_undetectable_interpreters: false
       install_license: false
       skip_tags: "@:nightly-only"
@@ -54,7 +54,7 @@ jobs:
       display_name: "electron (windows)"
       currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
-      enable_currents_reporter: false
+      report_currents: false
     secrets: inherit
 
   e2e-ubuntu-browser:
@@ -68,7 +68,7 @@ jobs:
       project: "e2e-browser"
       currents_tags: "pull-request,browser/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
-      enable_currents_reporter: false
+      report_currents: false
       install_undetectable_interpreters: false
       install_license: true
       skip_tags: "@:nightly-only"


### PR DESCRIPTION
### Summary
PR for https://github.com/posit-dev/positron/issues/7003

Disabling reporting to Currents when we trigger the Full Test Suite workflow.


### QA Notes

n/a
