### PR TITLE
Ensure create-universal-app.js is updated for recent change to .ts counterpart

### DIFF
--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -93,6 +93,8 @@ const stashPatterns = [
     '**/@vscode/node-addon-api/**',
     '**/@parcel/node-addon-api/**',
     '**/@parcel/**/watcher.node',
+    // Exclusions from positron-assistant
+    '**/resources/copilot/**', // Copilot language server binary
 ];
 // Some generated files may end up being different in both distributions.
 // `reconciliationFiles` contains relative paths of files that should be copied


### PR DESCRIPTION
Compiled .ts to .js as this doesn't happen for build dir from top level watches by default.
