### PR TITLE
Improve `getPlot` tool

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -77,8 +77,8 @@
       },
       {
         "name": "getPlot",
-        "displayName": "Get active plot",
-        "modelDescription": "Get the current active plot that is visible to the user.",
+        "displayName": "View active plot",
+        "modelDescription": "View the current active plot if one exists.",
         "canBeReferencedInPrompt": false,
         "tags": [
           "positron-assistant"

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -78,7 +78,7 @@
       {
         "name": "getPlot",
         "displayName": "View active plot",
-        "modelDescription": "View the current active plot if one exists.",
+        "modelDescription": "View the current active plot if one exists. Don't invoke this tool if there are no plots in the session.",
         "canBeReferencedInPrompt": false,
         "tags": [
           "positron-assistant"

--- a/extensions/positron-assistant/src/commands/default.ts
+++ b/extensions/positron-assistant/src/commands/default.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import { EXTENSION_ROOT_DIR } from '../constants';
 import { arrayBufferToBase64, BinaryMessageReferences, toLanguageModelChatMessage } from '../utils';
 import { documentEditToolAdapter, selectionEditToolAdapter } from '../tools';
+import { PositronAssistantToolName } from '../tools.js';
 
 const mdDir = `${EXTENSION_ROOT_DIR}/src/md/`;
 
@@ -41,7 +42,7 @@ export async function defaultHandler(
 			// CONSIDER: It would be better for us to introspect the tool itself
 			// to see if it requires confirmation, but that information isn't
 			// currently exposed in `vscode.LanguageModelChatTool`.
-			if (tool.name === 'executeCode' && request.location2) {
+			if (tool.name === PositronAssistantToolName.ExecuteCode && request.location2) {
 				return false;
 			}
 			return true;

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -11,6 +11,11 @@ import { z } from 'zod';
 import { padBase64String } from './utils';
 import { LanguageModelImage } from './languageModelParts.js';
 
+export enum PositronAssistantToolName {
+	ExecuteCode = 'executeCode',
+	GetPlot = 'getPlot',
+}
+
 export interface PositronToolAdapter {
 	toolData: vscode.LanguageModelChatTool;
 	provideAiTool(token: unknown, toolOptions: unknown): ai.Tool<any, string>;

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as ai from 'ai';
 import { isLanguageModelImagePart } from './languageModelParts.js';
+import { PositronAssistantToolName } from './tools.js';
 
 /**
  * Convert messages from VSCode Language Model format to Vercel AI format.
@@ -47,7 +48,7 @@ export function toAIMessage(messages: vscode.LanguageModelChatMessage[]): ai.Cor
 			if (toolParts.length > 0) {
 				toolParts.forEach((part) => {
 					const toolCall = toolCalls[part.callId];
-					if (toolCall.name === 'getPlot') {
+					if (toolCall.name === PositronAssistantToolName.GetPlot) {
 						aiMessages.push(getPlotToolResultToAiMessage(part));
 					} else {
 						aiMessages.push({
@@ -71,7 +72,7 @@ export function toAIMessage(messages: vscode.LanguageModelChatMessage[]): ai.Cor
 					if (part instanceof vscode.LanguageModelTextPart) {
 						return { type: 'text', text: part.value };
 					} else if (part instanceof vscode.LanguageModelToolCallPart) {
-						if (part.name === 'getPlot') {
+						if (part.name === PositronAssistantToolName.GetPlot) {
 							// Vercel AI does not yet support image tool results,
 							// so replace getPlot tool calls with text asking for the plot.
 							// The corresponding tool result will be replaced with a user

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -60,6 +60,9 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 				language: runtimeMetadata?.languageName ?? '',
 				version: runtimeMetadata?.languageVersion ?? '',
 			},
+			plots: {
+				hasPlots: this.getCurrentPlotUri() !== undefined,
+			},
 			variables: variablesInstance?.variableItems.map((item) => {
 				return {
 					name: item.displayName,

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -21,6 +21,9 @@ export interface IPositronChatContext {
 		language: string;
 		version: string;
 	};
+	plots?: {
+		hasPlots: boolean;
+	};
 	variables?: {
 		name: string;
 		value: string;


### PR DESCRIPTION
Some polishing of the plot tool:

1. Reword the model description to suggest that a plot may not exist.
2. Add `hasPlots` bool to the Positron chat context. Addresses https://github.com/posit-dev/positron/issues/6617.
3. Neater invocation and past tense messages.

<img width="471" alt="image" src="https://github.com/user-attachments/assets/08e8f22c-08bf-4ca3-94c4-3500a2f001c2" />
