### PR TITLE
Fix plotly hanging while rendering bug

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -478,7 +478,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			id: this.id,
 			origin: this.origin,
 			swVersion: String(this._expectedServiceWorkerVersion),
-			extensionId: extension?.id.value ?? '',
+			extensionId: extension?.id?.value ?? '',
 			platform: this.platform,
 			'vscode-resource-base-authority': webviewRootResourceAuthority,
 			parentOrigin: targetWindow.origin,


### PR DESCRIPTION
Addresses #6033

The problem that was occurring was that the webview was attempted to be opened with no extension. However, the extension object sent over looked like `{id: undefined}`, so when it was being unpacked by the webview class it checked if the id field exists, and then once it sees it _does_ it assumes we have a full id object, which we don't. Thus it was trying to pick off value from `undefined`. This PR simply adds one more optional chaining step for the accessing of `value` on the id. This fixed the error in my setup. 



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix plotly hanging while rendering bug. 


### QA Notes

- Run the following code: 
```python
import plotly.express as px
fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig
```
and you should get a plot and a nice and not frozen console. 
