### PR TITLE
e2e-test: skip sessions reload test due to known issues

### DIFF
--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -113,7 +113,7 @@ test.describe('Sessions: Management', {
 		await sessions.expectActiveSessionListsToMatch();
 	});
 
-	test('Validate session, console, variables, and plots persist after reload',
+	test.skip('Validate session, console, variables, and plots persist after reload',
 		{
 			tag: [tags.VARIABLES, tags.PLOTS],
 			annotation: [


### PR DESCRIPTION
### Summary

Skipping because right now this sometimes causes pipeline to fail.


### QA Notes

n/a
