### PR TITLE
update posit.publisher extension to 1.12.0 in 2025.04

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -880,7 +880,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d532234ad25d9767b98a089f00f0eb68ed18af4f",
+        "hashed_secret": "78616f31a7726d7ad5b7cc35455dd53b14853f04",
         "is_verified": false,
         "line_number": 110,
         "is_secret": false
@@ -944,7 +944,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "2b8c2e7b2988e554a43e6ee7527c9be82c0f2e8d",
+        "hashed_secret": "d063388a2bf45836401d99e6011749c61836ea1f",
         "is_verified": false,
         "line_number": 234,
         "is_secret": false
@@ -1354,6 +1354,15 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 96
+      }
+    ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
@@ -1403,5 +1412,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-29T00:20:52Z"
+  "generated_at": "2025-04-25T14:08:52Z"
 }

--- a/product.json
+++ b/product.json
@@ -230,8 +230,8 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.10.0",
-			"sha256sum": "32be8178b713656d5c532224dd7a4ce5eede7762ab87bf723e2b56ed8710cd1d",
+			"version": "1.12.0",
+			"sha256sum": "eb642fa964eb1a7efa03ba0fceec853ad00f28fedb0ed274ef49d9d15f349614",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",


### PR DESCRIPTION
Updating on the prerelease branch for potential inclusion in PWB 2025.04
1.12.0 isn't available on Open VSX yet so this PR should wait to merge until then 
https://open-vsx.org/extension/posit/publisher