### PR TITLE
assistant: add file contents retrieval and basic text search tools

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/filepaths.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/filepaths.md
@@ -1,0 +1,7 @@
+When the user mentions a file name, construct the full path to the file. You may need to invoke a tool to determine the path to the file, such as the project tree tool.
+
+When displaying file paths, if the paths are for files and directories in the workspace, display the paths as relative to the workspace root. If the paths are for files and directories outside of the workspace, display the paths as absolute paths.
+
+For example, if the workspace root is `/home/user/workspace` and the file path is `/home/user/workspace/src/file.txt`, display it as `src/file.txt`. If the file path is `/home/user/other/file.txt`, display it as `/home/user/other/file.txt`.
+
+Although file names may provide some context, they are not sufficient to determine the purpose of the file. Therefore, you should not use file names to infer the file type. Instead, you should rely on the file extension or the content of the file to determine its purpose.

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -426,7 +426,7 @@ class PositronAssistantChatParticipant extends PositronAssistantParticipant impl
 	id = ParticipantID.Chat;
 
 	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string | undefined> {
-		return await fs.promises.readFile(`${mdDir}/prompts/chat/filepath.md`, 'utf8');
+		return await fs.promises.readFile(`${mdDir}/prompts/chat/filepaths.md`, 'utf8');
 	}
 }
 
@@ -448,13 +448,26 @@ class PositronAssistantEditorParticipant extends PositronAssistantParticipant im
 			throw new Error('Editor participant only supports editor requests');
 		}
 
-		// If the user has not selected text, use the prompt for the whole document.
+		const prompts = [];
+
 		if (request.location2.selection.isEmpty) {
-			return await fs.promises.readFile(`${mdDir}/prompts/chat/editor.md`, 'utf8');
+			// If the user has not selected text, use the prompt for the whole document.
+			prompts.push(
+				await fs.promises.readFile(`${mdDir}/prompts/chat/editor.md`, 'utf8')
+			);
+		} else {
+			// If the user has selected text, generate a new version of the selection.
+			prompts.push(
+				await fs.promises.readFile(`${mdDir}/prompts/chat/selection.md`, 'utf8')
+			);
 		}
 
-		// If the user has selected text, generate a new version of the selection.
-		return await fs.promises.readFile(`${mdDir}/prompts/chat/selection.md`, 'utf8');
+		// Add filepaths handling to the system prompt.
+		prompts.push(
+			await fs.promises.readFile(`${mdDir}/prompts/chat/filepaths.md`, 'utf8')
+		);
+
+		return prompts.join('\n\n');
 	}
 
 	async getMessages(request: vscode.ChatRequest): Promise<vscode.LanguageModelChatMessage[]> {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -424,6 +424,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 /** The participant used in the chat pane in Ask mode. */
 class PositronAssistantChatParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
 	id = ParticipantID.Chat;
+
+	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string | undefined> {
+		return await fs.promises.readFile(`${mdDir}/prompts/chat/filepath.md`, 'utf8');
+	}
 }
 
 /** The participant used in terminal inline chats. */

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
-import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
 import { IToolInputProcessor } from '../../common/tools/tools.js';
 
 const getFileContentsModelDescription = `
@@ -79,6 +79,13 @@ export class FileContentsTool implements IToolImpl {
 
 		return {
 			content: [{ kind: 'text', value: JSON.stringify({ contents: value, size, encoding, }) }],
+		};
+	}
+
+	async prepareToolInvocation(_parameters: any, _token: CancellationToken): Promise<IPreparedToolInvocation> {
+		return {
+			invocationMessage: localize('fileContentsTool.invocationMessage', "Retrieving file contents"),
+			pastTenseMessage: localize('fileContentsTool.pastTenseMessage', "Retrieved file contents"),
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -79,7 +79,6 @@ export class FileContentsTool implements IToolImpl {
 
 		return {
 			content: [{ kind: 'text', value: JSON.stringify({ contents: value, size, encoding, }) }],
-			toolResultMessage: `Retrieved file contents for ${uri.path}`,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { isAbsolute } from '../../../../../base/common/path.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { IToolInputProcessor } from '../../common/tools/tools.js';
+
+const getFileContentsModelDescription = `
+This tool returns the contents of the specified file in the project.
+The provided file path must be a path to a file in the workspace or a file that is currently open in the editor.
+The file path can be either absolute or relative to the workspace root.
+The tool will return the contents of the file as a string, along with its size and encoding.
+`;
+
+export const ExtensionFileContentsToolId = 'positron_getFileContents';
+export const InternalFileContentsToolId = `${ExtensionFileContentsToolId}_internal`;
+export const FileContentsToolData: IToolData = {
+	id: InternalFileContentsToolId,
+	displayName: localize('chat.tools.getFileContents', "Get File Contents"),
+	source: { type: 'internal' },
+	modelDescription: getFileContentsModelDescription,
+	tags: ['positron-assistant'],
+	canBeReferencedInPrompt: false,
+	inputSchema: {
+		type: 'object',
+		properties: {
+			filePath: {
+				type: 'string',
+				description: 'The file path to get the contents of.',
+			},
+		},
+		required: ['filePath']
+	}
+};
+
+export class FileContentsTool implements IToolImpl {
+	constructor(
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _token: CancellationToken): Promise<IToolResult> {
+		const { filePath } = invocation.parameters as FileContentsToolParams;
+
+		// Construct the file URI
+		let uri: URI | undefined = undefined;
+		if (isAbsolute(filePath)) {
+			uri = URI.file(filePath);
+			if (!this.fileIsOpenOrInsideWorkspace(uri)) {
+				throw new Error(`File contents for ${filePath} can't be retrieved because the file is not open or inside the current workspace`);
+			}
+		} else {
+			// If the file path is relative, try to resolve it against the workspace folders
+			const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
+			for (const folder of workspaceFolders) {
+				const resolvedUri = folder.toResource(filePath);
+				if (this.fileIsOpenOrInsideWorkspace(resolvedUri)) {
+					uri = resolvedUri;
+					break;
+				}
+			}
+			if (!uri) {
+				throw new Error(`File contents for ${filePath} can't be retrieved because the file is not open or inside any folders in the current workspace`);
+			}
+		}
+
+		// The file is in the workspace, so grab the file contents
+		const { value, size, encoding } = await this._textFileService.read(uri);
+
+		return {
+			content: [{ kind: 'text', value: JSON.stringify({ contents: value, size, encoding, }) }],
+			toolResultMessage: `Retrieved file contents for ${uri.path}`,
+		};
+	}
+
+	fileIsOpenOrInsideWorkspace(uri: URI): boolean {
+		// Check if the file is inside the workspace
+		if (this._workspaceContextService.isInsideWorkspace(uri)) {
+			return true;
+		}
+
+		// Otherwise, check if the file is open in any editor
+		const groupsByLastActive = this._editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
+		return groupsByLastActive.some((group) => {
+			return group.editors.some((editor) => {
+				return isEqual(editor.resource, uri);
+			});
+		});
+	}
+}
+
+export interface FileContentsToolParams {
+	filePath: string;
+}
+
+export class FileContentsToolInputProcessor implements IToolInputProcessor {
+	processInput(input: FileContentsToolParams) {
+		// No input processing needed for this tool
+		return input;
+	}
+}
+

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { localize } from '../../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IExplorerService } from '../../../files/browser/files.js';
-import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
 import { ExplorerItem } from '../../../files/common/explorerModel.js';
 import { SortOrder } from '../../../files/common/files.js';
 import { IToolInputProcessor } from '../../common/tools/tools.js';
@@ -78,6 +78,13 @@ export class ProjectTreeTool implements IToolImpl {
 
 		return {
 			content: workspaceTrees.map(dirTree => ({ kind: 'text', value: JSON.stringify(dirTree) })),
+		};
+	}
+
+	async prepareToolInvocation(_parameters: any, _token: CancellationToken): Promise<IPreparedToolInvocation> {
+		return {
+			invocationMessage: localize('projectTreeTool.invocationMessage', "Constructing project tree"),
+			pastTenseMessage: localize('projectTreeTool.pastTenseMessage', "Constructed project tree"),
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -42,7 +42,7 @@ export class ProjectTreeTool implements IToolImpl {
 		@IExplorerService private readonly _explorerService: IExplorerService,
 	) { }
 
-	async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
+	async invoke(_invocation: IToolInvocation, _countTokens: CountTokensCallback, _token: CancellationToken): Promise<IToolResult> {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
 			return {

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -22,6 +22,7 @@ This tool lists the project tree of the current workspace as a JSON object.
 The project tree is represented as a nested array, where each entry can be either a file (string) or a directory (tuple with the directory name and an array of its children).
 This tool ignores node_modules, __pycache__, dist directories, certain files like .DS_Store, Thumbs.db, and desktop.ini. and files with certain extensions like *.o, *.a, *.so, *.pyo.
 This tool does not provide information for specific files or directories, but rather gives an overview of the entire project structure.
+This tool is helpful for locating files and directories in the workspace.
 This tool only needs to be called once per conversation, unless files or directories are added, removed, moved, or renamed in the workspace.
 `;
 

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { ITextQueryBuilderOptions, QueryBuilder } from '../../../../services/search/common/queryBuilder.js';
+import { ISearchConfigurationProperties, ISearchService } from '../../../../services/search/common/search.js';
+import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { IToolInputProcessor } from '../../common/tools/tools.js';
+
+const findTextInProjectModelDescription = `
+This tool searches for the case-insensitive specified text in the project and returns a set of files and their corresponding lines where the text is found.
+The search is performed across all files in the project, excluding files and directories that are ignored by the workspace settings.
+`;
+
+export const ExtensionTextSearchToolId = 'positron_findTextInProject';
+export const InternalTextSearchToolId = `${ExtensionTextSearchToolId}_internal`;
+export const TextSearchToolData: IToolData = {
+	id: InternalTextSearchToolId,
+	displayName: localize('chat.tools.findTextInProject', "Find Text In Project"),
+	modelDescription: findTextInProjectModelDescription,
+	tags: ['positron-assistant'],
+	canBeReferencedInPrompt: false,
+	inputSchema: {
+		type: 'object',
+		properties: {
+			textToFind: {
+				type: 'string',
+				description: 'The exact case-insensitive text to find in the project.',
+			},
+		},
+		required: ['textToFind']
+	}
+};
+
+export class TextSearchTool implements IToolImpl {
+	private readonly _queryBuilder = this._instantiationService.createInstance(QueryBuilder);
+
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ISearchService private readonly _searchService: ISearchService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	private get searchConfig(): ISearchConfigurationProperties {
+		return this._configurationService.getValue<ISearchConfigurationProperties>('search');
+	}
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _token: CancellationToken): Promise<IToolResult> {
+		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
+		if (workspaceFolders.length === 0) {
+			return {
+				content: [],
+				toolResultMessage: 'No workspace folders found.'
+			};
+		}
+
+		const { textToFind } = invocation.parameters as TextSearchToolParams;
+		const workspaceUris = workspaceFolders.map(folder => folder.uri);
+		const queryOptions: ITextQueryBuilderOptions = {
+			_reason: InternalTextSearchToolId,
+			maxResults: this.searchConfig.maxResults ?? undefined,
+			isSmartCase: this.searchConfig.smartCase ?? undefined,
+			disregardIgnoreFiles: this.searchConfig.useIgnoreFiles ? false : undefined,
+			disregardExcludeSettings: false,
+			onlyOpenEditors: false,
+		};
+
+		const content = {
+			pattern: textToFind
+		};
+		const query = this._queryBuilder.text(content, workspaceUris, queryOptions);
+		const { results, messages } = await this._searchService.textSearch(query, _token);
+
+		return {
+			content: results.map(result => ({ kind: 'text', value: JSON.stringify(({ file: result.resource.path, results: result.results })) })),
+			toolResultMessage: messages.map(message => message.text).join('\n'),
+		};
+	}
+}
+
+export interface TextSearchToolParams {
+	textToFind: string;
+}
+
+export class TextSearchToolInputProcessor implements IToolInputProcessor {
+	processInput(input: TextSearchToolParams) {
+		// No input processing needed for this tool
+		return input;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -77,11 +77,10 @@ export class TextSearchTool implements IToolImpl {
 			pattern: textToFind
 		};
 		const query = this._queryBuilder.text(content, workspaceUris, queryOptions);
-		const { results, messages } = await this._searchService.textSearch(query, _token);
+		const { results } = await this._searchService.textSearch(query, _token);
 
 		return {
 			content: results.map(result => ({ kind: 'text', value: JSON.stringify(({ file: result.resource.path, results: result.results })) })),
-			toolResultMessage: messages.map(message => message.text).join('\n'),
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -23,6 +23,7 @@ export const InternalTextSearchToolId = `${ExtensionTextSearchToolId}_internal`;
 export const TextSearchToolData: IToolData = {
 	id: InternalTextSearchToolId,
 	displayName: localize('chat.tools.findTextInProject', "Find Text In Project"),
+	source: { type: 'internal' },
 	modelDescription: findTextInProjectModelDescription,
 	tags: ['positron-assistant'],
 	canBeReferencedInPrompt: false,

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -22,8 +22,6 @@ The provided pattern is interpreted as text unless indicated to be a regular exp
 Other search options such as case sensitivity, whole word matching, and multiline matching can be specified.
 `;
 
-// File paths are returned as absolute paths, but you may want to display them relative to the workspace root for better readability.
-
 export const ExtensionTextSearchToolId = 'positron_findTextInProject';
 export const InternalTextSearchToolId = `${ExtensionTextSearchToolId}_internal`;
 export const TextSearchToolData: IToolData = {

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -10,7 +10,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ITextQueryBuilderOptions, QueryBuilder } from '../../../../services/search/common/queryBuilder.js';
 import { ISearchConfigurationProperties, ISearchService } from '../../../../services/search/common/search.js';
-import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
 import { IToolInputProcessor } from '../../common/tools/tools.js';
 
 const findTextInProjectModelDescription = `
@@ -81,6 +81,13 @@ export class TextSearchTool implements IToolImpl {
 
 		return {
 			content: results.map(result => ({ kind: 'text', value: JSON.stringify(({ file: result.resource.path, results: result.results })) })),
+		};
+	}
+
+	async prepareToolInvocation(_parameters: any, _token: CancellationToken): Promise<IPreparedToolInvocation> {
+		return {
+			invocationMessage: localize('textSearchTool.invocationMessage', "Searching for text in project"),
+			pastTenseMessage: localize('textSearchTool.pastTenseMessage', "Searched for text in project"),
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/tools.ts
@@ -23,21 +23,21 @@ export class PositronBuiltinToolsContribution extends Disposable implements IWor
 	static readonly ID = 'chat.positronBuiltinTools';
 
 	constructor(
-		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
-		@IInstantiationService instantiationService: IInstantiationService,
+		@ILanguageModelToolsService _toolsService: ILanguageModelToolsService,
+		@IInstantiationService _instantiationService: IInstantiationService,
 	) {
 		super();
 
-		const projectTreeTool = instantiationService.createInstance(ProjectTreeTool);
-		this._register(toolsService.registerToolData(ProjectTreeToolData));
-		this._register(toolsService.registerToolImplementation(ProjectTreeToolData.id, projectTreeTool));
+		const toolDescriptors = [
+			{ data: ProjectTreeToolData, ctor: ProjectTreeTool },
+			{ data: TextSearchToolData, ctor: TextSearchTool },
+			{ data: FileContentsToolData, ctor: FileContentsTool }
+		];
 
-		const textSearchTool = instantiationService.createInstance(TextSearchTool);
-		this._register(toolsService.registerToolData(TextSearchToolData));
-		this._register(toolsService.registerToolImplementation(TextSearchToolData.id, textSearchTool));
-
-		const fileContentsTool = instantiationService.createInstance(FileContentsTool);
-		this._register(toolsService.registerToolData(FileContentsToolData));
-		this._register(toolsService.registerToolImplementation(FileContentsToolData.id, fileContentsTool));
+		for (const { data, ctor } of toolDescriptors) {
+			const tool = _instantiationService.createInstance(ctor);
+			this._register(_toolsService.registerToolData(data));
+			this._register(_toolsService.registerToolImplementation(data.id, tool));
+		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/tools.ts
@@ -16,6 +16,7 @@ import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
 import { ProjectTreeTool, ProjectTreeToolData } from '../../browser/tools/projectTreeTool.js';
 import { TextSearchTool, TextSearchToolData } from './textSearchTool.js';
+import { FileContentsTool, FileContentsToolData } from './fileContentsTool.js';
 
 export class PositronBuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -34,5 +35,9 @@ export class PositronBuiltinToolsContribution extends Disposable implements IWor
 		const textSearchTool = instantiationService.createInstance(TextSearchTool);
 		this._register(toolsService.registerToolData(TextSearchToolData));
 		this._register(toolsService.registerToolImplementation(TextSearchToolData.id, textSearchTool));
+
+		const fileContentsTool = instantiationService.createInstance(FileContentsTool);
+		this._register(toolsService.registerToolData(FileContentsToolData));
+		this._register(toolsService.registerToolImplementation(FileContentsToolData.id, fileContentsTool));
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/tools.ts
@@ -15,6 +15,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
 import { ProjectTreeTool, ProjectTreeToolData } from '../../browser/tools/projectTreeTool.js';
+import { TextSearchTool, TextSearchToolData } from './textSearchTool.js';
 
 export class PositronBuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -29,5 +30,9 @@ export class PositronBuiltinToolsContribution extends Disposable implements IWor
 		const projectTreeTool = instantiationService.createInstance(ProjectTreeTool);
 		this._register(toolsService.registerToolData(ProjectTreeToolData));
 		this._register(toolsService.registerToolImplementation(ProjectTreeToolData.id, projectTreeTool));
+
+		const textSearchTool = instantiationService.createInstance(TextSearchTool);
+		this._register(toolsService.registerToolData(TextSearchToolData));
+		this._register(toolsService.registerToolImplementation(TextSearchToolData.id, textSearchTool));
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -51,6 +51,9 @@ export const EditToolData: IToolData = {
 	displayName: localize('chat.tools.editFile', "Edit File"),
 	modelDescription: `Edit a file in the workspace. Use this tool once per file that needs to be modified, even if there are multiple changes for a file. Generate the "explanation" property first. ${codeInstructions}`,
 	source: { type: 'internal' },
+	// --- Start Positron ---
+	tags: ['positron-assistant'],
+	// --- End Positron ---
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -51,9 +51,6 @@ export const EditToolData: IToolData = {
 	displayName: localize('chat.tools.editFile', "Edit File"),
 	modelDescription: `Edit a file in the workspace. Use this tool once per file that needs to be modified, even if there are multiple changes for a file. Generate the "explanation" property first. ${codeInstructions}`,
 	source: { type: 'internal' },
-	// --- Start Positron ---
-	tags: ['positron-assistant'],
-	// --- End Positron ---
 	inputSchema: {
 		type: 'object',
 		properties: {


### PR DESCRIPTION
## Summary

- addresses https://github.com/posit-dev/positron/issues/7110

- adds tools to:
    - search for specific content and return a set of matches (does a search in the workspace for the text or regex provided)
    - get the contents for a specific file (file needs to be in the workspace or open in an editor)

### Release Notes

#### New Features

- Positron Assistant now has tools to get the workspace project tree, search for text in the workspace, and get the contents of a specific file (#7110)

### QA Notes

@:assistant

- Some test cases: empty workspace, multi-root workspace, single-root workspace
- Text search can be exact text match, word match, regex, etc.
