### PR TITLE
Properly pass through buffers on comm_open events

### DIFF
--- a/extensions/positron-ipywidgets/renderer/src/manager.ts
+++ b/extensions/positron-ipywidgets/renderer/src/manager.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -134,6 +134,9 @@ export class PositronWidgetManager extends ManagerBase implements base.IWidgetMa
 					target_name: message.target_name,
 					data: message.data as JSONObject,
 				},
+				// Sometimes these buffers are not aligned, so we need to convert them to Uint8Arrays to avoid mangled data.
+				// This is handeled by the Comm class for subsequent messages.
+				buffers: message.buffers?.map(buffer => new Uint8Array(buffer.buffer)),
 				// This is expected to at least contain the backend widget protocol 'version', which
 				// should match the frontend version.
 				metadata: message.metadata as JSONObject,

--- a/extensions/positron-ipywidgets/renderer/src/manager.ts
+++ b/extensions/positron-ipywidgets/renderer/src/manager.ts
@@ -135,7 +135,7 @@ export class PositronWidgetManager extends ManagerBase implements base.IWidgetMa
 					data: message.data as JSONObject,
 				},
 				// Sometimes these buffers are not aligned, so we need to convert them to Uint8Arrays to avoid mangled data.
-				// This is handeled by the Comm class for subsequent messages.
+				// This is handled by the Comm class for subsequent messages.
 				buffers: message.buffers?.map(buffer => new Uint8Array(buffer.buffer)),
 				// This is expected to at least contain the backend widget protocol 'version', which
 				// should match the frontend version.

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1522,7 +1522,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	 */
 	handleJupyterMessage(data: any) {
 		// Deserialize the message buffers from base64, if any
-		if (data.buffers) {
+		if (data.buffers?.length > 0) {
 			data.buffers = data.buffers.map((b: string) => {
 				return Buffer.from(b, 'base64');
 			});

--- a/extensions/positron-supervisor/src/RuntimeMessageEmitter.ts
+++ b/extensions/positron-supervisor/src/RuntimeMessageEmitter.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -184,6 +184,7 @@ export class RuntimeMessageEmitter {
 			target_name: data.target_name,
 			data: data.data,
 			metadata: message.metadata,
+			buffers: message.buffers,
 		} as positron.LanguageRuntimeCommOpen);
 	}
 

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -323,6 +323,7 @@ export class IPyWidgetsInstance extends Disposable {
 				target_name: client.getClientType(),
 				data: message.data,
 				metadata: message.metadata,
+				buffers: message.buffers,
 			});
 		}));
 

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -400,6 +400,7 @@ suite('Positron - IPyWidgetsInstance', () => {
 			target_name: client.getClientType(),
 			data: {},
 			metadata: {},
+			buffers: [],
 		} as ToWebviewMessage]);
 
 		// Close the client.

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -27,6 +27,7 @@ import { PositronTestServiceAccessor, positronWorkbenchInstantiationService } fr
 import { INotebookRendererInfo, INotebookStaticPreloadInfo } from '../../../notebook/common/notebookCommon.js';
 import { NotebookOutputRendererInfo } from '../../../notebook/common/notebookOutputRenderer.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 
 class TestNotebookService implements Partial<INotebookService> {
 	getRenderers(): INotebookRendererInfo[] {
@@ -244,6 +245,40 @@ suite('Positron - IPyWidgetsInstance constructor', () => {
 
 		// Check that the initialize message was sent.
 		assert.deepStrictEqual(messaging.messagesToWebview, [{ type: 'initialize_result' }]);
+	});
+
+	test('forwards comm_open with buffers when client is created via session.createClient', async () => {
+		// Create instance and clear initial messages
+		await createIPyWidgetsInstance();
+		messaging.messagesToWebview.length = 0; // Clear initialize_result message
+
+		// Make some sample client data
+		const clientId = 'new-widget-client-id';
+		const clientType = RuntimeClientType.IPyWidget;
+		const messageData = { initial_state: 'some_value' };
+		const messageMetadata = { source: 'test' };
+		const messageBuffers = [
+			VSBuffer.wrap(new Uint8Array([1, 2, 3])),
+			VSBuffer.wrap(new Uint8Array([4, 5]))
+		];
+
+		// Act: Call session.createClient to simulate client creation and trigger the event
+		await session.createClient(
+			clientType,
+			messageData,
+			messageMetadata,
+			clientId,
+			messageBuffers
+		);
+		await timeout(0);
+
+		// Sanity check: only one message should be sent.
+		assert.strictEqual(messaging.messagesToWebview.length, 1, 'Expected exactly one message (comm_open) to be sent to the webview');
+		const sentMessage = messaging.messagesToWebview[0];
+
+		// The message should be comm_open and contain the correct buffers.
+		assert.strictEqual(sentMessage.type, 'comm_open', 'Expected message type to be comm_open');
+		assert.deepStrictEqual(sentMessage.buffers, messageBuffers, 'Expected buffers to be passed correctly in the comm_open message');
 	});
 
 	test('initialized session, one ipywidget client', async () => {

--- a/src/vs/workbench/services/languageRuntime/common/positronIPyWidgetsWebviewMessages.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronIPyWidgetsWebviewMessages.ts
@@ -1,7 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from '../../../../base/common/buffer.js';
 
 /**
  * Request the runtime to close a comm.
@@ -99,6 +101,7 @@ export interface ICommOpenToWebview {
 	comm_id: string;
 	target_name: string;
 	data: unknown;
+	buffers?: Array<VSBuffer>;
 	metadata: unknown;
 }
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -13,6 +13,7 @@ import { IRuntimeClientEvent } from '../../../languageRuntime/common/languageRun
 import { TestRuntimeClientInstance } from '../../../languageRuntime/test/common/testRuntimeClientInstance.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { TestUiClientInstance } from '../../../languageRuntime/test/common/testUiClientInstance.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 
 export class TestLanguageRuntimeSession extends Disposable implements ILanguageRuntimeSession {
 	private readonly _onDidChangeRuntimeState = this._register(new Emitter<RuntimeState>());
@@ -140,7 +141,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 	}
 
 	async createClient(
-		type: RuntimeClientType, params: any, metadata?: any, id?: string
+		type: RuntimeClientType, params: any, metadata?: any, id?: string, buffers?: VSBuffer[]
 	): Promise<TestRuntimeClientInstance> {
 		const client = type === RuntimeClientType.Ui ?
 			new TestUiClientInstance(id ?? generateUuid()) :
@@ -163,7 +164,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 					parent_id: '',
 					type: LanguageRuntimeMessageType.CommOpen,
 					when: new Date().toISOString(),
-					buffers: [],
+					buffers: buffers ?? [],
 				}
 			}
 		);


### PR DESCRIPTION
Addresses #5516


Previously we added support for buffer data in ipywidgets (#4208) however in that case the buffer data supported was on comm messages (i.e. after the comm has been established). Some widgets however (e.g. bqplot) will send across buffer data on the comm_open event too. We were simply stripping this off and it was resulting in confusing errors and results when trying to render these widgets. 

This PR plumbs the same buffer handling logic and passing from the positron supervisor to the positron-ipywidgets renderer. 

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

- Pass through buffers on comm_open events

#### New Features

- N/A

#### Bug Fixes

- bqplot now works on first run


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
BQ plots code should work properly now in notebooks: e.g. 

```python
import bqplot.pyplot as bplt
import numpy as np

x = np.linspace(-10, 10, 100)
y = np.sin(x)
axes_opts = {"x": {"label": "X"}, "y": {"label": "Y"}}

fig = bplt.figure(title="Line Chart")
line = bplt.plot(
    x=x, y=y, axes_options=axes_opts
)

bplt.show()
```

