### PR TITLE
E2E test: re-enable large python notebook test & add large R notebook test

### DIFF
--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -10,8 +10,9 @@ test.use({
 	suiteId: __filename,
 });
 
+// test is too heavy for web
 test.describe('Large Python Notebook', {
-	tag: [tags.NOTEBOOKS, tags.WIN, tags.WEB]
+	tag: [tags.NOTEBOOKS, tags.WIN]
 }, () => {
 
 	test('Python - Large notebook execution', async function ({ app, python }) {

--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -24,6 +24,8 @@ test.describe('Large Python Notebook', {
 
 		await notebooks.runAllCells(120000);
 
+		await app.workbench.layouts.enterLayout('notebook');
+
 		await app.workbench.quickaccess.runCommand('notebook.focusTop');
 		await app.code.driver.page.locator('span').filter({ hasText: 'import pandas as pd' }).locator('span').first().click();
 

--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -16,12 +16,9 @@ test.describe('Large Python Notebook', {
 	tag: [tags.NOTEBOOKS, tags.WIN]
 }, () => {
 
-	test.skip('Python - Large notebook execution', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7255' }]
-	}, async function ({ app, python }) {
-		test.setTimeout(480_000); // huge timeout because this is a heavy test
+	test('Python - Large notebook execution', async function ({ app, python }) {
+		test.slow();
 		const notebooks = app.workbench.notebooks;
-
 
 		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 		await notebooks.selectInterpreter('Python');
@@ -34,14 +31,9 @@ test.describe('Large Python Notebook', {
 		const allFigures: any[] = [];
 		const uniqueLocators = new Set<string>();
 
-		for (let i = 0; i < 6; i++) {
+		for (let i = 0; i < 12; i++) {
 
-			// the second param to wheel (y) seems to be ignored so we send
-			// more messages instead of one with a large y value
-			for (let j = 0; j < 100; j++) {
-				await app.code.driver.page.mouse.wheel(0, 1);
-				await app.code.driver.page.waitForTimeout(100);
-			}
+			await app.code.driver.page.keyboard.press('PageDown');
 
 			const figureLocator = app.workbench.notebooks.frameLocator.locator('.plot-container');
 			const figures = await figureLocator.all();

--- a/test/e2e/tests/notebook/notebook-large-r.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-r.test.ts
@@ -11,9 +11,9 @@ test.use({
 	snapshots: false
 });
 
-
+// test is too heavy for web
 test.describe('Large R Notebook', {
-	tag: [tags.NOTEBOOKS, tags.WIN, tags.WEB]
+	tag: [tags.NOTEBOOKS, tags.WIN]
 }, () => {
 
 	test('R - Large notebook execution', async function ({ app, r }) {

--- a/test/e2e/tests/notebook/notebook-large-r.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-r.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -8,32 +8,37 @@ import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename,
+	snapshots: false
 });
 
-test.describe('Large Python Notebook', {
+
+test.describe('Large R Notebook', {
 	tag: [tags.NOTEBOOKS, tags.WIN, tags.WEB]
 }, () => {
 
-	test('Python - Large notebook execution', async function ({ app, python }) {
+	test('R - Large notebook execution', async function ({ app, r }) {
 		test.slow();
 		const notebooks = app.workbench.notebooks;
 
-		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
-		await notebooks.selectInterpreter('Python');
+		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_r_notebook', 'spotify.ipynb'));
+		await notebooks.selectInterpreter('R');
 
 		await notebooks.runAllCells(120000);
 
 		await app.workbench.quickaccess.runCommand('notebook.focusTop');
-		await app.code.driver.page.locator('span').filter({ hasText: 'import pandas as pd' }).locator('span').first().click();
+		await app.code.driver.page.locator('span').filter({ hasText: 'library(dplyr)' }).locator('span').first().click();
 
 		const allFigures: any[] = [];
 		const uniqueLocators = new Set<string>();
 
-		for (let i = 0; i < 12; i++) {
+		for (let i = 0; i < 6; i++) {
 
-			await app.code.driver.page.keyboard.press('PageDown');
+			for (let j = 0; j < 100; j++) {
+				// second param to mouse.wheel is not processed correctly so loop is needed
+				await app.code.driver.page.mouse.wheel(0, 1);
+			}
 
-			const figureLocator = app.workbench.notebooks.frameLocator.locator('.plot-container');
+			const figureLocator = app.workbench.notebooks.frameLocator.locator('.output_container');
 			const figures = await figureLocator.all();
 
 			if (figures!.length > 0) {
@@ -46,6 +51,6 @@ test.describe('Large Python Notebook', {
 			}
 		}
 
-		expect(allFigures.length).toBeGreaterThan(20);
+		expect(allFigures.length).toBeGreaterThan(10);
 	});
 });

--- a/test/e2e/tests/notebook/notebook-large-r.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-r.test.ts
@@ -25,6 +25,8 @@ test.describe('Large R Notebook', {
 
 		await notebooks.runAllCells(120000);
 
+		await app.workbench.layouts.enterLayout('notebook');
+
 		await app.workbench.quickaccess.runCommand('notebook.focusTop');
 		await app.code.driver.page.locator('span').filter({ hasText: 'library(dplyr)' }).locator('span').first().click();
 
@@ -51,6 +53,6 @@ test.describe('Large R Notebook', {
 			}
 		}
 
-		expect(allFigures.length).toBeGreaterThan(10);
+		expect(allFigures.length).toBeGreaterThan(20);
 	});
 });


### PR DESCRIPTION
This test was disabled due to failure with the upstream merge.  For some reason mouse scroll no longer works to advance down the page with a large Python notebook, but PageDown does.  This is good news because it makes the test much faster.  However, PageDown does not work with a large R notebook and mouse scroll does (added a large R notebook test based on a conversion of the large Python notebook to R).

### QA Notes

@:win @:notebooks
