### PR TITLE
Updates language exit messages to include session name

### DIFF
--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -48,6 +48,7 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 		setTimeout(() => {
 			this._onDidEndSession.fire({
 				runtime_name: this.runtimeMetadata.runtimeName,
+				session_name: this.metadata.sessionName,
 				exit_code: 0,
 				reason: exitReason,
 				message: '',

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -852,6 +852,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			if (this._runtimeState === positron.RuntimeState.Starting) {
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
+					session_name: this.metadata.sessionName,
 					exit_code: 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message: summarizeError(err)
@@ -970,6 +971,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				}
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
+					session_name: this.metadata.sessionName,
 					exit_code: startupErr.exit_code ?? 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message
@@ -984,6 +986,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				// stringify it if it's not an Error
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
+					session_name: this.metadata.sessionName,
 					exit_code: 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message: summarizeError(err)
@@ -1458,6 +1461,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Create and fire the exit event.
 		const event: positron.LanguageRuntimeExit = {
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName,
 			exit_code: exitCode,
 			reason: this._exitReason,
 			message: ''

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1183,6 +1183,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.Restart,
 			message: ''
@@ -1243,6 +1244,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName,
 			exit_code: 0,
 			reason: exitReason,
 			message: ''
@@ -1255,6 +1257,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.ForcedQuit,
 			message: ''
@@ -2065,6 +2068,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName,
 			exit_code: 137,
 			reason: positron.RuntimeExitReason.Error,
 			message: `I'm terribly sorry, but a segmentation fault has occurred.`

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -188,6 +188,9 @@ declare module 'positron' {
 		/** Runtime name */
 		runtime_name: string;
 
+		/** Session name */
+		session_name: string;
+
 		/**
 		 * The process exit code, if the runtime is backed by a process. If the
 		 * runtime is not backed by a process, this should just be 0 for a

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1404,6 +1404,7 @@ export class MainThreadLanguageRuntime
 				session.markExited();
 				const exit: ILanguageRuntimeExit = {
 					runtime_name: session.runtimeMetadata.runtimeName,
+					session_name: session.metadata.sessionName,
 					exit_code: 0,
 					reason: RuntimeExitReason.ExtensionHost,
 					message: 'Extension host is shutting down'

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -390,6 +390,9 @@ export interface ILanguageRuntimeExit {
 	/** Runtime name */
 	runtime_name: string;
 
+	/** Session name */
+	session_name: string;
+
 	/**
 	 * The process exit code, if the runtime is backed by a process. If the
 	 * runtime is not backed by a process, this should just be 0 for a

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2281,27 +2281,27 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private formatExit(exit: ILanguageRuntimeExit): string {
 		switch (exit.reason) {
 			case RuntimeExitReason.ForcedQuit:
-				return localize('positronConsole.exit.forcedQuit', "{0} was forced to quit.", exit.runtime_name);
+				return localize('positronConsole.exit.forcedQuit', "{0} was forced to quit.", exit.session_name);
 
 			case RuntimeExitReason.Restart:
-				return localize('positronConsole.exit.restart', "{0} exited (preparing for restart)", exit.runtime_name);
+				return localize('positronConsole.exit.restart', "{0} exited (preparing for restart)", exit.session_name);
 
 			case RuntimeExitReason.Shutdown:
 			case RuntimeExitReason.SwitchRuntime:
-				return localize('positronConsole.exit.shutdown', "{0} shut down successfully.", exit.runtime_name);
+				return localize('positronConsole.exit.shutdown', "{0} shut down successfully.", exit.session_name);
 
 			case RuntimeExitReason.Error:
-				return localize('positronConsole.exit.error', "{0} exited unexpectedly: {1}", exit.runtime_name, this.formatExitCode(exit.exit_code));
+				return localize('positronConsole.exit.error', "{0} exited unexpectedly: {1}", exit.session_name, this.formatExitCode(exit.exit_code));
 
 			case RuntimeExitReason.StartupFailed:
-				return localize('positronConsole.exit.startupFailed', "{0} failed to start up (exit code {1})", exit.runtime_name, exit.exit_code);
+				return localize('positronConsole.exit.startupFailed', "{0} failed to start up (exit code {1})", exit.session_name, exit.exit_code);
 
 			case RuntimeExitReason.ExtensionHost:
-				return localize('positronConsole.exit.extensionHost', "{0} was disconnected from the extension host.", exit.runtime_name);
+				return localize('positronConsole.exit.extensionHost', "{0} was disconnected from the extension host.", exit.session_name);
 
 			default:
 			case RuntimeExitReason.Unknown:
-				return localize('positronConsole.exit.unknown', "{0} exited (exit code {1})", exit.runtime_name, exit.exit_code);
+				return localize('positronConsole.exit.unknown', "{0} exited (exit code {1})", exit.session_name, exit.exit_code);
 		}
 	}
 

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -911,6 +911,7 @@ suite('ExecutionHistoryService', () => {
 		// End session with shutdown reason
 		session.onDidEndSessionEmitter.fire({
 			runtime_name: 'test-runtime',
+			session_name: 'test-session',
 			exit_code: 0,
 			message: 'Session ended',
 			reason: RuntimeExitReason.Shutdown

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -263,6 +263,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			this._onDidChangeRuntimeState.fire(RuntimeState.Exited);
 			this._onDidEndSession.fire({
 				runtime_name: this.runtimeMetadata.runtimeName,
+				session_name: this.metadata.sessionName,
 				exit_code: 0,
 				reason: exitReason,
 				message: '',
@@ -445,6 +446,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			message: exit?.message ?? '',
 			reason: exit?.reason ?? RuntimeExitReason.Unknown,
 			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.metadata.sessionName
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<img width="1552" alt="Screenshot 2025-04-10 at 2 39 19 PM" src="https://github.com/user-attachments/assets/1b225011-f2a5-4791-a4de-13fa6cdebcdc" />



Addresses #6794

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Language session exit messages in console now use Session name instead of Runtime name


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:sessions @:console
