### PR TITLE
Assistant quick fix code actions

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "./out/extension.js",
   "enabledApiProposals": [
+    "codeActionAI",
     "defaultChatParticipant",
     "inlineCompletionsAdditions"
   ],

--- a/extensions/positron-assistant/src/codeActions.ts
+++ b/extensions/positron-assistant/src/codeActions.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
+
+const startEditorChatCommand = 'vscode.editorChat.start';
+const openChatViewCommand = 'workbench.action.chat.open';
+
+// Copied and renamed from positron/src/vs/workbench/api/common/extHostApiCommands.ts
+interface StartEditorChatOptions {
+	initialRange?: vscode.Range;
+	initialSelection?: vscode.Selection;
+	message?: string;
+	autoSend?: boolean;
+	position?: vscode.Position;
+}
+
+// Copied and renamed from positron/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+interface OpenChatViewOptions {
+	/**
+	 * The query for chat.
+	 */
+	query: string;
+	/**
+	 * Whether the query is partial and will await more input from the user.
+	 */
+	isPartialQuery?: boolean;
+	/**
+	 * A list of tools IDs with `canBeReferencedInPrompt` that will be resolved and attached if they exist.
+	 */
+	toolIds?: string[];
+	/**
+	 * Any previous chat requests and responses that should be shown in the chat view.
+	 */
+	previousRequests?: OpenChatViewRequestEntry[];
+	/**
+	 * Whether a screenshot of the focused window should be taken and attached
+	 */
+	attachScreenshot?: boolean;
+	/**
+	 * The mode to open the chat in.
+	 */
+	mode?: ChatMode;
+}
+
+// Copied from positron/src/vs/workbench/contrib/chat/common/constants.ts
+enum ChatMode {
+	Ask = 'ask',
+	Edit = 'edit',
+	Agent = 'agent'
+}
+
+// Copied and renamed from positron/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+export interface OpenChatViewRequestEntry {
+	request: string;
+	response: string;
+}
+
+class AssistantCodeActionProvider implements vscode.CodeActionProvider {
+	metadata: vscode.CodeActionProviderMetadata = {
+		providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
+	};
+
+	async provideCodeActions(
+		document: vscode.TextDocument,
+		range: vscode.Range | vscode.Selection,
+		context: vscode.CodeActionContext,
+		token: vscode.CancellationToken,
+	): Promise<(vscode.CodeAction | vscode.Command)[] | undefined> {
+		// We currently only provide quickfix actions.
+		// If the request is only for other action types, exit early.
+		if (!context.only?.intersects(vscode.CodeActionKind.QuickFix)) {
+			return undefined;
+		}
+
+		// If there are no diagnostics, exit early.
+		if (context.diagnostics.length === 0) {
+			return undefined;
+		}
+
+		// Create a single text message from the diagnostics.
+		// This will be used in prompts to the assistant.
+		const diagnosticsMessage = context.diagnostics.map(diagnostic => diagnostic.message).join('\n\n');
+
+		// Create the fix action.
+		const fixAction = new vscode.CodeAction(
+			vscode.l10n.t('Fix with Assistant'),
+			vscode.CodeActionKind.QuickFix,
+		);
+
+		// Setting isAI to true:
+		// 1. Shows the code action in the diagnostic hover.
+		// 2. Assigns the Cmd+I keyboard shortcut.
+		// 3. Adds a sparkle icon in the quick fix menu.
+		fixAction.isAI = true;
+
+		// The fix action will start an editor chat session with a message
+		// instructing the assistant to fix the diagnostics.
+		fixAction.command = {
+			title: fixAction.title,
+			command: startEditorChatCommand,
+			arguments: [{
+				initialRange: range instanceof vscode.Range ? range : undefined,
+				initialSelection: range instanceof vscode.Selection ? range : undefined,
+				message: `/fix ${diagnosticsMessage}`,
+				// Send the message immediately.
+				autoSend: true,
+				position: range.start,
+			} satisfies StartEditorChatOptions],
+		};
+
+		// Create the explain action.
+		const explainAction = new vscode.CodeAction(
+			vscode.l10n.t('Explain with Assistant'),
+			vscode.CodeActionKind.QuickFix,
+		);
+
+		// See above for an explanation of isAI.
+		explainAction.isAI = true;
+
+		// The explain action will open the (global) chat view with a message
+		// instructing the assistant to explain the diagnostics.
+		explainAction.command = {
+			title: explainAction.title,
+			command: openChatViewCommand,
+			arguments: [{
+				query: `/explain ${diagnosticsMessage}`,
+				// Send the message immediately.
+				isPartialQuery: false,
+				mode: ChatMode.Ask,
+			} satisfies OpenChatViewOptions],
+		};
+
+		return [
+			fixAction,
+			explainAction,
+		];
+	}
+}
+
+export function registerCodeActionProvider(context: vscode.ExtensionContext) {
+	const codeActionsProvider = new AssistantCodeActionProvider();
+	context.subscriptions.push(
+		vscode.languages.registerCodeActionsProvider(
+			ALL_DOCUMENTS_SELECTOR,
+			codeActionsProvider,
+			codeActionsProvider.metadata,
+		)
+	);
+}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -13,6 +13,7 @@ import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { registerAssistantTools } from './tools.js';
 import { registerCopilotService } from './copilot.js';
 import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
+import { registerCodeActionProvider } from './codeActions.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -188,6 +189,9 @@ function registerAssistant(context: vscode.ExtensionContext) {
 
 	// Register mapped edits provider
 	registerMappedEditsProvider(context, participantService);
+
+	// Register code action provider
+	registerCodeActionProvider(context);
 
 	// Dispose cleanup
 	context.subscriptions.push({

--- a/extensions/positron-assistant/tsconfig.json
+++ b/extensions/positron-assistant/tsconfig.json
@@ -12,6 +12,7 @@
 	"include": [
 		"src/**/*",
 		"../../src/vscode-dts/vscode.proposed.chat*.d.ts",
+		"../../src/vscode-dts/vscode.proposed.codeActionAI.d.ts",
 		"../../src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts",
 		"../../src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts",
 		"../../src/vscode-dts/vscode.proposed.defaultChat*.d.ts",

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -196,7 +196,8 @@ def _publish_diagnostics(
     doc = server.workspace.get_text_document(uri)
 
     # Comment out magic/shell/help command lines so that they don't appear as syntax errors.
-    source = "\n".join(
+    # No need to add newlines since doc.lines retains them.
+    source = "".join(
         (
             f"#{line}"
             if line.lstrip().startswith((_LINE_MAGIC_PREFIX, _SHELL_PREFIX, _HELP_PREFIX_OR_SUFFIX))

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -649,6 +649,17 @@ def test_positron_completion_item_resolve(
                 )
             ],
         ),
+        # Multiple lines with a single syntax error.
+        (
+            "1\n1 +",
+            [
+                (
+                    f"SyntaxError: invalid syntax ({TEST_DOCUMENT_URI}, line 2)"
+                    if os.name == "nt"
+                    else "SyntaxError: invalid syntax (foo.py, line 2)"
+                )
+            ],
+        ),
         # No errors for magic commands.
         (r"%ls", []),
         (r"%%bash", []),


### PR DESCRIPTION
This PR adds two Assistant quick fix code actions addressing https://github.com/posit-dev/positron/issues/7368. It also fixes incorrect line numbers in Python diagnostics: https://github.com/posit-dev/positron/issues/7377.

The actions only appear where there are diagnostics. There are two ways to use them.

1. The hover has a "Fix with Assistant" button.
    
    <img width="650" alt="image" src="https://github.com/user-attachments/assets/77e3e642-94a2-4bf9-ba5a-5fb2951d611c" />
    
2. The hover also has a "Quick Fix" button that shows the quick fix menu. Alternatively, `Cmd+.` also shows this menu.
    
    <img width="265" alt="image" src="https://github.com/user-attachments/assets/fe4bdc1d-f424-4d8c-81a8-46563644a7a4" />
    

The "Fix with Assistant" action starts an inline/editor chat and autosends a message prompting the model to fix the diagnostics:

<img width="907" alt="image" src="https://github.com/user-attachments/assets/b964455d-fd63-4696-a4be-0b32ab4223dc" />

The "Explain with Assistant" action sends a message in the global chat prompting the model to explain the diagnostics:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/44595ece-946b-414e-89d0-ad4989e4c398" />

### Release Notes

#### New Features

- Added "Fix with Assistant" and "Explain with Assistant" code actions.

#### Bug Fixes

- N/A