### PR TITLE
Copilot UI to sign in

### DIFF
--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -614,10 +614,11 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 			id: 'copilot',
 			displayName: 'GitHub Copilot'
 		},
-		supportedOptions: [],
+		supportedOptions: ['oauth'],
 		defaults: {
 			name: 'GitHub Copilot',
 			model: 'github-copilot',
+			oauth: true,
 		},
 	};
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -94,6 +94,9 @@ export function registerCopilotService(context: ExtensionContext) {
 	context.subscriptions.push(copilotService);
 }
 
+export const COPILOT_SIGNIN_COMMAND = 'positron-assistant.copilot.signin';
+export const COPILOT_SIGNOUT_COMMAND = 'positron-assistant.copilot.signout';
+
 export class CopilotService implements vscode.Disposable {
 	private readonly _disposables: vscode.Disposable[] = [];
 
@@ -128,10 +131,10 @@ export class CopilotService implements vscode.Disposable {
 	/** Register Copilot commands. */
 	private registerCommands() {
 		this._disposables.push(
-			vscode.commands.registerCommand('positron-assistant.copilot.signin', async () => {
+			vscode.commands.registerCommand(COPILOT_SIGNIN_COMMAND, async () => {
 				await this.signIn();
 			}),
-			vscode.commands.registerCommand('positron-assistant.copilot.signout', async () => {
+			vscode.commands.registerCommand(COPILOT_SIGNOUT_COMMAND, async () => {
 				await this.signOut();
 			})
 		);

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -165,13 +165,6 @@ export class CopilotService implements vscode.Disposable {
 	 * Prompt the user to sign in to Copilot if they aren't already signed in.
 	 */
 	private async signIn(): Promise<boolean> {
-		// HACK: Register the Copilot completion item provider.
-		// This is a temporary workaround until the configuration UI supports
-		// Copilot completions. It should be safe for now since the sign in
-		// command is only enabled when the hidden `positron.assistant.copilot.enable`
-		// setting is enabled.
-		this.registerInlineCompletionItemProvider();
-
 		const client = this.client();
 		const response = await client.sendRequest(SignInRequest.type, {});
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -8,10 +8,7 @@ import * as positron from 'positron';
 import * as path from 'path';
 
 import { ExtensionContext } from 'vscode';
-import { Command, Executable, ExecuteCommandRequest, InlineCompletionItem, InlineCompletionRequest, LanguageClient, LanguageClientOptions, NotificationType, RequestType, ServerOptions, TransportKind } from 'vscode-languageclient/node';
-import { ModelConfig } from './config.js';
-import { CopilotCompletion } from './completion.js';
-import { randomUUID } from 'crypto';
+import { Command, Executable, InlineCompletionItem, InlineCompletionRequest, LanguageClient, LanguageClientOptions, NotificationType, RequestType, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { platform } from 'os';
 
 interface EditorPluginInfo {
@@ -181,26 +178,10 @@ export class CopilotService implements vscode.Disposable {
 			'Cancel');
 
 		if (shouldLogin) {
-			const result = await client.sendRequest(ExecuteCommandRequest.type, response.command);
 			return true;
 		} else {
 			return false;
 		}
-	}
-
-	private registerInlineCompletionItemProvider(): void {
-		const modelConfig: ModelConfig = {
-			apiKey: '',
-			id: randomUUID(),
-			type: CopilotCompletion.source.type,
-			model: CopilotCompletion.source.defaults.model,
-			name: CopilotCompletion.source.defaults.name,
-			provider: CopilotCompletion.source.provider.id,
-		};
-		const provider = new CopilotCompletion(modelConfig);
-		this._disposables.push(
-			vscode.languages.registerInlineCompletionItemProvider({ pattern: '**/*.*' }, provider)
-		);
 	}
 
 	/** Sign out of Copilot. */
@@ -208,7 +189,6 @@ export class CopilotService implements vscode.Disposable {
 		const client = this.client();
 
 		try {
-			const result = await client.sendRequest(SignOutRequest.type, {});
 			return true;
 		} catch (error) {
 			if (error instanceof Error) {

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -58,8 +58,6 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			}
 
 			registerModelWithAPI(languageModel, modelConfig, context);
-		} else if (modelConfig.type === 'completion') {
-
 		}
 	} catch (e) {
 		vscode.window.showErrorMessage(

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1839,6 +1839,7 @@ declare module 'positron' {
 			}[keyof LanguageModelConfig], undefined>[];
 			defaults: LanguageModelConfigOptions;
 			signedIn?: boolean;
+			authMethods?: string[];
 		}
 
 		/**
@@ -1857,6 +1858,7 @@ declare module 'positron' {
 			model: string;
 			baseUrl?: string;
 			apiKey?: string;
+			oauth?: boolean;
 			toolCalls?: boolean;
 			resourceName?: string;
 			project?: string;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
@@ -7,7 +7,7 @@
 import './radioGroup.css';
 
 // React.
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 // Other dependencies.
 import { RadioButton, RadioButtonItem } from './radioButton.js';
@@ -39,6 +39,10 @@ export const RadioGroup = (props: PropsWithChildren<RadioGroupProps>) => {
 		setCurrentSelection(identifier);
 		props.onSelectionChanged(identifier);
 	};
+
+	useEffect(() => {
+		setCurrentSelection(props.initialSelectionId);
+	}, [props.initialSelectionId]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -27,6 +27,9 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 			case 'google':
 				return localize('positron.newConnectionModalDialog.googleTos',
 					"By using Gemini, you agree to abide by their [Terms of Service](https://gemini.google/policy-guidelines).");
+			case 'copilot':
+				return localize('positron.newConnectionModalDialog.copilotTos',
+					"By using Github Copilot, you agree to abide by their [Terms of Service](https://github.com/customer-terms/github-copilot-product-specific-terms)");
 			default:
 				return '';
 		}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -14,6 +14,7 @@ import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/
 interface LanguageModelConfigComponentProps {
 	provider: LanguageModelUIConfiguration,
 	source: IPositronLanguageModelSource,
+	signingIn?: boolean,
 	onChange: (config: IPositronLanguageModelConfig) => void,
 	onSignIn: () => void,
 }
@@ -42,7 +43,7 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 					props.onChange({ ...props.provider, apiKey: newApiKey });
 				}} onSignIn={props.onSignIn} />
 			)}
-			<SignInButton signedIn={props.source.signedIn} onSignIn={props.onSignIn} />
+			<SignInButton signedIn={props.source.signedIn} onSignIn={props.onSignIn} signingIn={props.signingIn} />
 		</div>
 		<div className='language-model-dialog-tos' id='model-tos'>
 			<EmbeddedLink>{getTos(props.provider.provider)}</EmbeddedLink>
@@ -64,8 +65,8 @@ const ApiKey = (props: { apiKey?: string, signedIn?: boolean, onChange: (newApiK
 	</>)
 }
 
-const SignInButton = (props: { signedIn?: boolean, onSignIn: () => void }) => {
-	return <Button className='language-model button sign-in' onPressed={props.onSignIn}>
+const SignInButton = (props: { signedIn?: boolean, signingIn?: boolean, onSignIn: () => void }) => {
+	return <Button className='language-model button sign-in' onPressed={props.onSignIn} disabled={props.signingIn}>
 		{(() => {
 			if (props.signedIn) {
 				return localize('positron.newConnectionModalDialog.signOut', "Sign out");

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -43,6 +43,11 @@
 	align-items: center;
 }
 
+.language-model.button.disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
 .language-model.button {
 	flex-direction: row;
 	align-items: center;

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -154,17 +154,17 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		new RadioButtonItem({
 			identifier: 'oauth',
 			title: localize('positron.newConnectionModalDialog.oauth', "OAuth"),
-			disabled: true,
+			disabled: source.provider.id !== 'copilot',
 		}),
 		new RadioButtonItem({
 			identifier: 'apiKey',
 			title: localize('positron.newConnectionModalDialog.apiKey', "API Key"),
-			disabled: false,
+			disabled: source.provider.id === 'copilot',
 		}),
 	];
 
 	const providers = props.sources
-		.filter(source => source.type === 'chat')
+		.filter(source => source.type === 'chat' || (source.type === 'completion' && source.provider.id === 'copilot'))
 		.sort((a, b) => {
 			return a.provider.displayName.localeCompare(b.provider.displayName);
 		})
@@ -386,7 +386,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				<div className='language-model-authentication-method-container'>
 					<RadioGroup
 						entries={authMethodRadioButtons}
-						initialSelectionId='apiKey'
+						initialSelectionId={source.provider.id === 'copilot' ? 'oauth' : 'apiKey'}
 						name='authMethod'
 						onSelectionChanged={(authMethod) => {
 							// setAuthMethod(authMethod);

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -110,11 +110,11 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 	}
 
 	getSupportedProviders(): string[] {
-		const providers = ['anthropic'];
+		const providers = ['anthropic', 'copilot'];
 		const useTestModels = this._configurationService.getValue<boolean>('positron.assistant.testModels');
 
 		if (useTestModels) {
-			providers.push('bedrock', 'error', 'echo', 'google', 'copilot');
+			providers.push('bedrock', 'error', 'echo', 'google');
 		}
 		return providers;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -50,6 +50,7 @@ export interface IPositronLanguageModelSource {
 	supportedOptions: PositronLanguageModelOptions[];
 	defaults: Omit<IPositronLanguageModelConfig, 'provider' | 'type'>;
 	signedIn?: boolean;
+	authMethods?: string[];
 }
 
 export interface IPositronLanguageModelConfig {
@@ -59,6 +60,7 @@ export interface IPositronLanguageModelConfig {
 	model: string;
 	baseUrl?: string;
 	apiKey?: string;
+	oauth?: boolean;
 	toolCalls?: boolean;
 	resourceName?: string;
 	project?: string;


### PR DESCRIPTION
Address #6615

This calls into the extension to kick off the sign-in. A progress bar is shown while authentication is in progress. The sign-in action calls the hidden Copilot sign-in command and waits for it to complete.

If the sign-in command fails, it will notify the user within the dialog.

Once signed-in, the button is available for signing out. This calls the command to sign out of Copilot.

The completion status in the bottom status bar isn't connected so we'll have to do something about that in a future PR.

### Release Notes

Add Copilot as a model provider. Once registering with Copilot, it will be added as a completion model. It will not be available for the Chat view at this time.

#### New Features

- Add Copilot registration as a completion provider #6615

#### Bug Fixes

- N/A


### QA Notes
The sign-in process kicks off an authentication flow that occurs outside of Positron. A code is generated at the beginning to be used in the authentication process. Once authentication is completed, Positron will register the completion provider.

Authentication flow:

1. Click sign-in
2. A code is generated and copied to the clipboard while also displaying to the user
3. A prompt is shown to open the browser to authenticate with Copilot
4. Once logged in with the browser, the user must paste the code as a secondary verification
5. The browser may be closed once the authentication is completed
6. Wait for Positron to process the authentication message and register the completion provider

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
