### PR TITLE
Add RStudio keybinding for setting working directory

### DIFF
--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -271,6 +271,13 @@ class PositronKeybindingsContribution extends Disposable {
 			},
 			primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyM
 		}));
+
+		// Go to Working Directory
+		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
+			id: 'workbench.action.setWorkingDirectory',
+			weight: KeybindingWeight.WorkbenchContrib,
+			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH
+		}));
 	}
 }
 


### PR DESCRIPTION
Quick change to extend the RStudio keymap with the Ctrl/Cmd+Shift+H binding, as suggested in https://github.com/posit-dev/positron/discussions/7346. 

This is a pretty overloaded keybinding:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/f942f07d-222c-49a7-8426-37f5bf950cfd" />

It is OK for other bindings to take precedence when their respective panes are active. RStudio users may want to rebind the _Replace in Files_ binding, though note that RStudio's equivalent command (_Find in Files_) already has the RStudio keybinding, Cmd/Ctrl+Shift+F. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Bound Ctrl/Cmd+Shift+H to _Set Working Directory_ when the RStudio keymap is active

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
