### PR TITLE
Fix: LSP server thread may be none

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -459,7 +459,7 @@ class PositronJediLanguageServer(JediLanguageServer):
             else:
                 self._stop_event.set()
                 self._server_thread.join(timeout=5)
-                if self._server_thread.is_alive():
+                if self._server_thread is not None and self._server_thread.is_alive():
                     logger.warning("LSP server thread did not exit after 5 seconds, dropping it")
 
         # Start Jedi LSP as an asyncio TCP server in a separate thread.


### PR DESCRIPTION
Fix a small issue in #7164 which was a workaround to #7163.

Logs from [this failed test](https://d38p2avprg8il3.cloudfront.net/playwright-report-14364696479-19637/index.html#?testId=a9981163c8161f46b452-f9c5484e6dc22cb7f420&q=s:flaky):

```
[Python] [positron.positron_jedilsp] WARNING | An LSP server thread already exists, shutting it down
[Python] [positron.positron_jedilsp] Shutting down LSP server thread
[Python] [asyncio] Close <_UnixSelectorEventLoop running=False closed=False debug=True>
[Python] [ipykernel.comm] ERROR | Exception opening comm with target: positron.lsp
[Python] Traceback (most recent call last):
[Python]   File "/home/runner/work/positron/positron/extensions/positron-python/python_files/lib/ipykernel/py3/ipykernel/comm/manager.py", line 49, in comm_open
[Python]     f(comm, msg)
[Python]   File "/home/runner/work/positron/positron/extensions/positron-python/python_files/posit/positron/lsp.py", line 43, in on_comm_open
[Python]     POSITRON.start(lsp_host=ip_address, shell=self._kernel.shell, comm=comm)
[Python]   File "/home/runner/work/positron/positron/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py", line 462, in start
[Python]     if self._server_thread.is_alive():
[Python]        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Python] AttributeError: 'NoneType' object has no attribute 'is_alive'
```

### QA Notes

e2e: @:sessions @:console