### PR TITLE
Add the ability for extensions to set the displayTitleOnActionBar property for commands

### DIFF
--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -694,6 +694,9 @@ namespace schema {
 		enablement?: string;
 		category?: string | ILocalizedString;
 		icon?: IUserFriendlyIcon;
+		// --- Start Positron ---
+		displayTitleOnActionBar?: boolean;
+		// --- End Positron ---
 	}
 
 	export type IUserFriendlyIcon = string | { light: string; dark: string };
@@ -723,8 +726,24 @@ namespace schema {
 		if (!isValidIcon(command.icon, collector)) {
 			return false;
 		}
+		// --- Start Positron ---
+		if (!isValidOptionalBoolean('displayTitleOnActionBar', command.displayTitleOnActionBar, collector)) {
+			return false;
+		}
+		// --- End Positron ---
 		return true;
 	}
+
+	// --- Start Positron ---
+	function isValidOptionalBoolean(propertyName: string, value: boolean | undefined, collector: ExtensionMessageCollector): boolean {
+		if (typeof value === 'undefined' || typeof value === 'boolean') {
+			return true;
+		} else {
+			collector.error(localize('optionalboolean', "property `{0}` can be omitted or must be either true or false`", propertyName));
+			return false;
+		}
+	}
+	// --- End Positron ---
 
 	function isValidIcon(icon: IUserFriendlyIcon | undefined, collector: ExtensionMessageCollector): boolean {
 		if (typeof icon === 'undefined') {
@@ -796,7 +815,13 @@ namespace schema {
 						}
 					}
 				}]
-			}
+			},
+			// --- Start Positron ---
+			displayTitleOnActionBar: {
+				description: localize('vscode.extension.contributes.commandType.displayTitleOnActionBar', '(Optional) A value which indicates whether to display the title when the command appears on an action bar.'),
+				type: 'boolean'
+			},
+			// --- End Positron ---
 		}
 	};
 
@@ -842,7 +867,10 @@ commandsExtensionPoint.setHandler(extensions => {
 		}
 		// --- End Positron ---
 
-		const { icon, enablement, category, title, shortTitle, command } = userFriendlyCommand;
+		// --- Start Positron ---
+		// Add displayTitleOnActionBar.
+		const { icon, enablement, category, title, shortTitle, command, displayTitleOnActionBar } = userFriendlyCommand;
+		// --- End Positron ---
 
 		let absoluteIcon: { dark: URI; light?: URI } | ThemeIcon | undefined;
 		if (icon) {
@@ -873,7 +901,10 @@ commandsExtensionPoint.setHandler(extensions => {
 			tooltip: title,
 			category,
 			precondition: ContextKeyExpr.deserialize(enablement),
-			icon: absoluteIcon
+			icon: absoluteIcon,
+			// --- Start Positron ---
+			displayTitleOnActionBar
+			// --- End Positron ---
 		}));
 	}
 


### PR DESCRIPTION
## Description

This PR addresses #7179 by adding a new feature that allows extensions to specify whether a command should display its title on an action bar.

To do this, add the `displayTitleOnActionBar` property to the extension's `package.json` file for each command that should display its title on an action bar.

```
"contributes": {
  "commands": [
    {
      "command": "testie.helloWorld",
      "title": "Hello World",
      "icon": "$(call-incoming)",
      "displayTitleOnActionBar": true
    }
  ],
  "menus": {
    "editor/title": [
      {
        "command": "testie.helloWorld",
        "group": "navigation@1"
      }
    ]
  }
},
```

Here's a screenshot of the above command displaying its title on the `editor/title` menu:

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/9a1e514e-693c-4e66-874c-ff35a1a1c340" />

### Release Notes

#### New Features

- #7179 Allow extensions to specify whether to display title on action bar for commands.

#### Bug Fixes

- N/A

### QA Notes

Testing this requires that you have a Positron extension that uses the new `displayTitleOnActionBar` property for commands. I have prepared such an extension and checked it into my personal GitHub account. 

Please visit:
https://github.com/softwarenerd/testie
to see it.

You can clone this repo:

```
git clone git@github.com:softwarenerd/testie.git
```

Or:

```
git clone https://github.com/softwarenerd/testie.git
```

Then build and run this extension in Positron like you would any other extension.
