### PR TITLE
Add Interpreter override tests

### DIFF
--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -92,3 +92,52 @@ test.describe('Interpreter: Excludes', {
 	});
 
 });
+
+test.describe('Interpreter: Override', {
+	tag: [tags.INTERPRETER, tags.WEB]
+}, () => {
+
+	test.beforeAll(async function ({ userSettings }) {
+		await userSettings.set([['r.interpreters.override', '["/opt/R/4.4.2"]']], true);
+	});
+
+	test('R - Can Override Interpreter Discovery', async function ({ app, sessions }) {
+
+		const alternateR = process.env.POSITRON_R_ALT_VER_SEL;
+
+		if (!alternateR) {
+			return fail('Alternate R version not set');
+		}
+
+		try {
+			await sessions.start('r', { reuse: false });
+			fail('selectInterpreter was supposed to fail as default R was overridden');
+		} catch (e) {
+			// Success = interpreter was correctly overriden
+		}
+
+		await app.code.driver.page.keyboard.press('Escape');
+	});
+
+	// test('Python - Can Exclude an Interpreter', async function ({ app, userSettings, sessions }) {
+
+	// 	const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
+
+	// 	if (!alternatePython) {
+	// 		return fail('Alternate Python version not set');
+	// 	}
+
+	// 	const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
+	// 	await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
+
+	// 	try {
+	// 		await sessions.start('pythonAlt', { reuse: false });
+	// 		fail(failMessage);
+	// 	} catch {
+	// 		// Success = interpreter was correctly excluded
+	// 	}
+
+	// 	await app.code.driver.page.keyboard.press('Escape');
+	// });
+
+});

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -106,7 +106,7 @@ test.describe('Interpreter: Override', {
 
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['python.interpreters.override', '["/home/runner/scratch/python-env"]']], true);
-		await userSettings.set([['r.interpreters.override', '["/opt/R/4.4.2/bin/R"]']], true);
+		await userSettings.set([['positron.r.interpreters.override', '["/opt/R/4.4.2/bin/R"]']], true);
 	});
 
 	test('R - Can Override Interpreter Discovery', async function ({ app, sessions }) {

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -128,7 +128,6 @@ test.describe('Interpreter: Override', {
 			return fail('Alternate Python version not set');
 		}
 
-		const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
 		await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
 
 		try {

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -128,8 +128,6 @@ test.describe('Interpreter: Override', {
 			return fail('Alternate Python version not set');
 		}
 
-		await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
-
 		try {
 			await sessions.start('python', { reuse: false });
 			fail('selectInterpreter was supposed to fail as ~/.pyenv was overriden');

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -120,7 +120,7 @@ test.describe('Interpreter: Override', {
 		await sessions.start('rAlt', { reuse: false });
 	});
 
-	test('Python - Can Override Intgerpreter Discovery', async function ({ app, userSettings, sessions }) {
+	test('Python - Can Override Interpreter Discovery', async function ({ app, userSettings, sessions }) {
 
 		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -117,7 +117,6 @@ test.describe('Interpreter: Override', {
 			// Success = interpreter was correctly overriden
 		}
 		await app.code.driver.page.keyboard.press('Escape');
-		await sessions.start('rAlt', { reuse: false });
 	});
 
 	test('Python - Can Override Interpreter Discovery', async function ({ app, userSettings, sessions }) {
@@ -136,7 +135,6 @@ test.describe('Interpreter: Override', {
 		}
 
 		await app.code.driver.page.keyboard.press('Escape');
-		await sessions.start('pythonAlt', { reuse: false });
 	});
 
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -98,6 +98,7 @@ test.describe('Interpreter: Override', {
 }, () => {
 
 	test.beforeAll(async function ({ userSettings }) {
+		await userSettings.set([['python.interpreters.override', '["/home/runner/scratch/python-env"]']], true);
 		await userSettings.set([['r.interpreters.override', '["/opt/R/4.4.2"]']], true);
 	});
 
@@ -115,29 +116,30 @@ test.describe('Interpreter: Override', {
 		} catch (e) {
 			// Success = interpreter was correctly overriden
 		}
-
 		await app.code.driver.page.keyboard.press('Escape');
+		await sessions.start('rAlt', { reuse: false });
 	});
 
-	// test('Python - Can Exclude an Interpreter', async function ({ app, userSettings, sessions }) {
+	test('Python - Can Override Intgerpreter Discovery', async function ({ app, userSettings, sessions }) {
 
-	// 	const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
+		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
 
-	// 	if (!alternatePython) {
-	// 		return fail('Alternate Python version not set');
-	// 	}
+		if (!alternatePython) {
+			return fail('Alternate Python version not set');
+		}
 
-	// 	const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
-	// 	await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
+		const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was excluded';
+		await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
 
-	// 	try {
-	// 		await sessions.start('pythonAlt', { reuse: false });
-	// 		fail(failMessage);
-	// 	} catch {
-	// 		// Success = interpreter was correctly excluded
-	// 	}
+		try {
+			await sessions.start('python', { reuse: false });
+			fail('selectInterpreter was supposed to fail as ~/.pyenv was overriden');
+		} catch {
+			// Success = interpreter was correctly overriden
+		}
 
-	// 	await app.code.driver.page.keyboard.press('Escape');
-	// });
+		await app.code.driver.page.keyboard.press('Escape');
+		await sessions.start('pythonAlt', { reuse: false });
+	});
 
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -60,10 +60,14 @@ test.describe('Interpreter: Excludes', {
 			return fail('Alternate R version not set');
 		}
 
+		const failMessage = 'selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded';
 		try {
 			await sessions.start('rAlt', { reuse: false });
-			fail('selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded');
+			fail(failMessage);
 		} catch (e) {
+			if (e instanceof Error && e.message.includes(failMessage)) {
+				fail(failMessage);
+			}
 			// Success = interpreter was correctly excluded
 		}
 
@@ -84,7 +88,10 @@ test.describe('Interpreter: Excludes', {
 		try {
 			await sessions.start('pythonAlt', { reuse: false });
 			fail(failMessage);
-		} catch {
+		} catch (e) {
+			if (e instanceof Error && e.message.includes(failMessage)) {
+				fail(failMessage);
+			}
 			// Success = interpreter was correctly excluded
 		}
 
@@ -110,10 +117,14 @@ test.describe('Interpreter: Override', {
 			return fail('Alternate R version not set');
 		}
 
+		const failMessage = 'selectInterpreter was supposed to fail as /opt/R/4.4.2 was overriden';
 		try {
 			await sessions.start('r', { reuse: false });
-			fail('selectInterpreter was supposed to fail as default R was overridden');
+			fail(failMessage);
 		} catch (e) {
+			if (e instanceof Error && e.message.includes(failMessage)) {
+				fail(failMessage);
+			}
 			// Success = interpreter was correctly overriden
 		}
 		await app.code.driver.page.keyboard.press('Escape');
@@ -127,10 +138,14 @@ test.describe('Interpreter: Override', {
 			return fail('Alternate Python version not set');
 		}
 
+		const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was overriden';
 		try {
 			await sessions.start('python', { reuse: false });
-			fail('selectInterpreter was supposed to fail as ~/.pyenv was overriden');
-		} catch {
+			fail(failMessage);
+		} catch (e) {
+			if (e instanceof Error && e.message.includes(failMessage)) {
+				fail(failMessage);
+			}
 			// Success = interpreter was correctly overriden
 		}
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -106,7 +106,7 @@ test.describe('Interpreter: Override', {
 
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['python.interpreters.override', '["/home/runner/scratch/python-env"]']], true);
-		await userSettings.set([['r.interpreters.override', '["/opt/R/4.4.2"]']], true);
+		await userSettings.set([['r.interpreters.override', '["/opt/R/4.4.2/bin/R"]']], true);
 	});
 
 	test('R - Can Override Interpreter Discovery', async function ({ app, sessions }) {


### PR DESCRIPTION
### Intent

Resloves #6823 to add interpreter override tests. (from #6203 adn #6206)

### Approach

I just extended the include-exclude tests. Sets the alt interpreter as the only interpreter, and checks that the default is no longer present.


### QA Notes
@:interpreter
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
