### PR TITLE
e2e-test: remove manually setting multisessions

### DIFF
--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -16,10 +16,6 @@ test.describe('New UV Environment', {
 	tag: [tags.INTERPRETER]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
-	});
-
 	test.afterAll(async () => {
 		const projPath = '/tmp/vscsmoke/qa-example-content/proj';
 		try {

--- a/test/e2e/tests/sessions/session-autocomplete.test.ts
+++ b/test/e2e/tests/sessions/session-autocomplete.test.ts
@@ -14,10 +14,6 @@ test.describe('Session: Autocomplete', {
 	tag: [tags.WEB, tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.EDITOR, tags.CRITICAL]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
-	});
-
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();
 	});

--- a/test/e2e/tests/sessions/session-delete.test.ts
+++ b/test/e2e/tests/sessions/session-delete.test.ts
@@ -13,10 +13,6 @@ test.describe('Sessions: Delete', {
 	tag: [tags.WEB, tags.CRITICAL, tags.WIN, tags.SESSIONS, tags.CRITICAL]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
-	});
-
 	test('Python - Validate can delete a single session', async function ({ sessions }) {
 		await sessions.start(['python']);
 		await sessions.expectSessionCountToBe(1);

--- a/test/e2e/tests/sessions/session-outline.test.ts
+++ b/test/e2e/tests/sessions/session-outline.test.ts
@@ -17,10 +17,6 @@ test.describe('Session: Outline', {
 	tag: [tags.WEB, tags.WIN, tags.SESSIONS, tags.OUTLINE, tags.CRITICAL]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
-	});
-
 	test.beforeAll(async function ({ app, openFile }) {
 		const { variables, outline } = app.workbench;
 

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -13,10 +13,6 @@ test.describe('Sessions: State', {
 	tag: [tags.WIN, tags.WEB, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['console.multipleConsoleSessions', 'true']], true);
-	});
-
 	test.beforeEach(async function ({ app, sessions }) {
 		await app.workbench.variables.togglePane('hide');
 		await sessions.deleteDisconnectedSessions();


### PR DESCRIPTION
### Summary

I assume these accidentally got added back in when merging upstream into the multisession branch. Removing these settings as they are no longer needed.

### QA Notes

@:sessions
