### PR TITLE
Fix `positron.window.getConsoleForLanguage()`

### DIFF
--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -38,7 +38,7 @@ export async function handleRCode(runtime: RSession, code: string): Promise<void
 	}
 
 	// Otherwise, it looks like runnable code but isn't safe enough to automatically run
-	return handleManuallyRunnable(runtime, code);
+	return await handleManuallyRunnable(runtime, code);
 }
 
 function handleNotRunnable(code: string) {
@@ -47,8 +47,8 @@ function handleNotRunnable(code: string) {
 	));
 }
 
-function handleManuallyRunnable(_runtime: RSession, code: string) {
-	const console = positron.window.getConsoleForLanguage('r');
+async function handleManuallyRunnable(_runtime: RSession, code: string) {
+	const console = await positron.window.getConsoleForLanguage('r');
 
 	if (!console) {
 		// Not an expected path, but technically possible,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1424,13 +1424,14 @@ declare module 'positron' {
 			okButtonTitle?: string): Thenable<null>;
 
 		/**
-		 * Get the `Console` for a runtime language `id`
+		 * Get the `Console` for a runtime `languageId`
 		 *
-		 * @param languageId The runtime language `id` to retrieve a `Console` for, i.e. 'r' or 'python'.
+		 * @param languageId The runtime language id to retrieve a `Console` for, i.e. 'r' or 'python'.
 		 *
-		 * @returns A `Console`, or `undefined` if no `Console` for that language exists.
+		 * @returns A Thenable that resolves to a `Console` or `undefined` if no `Console` for
+		 *   that `languageId` exists.
 		 */
-		export function getConsoleForLanguage(languageId: string): Console | undefined;
+		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
 
 		/**
 		 * Fires when the width of the console input changes. The new width is passed as

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1426,11 +1426,11 @@ declare module 'positron' {
 		/**
 		 * Get the `Console` for a runtime language `id`
 		 *
-		 * @param id The runtime language `id` to retrieve a `Console` for, i.e. 'r' or 'python'.
+		 * @param languageId The runtime language `id` to retrieve a `Console` for, i.e. 'r' or 'python'.
 		 *
 		 * @returns A `Console`, or `undefined` if no `Console` for that language exists.
 		 */
-		export function getConsoleForLanguage(id: string): Console | undefined;
+		export function getConsoleForLanguage(languageId: string): Console | undefined;
 
 		/**
 		 * Fires when the width of the console input changes. The new width is passed as

--- a/src/vs/workbench/api/browser/positron/mainThreadConsole.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsole.ts
@@ -5,6 +5,14 @@
 
 import { IPositronConsoleInstance } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 
+/**
+ * The main thread's view of a console instance
+ *
+ * Cousin to `ExtHostConsole`
+ *
+ * When the extension host requests console behavior from the main thread, it
+ * typically ends up here.
+ */
 export class MainThreadConsole {
 	constructor(
 		private readonly _console: IPositronConsoleInstance

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -65,13 +65,13 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		//
 		// this._disposables.add(
 		// 	this._positronConsoleService.onDidRemovePositronConsoleInstance((console) => {
-		// 		const id = console.session.sessionId;
+		// 		const sessionId = console.session.sessionId;
 		//
 		// 		// First update ext host
-		// 		this._proxy.$removeConsole(id);
+		// 		this._proxy.$removeConsole(sessionId);
 		//
 		// 		// Then update main thread
-		// 		this.removeConsole(id);
+		// 		this.removeConsole(sessionId);
 		// 	})
 		// )
 	}
@@ -80,9 +80,9 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		this._disposables.dispose();
 	}
 
-	private getConsoleForLanguage(id: string): MainThreadConsole | undefined {
+	private getConsoleForLanguage(languageId: string): MainThreadConsole | undefined {
 		return Array.from(this._mainThreadConsolesBySessionId.values())
-			.find(console => console.getLanguageId() === id);
+			.find(console => console.getLanguageId() === languageId);
 	}
 
 	private addConsole(sessionId: string, console: IPositronConsoleInstance) {
@@ -104,8 +104,9 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		return Promise.resolve(this._positronConsoleService.getConsoleWidth());
 	}
 
-	$tryPasteText(id: string, text: string): void {
-		const mainThreadConsole = this.getConsoleForLanguage(id);
+	$tryPasteText(sessionId: string, text: string): void {
+		// TODO!: This is very wrong!
+		const mainThreadConsole = this.getConsoleForLanguage(sessionId);
 
 		if (!mainThreadConsole) {
 			return;

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -176,8 +176,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Thenable<null> {
 				return extHostModalDialogs.showSimpleModalDialogMessage(title, message, okButtonTitle);
 			},
-			getConsoleForLanguage(id: string) {
-				return extHostConsoleService.getConsoleForLanguage(id);
+			getConsoleForLanguage(languageId: string) {
+				return extHostConsoleService.getConsoleForLanguage(languageId);
 			},
 			get onDidChangeConsoleWidth() {
 				return extHostConsoleService.onDidChangeConsoleWidth;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -104,6 +104,7 @@ export interface ExtHostContextKeyServiceShape { }
 
 export interface MainThreadConsoleServiceShape {
 	$getConsoleWidth(): Promise<number>;
+	$getSessionIdForLanguage(languageId: string): Promise<string | undefined>;
 	$tryPasteText(sessionId: string, text: string): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -104,13 +104,13 @@ export interface ExtHostContextKeyServiceShape { }
 
 export interface MainThreadConsoleServiceShape {
 	$getConsoleWidth(): Promise<number>;
-	$tryPasteText(id: string, text: string): void;
+	$tryPasteText(sessionId: string, text: string): void;
 }
 
 export interface ExtHostConsoleServiceShape {
 	$onDidChangeConsoleWidth(newWidth: number): void;
-	$addConsole(id: string): void;
-	$removeConsole(id: string): void;
+	$addConsole(sessionId: string): void;
+	$removeConsole(sessionId: string): void;
 }
 
 export interface MainThreadMethodsShape { }

--- a/src/vs/workbench/api/common/positron/extHostConsole.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsole.ts
@@ -14,14 +14,14 @@ export class ExtHostConsole {
 	private readonly _value: positron.Console;
 
 	constructor(
-		id: string,
+		sessionId: string,
 		proxy: MainThreadConsoleServiceShape,
 		logService: ILogService,
 	) {
 		// So we can access private fields later on
 		const that = this;
 
-		// Implement `Console` interface, scoped in such a way that we can access the `id`,
+		// Implement `Console` interface, scoped in such a way that we can access the `sessionId`,
 		// `proxy`, and `logService` at any time without requiring them as arguments
 		this._value = Object.freeze({
 			pasteText(text: string): void {
@@ -29,7 +29,7 @@ export class ExtHostConsole {
 					logService.warn('Console is closed/disposed.');
 					return;
 				}
-				proxy.$tryPasteText(id, text);
+				proxy.$tryPasteText(sessionId, text);
 			}
 		});
 	}

--- a/src/vs/workbench/api/common/positron/extHostConsole.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsole.ts
@@ -7,6 +7,18 @@ import * as positron from 'positron';
 import { MainThreadConsoleServiceShape } from './extHost.positron.protocol.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 
+/**
+ * The extension host's view of a console instance
+ *
+ * Cousin to `MainThreadConsole`
+ *
+ * Do not add more methods to this class directly. Instead, add them to the
+ * `positron.Console` API and implement them in `Object.freeze()` below by
+ * calling out to the main thread.
+ *
+ * `positron.Console` is modeled after the design of `vscode.TextEditor`, which
+ * similarly has both `ExtHostTextEditor` and `MainThreadTextEditor`.
+ */
 export class ExtHostConsole {
 
 	private _disposed: boolean = false;
@@ -40,10 +52,6 @@ export class ExtHostConsole {
 
 	getConsole(): positron.Console {
 		return this._value;
-	}
-
-	getLanguageId(): string {
-		return this.getLanguageId();
 	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -45,13 +45,13 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		return this._proxy.$getConsoleWidth();
 	}
 
-	getConsoleForLanguage(id: string): positron.Console | undefined {
-		// find a console for this langauge id
+	getConsoleForLanguage(languageId: string): positron.Console | undefined {
+		// Find a console for this `languageId`
 		const extHostConsole = Array.from(this._extHostConsolesBySessionId.values())
-			.find(extHostConsole => extHostConsole.getLanguageId() === id);
+			.find(extHostConsole => extHostConsole.getLanguageId() === languageId);
 
 		if (!extHostConsole) {
-			// Console for this language `id` doesn't exist yet
+			// Console for this `languageId` doesn't exist yet
 			return undefined;
 		}
 
@@ -67,15 +67,15 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	}
 
 	// Called when a new console instance is started
-	$addConsole(id: string): void {
-		const extHostConsole = new ExtHostConsole(id, this._proxy, this._logService);
-		this._extHostConsolesBySessionId.set(id, extHostConsole);
+	$addConsole(sessionId: string): void {
+		const extHostConsole = new ExtHostConsole(sessionId, this._proxy, this._logService);
+		this._extHostConsolesBySessionId.set(sessionId, extHostConsole);
 	}
 
 	// Called when a console instance is removed
-	$removeConsole(id: string): void {
-		const extHostConsole = this._extHostConsolesBySessionId.get(id);
-		this._extHostConsolesBySessionId.delete(id);
+	$removeConsole(sessionId: string): void {
+		const extHostConsole = this._extHostConsolesBySessionId.get(sessionId);
+		this._extHostConsolesBySessionId.delete(sessionId);
 		// "Dispose" of an `ExtHostConsole`, ensuring that future API calls warn / error
 		dispose(extHostConsole);
 	}

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -62,15 +62,30 @@ test.describe('Console Pane: R Hyperlinks', {
 
 	});
 
-	test('R - Verify runnable code link', async function ({ app, r }) {
+	test('R - Verify automatically runnable code link', async function ({ app, r }) {
 
 		await app.workbench.console.pasteCodeToConsole('library(cli)', true);
 		await app.workbench.console.pasteCodeToConsole('txt <- "Is rlang installed? Run this to find out: {.run rlang::is_installed(\'rlang\')}"', true);
 		await app.workbench.console.pasteCodeToConsole('cli_text(txt)', true);
 
+		// Clicking automatically runs (rlang is an approved package)
 		await app.workbench.console.activeConsole.locator('span', { hasText: 'rlang::is_installed(\'rlang\')' }).nth(2).click();
 
 		await app.workbench.console.waitForConsoleContents('[1] TRUE', { timeout: 30000 });
+
+	});
+
+	test('R - Verify manually runnable code link', async function ({ app, r }) {
+
+		await app.workbench.console.pasteCodeToConsole('library(cli)', true);
+		await app.workbench.console.pasteCodeToConsole('txt <- "Is foofy alive? Run this to find out: {.run foofy::alive()}"', true);
+		await app.workbench.console.pasteCodeToConsole('cli_text(txt)', true);
+
+		// Clicking pastes to console (not safe to automatically run, but not known to be unsafe either)
+		await app.workbench.console.activeConsole.locator('span', { hasText: 'foofy::alive()' }).nth(2).click();
+
+		await app.workbench.console.waitForCurrentConsoleLineContents('foofy::alive()');
+		await app.workbench.console.clearInput();
 
 	});
 
@@ -80,6 +95,7 @@ test.describe('Console Pane: R Hyperlinks', {
 		await app.workbench.console.pasteCodeToConsole('txt <- "You can\'t click to run {.run utils::sessionInfo()}"', true);
 		await app.workbench.console.pasteCodeToConsole('cli_text(txt)', true);
 
+		// Clicking denies with toast message (base packages are unsafe)
 		await app.workbench.console.activeConsole.locator('span', { hasText: 'utils::sessionInfo()' }).nth(3).click();
 
 		await app.workbench.popups.toastLocator.locator('span', { hasText: 'Code hyperlink not recognized.' }).waitFor({ state: 'visible', timeout: 30000 });
@@ -93,6 +109,7 @@ test.describe('Console Pane: R Hyperlinks', {
 		await app.workbench.console.pasteCodeToConsole('txt <- "This should work: {.run stringr::str_c(\'hello, \', \'world\')}"', true);
 		await app.workbench.console.pasteCodeToConsole('cli_text(txt)', true);
 
+		// Clicking automatically runs (loaded packages can automatically run)
 		await app.workbench.console.activeConsole.locator('span', { hasText: 'stringr::str_c(\'hello, \', \'world\')' }).nth(2).click();
 
 		await app.workbench.console.waitForConsoleContents('[1] "hello, world"', { timeout: 30000 });


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7169
See https://github.com/posit-dev/positron/issues/7169#issuecomment-2818886935 for the full story

See also https://github.com/posit-dev/positron/issues/7322 for a follow up issue we will need to handle, but it is more important to restore the behavior here first.

https://github.com/user-attachments/assets/4ea98d8b-c0ff-4110-b633-c556ebb9ec1b




### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Manually runnable cli hyperlinks are once again pasted into your console when you click on them (https://github.com/posit-dev/positron/issues/7169)


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:sessions @:console