### PR TITLE
Clean lockfiles after 1.98 merge

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -4187,17 +4187,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,

--- a/extensions/positron-environment/package-lock.json
+++ b/extensions/positron-environment/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "positron-environment",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "engines": {
         "vscode": "^1.65.0"
       }

--- a/extensions/positron-supervisor/package-lock.json
+++ b/extensions/positron-supervisor/package-lock.json
@@ -2068,21 +2068,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",


### PR DESCRIPTION
These lockfiles have uncommitted changes after an `npm install` in a freshly cloned repository. This change commits the lockfile updates.