### PR TITLE
Data Explorer: Use complete URIs rather than file paths for DuckDB

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -95,7 +95,7 @@ class PositronDataExplorerContribution extends Disposable {
 			},
 			{
 				createEditorInput: async ({ resource, options }, group) => {
-					await dataExplorerService.openWithDuckDB(resource.path);
+					await dataExplorerService.openWithDuckDB(resource);
 
 					// We create a data explorer URI that will use the DuckDB client
 					// that we just created.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -6,6 +6,7 @@
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { ArraySelection, BackendState, ColumnFilter, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSelection, ColumnSortKey, DataExplorerFrontendEvent, DataUpdateEvent, ExportedData, ExportFormat, FilterResult, FormatOptions, ReturnColumnProfilesEvent, RowFilter, SchemaUpdateEvent, SupportedFeatures, SupportStatus, TableData, TableRowLabels, TableSchema, TableSelection } from './positronDataExplorerComm.js';
 
@@ -36,7 +37,7 @@ export interface DataExplorerUiEvent {
 	/**
 	 * Unique resource identifier for routing method calls.
 	 */
-	uri: string;
+	uri: URI;
 
 	/**
 	 * Method name, as defined

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IPositronDataExplorerInstance } from './positronDataExplorerInstance.js';
 
@@ -70,9 +71,8 @@ export interface IPositronDataExplorerService {
 	clearFocusedPositronDataExplorer(identifier: string): void;
 
 	/**
-	 * Open a workspace file using the positron-duckdb extension for use with
-	 * the data explorer.
-	 * @param filePath Path to file to open with positron-duckdb extension
+	 * Open a URI in the data explorer using the positron-duckdb extension.
+	 * @param uri The URI, usually a file in the workspace.
 	 */
-	openWithDuckDB(filePath: string): Promise<void>;
+	openWithDuckDB(uri: URI): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -26,6 +26,7 @@ import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorer
 import { PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataExplorerDuckDBBackend } from '../common/positronDataExplorerDuckDBBackend.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
+import { URI } from '../../../../base/common/uri.js';
 
 /**
  * DataExplorerRuntime class.
@@ -207,7 +208,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		// (updates, async column profiles) normally invoked by a language runtime kernel
 		this._register(CommandsRegistry.registerCommand('positron-data-explorer.sendUiEvent',
 			(accessor: ServicesAccessor, event: DataExplorerUiEvent) => {
-				const handler = this._uiEventCommandHandlers.get(event.uri);
+				const handler = this._uiEventCommandHandlers.get(event.uri.toString());
 
 				// If not event handler registered, ignore for now
 				if (handler === undefined) {
@@ -313,13 +314,13 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * the data explorer.
 	 * @param filePath Path to file to open with positron-duckdb extension
 	 */
-	async openWithDuckDB(filePath: string) {
-		const backend = new PositronDataExplorerDuckDBBackend(this._commandService, filePath);
+	async openWithDuckDB(uri: URI) {
+		const backend = new PositronDataExplorerDuckDBBackend(this._commandService, uri);
 
 		// Associate UI events (like ReturnColumnProfiles) for this file path
 		// with this backend. We're presuming only one backend per file path, so
 		// if we need multiple backends per file path we can extend
-		this._uiEventCommandHandlers.set(filePath, (event) => {
+		this._uiEventCommandHandlers.set(uri.toString(), (event) => {
 			backend.handleUiEvent(event);
 		});
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -39,6 +39,7 @@ import {
 	TableSelection
 } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { ICommandService, CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { URI } from '../../../../base/common/uri.js';
 
 
 /**
@@ -93,10 +94,10 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 
 	constructor(
 		private readonly _commandService: ICommandService,
-		private readonly filePath: string
+		private readonly uri: URI
 	) {
 		super();
-		this.clientId = `duckdb:${this.filePath}`;
+		this.clientId = `duckdb:${this.uri.path}`;
 		this.initialSetup = this.openDataset();
 	}
 
@@ -149,7 +150,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async openDataset() {
 		const result = await this._execRpc<OpenDatasetResult>({
 			method: DataExplorerBackendRequest.OpenDataset,
-			params: { uri: this.filePath }
+			params: { uri: this.uri.toString() }
 		});
 
 		if (result.error_message) {
@@ -160,7 +161,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async getState(): Promise<BackendState> {
 		return this._execRpc<BackendState>({
 			method: DataExplorerBackendRequest.GetState,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: {}
 		});
 	}
@@ -168,7 +169,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async getSchema(columnIndices: Array<number>): Promise<TableSchema> {
 		return this._execRpc<TableSchema>({
 			method: DataExplorerBackendRequest.GetSchema,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: { column_indices: columnIndices } satisfies GetSchemaParams
 		});
 	}
@@ -176,7 +177,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async getDataValues(columns: Array<ColumnSelection>, formatOptions: FormatOptions): Promise<TableData> {
 		return this._execRpc<TableData>({
 			method: DataExplorerBackendRequest.GetDataValues,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: {
 				columns,
 				format_options: formatOptions
@@ -187,7 +188,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async getRowLabels(selection: ArraySelection, formatOptions: FormatOptions): Promise<TableRowLabels> {
 		return this._execRpc<TableRowLabels>({
 			method: DataExplorerBackendRequest.GetRowLabels,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: {
 				selection,
 				format_options: formatOptions
@@ -198,7 +199,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async exportDataSelection(selection: TableSelection, format: ExportFormat): Promise<ExportedData> {
 		return this._execRpc<ExportedData>({
 			method: DataExplorerBackendRequest.ExportDataSelection,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: {
 				selection,
 				format
@@ -209,7 +210,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async setColumnFilters(filters: Array<ColumnFilter>): Promise<void> {
 		return this._execRpc<void>({
 			method: DataExplorerBackendRequest.SetColumnFilters,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: { filters } satisfies SetColumnFiltersParams
 		});
 	}
@@ -217,7 +218,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async setRowFilters(filters: Array<RowFilter>): Promise<FilterResult> {
 		return this._execRpc<FilterResult>({
 			method: DataExplorerBackendRequest.SetRowFilters,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: { filters } satisfies SetRowFiltersParams
 		});
 	}
@@ -225,7 +226,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async setSortColumns(sortKeys: Array<ColumnSortKey>): Promise<void> {
 		return this._execRpc<void>({
 			method: DataExplorerBackendRequest.SetSortColumns,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: { sort_keys: sortKeys } satisfies SetSortColumnsParams
 		});
 	}
@@ -236,7 +237,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		formatOptions: FormatOptions): Promise<void> {
 		return this._execRpc<void>({
 			method: DataExplorerBackendRequest.GetColumnProfiles,
-			uri: this.filePath,
+			uri: this.uri.toString(),
 			params: {
 				callback_id: callbackId,
 				profiles: profiles,


### PR DESCRIPTION
This commit refactors the DuckDB data explorer backend and frontend to operate on complete URIs rather than filepaths, part of enabling the data explorer to support virtual filesystem providers. It almost all comes down to swapping out a series of string-typed fields for `vscode.Uri`-typed fields.

~~In local testing, I've been able to use this to open files from custom filesystem providers in the data explorer.~~

Part of #7351.

### Release Notes

#### New Features

- The data explorer can now open files backed by virtual filesystem providers.

#### Bug Fixes

- N/A

### QA Notes

It's not easy to test against virtual filesystem providers, unfortunately. [VS Code suggests using the GitHub Repositories extension](https://code.visualstudio.com/api/extension-guides/virtual-workspaces), but that's not available in OpenVSX if I understand correctly.
