### PR TITLE
Data Explorer: Add support for opening .xlsx files

### DIFF
--- a/extensions/positron-duckdb/package-lock.json
+++ b/extensions/positron-duckdb/package-lock.json
@@ -8,7 +8,7 @@
       "name": "positron-duckdb",
       "version": "0.0.1",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "1.29.0",
+        "@duckdb/duckdb-wasm": "1.29.1-dev68.0",
         "apache-arrow": "^16.0.0",
         "web-worker": "^1.3.0"
       },
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.0.tgz",
-      "integrity": "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q==",
+      "version": "1.29.1-dev68.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.1-dev68.0.tgz",
+      "integrity": "sha512-UttGAEDiCjSrn3anOlBwwrc+rDBY4jwyg+m9ZbNqazVWlanInQ8p6gZE1ZGDYp3Z0GG7fGSrkXs+bdT/mXSHEQ==",
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^17.0.0"

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -32,7 +32,7 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.29.0",
+    "@duckdb/duckdb-wasm": "1.29.1-dev68.0",
     "apache-arrow": "^16.0.0",
     "web-worker": "^1.3.0"
   },

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1570,6 +1570,12 @@ export class DataExplorerRpcHandler {
 				const query = `CREATE OR REPLACE TABLE ${catalogName} AS
 				SELECT * FROM parquet_scan('${virtualPath}');`;
 				await this.db.runQuery(query);
+			} else if (baseExt === '.xlsx') {
+				await this.db.runQuery('INSTALL excel FROM core_nightly;');
+				await this.db.runQuery('LOAD excel;');
+				await this.db.runQuery(
+					`CREATE OR REPLACE TABLE ${catalogName} AS SELECT * FROM read_xlsx('${virtualPath}');`
+				);
 			} else {
 				await importDelimited(virtualPath);
 			}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -77,7 +77,7 @@ class PositronDataExplorerContribution extends Disposable {
 			}
 		));
 
-		const DUCKDB_SUPPORTED_EXTENSIONS = ['parquet', 'parq', 'csv', 'tsv', 'gz'];
+		const DUCKDB_SUPPORTED_EXTENSIONS = ['parquet', 'parq', 'csv', 'tsv', 'xlsx', 'gz'];
 
 		this._register(editorResolverService.registerEditor(
 			`*.{${DUCKDB_SUPPORTED_EXTENSIONS.join(',')}}`,


### PR DESCRIPTION
DuckDB v1.2 launched native support for reading `.xlsx` files with the `excel` extension. This commit bumps our DuckDB WASM dependency to pick up this change, and wires up `.xlsx` as a supported extension for the data explorer.

In my testing, this was *incredibly* sensitive to the exact version of DuckDB WASM and requires nightly builds of the `excel` extension. (Some upstream discussion is here: https://github.com/duckdb/duckdb-wasm/issues/1956.) I'd understand if we want to hold off on this until WASM support for `read_xlsx()` feels more solidified.

As a secondary issue: we simply can't read all real-world Excel files, and there's no way at present to expose some of [the knobs that `read_xlsx()` supports][0] (e.g. header detection, sheet selection) with the existing data explorer UI. So in many cases this path will simply fail, silently, and leave users with a blank data explorer.

Addresses #4202.

[0]: https://duckdb.org/docs/stable/extensions/excel.html#reading-xlsx-files

### Release Notes

#### New Features

- The data explorer can now open well-behalved `.xlsx` files (#4202).

#### Bug Fixes

- N/A

### QA Notes

Add automated tests with sample `.xlsx` files.
