### PR TITLE
e2e-test: fix flake of metadata dialog closing prematurely

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -697,9 +697,12 @@ export class Sessions {
 	* Action: Open the metadata dialog for the current session
 	*/
 	async openMetadataDialog() {
-		await this.metadataButton.click();
-		await this.page.mouse.move(0, 0);
-		await expect(this.metadataDialog).toBeVisible();
+		await expect(async () => {
+			await this.metadataButton.click();
+			await this.page.mouse.move(0, 0);
+			await this.page.waitForTimeout(500);
+			await expect(this.metadataDialog).toBeVisible();
+		}).toPass();
 	}
 
 	// -- Verifications --
@@ -738,12 +741,11 @@ export class Sessions {
 	 * Verify: Check the metadata of the session dialog
 	 * @param session - the expected session info to verify
 	 */
-	async expectMetaDataToBe(session: SessionMetaData) {
+	async expectMetadataToBe(session: SessionMetaData) {
 		await test.step(`Verify ${session.name} metadata: ${session.state}, ${session.path}`, async () => {
 
-			// Click metadata button for desired session
 			await this.getSessionTab(session.id).click();
-			await this.metadataButton.click();
+			await this.openMetadataDialog();
 
 			// Verify metadata
 			await expect(this.metadataDialog.getByTestId('session-name')).toContainText(session.name);

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -107,29 +107,29 @@ test.describe('Sessions: State', {
 		await sessions.resizeSessionList({ x: -100 });
 
 		// Verify Python session metadata
-		await sessions.expectMetaDataToBe({ ...pySession, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...rSession, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...pySession, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...rSession, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...pySessionAlt, state: 'idle' });
 
 		// Shutdown Python session and verify metadata
 		await sessions.select(pySession.id);
 		await console.executeCode('Python', 'exit()', { waitForReady: false });
-		await sessions.expectMetaDataToBe({ ...pySession, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...rSession, state: 'idle' });
-		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...pySession, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...rSession, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...pySessionAlt, state: 'idle' });
 
 		// Shutdown R session and verify metadata
 		await sessions.select(rSession.id);
 		await console.executeCode('R', 'q()', { waitForReady: false });
-		await sessions.expectMetaDataToBe({ ...pySession, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...rSession, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'idle' });
+		await sessions.expectMetadataToBe({ ...pySession, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...rSession, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...pySessionAlt, state: 'idle' });
 
 		// Shutdown Alt Python session and verify metadata
 		await sessions.select(pySessionAlt.id);
 		await console.executeCode('Python', 'exit()', { waitForReady: false });
-		await sessions.expectMetaDataToBe({ ...pySession, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...rSession, state: 'exited' });
-		await sessions.expectMetaDataToBe({ ...pySessionAlt, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...pySession, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...rSession, state: 'exited' });
+		await sessions.expectMetadataToBe({ ...pySessionAlt, state: 'exited' });
 	});
 });


### PR DESCRIPTION
### Summary
Fixing flake in session tests:
When clicking the metadata button, sometimes the dialog closes prematurely because something steals focus.

### QA Notes

@:sessions