### PR TITLE
Bump ark to 0.1.178

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -766,7 +766,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.177"
+      "ark": "0.1.178"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
A number of nice ones here:

- https://github.com/posit-dev/ark/pull/771
- https://github.com/posit-dev/ark/pull/768
- https://github.com/posit-dev/ark/pull/765
- https://github.com/posit-dev/ark/pull/769

### Release Notes

#### New Features

- Parameter hints for R functions now show active parameter documentation (https://github.com/posit-dev/ark/pull/771)

#### Bug Fixes

- `function` and `return` keywords will now autocomplete for R (https://github.com/posit-dev/ark/pull/768)


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
