### PR TITLE
Pull in upstream changes (#7121)

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -28,9 +28,9 @@ import { getBootstrapExtensionStream } from './bootstrapExtensions';
 import { getVersion } from './getVersion';
 import { fetchUrls, fetchGithub } from './fetch';
 
-// --- Start Positron ---
+// --- Start PWB: from Positron ---
 import { PromiseHandles } from './util';
-// --- End Positron ---
+// --- End PWB: from Positron ---
 
 const root = path.dirname(path.dirname(__dirname));
 const commit = getVersion(root);
@@ -222,7 +222,7 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, 
 		console.error(packagedDependencies);
 		result.emit('error', err);
 	});
-	// --- End Positron ---
+	// --- End PWB: from Positron ---
 
 	return result.pipe(createStatsStream(path.basename(extensionPath)));
 }
@@ -231,7 +231,7 @@ function fromLocalNormal(extensionPath: string): Stream {
 	const vsce = require('@vscode/vsce') as typeof import('@vscode/vsce');
 	const result = es.through();
 
-	// --- Start Positron ---
+	// --- Start PWB: from Positron ---
 	// Replace vsce.listFiles with listExtensionFiles to queue the work
 	listExtensionFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Npm })
 		.then(fileNames => {
@@ -247,7 +247,7 @@ function fromLocalNormal(extensionPath: string): Stream {
 			es.readArray(files).pipe(result);
 		})
 		.catch(err => result.emit('error', err));
-	// --- End Positron ---
+	// --- End PWB: from Positron ---
 
 	return result.pipe(createStatsStream(path.basename(extensionPath)));
 }
@@ -807,7 +807,7 @@ export async function buildExtensionMedia(isWatch: boolean, outputRoot?: string)
 	})));
 }
 
-// --- Start Positron ---
+// --- Start PWB: from Positron ---
 
 // Node 20 consistently crashes when there are too many `vsce.listFiles`
 // operations in flight at once; these operations are expensive as they recurse
@@ -955,4 +955,4 @@ export async function copyExtensionBinaries(outputRoot: string) {
 		resolve();
 	});
 }
-// --- End Positron ---
+// --- End PWB: from Positron ---

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -253,7 +253,7 @@ export function stripSourceMappingURL(): NodeJS.ReadWriteStream {
 	return es.duplex(input, output);
 }
 
-// --- Start Positron ---
+// --- Start PWB: from positron ---
 /**
  * Strips and/or modifies import statements. This function only runs on
  * development builds, and helps make it possible to use the same set of source
@@ -320,7 +320,7 @@ export class PromiseHandles<T> {
 		});
 	}
 }
-// --- End Positron ---
+// --- End PWB: from positron ---
 
 /** Splits items in the stream based on the predicate, sending them to onTrue if true, or onFalse otherwise */
 export function $if(test: boolean | ((f: VinylFile) => boolean), onTrue: NodeJS.ReadWriteStream, onFalse: NodeJS.ReadWriteStream = es.through()) {

--- a/src/vs/workbench/services/encryption/browser/browserEncryptionService.ts
+++ b/src/vs/workbench/services/encryption/browser/browserEncryptionService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable header/header */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
@@ -37,7 +36,6 @@ export class BrowserEncryptionService implements IEncryptionService {
 	}
 
 	private async initializeEncryptionKey(): Promise<CryptoKey> {
-		// TO DO: Swap some info logging for trace logging
 		this.logService.trace('[BrowserEncryptionService] Initializing encryption key');
 		if (!this._keyInitPromise) {
 			this._keyInitPromise = new DeferredPromise<CryptoKey>();
@@ -151,7 +149,7 @@ export class BrowserEncryptionService implements IEncryptionService {
 
 	private async getSaltFromFileSystem(): Promise<Uint8Array> {
 		try {
-			const saltFileName = '.positron.salt';
+			const saltFileName = '.storage';
 			let salt: Uint8Array;
 
 			try {
@@ -179,7 +177,9 @@ export class BrowserEncryptionService implements IEncryptionService {
 	}
 
 	private getSaltFilePath(saltFileName: string): URI {
+		// --- Start Positron ---
 		return joinPath(this.environmentService.userRoamingDataHome, 'positron', saltFileName);
+		// --- End Positron ---
 	}
 
 	private async deriveKeyWrappingKey(salt: Uint8Array): Promise<CryptoKey> {
@@ -187,7 +187,7 @@ export class BrowserEncryptionService implements IEncryptionService {
 			const encoder = new TextEncoder();
 			const keyMaterial = await mainWindow.crypto.subtle.importKey(
 				'raw',
-				encoder.encode('positron-key-derivation'),
+				encoder.encode('product-key-derivation'),
 				{ name: 'PBKDF2' },
 				false,
 				['deriveBits', 'deriveKey']


### PR DESCRIPTION
Cherry pick changes from https://github.com/posit-dev/positron/pull/7121 into prerelease branch so they can be included in Workbench's Positron build

> Some "Positron" references made their way upstream, and then were removed in https://github.com/rstudio/vscode-server/pull/183 This PR closes the loop and removes them downstream or adds the appropriate Positron comments when the code shouldn't be changed.

