### PR TITLE
Display pre-renderings of new plots

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/plot_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/plot_comm.py
@@ -21,7 +21,7 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 @enum.unique
 class RenderFormat(str, enum.Enum):
     """
-    Possible values for Format in Render
+    Possible values for RenderFormat
     """
 
     Png = "png"
@@ -81,6 +81,11 @@ class PlotResult(BaseModel):
         description="The MIME type of the plot data",
     )
 
+    policy: Optional[RenderPolicy] = Field(
+        default=None,
+        description="The policy used to render the plot",
+    )
+
 
 class PlotSize(BaseModel):
     """
@@ -93,6 +98,24 @@ class PlotSize(BaseModel):
 
     width: StrictInt = Field(
         description="The plot's width, in pixels",
+    )
+
+
+class RenderPolicy(BaseModel):
+    """
+    The policy used to render the plot
+    """
+
+    size: PlotSize = Field(
+        description="Plot size of the render policy",
+    )
+
+    pixel_ratio: Union[StrictInt, StrictFloat] = Field(
+        description="The pixel ratio of the display device",
+    )
+
+    format: RenderFormat = Field(
+        description="Format of the render policy",
     )
 
 
@@ -191,6 +214,8 @@ IntrinsicSize.update_forward_refs()
 PlotResult.update_forward_refs()
 
 PlotSize.update_forward_refs()
+
+RenderPolicy.update_forward_refs()
 
 GetIntrinsicSizeRequest.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -182,7 +182,7 @@ def test_mpl_render(shell: PositronShell, plots_service: PlotsService, images_pa
         assert percent_difference(image.size[1], expected_size[1] * pixel_ratio) <= threshold
 
         # Check the rest of the response.
-        assert response == json_rpc_response({"mime_type": f"image/{format_}"})
+        assert response == json_rpc_response({"mime_type": f"image/{format_}", "policy": None})
 
     verify_response(response, "test-mpl-render-0-explicit-size", (size.width, size.height))
 

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -472,7 +472,11 @@ use serde::Serialize;
 				return yield `pub type ${snakeCaseToSentenceCase(name)} = serde_json::Value;\n\n`;
 			}
 
-			yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+			if (o.rust?.copy === true) {
+				yield '#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+			} else {
+				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+			}
 			yield `pub struct ${snakeCaseToSentenceCase(name)} {\n`;
 
 			for (let i = 0; i < props.length; i++) {
@@ -510,7 +514,7 @@ use serde::Serialize;
 				yield formatComment(`/// `,
 					`Possible values for ` +
 					snakeCaseToSentenceCase(context[0]));
-				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]\n';
+				yield '#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
 			} else {
 				// Enum field within another interface

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -117,7 +117,10 @@
 				"required": [
 					"height",
 					"width"
-				]
+				],
+				"rust": {
+					"copy": true
+				}
 			},
 			"render_format":{
 				"description": "The requested plot format",
@@ -150,7 +153,10 @@
 					"size",
 					"pixel_ratio",
 					"format"
-				]
+				],
+				"rust": {
+					"copy": true
+				}
 			}
 		}
 	}

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -67,8 +67,7 @@
 					"name": "format",
 					"description": "The requested plot format",
 					"schema": {
-						"type": "string",
-						"enum": ["png", "jpeg", "svg", "pdf", "tiff"]
+						"$ref": "#/components/schemas/render_format"
 					}
 				}
 			],
@@ -85,6 +84,10 @@
 						"mime_type": {
 							"description": "The MIME type of the plot data",
 							"type": "string"
+						},
+						"policy": {
+							"description": "The policy used to render the plot",
+							"$ref": "#/components/schemas/render_policy"
 						}
 					},
 					"required": [
@@ -116,10 +119,38 @@
 					"width"
 				]
 			},
+			"render_format":{
+				"description": "The requested plot format",
+				"type": "string",
+				"enum": ["png", "jpeg", "svg", "pdf", "tiff"]
+			},
 			"plot_unit": {
 				"type": "string",
 				"description": "The unit of measurement of a plot's dimensions",
 				"enum": ["pixels", "inches"]
+			},
+			"render_policy": {
+				"type": "object",
+				"description": "The policy used to render the plot",
+				"properties": {
+					"size": {
+						"description": "Plot size of the render policy",
+						"$ref": "#/components/schemas/plot_size"
+					},
+					"pixel_ratio": {
+						"description": "The pixel ratio of the display device",
+						"type": "number"
+					},
+					"format": {
+						"description": "Format of the render policy",
+						"$ref": "#/components/schemas/render_format"
+					}
+				},
+				"required": [
+					"size",
+					"pixel_ratio",
+					"format"
+				]
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -51,9 +51,13 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 		const ratio = DOM.getActiveWindow().devicePixelRatio;
 		const disposables = new DisposableStore();
 
-		// If the plot is already rendered, use the old image until the new one is ready.
 		if (props.plotClient.lastRender) {
+			// If the plot is already rendered, use the old image until the new one is ready.
 			setUri(props.plotClient.lastRender.uri);
+		} else if (props.plotClient.metadata.pre_render) {
+			// Otherwise use the pre-render if we have one.
+			const preRender = props.plotClient.metadata.pre_render;
+			setUri(`data:${preRender.mime_type};base64,${preRender.data}`);
 		}
 
 		// Request a plot render at the current viewport size, using a given sizing policy.

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -51,13 +51,9 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 		const ratio = DOM.getActiveWindow().devicePixelRatio;
 		const disposables = new DisposableStore();
 
+		// If the plot is already rendered, use the old image until the new one is ready.
 		if (props.plotClient.lastRender) {
-			// If the plot is already rendered, use the old image until the new one is ready.
 			setUri(props.plotClient.lastRender.uri);
-		} else if (props.plotClient.metadata.pre_render) {
-			// Otherwise use the pre-render if we have one.
-			const preRender = props.plotClient.metadata.pre_render;
-			setUri(`data:${preRender.mime_type};base64,${preRender.data}`);
 		}
 
 		// Request a plot render at the current viewport size, using a given sizing policy.

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -637,7 +637,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 					session_id: session.sessionId,
 					parent_id: event.message.parent_id,
 					code,
-					pre_render: data.pre_render,
+					pre_render: data?.pre_render,
 				};
 
 				// Register the plot client

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -628,6 +628,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				const code = this._recentExecutions.has(event.message.parent_id) ?
 					this._recentExecutions.get(event.message.parent_id)! : '';
 
+				const data = event.message.data as any;
+
 				// Create the metadata object
 				const metadata: IPositronPlotMetadata = {
 					created: Date.parse(event.message.when),
@@ -635,6 +637,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 					session_id: session.sessionId,
 					parent_id: event.message.parent_id,
 					code,
+					pre_render: data.pre_render,
 				};
 
 				// Register the plot client

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -6,7 +6,7 @@
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IPositronPlotClient } from '../../positronPlots/common/positronPlots.js';
-import { IntrinsicSize, RenderFormat } from './positronPlotComm.js';
+import { IntrinsicSize, PlotResult, RenderFormat } from './positronPlotComm.js';
 import { IPlotSize, IPositronPlotSizingPolicy } from '../../positronPlots/common/sizingPolicy.js';
 import { DeferredRender, IRenderedPlot, PositronPlotCommProxy, RenderRequest } from './positronPlotCommProxy.js';
 import { PlotSizingPolicyCustom } from '../../positronPlots/common/sizingPolicyCustom.js';
@@ -63,6 +63,9 @@ export interface IPositronPlotMetadata {
 
 	/** The plot's location for display. */
 	location?: PlotClientLocation;
+
+	/** The pre-rendering of the plot for initial display, if any. */
+	pre_render?: PlotResult;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -158,8 +158,24 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	constructor(
 		private readonly _commProxy: PositronPlotCommProxy,
 		private _sizingPolicy: IPositronPlotSizingPolicy,
-		public readonly metadata: IPositronPlotMetadata) {
+		public readonly metadata: IPositronPlotMetadata
+	) {
 		super();
+		// If the plot comes with a pre-rendering, set it as the last render. This
+		// will be picked up automatically by the plot instance component. This is
+		// also used to bypass render request if the pre-rendering render policy
+		// (size, pixel ratio, and format) matches.
+		if (metadata.pre_render) {
+			const preRender = metadata.pre_render;
+			const uri = `data:${preRender.mime_type};base64,${preRender.data}`;
+
+			this._lastRender = {
+				uri,
+				size: preRender.policy.size,
+				pixel_ratio: preRender.policy.pixel_ratio,
+				renderTimeMs: 0,
+			};
+		}
 
 		// Connect close emitter event
 		this.onDidClose = this._closeEmitter.event;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -167,14 +167,18 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		// (size, pixel ratio, and format) matches.
 		if (metadata.pre_render) {
 			const preRender = metadata.pre_render;
-			const uri = `data:${preRender.mime_type};base64,${preRender.data}`;
 
-			this._lastRender = {
-				uri,
-				size: preRender.policy.size,
-				pixel_ratio: preRender.policy.pixel_ratio,
-				renderTimeMs: 0,
-			};
+			// The policy should normally be defined in a pre-render result but we
+			// check just in case
+			if (preRender.policy) {
+				const uri = `data:${preRender.mime_type};base64,${preRender.data}`;
+				this._lastRender = {
+					uri,
+					size: preRender.policy.size,
+					pixel_ratio: preRender.policy.pixel_ratio,
+					renderTimeMs: 0,
+				};
+			}
 		}
 
 		// Connect close emitter event

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -51,6 +51,19 @@ export interface PlotResult {
 	 */
 	mime_type: string;
 
+	/**
+	 * The render policy used for the plot
+   */
+	policy: RenderPolicy;
+}
+
+/**
+ * A rendered plot
+ */
+export interface RenderPolicy {
+	size: PlotSize;
+	pixel_ratio: number;
+	format: RenderFormat;
 }
 
 /**
@@ -181,4 +194,3 @@ export class PositronPlotComm extends PositronBaseComm {
 	 */
 	onDidShow: Event<ShowEvent>;
 }
-

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -52,18 +52,10 @@ export interface PlotResult {
 	mime_type: string;
 
 	/**
-	 * The render policy used for the plot
-   */
-	policy: RenderPolicy;
-}
+	 * The policy used to render the plot
+	 */
+	policy?: RenderPolicy;
 
-/**
- * A rendered plot
- */
-export interface RenderPolicy {
-	size: PlotSize;
-	pixel_ratio: number;
-	format: RenderFormat;
 }
 
 /**
@@ -83,7 +75,28 @@ export interface PlotSize {
 }
 
 /**
- * Possible values for Format in Render
+ * The policy used to render the plot
+ */
+export interface RenderPolicy {
+	/**
+	 * Plot size of the render policy
+	 */
+	size: PlotSize;
+
+	/**
+	 * The pixel ratio of the display device
+	 */
+	pixel_ratio: number;
+
+	/**
+	 * Format of the render policy
+	 */
+	format: RenderFormat;
+
+}
+
+/**
+ * Possible values for RenderFormat
  */
 export enum RenderFormat {
 	Png = 'png',
@@ -194,3 +207,4 @@ export class PositronPlotComm extends PositronBaseComm {
 	 */
 	onDidShow: Event<ShowEvent>;
 }
+


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Addresses https://github.com/posit-dev/positron/issues/5184
Addresses https://github.com/posit-dev/positron/issues/6736
Requires the Ark side PR to be merged first. The Python side still needs to be implemented.

Plotting currently feels slow (#5184) to users because of the following back and forth between the frontend and the backend:

- The backend signals there is a plot to display
- The frontend requests a render
- The backend replies with the rendered plot

This setup also prevents plots from being displayed while an execute request is running since the render request is queued on the Shell socket and only runs when the execute request has finished. This breaks some common R patterns where plots are displayed interactively while taking inputs from users, since this interaction happens in the context of a single execute request (#6736.

To fix this, the plot widget now supports an optional `pre_render` field on `comm_open` messages. Backends are allowed to open a plot comm with a pre-rendering of the plot. This pre-rendering contains the settings used to generate the plot. If they match what the frontend needs, we're done. Otherwise we request a new rendering as before but we still display the pre-render in the meantime. This fixes both issues mentioned above.

Backends can remember the settings of the frontend's last render request and use that to generate their pre-renderings. With luck these settings will still be relevant. In the future however, we should send render settings to interested backends whenever they change (i.e. after the widget was resized), just like we send console width when the console is resized.

The comm generator was changed to accomodate a requirement on the Ark side. The new `RenderPolicy` type needs to be `Copy` so it can be stored in a `Cell`. This is achieved via a new field `rust.copy` that you can set on object types. Enum types are always made `Copy` since they will never contain complex types.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Plots are now displayed faster (#5184).
- Interactive plots (for instance when you call `plot()` on an `lm` object) are now supported (#6736).

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Since the backends don't get events with up-to-date render settings yet, the first plot will be displayed right away but it will look a little bit off since the backend doesn't know which settings to use. It will be quickly rerendered with the appropriate settings. The second plot will be displayed with the settings of the last plot which won't be quite right either since the plot area is resized to make room for the plot list when a second plot appears in the frontend. However, the third plot and any plots created after that should be displayed right away with the correct settings and don't need to be rerendered.

@:plots
