### PR TITLE
Ignore Copilot language server in macOS universal build

### DIFF
--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -60,6 +60,8 @@ const stashPatterns = [
 	'**/@vscode/node-addon-api/**',
 	'**/@parcel/node-addon-api/**',
 	'**/@parcel/**/watcher.node',
+	// Exclusions from positron-assistant
+	'**/resources/copilot/**',  // Copilot language server binary
 ];
 
 // Some generated files may end up being different in both distributions.

--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "positron-assistant",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@github/copilot-language-server": "^1.286.0",
@@ -4313,17 +4314,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",


### PR DESCRIPTION
Attempt to fix universal build. Also update the lock file which was missed in a previous PR.