### PR TITLE
Show progress feedback while variables pane is computing

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/variables_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/variables_comm.py
@@ -171,6 +171,9 @@ class VariablesBackendRequest(str, enum.Enum):
     # Clear all variables
     Clear = "clear"
 
+    # Asynchronously Clear all variables
+    AsyncClear = "async_clear"
+
     # Deletes a set of named variables
     Delete = "delete"
 
@@ -220,6 +223,39 @@ class ClearRequest(BaseModel):
 
     method: Literal[VariablesBackendRequest.Clear] = Field(
         description="The JSON-RPC method name (clear)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
+
+
+class AsyncClearParams(BaseModel):
+    """
+    Clears (deletes) all variables in the current session.
+    """
+
+    callback_id: StrictStr = Field(
+        description="A callback_id used to identify the request.",
+    )
+
+    include_hidden_objects: StrictBool = Field(
+        description="Whether to clear hidden objects in addition to normal variables",
+    )
+
+
+class AsyncClearRequest(BaseModel):
+    """
+    Clears (deletes) all variables in the current session.
+    """
+
+    params: AsyncClearParams = Field(
+        description="Parameters to the AsyncClear method",
+    )
+
+    method: Literal[VariablesBackendRequest.AsyncClear] = Field(
+        description="The JSON-RPC method name (async_clear)",
     )
 
     jsonrpc: str = Field(
@@ -357,6 +393,7 @@ class VariablesBackendMessageContent(BaseModel):
     data: Union[
         ListRequest,
         ClearRequest,
+        AsyncClearRequest,
         DeleteRequest,
         InspectRequest,
         ClipboardFormatRequest,
@@ -375,6 +412,9 @@ class VariablesFrontendEvent(str, enum.Enum):
 
     # Refresh variables
     Refresh = "refresh"
+
+    # Return async clear result
+    ReturnAsyncClear = "return_async_clear"
 
 
 class UpdateParams(BaseModel):
@@ -417,6 +457,20 @@ class RefreshParams(BaseModel):
     )
 
 
+class ReturnAsyncClearParams(BaseModel):
+    """
+    Return async clear result
+    """
+
+    callback_id: StrictStr = Field(
+        description="The callback ID that was used to send the async clear request.",
+    )
+
+    error_message: Optional[StrictStr] = Field(
+        description="Optional error message if something failed to compute",
+    )
+
+
 VariableList.update_forward_refs()
 
 InspectedVariable.update_forward_refs()
@@ -430,6 +484,10 @@ ListRequest.update_forward_refs()
 ClearParams.update_forward_refs()
 
 ClearRequest.update_forward_refs()
+
+AsyncClearParams.update_forward_refs()
+
+AsyncClearRequest.update_forward_refs()
 
 DeleteParams.update_forward_refs()
 
@@ -450,3 +508,5 @@ ViewRequest.update_forward_refs()
 UpdateParams.update_forward_refs()
 
 RefreshParams.update_forward_refs()
+
+ReturnAsyncClearParams.update_forward_refs()

--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -55,6 +55,28 @@
 			"result": {}
 		},
 		{
+			"name": "async_clear",
+			"summary": "Asynchronously Clear all variables",
+			"description": "Clears (deletes) all variables in the current session.",
+			"params": [
+				{
+					"name": "callback_id",
+					"description": "A callback_id used to identify the request.",
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "include_hidden_objects",
+					"description": "Whether to clear hidden objects in addition to normal variables",
+					"schema": {
+						"type": "boolean"
+					}
+				}
+			],
+			"result": {}
+		},
+		{
 			"name": "delete",
 			"summary": "Deletes a set of named variables",
 			"description": "Deletes the named variables from the current session.",

--- a/positron/comms/variables-frontend-openrpc.json
+++ b/positron/comms/variables-frontend-openrpc.json
@@ -79,6 +79,29 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "return_async_clear",
+			"summary": "Return async clear result",
+			"description": "Returns the result of an async clear operation.",
+			"params": [
+				{
+					"name": "callback_id",
+					"description": "The callback ID that was used to send the async clear request.",
+					"required": true,
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "error_message",
+					"description": "Optional error message if something failed to compute",
+					"required": false,
+					"schema": {
+						"type": "string"
+					}
+				}
+			]
 		}
 	]
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -194,7 +194,7 @@
 	opacity: 0;
 }
 
-.monaco-pane-view .pane .plots-container .monaco-progress-container {
+#variables-progress > .monaco-progress-container {
 	top: 0px;
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -194,7 +194,7 @@
 	opacity: 0;
 }
 
-#variables-progress > .monaco-progress-container {
+.monaco-pane-view .pane .plots-container .monaco-progress-container {
 	top: 0px;
 }
 

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.css
@@ -18,6 +18,6 @@
 	outline: none !important;
 }
 
-.positron-variables .variables-core .monaco-progress-container {
+#variables-progress > .monaco-progress-container {
 	top: 0px;
 }

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.css
@@ -17,3 +17,7 @@
 .positron-variables .variables-core .variables-instances-container:focus {
 	outline: none !important;
 }
+
+.positron-variables .variables-core .monaco-progress-container {
+	top: 0px;
+}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.tsx
@@ -7,7 +7,7 @@
 import './variablesCore.css';
 
 // React.
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 // Other dependencies.
 import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
@@ -15,6 +15,9 @@ import { ActionBars } from './actionBars.js';
 import { PositronVariablesProps } from '../positronVariables.js';
 import { VariablesInstance } from './variablesInstance.js';
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { VariablesClientStatus } from '../../../../services/languageRuntime/common/languageRuntimeVariablesClient.js';
+import { ProgressBar } from '../../../../../base/browser/ui/progressbar/progressbar.js';
 
 // VariablesCoreProps interface.
 interface VariablesCoreProps extends PositronVariablesProps {
@@ -31,6 +34,39 @@ interface VariablesCoreProps extends PositronVariablesProps {
 export const VariablesCore = (props: VariablesCoreProps) => {
 	// Context hooks.
 	const positronVariablesContext = usePositronVariablesContext();
+	const progressRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const disposables = new DisposableStore();
+
+		if (positronVariablesContext.activePositronVariablesInstance) {
+			let progressBar: ProgressBar | undefined;
+			disposables.add(positronVariablesContext.activePositronVariablesInstance.onDidChangeStatus((status) => {
+				// No work to do if we don't have a progress bar.
+				if (!progressRef.current) {
+					return;
+				}
+
+				if (status === VariablesClientStatus.Computing) {
+					// Before starting a new render, remove any existing progress bars. This prevents
+					// a buildup of progress bars when rendering multiple times and ensures the progress bar
+					// is removed when a new render is requested before the previous one completes.
+					progressRef.current.replaceChildren();
+					// Create the progress bar.
+					progressBar = new ProgressBar(progressRef.current);
+					progressBar.infinite();
+				} else {
+					if (progressBar) {
+						progressBar.done();
+						progressBar.dispose();
+						progressBar = undefined;
+					}
+				}
+			}));
+		}
+
+		return () => disposables.dispose();
+	}, [positronVariablesContext.activePositronVariablesInstance])
 
 	// If there are no instances, render nothing.
 	// TODO@softwarenerd - Render something specific for this case. TBD.
@@ -44,6 +80,8 @@ export const VariablesCore = (props: VariablesCoreProps) => {
 	// Render.
 	return (
 		<div className='variables-core'>
+			<div ref={progressRef} id='variables-progress' />
+			{/* Render the action bars. */}
 			<ActionBars {...props} />
 			<div className='variables-instances-container' style={{ width: props.width, height: adjustedHeight }}>
 				{positronVariablesContext.positronVariablesInstances.map(positronVariablesInstance =>

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
@@ -244,16 +244,6 @@ export class VariablesClientInstance extends Disposable {
 					});
 				}
 				await this._comm.asyncClear(callbackId, includeHiddenObjects);
-				const timeout = 60000;
-				setTimeout(() => {
-					if (promise.isSettled) {
-						return;
-					}
-					const timeoutSeconds = Math.round(timeout / 100) / 10;  // round to 1 decimal place
-					promise.error(new Error(`request_async_clear timed out after ${timeoutSeconds} seconds`));
-					this._asyncTasks.delete(callbackId);
-				}, timeout);
-
 				return promise.p;
 			},
 			() => ({ 'callback_id': callbackId, 'error_message': 'Client disconnected' })

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
@@ -236,9 +236,18 @@ export class VariablesClientInstance extends Disposable {
 					// Wait until the runtime is ready to receive the request
 					await new Promise<void>(resolve => {
 						const disposable = this.onDidChangeRuntimeState(state => {
-							if (state === RuntimeState.Idle) {
-								disposable.dispose();
-								resolve();
+							switch (state) {
+								case RuntimeState.Idle:
+									disposable.dispose();
+									resolve();
+									break;
+								case RuntimeState.Busy:
+								case RuntimeState.Interrupting:
+									// The runtime is busy; wait for it to become idle
+									break;
+								default:
+									disposable.dispose();
+									throw new Error('Runtime is not ready to receive the request');
 							}
 						});
 					});

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -172,6 +172,21 @@ export interface ClearParams {
 }
 
 /**
+ * Parameters for the AsyncClear method.
+ */
+export interface AsyncClearParams {
+	/**
+	 * A callback_id used to identify the request.
+	 */
+	callback_id: string;
+
+	/**
+	 * Whether to clear hidden objects in addition to normal variables
+	 */
+	include_hidden_objects: boolean;
+}
+
+/**
  * Parameters for the Delete method.
  */
 export interface DeleteParams {
@@ -264,6 +279,21 @@ export interface RefreshParams {
 }
 
 /**
+ * Parameters for the ReturnAsyncClear method.
+ */
+export interface ReturnAsyncClearParams {
+	/**
+	 * The callback ID that was used to send the async clear request.
+	 */
+	callback_id: string;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
+}
+
+/**
  * Event: Update variables
  */
 export interface UpdateEvent {
@@ -312,14 +342,32 @@ export interface RefreshEvent {
 
 }
 
+/**
+ * Event: Return async clear result
+ */
+export interface ReturnAsyncClearEvent {
+	/**
+	 * The callback ID that was used to send the async clear request.
+	 */
+	callback_id: string;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
+
+}
+
 export enum VariablesFrontendEvent {
 	Update = 'update',
-	Refresh = 'refresh'
+	Refresh = 'refresh',
+	ReturnAsyncClear = 'return_async_clear'
 }
 
 export enum VariablesBackendRequest {
 	List = 'list',
 	Clear = 'clear',
+	AsyncClear = 'async_clear',
 	Delete = 'delete',
 	Inspect = 'inspect',
 	ClipboardFormat = 'clipboard_format',
@@ -334,6 +382,7 @@ export class PositronVariablesComm extends PositronBaseComm {
 		super(instance, options);
 		this.onDidUpdate = super.createEventEmitter('update', ['assigned', 'unevaluated', 'removed', 'version']);
 		this.onDidRefresh = super.createEventEmitter('refresh', ['variables', 'length', 'version']);
+		this.onDidReturnAsyncClear = super.createEventEmitter('return_async_clear', ['callback_id', 'error_message']);
 	}
 
 	/**
@@ -359,6 +408,20 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 */
 	clear(includeHiddenObjects: boolean): Promise<void> {
 		return super.performRpc('clear', ['include_hidden_objects'], [includeHiddenObjects]);
+	}
+
+	/**
+	 * Asynchronously Clear all variables
+	 *
+	 * Clears (deletes) all variables in the current session.
+	 *
+	 * @param callbackId A callback_id used to identify the request.
+	 * @param includeHiddenObjects Whether to clear hidden objects in
+	 * addition to normal variables
+	 *
+	 */
+	asyncClear(callbackId: string, includeHiddenObjects: boolean): Promise<void> {
+		return super.performRpc('async_clear', ['callback_id', 'include_hidden_objects'], [callbackId, includeHiddenObjects]);
 	}
 
 	/**
@@ -433,5 +496,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 * the backend.
 	 */
 	onDidRefresh: Event<RefreshEvent>;
+	/**
+	 * Return async clear result
+	 *
+	 * Returns the result of an async clear operation.
+	 */
+	onDidReturnAsyncClear: Event<ReturnAsyncClearEvent>;
 }
 

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
@@ -9,6 +9,7 @@ import { IVariableGroup } from './variableGroup.js';
 import { IVariableOverflow as IVariableOverflow } from './variableOverflow.js';
 import { ILanguageRuntimeSession } from '../../../runtimeSession/common/runtimeSessionService.js';
 import { RuntimeClientState } from '../../../languageRuntime/common/languageRuntimeClientInstance.js';
+import { VariablesClientStatus } from '../../../languageRuntime/common/languageRuntimeVariablesClient.js';
 
 /**
  * PositronVariablesGrouping enumeration.
@@ -75,6 +76,11 @@ export interface IPositronVariablesInstance {
 	readonly state: RuntimeClientState;
 
 	/**
+	 * Gets the current status
+	 */
+	readonly status: VariablesClientStatus;
+
+	/**
 	 * Gets or sets the grouping.
 	 */
 	grouping: PositronVariablesGrouping;
@@ -99,6 +105,12 @@ export interface IPositronVariablesInstance {
 	 * changes.
 	 */
 	readonly onDidChangeState: Event<RuntimeClientState>;
+
+	/**
+	 * Event that fires when the status of the underlying comm
+	 * changes.
+	 */
+	readonly onDidChangeStatus: Event<VariablesClientStatus>;
 
 	/**
 	 * The onFocusElement event.

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -12,7 +12,7 @@ import { VariableOverflow } from './classes/variableOverflow.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService.js';
 import { sortVariableItemsByName, sortVariableItemsByRecent, sortVariableItemsBySize } from './helpers/utils.js';
-import { PositronVariablesList, PositronVariablesUpdate, VariablesClientInstance } from '../../languageRuntime/common/languageRuntimeVariablesClient.js';
+import { PositronVariablesList, PositronVariablesUpdate, VariablesClientInstance, VariablesClientStatus } from '../../languageRuntime/common/languageRuntimeVariablesClient.js';
 import { VariableEntry, IPositronVariablesInstance, PositronVariablesGrouping, PositronVariablesSorting } from './interfaces/positronVariablesInstance.js';
 import { VariableKind } from '../../languageRuntime/common/positronVariablesComm.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -48,7 +48,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 * Gets or sets the runtime disposable store. This contains things that are disposed when a
 	 * runtime is detached.
 	 */
-	private _runtimeDisposableStore = this._register(new DisposableStore());
+	private readonly _runtimeDisposableStore = this._register(new DisposableStore());
 
 	/**
 	 * Gets or sets the variable items map.
@@ -108,6 +108,13 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 * event before the emitter for the underlying comm has been set up.
 	 */
 	private readonly _onDidChangeStateEmitter = this._register(new Emitter<RuntimeClientState>());
+
+	/**
+	 * The onDidChangeStatus event emitter
+	 * Similar to the above onDidChangeState, we have a separate emitter so we can attach
+	 * to the event before the comm has been set up.
+	 */
+	private readonly _onDidChangeStatusEmitter = this._register(new Emitter<VariablesClientStatus>());
 
 	/**
 	 * The _onFocusInput event emitter.
@@ -170,6 +177,13 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	get state(): RuntimeClientState {
 		return this._variablesClient ?
 			this._variablesClient.clientState.get() : RuntimeClientState.Uninitialized;
+	}
+
+	/**
+	 * Gets the current status.
+	 */
+	get status(): VariablesClientStatus {
+		return this._variablesClient ? this._variablesClient.status : VariablesClientStatus.Disconnected;
 	}
 
 	/**
@@ -240,6 +254,11 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	readonly onDidChangeState: Event<RuntimeClientState> = this._onDidChangeStateEmitter.event;
 
 	/**
+	 * onDidChangeStatus event.
+	 */
+	readonly onDidChangeStatus: Event<VariablesClientStatus> = this._onDidChangeStatusEmitter.event;
+
+	/**
 	 * onFocusElement event.
 	 */
 	readonly onFocusElement = this._onFocusElementEmitter.event;
@@ -271,7 +290,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	async requestClear(includeHiddenVariables: boolean) {
 		if (this._variablesClient) {
 			try {
-				await this._variablesClient.requestClear(includeHiddenVariables);
+				await this._variablesClient.requestAsyncClear(includeHiddenVariables);
 			} catch (e) {
 				const err = e as PositronCommError;
 				const message = localize('positronVariables.requestClearError',
@@ -493,6 +512,10 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 				RuntimeClientType.Variables, {}));
 			this._variablesClient = new VariablesClientInstance(client);
 
+			this._runtimeDisposableStore.add(this._session.onDidChangeRuntimeState((runtimeState) => {
+				this._variablesClient?.setRuntimeState(runtimeState);
+			}));
+
 			// Add the onDidReceiveList event handler.
 			this._runtimeDisposableStore.add(
 				this._variablesClient.onDidReceiveList(environmentClientMessageList => {
@@ -509,7 +532,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 
 			// Create an event handler for the client state.
 			const event = Event.fromObservable(
-				this._variablesClient.clientState, this._runtimeDisposableStore)
+				this._variablesClient.clientState, this._runtimeDisposableStore);
 
 			this._runtimeDisposableStore.add(event(state => {
 				// Clear all expanded paths if the client is closed.
@@ -519,6 +542,10 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 
 				// Fire the onDidChangeState event.
 				this._onDidChangeStateEmitter.fire(state);
+			}));
+
+			this._runtimeDisposableStore.add(this._variablesClient.onDidChangeStatus(status => {
+				this._onDidChangeStatusEmitter.fire(status);
 			}));
 
 			// Add the runtime client to the runtime disposable store.

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -48,7 +48,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 * Gets or sets the runtime disposable store. This contains things that are disposed when a
 	 * runtime is detached.
 	 */
-	private readonly _runtimeDisposableStore = this._register(new DisposableStore());
+	private _runtimeDisposableStore = this._register(new DisposableStore());
 
 	/**
 	 * Gets or sets the variable items map.


### PR DESCRIPTION
This is a draft PR to discuss a possible approach to addressing https://github.com/posit-dev/positron/issues/6169 and https://github.com/posit-dev/positron/issues/3659

The issues with timeouts when interacting with the variables pane may have two different causes:

1. The RPC method is slow. Eg inspecting a large data.frame may be slow because it triggers a lot of computation, or deleting a lot of variables from an environment can take long.
2. The runtime is busy, and thus cannot handle the RPC messages at the moment. The request is sent, but it will only be handled when the runtime is idle - causing the timeout.

To fix (1.) we implement a task-like machanism that is identical to what `langugaeRuntimeDataExplorer` also uses.
Sending an RPC request to 'schedule' a task and then wait for the backend to send a 'return' event with the results.

To fix (2.) we wait for the runtime to be idle before sending the first RPC request, avoiding the timeout if it's running
code.

Once we agree with the approach, I can port it to the other variables pane RPC methods, as well as implementing the behavior for R in ark.

Here's a preview of the feature:

https://github.com/user-attachments/assets/2e17905d-19cf-4baa-a382-736eebb508b2

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
