### PR TITLE
e2e test: Skipping assistant bad api key due to issue

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -24,7 +24,7 @@ test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] 
 	});
 
 	test.skip('Antropic: Verfy Bad API key results in error', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7255' }]
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7291' }]
 	}, async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.clickAddModelButton();

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
 	test.beforeAll('How to set User Settings', async function ({ userSettings }) {
 		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
 		await userSettings.set([['positron.assistant.enable', 'true'],

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -23,7 +23,9 @@ test.describe('Positron Assistant', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] 
 		await app.workbench.assistant.verifyAddModelButtonVisible();
 	});
 
-	test('Antropic: Verfy Bad API key results in error', async function ({ app }) {
+	test.skip('Antropic: Verfy Bad API key results in error', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7255' }]
+	}, async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.clickAddModelButton();
 		await app.workbench.assistant.selectModelProvider('Anthropic');


### PR DESCRIPTION
Due to https://github.com/posit-dev/positron/issues/7291, this test needs to be skipped until it's fixed.

### QA Notes
@:assistant
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
