### PR TITLE
Use a different filterText per variable instance

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -7,7 +7,7 @@
 import './actionBarFilter.css';
 
 // React.
-import React, { ChangeEvent, useRef, useState } from 'react';
+import React, { ChangeEvent, forwardRef, useImperativeHandle, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
@@ -22,12 +22,16 @@ interface ActionBarFilterProps {
 	onFilterTextChanged: (filterText: string) => void;
 }
 
+export interface ActionBarFilterHandle {
+	setFilterText: (text: string) => void;
+}
+
 /**
  * ActionBarFilter component.
  * @param props An ActionBarFilterProps that contains the component properties.
  * @returns The rendered component.
  */
-export const ActionBarFilter = (props: ActionBarFilterProps) => {
+export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilterProps>((props, ref) => {
 	// Reference hooks.
 	const inputRef = useRef<HTMLInputElement>(undefined!);
 
@@ -47,6 +51,14 @@ export const ActionBarFilter = (props: ActionBarFilterProps) => {
 		setFilterText('');
 		props.onFilterTextChanged('');
 	};
+
+	useImperativeHandle(ref, () => ({
+		setFilterText: (text: string) => {
+			setFilterText(text);
+			inputRef.current.value = text;
+			props.onFilterTextChanged(text);
+		}
+	}));
 
 	// Render.
 	return (
@@ -69,4 +81,4 @@ export const ActionBarFilter = (props: ActionBarFilterProps) => {
 			</div>
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
@@ -160,6 +160,12 @@ export interface IPositronVariablesInstance {
 	hasFilterText(): boolean;
 
 	/**
+	 * Gets the filter text.
+	 * @returns The filter text.
+	 */
+	getFilterText(): string;
+
+	/**
 	 * Focuses element in the variable tree.
 	 */
 	focusElement(): void;

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -408,6 +408,14 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 		return this._filterText !== '';
 	}
 
+	/**
+	 * Gets the filter text.
+	 * @returns The filter text.
+	 */
+	getFilterText(): string {
+		return this._filterText;
+	}
+
 	//#endregion IPositronVariablesInstance Implementation
 
 	//#region Public Methods

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -22,6 +22,7 @@ const VARIABLES_INTERPRETER = '.positron-variables-container .action-bar-button-
 const VARIABLE_CHEVRON_ICON = '.gutter .expand-collapse-icon';
 const VARIABLE_INDENTED = '.name-column-indenter[style*="margin-left: 40px"]';
 const VARIABLES_GROUP_SELECTOR = '.positron-variables-container .action-bar-button-text';
+const VARIABLES_FILTER_SELECTOR = '.positron-variables-container .action-bar-filter-input .text-input';
 
 /*
  *  Reuseable Positron variables functionality for tests to leverage.
@@ -40,7 +41,6 @@ export class Variables {
 		const variables = new Map<string, FlatVariables>();
 		await expect(this.code.driver.page.locator(`${CURRENT_VARIABLES_GROUP} ${VARIABLE_ITEMS}`).first()).toBeVisible();
 		const variableItems = await this.code.driver.page.locator(`${CURRENT_VARIABLES_GROUP} ${VARIABLE_ITEMS}`).all();
-
 		for (const item of variableItems) {
 			const nameElement = item.locator(`.${VARIABLE_NAMES}`).first();
 			const detailsElement = item.locator(`.${VARIABLE_DETAILS}`).first();
@@ -176,6 +176,10 @@ export class Variables {
 		const groupList = await this.code.driver.page.locator('a.action-menu-item').all();
 		const groupNames = await Promise.all(groupList.map(async (group) => group.innerText()));
 		return groupNames;
+	}
+
+	async setFilterText(filterText: string) {
+		await this.code.driver.page.locator(VARIABLES_FILTER_SELECTOR).fill(filterText);
 	}
 
 	async clickDatabaseIconForVariableRow(rowName: string) {

--- a/test/e2e/tests/variables/variables-filter.test.ts
+++ b/test/e2e/tests/variables/variables-filter.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Variables - Filters', { tag: [tags.WEB, tags.VARIABLES] }, () => {
+
+	test.afterEach(async function ({ app }) {
+		await app.workbench.layouts.enterLayout('stacked');
+	});
+
+	test('Setting filter text is reflected in the variables pane', async function ({ app, sessions }) {
+
+		await sessions.start('r');
+		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+		await app.workbench.console.pasteCodeToConsole('hello <- 1; foo <- 2', true);
+
+		const variables = app.workbench.variables;
+		await expect(async () => {
+			const vars = await variables.getFlatVariables();
+			expect(vars.has('hello')).toBe(true);
+			expect(vars.has('foo')).toBe(true);
+		}).toPass({ timeout: 20000 });
+
+		await variables.setFilterText('hello');
+		await expect(async () => {
+			const vars = await variables.getFlatVariables();
+			expect(vars.has('hello')).toBe(true);
+			expect(vars.has('foo')).toBe(false);
+		}).toPass({ timeout: 20000 });
+
+		await sessions.start('python');
+		await app.workbench.console.pasteCodeToConsole('hello = 1; foo = 2', true);
+		await expect(async () => {
+			const vars = await variables.getFlatVariables();
+			expect(vars.has('hello')).toBe(true);
+			expect(vars.has('foo')).toBe(true);
+		}).toPass({ timeout: 20000 });
+
+		await variables.setFilterText('foo');
+		await expect(async () => {
+			const vars = await variables.getFlatVariables();
+			expect(vars.has('hello')).toBe(false);
+			expect(vars.has('foo')).toBe(true);
+		}).toPass({ timeout: 20000 });
+
+	});
+});


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1829

We update the filterText so it correctly reflects the current selected session.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed a bug causing the Variables pane to enter a weird state when switching sessions with some filter enabled (https://github.com/posit-dev/positron/issues/1829).


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

I added a regresssion test to check for the filtering behavior.

@:variables
