### PR TITLE
change jupyter kernel selector to use Positron's dropdown

### DIFF
--- a/extensions/positron-notebook-controllers/src/commands.ts
+++ b/extensions/positron-notebook-controllers/src/commands.ts
@@ -44,8 +44,8 @@ export function registerCommands(context: vscode.ExtensionContext, notebookSessi
 					session.runtimeMetadata.runtimeName, notebook.uri.path, error.message));
 		}
 	}), vscode.commands.registerCommand('positron.notebooks.selectPythonEnvironment', async () => {
-		return await vscode.commands.executeCommand('workbench.action.languageRuntime.pick', 'python');
+		return await vscode.commands.executeCommand('workbench.action.languageRuntime.pick');
 	}), vscode.commands.registerCommand('positron.notebooks.selectREnvironment', async () => {
-		return await vscode.commands.executeCommand('workbench.action.languageRuntime.pick', 'r');
+		return await vscode.commands.executeCommand('workbench.action.languageRuntime.pick');
 	}));
 }

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -263,7 +263,6 @@ const selectLanguageRuntime = async (
 		input.canSelectMany = false;
 		const languageName = languageService.getLanguageName(languageId);
 		input.title = nls.localize('positron.languageRuntime.select.selectInterpreter', 'Select {0} Interpreter', languageName);
-		input.placeholder = nls.localize('positron.languageRuntime.select.discoveringInterpreters', 'Discovering Interpreters...');
 		input.matchOnDescription = true;
 
 		for (const runtimeMetadata of languageRuntimeService.registeredRuntimes) {
@@ -563,8 +562,8 @@ export function registerLanguageRuntimeActions() {
 			});
 		}
 
-		async run(accessor: ServicesAccessor, languageId: string) {
-			const languageRuntime = await selectLanguageRuntime(accessor, languageId, undefined);
+		async run(accessor: ServicesAccessor) {
+			const languageRuntime = await selectNewLanguageRuntime(accessor);
 			return languageRuntime?.runtimeId;
 		}
 	});

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -141,19 +141,10 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			async provideKernelSourceActions() {
 				return [
 					{
-						label: 'Python Environments...',
+						label: 'Select Environment...',
 						command: {
 							id: 'workbench.action.languageRuntime.pick',
-							title: 'Select Python Interpreter',
-							arguments: ['python'],
-						},
-					},
-					{
-						label: 'R Environments...',
-						command: {
-							id: 'workbench.action.languageRuntime.pick',
-							title: 'Select R Interpreter',
-							arguments: ['r'],
+							title: 'Select Environment',
 						},
 					}
 				];


### PR DESCRIPTION
Updating the jupyter kernel quickpick to use Positron's main interpreter selector

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Use Positron's main interpreter selector for Jupyter kernels. Addresses https://github.com/posit-dev/positron/issues/5584

#### Bug Fixes

- N/A


### QA Notes

- Open a Jupyter notebook
- Click on the kernel selector in notebook
- Click `Select Environment...`
- Should see the multiconsole interpreter selector (you should actually see this selector, even if the multiconsole setting is turned off)
