### PR TITLE
Remove createRawHtml output method for notebook renderers

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -77,20 +77,5 @@ export interface IPositronNotebookOutputWebviewService {
 			viewType?: string;
 		}): Promise<INotebookOutputWebview | undefined>;
 
-	/**
-	 * Create a new raw HTML output webview.
-	 *
-	 * @param opts The options for the webview
-	 * @param opts.id A unique ID for this webview; typically the ID of the message
-	 *  that created it.
-	 * @param opts.runtimeOrSessionId The runtime that owns this webview. Can also be a string of the ID of the runtime.
-	 * @param opts.html The HTML content to render in the webview.
-	 * @returns A promise that resolves to the new webview of the desired type.
-	 */
-	createRawHtmlOutput(opts: {
-		id: string;
-		html: string;
-		runtimeOrSessionId: ILanguageRuntimeSession | string;
-	}): Promise<INotebookOutputWebview>;
 }
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -152,7 +152,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	 * @param outputs Array of output objects containing mime types to check
 	 * @returns The type of webview message ('display', 'preload') or null if not handled
 	 */
-	static getWebviewMessageType(outputs: { mime: string }[]): NotebookPreloadOutputResults['preloadMessageType'] | 'html' | null {
+	static getWebviewMessageType(outputs: { mime: string }[]): NotebookPreloadOutputResults['preloadMessageType'] | null {
 		const mimeTypes = outputs.map(output => output.mime);
 		if (isWebviewDisplayMessage(mimeTypes)) {
 			return 'display';
@@ -160,9 +160,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		if (isWebviewReplayMessage(mimeTypes)) {
 			return 'preload';
 		}
-		if (mimeTypes.includes('text/html')) {
-			return 'html';
-		}
+
 		return null;
 	}
 
@@ -211,7 +209,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		// Preload messages contain setup code or dependencies that need to be stored
 		// for future webviews but don't need to be displayed themselves
 		notebookMessages.push(runtimeOutput);
-		return { preloadMessageType: messageType as 'preload' };
+		return { preloadMessageType: messageType };
 	}
 	/**
 	 * Create a plot client for a display message by replaying all the associated previous messages.

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -15,7 +15,6 @@ import { UiFrontendEvent } from '../../../services/languageRuntime/common/positr
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { isWebviewDisplayMessage, isWebviewReplayMessage } from './utils.js';
 import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
-import { buildWebviewHTML, webviewMessageCodeString } from './notebookOutputUtils.js';
 
 /**
  * Format of output from a notebook cell
@@ -209,41 +208,10 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			};
 		}
 
-		// We also want to send plain (non preload reliant) html messages to output.
-		if (messageType === 'html') {
-			return {
-				preloadMessageType: 'display',
-				webview: this._handleHtmlOutput(instance, outputId, outputs)
-			};
-		}
-
 		// Preload messages contain setup code or dependencies that need to be stored
 		// for future webviews but don't need to be displayed themselves
 		notebookMessages.push(runtimeOutput);
-		return { preloadMessageType: messageType };
-	}
-
-	/**
-	 * Create a webview for a plain html output.
-	 */
-	private async _handleHtmlOutput(instance: IPositronNotebookInstance, outputId: NotebookOutput['outputId'], outputs: NotebookOutput['outputs']) {
-
-		// Get the output with mime type of html
-		const htmlOutput = outputs.find(output => output.mime === 'text/html');
-		if (!htmlOutput) {
-			throw new Error('Expected HTML output');
-		}
-
-		const notebookWebview = await this._notebookOutputWebviewService.createRawHtmlOutput({
-			id: outputId,
-			runtimeOrSessionId: instance.id,
-			html: buildWebviewHTML({
-				content: htmlOutput.data.toString(),
-				script: webviewMessageCodeString,
-			})
-		});
-
-		return notebookWebview;
+		return { preloadMessageType: messageType as 'preload' };
 	}
 	/**
 	 * Create a plot client for a display message by replaying all the associated previous messages.


### PR DESCRIPTION
Addresses #4407

This method was a leftover from when we didn't have full integration with the built-in notebook renderers. Since we have since greatly improved this integration we can simply rely on the html renderer from vscode (and all the nicities that brings with it). 

This PR just strips out all the code paths related to our bespoke html rendering. 



#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

All simple html outputs should continue to work as expected. The main one that was a sticking point previously was great-tables:

```python
import polars as pl

from great_tables import GT

df = pl.DataFrame({"x": [1,2,3]})
GT(df)
```
