### PR TITLE
Add the Copilot completion provider

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -8,7 +8,9 @@
       "name": "positron-assistant",
       "version": "0.0.1",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0"
+        "@anthropic-ai/sdk": "^0.39.0",
+        "@github/copilot-language-server": "^1.286.0",
+        "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "^1.1.6",
@@ -1610,6 +1612,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@github/copilot-language-server": {
+      "version": "1.297.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server/-/copilot-language-server-1.297.0.tgz",
+      "integrity": "sha512-Bv91fBW+XeJDjO8w3UTBs5+xlLH2i6ASGo/TU9QOdukJVEwI/dxczsGF+n36P80sUcViZVcJEsV5L8ZX2FKT8g==",
+      "license": "https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features",
+      "dependencies": {
+        "vscode-languageserver-protocol": "^3.17.5"
+      },
+      "bin": {
+        "copilot-language-server": "dist/language-server.js"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -2875,7 +2889,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4187,6 +4200,17 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
@@ -4254,7 +4278,6 @@
     },
     "node_modules/semver": {
       "version": "7.6.3",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4453,6 +4476,66 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",

--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.13.0",
         "google-auth-library": "^9.15.1",
         "ollama-ai-provider": "^1.1.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.11.0",
         "zod": "^3.24.1"
@@ -1506,6 +1507,19 @@
         }
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
       "dev": true,
@@ -1678,6 +1692,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2481,6 +2523,34 @@
         "eslint": ">=8.40.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/diff-match-patch": {
       "version": "1.0.36",
       "dev": true,
@@ -2758,6 +2828,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -2875,6 +2958,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3025,6 +3115,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -3076,6 +3173,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-match-patch": {
@@ -3920,6 +4027,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4389,6 +4503,50 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4476,6 +4634,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -4582,6 +4747,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -150,7 +150,9 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src --ext ts"
+    "lint": "eslint src --ext ts",
+    "install-copilot-language-server": "ts-node scripts/install-copilot-language-server.ts",
+    "postinstall": "ts-node scripts/post-install.ts"
   },
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "^1.1.6",
@@ -169,6 +171,7 @@
     "eslint": "^9.13.0",
     "google-auth-library": "^9.15.1",
     "ollama-ai-provider": "^1.1.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.11.0",
     "zod": "^3.24.1"

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -45,6 +45,18 @@
         "title": "%commands.configureModels.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.copilot.signin",
+        "title": "Copilot Sign In",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
+      },
+      {
+        "command": "positron-assistant.copilot.signout",
+        "title": "Copilot Sign Out",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
       }
     ],
     "languageModels": [
@@ -162,6 +174,8 @@
     "zod": "^3.24.1"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0"
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@github/copilot-language-server": "^1.286.0",
+    "vscode-languageclient": "^9.0.1"
   }
 }

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -48,13 +48,13 @@
       },
       {
         "command": "positron-assistant.copilot.signin",
-        "title": "Copilot Sign In",
+        "title": "%commands.copilot.signin.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
       },
       {
         "command": "positron-assistant.copilot.signout",
-        "title": "Copilot Sign Out",
+        "title": "%commands.copilot.signout.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
       }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -3,5 +3,7 @@
 	"description": "Provides default assistant and language models for Positron.",
 	"commands.addModelConfiguration.title": "Add Language Model",
 	"commands.configureModels.title": "Configure Language Models",
+	"commands.copilot.signin.title": "Copilot Sign In",
+	"commands.copilot.signout.title": "Copilot Sign Out",
 	"commands.category": "Positron Assistant"
 }

--- a/extensions/positron-assistant/resources/.gitignore
+++ b/extensions/positron-assistant/resources/.gitignore
@@ -1,0 +1,1 @@
+copilot

--- a/extensions/positron-assistant/scripts/install-copilot-language-server.ts
+++ b/extensions/positron-assistant/scripts/install-copilot-language-server.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
+import { arch, platform } from 'os';
+import * as path from 'path';
+
+async function getNpmCopilotVersion(copilotDir: string): Promise<string> {
+	const packageJsonPath = path.join(copilotDir, 'package.json');
+	const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+	if (packageJson.version === undefined) {
+		throw new Error('Version not found in package.json');
+	}
+	return packageJson.version;
+}
+
+async function getBundledCopilotVersion(versionPath: string): Promise<string | undefined> {
+	try {
+		return await readFile(versionPath, 'utf8');
+	} catch (error) {
+		// Ignore ENOENT errors e.g. if this is the first run.
+		if (error instanceof Error &&
+			'code' in error &&
+			error.code === 'ENOENT') {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+async function main() {
+	const bundleDir = path.join('resources', 'copilot');
+	await mkdir(bundleDir, { recursive: true });
+
+	const npmDir = path.join('node_modules', '@github', 'copilot-language-server');
+	const npmVersion = await getNpmCopilotVersion(npmDir);
+
+	const bundleVersionPath = path.join(bundleDir, 'VERSION');
+	const bundleVersion = await getBundledCopilotVersion(bundleVersionPath);
+
+	if (bundleVersion === npmVersion) {
+		console.log(`Copilot Language Server ${npmVersion} is already installed.`);
+		return;
+	}
+
+	console.log(`Updating Copilot Language Server: ${bundleVersion} -> ${npmVersion}`);
+
+	const serverName = platform() === 'win32' ? 'copilot-language-server.exe' : 'copilot-language-server';
+	// There is no win32-arm64 build yet; try to use x64 instead.
+	// See: https://github.com/github/copilot-language-server-release/issues/5.
+	const targetArch = platform() === 'win32' ? 'x64' : arch();
+	const npmServerPath = path.join(npmDir, 'native', `${platform()}-${targetArch}`, serverName);
+	const bundledServerPath = path.join(bundleDir, serverName);
+	await copyFile(npmServerPath, bundledServerPath);
+	await writeFile(bundleVersionPath, npmVersion, 'utf8');
+}
+
+main().catch(error => {
+	console.error('An error occurred:', error);
+});
+

--- a/extensions/positron-assistant/scripts/post-install.ts
+++ b/extensions/positron-assistant/scripts/post-install.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execSync } from 'child_process';
+
+// Install or update the Copilot Language Server binary
+execSync('npm run install-copilot-language-server', {
+	stdio: 'inherit'
+});

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -632,8 +632,17 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 		position: vscode.Position,
 		context: vscode.InlineCompletionContext,
 		token: vscode.CancellationToken
-	): Promise<vscode.InlineCompletionList> {
-		return await this._copilotService.provideInlineCompletionItems(document, position, context, token);
+	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
+		return await this._copilotService.inlineCompletion(document, position, context, token);
+	}
+
+	handleDidPartiallyAcceptCompletionItem(completionItem: vscode.InlineCompletionItem, infoOrAcceptedLength: vscode.PartialAcceptInfo | number): void {
+		const acceptedLength = typeof infoOrAcceptedLength === 'number' ? infoOrAcceptedLength : infoOrAcceptedLength.acceptedLength;
+		this._copilotService.didPartiallyAcceptCompletionItem(completionItem, acceptedLength);
+	}
+
+	handleDidShowCompletionItem(completionItem: vscode.InlineCompletionItem, updatedInsertText: string): void {
+		this._copilotService.didShowCompletionItem(completionItem, updatedInsertText);
 	}
 }
 

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -21,6 +21,7 @@ import { createAzure } from '@ai-sdk/azure';
 import { loadSetting } from '@ai-sdk/provider-utils';
 import { GoogleAuth } from 'google-auth-library';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { CopilotService } from './copilot.js';
 
 const mdDir = `${EXTENSION_ROOT_DIR}/src/md/`;
 
@@ -602,6 +603,40 @@ class AzureCompletion extends FimPromptCompletion {
 	}
 }
 
+export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
+	public name;
+	public identifier;
+	private readonly _copilotService;
+
+	static source: positron.ai.LanguageModelSource = {
+		type: positron.PositronLanguageModelType.Completion,
+		provider: {
+			id: 'copilot',
+			displayName: 'GitHub Copilot'
+		},
+		supportedOptions: [],
+		defaults: {
+			name: 'GitHub Copilot',
+			model: 'github-copilot',
+		},
+	};
+
+	constructor(_config: ModelConfig) {
+		this.identifier = _config.id;
+		this.name = _config.name;
+		this._copilotService = CopilotService.instance();
+	}
+
+	async provideInlineCompletionItems(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		context: vscode.InlineCompletionContext,
+		token: vscode.CancellationToken
+	): Promise<vscode.InlineCompletionList> {
+		return await this._copilotService.provideInlineCompletionItems(document, position, context, token);
+	}
+}
+
 //#endregion
 //#region Module exports
 
@@ -610,6 +645,7 @@ export function newCompletionProvider(config: ModelConfig): vscode.InlineComplet
 		'anthropic': AnthropicCompletion,
 		'azure': AzureCompletion,
 		'bedrock': AWSCompletion,
+		'copilot': CopilotCompletion,
 		'deepseek': DeepSeekCompletion,
 		'google': GoogleCompletion,
 		'mistral': MistralCompletion,
@@ -632,6 +668,7 @@ export const completionModels = [
 	AnthropicCompletion,
 	AWSCompletion,
 	AzureCompletion,
+	CopilotCompletion,
 	DeepSeekCompletion,
 	MistralCompletion,
 	GoogleCompletion,

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -1,0 +1,292 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import * as path from 'path';
+
+import { ExtensionContext } from 'vscode';
+import { Command, ExecuteCommandRequest, InlineCompletionParams, LanguageClient, LanguageClientOptions, NotificationType, Range, RequestType, ServerOptions, TransportKind } from 'vscode-languageclient/node';
+import { ModelConfig } from './config.js';
+import { CopilotCompletion } from './completion.js';
+import { randomUUID } from 'crypto';
+
+interface EditorPluginInfo {
+	name: string;
+	version: string;
+}
+
+/** A command that opens the browser to the Copilot authentication page. */
+interface SignInCommand {
+	command: Command;
+	userCode: string;
+}
+
+/** The status returned from a {@link SignInRequest} if a user is already signed in. */
+interface AlreadySignedInStatus {
+	status: 'AlreadySignedIn';
+	user: string;
+}
+
+/** The kind of the status notification. */
+enum StatusKind {
+	Normal = 'Normal',
+	Error = 'Error',
+	Warning = 'Warning',
+	Inactive = 'Inactive',
+}
+
+/** The parameters for a {@link SignInRequest}. */
+interface SignInParams { }
+
+/** The parameters for a {@link SignOutRequest}. */
+interface SignOutParams { }
+
+/** The parameters for a {@link DidChangeStatusNotification}. */
+interface DidChangeStatusParams {
+	message?: string;
+	busy: boolean;
+	kind: StatusKind;
+}
+
+/** A Copilot inline completion item; a special case of vscode-languageclient's InlineCompletionItem. */
+interface CopilotInlineCompletionItem {
+	insertText: string;
+	range: Range;
+	command: Command;
+}
+
+/** A Copilot inline completion list; a special case of vscode-languageclient's InlineCompletionList. */
+interface CopilotCompletionList {
+	items: CopilotInlineCompletionItem[];
+}
+
+/** Initiate Copilot authentication. */
+namespace SignInRequest {
+	export const type = new RequestType<SignInParams, SignInCommand | AlreadySignedInStatus, void>('signIn');
+}
+
+/** Sign out of Copilot. */
+namespace SignOutRequest {
+	export const type = new RequestType<SignOutParams, void, void>('signOut');
+}
+
+/** Emitted when the status of the client has changed. */
+namespace DidChangeStatusNotification {
+	export const type = new NotificationType<DidChangeStatusParams>('didChangeStatus');
+}
+
+/** Request inline completions; a special-case of vscode-languageclient's InlineCompletionRequest. */
+namespace CopilotInlineCompletionRequest {
+	export const type = new RequestType<InlineCompletionParams, CopilotCompletionList, void>('textDocument/inlineCompletion');
+}
+
+/** Register the Copilot service. */
+export function registerCopilotService(context: ExtensionContext) {
+	const copilotService = CopilotService.create(context);
+	context.subscriptions.push(copilotService);
+}
+
+export class CopilotService implements vscode.Disposable {
+	private readonly _disposables: vscode.Disposable[] = [];
+
+	/** The CopilotService singleton instance. */
+	private static _instance?: CopilotService;
+
+	/** The path to the bundled language server module. */
+	private _serverModule: string;
+
+	private _client?: CopilotLanguageClient;
+
+	/** Create the CopilotLanguageService singleton instance. */
+	public static create(context: ExtensionContext) {
+		if (CopilotService._instance) {
+			throw new Error('CopilotService was already created.');
+		}
+		CopilotService._instance = new CopilotService(context);
+		return CopilotService._instance;
+	}
+
+	/** Retrieve the CopilotLanguageService singleton instance. */
+	public static instance(): CopilotService {
+		if (!CopilotService._instance) {
+			throw new Error('CopilotService was not created. Call create() first.');
+		}
+		return CopilotService._instance;
+	}
+
+	private constructor(
+		private readonly _context: vscode.ExtensionContext,
+	) {
+		// Get the path to the language server module.
+		this._serverModule = path.join(this._context.extensionPath, 'node_modules', '@github', 'copilot-language-server', 'dist', 'language-server.js');
+
+		this.registerCommands();
+	}
+
+	/** Register Copilot commands. */
+	private registerCommands() {
+		this._disposables.push(
+			vscode.commands.registerCommand('positron-assistant.copilot.signin', async () => {
+				await this.signIn();
+			}),
+			vscode.commands.registerCommand('positron-assistant.copilot.signout', async () => {
+				await this.signOut();
+			})
+		);
+	}
+
+	/** Get the Copilot language client. */
+	private client(): CopilotLanguageClient {
+		if (!this._client) {
+			// The client does not exist, create it.
+			const packageJSON = this._context.extension.packageJSON;
+			const editorPluginInfo: EditorPluginInfo = {
+				name: packageJSON.name,
+				version: packageJSON.version,
+			};
+			this._client = new CopilotLanguageClient(this._serverModule, editorPluginInfo);
+		}
+		return this._client;
+	}
+
+	/**
+	 * Prompt the user to sign in to Copilot if they aren't already signed in.
+	 */
+	private async signIn(): Promise<void> {
+		// HACK: Register the Copilot completion item provider.
+		// This is a temporary workaround until the configuration UI supports
+		// Copilot completions. It should be safe for now since the sign in
+		// command is only enabled when the hidden `positron.assistant.copilot.enable`
+		// setting is enabled.
+		this.registerInlineCompletionItemProvider();
+
+		const client = this.client();
+		const response = await client.sendRequest(SignInRequest.type, {});
+
+		if ('status' in response && 'user' in response) {
+			return;
+		}
+
+		await vscode.env.clipboard.writeText(response.userCode);
+		const shouldLogin = await positron.methods.showQuestion(
+			'GitHub Copilot Sign In',
+			`You will need this code to sign in: <code>${response.userCode}</code>. It has been copied to your clipboard.`,
+			'OK',
+			'Cancel');
+
+		if (shouldLogin) {
+			await client.sendRequest(ExecuteCommandRequest.type, response.command);
+		}
+	}
+
+	private registerInlineCompletionItemProvider(): void {
+		const modelConfig: ModelConfig = {
+			apiKey: '',
+			id: randomUUID(),
+			type: CopilotCompletion.source.type,
+			model: CopilotCompletion.source.defaults.model,
+			name: CopilotCompletion.source.defaults.name,
+			provider: CopilotCompletion.source.provider.id,
+		};
+		const provider = new CopilotCompletion(modelConfig);
+		this._disposables.push(
+			vscode.languages.registerInlineCompletionItemProvider({ pattern: '**/*.*' }, provider)
+		);
+	}
+
+	/** Sign out of Copilot. */
+	private async signOut(): Promise<void> {
+		const client = this.client();
+		await client.sendRequest(SignOutRequest.type, {});
+	}
+
+	async provideInlineCompletionItems(
+		textDocument: vscode.TextDocument,
+		position: vscode.Position,
+		context: vscode.InlineCompletionContext,
+		token: vscode.CancellationToken
+	): Promise<vscode.InlineCompletionList> {
+		const client = this.client();
+		const request = client.code2ProtocolConverter.asInlineCompletionParams(textDocument, position, context);
+		const result = await client.sendRequest(CopilotInlineCompletionRequest.type, request, token);
+		return client.protocol2CodeConverter.asInlineCompletionResult(result);
+	}
+
+	dispose(): void {
+		this._disposables.forEach((disposable) => disposable.dispose());
+	}
+}
+
+export class CopilotLanguageClient implements vscode.Disposable {
+	private readonly _disposables: vscode.Disposable[] = [];
+
+	/** The wrapped language client. */
+	private readonly _client: LanguageClient;
+
+	// Expose wrapped properties from the language client.
+	public code2ProtocolConverter: typeof this._client.code2ProtocolConverter;
+	public onNotification: typeof this._client.onNotification;
+	public protocol2CodeConverter: typeof this._client.protocol2CodeConverter;
+	public sendRequest: typeof this._client.sendRequest;
+	public start: typeof this._client.start;
+
+	/**
+	 * @param module The path to the language server module.
+	 * @param editorPluginInfo The editor plugin information used to initialize the client.
+	 */
+	constructor(
+		module: string,
+		editorPluginInfo: EditorPluginInfo,
+	) {
+		const serverOptions: ServerOptions = {
+			run: { module, transport: TransportKind.ipc },
+			debug: { module, transport: TransportKind.ipc },
+		};
+
+		const outputChannel = vscode.window.createOutputChannel('GitHub Copilot Language Server', { log: true });
+		this._disposables.push(outputChannel);
+
+		const clientOptions: LanguageClientOptions = {
+			documentSelector: [{ scheme: '*' }],
+			progressOnInitialization: true,
+			outputChannel,
+			initializationOptions: {
+				editorInfo: {
+					name: 'Positron',
+					version: positron.version,
+				},
+				editorPluginInfo,
+			},
+		};
+
+		// Create the client.
+		this._client = new LanguageClient(
+			'githubCopilotLanguageServer',
+			'GitHub Copilot Language Server',
+			serverOptions,
+			clientOptions,
+		);
+		this._disposables.push(this._client);
+
+		// Log status changes for debugging.
+		this._disposables.push(
+			this._client.onNotification(DidChangeStatusNotification.type, (params: DidChangeStatusParams) => {
+				outputChannel.debug(`DidChangeStatusNotification: ${JSON.stringify(params)}`);
+			})
+		);
+
+		// Expose wrapped properties from the language client.
+		this.code2ProtocolConverter = this._client.code2ProtocolConverter;
+		this.onNotification = this._client.onNotification.bind(this._client);
+		this.protocol2CodeConverter = this._client.protocol2CodeConverter;
+		this.sendRequest = this._client.sendRequest.bind(this._client);
+		this.start = this._client.start.bind(this._client);
+	}
+
+	dispose(): void {
+		this._disposables.forEach((disposable) => disposable.dispose());
+	}
+}

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -173,6 +173,7 @@ export class CopilotService implements vscode.Disposable {
 		const response = await client.sendRequest(SignInRequest.type, {});
 
 		if ('status' in response && 'user' in response) {
+			vscode.window.showInformationMessage(vscode.l10n.t('Already signed in to GitHub Copilot as {0}.', response.user));
 			return;
 		}
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -11,6 +11,7 @@ import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { editsProvider } from './edits';
 import { createParticipants } from './participants';
 import { registerAssistantTools } from './tools.js';
+import { registerCopilotService } from './copilot.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -192,6 +193,9 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	const storage = vscode.env.uiKind === vscode.UIKind.Web ?
 		new GlobalSecretStorage(context) :
 		new EncryptedSecretStorage(context);
+
+	// Register Copilot service
+	registerCopilotService(context);
 
 	// Register chat participants
 	const participants = registerParticipants(context);


### PR DESCRIPTION
Addresses #6805. Actually using it is still a bit of a hack until we address #6615:

1. Set the hidden `positron.assistant.copilot.enable` setting to `true`.
2. Run the `Positron Assistant: Copilot Sign In` command. This will register a completion item provider and start the auth flow.
3. You should now get Copilot completions.

Right now, you have to do this on every restart.

I'm also not sure how multiple completion providers will be handled.