### PR TITLE
Variables: Improve discoverability of "click to view" variable-icon

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -116,10 +116,14 @@
 .variable-item .details-column .right-column .viewer-icon {
 	display: flex;
 	cursor: pointer;
-	opacity: 0.75;
-	transition: opacity 0.1s ease;
+	transition: background-color 0.2s ease, border-color 0.2s ease;
+	border-radius: 4px;
+	padding: 4px;
+	border: 1px solid transparent;
+	background-color: transparent;
 }
 
 .variable-item .details-column .right-column .viewer-icon:hover {
-	opacity: 1;
+	border: 1px solid var(--vscode-button-foreground, #ffffff);
+	background-color: var(--vscode-button-background, #0e639c);
 }

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -115,4 +115,11 @@
 
 .variable-item .details-column .right-column .viewer-icon {
 	display: flex;
+	cursor: pointer;
+	opacity: 0.75;
+	transition: opacity 0.1s ease;
+}
+
+.variable-item .details-column .right-column .viewer-icon:hover {
+	opacity: 1;
 }

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -396,7 +396,11 @@ export const VariableItem = (props: VariableItemProps) => {
 
 			return (
 				<div className='right-column'>
-					<div className={icon} onMouseDown={viewerMouseDownHandler}></div>
+					<div
+						className={icon}
+						onMouseDown={viewerMouseDownHandler}
+						title={localize('positron.variables.clickToView', "Click to view")}
+					></div>
 				</div>
 			);
 		} else if (props.rightColumnVisible) {


### PR DESCRIPTION
Addresses #2869 (note: AI-assisted changes). Adds color contrast and tooltip to make it clear that this icon is clickable.

Dark theme:

![image](https://github.com/user-attachments/assets/7f303ec1-e68a-4c2b-9f5c-36fefe23ec38)

Light them:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/a441edb6-5de7-4f2a-bf0d-6031d89743f0" />

### Release Notes

#### New Features

- Added color contrast and tooltips when hovering over a variable icon that is viewable.

#### Bug Fixes

- N/A

### QA Notes

This should only apply to Data variables in the variables pane that can be viewed.