### PR TITLE
e2e Testing Positron Assistant: tesadd api key radio button

### DIFF
--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -22,7 +22,7 @@ const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-provider-button)';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
 // const OATH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
-// const APIKEY_RADIO = '.language-model-authentication-method-container input#apiKey[type="radio"]';
+const APIKEY_RADIO = '.language-model-authentication-method-container input#apiKey[type="radio"]';
 /*
  *  Reuseable Positron Assistant functionality for tests to leverage.
  */
@@ -90,6 +90,7 @@ export class Assistant {
 	}
 
 	async enterApiKey(apiKey: string) {
+		await this.code.driver.page.locator(APIKEY_RADIO).check();
 		const apiKeyInput = this.code.driver.page.locator(APIKEY_INPUT);
 		await apiKeyInput.fill(apiKey);
 	}


### PR DESCRIPTION
Use the API Key radio button in the positron assistant.

Note - This is the only path currently. OATH isn't yet implemented.

### QA Notes
@:assistant
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
