### PR TITLE
Add ability to rename console sessions 

### DIFF
--- a/extensions/positron-javascript/src/session.ts
+++ b/extensions/positron-javascript/src/session.ts
@@ -34,6 +34,7 @@ export class JavaScriptLanguageRuntimeSession implements positron.LanguageRuntim
 		readonly context: vscode.ExtensionContext) {
 
 		this.dynState = {
+			sessionName: runtimeMetadata.runtimeName,
 			inputPrompt: `>`,
 			continuationPrompt: '…',
 		};

--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -14,6 +14,7 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 	private readonly _onDidExecute = new vscode.EventEmitter<string>();
 	private readonly _onDidEndSession = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
 
+	public dynState: positron.LanguageRuntimeDynState;
 	public readonly onDidChangeRuntimeState = this._onDidChangeRuntimeState.event;
 	public readonly onDidReceiveRuntimeMessage = this._onDidReceiveRuntimeMessage.event;
 	public readonly onDidExecute = this._onDidExecute.event;
@@ -30,7 +31,13 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 		languageId: 'test-language',
 	} as positron.LanguageRuntimeMetadata;
 
-	constructor() { }
+	constructor() {
+		this.dynState = {
+			sessionName: this.runtimeMetadata.runtimeName,
+			inputPrompt: `T>`,
+			continuationPrompt: 'T+',
+		};
+	}
 
 	execute(_code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior) {
 		this._lastExecutionId = id;
@@ -48,7 +55,7 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 		setTimeout(() => {
 			this._onDidEndSession.fire({
 				runtime_name: this.runtimeMetadata.runtimeName,
-				session_name: this.metadata.sessionName,
+				session_name: this.dynState.sessionName,
 				exit_code: 0,
 				reason: exitReason,
 				message: '',

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -171,12 +171,14 @@ export interface PositronSupervisorApi extends vscode.Disposable {
      * @param runtimeMetadata The metadata for the language runtime to be
      * wrapped by the adapter.
      * @param sessionMetadata The metadata for the session to be reconnected.
+     * @param dynState The initial dynamic state of the session.
      *
      * @returns A JupyterLanguageRuntimeSession that wraps the kernel.
      */
     restoreSession(
         runtimeMetadata: positron.LanguageRuntimeMetadata,
         sessionMetadata: positron.RuntimeSessionMetadata,
+        dynState: positron.LanguageRuntimeDynState,
     ): Promise<JupyterLanguageRuntimeSession>;
 }
 

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -98,21 +98,21 @@ export class PythonLsp implements vscode.Disposable {
         this._clientOptions.documentSelector = notebookUri
             ? [{ language: 'python', pattern: notebookUri.fsPath }]
             : [
-                { language: 'python', scheme: 'untitled' },
-                { language: 'python', scheme: 'inmemory' }, // Console
-                { language: 'python', pattern: '**/*.py' },
-            ];
+                  { language: 'python', scheme: 'untitled' },
+                  { language: 'python', scheme: 'inmemory' }, // Console
+                  { language: 'python', pattern: '**/*.py' },
+              ];
 
         // This is needed in addition to the document selector, otherwise every client seems to
         // produce diagnostics for each notebook.
         this._clientOptions.notebookDocumentOptions = notebookUri
             ? // If this client belongs to a notebook, only include cells belonging to the notebook.
-            {
-                filterCells: (notebookDocument, cells) =>
-                    notebookUri.toString() === notebookDocument.uri.toString() ? cells : [],
-            }
+              {
+                  filterCells: (notebookDocument, cells) =>
+                      notebookUri.toString() === notebookDocument.uri.toString() ? cells : [],
+              }
             : // For console clients, exclude all notebook cells.
-            { filterCells: () => [] };
+              { filterCells: () => [] };
 
         // Override default error handler with one that doesn't automatically restart the client,
         // and that logs to the appropriate place.

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -302,22 +302,31 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
      *
      * @param runtimeMetadata The metadata for the runtime to restore
      * @param sessionMetadata The metadata for the session to restore
+     * @param sessionName The name of the session to restore
      *
      * @returns The restored session.
      */
     async restoreSession(
         runtimeMetadata: positron.LanguageRuntimeMetadata,
         sessionMetadata: positron.RuntimeSessionMetadata,
+        sessionName: string,
     ): Promise<positron.LanguageRuntimeSession> {
-        return this.createPythonSession(runtimeMetadata, sessionMetadata);
+        return this.createPythonSession(runtimeMetadata, sessionMetadata, undefined, sessionName);
     }
 
     private createPythonSession(
         runtimeMetadata: positron.LanguageRuntimeMetadata,
         sessionMetadata: positron.RuntimeSessionMetadata,
         kernelSpec?: JupyterKernelSpec,
+        sessionName?: string,
     ): positron.LanguageRuntimeSession {
-        const session = new PythonRuntimeSession(runtimeMetadata, sessionMetadata, this.serviceContainer, kernelSpec);
+        const session = new PythonRuntimeSession(
+            runtimeMetadata,
+            sessionMetadata,
+            this.serviceContainer,
+            kernelSpec,
+            sessionName,
+        );
         this._onDidCreateSession.fire(session);
         return session;
     }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -199,10 +199,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             name: positron.LanguageRuntimeStreamName.Stdout,
             text: vscode.l10n.t(
                 'Cannot uninstall the following packages:\n\n{0}\n\n' +
-                'These packages are bundled with Positron, ' +
-                "and removing them would break Positron's Python functionality.\n\n" +
-                'If you would like to uninstall these packages from the active environment, ' +
-                'please rerun `{1}` in a terminal.',
+                    'These packages are bundled with Positron, ' +
+                    "and removing them would break Positron's Python functionality.\n\n" +
+                    'If you would like to uninstall these packages from the active environment, ' +
+                    'please rerun `{1}` in a terminal.',
                 protectedPackagesStr,
                 code,
             ),
@@ -531,8 +531,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     async activateLsp(reason: string): Promise<void> {
         this._kernel?.emitJupyterLog(
             `Queuing LSP activation. Reason: ${reason}. ` +
-            `Queue size: ${this._lspQueue.size}, ` +
-            `pending: ${this._lspQueue.pending}`,
+                `Queue size: ${this._lspQueue.size}, ` +
+                `pending: ${this._lspQueue.pending}`,
             vscode.LogLevel.Debug,
         );
         return this._lspQueue.add(async () => {
@@ -543,8 +543,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
             this._kernel.emitJupyterLog(
                 `LSP activation started. Reason: ${reason}. ` +
-                `Queue size: ${this._lspQueue.size}, ` +
-                `pending: ${this._lspQueue.pending}`,
+                    `Queue size: ${this._lspQueue.size}, ` +
+                    `pending: ${this._lspQueue.pending}`,
                 vscode.LogLevel.Debug,
             );
 
@@ -600,15 +600,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     async deactivateLsp(reason: string): Promise<void> {
         this._kernel?.emitJupyterLog(
             `Queuing LSP deactivation. Reason: ${reason}. ` +
-            `Queue size: ${this._lspQueue.size}, ` +
-            `pending: ${this._lspQueue.pending}`,
+                `Queue size: ${this._lspQueue.size}, ` +
+                `pending: ${this._lspQueue.pending}`,
             vscode.LogLevel.Debug,
         );
         return this._lspQueue.add(async () => {
             this._kernel?.emitJupyterLog(
                 `LSP deactivation started. Reason: ${reason}. ` +
-                `Queue size: ${this._lspQueue.size}, ` +
-                `pending: ${this._lspQueue.pending}`,
+                    `Queue size: ${this._lspQueue.size}, ` +
+                    `pending: ${this._lspQueue.pending}`,
                 vscode.LogLevel.Debug,
             );
             if (!this._lsp || this._lsp.state !== LspState.running) {
@@ -721,15 +721,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this.adapterApi = ext?.exports as PositronSupervisorApi;
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-            await this.adapterApi.createSession(
-                this.runtimeMetadata,
-                this.metadata,
-                this.kernelSpec,
-                this.dynState,
-                createJupyterKernelExtra(),
-            )
+              await this.adapterApi.createSession(
+                  this.runtimeMetadata,
+                  this.metadata,
+                  this.kernelSpec,
+                  this.dynState,
+                  createJupyterKernelExtra(),
+              )
             : // We don't have a kernel spec, so we're restoring a session
-            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -827,10 +827,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                    '{0} exited unexpectedly with error: {1}',
-                    kernel.runtimeMetadata.runtimeName,
-                    logFileContent,
-                )
+                      '{0} exited unexpectedly with error: {1}',
+                      kernel.runtimeMetadata.runtimeName,
+                      logFileContent,
+                  )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -135,6 +135,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this._lspQueue = new PQueue({ concurrency: 1 });
 
         this.dynState = {
+            sessionName: runtimeMetadata.runtimeName,
             inputPrompt: '>>>',
             continuationPrompt: '...',
         };
@@ -198,10 +199,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             name: positron.LanguageRuntimeStreamName.Stdout,
             text: vscode.l10n.t(
                 'Cannot uninstall the following packages:\n\n{0}\n\n' +
-                    'These packages are bundled with Positron, ' +
-                    "and removing them would break Positron's Python functionality.\n\n" +
-                    'If you would like to uninstall these packages from the active environment, ' +
-                    'please rerun `{1}` in a terminal.',
+                'These packages are bundled with Positron, ' +
+                "and removing them would break Positron's Python functionality.\n\n" +
+                'If you would like to uninstall these packages from the active environment, ' +
+                'please rerun `{1}` in a terminal.',
                 protectedPackagesStr,
                 code,
             ),
@@ -515,6 +516,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this.runtimeMetadata.languageVersion,
             languageClientOptions,
             this.metadata,
+            this.dynState,
         );
     }
 
@@ -529,8 +531,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     async activateLsp(reason: string): Promise<void> {
         this._kernel?.emitJupyterLog(
             `Queuing LSP activation. Reason: ${reason}. ` +
-                `Queue size: ${this._lspQueue.size}, ` +
-                `pending: ${this._lspQueue.pending}`,
+            `Queue size: ${this._lspQueue.size}, ` +
+            `pending: ${this._lspQueue.pending}`,
             vscode.LogLevel.Debug,
         );
         return this._lspQueue.add(async () => {
@@ -541,8 +543,8 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
             this._kernel.emitJupyterLog(
                 `LSP activation started. Reason: ${reason}. ` +
-                    `Queue size: ${this._lspQueue.size}, ` +
-                    `pending: ${this._lspQueue.pending}`,
+                `Queue size: ${this._lspQueue.size}, ` +
+                `pending: ${this._lspQueue.pending}`,
                 vscode.LogLevel.Debug,
             );
 
@@ -598,15 +600,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     async deactivateLsp(reason: string): Promise<void> {
         this._kernel?.emitJupyterLog(
             `Queuing LSP deactivation. Reason: ${reason}. ` +
-                `Queue size: ${this._lspQueue.size}, ` +
-                `pending: ${this._lspQueue.pending}`,
+            `Queue size: ${this._lspQueue.size}, ` +
+            `pending: ${this._lspQueue.pending}`,
             vscode.LogLevel.Debug,
         );
         return this._lspQueue.add(async () => {
             this._kernel?.emitJupyterLog(
                 `LSP deactivation started. Reason: ${reason}. ` +
-                    `Queue size: ${this._lspQueue.size}, ` +
-                    `pending: ${this._lspQueue.pending}`,
+                `Queue size: ${this._lspQueue.size}, ` +
+                `pending: ${this._lspQueue.pending}`,
                 vscode.LogLevel.Debug,
             );
             if (!this._lsp || this._lsp.state !== LspState.running) {
@@ -719,15 +721,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this.adapterApi = ext?.exports as PositronSupervisorApi;
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-              await this.adapterApi.createSession(
-                  this.runtimeMetadata,
-                  this.metadata,
-                  this.kernelSpec,
-                  this.dynState,
-                  createJupyterKernelExtra(),
-              )
+            await this.adapterApi.createSession(
+                this.runtimeMetadata,
+                this.metadata,
+                this.kernelSpec,
+                this.dynState,
+                createJupyterKernelExtra(),
+            )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -825,10 +827,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                      '{0} exited unexpectedly with error: {1}',
-                      kernel.runtimeMetadata.runtimeName,
-                      logFileContent,
-                  )
+                    '{0} exited unexpectedly with error: {1}',
+                    kernel.runtimeMetadata.runtimeName,
+                    logFileContent,
+                )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -118,6 +118,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         readonly metadata: positron.RuntimeSessionMetadata,
         readonly serviceContainer: IServiceContainer,
         readonly kernelSpec?: JupyterKernelSpec | undefined,
+        sessionName?: string,
     ) {
         // Extract the extra data from the runtime metadata; it contains the
         // Python path that was saved when the metadata was created.
@@ -135,7 +136,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this._lspQueue = new PQueue({ concurrency: 1 });
 
         this.dynState = {
-            sessionName: runtimeMetadata.runtimeName,
+            sessionName: sessionName || runtimeMetadata.runtimeName,
             inputPrompt: '>>>',
             continuationPrompt: '...',
         };
@@ -729,7 +730,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
                   createJupyterKernelExtra(),
               )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata, this.dynState);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -54,7 +54,8 @@ export class ArkLsp implements vscode.Disposable {
 
 	public constructor(
 		private readonly _version: string,
-		private readonly _metadata: positron.RuntimeSessionMetadata
+		private readonly _metadata: positron.RuntimeSessionMetadata,
+		private readonly _dynState: positron.LanguageRuntimeDynState,
 	) { }
 
 	private setState(state: LspState) {
@@ -99,7 +100,7 @@ export class ArkLsp implements vscode.Disposable {
 
 		// Persistant output channel, used across multiple sessions of the same name + mode combination
 		const outputChannel = RLspOutputChannelManager.instance.getOutputChannel(
-			this._metadata.sessionName,
+			this._dynState.sessionName,
 			this._metadata.sessionMode
 		);
 
@@ -296,7 +297,7 @@ export class ArkLsp implements vscode.Disposable {
 
 	public showOutput() {
 		const outputChannel = RLspOutputChannelManager.instance.getOutputChannel(
-			this._metadata.sessionName,
+			this._dynState.sessionName,
 			this._metadata.sessionMode
 		);
 		outputChannel.show();

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -171,12 +171,14 @@ export interface PositronSupervisorApi extends vscode.Disposable {
 	 * @param runtimeMetadata The metadata for the language runtime to be
 	 * wrapped by the adapter.
 	 * @param sessionMetadata The metadata for the session to be reconnected.
+	 * @param dynState The initial dynamic state of the session.
 	 *
 	 * @returns A JupyterLanguageRuntimeSession that wraps the kernel.
 	 */
 	restoreSession(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
-		sessionMetadata: positron.RuntimeSessionMetadata
+		sessionMetadata: positron.RuntimeSessionMetadata,
+		dynState: positron.LanguageRuntimeDynState,
 	): Promise<JupyterLanguageRuntimeSession>;
 }
 

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -142,10 +142,11 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 
 	restoreSession(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
-		sessionMetadata: positron.RuntimeSessionMetadata): Thenable<positron.LanguageRuntimeSession> {
+		sessionMetadata: positron.RuntimeSessionMetadata,
+		sessionName: string): Thenable<positron.LanguageRuntimeSession> {
 
 		// When restoring an existing session, the kernelspec is stored.
-		const session = new RSession(runtimeMetadata, sessionMetadata);
+		const session = new RSession(runtimeMetadata, sessionMetadata, undefined, undefined, sessionName);
 
 		return Promise.resolve(session);
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -88,16 +88,18 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		readonly kernelSpec?: JupyterKernelSpec,
 		readonly extra?: JupyterKernelExtra,
 	) {
-		this._lsp = new ArkLsp(runtimeMetadata.languageVersion, metadata);
+		// Set the initial dynamic state
+		this.dynState = {
+			sessionName: runtimeMetadata.runtimeName,
+			continuationPrompt: '+',
+			inputPrompt: '>',
+		};
+
+		this._lsp = new ArkLsp(runtimeMetadata.languageVersion, metadata, this.dynState);
 		this._lspQueue = new PQueue({ concurrency: 1 });
 		this.onDidReceiveRuntimeMessage = this._messageEmitter.event;
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
 		this.onDidEndSession = this._exitEmitter.event;
-
-		this.dynState = {
-			continuationPrompt: '+',
-			inputPrompt: '>',
-		};
 
 		// Timestamp the session creation
 		this._created = Date.now();

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -87,10 +87,11 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		readonly metadata: positron.RuntimeSessionMetadata,
 		readonly kernelSpec?: JupyterKernelSpec,
 		readonly extra?: JupyterKernelExtra,
+		sessionName?: string,
 	) {
 		// Set the initial dynamic state
 		this.dynState = {
-			sessionName: runtimeMetadata.runtimeName,
+			sessionName: sessionName || runtimeMetadata.runtimeName,
 			continuationPrompt: '+',
 			inputPrompt: '>',
 		};
@@ -620,7 +621,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			// We don't have a kernel spec, so restore (reconnect) the session
 			await this.adapterApi.restoreSession(
 				this.runtimeMetadata,
-				this.metadata);
+				this.metadata,
+				this.dynState);
 
 		kernel.onDidChangeRuntimeState((state) => {
 			this._stateEmitter.fire(state);

--- a/extensions/positron-r/src/test/session-manager.unit.test.ts
+++ b/extensions/positron-r/src/test/session-manager.unit.test.ts
@@ -42,12 +42,12 @@ suite('Session manager', () => {
 		onDidChangeForegroundSession = new vscode.EventEmitter();
 		suiteDisposables.push(onDidChangeForegroundSession);
 		sinon.stub(positron.runtime, 'onDidChangeForegroundSession').get(() => onDidChangeForegroundSession.event);
-	})
+	});
 
 	suiteTeardown(() => {
 		sinon.restore();
 		suiteDisposables.forEach((d) => d.dispose());
-	})
+	});
 
 	setup(() => {
 		foregroundSession = mockSession();

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -665,11 +665,11 @@ export class KCApi implements PositronSupervisorApi {
 						// The session could not be reconnected; mark it as
 						// offline and explain to the user what happened.
 						session.markOffline('Lost connection to the session WebSocket event stream and could not restore it: ' + err);
-						vscode.window.showErrorMessage(vscode.l10n.t('Unable to re-establish connection to {0}: {1}', session.dynState.sessionName, err));
+						vscode.window.showErrorMessage(vscode.l10n.t('Unable to re-establish connection to {0}: {1}', session.metadata.sessionId, err));
 					}
 				}
 			} else if (evt.reason === DisconnectReason.Transferred) {
-				this._log.appendLine(`Session '${session.metadata.sessionName}' disconnected ` +
+				this._log.appendLine(`Session '${session.metadata.sessionId}' disconnected ` +
 					`because another client connected to it.`);
 				if (!this._showingDisconnectedWarning) {
 					this._showingDisconnectedWarning = true;

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -649,7 +649,7 @@ export class KCApi implements PositronSupervisorApi {
 				// The websocket disconnected while the session was still
 				// running. This could signal a problem with the supervisor; we
 				// should see if it's still running.
-				this._log.appendLine(`Session '${session.metadata.sessionName}' disconnected ` +
+				this._log.appendLine(`Session '${session.metadata.sessionId}' disconnected ` +
 					`while in state '${evt.state}'. This is unexpected; checking server status.`);
 
 				// If the server did not exit, and the session also appears to
@@ -665,7 +665,7 @@ export class KCApi implements PositronSupervisorApi {
 						// The session could not be reconnected; mark it as
 						// offline and explain to the user what happened.
 						session.markOffline('Lost connection to the session WebSocket event stream and could not restore it: ' + err);
-						vscode.window.showErrorMessage(vscode.l10n.t('Unable to re-establish connection to {0}: {1}', session.metadata.sessionName, err));
+						vscode.window.showErrorMessage(vscode.l10n.t('Unable to re-establish connection to {0}: {1}', session.dynState.sessionName, err));
 					}
 				}
 			} else if (evt.reason === DisconnectReason.Transferred) {
@@ -821,11 +821,14 @@ export class KCApi implements PositronSupervisorApi {
 	 *
 	 * @param runtimeMetadata The metadata for the associated language runtime
 	 * @param sessionMetadata The metadata for the session to be restored
+	 * @param dynState The kernel's initial dynamic state
 	 * @returns The restored session
 	 */
 	async restoreSession(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
-		sessionMetadata: positron.RuntimeSessionMetadata): Promise<JupyterLanguageRuntimeSession> {
+		sessionMetadata: positron.RuntimeSessionMetadata,
+		dynState: positron.LanguageRuntimeDynState
+	): Promise<JupyterLanguageRuntimeSession> {
 
 		// Ensure the server is started before trying to restore the session
 		await this.ensureStarted();
@@ -837,12 +840,13 @@ export class KCApi implements PositronSupervisorApi {
 				const kcSession = response.body;
 				if (kcSession.status === Status.Exited) {
 					this._log.appendLine(`Attempt to reconnect to session ${sessionMetadata.sessionId} failed because it is no longer running`);
-					reject(`Session ${sessionMetadata.sessionName} (${sessionMetadata.sessionId}) is no longer running`);
+					reject(`Session (${sessionMetadata.sessionId}) is no longer running`);
 					return;
 				}
 
 				// Create the session object
 				const session = new KallichoreSession(sessionMetadata, runtimeMetadata, {
+					sessionName: dynState.sessionName,
 					continuationPrompt: kcSession.continuationPrompt,
 					inputPrompt: kcSession.inputPrompt,
 				}, this._api, false);
@@ -962,13 +966,13 @@ export class KCApi implements PositronSupervisorApi {
 		// Find the session in our list
 		const kallichoreSession = this._sessions.find(s => s.metadata.sessionId === session.metadata.sessionId);
 		if (!kallichoreSession) {
-			vscode.window.showInformationMessage(vscode.l10n.t('Active session {0} not managed by the kernel supervisor', session.metadata.sessionName));
+			vscode.window.showInformationMessage(vscode.l10n.t('Active session {0} not managed by the kernel supervisor', session.dynState.sessionName));
 			return;
 		}
 
 		// Ensure the session is still active
 		if (kallichoreSession.runtimeState === positron.RuntimeState.Exited) {
-			vscode.window.showInformationMessage(vscode.l10n.t('Session {0} is not running', session.metadata.sessionName));
+			vscode.window.showInformationMessage(vscode.l10n.t('Session {0} is not running', session.dynState.sessionName));
 			return;
 		}
 

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -207,7 +207,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		this._kernelChannel = positron.window.createRawLogOutputChannel(
 			`${runtimeMetadata.runtimeName}: Kernel`);
-		this._kernelChannel.appendLine(`** Begin kernel log for session ${metadata.sessionName} (${metadata.sessionId}) at ${new Date().toLocaleString()} **`);
+		this._kernelChannel.appendLine(`** Begin kernel log for session ${dynState.sessionName} (${metadata.sessionId}) at ${new Date().toLocaleString()} **`);
 	}
 
 	/**
@@ -416,7 +416,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			argv: args,
 			sessionId: this.metadata.sessionId,
 			language: kernelSpec.language,
-			displayName: this.metadata.sessionName,
+			displayName: this.dynState.sessionName,
 			inputPrompt: '',
 			continuationPrompt: '',
 			env: varActions,
@@ -922,7 +922,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			if (this._runtimeState === positron.RuntimeState.Starting) {
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
-					session_name: this.metadata.sessionName,
+					session_name: this.dynState.sessionName,
 					exit_code: 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message: summarizeError(err)
@@ -1041,7 +1041,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				}
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
-					session_name: this.metadata.sessionName,
+					session_name: this.dynState.sessionName,
 					exit_code: startupErr.exit_code ?? 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message
@@ -1056,7 +1056,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				// stringify it if it's not an Error
 				const event: positron.LanguageRuntimeExit = {
 					runtime_name: this.runtimeMetadata.runtimeName,
-					session_name: this.metadata.sessionName,
+					session_name: this.dynState.sessionName,
 					exit_code: 0,
 					reason: positron.RuntimeExitReason.StartupFailed,
 					message: summarizeError(err)
@@ -1134,7 +1134,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				// (i.e. all UI is usable but the busy indicator is shown).
 				vscode.window.withProgress({
 					location: vscode.ProgressLocation.Notification,
-					title: vscode.l10n.t('{0} is busy; waiting for it to become idle before reconnecting.', this.metadata.sessionName),
+					title: vscode.l10n.t('{0} is busy; waiting for it to become idle before reconnecting.', this.dynState.sessionName),
 					cancellable: false,
 				}, async () => {
 					await this.waitForIdle();
@@ -1225,7 +1225,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 					// something bad happened. Close the connected barrier and
 					// show an error.
 					this._connected = new Barrier();
-					vscode.window.showErrorMessage(`Error connecting to ${this.metadata.sessionName} (${this.metadata.sessionId}): ${JSON.stringify(err)}`);
+					vscode.window.showErrorMessage(`Error connecting to ${this.dynState.sessionName} (${this.metadata.sessionId}): ${JSON.stringify(err)}`);
 				} else {
 					// The connection never established; reject the promise and
 					// let the caller handle it.
@@ -1573,7 +1573,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Create and fire the exit event.
 		const event: positron.LanguageRuntimeExit = {
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName,
+			session_name: this.dynState.sessionName,
 			exit_code: exitCode,
 			reason: this._exitReason,
 			message: ''

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1453,7 +1453,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				exit_code: 0,
 				reason: positron.RuntimeExitReason.Transferred,
 				runtime_name: this.runtimeMetadata.runtimeName,
-				session_name: this.metadata.sessionName,
+				session_name: this.dynState.sessionName,
 				message: ''
 			};
 			this._exit.fire(exitEvent);

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -173,12 +173,14 @@ export interface PositronSupervisorApi extends vscode.Disposable {
 	 * @param runtimeMetadata The metadata for the language runtime to be
 	 * wrapped by the adapter.
 	 * @param sessionMetadata The metadata for the session to be reconnected.
+	 * @param dynState The initial dynamic state of the session.
 	 *
 	 * @returns A JupyterLanguageRuntimeSession that wraps the kernel.
 	 */
 	restoreSession(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
-		sessionMetadata: positron.RuntimeSessionMetadata
+		sessionMetadata: positron.RuntimeSessionMetadata,
+		dynState: positron.LanguageRuntimeDynState,
 	): Promise<JupyterLanguageRuntimeSession>;
 }
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -218,6 +218,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._state = positron.RuntimeState.Uninitialized;
 
 		this.dynState = {
+			sessionName: this.runtimeMetadata.runtimeName,
 			inputPrompt: `Z>`,
 			continuationPrompt: 'Z+',
 		};
@@ -1183,7 +1184,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName,
+			session_name: this.dynState.sessionName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.Restart,
 			message: ''
@@ -1244,7 +1245,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName,
+			session_name: this.dynState.sessionName,
 			exit_code: 0,
 			reason: exitReason,
 			message: ''
@@ -1257,7 +1258,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName,
+			session_name: this.dynState.sessionName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.ForcedQuit,
 			message: ''
@@ -2068,7 +2069,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName,
+			session_name: this.dynState.sessionName,
 			exit_code: 137,
 			reason: positron.RuntimeExitReason.Error,
 			message: `I'm terribly sorry, but a segmentation fault has occurred.`

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
@@ -21,16 +21,18 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage> = this._onDidReceiveRuntimeMessage.event;
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState> = this._onDidChangeRuntimeState.event;
 	onDidEndSession: vscode.Event<positron.LanguageRuntimeExit> = this._onDidEndSession.event;
-
-	readonly dynState = {
-		inputPrompt: `T>`,
-		continuationPrompt: 'T+',
-	};
+	dynState: positron.LanguageRuntimeDynState;
 
 	constructor(
 		readonly runtimeMetadata: positron.LanguageRuntimeMetadata,
 		readonly metadata: positron.RuntimeSessionMetadata
-	) { }
+	) {
+		this.dynState = {
+			sessionName: this.runtimeMetadata.runtimeName,
+			inputPrompt: 'T>',
+			continuationPrompt: 'T+',
+		};
+	}
 
 	generateMessageId(): string {
 		return `msg-${TestLanguageRuntimeSession.messageId++}`;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -471,9 +471,6 @@ declare module 'positron' {
 		/** The ID of this session */
 		readonly sessionId: string;
 
-		/** The user-facing name of this session */
-		readonly sessionName: string;
-
 		/** The session's mode */
 		readonly sessionMode: LanguageRuntimeSessionMode;
 
@@ -510,6 +507,9 @@ declare module 'positron' {
 
 		/** The text the language's interpreter uses to prompt the user for continued input, e.g. "+" or "..." */
 		continuationPrompt: string;
+
+		/** The user-facing name of this session */
+		sessionName: string;
 	}
 
 	export enum LanguageRuntimeStartupBehavior {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -815,12 +815,13 @@ declare module 'positron' {
 		 * @param runtimeMetadata The metadata for the runtime that owns the
 		 * session.
 		 * @param sessionMetadata The metadata for the session to reconnect.
-		 *
+		 * @param sessionName The name of the session to reconnect.
 		 * @returns A Thenable that resolves with the reconnected session, or
 		 * rejects with an error.
 		 */
 		restoreSession?(runtimeMetadata: LanguageRuntimeMetadata,
-			sessionMetadata: RuntimeSessionMetadata):
+			sessionMetadata: RuntimeSessionMetadata,
+			sessionName: string):
 			Thenable<LanguageRuntimeSession>;
 	}
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1370,13 +1370,13 @@ export class MainThreadLanguageRuntime
 		this._disposables.add(
 			this._positronConsoleService.onDidExecuteCode(
 				(event) => {
-					this._proxy.$notifyCodeExecuted(event)
+					this._proxy.$notifyCodeExecuted(event);
 				}
 			));
 		this._disposables.add(
 			this._runtimeNotebookKernelService.onDidExecuteCode(
 				(event) => {
-					this._proxy.$notifyCodeExecuted(event)
+					this._proxy.$notifyCodeExecuted(event);
 				}
 			));
 
@@ -1534,7 +1534,7 @@ export class MainThreadLanguageRuntime
 			metadata: {
 				extensionId: extensionId,
 			}
-		}
+		};
 
 		return this._positronConsoleService.executeCode(
 			languageId, code, attribution, focus, allowIncomplete, mode, errorBehavior, executionId);

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -946,7 +946,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 	}
 
 	getLabel(): string {
-		// If we're a notebook session, use the notebook name, otherwise use the runtime name
+		// If we're a notebook session, use the notebook name, otherwise use the session name
 		if (this.dynState.currentNotebookUri) {
 			return basename(this.dynState.currentNotebookUri);
 		}

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1607,11 +1607,13 @@ export class MainThreadLanguageRuntime
 	 */
 	async restoreSession(
 		runtimeMetadata: ILanguageRuntimeMetadata,
-		sessionMetadata: IRuntimeSessionMetadata):
+		sessionMetadata: IRuntimeSessionMetadata,
+		sessionName: string
+	):
 		Promise<ILanguageRuntimeSession> {
 
 		const initialState = await this._proxy.$restoreLanguageRuntimeSession(runtimeMetadata,
-			sessionMetadata);
+			sessionMetadata, sessionName);
 		const session = this.createSessionAdapter(initialState, runtimeMetadata, sessionMetadata);
 		this._sessions.set(initialState.handle, session);
 		return session;

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -142,16 +142,13 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		// Save handle
 		this.handle = initialState.handle;
 		this.dynState = {
-			currentWorkingDirectory: '',
 			busy: false,
+			// If the session is a notebook session, set the current notebook URI
+			// to dynamic data so that it can be displayed in the UI.
+			currentNotebookUri: metadata.notebookUri || undefined,
+			currentWorkingDirectory: '',
 			...initialState.dynState,
 		};
-
-		// If the session is a notebook session, set the current notebook URI
-		// to dynamic data so that it can be displayed in the UI.
-		if (metadata.notebookUri) {
-			this.dynState.currentNotebookUri = metadata.notebookUri;
-		}
 
 		// Bind events to emitters
 		this.onDidChangeRuntimeState = this._stateEmitter.event;

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -950,7 +950,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		if (this.dynState.currentNotebookUri) {
 			return basename(this.dynState.currentNotebookUri);
 		}
-		return this.metadata.sessionName;
+		return this.dynState.sessionName;
 	}
 	static clientCounter = 0;
 
@@ -1467,7 +1467,8 @@ export class MainThreadLanguageRuntime
 	}
 
 	// Called by the extension host to start a previously registered language runtime
-	async $startLanguageRuntime(runtimeId: string,
+	async $startLanguageRuntime(
+		runtimeId: string,
 		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
 		notebookUri: URI | undefined): Promise<string> {
@@ -1548,7 +1549,7 @@ export class MainThreadLanguageRuntime
 				session.markExited();
 				const exit: ILanguageRuntimeExit = {
 					runtime_name: session.runtimeMetadata.runtimeName,
-					session_name: session.metadata.sessionName,
+					session_name: session.dynState.sessionName,
 					exit_code: 0,
 					reason: RuntimeExitReason.ExtensionHost,
 					message: 'Extension host is shutting down'

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -82,7 +82,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$discoverLanguageRuntimes(disabledLanguageIds: string[]): void;
 	$recommendWorkspaceRuntimes(disabledLanguageIds: string[]): Promise<ILanguageRuntimeMetadata[]>;
 	$notifyForegroundSessionChanged(sessionId: string | undefined): void;
-	$notifyCodeExecuted(event: ILanguageRuntimeCodeExecutedEvent): void
+	$notifyCodeExecuted(event: ILanguageRuntimeCodeExecutedEvent): void;
 }
 
 // This is the interface that the main process exposes to the extension host

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -58,7 +58,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 export interface ExtHostLanguageRuntimeShape {
 	$isHostForLanguageRuntime(runtimeMetadata: ILanguageRuntimeMetadata): Promise<boolean>;
 	$createLanguageRuntimeSession(runtimeMetadata: ILanguageRuntimeMetadata, sessionMetadata: RuntimeSessionMetadata): Promise<RuntimeInitialState>;
-	$restoreLanguageRuntimeSession(runtimeMetadata: ILanguageRuntimeMetadata, sessionMetadata: RuntimeSessionMetadata): Promise<RuntimeInitialState>;
+	$restoreLanguageRuntimeSession(runtimeMetadata: ILanguageRuntimeMetadata, sessionMetadata: RuntimeSessionMetadata, sessionName: string): Promise<RuntimeInitialState>;
 	$validateLanguageRuntimeMetadata(metadata: ILanguageRuntimeMetadata): Promise<ILanguageRuntimeMetadata>;
 	$validateLanguageRuntimeSession(metadata: ILanguageRuntimeMetadata, sessionId: string): Promise<boolean>;
 	$disposeLanguageRuntime(handle: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -366,12 +366,13 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 *
 	 * @param runtimeMetadata The metadata for the language runtime.
 	 * @param sessionMetadata The metadata for the session.
-	 *
+	 * @param sessionName The name of the session.
 	 * @returns A promise that resolves with a handle to the runtime session.
 	 */
 	async $restoreLanguageRuntimeSession(
 		runtimeMetadata: ILanguageRuntimeMetadata,
-		sessionMetadata: IRuntimeSessionMetadata): Promise<extHostProtocol.RuntimeInitialState> {
+		sessionMetadata: IRuntimeSessionMetadata,
+		sessionName: string): Promise<extHostProtocol.RuntimeInitialState> {
 		// Look up the session manager responsible for restoring this session
 		console.debug(`[Reconnect ${sessionMetadata.sessionId}]: Await runtime manager for runtime ${runtimeMetadata.extensionId.value}...`);
 		const sessionManager = await this.runtimeManagerForRuntime(runtimeMetadata, true);
@@ -382,7 +383,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 				// around any more.
 				console.debug(`[Reconnect ${sessionMetadata.sessionId}]: Await restore session...`);
 				const session =
-					await sessionManager.manager.restoreSession(runtimeMetadata, sessionMetadata);
+					await sessionManager.manager.restoreSession(runtimeMetadata, sessionMetadata, sessionName);
 				const handle = this.attachToSession(session);
 				const initalState = {
 					handle,

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -30,11 +30,10 @@ export const TopActionBarSessionManager = () => {
 	const context = usePositronTopActionBarContext();
 
 	const [activeSession, setActiveSession] = useState<ILanguageRuntimeSession>();
-
-	const labelText = activeSession?.runtimeMetadata?.runtimeName ?? startSession;
+	const [labelText, setLabelText] = useState<string>(activeSession?.dynState?.sessionName ?? startSession);
 
 	// Check if there are any active console sessions to determine
-	// if the active session picker or the create session pikcer
+	// if the active session picker or the create session picker
 	// should be shown.
 	const hasActiveConsoleSessions = context.runtimeSessionService.activeSessions.find(
 		session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
@@ -53,8 +52,19 @@ export const TopActionBarSessionManager = () => {
 				if (session?.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 					setActiveSession(
 						context.runtimeSessionService.foregroundSession);
+					setLabelText(session.dynState.sessionName);
 				} else if (!session) {
 					setActiveSession(undefined);
+					setLabelText(startSession);
+				}
+			})
+		);
+
+		// Add the onDidUpdateSessionName event handler.
+		disposableStore.add(
+			context.runtimeSessionService.onDidUpdateSessionName(session => {
+				if (session.sessionId === context.runtimeSessionService.foregroundSession?.sessionId) {
+					setLabelText(session.dynState.sessionName);
 				}
 			})
 		);

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -148,7 +148,7 @@ export const selectLanguageRuntimeSession = async (
 				session.sessionId === runtimeSessionService.foregroundSession?.sessionId;
 			return {
 				id: session.sessionId,
-				label: session.metadata.sessionName,
+				label: session.dynState.sessionName,
 				detail: session.runtimeMetadata.runtimePath,
 				description: isForegroundSession ? 'Currently Selected' : undefined,
 				iconPath: {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -39,6 +39,7 @@ interface RuntimeClientInstanceQuickPickItem extends IQuickPickItem { runtimeCli
 // Action IDs
 export const LANGUAGE_RUNTIME_OPEN_ACTIVE_SESSIONS_ID = 'workbench.action.language.runtime.openActivePicker';
 export const LANGUAGE_RUNTIME_START_SESSION_ID = 'workbench.action.language.runtime.openStartPicker';
+export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 
 /**
  * Helper function that askses the user to select a language from the list of registered language
@@ -1132,6 +1133,61 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 			session.setWorkingDirectory(resource.fsPath);
 		} catch (e) {
 			notificationService.error(e);
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: LANGUAGE_RUNTIME_RENAME_SESSION_ID,
+			title: nls.localize2('positron.console.renameSesison', "Rename Console Session"),
+			category,
+			f1: true
+		});
+	}
+
+	/**
+	 * Renames a console session
+	 *
+	 * @param accessor The service accessor
+	 * @returns A promise that resolves when the session has been renamed
+	 */
+	async run(accessor: ServicesAccessor) {
+		const sessionService = accessor.get(IRuntimeSessionService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		// Prompt the user to select a session they want to rename.
+		const session = await selectLanguageRuntimeSession(accessor);
+		if (!session) {
+			return;
+		}
+
+		// Prompt the user to enter the new session name.
+		const sessionName = await quickInputService.input({
+			value: '',
+			placeHolder: '',
+			prompt: nls.localize('positron.console.renameSession.prompt', "Enter the new session name"),
+		});
+
+		// Validate the new session name
+		const newSessionName = sessionName?.trim();
+		if (!newSessionName?.trim()) {
+			return;
+		}
+
+		// Attempt to rename the session.
+		try {
+			sessionService.updateSessionName(session.sessionId, newSessionName);
+		} catch (error) {
+			notificationService.error(
+				localize('positron.console.renameSession.error',
+					"Failed to rename session {0}: {1}",
+					session.sessionId,
+					error
+				)
+			);
 		}
 	}
 });

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -137,7 +137,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		>
 			<div className='console-instance-info'>
 				<div className='content'>
-					<p className='line' data-testid='session-name'>{props.session.metadata.sessionName}</p>
+					<p className='line' data-testid='session-name'>{props.session.dynState.sessionName}</p>
 					<div className='top-separator'>
 						<p className='line' data-testid='session-id'>
 							{(() => localize(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.css
@@ -61,6 +61,9 @@
 }
 
 .tabs-container .tab-button .session-name {
+	/* Grow items after session name to fill available space */
+	flex: 1;
+
 	margin: 0;
 	line-height: 22px;
 	overflow: hidden;
@@ -68,9 +71,17 @@
 	text-overflow: ellipsis;
 }
 
-/* Grow second to last item to fill available space */
-.tabs-container .tab-button :nth-last-child(2) {
+.tabs-container .tab-button .session-name-input {
+	background-color: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border);
+	color: var(--vscode-input-foreground);
+
+	/* Grow input to fill available space */
 	flex: 1;
+}
+
+.tabs-container .tab-button .session-name-input:focus {
+	border-color: var(--vscode-focusBorder);
 }
 
 .tabs-container .tab-button .delete-button {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -59,7 +59,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 		} catch (error) {
 			// Show an error notification if the session could not be deleted.
 			positronConsoleContext.notificationService.error(
-				localize('positronDeleteSessionError', "Failed to delete session: {0}", error)
+				localize('positronDeleteSessionError', "Failed to delete session {0}: {1}", positronConsoleInstance.sessionId, error)
 			);
 			// Re-enable the button if the session could not be deleted.
 			// If it is deleted, the component is destroyed and the
@@ -122,15 +122,20 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 		}
 
 		try {
-			await positronConsoleContext.runtimeSessionService.updateSessionName(
+			const sessionId = positronConsoleContext.runtimeSessionService.updateSessionName(
 				positronConsoleInstance.sessionId,
 				newName
 			);
-			setNewSessionName(newName);
+
+			// Session rename was successful so we can update the UI state
+			if (sessionId) {
+				setNewSessionName(newName);
+			}
 		} catch (error) {
 			positronConsoleContext.notificationService.error(
 				localize('positron.console.renameInstanceError',
-					"Failed to rename session: {0}",
+					"Failed to rename session {0}: {1}",
+					positronConsoleInstance.sessionId,
 					error
 				)
 			);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -7,14 +7,16 @@
 import './consoleTabList.css';
 
 // React.
-import React, { useState } from 'react';
+import React, { KeyboardEvent, MouseEvent, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { ConsoleInstanceState } from './consoleInstanceState.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { IPositronConsoleInstance } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
-
+import { IAction } from '../../../../../base/common/actions.js';
+import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
+import { isMacintosh } from '../../../../../base/common/platform.js';
 
 interface ConsoleTabProps {
 	positronConsoleInstance: IPositronConsoleInstance;
@@ -22,28 +24,37 @@ interface ConsoleTabProps {
 }
 
 const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
+	// Context
 	const positronConsoleContext = usePositronConsoleContext();
-	const [deleteDisabled, setDeleteDisabled] = useState(false);
 
-	const handleTabDeleteClick = async (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>, consoleInstance: IPositronConsoleInstance) => {
-		evt.stopPropagation();
+	// State
+	const [deleteDisabled, setDeleteDisabled] = useState(false);
+	const [isRenamingSession, setIsRenamingSession] = useState(false);
+	const [newSessionName, setNewSessionName] = useState(positronConsoleInstance.sessionMetadata.sessionName);
+
+	// Refs
+	const inputRef = React.useRef<HTMLInputElement>(null);
+
+	// Variables
+	const sessionId = positronConsoleInstance.sessionId;
+
+	const handleDeleteClick = async (e: MouseEvent<HTMLButtonElement>) => {
+		e.stopPropagation();
 
 		// Prevent the button from being clicked multiple times
 		setDeleteDisabled(true);
 		try {
 			// Updated to support proper deletion of sessions that have
 			// been shutdown or exited.
-			if (positronConsoleContext.runtimeSessionService.getSession(consoleInstance.sessionId)) {
+			if (positronConsoleContext.runtimeSessionService.getSession(sessionId)) {
 				// Attempt to delete the session from the runtime session service.
 				// This will throw an error if the session is not found.
-				await positronConsoleContext.runtimeSessionService.deleteSession(
-					consoleInstance.sessionId);
+				await positronConsoleContext.runtimeSessionService.deleteSession(sessionId);
 			} else {
 				// If the session is not found, it may have been deleted already
 				// or is a provisional session. In this case, we can delete the
 				// session from the Positron Console service.
-				positronConsoleContext.positronConsoleService.deletePositronConsoleSession(
-					consoleInstance.sessionId);
+				positronConsoleContext.positronConsoleService.deletePositronConsoleSession(sessionId);
 			}
 		} catch (error) {
 			// Show an error notification if the session could not be deleted.
@@ -57,7 +68,121 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 		}
 	}
 
-	const sessionId = positronConsoleInstance.sessionMetadata.sessionId;
+	/**
+	 * Shows the context menu when a user right-clicks on a console instance tab.
+	 * @param {number} x The x coordinate of the mouse event.
+	 * @param {number} y The y coordinate of the mouse event.
+	 * @returns {Promise<void>} A promise that resolves when the context menu is shown.
+	 */
+	const showContextMenu = async (x: number, y: number): Promise<void> => {
+		// The actions that are built below.
+		const actions: IAction[] = [];
+
+		// Add the rename action
+		actions.push({
+			id: 'workbench.action.positronConsole.renameConsoleSession',
+			label: localize('positron.console.renameInstance', "Rename..."),
+			tooltip: '',
+			class: undefined,
+			enabled: true,
+			run: () => renameConsoleSession()
+		});
+
+		// Show the context menu.
+		positronConsoleContext.contextMenuService.showContextMenu({
+			getActions: () => actions,
+			getAnchor: () => ({ x, y }),
+			anchorAlignment: AnchorAlignment.LEFT,
+			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL
+		});
+	}
+
+
+	const renameConsoleSession = async () => {
+		// Show a prompt to rename the console session in the UI
+		setIsRenamingSession(true);
+		// Focus the input field after it renders and select all text
+		setTimeout(() => {
+			if (inputRef.current) {
+				inputRef.current.focus();
+				inputRef.current.select();
+			}
+		}, 0);
+	}
+
+	/**
+	 * Submits the new session name when the user presses Enter or clicks outside the input field.
+	 */
+	const handleRenameSubmit = async () => {
+		// Validate the new session name
+		const newName = newSessionName.trim();
+		if (!newName || newName === positronConsoleInstance.sessionMetadata.sessionName) {
+			setIsRenamingSession(false);
+			return;
+		}
+
+		try {
+			setNewSessionName(newName);
+		} catch (error) {
+			positronConsoleContext.notificationService.error(
+				localize('positron.console.renameInstanceError',
+					"Failed to rename session: {0}",
+					error
+				)
+			);
+			setNewSessionName(positronConsoleInstance.sessionMetadata.sessionName);
+		} finally {
+			setIsRenamingSession(false);
+		}
+	}
+
+
+	/**
+	 * The mouse down handler for the parent element of the console tab instance.
+	 * This handler is used to show the context menu when the user right-clicks on a tab.
+	 * @param {MouseEvent<HTMLDivElement>} e The mouse event.
+	 */
+	const mouseDownHandler = (e: MouseEvent<HTMLDivElement>) => {
+		// Prevent the default action and stop the event from propagating.
+		e.preventDefault();
+		e.stopPropagation();
+
+		// Show the context menu when the user right-clicks on a tab or
+		// when the user executes ctrl + left-click on macOS
+		if ((e.button === 0 && isMacintosh && e.ctrlKey) || e.button === 2) {
+			showContextMenu(e.clientX, e.clientY);
+		}
+	}
+
+	/**
+	 * The mouse down handler for the delete button.
+	 * This handler is used to prevent the context menu from showing up when the user right-clicks on the delete button.
+	 * @param e The mouse event.
+	 */
+	const deleteButtonMouseDownHandler = (e: MouseEvent<HTMLButtonElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+	}
+
+	/**
+	 * Handles keyboard events for the input field.
+	 * If the user presses Enter, the new session name is submitted.
+	 * If the user presses Escape, the rename operation is cancelled.
+	 * @param e The keyboard event
+	 */
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			handleRenameSubmit();
+		} else if (e.key === 'Escape') {
+			e.preventDefault();
+			// hide the input field
+			setIsRenamingSession(false);
+			// restore the original session name
+			setNewSessionName(positronConsoleInstance.sessionMetadata.sessionName);
+		}
+	};
+
 
 	return (
 		<div
@@ -69,20 +194,42 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 			data-testid={`console-tab-${positronConsoleInstance.sessionMetadata.sessionId}`}
 			role='tab'
 			onClick={() => onClick(positronConsoleInstance)}
+			onMouseDown={mouseDownHandler}
 		>
 			<ConsoleInstanceState positronConsoleInstance={positronConsoleInstance} />
 			<img
 				className='icon'
 				src={`data:image/svg+xml;base64,${positronConsoleInstance.runtimeMetadata.base64EncodedIconSvg}`}
 			/>
-			<p className='session-name'>
-				{positronConsoleInstance.sessionMetadata.sessionName}
-			</p>
-			<button className='delete-button' data-testid='trash-session' disabled={deleteDisabled} onClick={evt => handleTabDeleteClick(evt, positronConsoleInstance)}>
-				<span className='codicon codicon-trash' />
-			</button>
+			{isRenamingSession ? (
+				<input
+					ref={inputRef}
+					className='session-name-input'
+					type='text'
+					value={newSessionName}
+					onBlur={handleRenameSubmit}
+					onChange={e => setNewSessionName(e.target.value)}
+					onClick={e => e.stopPropagation()}
+					onKeyDown={handleKeyDown}
+				/>
+			) : (
+				<>
+					<p className='session-name'>
+						{positronConsoleInstance.sessionMetadata.sessionName}
+					</p>
+					<button
+						className='delete-button'
+						data-testid='trash-session'
+						disabled={deleteDisabled}
+						onClick={handleDeleteClick}
+						onMouseDown={deleteButtonMouseDownHandler}
+					>
+						<span className='codicon codicon-trash' />
+					</button>
+				</>
+			)}
 		</div>
-	);
+	)
 }
 
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -30,7 +30,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 	// State
 	const [deleteDisabled, setDeleteDisabled] = useState(false);
 	const [isRenamingSession, setIsRenamingSession] = useState(false);
-	const [newSessionName, setNewSessionName] = useState(positronConsoleInstance.sessionMetadata.sessionName);
+	const [newSessionName, setNewSessionName] = useState(positronConsoleInstance.sessionName);
 
 	// Refs
 	const inputRef = React.useRef<HTMLInputElement>(null);
@@ -116,7 +116,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 	const handleRenameSubmit = async () => {
 		// Validate the new session name
 		const newName = newSessionName.trim();
-		if (!newName || newName === positronConsoleInstance.sessionMetadata.sessionName) {
+		if (!newName || newName === positronConsoleInstance.sessionName) {
 			setIsRenamingSession(false);
 			return;
 		}
@@ -134,7 +134,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 					error
 				)
 			);
-			setNewSessionName(positronConsoleInstance.sessionMetadata.sessionName);
+			setNewSessionName(positronConsoleInstance.sessionName);
 		} finally {
 			setIsRenamingSession(false);
 		}
@@ -183,7 +183,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 			// hide the input field
 			setIsRenamingSession(false);
 			// restore the original session name
-			setNewSessionName(positronConsoleInstance.sessionMetadata.sessionName);
+			setNewSessionName(positronConsoleInstance.sessionName);
 		}
 	};
 
@@ -191,7 +191,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 	return (
 		<div
 			key={`tab-${sessionId}`}
-			aria-label={positronConsoleInstance.sessionMetadata.sessionName}
+			aria-label={positronConsoleInstance.sessionName}
 			aria-labelledby={`console-panel-${sessionId}`}
 			aria-selected={positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === sessionId}
 			className={`tab-button ${positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === sessionId && 'tab-button--active'}`}
@@ -219,7 +219,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 			) : (
 				<>
 					<p className='session-name'>
-						{positronConsoleInstance.sessionMetadata.sessionName}
+						{positronConsoleInstance.sessionName}
 					</p>
 					<button
 						className='delete-button'

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -122,15 +122,11 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 		}
 
 		try {
-			const sessionId = positronConsoleContext.runtimeSessionService.updateSessionName(
+			positronConsoleContext.runtimeSessionService.updateSessionName(
 				positronConsoleInstance.sessionId,
 				newName
 			);
-
-			// Session rename was successful so we can update the UI state
-			if (sessionId) {
-				setNewSessionName(newName);
-			}
+			setNewSessionName(newName);
 		} catch (error) {
 			positronConsoleContext.notificationService.error(
 				localize('positron.console.renameInstanceError',
@@ -144,7 +140,6 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 			setIsRenamingSession(false);
 		}
 	}
-
 
 	/**
 	 * The mouse down handler for the parent element of the console tab instance.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -122,6 +122,10 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 		}
 
 		try {
+			await positronConsoleContext.runtimeSessionService.updateSessionName(
+				positronConsoleInstance.sessionId,
+				newName
+			);
 			setNewSessionName(newName);
 		} catch (error) {
 			positronConsoleContext.notificationService.error(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -116,8 +116,11 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 	const handleRenameSubmit = async () => {
 		// Validate the new session name
 		const newName = sessionName.trim();
-		if (!newName || newName === positronConsoleInstance.sessionName) {
+		if (newName.length === 0 || newName === positronConsoleInstance.sessionName) {
+			// Hide the input field
 			setIsRenamingSession(false);
+			// Restore the original session name
+			setSessionName(positronConsoleInstance.sessionName);
 			return;
 		}
 
@@ -137,6 +140,7 @@ const ConsoleTab = ({ positronConsoleInstance, onClick }: ConsoleTabProps) => {
 			);
 			setSessionName(positronConsoleInstance.sessionName);
 		} finally {
+			// Hide the input field
 			setIsRenamingSession(false);
 		}
 	}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -39,8 +39,6 @@ const enum PositronConsoleCommandId {
 	ClearInputHistory = 'workbench.action.positronConsole.clearInputHistory',
 	ExecuteCode = 'workbench.action.positronConsole.executeCode',
 	FocusConsole = 'workbench.action.positronConsole.focusConsole',
-	NewConsoleSession = 'workbench.action.positronConsole.newConsoleSession',
-	NewConsoleSessionActiveRuntime = 'workbench.action.positronConsole.newConsoleSessionActiveRuntime'
 }
 
 /**

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -541,7 +541,7 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 			if (existingClients.length > 1) {
 				const clientIds = existingClients.map(client => client.getClientId()).join(', ');
 				this._logService.warn(
-					`Session ${session.metadata.sessionName} has multiple help clients: ` +
+					`Session ${session.dynState.sessionName} has multiple help clients: ` +
 					`${clientIds}`);
 			}
 

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -409,7 +409,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 					const overlay = this.createOverlayWebview(webview.webview);
 					const preview = new PreviewWebview(
 						'notebookRenderer',
-						e.id, session.metadata.sessionName,
+						e.id, session.dynState.sessionName,
 						overlay);
 					this._items.set(e.id, preview);
 					this.openPreviewWebview(preview, false);

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
@@ -54,7 +54,7 @@ export const RuntimeSession = (props: RuntimeSessionProps) => {
 					<a href='#' onClick={() => setExpanded(!expanded)}>
 						<span className={'codicon ' + (expanded ? 'codicon-chevron-down' : 'codicon-chevron-right')}></span>
 						&nbsp;
-						{props.session.metadata.sessionName}
+						{props.session.dynState.sessionName}
 					</a>
 				</td>
 				<td>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -47,6 +47,12 @@ export const VariablesInstanceMenuButton = () => {
 			setSessionLabel(labelForRuntime(instance?.session));
 		}));
 
+		disposables.add(positronVariablesContext.runtimeSessionService.onDidUpdateSessionName(session => {
+			if (session.sessionId === positronVariablesContext.activePositronVariablesInstance?.session.sessionId) {
+				setSessionLabel(labelForRuntime(session));
+			}
+		}));
+
 		return () => disposables.dispose();
 	}, [positronVariablesContext.positronVariablesService, positronVariablesContext.runtimeSessionService, positronVariablesContext.activePositronVariablesInstance]);
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -35,7 +35,7 @@ export const formatLanguageRuntimeMetadata = (metadata: ILanguageRuntimeMetadata
  * @returns A string suitable for logging the language runtime.
  */
 export const formatLanguageRuntimeSession = (session: ILanguageRuntimeSession) => {
-	return `Session ${session.metadata.sessionName} (${session.sessionId}) from runtime ${formatLanguageRuntimeMetadata(session.runtimeMetadata)}`;
+	return `Session ${session.dynState.sessionName} (${session.sessionId}) from runtime ${formatLanguageRuntimeMetadata(session.runtimeMetadata)}`;
 };
 
 /**
@@ -752,6 +752,9 @@ export interface ILanguageRuntimeSessionState extends ILangaugeRuntimeDynState {
 	 * in the PositronVariablesView.
 	 */
 	currentNotebookUri?: URI;
+
+	/** The user-facing name of this session */
+	sessionName: string;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -334,6 +334,8 @@ export interface ILanguageRuntimeInfo {
 	/** The language version number */
 	language_version: string;
 
+	// TODO: add sessionName here?
+
 	/** Custom input prompt, if any */
 	input_prompt?: string;
 

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -236,6 +236,11 @@ export interface IPositronConsoleInstance {
 	readonly sessionId: string;
 
 	/**
+	 * Gets the session name.
+	 */
+	readonly sessionName: string;
+
+	/**
 	 * Gets a value which indicates whether trace is enabled.
 	 */
 	readonly trace: boolean;

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -815,9 +815,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 	/**
 	 * The name of the session when the console instance was created.
-	 * This is used as a fallback if the session is not attached.
+	 * This is used as a fallback when the session is not attached.
 	 */
-	private _fallbackSessionName: string;
+	private _initialSessionName: string;
 
 	/**
 	 * Gets or sets the disposable store. This contains things that are disposed when a runtime is
@@ -1008,7 +1008,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		super();
 
 		// Initialize the session name.
-		this._fallbackSessionName = sessionName;
+		this._initialSessionName = sessionName;
 
 		// Initialize the scrollback configuration.
 		this._scrollbackSize = this._configurationService.getValue<number>(scrollbackSizeSettingId);
@@ -1060,7 +1060,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * session name provided when the console was created.
 	 */
 	get sessionName(): string {
-		return this._session?.dynState.sessionName || this._fallbackSessionName;
+		return this._session?.dynState.sessionName || this._initialSessionName;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1058,8 +1058,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 *
 	 * If there is no session associated with the console, we fallback to the
 	 * session name provided when the console was created.
-	 *
-	 * TODO: describe the scenarios in which the fallback session name is used.
 	 */
 	get sessionName(): string {
 		return this._session?.dynState.sessionName || this._fallbackSessionName;

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2258,8 +2258,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				crashedAndNeedRestartButton);
 
 			if (showRestartButton) {
-				const restartButton = new RuntimeItemRestartButton(generateUuid(),
-					this.sessionMetadata.sessionName,
+				const restartButton = new RuntimeItemRestartButton(
+					generateUuid(),
+					this._session?.dynState.sessionName || this.runtimeMetadata.runtimeName,
 					() => {
 						this._onDidRequestRestart.fire();
 					});

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -502,7 +502,11 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		// successfully reconnects.
 		const sessionId = session.metadata.sessionId;
 		const console = this.createPositronConsoleInstance(
-			session.metadata, session.runtimeMetadata, activate);
+			session.sessionName,
+			session.metadata,
+			session.runtimeMetadata,
+			activate
+		);
 
 		// Set the initial working directory to the session's working directory.
 		console.initialWorkingDirectory = session.workingDirectory;
@@ -550,14 +554,16 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 				// Start the preferred runtime.
 				this._logService.trace(`Language runtime ` +
 					`${formatLanguageRuntimeMetadata(languageRuntime)} automatically starting`);
-				await this._runtimeSessionService.startNewRuntimeSession(languageRuntime.runtimeId,
+				await this._runtimeSessionService.startNewRuntimeSession(
+					languageRuntime.runtimeId,
 					languageRuntime.runtimeName,
 					LanguageRuntimeSessionMode.Console,
 					undefined, // No notebook URI (console sesion)
 					`User executed code in language ${languageId}, and no running runtime session was found ` +
 					`for the language.`,
 					RuntimeStartMode.Starting,
-					true);
+					true
+				);
 			} else {
 				// There is no registered runtime for the language, so we can't execute code.
 				throw new Error(
@@ -626,7 +632,11 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	): IPositronConsoleInstance {
 		// Create the instance
 		const instance = this.createPositronConsoleInstance(
-			session.metadata, session.runtimeMetadata, activate);
+			session.dynState.sessionName,
+			session.metadata,
+			session.runtimeMetadata,
+			activate
+		);
 
 		// Attach it to the session
 		instance.attachRuntimeSession(session, attachMode);
@@ -641,18 +651,21 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	 * the session; use the `attachRuntimeSession` method to connect it to a
 	 * live session.
 	 *
+	 * @param sessionName The name of the session.
 	 * @param sessionMetadata The session metadata.
 	 * @param runtimeMetadata The runtime metadata.
 	 * @param activate Whether to activate the console instance immediately.
 	 * @returns The new Positron console instance.
 	 */
 	private createPositronConsoleInstance(
+		sessionName: string,
 		sessionMetadata: IRuntimeSessionMetadata,
 		runtimeMetadata: ILanguageRuntimeMetadata,
 		activate: boolean): IPositronConsoleInstance {
 		// Create the new Positron console instance.
 		const positronConsoleInstance = this._register(this._instantiationService.createInstance(
 			PositronConsoleInstance,
+			sessionName,
 			sessionMetadata,
 			runtimeMetadata,
 		));
@@ -799,6 +812,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Gets or sets the session, if attached.
 	 */
 	private _session: ILanguageRuntimeSession | undefined;
+
+	/**
+	 * The name of the session when the console instance was created.
+	 * This is used as a fallback if the session is not attached.
+	 */
+	private _fallbackSessionName: string;
 
 	/**
 	 * Gets or sets the disposable store. This contains things that are disposed when a runtime is
@@ -973,11 +992,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Constructor.
 	 *
+	 * @param sessionName The name of the session.
 	 * @param _sessionMetadata The metadata for the session.
 	 * @param _runtimeMetadata The metadata for the runtime.
 	 * @param _notificationService The notification service.
 	 */
 	constructor(
+		sessionName: string,
 		private _sessionMetadata: IRuntimeSessionMetadata,
 		private _runtimeMetadata: ILanguageRuntimeMetadata,
 		@INotificationService private readonly _notificationService: INotificationService,
@@ -985,6 +1006,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	) {
 		// Call the base class's constructor.
 		super();
+
+		// Initialize the session name.
+		this._fallbackSessionName = sessionName;
 
 		// Initialize the scrollback configuration.
 		this._scrollbackSize = this._configurationService.getValue<number>(scrollbackSizeSettingId);
@@ -1027,6 +1051,18 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 	get sessionId(): string {
 		return this._sessionMetadata.sessionId;
+	}
+
+	/**
+	 * Gets the name of the runtime session associated with the console instance.
+	 *
+	 * If there is no session associated with the console, we fallback to the
+	 * session name provided when the console was created.
+	 *
+	 * TODO: describe the scenarios in which the fallback session name is used.
+	 */
+	get sessionName(): string {
+		return this._session?.dynState.sessionName || this._fallbackSessionName;
 	}
 
 	/**
@@ -1694,13 +1730,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 								switch (runtimeItem.attachMode) {
 									case SessionAttachMode.Starting:
 									case SessionAttachMode.Switching:
-										msg = localize('positronConsole.started', "{0} started.", this._sessionMetadata.sessionName);
+										msg = localize('positronConsole.started', "{0} started.", this.sessionName);
 										break;
 									case SessionAttachMode.Restarting:
-										msg = localize('positronConsole.restarted', "{0} restarted.", this._sessionMetadata.sessionName);
+										msg = localize('positronConsole.restarted', "{0} restarted.", this.sessionName);
 										break;
 									case SessionAttachMode.Connected:
-										msg = localize('positronConsole.connected', "{0} connected.", this._sessionMetadata.sessionName);
+										msg = localize('positronConsole.connected', "{0} connected.", this.sessionName);
 										break;
 								}
 								if (msg) {
@@ -1719,7 +1755,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						this.addRuntimeItem(
 							new RuntimeItemReconnected(
 								generateUuid(),
-								`${this._sessionMetadata.sessionName} reconnected.`
+								`${this.sessionName} reconnected.`
 							)
 						);
 						break;
@@ -1730,7 +1766,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				this.addRuntimeItem(
 					new RuntimeItemOffline(
 						generateUuid(),
-						`${this._sessionMetadata.sessionName} offline. Waiting to reconnect.`
+						`${this.sessionName} offline. Waiting to reconnect.`
 					)
 				);
 				break;
@@ -1751,7 +1787,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param attachMode A value which indicates the attachment mode.
 	 */
 	private emitStartRuntimeItems(attachMode: SessionAttachMode) {
-		const sessionName = this._sessionMetadata.sessionName;
+		const sessionName = this.sessionName;
 		// Set the state and add the appropriate runtime item indicating the session attach mode.
 		if (attachMode === SessionAttachMode.Restarting ||
 			// Consider starting from an exited state a restart.
@@ -1799,7 +1835,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// If trace is enabled, add a trace runtime item.
 		if (this._trace) {
-			this.addRuntimeItemTrace(`Attach session ${this._session.metadata.sessionName} ` +
+			this.addRuntimeItemTrace(`Attach session ${this.sessionName} ` +
 				`(attach mode = ${attachMode})`);
 		}
 
@@ -1857,7 +1893,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 							this.addRuntimeItem(new RuntimeItemExited(
 								generateUuid(),
 								RuntimeExitReason.StartupFailed,
-								`${session.metadata.sessionName} failed to start.`
+								`${session.dynState.sessionName} failed to start.`
 							));
 						}
 					}, 1000);
@@ -2333,7 +2369,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private detachRuntime() {
 		// If trace is enabled, add a trace runtime item.
 		if (this._trace) {
-			this.addRuntimeItemTrace(`Detach session ${this.sessionMetadata.sessionName}`);
+			this.addRuntimeItemTrace(`Detach session ${this.sessionName} with ID: ${this.sessionMetadata.sessionId}`);
 		}
 
 		if (this.runtimeAttached) {
@@ -2357,7 +2393,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		} else {
 			// We are not currently attached; warn.
 			console.warn(
-				`Attempt to detach already detached session ${this._sessionMetadata.sessionName}.`);
+				`Attempt to detach already detached session ${this.sessionName} with ID: ${this.sessionMetadata.sessionId}.`);
 		}
 	}
 

--- a/src/vs/workbench/services/positronHistory/common/languageInputHistory.ts
+++ b/src/vs/workbench/services/positronHistory/common/languageInputHistory.ts
@@ -53,7 +53,7 @@ export class LanguageInputHistory extends Disposable {
 		// Don't attach to the same runtime twice.
 		if (this._attachedSessions.has(session.sessionId)) {
 			this._logService.debug(`LanguageInputHistory (${this._languageId}): ` +
-				`Already attached to session ${session.metadata.sessionName} (${session.sessionId})`);
+				`Already attached to session ${session.dynState.sessionName} (${session.sessionId})`);
 			return;
 		}
 

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -105,6 +105,9 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 	private readonly _onDidUpdateNotebookSessionUri = new Emitter<INotebookSessionUriChangedEvent>();
 	readonly onDidUpdateNotebookSessionUri = this._onDidUpdateNotebookSessionUri.event;
 
+	private readonly _onDidUpdateSessionName = new Emitter<ILanguageRuntimeSession>();
+	readonly onDidUpdateSessionName = this._onDidUpdateSessionName.event;
+
 	foregroundSession: ILanguageRuntimeSession | undefined;
 
 	updateNotebookSessionUri(oldUri: URI, newUri: URI): string | undefined {
@@ -196,8 +199,8 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		throw new Error('Method not implemented.');
 	}
 
-	updateSessionName(_sessionId: string, _name: string): Promise<void> {
-		throw new Error('Method not implemented.');
+	updateSessionName(_sessionId: string, _name: string): string | undefined {
+		return undefined;
 	}
 
 	shutdownNotebookSession(_notebookUri: any, _exitReason: RuntimeExitReason, _source: string): Promise<void> {

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -171,7 +171,7 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		throw new Error('Method not implemented.');
 	}
 
-	restoreRuntimeSession(_runtimeMetadata: any, _sessionMetadata: any, _activate: boolean): Promise<void> {
+	restoreRuntimeSession(_runtimeMetadata: any, _sessionMetadata: any, _sessionName: string, _activate: boolean): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -196,6 +196,10 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		throw new Error('Method not implemented.');
 	}
 
+	updateSessionName(_sessionId: string, _name: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
 	shutdownNotebookSession(_notebookUri: any, _exitReason: RuntimeExitReason, _source: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
@@ -361,16 +365,16 @@ function createSessionMetadata(sessionId: string): IRuntimeSessionMetadata {
 		createdTimestamp: 0,
 		sessionMode: LanguageRuntimeSessionMode.Console,
 		notebookUri: undefined,
-		sessionName: `Test Session ${sessionId}`,
 		startReason: 'Unit Test'
 	};
 }
 
-function createSerializedSessionMetadata(sessionId: string): SerializedSessionMetadata {
+function createSerializedSessionMetadata(session: ILanguageRuntimeSession): SerializedSessionMetadata {
 	return {
 		lastUsed: 0,
-		metadata: createSessionMetadata(sessionId),
+		metadata: createSessionMetadata(session.sessionId),
 		runtimeMetadata: TestLanguageRuntimeMetadata,
+		sessionName: session.dynState.sessionName,
 		sessionState: RuntimeState.Idle,
 		workingDirectory: '',
 		localWindowId: 'test-window-id',
@@ -428,6 +432,7 @@ class TestLanguageRuntimeSession extends Disposable implements ILanguageRuntimeS
 			continuationPrompt: '',
 			currentWorkingDirectory: '',
 			inputPrompt: '',
+			sessionName: `Test Session ${sessionId}`,
 		};
 		this.runtimeMetadata = TestLanguageRuntimeMetadata;
 		this.metadata = createSessionMetadata(sessionId);
@@ -438,7 +443,7 @@ class TestLanguageRuntimeSession extends Disposable implements ILanguageRuntimeS
 	}
 
 	getLabel(): string {
-		return this.metadata.sessionName;
+		return this.dynState.sessionName;
 	}
 
 	isIdle(): boolean {
@@ -934,15 +939,19 @@ suite('ExecutionHistoryService', () => {
 
 		// Create a session that will be considered active
 		createSession(activeSessionId);
+
+		// Verify the active session can be retrieved from the runtimeSessionService
+		const activeSession = runtimeSessionService.sessions.get(activeSessionId)!;
+
 		runtimeSessionService.onWillStartSessionEmitter.fire({
-			session: runtimeSessionService.sessions.get(activeSessionId)!,
+			session: activeSession,
 			startMode: RuntimeStartMode.Starting,
 			activate: false
 		});
 
 		// Set up restored sessions (only active one)
 		runtimeStartupService.setRestoredSessions([
-			createSerializedSessionMetadata(activeSessionId),
+			createSerializedSessionMetadata(activeSession),
 		]);
 
 		// Add some fake storage for both active and inactive sessions
@@ -957,7 +966,7 @@ suite('ExecutionHistoryService', () => {
 
 		// Call prune storage
 		(executionHistoryService as ExecutionHistoryService).pruneStorage([
-			createSerializedSessionMetadata(activeSessionId),
+			createSerializedSessionMetadata(activeSession),
 		]);
 
 		// Verify inactive session storage was removed but active was kept

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1461,7 +1461,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * ready to use.
 	 */
 	private async doCreateRuntimeSession(runtimeMetadata: ILanguageRuntimeMetadata,
-		sessionName: string, // TODO @dhruvisompura: Remove this parameter?
+		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
 		source: string,
 		startMode: RuntimeStartMode,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -940,9 +940,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 *
 	 * @param sessionId The session ID of the runtime to update.
 	 * @param name The new name for the session.
-	 * @returns The session ID of the updated session, or undefined if no update occurred
 	 */
-	updateSessionName(sessionId: string, name: string): string | undefined {
+	updateSessionName(sessionId: string, name: string) {
 		// Find the active session to update.
 		const session = this.getSession(sessionId);
 		if (!session) {
@@ -953,23 +952,18 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		this._logService.info(
 			`Updating session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
 
-		try {
-			// Update the sesion name in its dynamic state
-			session.dynState.sessionName = name;
-			this._logService.info(
-				`Successfully updated session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
+		// Update the sesion name in its dynamic state
+		session.dynState.sessionName = name;
+		this._logService.info(
+			`Successfully updated session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
 
-			/**
-			 * Notify listeners that the session name has changed
-			 * so other parts of the application can update their UI
-			 * to reflect the new name.
-			 */
-			this._onDidUpdateSessionNameEmitter.fire(session);
-			return session.sessionId;
-		} catch (error) {
-			this._logService.error(`Failed to update session name to ${name} for session ${formatLanguageRuntimeSession(session)}. Reason: ${error}`);
-			return undefined;
-		}
+		/**
+		 * Notify listeners that the session name has changed
+		 * so other parts of the application can update their UI
+		 * to reflect the new name.
+		 */
+		this._onDidUpdateSessionNameEmitter.fire(session);
+		return session.sessionId;
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -100,10 +100,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	// This map is keyed by the runtimeId (metadata.runtimeId) of the session.
 	private readonly _consoleSessionsByRuntimeId = new Map<string, ILanguageRuntimeSession[]>();
 
-	// A map of the number of sessions created per runtime ID. This is used to
-	// make each session name unique.
-	private readonly _consoleSessionCounterByRuntimeId = new Map<string, number>();
-
 	// A map of the last active console session per langauge.
 	// We can have multiple console sessions per language,
 	// and this map provides access to the session that was
@@ -1447,26 +1443,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			throw err;
 		}
 
-		// Determine if the console session name should be appended with a session count to make it unique.
-		let updatedSessionName = sessionName;
-		if (sessionMode === LanguageRuntimeSessionMode.Console) {
-			let sessionCount = this._consoleSessionCounterByRuntimeId.get(runtimeMetadata.runtimeId);
-			if (sessionCount) {
-				// Increment the session count for the runtime and append it to the session name.
-				sessionCount++;
-				this._consoleSessionCounterByRuntimeId.set(runtimeMetadata.runtimeId, sessionCount);
-				updatedSessionName = `${sessionName} - ${sessionCount}`;
-			} else {
-				// Initialize the session count for the runtime.
-				// The first session for a runtime does not append this count to the session name.
-				this._consoleSessionCounterByRuntimeId.set(runtimeMetadata.runtimeId, 1);
-			}
-		}
-
 		const sessionId = this.generateNewSessionId(runtimeMetadata, sessionMode === LanguageRuntimeSessionMode.Notebook);
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId,
-			sessionName: updatedSessionName,
+			sessionName,
 			sessionMode,
 			notebookUri,
 			createdTimestamp: Date.now(),

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -953,7 +953,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		this._logService.info(
 			`Updating session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
 
-
 		try {
 			// Update the sesion name in its dynamic state
 			session.dynState.sessionName = name;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -527,7 +527,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param startMode The mode in which to start the runtime.
 	 * @param activate Whether to activate/focus the session after it is started.
 	 */
-	async startNewRuntimeSession(runtimeId: string,
+	async startNewRuntimeSession(
+		runtimeId: string,
 		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
 		notebookUri: URI | undefined,
@@ -888,13 +889,15 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		} else if (state === RuntimeState.Uninitialized) {
 			// The runtime has never been started, or is no longer running. Just
 			// tell it to start.
-			await this.startNewRuntimeSession(session.runtimeMetadata.runtimeId,
-				session.metadata.sessionName,
+			await this.startNewRuntimeSession(
+				session.runtimeMetadata.runtimeId,
+				session.dynState.sessionName,
 				session.metadata.sessionMode,
 				session.metadata.notebookUri,
 				`'Restart Interpreter' command invoked`,
 				RuntimeStartMode.Starting,
-				true);
+				true
+			);
 			return;
 		} else if (state === RuntimeState.Starting ||
 			state === RuntimeState.Restarting) {
@@ -1465,7 +1468,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		const sessionId = this.generateNewSessionId(runtimeMetadata, sessionMode === LanguageRuntimeSessionMode.Notebook);
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId,
-			sessionName,
 			sessionMode,
 			notebookUri,
 			createdTimestamp: Date.now(),
@@ -1896,7 +1898,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param session The runtime to watch.
 	 */
 	private async waitForInterrupt(session: ILanguageRuntimeSession) {
-		const warning = nls.localize('positron.runtimeInterruptTimeoutWarning', "{0} isn't responding to your request to interrupt the command. Do you want to forcefully quit your {1} session? You'll lose any unsaved objects.", session.metadata.sessionName, session.runtimeMetadata.languageName);
+		const warning = nls.localize('positron.runtimeInterruptTimeoutWarning', "{0} isn't responding to your request to interrupt the command. Do you want to forcefully quit your {1} session? You'll lose any unsaved objects.", session.dynState.sessionName, session.runtimeMetadata.languageName);
 		this.awaitStateChange(session,
 			[RuntimeState.Idle],
 			10,
@@ -1911,7 +1913,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param session The runtime to watch.
 	 */
 	private async waitForShutdown(session: ILanguageRuntimeSession) {
-		const warning = nls.localize('positron.runtimeShutdownTimeoutWarning', "{0} isn't responding to your request to shut down the session. Do you want use a forced quit to end your {1} session? You'll lose any unsaved objects.", session.metadata.sessionName, session.runtimeMetadata.languageName);
+		const warning = nls.localize('positron.runtimeShutdownTimeoutWarning', "{0} isn't responding to your request to shut down the session. Do you want use a forced quit to end your {1} session? You'll lose any unsaved objects.", session.dynState.sessionName, session.runtimeMetadata.languageName);
 		this.awaitStateChange(session,
 			[RuntimeState.Exited],
 			10,
@@ -1926,7 +1928,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param session The runtime to watch.
 	 */
 	private async waitForReconnect(session: ILanguageRuntimeSession) {
-		const warning = nls.localize('positron.runtimeReconnectTimeoutWarning', "{0} has been offline for more than 30 seconds. Do you want to force quit your {1} session? You'll lose any unsaved objects.", session.metadata.sessionName, session.runtimeMetadata.languageName);
+		const warning = nls.localize('positron.runtimeReconnectTimeoutWarning', "{0} has been offline for more than 30 seconds. Do you want to force quit your {1} session? You'll lose any unsaved objects.", session.dynState.sessionName, session.runtimeMetadata.languageName);
 		this.awaitStateChange(session,
 			[RuntimeState.Ready, RuntimeState.Idle],
 			30,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -212,7 +212,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 						// Attempt to reconnect the session.
 						this._logService.debug(`Extension ${extensionId.value} has been reloaded; ` +
 							`attempting to reconnect session ${session.sessionId}`);
-						this.restoreRuntimeSession(session.runtimeMetadata, session.metadata, false);
+						this.restoreRuntimeSession(session.runtimeMetadata, session.metadata, session.dynState.sessionName, false);
 					}
 				}
 			}
@@ -611,12 +611,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 *
 	 * @param runtimeMetadata The metadata of the runtime to start.
 	 * @param sessionMetadata The metadata of the session to start.
+	 * @param sessionName A human readable name for the session.
 	 * @param activate Whether to activate/focus the session after it is
 	 * reconnected.
 	 */
 	async restoreRuntimeSession(
 		runtimeMetadata: ILanguageRuntimeMetadata,
 		sessionMetadata: IRuntimeSessionMetadata,
+		sessionName: string,
 		activate: boolean): Promise<void> {
 		// See if we are already starting the requested session. If we
 		// are, return the promise that resolves when the session is ready to
@@ -682,7 +684,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// reconnect, etc.
 		let session: ILanguageRuntimeSession;
 		try {
-			session = await sessionManager.restoreSession(runtimeMetadata, sessionMetadata);
+			session = await sessionManager.restoreSession(runtimeMetadata, sessionMetadata, sessionName);
 		} catch (err) {
 			this._logService.error(
 				`Reconnecting to session '${sessionMetadata.sessionId}' for language runtime ` +

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -963,7 +963,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		 * to reflect the new name.
 		 */
 		this._onDidUpdateSessionNameEmitter.fire(session);
-		return session.sessionId;
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -950,14 +950,22 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			throw new Error(`No session with ID '${sessionId}' was found.`);
 		}
 
+		// Validate the new session name.
+		const validatedName = name.trim();
+		if (validatedName.trim().length === 0) {
+			throw new Error(`Session name cannot be empty.`);
+		}
+
 		// Log the start of the session name update
 		this._logService.info(
-			`Updating session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
+			`Updating session name to ${validatedName} for session ${formatLanguageRuntimeSession(session)}'`);
 
 		// Update the sesion name in its dynamic state
-		session.dynState.sessionName = name;
+		session.dynState.sessionName = validatedName;
+
+		// Log the end of the session name update
 		this._logService.info(
-			`Successfully updated session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
+			`Successfully updated session name to ${validatedName} for session ${formatLanguageRuntimeSession(session)}'`);
 
 		/**
 		 * Notify listeners that the session name has changed

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -908,6 +908,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				`and cannot be restarted.`);
 		}
 	}
+
 	/**
 	 * Interrupt a runtime session.
 	 *
@@ -922,6 +923,24 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			`Interrupting session ${formatLanguageRuntimeSession(session)}'`);
 
 		return session.interrupt();
+	}
+
+	/**
+	 * Update the name of a runtime session.
+	 *
+	 * @param sessionId The session ID of the runtime to update.
+	 * @param name The new name for the session.
+	 */
+	updateSessionName(sessionId: string, name: string): Promise<void> {
+		const session = this.getSession(sessionId);
+		if (!session) {
+			throw new Error(`No session with ID '${sessionId}' was found.`);
+		}
+		this._logService.info(
+			`Updating session name to ${name} for session ${formatLanguageRuntimeSession(session)}'`);
+
+		//@dhruvisompura TODO: figure out how to update the sessionName field in the session
+		return Promise.resolve();
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -264,12 +264,14 @@ export interface ILanguageRuntimeSessionManager {
 	 * @param runtimeMetadata The metadata of the runtime for which a session is
 	 *  	to be restored (reconnected).
 	 * @param sessionMetadata The metadata of the session to be restored.
+	 * @param sessionName A human-readable (displayed) name for the session.
 	 *
 	 * @returns A promise that resolves to the reconnected session.
 	 */
 	restoreSession(
 		runtimeMetadata: ILanguageRuntimeMetadata,
-		sessionMetadata: IRuntimeSessionMetadata):
+		sessionMetadata: IRuntimeSessionMetadata,
+		sessionName: string):
 		Promise<ILanguageRuntimeSession>;
 
 	/**
@@ -428,11 +430,13 @@ export interface IRuntimeSessionService {
 	 *
 	 * @param runtimeMetadata The metadata of the runtime to start.
 	 * @param sessionMetadata The metadata of the session to start.
+	 * @param sessionName A human-readable (displayed) name for the session.
 	 * @param activate Whether to activate/focus the session after it is reconnected.
 	 */
 	restoreRuntimeSession(
 		runtimeMetadata: ILanguageRuntimeMetadata,
 		sessionMetadata: IRuntimeSessionMetadata,
+		sessionName: string,
 		activate: boolean): Promise<void>;
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -79,9 +79,6 @@ export interface IRuntimeSessionMetadata {
 	/** The unique identifier of the session */
 	readonly sessionId: string;
 
-	/** A user-friendly name for the session */
-	readonly sessionName: string;
-
 	/** The session's mode  */
 	readonly sessionMode: LanguageRuntimeSessionMode;
 
@@ -404,7 +401,8 @@ export interface IRuntimeSessionService {
 	 *
 	 * Returns a promise that resolves to the session ID of the new session.
 	 */
-	startNewRuntimeSession(runtimeId: string,
+	startNewRuntimeSession(
+		runtimeId: string,
 		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
 		notebookUri: URI | undefined,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -485,6 +485,14 @@ export interface IRuntimeSessionService {
 	interruptSession(sessionId: string): Promise<void>;
 
 	/**
+	 * Update the name of a runtime session.
+	 *
+	 * @param sessionId The identifier of the session to update.
+	 * @param name The new name for the session.
+	 */
+	updateSessionName(sessionId: string, name: string): Promise<void>;
+
+	/**
 	 * Shutdown a runtime session for a notebook.
 	 *
 	 * @param notebookUri The notebook's URI.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -332,6 +332,9 @@ export interface IRuntimeSessionService {
 	// An event that fires when a notebook session's URI is updated.
 	readonly onDidUpdateNotebookSessionUri: Event<INotebookSessionUriChangedEvent>;
 
+	// An event that fires when a runtime session name changes.
+	readonly onDidUpdateSessionName: Event<ILanguageRuntimeSession>;
+
 	/**
 	 * Gets the active runtime sessions
 	 */
@@ -483,12 +486,13 @@ export interface IRuntimeSessionService {
 	interruptSession(sessionId: string): Promise<void>;
 
 	/**
-	 * Update the name of a runtime session.
+	 * Update the name of an active runtime session.
 	 *
 	 * @param sessionId The identifier of the session to update.
 	 * @param name The new name for the session.
+	 * @returns The session ID of the updated session, or undefined if no update occurred
 	 */
-	updateSessionName(sessionId: string, name: string): Promise<void>;
+	updateSessionName(sessionId: string, name: string): string | undefined;
 
 	/**
 	 * Shutdown a runtime session for a notebook.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -490,9 +490,8 @@ export interface IRuntimeSessionService {
 	 *
 	 * @param sessionId The identifier of the session to update.
 	 * @param name The new name for the session.
-	 * @returns The session ID of the updated session, or undefined if no update occurred
 	 */
-	updateSessionName(sessionId: string, name: string): string | undefined;
+	updateSessionName(sessionId: string, name: string): void;
 
 	/**
 	 * Shutdown a runtime session for a notebook.

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1125,4 +1125,18 @@ suite.skip('Positron - RuntimeSessionService', () => {
 		assert.strictEqual(returnedSessionId, undefined,
 			'Function should return undefined when no session exists for the old URI');
 	});
+
+	test('updateSessionName updates session name correctly', async () => {
+		// Create a new session
+		const session = await startConsole();
+		await waitForRuntimeState(session, RuntimeState.Ready);
+		assert.strictEqual(session.metadata.sessionName, 'test-session', 'Initial session name should match');
+
+		// Set a new name for the session
+		const newName = 'updated-session-name';
+		runtimeSessionService.updateSessionName(session.sessionId, newName);
+
+		// Verify the session's name has been updated
+		assert.strictEqual(session.metadata.sessionName, newName, 'Session name should be updated correctly');
+	});
 });

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1128,7 +1128,7 @@ suite.skip('Positron - RuntimeSessionService', () => {
 		// Create a new session
 		const session = await startConsole();
 		await waitForRuntimeState(session, RuntimeState.Ready);
-		assert.strictEqual(session.dynState.sessionName, 'test-session', 'Initial session name should match');
+		assert.strictEqual(session.dynState.sessionName, runtime.runtimeName, 'Initial session name should match');
 
 		// Set a new name for the session
 		const newName = 'updated-session-name';

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -211,7 +211,6 @@ suite.skip('Positron - RuntimeSessionService', () => {
 	function restoreConsole(runtimeMetadata = runtime) {
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId: 'test-console-session-id',
-			sessionName,
 			sessionMode: LanguageRuntimeSessionMode.Console,
 			createdTimestamp: Date.now(),
 			notebookUri: undefined,
@@ -223,7 +222,6 @@ suite.skip('Positron - RuntimeSessionService', () => {
 	function restoreNotebook(runtimeMetadata = runtime) {
 		const sessionMetadata: IRuntimeSessionMetadata = {
 			sessionId: 'test-notebook-session-id',
-			sessionName,
 			sessionMode: LanguageRuntimeSessionMode.Notebook,
 			createdTimestamp: Date.now(),
 			notebookUri,
@@ -272,7 +270,7 @@ suite.skip('Positron - RuntimeSessionService', () => {
 				const session = await start();
 
 				assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
-				assert.strictEqual(session.metadata.sessionName, sessionName);
+				assert.strictEqual(session.dynState.sessionName, sessionName);
 				assert.strictEqual(session.metadata.sessionMode, mode);
 				assert.strictEqual(session.metadata.startReason, startReason);
 				assert.strictEqual(session.runtimeMetadata, runtime);
@@ -904,7 +902,7 @@ suite.skip('Positron - RuntimeSessionService', () => {
 				activate: true
 			});
 
-			assert.strictEqual(newSession.metadata.sessionName, session.metadata.sessionName);
+			assert.strictEqual(newSession.dynState.sessionName, session.dynState.sessionName);
 			assert.strictEqual(newSession.metadata.sessionMode, session.metadata.sessionMode);
 			assert.strictEqual(newSession.metadata.notebookUri, session.metadata.notebookUri);
 			assert.strictEqual(newSession.runtimeMetadata, session.runtimeMetadata);
@@ -1130,13 +1128,13 @@ suite.skip('Positron - RuntimeSessionService', () => {
 		// Create a new session
 		const session = await startConsole();
 		await waitForRuntimeState(session, RuntimeState.Ready);
-		assert.strictEqual(session.metadata.sessionName, 'test-session', 'Initial session name should match');
+		assert.strictEqual(session.dynState.sessionName, 'test-session', 'Initial session name should match');
 
 		// Set a new name for the session
 		const newName = 'updated-session-name';
 		runtimeSessionService.updateSessionName(session.sessionId, newName);
 
 		// Verify the session's name has been updated
-		assert.strictEqual(session.metadata.sessionName, newName, 'Session name should be updated correctly');
+		assert.strictEqual(session.dynState.sessionName, newName, 'Session name should be updated correctly');
 	});
 });

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -198,7 +198,7 @@ suite.skip('Positron - RuntimeSessionService', () => {
 	async function restoreSession(
 		sessionMetadata: IRuntimeSessionMetadata, runtimeMetadata = runtime,
 	) {
-		await runtimeSessionService.restoreRuntimeSession(runtimeMetadata, sessionMetadata, true);
+		await runtimeSessionService.restoreRuntimeSession(runtimeMetadata, sessionMetadata, sessionName, true);
 
 		// Ensure that the session gets disposed after the test.
 		const session = runtimeSessionService.getSession(sessionMetadata.sessionId);

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -267,7 +267,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			this._onDidChangeRuntimeState.fire(RuntimeState.Exited);
 			this._onDidEndSession.fire({
 				runtime_name: this.runtimeMetadata.runtimeName,
-				session_name: this.metadata.sessionName,
+				session_name: this.dynState.sessionName,
 				exit_code: 0,
 				reason: exitReason,
 				message: '',
@@ -450,12 +450,12 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			message: exit?.message ?? '',
 			reason: exit?.reason ?? RuntimeExitReason.Unknown,
 			runtime_name: this.runtimeMetadata.runtimeName,
-			session_name: this.metadata.sessionName
+			session_name: this.dynState.sessionName
 		});
 	}
 
 	getLabel(): string {
-		return this.runtimeMetadata.runtimeName;
+		return this.dynState.sessionName;
 	}
 }
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionMetadata, LanguageRuntimeSessionChannel, RuntimeClientType } from '../../common/runtimeSessionService.js';
-import { ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageIPyWidget, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageIPyWidget, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeSessionState, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeClientEvent } from '../../../languageRuntime/common/languageRuntimeUiClient.js';
 import { TestRuntimeClientInstance } from '../../../languageRuntime/test/common/testRuntimeClientInstance.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
@@ -70,14 +70,9 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 	// Track the working directory.
 	private _workingDirectory = '';
 
-	readonly dynState = {
-		inputPrompt: `T>`,
-		continuationPrompt: 'T+',
-		currentWorkingDirectory: '',
-		busy: false,
-	};
-
 	readonly sessionId: string;
+
+	dynState: ILanguageRuntimeSessionState;
 
 	clientInstances = new Array<IRuntimeClientInstance<any, any>>();
 
@@ -86,6 +81,14 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		readonly runtimeMetadata: ILanguageRuntimeMetadata,
 	) {
 		super();
+
+		this.dynState = {
+			inputPrompt: `T>`,
+			continuationPrompt: 'T+',
+			currentWorkingDirectory: '',
+			busy: false,
+			sessionName: this.runtimeMetadata.runtimeName,
+		};
 
 		this.sessionId = this.metadata.sessionId;
 

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1243,7 +1243,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// Browser sessions are never valid since they cannot be
 				// reconnected. It'd be surprising to find one persisted.
 				this._logService.info(`[Runtime startup] Not restoring unexpected persisted ` +
-					`browser session ${session.metadata.sessionName} (${session.metadata.sessionId})`);
+					`browser session ${session.sessionName} (${session.metadata.sessionId})`);
 				return false;
 			} else {
 				// If the session is persistent on the machine, we need to

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1332,7 +1332,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// Reconnect to the session; activate it if it is the first console
 				// session
 				await this._runtimeSessionService.restoreRuntimeSession(
-					session.runtimeMetadata, session.metadata, activate);
+					session.runtimeMetadata, session.metadata, session.sessionName, activate);
 			} catch (err) {
 				// If an error occurs, fire an event to clean up provisional copies
 				const error: ISessionRestoreFailedEvent = {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -53,7 +53,7 @@ interface IAffiliatedRuntimeMetadata {
  * sessions separately, and with a version number to allow for future changes to
  * the storage format.
  */
-const PERSISTENT_WORKSPACE_SESSIONS = 'positron.workspaceSessionList.v2';
+const PERSISTENT_WORKSPACE_SESSIONS = 'positron.workspaceSessionList.v3';
 
 const languageRuntimeExtPoint =
 	ExtensionsRegistry.registerExtensionPoint<ILanguageRuntimeProviderMetadata[]>({

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -796,7 +796,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					return;
 				}
 
-				this._runtimeSessionService.startNewRuntimeSession(metadata.runtimeId,
+				this._runtimeSessionService.startNewRuntimeSession(
+					metadata.runtimeId,
 					metadata.runtimeName,
 					LanguageRuntimeSessionMode.Console,
 					undefined, // Console session
@@ -1225,7 +1226,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			if (activatedExtensions.indexOf(session.runtimeMetadata.extensionId) === -1) {
 				this._logService.debug(`[Runtime startup] Activating extension ` +
 					`${session.runtimeMetadata.extensionId.value} for persisted session ` +
-					`${session.metadata.sessionName} (${session.metadata.sessionId})`);
+					`${session.sessionName} (${session.metadata.sessionId})`);
 				activatedExtensions.push(session.runtimeMetadata.extensionId);
 				return this._extensionService.activateById(session.runtimeMetadata.extensionId,
 					{
@@ -1249,7 +1250,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// check to see if it is still valid (i.e. still running)
 				// before reconnecting.
 				this._logService.debug(`[Runtime startup] Checking to see if persisted session ` +
-					`${session.metadata.sessionName} (${session.metadata.sessionId}) is still valid.`);
+					`${session.sessionName} (${session.metadata.sessionId}) is still valid.`);
 				try {
 					// Ask the runtime session service to validate the session.
 					// This call will eventually be proxied through to the
@@ -1260,7 +1261,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 					this._logService.debug(
 						`[Runtime startup] Session ` +
-						`${session.metadata.sessionName} (${session.metadata.sessionId}) valid = ${valid}`);
+						`${session.sessionName} (${session.metadata.sessionId}) valid = ${valid}`);
 
 					// Fire an event to clean up provisional copies of the session
 					if (!valid) {
@@ -1277,7 +1278,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					// to the session.
 					this._logService.error(
 						`Error validating persisted session ` +
-						`${session.metadata.sessionName} (${session.metadata.sessionId}): ${err}`);
+						`${session.sessionName} (${session.metadata.sessionId}): ${err}`);
 
 					// Fire an event to clean up provisional copies of the session
 					const error: ISessionRestoreFailedEvent = {
@@ -1295,7 +1296,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 		// Reconnect to the remaining sessions.
 		this._logService.debug(`Reconnecting to sessions: ` +
-			sessions.map(session => session.metadata.sessionName).join(', '));
+			sessions.map(session => session.sessionName).join(', '));
 
 		// Keep track of whether we are expecting to see the first console
 		// session
@@ -1318,7 +1319,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			}
 
 			this._logService.debug(`${marker}: Restoring session for ` +
-				`${session.metadata.sessionName}`);
+				`${session.sessionName}`);
 
 			// We want to activate the first console session we see, but no
 			// following sessions
@@ -1376,7 +1377,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			.map(session => {
 				const activeSession =
 					this._runtimeSessionService.getActiveSession(session.metadata.sessionId);
+
 				const metadata: SerializedSessionMetadata = {
+					sessionName: session.dynState.sessionName,
 					metadata: session.metadata,
 					sessionState: session.getRuntimeState(),
 					runtimeMetadata: session.runtimeMetadata,
@@ -1384,12 +1387,13 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					lastUsed: session.lastUsed,
 					localWindowId: this._localWindowId,
 				};
+
 				return metadata;
 			});
 
 		// Diagnostic logs: what are we saving?
 		this._logService.trace(`Saving workspace sessions: ${activeSessions.map(session =>
-			`${session.metadata.sessionName} (${session.metadata.sessionId}, ${session.runtimeMetadata.sessionLocation})`).join(', ')}`);
+			`${session.sessionName} (${session.metadata.sessionId}, ${session.runtimeMetadata.sessionLocation})`).join(', ')}`);
 
 		// Save the ephemeral sessions to the workspace storage.
 		const workspaceSessions = activeSessions.filter(session =>

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
@@ -37,6 +37,9 @@ export interface ISessionRestoreFailedEvent {
  * Metadata for serialized runtime sessions.
  */
 export interface SerializedSessionMetadata {
+	// The user-facing name of the session.
+	sessionName: string;
+
 	/// The metadata for the runtime session itself.
 	metadata: IRuntimeSessionMetadata;
 

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -65,7 +65,7 @@ test.describe('Reticulate', {
 
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 
-		await verifyReticulateFunctionality(app, rSessionMetaData2.id, 'Python (reticulate) - 2', '300', '500', '7');
+		await verifyReticulateFunctionality(app, rSessionMetaData2.id, 'Python (reticulate)', '300', '500', '7');
 
 	});
 });

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe('Reticulate', {
+test.describe.skip('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe('Reticulate', {
+test.describe.skip('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {
@@ -49,7 +49,7 @@ test.describe('Reticulate', {
 
 		await app.workbench.console.waitForReadyAndStarted('>>>', 30000);
 
-		await verifyReticulateFunctionality(app, `R ${process.env.POSITRON_R_VER_SEL!} - 2`, 'Python (reticulate) - 2');
+		await verifyReticulateFunctionality(app, `R ${process.env.POSITRON_R_VER_SEL!}`, 'Python (reticulate)');
 
 	});
 


### PR DESCRIPTION
Addresses #6825
Addresses #7340 

The `sessionName` field is a user friendly name that can be used in the UI to identify a session - think of it as a display name. The `sessionName` field for a session defaults to the `runtimeName` field from the `runtimeMetaData` object (this is provided by the language packs). A user couldn't have more than one console session at a time so the `sessionName` _always_ being the `runtimeName` was sufficient.

Having the `sessionName` field initialized to the `runtimeName` is a reasonable default that we want to keep. We need to solve the situation where a user has multiple sessions of the exact same runtime. The first approach to solve this in #6683 was a _very_ lightweight change. We introduced a counter to the end of the `sessionName` whenever a user created more than one session for a given runtime. This change was a stopgap until we added the ability to rename sessions.

We've gotten enough feedback early on that this functionality needs to be added sooner rather than later, so this PR does that with the caveat that the changes aren't as robust as we'd like across the stack (specifically with getting this change piped up to the API so extensions know when the session name changes). For example, when restarting a session, some of the output in the console that comes from an extension will show the outdated session name. This will mean that there will be a regression of #7217.

Language packs manage the creation of output channels and they currently utilize a combination of the `runtimeName`, `sessionName` and/or `sessionMode` to determine where output should be sent. In the multiple console session world we are seeing that all output for a given runtime is sent to the same channel (this is happening even with counters appended to the `sessionName`. We get two output channels that are both populated with output data from all sessions for the runtime).  This PR does not resolve the problem of what to do with the output channel name mismatch that arises when a user renames a session.

A couple things we will want to add in the future:
- An event that extensions can listen to when the session name changes to keep extensions and positron core in sync
- Configure output channels with different keys to allow session specific channels

Note: Keyboard actions such as select all/copy/paste are not working in this PR. These issues will be resolved in #6451 which is addressing the core issue causing these problems!

### Technical Details

The `sessionName` field has been moved out of the readonly `RuntimeSessionMetadata` object and into the `LanguageRuntimeDynState` object. A majority of the files changed in this PR include updating all the references to `sessionName`. 

The `runtimeSession` service includes two additions:
- `updateSessionName` function which handles updating the `sessionName`
- `onDidUpdateSessionName` event that is fired when the `sessionName` changes. UI components can listen to this event to keep local state up to date.

There is a new command that allows renaming a session called: "Interpreter: Rename Console Session" with an id of `workbench.action.language.runtime.renameSession`

The `consoleTabList` component contains the UI changes that allow a user to rename a session by right clicking the console tab and selecting the `Rename` action. This behavior should be equivalent to what the Terminal pane does.

### Release Notes

#### New Features

- Add ability to rename a console session 

#### Bug Fixes

- N/A

### QA Notes

@:sessions

### Screenshots

https://github.com/user-attachments/assets/55c596f6-d213-4cfc-8063-26986e28adee

**UPDATED CHANGES**

https://github.com/user-attachments/assets/47a5731a-9e25-40bf-8b92-bc33103030b7


