### PR TITLE
Show active completion providers

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -138,7 +138,7 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 	// Register with VS Code completions API
 	else if (modelConfig.type === 'completion') {
 		const completionProvider = newCompletionProvider(modelConfig);
-		const complDisp = vscode.languages.registerInlineCompletionItemProvider(ALL_DOCUMENTS_SELECTOR, completionProvider);
+		const complDisp = vscode.languages.registerInlineCompletionItemProvider(ALL_DOCUMENTS_SELECTOR, completionProvider, { displayName: modelConfig.name });
 		modelDisposables.push(complDisp);
 	}
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -138,6 +138,7 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 	// Register with VS Code completions API
 	else if (modelConfig.type === 'completion') {
 		const completionProvider = newCompletionProvider(modelConfig);
+		// this uses the proposed inlineCompletionAdditions API
 		const complDisp = vscode.languages.registerInlineCompletionItemProvider(ALL_DOCUMENTS_SELECTOR, completionProvider, { displayName: modelConfig.name });
 		modelDisposables.push(complDisp);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -369,26 +369,39 @@ class ChatStatusDashboard extends Disposable {
 		// --- Start Positron ---
 		// Completion Providers
 		{
-			const providers = $('div.header', undefined, localize('completionProvidersTitle', "Completion Providers"));
-			this.element.appendChild(providers);
+			const entry = {
+				id: 'positron-assistant.completionProviders',
+				label: localize('completionProvidersLabel', "Completion Providers"),
+				description: '',
+				detail: '',
+			}
 			this.languageFeaturesService.inlineCompletionsProvider.allNoModel().forEach(provider => {
 				const name = provider.displayName;
 				if (name) {
 					// add an element to the container with the name
-					providers.append($('div', undefined, name));
+					entry.description += `${name}\n`;
 				}
 			});
+
+			if (entry.description.length === 0) {
+				entry.description = localize('noCompletionProviders', "No completion providers available");
+			}
+
+			const rendered = this.renderContributedChatStatusItem(entry);
+			this.element.appendChild(rendered.element);
 		}
-		// Remove settings related to Copilot extension
+		// --- End Positron ---
 
 		// Settings
-		// {
-		// 	addSeparator(localize('settingsTitle', "Settings"));
+		{
+			addSeparator(localize('settingsTitle', "Settings"));
 
-		// 	this.createSettings(this.element, disposables);
-		// }
+			this.createSettings(this.element, disposables);
+		}
 
 
+		// --- Start Positron ---
+		// Remove Copilot
 
 		// New to Copilot / Signed out
 		// {
@@ -398,7 +411,6 @@ class ChatStatusDashboard extends Disposable {
 		// 		addSeparator(undefined);
 
 		// 		this.element.appendChild($('div.description', undefined, newUser ? localize('activateDescription', "Set up Copilot to use AI features.") : localize('signInDescription', "Sign in to use Copilot AI features.")));
-
 		// 		const button = disposables.add(new Button(this.element, { ...defaultButtonStyles }));
 		// 		button.label = newUser ? localize('activateCopilotButton', "Set up Copilot") : localize('signInToUseCopilotButton', "Sign in to use Copilot");
 		// 		disposables.add(button.onDidClick(() => this.runCommandAndClose(newUser ? 'workbench.action.chat.triggerSetup' : () => this.chatEntitlementService.requests?.value.signIn())));
@@ -491,8 +503,6 @@ class ChatStatusDashboard extends Disposable {
 		return update;
 	}
 
-	// --- Start Positron ---
-	// @ts-ignore
 	private createSettings(container: HTMLElement, disposables: DisposableStore): HTMLElement {
 		const modeId = this.editorService.activeTextEditorLanguageId;
 		const settings = container.appendChild($('div.settings'));
@@ -516,7 +526,6 @@ class ChatStatusDashboard extends Disposable {
 
 		return settings;
 	}
-	// --- End Positron ---
 
 	private createSetting(container: HTMLElement, settingId: string, label: string, accessor: ISettingsAccessor, disposables: DisposableStore): Checkbox {
 		const checkbox = disposables.add(new Checkbox(label, Boolean(accessor.readSetting()), defaultCheckboxStyles));

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -179,7 +179,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 	private getEntryProps(): IStatusbarEntry {
 		// --- Start Positron ---
 		let text = '$(positron-assistant)';
-		let ariaLabel = localize('chatStatus', "Positron Assistant Status");
+		let ariaLabel = localize('chatStatus', "Assistant Status");
 		// --- End Positron ---
 		let kind: StatusbarEntryKind | undefined;
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -390,14 +390,13 @@ class ChatStatusDashboard extends Disposable {
 			const rendered = this.renderContributedChatStatusItem(entry);
 			this.element.appendChild(rendered.element);
 		}
-		// --- End Positron ---
 
 		// Settings
-		{
-			addSeparator(localize('settingsTitle', "Settings"));
+		// {
+		// 	addSeparator(localize('settingsTitle', "Settings"));
 
-			this.createSettings(this.element, disposables);
-		}
+		// 	this.createSettings(this.element, disposables);
+		// }
 
 
 		// --- Start Positron ---
@@ -503,6 +502,9 @@ class ChatStatusDashboard extends Disposable {
 		return update;
 	}
 
+	// --- Start Positron ---
+	// Removed Settings section since it doesn't change Positron Assistant
+	// @ts-ignore
 	private createSettings(container: HTMLElement, disposables: DisposableStore): HTMLElement {
 		const modeId = this.editorService.activeTextEditorLanguageId;
 		const settings = container.appendChild($('div.settings'));
@@ -526,6 +528,7 @@ class ChatStatusDashboard extends Disposable {
 
 		return settings;
 	}
+	// --- End Positron ---
 
 	private createSetting(container: HTMLElement, settingId: string, label: string, accessor: ISettingsAccessor, disposables: DisposableStore): Checkbox {
 		const checkbox = disposables.add(new Checkbox(label, Boolean(accessor.readSetting()), defaultCheckboxStyles));

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -164,8 +164,10 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 	}
 
 	private getEntryProps(): IStatusbarEntry {
-		let text = '$(copilot)';
-		let ariaLabel = localize('chatStatus', "Copilot Status");
+		// --- Start Positron ---
+		let text = '$(positron-assistant)';
+		let ariaLabel = localize('chatStatus', "Positron Assistant Status");
+		// --- End Positron ---
 		let kind: StatusbarEntryKind | undefined;
 
 		if (!isNewUser(this.chatEntitlementService)) {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -132,19 +132,21 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		this.statusbarService.updateEntryVisibility(completionsStatusId, false);
 		this.statusbarService.overrideEntry(completionsStatusId, { name: localize('codeCompletionsStatus', "Copilot Code Completions"), text: localize('codeCompletionsStatusText', "$(copilot) Completions") });
 
-		// const hidden = this.chatEntitlementService.sentiment === ChatSentiment.Disabled;
+		/*
+		const hidden = this.chatEntitlementService.sentiment === ChatSentiment.Disabled;
 
-		// if (!hidden) {
-		// 	this.entry ||= this.statusbarService.addEntry(this.getEntryProps(), 'chat.statusBarEntry', StatusbarAlignment.RIGHT, { location: { id: 'status.editor.mode', priority: 100.1 }, alignment: StatusbarAlignment.RIGHT });
+		if (!hidden) {
+			this.entry ||= this.statusbarService.addEntry(this.getEntryProps(), 'chat.statusBarEntry', StatusbarAlignment.RIGHT, { location: { id: 'status.editor.mode', priority: 100.1 }, alignment: StatusbarAlignment.RIGHT });
 
-		// 	// TODO@bpasero: remove this eventually
-		// 	const completionsStatusId = `${defaultChat.extensionId}.status`;
-		// 	this.statusbarService.updateEntryVisibility(completionsStatusId, false);
-		// 	this.statusbarService.overrideEntry(completionsStatusId, { name: localize('codeCompletionsStatus', "Copilot Code Completions"), text: localize('codeCompletionsStatusText', "$(copilot) Completions") });
-		// } else {
-		// 	this.entry?.dispose();
-		// 	this.entry = undefined;
-		// }
+			// TODO@bpasero: remove this eventually
+			const completionsStatusId = `${defaultChat.extensionId}.status`;
+			this.statusbarService.updateEntryVisibility(completionsStatusId, false);
+			this.statusbarService.overrideEntry(completionsStatusId, { name: localize('codeCompletionsStatus', "Copilot Code Completions"), text: localize('codeCompletionsStatusText', "$(copilot) Completions") });
+		} else {
+			this.entry?.dispose();
+			this.entry = undefined;
+		}
+		*/
 		// --- End Positron ---
 	}
 
@@ -391,6 +393,7 @@ class ChatStatusDashboard extends Disposable {
 			this.element.appendChild(rendered.element);
 		}
 
+		/*
 		// Settings
 		// {
 		// 	addSeparator(localize('settingsTitle', "Settings"));
@@ -399,22 +402,22 @@ class ChatStatusDashboard extends Disposable {
 		// }
 
 
-		// --- Start Positron ---
 		// Remove Copilot
 
 		// New to Copilot / Signed out
-		// {
-		// 	const newUser = isNewUser(this.chatEntitlementService);
-		// 	const signedOut = this.chatEntitlementService.entitlement === ChatEntitlement.Unknown;
-		// 	if (newUser || signedOut) {
-		// 		addSeparator(undefined);
+		{
+			const newUser = isNewUser(this.chatEntitlementService);
+			const signedOut = this.chatEntitlementService.entitlement === ChatEntitlement.Unknown;
+			if (newUser || signedOut) {
+				addSeparator(undefined);
 
-		// 		this.element.appendChild($('div.description', undefined, newUser ? localize('activateDescription', "Set up Copilot to use AI features.") : localize('signInDescription', "Sign in to use Copilot AI features.")));
-		// 		const button = disposables.add(new Button(this.element, { ...defaultButtonStyles }));
-		// 		button.label = newUser ? localize('activateCopilotButton', "Set up Copilot") : localize('signInToUseCopilotButton', "Sign in to use Copilot");
-		// 		disposables.add(button.onDidClick(() => this.runCommandAndClose(newUser ? 'workbench.action.chat.triggerSetup' : () => this.chatEntitlementService.requests?.value.signIn())));
-		// 	}
-		// }
+				this.element.appendChild($('div.description', undefined, newUser ? localize('activateDescription', "Set up Copilot to use AI features.") : localize('signInDescription', "Sign in to use Copilot AI features.")));
+				const button = disposables.add(new Button(this.element, { ...defaultButtonStyles }));
+				button.label = newUser ? localize('activateCopilotButton', "Set up Copilot") : localize('signInToUseCopilotButton', "Sign in to use Copilot");
+				disposables.add(button.onDidClick(() => this.runCommandAndClose(newUser ? 'workbench.action.chat.triggerSetup' : () => this.chatEntitlementService.requests?.value.signIn())));
+			}
+		}
+		*/
 		// --- End Positron ---
 
 		return this.element;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #6818 

This activates the Chat status bar entry and updates the icon to Positron Assistant. It seems to be hidden by default and had some context keys to determine whether to show it. It's possibly due to the changes going on with Chat from upstream. See `chatStatus.ts L#130` where some parts will be removed in the future. It's likely that extensions will contribute to the tooltip and the Copilot specific code will be moved out to its extension.

This does use proposed API so it may break in a future upstream merge.

For us, we could contribute the information from the extension but it might be good to let this API stabilize. Then we can look into enhancements like changing the status icon when completion providers are running.

![image](https://github.com/user-attachments/assets/2c198e98-73cd-4d8e-b5ba-e37b8830b3b1)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Show in Chat status bar tooltip the active completion providers #6818

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
