### PR TITLE
Fix CSS errors that caused #3357

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter.css
@@ -15,7 +15,7 @@
 	font-size: 12px;
 	border-radius: 4px;
 	align-items: center;
-	background: var(--positronActionBar-textInputBackground);
+	background: var(--vscode-positronModalDialog-textInputBackground);
 	border: 1px solid var(--vscode-positronDropDownListBox-border);
 }
 
@@ -36,12 +36,11 @@
 
 .row-filter-parameter-input
 .text-input::placeholder {
-	opacity: 0.5;
-	color: var(--positronActionBar-foreground);
+	opacity: 0.75;
 }
 
 .row-filter-parameter-input
 .text-input::selection {
-	color: var(--positronActionBar-textInputSelectionForeground);
-	background: var(--positronActionBar-textInputSelectionBackground);
+	color: var(--vscode-positronModalDialog-textInputSelectionForeground);
+	background: var(--vscode-positronModalDialog-textInputSelectionBackground);
 }


### PR DESCRIPTION
## Description

This PR addresses #3357 by fixing a few CSS errors that were causing the issue.

https://github.com/user-attachments/assets/16b3c548-a8d7-4261-a6ac-c2e9bab09eda

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #3357

### QA Notes

You should now be able to select and edit text in the Data Explorer filter UI value text boxes.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/07df3fb7-4470-48d5-ab19-3c0b76b06d56" />
