### PR TITLE
Fix CSS for Top Bar Session Picker

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -979,10 +979,10 @@ export const POSITRON_TOP_ACTION_BAR_HOVER_BACKGROUND = registerColor('positronT
 
 // Positron top action bar text input background color.
 export const POSITRON_TOP_ACTION_BAR_TEXT_INPUT_BACKGROUND = registerColor('positronTopActionBar.textInputBackground', {
-	dark: '#3a3d41',
-	light: '#ffffff',
-	hcDark: '#3a3d41',
-	hcLight: '#ffffff'
+	dark: editorBackground,
+	light: editorBackground,
+	hcDark: editorBackground,
+	hcLight: editorBackground
 }, localize('positronTopActionBar.textInputBackground', "Positron top action bar text input background color."));
 
 // Positron top action bar text input border color.

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -915,10 +915,10 @@ export const POSITRON_TOP_ACTION_BAR_LOGO_BACKGROUND = registerColor('positronTo
 
 // Positron top action bar border color.
 export const POSITRON_TOP_ACTION_BAR_BORDER = registerColor('positronTopActionBar.border', {
-	dark: '#252527',
-	light: '#cbd0d5',
-	hcDark: contrastBorder,
-	hcLight: contrastBorder
+	dark: selectBorder,
+	light: selectBorder,
+	hcDark: selectBorder,
+	hcLight: selectBorder
 }, localize('positronTopActionBar.border', "Positron top action bar border color."));
 
 // Positron top action bar background color.


### PR DESCRIPTION
Addresses #6730 

This PR addresses a discrepancy in the `background-color` for the session picker in the top bar for multi-console session. 

The underlying component the session picker uses is the `<ActionBarButton>`. While this button has minimal styling, the styling it does have was effecting the look of the session picker. None of the other elements in the top bar utilize this component which is why this discrepancy was quite noticeable. 

The underlying issue causing the color mismatch is the `positronTopActionBar.textInputBackground` variable used by `<ActionBarButton>`. The color values of this variable were hard-coded values from two years ago. Since that time, it looks as if the colors used for the dark theme have been updated and this color needed to match the new dark theme background color we use in most other places. Based off some visual inspection in the app, it looks as if this should match the `editorBackground` variable that is used extensively.

### Screenshots

https://github.com/user-attachments/assets/1daeebfd-18f9-4dbf-9dc5-71688d6e520d


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:sessions
