### PR TITLE
navigate plot history thumbnails with arrow keys instead of tab

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotGalleryThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotGalleryThumbnail.tsx
@@ -42,8 +42,10 @@ export const PlotGalleryThumbnail = (props: PropsWithChildren<PlotGalleryThumbna
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+			e.preventDefault();
 			props.focusPreviousPlotThumbnail(props.plotClient.id);
 		} else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+			e.preventDefault();
 			props.focusNextPlotThumbnail(props.plotClient.id);
 		} else if (e.key === 'Enter' || e.key === ' ') {
 			// if the focus is on the remove button, call the removePlot function

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotGalleryThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotGalleryThumbnail.tsx
@@ -1,10 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 
 // Other dependencies.
 import { PositronPlotsServices } from '../positronPlotsState.js';
@@ -17,6 +17,8 @@ interface PlotGalleryThumbnailProps {
 	selected: boolean;
 	plotService: PositronPlotsServices;
 	plotClient: IPositronPlotClient;
+	focusPreviousPlotThumbnail: (currentPlotId: string) => void;
+	focusNextPlotThumbnail: (currentPlotId: string) => void;
 }
 
 /**
@@ -27,6 +29,8 @@ interface PlotGalleryThumbnailProps {
  * @returns The rendered component.
  */
 export const PlotGalleryThumbnail = (props: PropsWithChildren<PlotGalleryThumbnailProps>) => {
+	const plotThumbnailButtonRef = useRef<HTMLButtonElement>(undefined!);
+	const plotRemoveButtonRef = useRef<HTMLButtonElement>(undefined!);
 
 	const selectPlot = () => {
 		props.plotService.positronPlotsService.selectPlot(props.plotClient.id);
@@ -36,12 +40,52 @@ export const PlotGalleryThumbnail = (props: PropsWithChildren<PlotGalleryThumbna
 		props.plotService.positronPlotsService.removePlot(props.plotClient.id);
 	};
 
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+			props.focusPreviousPlotThumbnail(props.plotClient.id);
+		} else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+			props.focusNextPlotThumbnail(props.plotClient.id);
+		} else if (e.key === 'Enter' || e.key === ' ') {
+			// if the focus is on the remove button, call the removePlot function
+			if (e.target === plotRemoveButtonRef.current) {
+				if (e.key === 'Enter' || e.key === ' ') {
+					removePlot();
+				}
+				return;
+			}
+			// otherwise, we are on the thumbnail button and we want to select
+			// the plot and focus the thumbnail
+			selectPlot();
+			if (plotThumbnailButtonRef.current) {
+				plotThumbnailButtonRef.current.focus();
+			}
+		} else {
+			return;
+		}
+	};
+
 	return (
-		<div className={'plot-thumbnail' + (props.selected ? ' selected' : '')}>
-			<button className='image-wrapper' onClick={selectPlot}>
+		<div
+			className={'plot-thumbnail' + (props.selected ? ' selected' : '')}
+			data-plot-id={props.plotClient.id}
+			tabIndex={-1}
+			onKeyDown={handleKeyDown}
+		>
+			<button
+				ref={plotThumbnailButtonRef}
+				className='image-wrapper'
+				tabIndex={props.selected ? 0 : -1}
+				onClick={selectPlot}
+			>
 				{props.children}
 			</button>
-			<button className='plot-close codicon codicon-close' onClick={removePlot}></button>
+			<button
+				ref={plotRemoveButtonRef}
+				className='plot-close codicon codicon-close'
+				tabIndex={props.selected ? 0 : -1}
+				onClick={removePlot}
+			>
+			</button>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -74,7 +74,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 			const selectedPlot = plotHistory.querySelector('.selected');
 			if (selectedPlot) {
 				// If a plot is selected, scroll it into view.
-				selectedPlot.scrollIntoView();
+				selectedPlot.scrollIntoView({ behavior: 'smooth' });
 			} else {
 				// If no plot is selected, scroll the history to the end, which
 				// will show the most recently generated plot.
@@ -117,6 +117,59 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 	};
 
 	/**
+	 * Focuses the plot thumbnail for the given plot ID.
+	 * @param plotId The ID of the plot to focus on.
+	 */
+	const focusPlotThumbnail = (plotId: string) => {
+		const plotHistory = plotHistoryRef.current;
+		if (!plotHistory) {
+			return;
+		}
+		const plotThumbnailElement = plotHistory.querySelector(
+			`.plot-thumbnail[data-plot-id="${plotId}"]`
+		) as HTMLButtonElement;
+		if (plotThumbnailElement) {
+			plotThumbnailElement.focus();
+		}
+	};
+
+	/**
+	 * Focuses the previous plot thumbnail in the history.
+	 * @param currentPlotId The ID of the currently selected plot.
+	 */
+	const focusPreviousPlotThumbnail = (currentPlotId: string) => {
+		const currentPlotIndex = positronPlotsContext.positronPlotInstances.findIndex(
+			(plotInstance) => plotInstance.id === currentPlotId
+		);
+		if (currentPlotIndex === -1) {
+			return;
+		}
+		if (currentPlotIndex === 0) {
+			return;
+		}
+		const previousPlotInstance = positronPlotsContext.positronPlotInstances[currentPlotIndex - 1];
+		focusPlotThumbnail(previousPlotInstance.id);
+	}
+
+	/**
+	 * Focuses the next plot thumbnail in the history.
+	 * @param currentPlotId The ID of the currently selected plot.
+	 */
+	const focusNextPlotThumbnail = (currentPlotId: string) => {
+		const currentPlotIndex = positronPlotsContext.positronPlotInstances.findIndex(
+			(plotInstance) => plotInstance.id === currentPlotId
+		);
+		if (currentPlotIndex === -1) {
+			return;
+		}
+		if (currentPlotIndex === positronPlotsContext.positronPlotInstances.length - 1) {
+			return;
+		}
+		const nextPlotInstance = positronPlotsContext.positronPlotInstances[currentPlotIndex + 1];
+		focusPlotThumbnail(nextPlotInstance.id);
+	}
+
+	/**
 	 * Renders a thumbnail of either a DynamicPlotInstance (resizable plot), a
 	 * StaticPlotInstance (static plot image), or a WebviewPlotInstance
 	 * (interactive HTML plot) depending on the type of plot instance.
@@ -140,6 +193,8 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 
 		return <PlotGalleryThumbnail
 			key={plotInstance.id}
+			focusNextPlotThumbnail={focusNextPlotThumbnail}
+			focusPreviousPlotThumbnail={focusPreviousPlotThumbnail}
 			plotClient={plotInstance}
 			plotService={positronPlotsContext}
 			selected={selected}>


### PR DESCRIPTION
## Summary

- addresses https://github.com/posit-dev/positron/issues/426
- navigate between plot thumbnails with arrow keys instead of tab
- select a plot by using arrow keys to focus a plot thumbnail, then use Enter/Space to select it
- remove a plot by tabbing to the remove plot X button, then use Enter/Space to remove it
- selected plot thumbnail and respective remove button are tab-navigable
- also changed plot thumbnail "scroll into view" scrolling behaviour to 'smooth'

https://github.com/user-attachments/assets/dc6aa13b-2840-44a1-adf9-aa102f4b0755


### Release Notes

#### New Features

- Navigating the plot history filmstrip now uses arrow keys instead of tab (https://github.com/posit-dev/positron/issues/426)


### QA Notes

@:plots

Using arrow keys + Space/Enter to select/remove a plot should have the same behaviour as clicking to select/remove a plot. Arrow key navigation should work whether the history filmstrip is vertical/to the right or horizontal/below the rendered plot.