### PR TITLE
E2E test: re-enable default interpreter tests

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -93,7 +93,7 @@ runs:
         CONDA_ENV_DIR="$HOME/scratch/python-env"
 
         # Create a new Conda environment with Python 3.12
-        conda create -y -p "$CONDA_ENV_DIR" python=3.12 pip setuptools
+        conda create -y -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 
         # Activate environment
         conda activate "$CONDA_ENV_DIR"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -158,7 +158,7 @@ jobs:
           POSITRON_R_VER_SEL: 4.4.0
           POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2
-          POSITRON_HIDDEN_PY: "3.12.9 (Conda)"
+          POSITRON_HIDDEN_PY: "3.12.10 (Conda)"
           POSITRON_HIDDEN_R: 4.4.1
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,9 +39,9 @@ jobs:
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       report_currents: false
-      install_undetectable_interpreters: true
+      install_undetectable_interpreters: false
       install_license: false
-
+      skip_tags: "@:nightly-only"
     secrets: inherit
 
   e2e-windows-electron:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,9 +39,9 @@ jobs:
       currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       report_currents: false
-      install_undetectable_interpreters: false
+      install_undetectable_interpreters: true
       install_license: false
-      skip_tags: "@:nightly-only"
+
     secrets: inherit
 
   e2e-windows-electron:

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -12,32 +12,44 @@ test.use({
 });
 
 // electron only for now - windows doesn't have hidden interpreters and for web the deletePositronHistoryFiles is not valid
-test.describe.skip('Default Interpreters - Python', {
+test.describe('Default Interpreters - Python', {
 	tag: [tags.INTERPRETER, tags.NIGHTLY_ONLY]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
+	test.beforeAll(async function ({ app, userSettings }) {
+
+		await app.workbench.settings.removeWorkspaceSettings(['interpreters.startupBehavior']);
+
+		await deletePositronHistoryFiles();
 
 		// local debugging sample:
 		// const homeDir = process.env.HOME || '';
-		// await userSettings.set([['python.defaultInterpreterPath', `"${path.join(homeDir, '.pyenv/versions/3.13.0/bin/python')}"`]], false);
+		// await userSettings.set([['python.defaultInterpreterPath', `"${path.join(homeDir, '.pyenv/versions/3.13.0/bin/python')}"`]], true);
 
 		// hidden interpreter (Conda)
-		await userSettings.set([['python.defaultInterpreterPath', '"/home/runner/scratch/python-env/bin/python"']], false);
+		await userSettings.set([['python.defaultInterpreterPath', '"/home/runner/scratch/python-env/bin/python"']], true);
 
 		await deletePositronHistoryFiles();
 	});
 
+	test.afterAll(async function ({ cleanup }) {
+
+		await cleanup.discardAllChanges();
+
+	});
+
 	test('Python - Add a default interpreter (Conda)', async function ({ app, runCommand, sessions }) {
-		await sessions.expectAllSessionsToBeReady();
+
 		await runCommand('workbench.action.reloadWindow');
+
+		// await app.code.wait(20000);
 		await sessions.expectAllSessionsToBeReady();
 
 		const { name, path } = await sessions.getMetadata();
 
 		// Local debugging sample:
-		// expect(name).toContain('Python 3.13.0');
-		// expect(path).toContain('.pyenv/versions/3.13.0/bin/python');
+		// expect(name).toMatch(/Python 3\.13\.0/);
+		// expect(path).toMatch(/.pyenv\/versions\/3.13.0\/bin\/python/);
 
 		// hidden CI interpreter:
 		expect(name).toMatch(/Python 3\.12\.9/);

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -42,8 +42,7 @@ test.describe('Default Interpreters - Python', {
 
 		await runCommand('workbench.action.reloadWindow');
 
-		// await app.code.wait(20000);
-		await sessions.expectAllSessionsToBeReady();
+		await app.code.wait(20000);
 
 		const { name, path } = await sessions.getMetadata();
 
@@ -52,7 +51,7 @@ test.describe('Default Interpreters - Python', {
 		// expect(path).toMatch(/.pyenv\/versions\/3.13.0\/bin\/python/);
 
 		// hidden CI interpreter:
-		expect(name).toMatch(/Python 3\.12\.9/);
+		expect(name).toMatch(/Python 3\.12\.10/);
 		expect(path).toMatch(/python-env\/bin\/python/);
 	});
 });

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -41,17 +41,18 @@ test.describe('Default Interpreters - Python', {
 	test('Python - Add a default interpreter (Conda)', async function ({ app, runCommand, sessions }) {
 
 		await runCommand('workbench.action.reloadWindow');
+		await expect(async () => {
 
-		await app.code.wait(20000);
+			const { name, path } = await sessions.getMetadata();
 
-		const { name, path } = await sessions.getMetadata();
+			// Local debugging sample:
+			// expect(name).toMatch(/Python 3\.13\.0/);
+			// expect(path).toMatch(/.pyenv\/versions\/3.13.0\/bin\/python/);
 
-		// Local debugging sample:
-		// expect(name).toMatch(/Python 3\.13\.0/);
-		// expect(path).toMatch(/.pyenv\/versions\/3.13.0\/bin\/python/);
+			// hidden CI interpreter:
+			expect(name).toMatch(/Python 3\.12\.10/);
+			expect(path).toMatch(/python-env\/bin\/python/);
 
-		// hidden CI interpreter:
-		expect(name).toMatch(/Python 3\.12\.10/);
-		expect(path).toMatch(/python-env\/bin\/python/);
+		}).toPass({ timeout: 60000 });
 	});
 });

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -40,16 +40,18 @@ test.describe('Default Interpreters - R', {
 
 		await runCommand('workbench.action.reloadWindow');
 
-		await app.code.wait(20000);
+		await expect(async () => {
 
-		const { name, path } = await sessions.getMetadata();
+			const { name, path } = await sessions.getMetadata();
 
-		// Local debugging sample:
-		// expect(name).toContain('R 4.3.3');
-		// expect(path).toContain('R.framework/Versions/4.3-arm64/Resources/R');
+			// Local debugging sample:
+			// expect(name).toContain('R 4.3.3');
+			// expect(path).toContain('R.framework/Versions/4.3-arm64/Resources/R');
 
-		// hidden CI interpreter:
-		expect(name).toMatch(/R 4\.4\.1/);
-		expect(path).toMatch(/R-4\.4\.1\/bin\/R/);
+			// hidden CI interpreter:
+			expect(name).toMatch(/R 4\.4\.1/);
+			expect(path).toMatch(/R-4\.4\.1\/bin\/R/);
+
+		}).toPass({ timeout: 60000 });
 	});
 });

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -12,25 +12,35 @@ test.use({
 });
 
 // electron only for now - windows doesn't have hidden interpreters and for web the deletePositronHistoryFiles is not valid
-test.describe.skip('Default Interpreters - R', {
+test.describe('Default Interpreters - R', {
 	tag: [tags.INTERPRETER, tags.NIGHTLY_ONLY]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings }) {
+	test.beforeAll(async function ({ app, userSettings }) {
 
-		// local debugging sample:
-		// await userSettings.set([['positron.r.interpreters.default', '"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/R"']], false);
-
-		// hidden CI interpreter:
-		await userSettings.set([['positron.r.interpreters.default', '"/home/runner/scratch/R-4.4.1/bin/R"']], false);
+		await app.workbench.settings.removeWorkspaceSettings(['interpreters.startupBehavior']);
 
 		await deletePositronHistoryFiles();
+
+		// local debugging sample:
+		// await userSettings.set([['positron.r.interpreters.default', '"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/R"']], true);
+
+		// hidden CI interpreter:
+		await userSettings.set([['positron.r.interpreters.default', '"/home/runner/scratch/R-4.4.1/bin/R"']], true);
+
+	});
+
+	test.afterAll(async function ({ cleanup }) {
+
+		await cleanup.discardAllChanges();
 
 	});
 
 	test('R - Add a default interpreter', async function ({ app, runCommand, sessions }) {
-		await sessions.expectAllSessionsToBeReady();
+
 		await runCommand('workbench.action.reloadWindow');
+
+		// await app.code.wait(20000);
 		await sessions.expectAllSessionsToBeReady();
 
 		const { name, path } = await sessions.getMetadata();

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -40,8 +40,7 @@ test.describe('Default Interpreters - R', {
 
 		await runCommand('workbench.action.reloadWindow');
 
-		// await app.code.wait(20000);
-		await sessions.expectAllSessionsToBeReady();
+		await app.code.wait(20000);
 
 		const { name, path } = await sessions.getMetadata();
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -16,8 +16,8 @@ test.describe('Interpreter: Includes', {
 }, () => {
 
 	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]']], true);
-		await userSettings.set([['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
+		await userSettings.set([['python.interpreters.include', '["/home/runner/scratch/python-env"]'],
+		['positron.r.customRootFolders', '["/home/runner/scratch"]']], true);
 	});
 
 	test('Python - Can Include an Interpreter', {
@@ -48,8 +48,8 @@ test.describe('Interpreter: Excludes', {
 }, () => {
 
 	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]']], true);
-		await userSettings.set([['positron.r.interpreters.exclude', '["/opt/R/4.4.2"]']], true);
+		await userSettings.set([['python.interpreters.exclude', '["~/.pyenv"]'],
+		['positron.r.interpreters.exclude', '["/opt/R/4.4.2"]']], true);
 	});
 
 	test('R - Can Exclude an Interpreter', async function ({ app, sessions }) {


### PR DESCRIPTION
Re-enable the default interpreter tests.

### QA Notes

@:interpreter
