### PR TITLE
Fix hanging runtime on new jupyter notebook project

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -71,6 +71,7 @@
         "Machine Learning"
     ],
     "activationEvents": [
+        "onCommand:python.createEnvironmentAndRegister",
         "onStartupFinished",
         "onDebugInitialConfigurations",
         "onLanguage:python",

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -424,18 +424,17 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 				// specified Python interpreter is invalid for some reason (e.g. for Venv, if the
 				// specified interpreter is not considered to be a Global Python installation).
 				const createEnvCommand = 'python.createEnvironmentAndRegister';
-				const createEnv = async () => {
-					return await this._commandService.executeCommand(
-						createEnvCommand,
-						{
-							workspaceFolder,
-							providerId: provider,
-							interpreterPath,
-							condaPythonVersion,
-							selectEnvironment: true
-						}
-					);
-				};
+				const createEnv = async () => this._commandService.executeCommand(
+					createEnvCommand,
+					{
+						workspaceFolder,
+						providerId: provider,
+						interpreterPath,
+						condaPythonVersion,
+						selectEnvironment: true
+					}
+				);
+
 
 				const pythonExtensionReady = async (): Promise<boolean> => {
 					// Use a DisposableStore to manage the lifetime of the event listener.


### PR DESCRIPTION
Addresses #5914 

@:new-project-wizard

On new project load sometimes we were trying to run the create environment command before the python extension had loaded. This then errored and caused the whole ide to get into a state that looked like it was perpetually loading the runtime.

This PR adds a function that waits for the python extension to be initialized before sending the command. 

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- App shouldn't hang initializing runtime on new python projects


### QA Notes

No tests added because this will hopefully fix some existing flakey tests.
