### PR TITLE
Skip test due to issue

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -93,7 +93,8 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 /**
  * Test suite Positron Assistant actions from the chat interface.
  */
-test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
+// Skipped due to https://github.com/posit-dev/positron/issues/7391
+test.describe.skip('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
 	test.beforeAll('How to set User Settings', async function ({ app, userSettings }) {
 		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
 		await userSettings.set([['positron.assistant.enable', 'true'],


### PR DESCRIPTION
See https://github.com/posit-dev/positron/issues/7391

Skipping tests that fail now because of this. This is a regression that was recently introduced and causes the failure.


### QA Notes
Assistant tests are already marked critical.

The Chat editing tests should be skipped
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
