### PR TITLE
Update/support svg icons in action bars

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -120,8 +120,6 @@ export const ActionBarActionButton = (props: ActionBarActionButtonProps) => {
 		menuItemAction.alt :
 		props.action;
 
-	//brianlambert
-
 	// Render.
 	return (
 		<ActionBarButton

--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -23,11 +23,6 @@ import { IAccessibilityService } from '../../../accessibility/common/accessibili
 import { IModifierKeyStatus, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 
 /**
- * Constants.
- */
-const CODICON_ID = /^codicon codicon-(.+)$/;
-
-/**
  * Determines whether the alternative action should be used.
  * @param accessibilityService The accessibility service.
  * @param menuItemAction The menu item action.
@@ -125,9 +120,7 @@ export const ActionBarActionButton = (props: ActionBarActionButtonProps) => {
 		menuItemAction.alt :
 		props.action;
 
-	// Extract the icon ID from the action's class.
-	const iconIdResult = action.class?.match(CODICON_ID);
-	const iconId = iconIdResult?.length === 2 ? iconIdResult[1] : undefined;
+	//brianlambert
 
 	// Render.
 	return (
@@ -136,7 +129,7 @@ export const ActionBarActionButton = (props: ActionBarActionButtonProps) => {
 			ariaLabel={action.label ?? action.tooltip}
 			checked={action.checked}
 			disabled={!action.enabled}
-			iconId={iconId}
+			icon={menuItemAction?.item.icon}
 			label={isPositronActionBarButtonOptions(menuItemAction?.positronActionBarOptions) && menuItemAction.positronActionBarOptions.displayTitle ?
 				action.label :
 				undefined

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -17,6 +17,7 @@ import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { Button, MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { optionalBoolean, optionalValue, positronClassNames } from '../../../../base/common/positronUtilities.js';
 import { ColorScheme } from '../../../theme/common/theme.js';
+import { URI } from '../../../../base/common/uri.js';
 
 /**
  * ActionBarButtonIconProps type
@@ -105,24 +106,24 @@ export const ActionBarButton = forwardRef<
 			const colorThemeType = context.themeService.getColorTheme().type;
 
 			// Determine the css background image based on the color theme type and icon.
-			let cssBackgroundImage: CssFragment | undefined;
+			let icon: URI | undefined;
 			if (colorThemeType === ColorScheme.LIGHT && props.icon.light) {
-				cssBackgroundImage = asCSSUrl(props.icon.light);
+				icon = props.icon.light;
 			} else if (colorThemeType === ColorScheme.DARK && props.icon.dark) {
-				cssBackgroundImage = asCSSUrl(props.icon.dark);
+				icon = props.icon.dark;
 			} else {
 				// Fallback to the dark icon if the light icon is not available.
-				cssBackgroundImage = asCSSUrl(props.icon.light ?? props.icon.dark);
+				icon = props.icon.light ?? props.icon.dark;
 			}
 
-			// Set the icon style, if the css background image is defined.
-			if (cssBackgroundImage) {
+			// Set the icon style.
+			if (icon) {
 				iconStyle.width = '16px';
 				iconStyle.height = '16px';
 				iconStyle.backgroundSize = '16px';
 				iconStyle.backgroundPosition = '50%';
 				iconStyle.backgroundRepeat = 'no-repeat';
-				iconStyle.backgroundImage = cssBackgroundImage;
+				iconStyle.backgroundImage = asCSSUrl(icon);
 			}
 		}
 	}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -10,14 +10,14 @@ import './actionBarButton.css';
 import React, { useRef, PropsWithChildren, useImperativeHandle, forwardRef } from 'react';
 
 // Other dependencies.
+import { URI } from '../../../../base/common/uri.js';
 import { Icon } from '../../../action/common/action.js';
-import { asCSSUrl, CssFragment } from '../../../../base/browser/cssValue.js';
+import { ColorScheme } from '../../../theme/common/theme.js';
+import { asCSSUrl } from '../../../../base/browser/cssValue.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { Button, MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { optionalBoolean, optionalValue, positronClassNames } from '../../../../base/common/positronUtilities.js';
-import { ColorScheme } from '../../../theme/common/theme.js';
-import { URI } from '../../../../base/common/uri.js';
 
 /**
  * ActionBarButtonIconProps type

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -101,14 +101,18 @@ export const ActionBarButton = forwardRef<
 		if (ThemeIcon.isThemeIcon(props.icon)) {
 			iconClassNames = ThemeIcon.asClassNameArray(props.icon);
 		} else {
-			// Determine the css background image based on the color theme and icon.
+			// Get the color theme type.
+			const colorThemeType = context.themeService.getColorTheme().type;
+
+			// Determine the css background image based on the color theme type and icon.
 			let cssBackgroundImage: CssFragment | undefined;
-			if (context.themeService.getColorTheme().type === ColorScheme.LIGHT && props.icon.light) {
+			if (colorThemeType === ColorScheme.LIGHT && props.icon.light) {
 				cssBackgroundImage = asCSSUrl(props.icon.light);
-			} if (context.themeService.getColorTheme().type === ColorScheme.DARK && props.icon.dark) {
-				asCSSUrl(props.icon.dark);
+			} else if (colorThemeType === ColorScheme.DARK && props.icon.dark) {
+				cssBackgroundImage = asCSSUrl(props.icon.dark);
 			} else {
-				cssBackgroundImage = asCSSUrl(props.icon.dark ?? props.icon.light);
+				// Fallback to the dark icon if the light icon is not available.
+				cssBackgroundImage = asCSSUrl(props.icon.light ?? props.icon.dark);
 			}
 
 			// Set the icon style, if the css background image is defined.

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -116,7 +116,7 @@ export const ActionBarButton = forwardRef<
 				icon = props.icon.light ?? props.icon.dark;
 			}
 
-			// Set the icon style.
+			// If there is an icon, set the icon style.
 			if (icon) {
 				iconStyle.width = '16px';
 				iconStyle.height = '16px';

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -10,21 +10,25 @@ import './actionBarButton.css';
 import React, { useRef, PropsWithChildren, useImperativeHandle, forwardRef } from 'react';
 
 // Other dependencies.
+import { Icon } from '../../../action/common/action.js';
+import { asCSSUrl, CssFragment } from '../../../../base/browser/cssValue.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { Button, MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { optionalBoolean, optionalValue, positronClassNames } from '../../../../base/common/positronUtilities.js';
+import { ColorScheme } from '../../../theme/common/theme.js';
 
 /**
  * ActionBarButtonIconProps type
  */
 type ActionBarButtonIconProps = {
-	readonly iconId?: string;
+	readonly icon?: Icon;
 	readonly iconFontSize?: number;
 	readonly iconImageSrc?: never;
 	readonly iconHeight?: never;
 	readonly iconWidth?: never;
 } | {
-	readonly iconId?: never;
+	readonly icon?: never;
 	readonly iconFontSize?: never;
 	readonly iconImageSrc?: string;
 	readonly iconHeight?: number;
@@ -84,16 +88,40 @@ export const ActionBarButton = forwardRef<
 		dropdownButtonRef.current : buttonRef.current
 	);
 
-	// Create the icon style.
-	let iconStyle: React.CSSProperties = {};
-	if (props.iconId && props.iconFontSize) {
-		iconStyle = { ...iconStyle, fontSize: props.iconFontSize };
-	}
-
 	// Aria-hide the inner elements and promote the button text to an aria-label in order to
 	// avoid VoiceOver treating buttons as groups. See VSCode issue for more:
 	// https://github.com/microsoft/vscode/issues/181739#issuecomment-1779701917
 	const ariaLabel = props.ariaLabel ? props.ariaLabel : props.label;
+
+	// Figure out how to display the icon.
+	let iconClassNames: string[] = [];
+	const iconStyle: React.CSSProperties = {};
+	if (props.icon) {
+		// If it's a theme icon, use the theme icon class names.
+		if (ThemeIcon.isThemeIcon(props.icon)) {
+			iconClassNames = ThemeIcon.asClassNameArray(props.icon);
+		} else {
+			// Determine the css background image based on the color theme and icon.
+			let cssBackgroundImage: CssFragment | undefined;
+			if (context.themeService.getColorTheme().type === ColorScheme.LIGHT && props.icon.light) {
+				cssBackgroundImage = asCSSUrl(props.icon.light);
+			} if (context.themeService.getColorTheme().type === ColorScheme.DARK && props.icon.dark) {
+				asCSSUrl(props.icon.dark);
+			} else {
+				cssBackgroundImage = asCSSUrl(props.icon.dark ?? props.icon.light);
+			}
+
+			// Set the icon style, if the css background image is defined.
+			if (cssBackgroundImage) {
+				iconStyle.width = '16px';
+				iconStyle.height = '16px';
+				iconStyle.backgroundSize = '16px';
+				iconStyle.backgroundPosition = '50%';
+				iconStyle.backgroundRepeat = 'no-repeat';
+				iconStyle.backgroundImage = cssBackgroundImage;
+			}
+		}
+	}
 
 	/**
 	 * ActionBarButtonFace component.
@@ -102,13 +130,12 @@ export const ActionBarButton = forwardRef<
 	const ActionBarButtonFace = () => {
 		return (
 			<div aria-hidden='true' className='action-bar-button-face' data-testid={props.dataTestId}>
-				{props.iconId &&
+				{props.icon &&
 					<div
 						className={positronClassNames(
 							'action-bar-button-icon',
 							props.dropdownIndicator,
-							'codicon',
-							`codicon-${props.iconId}`
+							...iconClassNames
 						)}
 						style={iconStyle}
 					/>
@@ -132,7 +159,7 @@ export const ActionBarButton = forwardRef<
 					<div
 						className='action-bar-button-label'
 						style={{
-							marginLeft: (props.iconId || props.iconImageSrc) ? 0 : 4,
+							marginLeft: (props.icon || props.iconImageSrc) ? 0 : 4,
 							maxWidth: optionalValue(props.maxTextWidth, 'none')
 						}}
 					>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
@@ -11,8 +11,9 @@ import React, { ChangeEvent, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
-import { positronClassNames } from '../../../../base/common/positronUtilities.js';
 import { ActionBarButton } from './actionBarButton.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { positronClassNames } from '../../../../base/common/positronUtilities.js';
 
 /**
  * ActionBarFindProps interface.
@@ -69,8 +70,8 @@ export const ActionBarFind = (props: ActionBarFindProps) => {
 					</button>
 				)}
 			</div>
-			<ActionBarButton align='right' disabled={!props.findResults} iconId='chevron-up' tooltip={(() => localize('positronFindPrevious', "Find previous"))()} onPressed={() => props.onFindPrevious!()} />
-			<ActionBarButton align='right' disabled={!props.findResults} iconId='chevron-down' tooltip={(() => localize('positronFindNext', "Find next"))()} onPressed={() => props.onFindNext!()} />
+			<ActionBarButton align='right' disabled={!props.findResults} icon={ThemeIcon.fromId('chevron-up')} tooltip={(() => localize('positronFindPrevious', "Find previous"))()} onPressed={() => props.onFindPrevious!()} />
+			<ActionBarButton align='right' disabled={!props.findResults} icon={ThemeIcon.fromId('chevron-down')} tooltip={(() => localize('positronFindNext', "Find next"))()} onPressed={() => props.onFindNext!()} />
 		</div>
 	);
 };

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -10,19 +10,20 @@ import './actionBarMenuButton.css';
 import React, { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
-import { IAction } from '../../../../base/common/actions.js';
-import { IContextMenuEvent } from '../../../../base/browser/contextmenu.js';
-import { AnchorAlignment, AnchorAxisAlignment } from '../../../../base/browser/ui/contextview/contextview.js';
 import { ActionBarButton } from './actionBarButton.js';
+import { Icon } from '../../../action/common/action.js';
+import { IAction } from '../../../../base/common/actions.js';
 import { useRegisterWithActionBar } from '../useRegisterWithActionBar.js';
+import { IContextMenuEvent } from '../../../../base/browser/contextmenu.js';
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
+import { AnchorAlignment, AnchorAxisAlignment } from '../../../../base/browser/ui/contextview/contextview.js';
 
 /**
  * ActionBarMenuButtonProps interface.
  */
 interface ActionBarMenuButtonProps {
-	readonly iconId?: string;
+	readonly icon?: Icon;
 	readonly iconFontSize?: number;
 	readonly label?: string;
 	readonly ariaLabel?: string;

--- a/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 // Other dependencies.
 import { IHoverService } from '../../hover/browser/hover.js';
 import { unmnemonicLabel } from '../../../base/common/labels.js';
+import { IThemeService } from '../../theme/common/themeService.js';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { ICommandService } from '../../commands/common/commands.js';
 import { IHoverManager } from '../../hover/browser/hoverManager.js';
@@ -35,6 +36,7 @@ export interface PositronActionBarServices {
 	readonly hoverService: IHoverService;
 	readonly keybindingService: IKeybindingService;
 	readonly layoutService: ILayoutService;
+	readonly themeService: IThemeService;
 }
 
 /**

--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -11,6 +11,7 @@ import React, { CSSProperties, KeyboardEvent, useEffect, useLayoutEffect, useRef
 
 // Other dependencies.
 import * as DOM from '../../../base/browser/dom.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
 import { ActionBarButton } from './components/actionBarButton.js';
 import { ActionBarSeparator } from './components/actionBarSeparator.js';
 import { usePositronActionBarContext } from './positronActionBarContext.js';
@@ -360,7 +361,7 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 						ref={refOverflowButton}
 						align='right'
 						ariaLabel={'overflow'}
-						iconId='toolbar-more'
+						icon={ThemeIcon.fromId('toolbar-more')}
 						tooltip={'overflow'}
 						onPressed={async () => {
 							// The custom context menu entries for the overflow context menu.

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -27,6 +27,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { EditorActionBarFactory } from './editorActionBarFactory.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 
 /**
  * Constants.
@@ -68,6 +69,7 @@ export class EditorActionBarControl extends Disposable {
 	 * @param _layoutService The layout service.
 	 * @param _menuService The menu service.
 	 * @param _telemetryService The telemetry service.
+	 * @param _themeService The theme service.
 	 */
 	constructor(
 		private readonly _parent: HTMLElement,
@@ -82,6 +84,7 @@ export class EditorActionBarControl extends Disposable {
 		@ILayoutService private readonly _layoutService: ILayoutService,
 		@IMenuService private readonly _menuService: IMenuService,
 		@ITelemetryService _telemetryService: ITelemetryService,
+		@IThemeService private readonly _themeService: IThemeService,
 	) {
 		// Call the base class's constructor.
 		super();
@@ -112,6 +115,7 @@ export class EditorActionBarControl extends Disposable {
 				hoverService={this._hoverService}
 				keybindingService={this._keybindingService}
 				layoutService={this._layoutService}
+				themeService={this._themeService}
 			/>
 		);
 	}

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -204,7 +204,7 @@ export class EditorActionBarFactory extends Disposable {
 				ariaLabel={positronMoveIntoNewWindowAriaLabel}
 				commandId='workbench.action.moveEditorToNewWindow'
 				disabled={auxiliaryWindow}
-				iconId='positron-open-in-new-window'
+				icon={ThemeIcon.fromId('positron-open-in-new-window')}
 				tooltip={positronMoveIntoNewWindowTooltip}
 			/>
 		);

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -52,11 +52,6 @@ const positronMoveIntoNewWindowAriaLabel = localize(
 );
 
 /**
- * Constants.
- */
-const CODICON_ID = /^codicon codicon-(.+)$/;
-
-/**
  * SubmenuDescriptor interface.
  */
 interface SubmenuDescriptor {
@@ -369,11 +364,6 @@ export class EditorActionBarFactory extends Disposable {
 			} else if (action instanceof SubmenuItemAction) {
 				// Process the action.
 				if (!action.item.rememberDefaultAction) {
-					// Get the icon ID. TODO: Deal with non-theme icons.
-					const iconId = ThemeIcon.isThemeIcon(action.item.icon) ?
-						action.item.icon.id :
-						undefined;
-
 					// Push the action bar menu button.
 					elements.push(
 						<ActionBarMenuButton
@@ -381,7 +371,7 @@ export class EditorActionBarFactory extends Disposable {
 							align='left'
 							ariaLabel={action.label ?? action.tooltip}
 							dropdownIndicator='disabled'
-							iconId={iconId}
+							icon={action.item.icon}
 							tooltip={actionTooltip(
 								this._contextKeyService,
 								this._keybindingService,
@@ -396,10 +386,6 @@ export class EditorActionBarFactory extends Disposable {
 
 					// The first action must be a menu item action.
 					if (firstAction instanceof MenuItemAction) {
-						// Extract the icon ID from the class.
-						const iconIdResult = action.actions[0].class?.match(CODICON_ID);
-						const iconId = iconIdResult?.length === 2 ? iconIdResult[1] : undefined;
-
 						// Push the action bar menu button.
 						elements.push(
 							<ActionBarMenuButton
@@ -414,8 +400,8 @@ export class EditorActionBarFactory extends Disposable {
 									action,
 									false
 								)}
-								iconId={iconId}
-								label={iconId ? undefined : firstAction.label}
+								icon={firstAction.item.icon}
+								label={firstAction.item.icon ? undefined : firstAction.label}
 								tooltip={actionTooltip(
 									this._contextKeyService,
 									this._keybindingService,
@@ -438,7 +424,7 @@ export class EditorActionBarFactory extends Disposable {
 					align='left'
 					ariaLabel={positronMoreActionsAriaLabel}
 					dropdownIndicator='disabled'
-					iconId='toolbar-more'
+					icon={ThemeIcon.fromId('toolbar-more')}
 					tooltip={positronMoreActionsTooltip}
 				/>
 			);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -22,6 +22,7 @@ import { ActionBarCommandButton } from '../../../../../platform/positronActionBa
 import { CommandCenter } from '../../../../../platform/commandCenter/common/commandCenter.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { localize } from '../../../../../nls.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 const startInterpreter = localize('positron.startInterpreter', "Start Interpreter");
 const startSession = localize('positron.console.startSession', "Start Session");
@@ -198,7 +199,7 @@ export const TopActionBarInterpretersManager_New = (props: TopActionBarInterpret
 			...(
 				activeSession
 					? { iconImageSrc: `data:image/svg+xml;base64,${activeSession?.runtimeMetadata.base64EncodedIconSvg}` }
-					: { iconId: 'arrow-swap' }
+					: { icon: ThemeIcon.fromId('codicon-arrow-swap') }
 			)
 			}
 		/>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { usePositronActionBarContext } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
@@ -59,7 +60,7 @@ export const TopActionBarNewMenu = () => {
 	return (
 		<ActionBarMenuButton
 			actions={actions}
-			iconId='positron-new'
+			icon={ThemeIcon.fromId('positron-new')}
 			label={positronNew}
 			tooltip={positronNewFileFolder}
 		/>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
@@ -27,6 +27,7 @@ import { usePositronActionBarContext } from '../../../../../platform/positronAct
 import { PositronTopActionBarState } from '../positronTopActionBarState.js';
 import { OpenFileAction, OpenFileFolderAction, OpenFolderAction } from '../../../actions/workspaceActions.js';
 import { usePositronTopActionBarContext } from '../positronTopActionBarContext.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 /**
  * Constants.
@@ -96,8 +97,8 @@ export const TopActionBarOpenMenu = () => {
 	return (
 		<ActionBarMenuButton
 			actions={actions}
+			icon={ThemeIcon.fromId('folder-opened')}
 			iconFontSize={18}
-			iconId='folder-opened'
 			label={positronOpen}
 			tooltip={positronOpenFileFolder}
 		/>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -38,6 +38,7 @@ import { TopActionBarCustomFolderMenu } from './components/topActionBarCustomFol
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { TopActionBarInterpretersManager } from './components/topActionBarInterpretersManager.js';
 import { SAVE_ALL_COMMAND_ID, SAVE_FILE_COMMAND_ID } from '../../../contrib/files/browser/fileConstants.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 
 // Constants.
 const kHorizontalPadding = 4;
@@ -163,12 +164,12 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 						<ActionBarCommandButton
 							ariaLabel={CommandCenter.title(SAVE)}
 							commandId={SAVE}
-							iconId='positron-save'
+							icon={ThemeIcon.fromId('positron-save')}
 						/>
 						<ActionBarCommandButton
 							ariaLabel={CommandCenter.title(SAVE_ALL)}
 							commandId={SAVE_ALL}
-							iconId='positron-save-all'
+							icon={ThemeIcon.fromId('positron-save-all')}
 						/>
 					</ActionBarRegion>
 
@@ -181,12 +182,12 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 										<ActionBarCommandButton
 											ariaLabel={CommandCenter.title(NAV_BACK)}
 											commandId={NAV_BACK}
-											iconId='chevron-left'
+											icon={ThemeIcon.fromId('chevron-left')}
 										/>
 										<ActionBarCommandButton
 											ariaLabel={CommandCenter.title(NAV_FORWARD)}
 											commandId={NAV_FORWARD}
-											iconId='chevron-right'
+											icon={ThemeIcon.fromId('chevron-right')}
 										/>
 									</ActionBarRegion>
 								)}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
@@ -156,6 +156,7 @@ export class PositronTopActionBarPart extends Part implements IPositronTopAction
 				quickInputService={this.quickInputService}
 				runtimeSessionService={this.runtimeSessionService}
 				runtimeStartupService={this.runtimeStartupService}
+				themeService={this.themeService}
 				workspaceContextService={this.workspaceContextService}
 				workspacesService={this.workspacesService}
 			/>

--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useRef, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { LayoutMenuButton } from './components/layoutMenuButton.js';
 import { isAuxiliaryWindow } from '../../../../../base/browser/window.js';
 import { usePositronDataExplorerContext } from '../../positronDataExplorerContext.js';
@@ -68,7 +69,7 @@ export const ActionBar = () => {
 					<ActionBarRegion location='left'>
 						<ActionBarButton
 							ariaLabel={clearSortButtonDescription}
-							iconId='positron-clear-sorting'
+							icon={ThemeIcon.fromId('positron-clear-sorting')}
 							label={clearSortButtonTitle}
 							tooltip={clearSortButtonDescription}
 							onPressed={async () =>
@@ -82,7 +83,7 @@ export const ActionBar = () => {
 						<ActionBarButton
 							ariaLabel={moveIntoNewWindowButtonDescription}
 							disabled={moveIntoNewWindowDisabled}
-							iconId='positron-open-in-new-window'
+							icon={ThemeIcon.fromId('positron-open-in-new-window')}
 							tooltip={moveIntoNewWindowButtonDescription}
 							onPressed={() =>
 								context.commandService.executeCommand(

--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
@@ -12,9 +12,10 @@ import React, { useEffect, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../../nls.js';
 import { IAction } from '../../../../../../base/common/actions.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { ActionBarMenuButton } from '../../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { usePositronDataExplorerContext } from '../../../positronDataExplorerContext.js';
+import { ActionBarMenuButton } from '../../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { PositronDataExplorerLayout } from '../../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 
 /**
@@ -96,11 +97,11 @@ export const LayoutMenuButton = () => {
 		switch (layout) {
 			// Summary on left.
 			case PositronDataExplorerLayout.SummaryOnLeft:
-				return 'positron-data-explorer-summary-on-left';
+				return ThemeIcon.fromId('positron-data-explorer-summary-on-left');
 
 			// Summary on right.
 			case PositronDataExplorerLayout.SummaryOnRight:
-				return 'positron-data-explorer-summary-on-right';
+				return ThemeIcon.fromId('positron-data-explorer-summary-on-right');
 
 			// Can't happen.
 			default:
@@ -113,7 +114,7 @@ export const LayoutMenuButton = () => {
 		<ActionBarMenuButton
 			actions={actions}
 			ariaLabel={layoutButtonDescription}
-			iconId={selectIconId(currentLayout)}
+			icon={selectIconId(currentLayout)}
 			label={layoutButtonTitle}
 			tooltip={layoutButtonDescription}
 		/>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
@@ -26,6 +26,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { showResumeConnectionModalDialog } from './resumeConnectionModalDialog.js';
 import { localize } from '../../../../../nls.js';
 import { showNewConnectionModalDialog } from './newConnectionModalDialog.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 export interface ListConnnectionsProps extends ViewsProps { }
 
@@ -200,7 +201,7 @@ const ActionBar = (props: React.PropsWithChildren<ActionBarProps>) => {
 					<ActionBarRegion location='left'>
 						<ActionBarButton
 							align='left'
-							iconId='positron-new-connection'
+							icon={ThemeIcon.fromId('positron-new-connection')}
 							label={localize('positron.listConnections.newConnection', 'New Connection')}
 							onPressed={() => {
 								props.onNewConnection();
@@ -211,7 +212,7 @@ const ActionBar = (props: React.PropsWithChildren<ActionBarProps>) => {
 						<ActionBarButton
 							align='right'
 							disabled={props.onDeleteConnection === undefined}
-							iconId='close'
+							icon={ThemeIcon.fromId('close')}
 							label={localize('positron.listConnections.deleteConnection', 'Delete Connection')}
 							onPressed={props.onDeleteConnection}
 						/>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
@@ -24,6 +24,8 @@ import { IContextMenuService } from '../../../../../platform/contextview/browser
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
 
 const ACTION_BAR_PADDING_LEFT = 8;
 const ACTION_BAR_PADDING_RIGHT = 8;
@@ -38,6 +40,7 @@ interface ActionBarProps {
 	readonly hoverService: IHoverService;
 	readonly keybindingService: IKeybindingService;
 	readonly layoutService: ILayoutService;
+	readonly themeService: IThemeService;
 }
 
 interface ConnectionActionBarProps extends ActionBarProps {
@@ -61,21 +64,21 @@ export const ActionBar = (props: React.PropsWithChildren<ConnectionActionBarProp
 					<ActionBarRegion location='left'>
 						<ActionBarButton
 							align='left'
-							iconId='arrow-left'
+							icon={ThemeIcon.fromId('arrow-left')}
 							tooltip={(() => localize('positron.schemaNavigationActionBar.back', 'Back'))()}
 							onPressed={() => props.onBack()}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='left'
-							iconId='positron-disconnect-connection'
+							icon={ThemeIcon.fromId('positron-disconnect-connection')}
 							label={(() => localize('positron.schemaNavigationActionBar.disconnect', 'Disconnect'))()}
 							onPressed={() => props.onDisconnect()}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='left'
-							iconId='refresh'
+							icon={ThemeIcon.fromId('refresh')}
 							label={(() => localize('positron.schemaNavigationActionBar.refresh', 'Refresh'))()}
 							onPressed={() => props.onRefresh()}
 						/>

--- a/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsContext.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsContext.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -25,6 +25,7 @@ import { ILanguageRuntimeService } from '../../../services/languageRuntime/commo
 import { IPositronConnectionsService } from '../../../services/positronConnections/common/interfaces/positronConnectionsService.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 
 export interface PositronConnectionsServices {
 	readonly accessibilityService: IAccessibilityService;
@@ -45,6 +46,7 @@ export interface PositronConnectionsServices {
 	readonly languageRuntimeService: ILanguageRuntimeService;
 	readonly runtimeAffiliationService: IRuntimeStartupService;
 	readonly runtimeSessionService: IRuntimeSessionService;
+	readonly themeService: IThemeService;
 }
 
 const PositronConnectionsContext = createContext<PositronConnectionsServices>(undefined!);

--- a/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
@@ -154,6 +154,7 @@ export class PositronConnectionsView
 				reactComponentContainer={this}
 				runtimeAffiliationService={this.runtimeStartupService}
 				runtimeSessionService={this.runtimeSessionService}
+				themeService={this.themeService}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { CurrentWorkingDirectory } from './currentWorkingDirectory.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -423,7 +424,7 @@ export const ActionBar = (props: ActionBarProps) => {
 					align='right'
 					ariaLabel={canStart ? positronStartConsole : positronShutdownConsole}
 					disabled={!(canShutdown || canStart)}
-					iconId='positron-power-button-thin'
+					icon={ThemeIcon.fromId('positron-power-button-thin')}
 					tooltip={canStart ? positronStartConsole : positronShutdownConsole}
 					onPressed={powerCycleConsoleHandler}
 				/>
@@ -440,7 +441,7 @@ export const ActionBar = (props: ActionBarProps) => {
 				align='right'
 				ariaLabel={positronRestartConsole}
 				disabled={!canShutdown}
-				iconId='positron-restart-runtime-thin'
+				icon={ThemeIcon.fromId('positron-restart-runtime-thin')}
 				tooltip={positronRestartConsole}
 				onPressed={restartConsoleHandler}
 			/>
@@ -464,7 +465,7 @@ export const ActionBar = (props: ActionBarProps) => {
 					ariaLabel={positronDeleteConsole}
 					dataTestId='trash-session'
 					disabled={!(canShutdown || canStart)}
-					iconId='trash'
+					icon={ThemeIcon.fromId('trash')}
 					tooltip={positronDeleteConsole}
 					onPressed={deleteSessionHandler}
 				/>
@@ -496,7 +497,7 @@ export const ActionBar = (props: ActionBarProps) => {
 				<ActionBarButton
 					align='right'
 					ariaLabel={positronToggleTrace}
-					iconId='wand'
+					icon={ThemeIcon.fromId('wand')}
 					tooltip={positronToggleTrace}
 					onPressed={toggleTraceHandler}
 				/>
@@ -518,7 +519,7 @@ export const ActionBar = (props: ActionBarProps) => {
 			<ActionBarButton
 				align='right'
 				ariaLabel={positronToggleWordWrap}
-				iconId='word-wrap'
+				icon={ThemeIcon.fromId('word-wrap')}
 				tooltip={positronToggleWordWrap}
 				onPressed={toggleWordWrapHandler}
 			/>
@@ -539,7 +540,7 @@ export const ActionBar = (props: ActionBarProps) => {
 			<ActionBarButton
 				align='right'
 				ariaLabel={positronOpenInEditor}
-				iconId='positron-open-in-editor'
+				icon={ThemeIcon.fromId('positron-open-in-editor')}
 				tooltip={positronOpenInEditor}
 				onPressed={openInEditorHandler}
 			/>
@@ -560,7 +561,7 @@ export const ActionBar = (props: ActionBarProps) => {
 			<ActionBarButton
 				align='right'
 				ariaLabel={positronClearConsole}
-				iconId='clear-all'
+				icon={ThemeIcon.fromId('clear-all')}
 				tooltip={positronClearConsole}
 				onPressed={clearConsoleHandler}
 			/>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -12,13 +12,14 @@ import React, { useEffect, useRef, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { PositronModalPopup } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js'
-import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
-import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
-import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
-import { ILanguageRuntimeSession, LanguageRuntimeSessionChannel } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+import { PositronModalPopup } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js'
+import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
+import { ILanguageRuntimeSession, LanguageRuntimeSessionChannel } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 
 const positronConsoleInfo = localize('positron.console.info.label', "Console information");
 const localizeShowKernelOutputChannel = (channelName: string) => localize('positron.console.info.showKernelOutputChannel', "Show {0} Output Channel", channelName);
@@ -89,7 +90,7 @@ export const ConsoleInstanceInfoButton = () => {
 			align='right'
 			ariaLabel={positronConsoleInfo}
 			dataTestId={`info-${positronConsoleContext.activePositronConsoleInstance?.sessionId ?? 'unknown'}`}
-			iconId='info'
+			icon={ThemeIcon.fromId('info')}
 			tooltip={positronConsoleInfo}
 			onPressed={handlePressed}
 		/>

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -302,6 +302,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				reactComponentContainer={this}
 				runtimeSessionService={this.runtimeSessionService}
 				runtimeStartupService={this.runtimeStartupService}
+				themeService={this.themeService}
 				viewsService={this.viewsService}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -383,6 +383,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 						instance={positronDataExplorerInstance}
 						keybindingService={this._keybindingService}
 						layoutService={this._layoutService}
+						themeService={this.themeService}
 						onClose={() => this._group.closeEditor(this.input)}
 					/>
 				);

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -12,13 +12,14 @@ import React, { PropsWithChildren, useEffect, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { IAction } from '../../../../../base/common/actions.js';
+import { IPositronHelpService } from '../positronHelpService.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
 import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
-import { IPositronHelpService } from '../positronHelpService.js';
 import { PositronActionBarServices } from '../../../../../platform/positronActionBar/browser/positronActionBarState.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
@@ -153,14 +154,14 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarButton
 						ariaLabel={tooltipPreviousTopic}
 						disabled={!canNavigateBackward}
-						iconId='positron-left-arrow'
+						icon={ThemeIcon.fromId('positron-left-arrow')}
 						tooltip={tooltipPreviousTopic}
 						onPressed={() => props.positronHelpService.navigateBackward()}
 					/>
 					<ActionBarButton
 						ariaLabel={tooltipNextTopic}
 						disabled={!canNavigateForward}
-						iconId='positron-right-arrow'
+						icon={ThemeIcon.fromId('positron-right-arrow')}
 						tooltip={tooltipNextTopic}
 						onPressed={() => props.positronHelpService.navigateForward()}
 					/>
@@ -170,7 +171,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarButton
 						ariaLabel={tooltipShowPositronHelp}
 						disabled={true}
-						iconId='positron-home'
+						icon={ThemeIcon.fromId('positron-home')}
 						tooltip={tooltipShowPositronHelp}
 						onPressed={() => props.onHome()}
 					/>
@@ -203,7 +204,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							align='right'
 							ariaLabel={tooltipShowPositronHelp}
 							disabled={currentHelpEntry === undefined}
-							iconId='positron-search'
+							icon={ThemeIcon.fromId('positron-search')}
 							tooltip={tooltipShowPositronHelp}
 							onPressed={() => currentHelpEntry?.showFind()}
 						/>

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -277,6 +277,7 @@ export class PositronHelpView extends PositronViewPane implements IReactComponen
 				layoutService={this._layoutService}
 				positronHelpService={this.positronHelpService}
 				reactComponentContainer={this}
+				themeService={this.themeService}
 				onHome={homeHandler}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -36,6 +36,8 @@ import { IAccessibilityService } from '../../../../../platform/accessibility/com
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
 import { DarkFilterMenuButton } from './darkFilterMenuButton.js';
 import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
 
 // Constants.
 const kPaddingLeft = 14;
@@ -65,6 +67,7 @@ export interface ActionBarsProps {
 	readonly layoutService: IWorkbenchLayoutService;
 	readonly notificationService: INotificationService;
 	readonly preferencesService: IPreferencesService;
+	readonly themeService: IThemeService;
 	readonly zoomHandler: (zoomLevel: number) => void;
 	readonly zoomLevel: number;
 }
@@ -160,14 +163,14 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton
 							ariaLabel={showPreviousPlot}
 							disabled={disableLeft}
-							iconId='positron-left-arrow'
+							icon={ThemeIcon.fromId('positron-left-arrow')}
 							tooltip={showPreviousPlot}
 							onPressed={showPreviousPlotHandler}
 						/>
 						<ActionBarButton
 							ariaLabel={showNextPlot}
 							disabled={disableRight}
-							iconId='positron-right-arrow'
+							icon={ThemeIcon.fromId('positron-right-arrow')}
 							tooltip={showNextPlot}
 							onPressed={showNextPlotHandler}
 						/>
@@ -179,7 +182,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						{enableSavingPlots &&
 							<ActionBarButton
 								ariaLabel={savePlot}
-								iconId='positron-save'
+								icon={ThemeIcon.fromId('positron-save')}
 								tooltip={savePlot}
 								onPressed={savePlotHandler}
 							/>
@@ -188,7 +191,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							<ActionBarButton
 								ariaLabel={copyPlotToClipboard}
 								disabled={!hasPlots}
-								iconId='copy'
+								icon={ThemeIcon.fromId('copy')}
 								tooltip={copyPlotToClipboard}
 								onPressed={copyPlotHandler}
 							/>
@@ -211,7 +214,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							<ActionBarButton
 								align='right'
 								ariaLabel={openPlotInNewWindow}
-								iconId='positron-open-in-new-window'
+								icon={ThemeIcon.fromId('positron-open-in-new-window')}
 								tooltip={openPlotInNewWindow}
 								onPressed={popoutPlotHandler}
 							/>
@@ -240,7 +243,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							align='right'
 							ariaLabel={clearAllPlots}
 							disabled={noPlots}
-							iconId='clear-all'
+							icon={ThemeIcon.fromId('clear-all')}
 							tooltip={clearAllPlots}
 							onPressed={clearAllPlotsHandler}
 						/>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -14,6 +14,8 @@ import * as nls from '../../../../../nls.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
 import { localize } from '../../../../../nls.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { Icon } from '../../../../../platform/action/common/action.js';
 
 interface DarkFilterMenuButtonProps {
 	readonly plotsService: IPositronPlotsService;
@@ -60,14 +62,14 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 		}
 	};
 
-	const iconForDarkFilter = (policy: DarkFilter): string => {
+	const iconForDarkFilter = (policy: DarkFilter): Icon => {
 		switch (policy) {
 			case DarkFilter.On:
-				return 'circle-large-filled';
+				return ThemeIcon.fromId('circle-large-filled');
 			case DarkFilter.Off:
-				return 'circle-large';
+				return ThemeIcon.fromId('circle-large');
 			case DarkFilter.Auto:
-				return 'color-mode';
+				return ThemeIcon.fromId('color-mode');
 		}
 	}
 
@@ -113,7 +115,7 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 			actions={actions}
 			align='right'
 			ariaLabel={darkFilterTooltip}
-			iconId={iconForDarkFilter(darkFilterMode)}
+			icon={iconForDarkFilter(darkFilterMode)}
 			tooltip={darkFilterTooltip}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
@@ -11,6 +11,7 @@ import { IAction } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { HistoryPolicy, IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
 import * as nls from '../../../../../nls.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 interface HistoryPolicyMenuButtonProps {
 	readonly plotsService: IPositronPlotsService;
@@ -68,7 +69,7 @@ export const HistoryPolicyMenuButton = (props: HistoryPolicyMenuButtonProps) => 
 			actions={actions}
 			align='right'
 			ariaLabel={historyPolicyTooltip}
-			iconId='layout'
+			icon={ThemeIcon.fromId('layout')}
 			tooltip={historyPolicyTooltip}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -11,6 +11,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { AUX_WINDOW_GROUP_TYPE, ACTIVE_GROUP_TYPE, SIDE_GROUP_TYPE, AUX_WINDOW_GROUP, ACTIVE_GROUP, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { PlotsEditorAction } from '../positronPlotsActions.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 interface OpenInEditorMenuButtonProps {
 	tooltip: string;
@@ -82,7 +83,7 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 			dropdownAriaLabel={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
 			dropdownIndicator='enabled-split'
 			dropdownTooltip={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
-			iconId='go-to-file'
+			icon={ThemeIcon.fromId('go-to-file')}
 			tooltip={props.tooltip}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
@@ -21,6 +21,7 @@ import { IPositronPlotSizingPolicy } from '../../../../services/positronPlots/co
 import { PlotSizingPolicyIntrinsic } from '../../../../services/positronPlots/common/sizingPolicyIntrinsic.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { disposableTimeout } from '../../../../../base/common/async.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 interface SizingPolicyMenuButtonProps {
 	readonly keybindingService: IKeybindingService;
@@ -176,7 +177,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 	return (
 		<ActionBarMenuButton
 			actions={actions}
-			iconId='symbol-ruler'
+			icon={ThemeIcon.fromId('symbol-ruler')}
 			label={activePolicyLabel}
 			tooltip={sizingPolicyTooltip}
 		/>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import * as nls from '../../../../../nls.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 export enum ZoomLevel {
 	Fit = 0,
@@ -71,7 +72,7 @@ export const ZoomPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
 	return (
 		<ActionBarMenuButton
 			actions={actions}
-			iconId='positron-size-to-fit'
+			icon={ThemeIcon.fromId('positron-size-to-fit')}
 			label={activeZoomLabel}
 			tooltip={zoomPlotTooltip}
 		/>

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
@@ -256,7 +256,9 @@ export class PositronPlotsViewPane extends PositronViewPane implements IReactCom
 				notificationService={this.notificationService}
 				positronPlotsService={this.positronPlotsService}
 				preferencesService={this.preferencesService}
-				reactComponentContainer={this} />
+				reactComponentContainer={this}
+				themeService={this.themeService}
+			/>
 		);
 	}
 

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -145,6 +145,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 				notificationService={this._notificationService}
 				positronPlotsService={this._positronPlotsService}
 				preferencesService={this._preferencesService}
+				themeService={this.themeService}
 			>
 				<EditorPlotsContainer
 					height={this._height}

--- a/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
@@ -19,6 +19,7 @@ import { ActionBarRegion } from '../../../../../platform/positronActionBar/brows
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 const reload = localize('positron.preview.html.reload', "Reload the content");
 const clear = localize('positron.preview.html.clear', "Clear the content");
@@ -89,27 +90,27 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 						<ActionBarButton
 							align='right'
 							ariaLabel={reload}
-							iconId='positron-refresh'
+							icon={ThemeIcon.fromId('positron-refresh')}
 							tooltip={reload}
 							onPressed={reloadHandler} />
 						<ActionBarButton
 							align='right'
 							ariaLabel={openInBrowser}
-							iconId='positron-open-in-new-window'
+							icon={ThemeIcon.fromId('positron-open-in-new-window')}
 							tooltip={openInBrowser}
 							onPressed={openInBrowserHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'
 							ariaLabel={openInEditor}
-							iconId='go-to-file'
+							icon={ThemeIcon.fromId('go-to-file')}
 							tooltip={openInEditor}
 							onPressed={openInEditorHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'
 							ariaLabel={clear}
-							iconId='clear-all'
+							icon={ThemeIcon.fromId('clear-all')}
 							tooltip={clear}
 							onPressed={clearHandler} />
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -20,6 +20,7 @@ import { ActionBarSeparator } from '../../../../../platform/positronActionBar/br
 import { URI } from '../../../../../base/common/uri.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { kPaddingLeft, kPaddingRight, PreviewActionBarsProps } from './actionBars.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 // Constants.
 const kUrlBarInputName = 'url-bar';
@@ -166,12 +167,12 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight} size='small'>
 					<ActionBarRegion location='left'>
 						<ActionBarButton ariaLabel={navigateBack}
-							iconId='positron-left-arrow'
+							icon={ThemeIcon.fromId('positron-left-arrow')}
 							tooltip={navigateBack}
 							onPressed={navigateBackHandler} />
 						<ActionBarButton
 							ariaLabel={navigateForward}
-							iconId='positron-right-arrow'
+							icon={ThemeIcon.fromId('positron-right-arrow')}
 							tooltip={navigateForward}
 							onPressed={navigateForwardHandler} />
 					</ActionBarRegion>
@@ -191,27 +192,27 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 						<ActionBarButton
 							align='right'
 							ariaLabel={reload}
-							iconId='positron-refresh'
+							icon={ThemeIcon.fromId('positron-refresh')}
 							tooltip={reload}
 							onPressed={reloadHandler} />
 						<ActionBarButton
 							align='right'
 							ariaLabel={openInBrowser}
-							iconId='positron-open-in-new-window'
+							icon={ThemeIcon.fromId('positron-open-in-new-window')}
 							tooltip={openInBrowser}
 							onPressed={openInBrowserHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'
 							ariaLabel={openInEditor}
-							iconId='go-to-file'
+							icon={ThemeIcon.fromId('go-to-file')}
 							tooltip={openInEditor}
 							onPressed={openInEditorHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'
 							ariaLabel={clear}
-							iconId='clear-all'
+							icon={ThemeIcon.fromId('clear-all')}
 							tooltip={clear}
 							onPressed={clearHandler} />
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
@@ -32,6 +32,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { PreviewHtml } from './previewHtml.js';
 import { HtmlActionBars } from './components/htmlActionBars.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 
 /**
  * PositronPreviewProps interface.
@@ -51,6 +52,7 @@ export interface PositronPreviewProps extends PositronPreviewServices {
 	readonly positronPreviewService: IPositronPreviewService;
 	readonly reactComponentContainer: PositronPreviewViewPane;
 	readonly runtimeSessionService: IRuntimeSessionService;
+	readonly themeService: IThemeService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -191,7 +191,9 @@ export class PositronPreviewViewPane extends PositronViewPane implements IReactC
 				openerService={this.openerService}
 				positronPreviewService={this.positronPreviewService}
 				reactComponentContainer={this}
-				runtimeSessionService={this.runtimeSessionService} />
+				runtimeSessionService={this.runtimeSessionService}
+				themeService={this.themeService}
+			/>
 		);
 	}
 

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
@@ -246,6 +246,7 @@ export class PositronRuntimeSessionsViewPane extends PositronViewPane implements
 				layoutService={this._layoutService}
 				reactComponentContainer={this}
 				runtimeSessionService={this._runtimeSessionService}
+				themeService={this.themeService}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -25,6 +25,7 @@ import { usePositronVariablesContext } from '../positronVariablesContext.js';
 import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
 import { VariablesInstanceMenuButton } from './variablesInstanceMenuButton.js';
 import { DeleteAllVariablesModalDialog } from '../modalDialogs/deleteAllVariablesModalDialog.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 // Constants.
 const kSecondaryActionBarGap = 4;
@@ -145,7 +146,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton
 							align='right'
 							ariaLabel={positronRefreshObjects}
-							iconId='positron-refresh'
+							icon={ThemeIcon.fromId('positron-refresh')}
 							tooltip={positronRefreshObjects}
 							onPressed={refreshObjectsHandler}
 						/>
@@ -153,7 +154,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton
 							align='right'
 							ariaLabel={positronDeleteAllObjects}
-							iconId='clear-all'
+							icon={ThemeIcon.fromId('clear-all')}
 							tooltip={positronDeleteAllObjects}
 							onPressed={deleteAllObjectsHandler}
 						/>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
@@ -15,6 +15,7 @@ import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
 import { PositronVariablesGrouping } from '../../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 /**
  * Localized strings.
@@ -113,7 +114,7 @@ export const GroupingMenuButton = () => {
 		<ActionBarMenuButton
 			actions={actions}
 			ariaLabel={positronChangeHowVariablesAreGrouped}
-			iconId='positron-variables-grouping'
+			icon={ThemeIcon.fromId('positron-variables-grouping')}
 			tooltip={positronChangeHowVariablesAreGrouped}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronVariables/browser/components/sortingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/sortingMenuButton.tsx
@@ -15,6 +15,7 @@ import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
 import { PositronVariablesSorting } from '../../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 
 /**
  * Localized strings.
@@ -134,7 +135,7 @@ export const SortingMenuButton = () => {
 		<ActionBarMenuButton
 			actions={actions}
 			ariaLabel={positronChangeHowVariablesAreSorted}
-			iconId='positron-variables-sorting'
+			icon={ThemeIcon.fromId('positron-variables-sorting')}
 			tooltip={positronChangeHowVariablesAreSorted}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -284,6 +284,7 @@ export class PositronVariablesViewPane extends PositronViewPane implements IReac
 				positronVariablesService={this._positronVariablesService}
 				reactComponentContainer={this}
 				runtimeSessionService={this._runtimeSessionService}
+				themeService={this.themeService}
 			/>
 		);
 	}


### PR DESCRIPTION
## Description

This PR addresses #6578. Prior to this PR, Action Bar icons were specified using the Codicon ID of the desired icon. For example:

```
<ActionBarCommandButton {...otherProps} iconId='positron-save' />
```

After this PR, Action Bar icons are now specified using the `Icon` type:

```
export type Icon = { dark?: URI; light?: URI } | ThemeIcon;
```

Which can be either a `ThemeIcon`:

```
<ActionBarCommandButton {...otherProps} icon={ThemeIcon.fromId('positron-save')} />
```

Or an object that specifies `light` / `dark` URLs for the icons (SVG, PNG, etc.) to display. There are no examples of this in VS Code / Positron, but that would look something like this:

```
{
    dark: FileAccess.asFileUri('vs/workbench/browser/parts/somepart/media/back.svg'),
    light: FileAccess.asFileUri('vs/workbench/browser/parts/somepart/media/white.svg')
}
```

```
{
    dark: FileAccess.asFileUri('vs/workbench/browser/parts/somepart/media/back.png'),
    light: FileAccess.asFileUri('vs/workbench/browser/parts/somepart/media/white.png')
}
```

This work fixes the Editor Actions Toolbar so that the **Gemini Code Assist: Smart Actions** button appears:

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/b8f7c33d-c192-445f-b27a-5cef5393de04" />

This fix applies to any extension that uses images (SVG, PNG, etc.) as icons in command definitions. For example:

```
{
    "command": "package.someCommand",
    "title": "Some Command",
    "icon": "./assets/icon/image.svg"
}
```

or, when `light` and `dark` images are required:

```
{
    "command": "package.someCommand",
    "title": "Some Command",
    "icon": {
        "light": "./assets/icon/light-image.svg",
        "dark": "./assets/icon/dark-image.svg"
    }
}
```

Tests:
@:console
@:critical
@:data-explorer
@:editor-action-bar
@:help
@:top-action-bar
@:variables

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6578 Fix Action Bar to render SVG icons for the Gemini 

### QA Notes

Please review every Action Bar to ensure that it looks correct.