### PR TITLE
python: resolve paths for fastapi startup

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -246,7 +246,7 @@ async function getFastAPIDebugConfig(
 ): Promise<DebugConfiguration | undefined> {
     let mod: string | undefined;
     let args: string[];
-    if (await isFastAPICLIInstalled(serviceContainer, runtime.runtimePath)) {
+    if (await isFastAPICLIInstalled(serviceContainer, runtime.extraRuntimeData.pythonPath)) {
         mod = 'fastapi';
         args = ['dev', document.uri.fsPath];
     } else {

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -131,7 +131,10 @@ suite('Web app commands', () => {
         assert.ok(runAppOptions, `runAppOptions not set for command: ${command}`);
 
         // Test `getTerminalOptions`.
-        const runtime = { runtimePath } as positron.LanguageRuntimeMetadata;
+        const runtime = {
+            runtimePath,
+            extraRuntimeData: { pythonPath: runtimePath },
+        } as positron.LanguageRuntimeMetadata;
         const document = {
             uri: { fsPath: documentPath },
             getText() {
@@ -269,7 +272,10 @@ suite('Web app commands', () => {
         assert.ok(debugAppOptions, `debugAppOptions not set for command: ${command}`);
 
         // Test `getDebugConfiguration`.
-        const runtime = { runtimePath } as positron.LanguageRuntimeMetadata;
+        const runtime = {
+            runtimePath,
+            extraRuntimeData: { pythonPath: runtimePath },
+        } as positron.LanguageRuntimeMetadata;
         const document = {
             uri: { fsPath: documentPath },
             getText() {

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -48,7 +48,7 @@ test.describe('Python Applications', {
 		});
 	});
 
-	test.skip('Python - Verify Basic FastAPI App', {
+	test('Python - Verify Basic FastAPI App', {
 		tag: [tags.WIN]
 	}, async function ({ app, openFile, python }) {
 		const viewer = app.workbench.viewer;


### PR DESCRIPTION
So, the native locator will not resolve any path with a tilde; changed the startup command to use to the untildified path instead.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes a bug where FastAPI apps won't start up with the native Python locator #5312 


### QA Notes

This should work for both js and native locator. Not sure if we need to turn back on any tests?

```python
from fastapi import FastAPI
app = FastAPI()
@app.get("/")
async def root():
    return {"message": "Hello World"}
```