### PR TITLE
Allow for architecture-specific bootstrapped extensions

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -288,7 +288,7 @@
 		},
 		{
 			"type": "shell",
-			"command": "node build/lib/preLaunch.js",
+			"command": "VSCODE_DEV=1 node build/lib/preLaunch.js",
 			"label": "Ensure Prelaunch Dependencies",
 			"presentation": {
 				"reveal": "silent",

--- a/build/lib/bootstrapExtensions.js
+++ b/build/lib/bootstrapExtensions.js
@@ -62,48 +62,138 @@ function log(...messages) {
         (0, fancy_log_1.default)(...messages);
     }
 }
+function getBootstrapDir() {
+    return path.join(root, '.build', 'bootstrapExtensions');
+}
 function getExtensionPath(extension) {
-    return path.join(root, '.build', 'bootstrapExtensions', `${extension.name}-${extension.version}.vsix`);
+    return path.join(getBootstrapDir(), `${extension.name}-${extension.version}.vsix`);
 }
 function isUpToDate(extension) {
     const regex = new RegExp(`^${extension.name}-(\\d+\\.\\d+\\.\\d+)\\.vsix$`);
-    const bootstrapDir = path.join(root, '.build', 'bootstrapExtensions');
+    const bootstrapDir = getBootstrapDir();
     if (!fs.existsSync(bootstrapDir)) {
         return false;
     }
-    const files = fs.readdirSync(bootstrapDir);
-    const matchingFiles = files.filter(f => regex.test(f));
-    for (const vsixPath of matchingFiles) {
-        try {
-            const match = vsixPath.match(regex);
-            const diskVersion = match ? match[1] : null;
-            if (diskVersion !== extension.version) {
-                log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
-                fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+    // Production builds for macOS are universal and require packaging for both arm64 and x64.
+    // For these builds, multi-arch extensions are stored in separate directories ./arm64 and ./x64.
+    // We need to make sure both directories are up to date, and otherwise return false.
+    // For non production and non-macOS builds, we only package one extension and therefore only need
+    // to check the main directory
+    const isMultiArch = !process.env['VSCODE_DEV'] && process.platform === 'darwin' && extension.metadata?.multiPlatformServiceUrl;
+    if (isMultiArch) {
+        // First, remove all versions of the extension from the main directory
+        const files = fs.readdirSync(bootstrapDir);
+        const matchingFiles = files.filter(f => regex.test(f));
+        for (const vsixPath of matchingFiles) {
+            log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+            fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+        }
+        // Now check the architecture directories
+        const archDirs = ['arm64', 'x64'];
+        for (const arch of archDirs) {
+            const archDir = path.join(bootstrapDir, arch);
+            if (!fs.existsSync(archDir)) {
+                log(`[extensions]`, `Architecture folder ${archDir} does not exist`);
+                return false;
             }
-            else {
-                log(`[extensions]`, `Found up-to-date extension: ${vsixPath}`);
-                return true;
+            const archFiles = fs.readdirSync(archDir);
+            const matchingArchFiles = archFiles.filter(f => regex.test(f));
+            if (matchingArchFiles.length === 0) {
+                log(`[extensions]`, `No matching extensions in ${arch} directory`);
+                return false;
+            }
+            let archUpToDate = false;
+            for (const vsixPath of matchingArchFiles) {
+                try {
+                    const match = vsixPath.match(regex);
+                    const diskVersion = match ? match[1] : null;
+                    if (diskVersion !== extension.version) {
+                        log(`[extensions]`, `Outdated version detected in ${arch}, deleting ${vsixPath}`);
+                        fs.unlinkSync(path.join(archDir, vsixPath));
+                    }
+                    else {
+                        log(`[extensions]`, `Found up-to-date extension in ${arch}: ${vsixPath}`);
+                        archUpToDate = true;
+                    }
+                }
+                catch (err) {
+                    log(`[extensions]`, `Error checking version of ${vsixPath} in ${arch}`, err);
+                    return false;
+                }
+            }
+            if (!archUpToDate) {
+                return false;
             }
         }
-        catch (err) {
-            log(`[extensions]`, `Error checking version of ${vsixPath}`, err);
-            return false;
-        }
+        return true;
     }
-    return false;
+    else {
+        // First, remove from any architecture directories
+        const archDirs = ['arm64', 'x64'];
+        for (const arch of archDirs) {
+            const archDir = path.join(bootstrapDir, arch);
+            if (fs.existsSync(archDir)) {
+                const archFiles = fs.readdirSync(archDir);
+                const matchingArchFiles = archFiles.filter(f => regex.test(f));
+                for (const vsixPath of matchingArchFiles) {
+                    log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+                    fs.unlinkSync(path.join(archDir, vsixPath));
+                }
+            }
+        }
+        // Now check the main directory
+        const files = fs.readdirSync(bootstrapDir);
+        const matchingFiles = files.filter(f => regex.test(f));
+        for (const vsixPath of matchingFiles) {
+            try {
+                const match = vsixPath.match(regex);
+                const diskVersion = match ? match[1] : null;
+                if (diskVersion !== extension.version) {
+                    log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+                    fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+                }
+                else {
+                    log(`[extensions]`, `Found up-to-date extension: ${vsixPath}`);
+                    return true;
+                }
+            }
+            catch (err) {
+                log(`[extensions]`, `Error checking version of ${vsixPath}`, err);
+                return false;
+            }
+        }
+        return false;
+    }
 }
 function getExtensionDownloadStream(extension) {
     const url = extension.metadata.multiPlatformServiceUrl || productjson.extensionsGallery?.serviceUrl;
-    return (url ? ext.fromMarketplace(url, extension, true) : ext.fromGithub(extension))
-        .pipe((0, gulp_rename_1.default)(p => { p.basename = `${extension.name}-${extension.version}.vsix`; }));
+    const stream = url ? ext.fromMarketplace(url, extension, true) : ext.fromGithub(extension);
+    return stream.pipe((0, gulp_rename_1.default)(p => {
+        if (p.basename === 'x64' || p.basename === 'arm64') {
+            p.dirname = path.join(p.dirname || '', p.basename);
+        }
+        p.basename = `${extension.name}-${extension.version}.vsix`;
+    }));
 }
 function getBootstrapExtensionStream(extension) {
     // if the extension exists on disk, use those files instead of downloading anew
     if (isUpToDate(extension)) {
         log('[extensions]', `${extension.name}@${extension.version} up to date`, ansiColors.green('✔︎'));
         return vfs.src(['**'], { cwd: getExtensionPath(extension), dot: true })
-            .pipe((0, gulp_rename_1.default)(p => p.dirname = `${extension.name}/${p.dirname}`));
+            .pipe((0, gulp_rename_1.default)(p => {
+            if (p.dirname === undefined) {
+                p.dirname = `${extension.name}/${p.dirname}`;
+                return;
+            }
+            const dirParts = p.dirname.split(path.sep);
+            const isArchDir = dirParts[0] === 'arm64' || dirParts[0] === 'x64';
+            if (isArchDir) {
+                p.dirname = `${dirParts[0]}/${extension.name}/${dirParts.slice(1).join(path.sep)}`;
+            }
+            else {
+                p.dirname = `${extension.name}/${p.dirname}`;
+            }
+        }));
     }
     return getExtensionDownloadStream(extension);
 }
@@ -159,6 +249,17 @@ function writeControlFile(control) {
     fs.writeFileSync(controlFilePath, JSON.stringify(control, null, 2));
 }
 function getBootstrapExtensions() {
+    // Clean up and remove any architecture folders if they exist and aren't necessary
+    if (process.env['VSCODE_DEV'] || process.platform !== 'darwin') {
+        const archDirs = ['arm64', 'x64'];
+        for (const arch of archDirs) {
+            const archDir = path.join(getBootstrapDir(), arch);
+            if (fs.existsSync(archDir)) {
+                log(`[extensions]`, `Removing architecture folder ${archDir}`);
+                rimraf.sync(archDir);
+            }
+        }
+    }
     const control = readControlFile();
     const streams = [];
     for (const extension of [...bootstrapExtensions]) {

--- a/build/lib/bootstrapExtensions.js
+++ b/build/lib/bootstrapExtensions.js
@@ -182,7 +182,7 @@ function getBootstrapExtensionStream(extension) {
         return vfs.src(['**'], { cwd: getExtensionPath(extension), dot: true })
             .pipe((0, gulp_rename_1.default)(p => {
             if (p.dirname === undefined) {
-                p.dirname = `${extension.name}/${p.dirname}`;
+                p.dirname = `${extension.name}`;
                 return;
             }
             const dirParts = p.dirname.split(path.sep);

--- a/build/lib/bootstrapExtensions.ts
+++ b/build/lib/bootstrapExtensions.ts
@@ -165,7 +165,7 @@ export function getBootstrapExtensionStream(extension: IExtensionDefinition) {
 		return vfs.src(['**'], { cwd: getExtensionPath(extension), dot: true })
 			.pipe(rename(p => {
 				if (p.dirname === undefined) {
-					p.dirname = `${extension.name}/${p.dirname}`;
+					p.dirname = `${extension.name}`;
 					return;
 				}
 				const dirParts = p.dirname.split(path.sep);

--- a/build/lib/bootstrapExtensions.ts
+++ b/build/lib/bootstrapExtensions.ts
@@ -29,43 +29,133 @@ function log(...messages: string[]): void {
 	}
 }
 
+function getBootstrapDir(): string {
+	return path.join(root, '.build', 'bootstrapExtensions');
+}
+
 function getExtensionPath(extension: IExtensionDefinition): string {
-	return path.join(root, '.build', 'bootstrapExtensions', `${extension.name}-${extension.version}.vsix`);
+	return path.join(getBootstrapDir(), `${extension.name}-${extension.version}.vsix`);
 }
 
 function isUpToDate(extension: IExtensionDefinition): boolean {
 	const regex = new RegExp(`^${extension.name}-(\\d+\\.\\d+\\.\\d+)\\.vsix$`);
-	const bootstrapDir = path.join(root, '.build', 'bootstrapExtensions');
+	const bootstrapDir = getBootstrapDir();
 	if (!fs.existsSync(bootstrapDir)) {
 		return false;
 	}
 
-	const files = fs.readdirSync(bootstrapDir);
-	const matchingFiles = files.filter(f => regex.test(f));
-	for (const vsixPath of matchingFiles) {
-		try {
-			const match = vsixPath.match(regex);
-			const diskVersion = match ? match[1] : null;
+	// Production builds for macOS are universal and require packaging for both arm64 and x64.
+	// For these builds, multi-arch extensions are stored in separate directories ./arm64 and ./x64.
+	// We need to make sure both directories are up to date, and otherwise return false.
+	// For non production and non-macOS builds, we only package one extension and therefore only need
+	// to check the main directory
 
-			if (diskVersion !== extension.version) {
-				log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
-				fs.unlinkSync(path.join(bootstrapDir, vsixPath));
-			} else {
-				log(`[extensions]`, `Found up-to-date extension: ${vsixPath}`);
-				return true;
-			}
-		} catch (err) {
-			log(`[extensions]`, `Error checking version of ${vsixPath}`, err);
-			return false;
+	const isMultiArch = !process.env['VSCODE_DEV'] && process.platform === 'darwin' && extension.metadata?.multiPlatformServiceUrl;
+
+	if (isMultiArch) {
+		// First, remove all versions of the extension from the main directory
+		const files = fs.readdirSync(bootstrapDir);
+		const matchingFiles = files.filter(f => regex.test(f));
+
+		for (const vsixPath of matchingFiles) {
+			log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+			fs.unlinkSync(path.join(bootstrapDir, vsixPath));
 		}
+
+		// Now check the architecture directories
+		const archDirs = ['arm64', 'x64'];
+		for (const arch of archDirs) {
+			const archDir = path.join(bootstrapDir, arch);
+
+			if (!fs.existsSync(archDir)) {
+				log(`[extensions]`, `Architecture folder ${archDir} does not exist`);
+				return false;
+			}
+
+			const archFiles = fs.readdirSync(archDir);
+			const matchingArchFiles = archFiles.filter(f => regex.test(f));
+
+			if (matchingArchFiles.length === 0) {
+				log(`[extensions]`, `No matching extensions in ${arch} directory`);
+				return false;
+			}
+
+			let archUpToDate = false;
+
+			for (const vsixPath of matchingArchFiles) {
+				try {
+					const match = vsixPath.match(regex);
+					const diskVersion = match ? match[1] : null;
+
+					if (diskVersion !== extension.version) {
+						log(`[extensions]`, `Outdated version detected in ${arch}, deleting ${vsixPath}`);
+						fs.unlinkSync(path.join(archDir, vsixPath));
+					} else {
+						log(`[extensions]`, `Found up-to-date extension in ${arch}: ${vsixPath}`);
+						archUpToDate = true;
+					}
+				} catch (err) {
+					log(`[extensions]`, `Error checking version of ${vsixPath} in ${arch}`, err);
+					return false;
+				}
+			}
+
+			if (!archUpToDate) {
+				return false;
+			}
+		}
+
+		return true;
+	} else {
+		// First, remove from any architecture directories
+		const archDirs = ['arm64', 'x64'];
+		for (const arch of archDirs) {
+			const archDir = path.join(bootstrapDir, arch);
+			if (fs.existsSync(archDir)) {
+				const archFiles = fs.readdirSync(archDir);
+				const matchingArchFiles = archFiles.filter(f => regex.test(f));
+
+				for (const vsixPath of matchingArchFiles) {
+					log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+					fs.unlinkSync(path.join(archDir, vsixPath));
+				}
+			}
+		}
+
+		// Now check the main directory
+		const files = fs.readdirSync(bootstrapDir);
+		const matchingFiles = files.filter(f => regex.test(f));
+
+		for (const vsixPath of matchingFiles) {
+			try {
+				const match = vsixPath.match(regex);
+				const diskVersion = match ? match[1] : null;
+
+				if (diskVersion !== extension.version) {
+					log(`[extensions]`, `Outdated version detected, deleting ${vsixPath}`);
+					fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+				} else {
+					log(`[extensions]`, `Found up-to-date extension: ${vsixPath}`);
+					return true;
+				}
+			} catch (err) {
+				log(`[extensions]`, `Error checking version of ${vsixPath}`, err);
+				return false;
+			}
+		}
+		return false;
 	}
-	return false;
 }
 
 function getExtensionDownloadStream(extension: IExtensionDefinition) {
 	const url = extension.metadata.multiPlatformServiceUrl || productjson.extensionsGallery?.serviceUrl;
-	return (url ? ext.fromMarketplace(url, extension, true) : ext.fromGithub(extension))
-		.pipe(rename(p => { p.basename = `${extension.name}-${extension.version}.vsix`; }));
+	const stream = url ? ext.fromMarketplace(url, extension, true) : ext.fromGithub(extension);
+	return stream.pipe(rename(p => {
+		if (p.basename === 'x64' || p.basename === 'arm64') {
+			p.dirname = path.join(p.dirname || '', p.basename);
+		}
+		p.basename = `${extension.name}-${extension.version}.vsix`;
+	}));
 }
 
 export function getBootstrapExtensionStream(extension: IExtensionDefinition) {
@@ -73,7 +163,19 @@ export function getBootstrapExtensionStream(extension: IExtensionDefinition) {
 	if (isUpToDate(extension)) {
 		log('[extensions]', `${extension.name}@${extension.version} up to date`, ansiColors.green('✔︎'));
 		return vfs.src(['**'], { cwd: getExtensionPath(extension), dot: true })
-			.pipe(rename(p => p.dirname = `${extension.name}/${p.dirname}`));
+			.pipe(rename(p => {
+				if (p.dirname === undefined) {
+					p.dirname = `${extension.name}/${p.dirname}`;
+					return;
+				}
+				const dirParts = p.dirname.split(path.sep);
+				const isArchDir = dirParts[0] === 'arm64' || dirParts[0] === 'x64';
+				if (isArchDir) {
+					p.dirname = `${dirParts[0]}/${extension.name}/${dirParts.slice(1).join(path.sep)}`;
+				} else {
+					p.dirname = `${extension.name}/${p.dirname}`;
+				}
+			}));
 	}
 
 	return getExtensionDownloadStream(extension);
@@ -145,6 +247,18 @@ function writeControlFile(control: IControlFile): void {
 }
 
 export function getBootstrapExtensions(): Promise<void> {
+
+	// Clean up and remove any architecture folders if they exist and aren't necessary
+	if (process.env['VSCODE_DEV'] || process.platform !== 'darwin') {
+		const archDirs = ['arm64', 'x64'];
+		for (const arch of archDirs) {
+			const archDir = path.join(getBootstrapDir(), arch);
+			if (fs.existsSync(archDir)) {
+				log(`[extensions]`, `Removing architecture folder ${archDir}`);
+				rimraf.sync(archDir);
+			}
+		}
+	}
 
 	const control = readControlFile();
 	const streams: Stream[] = [];

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -78,6 +78,7 @@ const getVersion_1 = require("./getVersion");
 const fetch_1 = require("./fetch");
 // --- Start PWB: from Positron ---
 const util_1 = require("./util");
+const os_1 = __importDefault(require("os"));
 // --- End PWB: from Positron ---
 const root = path_1.default.dirname(path_1.default.dirname(__dirname));
 const commit = (0, getVersion_1.getVersion)(root);
@@ -276,50 +277,89 @@ const baseHeaders = {
     'X-Market-User-Id': '291C1CD0-051A-4123-9B4B-30D60EF52EE2',
 };
 // --- Start Positron ---
+function getPlatformDownloads(bootstrap) {
+    // return both architectures for mac universal installer
+    if (bootstrap && process.platform === 'darwin' && !process.env['VSCODE_DEV']) {
+        return ['darwin-x64', 'darwin-arm64'];
+    }
+    switch (os_1.default.arch()) {
+        case 'arm64':
+            return [`${process.platform}-arm64`];
+        case 'x64':
+        case 'x86_64':
+            return [`${process.platform}-x64`];
+        default:
+            throw new Error(`Unsupported architecture: ${os_1.default.arch()}`);
+    }
+}
+function createPlatformSpecificUrl(serviceUrl, publisher, name, version, platformDownload) {
+    return `${serviceUrl}/${publisher}/${name}/${platformDownload}/${version}/file/${publisher}.${name}-${version}@${platformDownload}.vsix`;
+}
+function getArchFromPlatformId(platformId) {
+    if (platformId.includes('arm64')) {
+        return 'arm64';
+    }
+    else if (platformId.includes('x64')) {
+        return 'x64';
+    }
+    return 'unknown';
+}
 function fromMarketplace(serviceUrl, { name: extensionName, version, sha256, metadata }, bootstrap = false) {
     // --- End Positron ---
     const json = require('gulp-json-editor');
     const [publisher, name] = extensionName.split('.');
     // --- Start Positron ---
-    let url;
+    let urls;
+    let platformDownloads = [];
     if (metadata.multiPlatformServiceUrl) {
-        let platformDownload;
-        switch (process.platform) {
-            case 'darwin':
-                platformDownload = 'darwin-arm64';
-                break;
-            case 'win32':
-                platformDownload = 'win32-x64';
-                break;
-            case 'linux':
-                platformDownload = 'linux-x64';
-                break;
-            default:
-                throw new Error('Unsupported platform');
-        }
-        ;
-        url = `${serviceUrl}/${publisher}/${name}/${platformDownload}/${version}/file/${extensionName}-${version}@${platformDownload}.vsix`;
+        platformDownloads = getPlatformDownloads(bootstrap);
+        urls = platformDownloads.map(platformDownload => createPlatformSpecificUrl(serviceUrl, publisher, name, version, platformDownload));
+        (0, fancy_log_1.default)('Downloading multi-platform extension:', ansi_colors_1.default.yellow(`${extensionName}@${version}`), `for ${platformDownloads.join(', ')}...`);
     }
     else {
-        url = `${serviceUrl}/publishers/${publisher}/vsextensions/${name}/${version}/vspackage`;
+        urls = [`${serviceUrl}/publishers/${publisher}/vsextensions/${name}/${version}/vspackage`];
+        (0, fancy_log_1.default)('Downloading extension:', ansi_colors_1.default.yellow(`${extensionName}@${version}`), '...');
     }
     // --- End Positron ---
-    (0, fancy_log_1.default)('Downloading extension:', ansi_colors_1.default.yellow(`${extensionName}@${version}`), '...');
     const packageJsonFilter = (0, gulp_filter_1.default)('package.json', { restore: true });
     // --- Start Positron ---
     if (bootstrap) {
-        return (0, fetch_1.fetchUrls)('', {
-            base: url,
-            nodeFetchOptions: {
-                headers: baseHeaders
-            },
-            checksumSha256: sha256
-        })
-            .pipe((0, gulp_buffer_1.default)());
+        if (urls.length > 1) {
+            if (process.platform !== 'darwin') {
+                (0, fancy_log_1.default)('Developer error: Unexpected number of URLS for bootstrap extension.');
+            }
+            return event_stream_1.default.merge(...urls.map((url, index) => {
+                const platformId = platformDownloads[index];
+                const arch = getArchFromPlatformId(platformId);
+                return (0, fetch_1.fetchUrls)('', {
+                    base: url,
+                    nodeFetchOptions: { headers: baseHeaders },
+                    checksumSha256: sha256
+                })
+                    .pipe((0, gulp_buffer_1.default)())
+                    .pipe((0, gulp_rename_1.default)(p => {
+                    // Add architecture folder to the path
+                    p.dirname = arch;
+                }));
+            }));
+        }
+        else {
+            return (0, fetch_1.fetchUrls)('', {
+                base: urls[0],
+                nodeFetchOptions: {
+                    headers: baseHeaders
+                },
+                checksumSha256: sha256
+            })
+                .pipe((0, gulp_buffer_1.default)());
+        }
     }
     else {
+        if (urls.length > 1) {
+            (0, fancy_log_1.default)(`Developer error: Unexpected number of URLS for built-in extension.`);
+        }
         return (0, fetch_1.fetchUrls)('', {
-            base: url,
+            base: urls[0],
             nodeFetchOptions: {
                 headers: baseHeaders
             },

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -607,7 +607,7 @@ function packageBootstrapExtensionsStream() {
     return event_stream_1.default.merge(...bootstrapExtensions
         .map(extension => {
         const src = (0, bootstrapExtensions_1.getBootstrapExtensionStream)(extension).pipe((0, gulp_rename_1.default)(p => {
-            p.dirname = `extensions/bootstrap`;
+            p.dirname = `extensions/bootstrap/${p.dirname}`;
         }));
         return src;
     }));

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -30,6 +30,7 @@ import { fetchUrls, fetchGithub } from './fetch';
 
 // --- Start PWB: from Positron ---
 import { PromiseHandles } from './util';
+import os from 'os';
 // --- End PWB: from Positron ---
 
 const root = path.dirname(path.dirname(__dirname));
@@ -261,53 +262,95 @@ const baseHeaders = {
 };
 
 // --- Start Positron ---
+function getPlatformDownloads(bootstrap: boolean): string[] {
+	// return both architectures for mac universal installer
+	if (bootstrap && process.platform === 'darwin' && !process.env['VSCODE_DEV']) {
+		return ['darwin-x64', 'darwin-arm64'];
+	}
+	switch (os.arch()) {
+		case 'arm64':
+			return [`${process.platform}-arm64`];
+		case 'x64':
+		case 'x86_64':
+			return [`${process.platform}-x64`];
+		default:
+			throw new Error(`Unsupported architecture: ${os.arch()}`);
+	}
+}
+
+function createPlatformSpecificUrl(serviceUrl: string, publisher: string, name: string, version: string, platformDownload: string): string {
+	return `${serviceUrl}/${publisher}/${name}/${platformDownload}/${version}/file/${publisher}.${name}-${version}@${platformDownload}.vsix`;
+}
+
+function getArchFromPlatformId(platformId: string): string {
+	if (platformId.includes('arm64')) {
+		return 'arm64';
+	} else if (platformId.includes('x64')) {
+		return 'x64';
+	}
+	return 'unknown';
+}
+
 export function fromMarketplace(serviceUrl: string, { name: extensionName, version, sha256, metadata }: IExtensionDefinition, bootstrap: boolean = false): Stream {
 	// --- End Positron ---
 	const json = require('gulp-json-editor') as typeof import('gulp-json-editor');
 
 	const [publisher, name] = extensionName.split('.');
 	// --- Start Positron ---
-	let url: string;
+	let urls: string[];
+	let platformDownloads: string[] = [];
 
 	if (metadata.multiPlatformServiceUrl) {
-		let platformDownload: string;
-		switch (process.platform) {
-			case 'darwin':
-				platformDownload = 'darwin-arm64';
-				break;
-			case 'win32':
-				platformDownload = 'win32-x64';
-				break;
-			case 'linux':
-				platformDownload = 'linux-x64';
-				break;
-			default:
-				throw new Error('Unsupported platform');
-		};
-		url = `${serviceUrl}/${publisher}/${name}/${platformDownload}/${version}/file/${extensionName}-${version}@${platformDownload}.vsix`
-
+		platformDownloads = getPlatformDownloads(bootstrap);
+		urls = platformDownloads.map(platformDownload => createPlatformSpecificUrl(serviceUrl, publisher, name, version, platformDownload));
+		fancyLog('Downloading multi-platform extension:', ansiColors.yellow(`${extensionName}@${version}`),
+			`for ${platformDownloads.join(', ')}...`);
 	} else {
-		url = `${serviceUrl}/publishers/${publisher}/vsextensions/${name}/${version}/vspackage`;
+		urls = [`${serviceUrl}/publishers/${publisher}/vsextensions/${name}/${version}/vspackage`];
+		fancyLog('Downloading extension:', ansiColors.yellow(`${extensionName}@${version}`), '...');
 	}
 	// --- End Positron ---
 
-	fancyLog('Downloading extension:', ansiColors.yellow(`${extensionName}@${version}`), '...');
 
 	const packageJsonFilter = filter('package.json', { restore: true });
 
 	// --- Start Positron ---
 	if (bootstrap) {
-		return fetchUrls('', {
-			base: url,
-			nodeFetchOptions: {
-				headers: baseHeaders
-			},
-			checksumSha256: sha256
-		})
-			.pipe(buffer());
+		if (urls.length > 1) {
+			if (process.platform !== 'darwin') {
+				fancyLog('Developer error: Unexpected number of URLS for bootstrap extension.');
+			}
+			return es.merge(...urls.map((url, index) => {
+				const platformId = platformDownloads[index];
+				const arch = getArchFromPlatformId(platformId);
+
+				return fetchUrls('', {
+					base: url,
+					nodeFetchOptions: { headers: baseHeaders },
+					checksumSha256: sha256
+				})
+					.pipe(buffer())
+					.pipe(rename(p => {
+						// Add architecture folder to the path
+						p.dirname = arch;
+					}));
+			}));
+		} else {
+			return fetchUrls('', {
+				base: urls[0],
+				nodeFetchOptions: {
+					headers: baseHeaders
+				},
+				checksumSha256: sha256
+			})
+				.pipe(buffer());
+		}
 	} else {
+		if (urls.length > 1) {
+			fancyLog(`Developer error: Unexpected number of URLS for built-in extension.`);
+		}
 		return fetchUrls('', {
-			base: url,
+			base: urls[0],
 			nodeFetchOptions: {
 				headers: baseHeaders
 			},

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -654,7 +654,7 @@ export function packageBootstrapExtensionsStream(): Stream {
 		...bootstrapExtensions
 			.map(extension => {
 				const src = getBootstrapExtensionStream(extension).pipe(rename(p => {
-					p.dirname = `extensions/bootstrap`;
+					p.dirname = `extensions/bootstrap/${p.dirname}`;
 				}));
 				return src;
 			})

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -391,6 +391,50 @@
         "is_secret": false
       }
     ],
+    ".config/guardian/.gdnsuppress": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "85d819d560eee2c39d132c6b64d423ac0b51cb64",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "a51813568421e33416e9677f5abf9cbdbb78d5d2",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "a40a44b0fc85fdd60e348a0e81c566c21e897168",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "3b65278ea81525d3cb95e83ac4f2b287c3b77e80",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "f77aab176d7fe08dc87889cff00d1ee06cb1e247",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".config/guardian/.gdnsuppress",
+        "hashed_secret": "98524b4d37c96618662a795c3e516471bd2908a2",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
     ".github/workflows/test-full-suite.yml": [
       {
         "type": "Secret Keyword",
@@ -572,7 +616,7 @@
         "filename": "build/lib/stylelint/vscode-known-variables.json",
         "hashed_secret": "bebac042cf8ae1cf5954a7f233759a1373a1bd5b",
         "is_verified": false,
-        "line_number": 772,
+        "line_number": 775,
         "is_secret": false
       }
     ],
@@ -846,10 +890,9 @@
       {
         "type": "Hex High Entropy String",
         "filename": "package.json",
-        "hashed_secret": "3ec39d3b4bc4de63741ad7447d35e1f4f7e2a42e",
+        "hashed_secret": "74127074589a15ea62f7e7e6ba448b05a94cc410",
         "is_verified": false,
-        "line_number": 4,
-        "is_secret": false
+        "line_number": 4
       }
     ],
     "product.json": [
@@ -858,7 +901,7 @@
         "filename": "product.json",
         "hashed_secret": "829eaa1d03499ac3be472b80e2d7a7b7df709fca",
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 47,
         "is_secret": false
       },
       {
@@ -866,7 +909,7 @@
         "filename": "product.json",
         "hashed_secret": "7d90ce633d209ed03d95296b71881dd348582702",
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 63,
         "is_secret": false
       },
       {
@@ -874,7 +917,7 @@
         "filename": "product.json",
         "hashed_secret": "98f6b0e364fc315e344dd24ce8ccd59b9a827ccd",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 79,
         "is_secret": false
       },
       {
@@ -882,7 +925,7 @@
         "filename": "product.json",
         "hashed_secret": "d532234ad25d9767b98a089f00f0eb68ed18af4f",
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 112,
         "is_secret": false
       },
       {
@@ -890,7 +933,7 @@
         "filename": "product.json",
         "hashed_secret": "3285718bc1c9d739ee089f65966ef334cfbccabf",
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 122,
         "is_secret": false
       },
       {
@@ -898,7 +941,7 @@
         "filename": "product.json",
         "hashed_secret": "4ecc1a40769a784c894984448c2aa8fe7c6b6d9c",
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 138,
         "is_secret": false
       },
       {
@@ -906,7 +949,7 @@
         "filename": "product.json",
         "hashed_secret": "62bc923c10a3b051de823593ac7dd26a5d1a3fd1",
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 154,
         "is_secret": false
       },
       {
@@ -914,7 +957,7 @@
         "filename": "product.json",
         "hashed_secret": "a98c117e7ff47453ec91a18892f2158eee3391d1",
         "is_verified": false,
-        "line_number": 168,
+        "line_number": 170,
         "is_secret": false
       },
       {
@@ -922,7 +965,7 @@
         "filename": "product.json",
         "hashed_secret": "55a2958461cccfebfa42b8b4218ab19c520986a1",
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 187,
         "is_secret": false
       },
       {
@@ -930,29 +973,13 @@
         "filename": "product.json",
         "hashed_secret": "38c2ef71b7eddafaafff83b53ac51c275aa8d6a9",
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 203,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d2e33af99d17bf1b0ea776a06f06a35003dfa634",
-        "is_verified": false,
-        "line_number": 217,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "product.json",
-        "hashed_secret": "2b8c2e7b2988e554a43e6ee7527c9be82c0f2e8d",
-        "is_verified": false,
-        "line_number": 234,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "product.json",
-        "hashed_secret": "811711522a3ece19af27f5f20248a6b41b773add",
+        "hashed_secret": "ab3a55d44f93c550d1c2f4ec085d83dbbf85e5d6",
         "is_verified": false,
         "line_number": 247,
         "is_secret": false
@@ -1324,6 +1351,22 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/contrib/notebook/test/browser/diff/notebookDiffService.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/workbench/contrib/notebook/test/browser/diff/notebookDiffService.test.ts",
+        "hashed_secret": "69c5ba8c11c53cc23c5dd38f44bc1ea58cb7ac09",
+        "is_verified": false,
+        "line_number": 12644
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/workbench/contrib/notebook/test/browser/diff/notebookDiffService.test.ts",
+        "hashed_secret": "359d086dde2d33ba01605b433c9209c5943fdcc7",
+        "is_verified": false,
+        "line_number": 12645
+      }
+    ],
     "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts": [
       {
         "type": "Basic Auth Credentials",
@@ -1338,7 +1381,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/vs/workbench/contrib/webview/browser/pre/index.html",
-        "hashed_secret": "18e28cb104e16a9281ba04f02b3d657de3110053",
+        "hashed_secret": "cc00b908949fd6679a80652b02f7c2ece4e352bf",
         "is_verified": false,
         "line_number": 9,
         "is_secret": false
@@ -1352,6 +1395,15 @@
         "is_verified": false,
         "line_number": 299,
         "is_secret": false
+      }
+    ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 96
       }
     ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
@@ -1403,5 +1455,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-11T03:03:57Z"
+  "generated_at": "2025-04-22T16:07:11Z"
 }

--- a/product.json
+++ b/product.json
@@ -216,7 +216,6 @@
 		{
 			"name": "ms-python.debugpy",
 			"version": "2025.0.1",
-			"sha256sum": "b6c1639cc839b671125bf5511c36eeb0512744f693925c55c5401fe7a132a978",
 			"repo": "https://github.com/microsoft/vscode-python-debugger",
 			"metadata": {
 				"id": "4bd5d2c9-9d65-401a-b0b2-7498d9f17615",
@@ -233,7 +232,6 @@
 		{
 			"name": "posit.publisher",
 			"version": "1.10.0",
-			"sha256sum": "32be8178b713656d5c532224dd7a4ce5eede7762ab87bf723e2b56ed8710cd1d",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",
@@ -258,6 +256,17 @@
 				},
 				"publisherDisplayName": "Quarto"
 			}
+		},
+		{
+			"name": "posit.air-vscode",
+			"version": "0.10.0",
+			"repo": "https://github.com/posit-dev/air",
+			"metadata": {
+				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",
+				"displayName": "Air - R Language Support",
+				"multiPlatformServiceUrl": "https://open-vsx.org/api"
+			},
+			"publisherDisplayName": "Posit Software, PBC"
 		}
 	],
 	"extensionsGallery": {

--- a/product.json
+++ b/product.json
@@ -231,7 +231,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.12.0",
+			"version": "1.10.0",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",

--- a/product.json
+++ b/product.json
@@ -231,7 +231,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.10.0",
+			"version": "1.12.1",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",

--- a/product.json
+++ b/product.json
@@ -231,7 +231,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.10.0",
+			"version": "1.12.0",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",

--- a/src/vs/base/node/arch.ts
+++ b/src/vs/base/node/arch.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from 'os';
+
+export function getSystemArchitecture(): string {
+	const arch = os.arch();
+
+	switch (arch) {
+		case 'arm64':
+			return 'arm64';
+		case 'x64':
+		case 'x86_64':
+			return 'x64';
+		case 'ia32':
+		case 'x32':
+			return 'x86';
+		default:
+			return arch;
+	}
+}

--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -87,7 +87,7 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 			if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
 				this.logService.debug(`No ${sourceType} extensions to install`, extensionsLocation.toString());
 			} else {
-				this.logService.error(`Error initializing ${sourceType}extensions `, error);
+				this.logService.error(`Error initializing ${sourceType} extensions `, error);
 			}
 			return;
 		}

--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -114,7 +114,7 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 					}
 				}
 				await this.extensionManagementService.install(vsix.resource, { donotIncludePackAndDependencies: true, keepExisting: false });
-				this.logService.info(`Successfully installed ${sourceType}extension:`, vsix.resource.toString());
+				this.logService.info(`Successfully installed ${sourceType} extension:`, vsix.resource.toString());
 			} catch (error) {
 				this.logService.error(`Error installing ${sourceType} extension:`, vsix.resource.toString(), getErrorMessage(error));
 			}


### PR DESCRIPTION
**This PR relies on merging https://github.com/posit-dev/positron-builds/pull/337 first to properly handle macOS signing**
Addresses #6587, #6462

- Update the bootstrapped extensions build process so it downloads architecture-specific extensions depending on the system it is running on (with one exception, explained below).
- Update the bootstrapped extensions install process so that when architecture folders exist in the bootstrap extensions folder, only the extensions for the architecture Positron is currently running on are installed
- Adds Air extension to bootstrapped extensions
- Updates Posit Publisher bootstrap extension to 1.12.1

**Exception**
When running on a mac production build, download both the arm64 and x64 extensions since we are building a universal installer. We determine whether or not we're building for production by the setting of `VSCODE_DEV` which is now being passed to the prelaunch script. This required making significant updates to the version checker of the boostrapped extensions download process to check the appropriate folders and clean up the appropriate locations so that developers can test production builds and dev builds.

### Release Notes

#### New Features

- Added Air - R Language Support 0.10.0 as a bootstrapped extension
- Updated the Posit Publisher bootstrap extension to 1.12.1


### QA Notes

@:extensions 
@:editor
@:r-markdown
@:r-pkg-development
@:reticulate
@:plots
