### PR TITLE
[reticulate] starting reticulate starts another Python session

### DIFF
--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -27,6 +27,7 @@ import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
 export interface PythonRuntimeExtraData {
     pythonPath: string;
     ipykernelBundle?: IpykernelBundle;
+    externallyManaged?: boolean;
 }
 
 export async function createPythonRuntimeMetadata(

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -102,6 +102,9 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     /** The IPykernel bundle paths */
     private _ipykernelBundle: IpykernelBundle;
 
+    /** The Runtime is externally managed. eg. a reticulate runtime */
+    private _isExternallyManaged: boolean;
+
     dynState: positron.LanguageRuntimeDynState;
 
     onDidReceiveRuntimeMessage = this._messageEmitter.event;
@@ -127,6 +130,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         this._pythonPath = extraData.pythonPath;
         this._ipykernelBundle = extraData.ipykernelBundle;
+        this._isExternallyManaged = extraData.externallyManaged ?? false;
 
         this._lspQueue = new PQueue({ concurrency: 1 });
 
@@ -433,8 +437,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         if (
             this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console &&
-            // startKernel being present implies a session that is not known to the Python extension
-            !this.kernelSpec?.startKernel
+            !this._isExternallyManaged
         ) {
             // Update the active environment in the Python extension.
             this._interpreterPathService.update(

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -431,7 +431,11 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this._kernel = await this.createKernel();
         }
 
-        if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
+        if (
+            this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console &&
+            // startKernel being present implies a session that is not known to the Python extension
+            !this.kernelSpec?.startKernel
+        ) {
             // Update the active environment in the Python extension.
             this._interpreterPathService.update(
                 undefined,

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -435,10 +435,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this._kernel = await this.createKernel();
         }
 
-        if (
-            this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console &&
-            !this._isExternallyManaged
-        ) {
+        if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console && !this._isExternallyManaged) {
             // Update the active environment in the Python extension.
             this._interpreterPathService.update(
                 undefined,

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -875,6 +875,7 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 		ipykernelBundle: {
 			disabledReason: 'Cannot bundle ipykernel for reticulate sessions',
 		},
+		externallyManaged: true,
 	};
 	base64EncodedIconSvg: string | undefined;
 	constructor() {


### PR DESCRIPTION
Currently, if you set a Python interpreter and then later start reticulate, this will start both reticulate and another Python interpreter using the same interpreter path as the reticulate path.

This is caused by this line:

https://github.com/posit-dev/positron/blob/caf5ab59d563649e0b68a7f7a8c1e7164cc08d53/extensions/positron-python/src/client/positron/manager.ts#L98-L99

This event seems to be fired whenever we update the active interpreter in the Python extension:

https://github.com/posit-dev/positron/blob/caf5ab59d563649e0b68a7f7a8c1e7164cc08d53/extensions/positron-python/src/client/positron/session.ts#L439-L445

This PR avoids updating it when the kernel specifies a `startKernel` method, which implies this is a atypical runtime, which shouldn't be tracked by the Python extension.

Do you have a better idea @seeM ?

Addresses https://github.com/posit-dev/positron/pull/7024#pullrequestreview-2743877184

To repro, you need to use the `Python: Select interpreter`, select a python interpreter and then start reticulate. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:reticulate