### PR TITLE
Make multi-console session feature flag on by default

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
+++ b/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
@@ -36,7 +36,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[USE_POSITRON_MULTIPLE_CONSOLE_SESSIONS_CONFIG_KEY]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			markdownDescription: localize(
 				'console.enableMultipleConsoleSessionsFeature',
 				'**CAUTION**: Enable experimental Positron multiple console sessions features which may result in unexpected behaviour. Please restart Positron if you change this option.'

--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -16,7 +16,7 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 	const testRepoUrl = 'https://github.com/posit-dev/qa-example-content.git';
 	const cacheDir = path.join(os.tmpdir(), 'qa-example-content-cache');
 	const cachedCommitFile = path.join(cacheDir, '.cached-commit');
-	const branch = 'mi/enable-multisessions-ff';
+	const branch = 'main';
 
 	// Check if the machine is online by attempting to fetch the latest commit hash.
 	let remoteCommitHash: string | null = null;


### PR DESCRIPTION
Addresses the first ask in #6887 by making the feature flag on by default for users. Users will now have to opt out of the feature if they don't want to use multi console sessions.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:sessions
