### PR TITLE
Use a different string when the filter doesn't match any variable

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesEmpty.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesEmpty.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { usePositronVariablesContext } from '../positronVariablesContext.js';
 
 // VariablesEmptyProps interface.
 interface VariablesEmptyProps {
@@ -21,6 +22,7 @@ interface VariablesEmptyProps {
  * Localized strings.
  */
 const title = localize('positron.noVariablesCreated', 'No variables have been created.');
+const titleFilter = localize('positron.noVariables.filter', 'No variables match the current filter.');
 
 /**
  * VariablesEmpty component.
@@ -28,10 +30,14 @@ const title = localize('positron.noVariablesCreated', 'No variables have been cr
  * @returns The rendered component.
  */
 export const VariablesEmpty = (props: VariablesEmptyProps) => {
+
+	const context = usePositronVariablesContext();
+	const hasFilter = context.activePositronVariablesInstance?.hasFilterText();
+
 	return <div className='variables-empty'>
 		{props.initializing ?
 			<div className='title'>...</div> :
-			<div className='title'>{title}</div>
+			<div className='title'>{hasFilter ? titleFilter : title}</div>
 		}
 	</div>;
 };

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
@@ -154,6 +154,12 @@ export interface IPositronVariablesInstance {
 	setFilterText(filterText: string): void;
 
 	/**
+	 * Has a filter text enabled
+	 * @returns true if there's a filter string active for the instance
+	 */
+	hasFilterText(): boolean;
+
+	/**
 	 * Focuses element in the variable tree.
 	 */
 	focusElement(): void;

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -401,6 +401,13 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 		}
 	}
 
+	/**
+	 * Has filter text
+	 */
+	hasFilterText(): boolean {
+		return this._filterText !== '';
+	}
+
 	//#endregion IPositronVariablesInstance Implementation
 
 	//#region Public Methods


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1832

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed a bug where Positron would say 'No variables have been created' when the filter didn't match any variable (https://github.com/posit-dev/positron/issues/1832)

### QA Notes

Create a variable in a console session
Use a filter that don't match the variable name


@:variables
