### PR TITLE
Update provider TOS and privacy template

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.css
+++ b/src/vs/base/browser/ui/positronComponents/button/button.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,6 +11,16 @@
 	/* Unset user agent stylesheet styles. */
 	font-family: unset !important;
 	text-align: unset !important;
+}
+
+.hc-black .positron-button,
+.hc-light .positron-button {
+	border: 1px solid transparent;
+}
+
+.hc-black .positron-button:hover,
+.hc-light .positron-button:hover {
+	border: 1px dashed var(--vscode-focusBorder);
 }
 
 .positron-button:focus {

--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.tsx
@@ -9,37 +9,49 @@ import React from 'react';
 
 /**
  * A component that displays a string and converts any markdown links in the string to a href links.
+ * It also handles paragraphs by splitting the input text by newlines and wrapping each paragraph
+ * in appropriate HTML elements.
  *
  * @param props the string to display containing markdown links to convert to a link
  */
 export const EmbeddedLink = (props: React.PropsWithChildren) => {
 	// capture markdown links in the format [text](url)
-	const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
+	const regex = /\[([^\]]*)\]\(([^)]+)\)/g;
 	const text = props.children as string;
+
+	// Split text into paragraphs first
+	const paragraphs = text.split(/\n\n+/);
 
 	// Splits the text into tuples of [text, linkText, linkUrl]
 	// e.g. "This is a [link](https://example.com)" becomes ["This is a ", "link", "https://example.com"]
 	// If a markdown link has no plain text before it, it will be split into ["", "link", "https://example.com"]
-	const parts = text.split(regex);
+	const processMarkdownLinks = (paragraph: string) => {
+		const parts = paragraph.split(regex);
+		return parts.map((part, index) => {
+			if (index % 3 === 1) {
+				// The second part of the markdown link
+				const link = parts[index + 1];
+				const linkText = part || link; // Use URL as text if no text provided
+				return (
+					<a key={index} href={link} rel='noreferrer' target='_blank'>
+						{linkText}
+					</a>
+				);
+			} else if (index % 3 === 0) {
+				// This is plain text
+				return part;
+			}
+			return null;
+		});
+	};
 
 	return (
 		<span className='embedded-link'>
-			{parts.map((part, index) => {
-				// This is the first part of the markdown link
-				if (index % 3 === 1) {
-					// The second part of the markdown link
-					const link = parts[index + 1];
-					return (
-						<a key={index} href={link} rel='noreferrer' target='_blank'>
-							{part}
-						</a>
-					);
-				} else if (index % 3 === 0) {
-					// This is plain text
-					return part;
-				}
-				return null;
-			})}
+			{paragraphs.map((paragraph, index) => (
+				<p key={index}>
+					{processMarkdownLinks(paragraph)}
+				</p>
+			))}
 		</span>
 	);
-}
+};

--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
@@ -3,6 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.embedded-link > a {
+.embedded-link a {
 	color: var(--vscode-textLink-foreground);
 }

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -42,6 +42,11 @@
 	background: var(--positronActionBar-hoverBackground);
 }
 
+.hc-black .action-bar-button:hover,
+.hc-light .action-bar-button:hover {
+	border: 1px dashed var(--vscode-focusBorder);
+}
+
 .action-bar-button.fade-in {
 	opacity: 0;
 	animation: positronActionBarButton-fadeIn 0.25s ease-in 0.25s 1 forwards;

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.css
@@ -27,6 +27,11 @@
 	border-color: var(--vscode-positronModalDialog-projectTypeBorderHover);
 }
 
+.hc-black .project-type:hover,
+.hc-light .project-type:hover {
+	border: 1px dashed var(--vscode-focusBorder);
+}
+
 .project-type-selection-step
 .project-type-group
 .project-type-selected {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -29,7 +29,9 @@ import { // eslint-disable-line no-duplicate-imports
 	menuBorder,
 	tableColumnsBorder,
 	textPreformatForeground,
-	selectBorder
+	selectBorder,
+	inputActiveOptionBackground,
+	inputActiveOptionBorder
 } from '../../platform/theme/common/colorRegistry.js';
 // --- End Positron ---
 
@@ -1455,18 +1457,18 @@ export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BACKGROUND = registerColor('posi
 
 // Positron modal dialog project type hover background color.
 export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BACKGROUND_HOVER = registerColor('positronModalDialog.projectTypeBackgroundHover', {
-	dark: listInactiveSelectionBackground,
-	light: listInactiveSelectionBackground,
-	hcDark: listHoverBackground,
-	hcLight: listHoverBackground
+	dark: inputActiveOptionBackground,
+	light: inputActiveOptionBackground,
+	hcDark: inputActiveOptionBackground,
+	hcLight: inputActiveOptionBackground
 }, localize('positronModalDialog.projectTypeBackgroundHover', "Positron modal dialog project type background hover color."));
 
 // Positron modal dialog project type background selected color.
 export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BACKGROUND_SELECTED = registerColor('positronModalDialog.projectTypeBackgroundSelected', {
-	dark: listInactiveSelectionBackground,
-	light: listInactiveSelectionBackground,
-	hcDark: listHoverBackground,
-	hcLight: listHoverBackground
+	dark: inputActiveOptionBackground,
+	light: inputActiveOptionBackground,
+	hcDark: inputActiveOptionBackground,
+	hcLight: inputActiveOptionBackground
 }, localize('positronModalDialog.projectTypeBackgroundSelected', "Positron modal dialog project type background selected color."));
 
 // Positron modal dialog project type foreground color.
@@ -1511,25 +1513,25 @@ export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BORDER_HOVER = registerColor('po
 
 // Positron modal dialog project type border selected color.
 export const POSITRON_MODAL_DIALOG_PROJECT_TYPE_BORDER_SELECTED = registerColor('positronModalDialog.projectTypeBorderSelected', {
-	dark: darken(editorForeground, 0.25),
-	light: focusBorder,
-	hcDark: activeContrastBorder,
-	hcLight: activeContrastBorder
+	dark: inputActiveOptionBorder,
+	light: inputActiveOptionBorder,
+	hcDark: inputActiveOptionBorder,
+	hcLight: inputActiveOptionBorder
 }, localize('positronModalDialog.projectTypeBorderSelected', "Positron modal dialog project type border selected color."));
 
 // < --- Positron Icon Button --- >
 export const POSITRON_ICON_BUTTON_BORDER = registerColor('positronIconButton.border', {
-	dark: focusBorder,
-	light: focusBorder,
-	hcDark: focusBorder,
-	hcLight: focusBorder
+	dark: inputActiveOptionBorder,
+	light: inputActiveOptionBorder,
+	hcDark: inputActiveOptionBorder,
+	hcLight: inputActiveOptionBorder
 }, localize('positronIconButton.border', "Positron icon button border color."));
 
 export const POSITRON_ICON_BUTTON_BACKGROUND = registerColor('positronIconButton.background', {
-	dark: listInactiveSelectionBackground,
-	light: listInactiveSelectionBackground,
-	hcDark: listHoverBackground,
-	hcLight: listHoverBackground
+	dark: inputActiveOptionBackground,
+	light: inputActiveOptionBackground,
+	hcDark: inputActiveOptionBackground,
+	hcLight: inputActiveOptionBackground
 }, localize('positronIconButton.background', "Positron icon button background color."));
 
 // < --- Positron Drop Down --- >

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -56,7 +56,9 @@ export const LanguageModelButton = (props: LanguageModelButtonProps) => {
 			<div id={`${props.identifier}-provider-button`}>
 				<VerticalStack>
 					{getIcon()}
-					{props.displayName}
+					<div>
+						{props.displayName}
+					</div>
 				</VerticalStack>
 			</div>
 		</Button>

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -34,7 +34,7 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 			case 'google':
 				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
 					'Google Gemini',
-					'[Terms of Service](https://gemini.google/policy-guidelines)',
+					'[Terms of Service](https://policies.google.com/terms)',
 					'[Privacy Policy](https://policies.google.com/privacy)'
 				);
 			case 'copilot':

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -19,18 +19,30 @@ interface LanguageModelConfigComponentProps {
 	onSignIn: () => void,
 }
 
+const TOS_TEMPLATE = `{0} is considered "Third Party Materials" as defined in the [Posit EULA](https://posit.co/about/eula/)
+and subject to the {0} terms of service at {1} and privacy policy at {2}.\n\n
+Your use of {0} is optional and at your sole risk.`
+
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	function getTos(provider: string) {
 		switch (provider) {
 			case 'anthropic':
-				return localize('positron.newConnectionModalDialog.anthropicTos',
-					"By using Anthropic, you agree to abide by their [Consumer](https://www.anthropic.com/legal/consumer-terms) or [Commercial](https://www.anthropic.com/legal/commercial-terms) terms of service.");
+				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
+					'Anthropic',
+					'[Terms of Service](https://www.anthropic.com/legal/consumer-terms)',
+					'[Privacy Policy](https://www.anthropic.com/legal/privacy)');
 			case 'google':
-				return localize('positron.newConnectionModalDialog.googleTos',
-					"By using Gemini, you agree to abide by their [Terms of Service](https://gemini.google/policy-guidelines).");
+				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
+					'Google Gemini',
+					'[Terms of Service](https://gemini.google/policy-guidelines)',
+					'[Privacy Policy](https://policies.google.com/privacy)'
+				);
 			case 'copilot':
-				return localize('positron.newConnectionModalDialog.copilotTos',
-					"By using Github Copilot, you agree to abide by their [Terms of Service](https://github.com/customer-terms/github-copilot-product-specific-terms)");
+				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
+					'Copilot',
+					'[Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)',
+					'[Privacy Policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)'
+				);
 			default:
 				return '';
 		}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -90,6 +90,7 @@
 	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
 	background: var(--vscode-positronModalDialog-buttonBackground);
 	width: 80px;
+	min-width: 80px;
 	text-align: center !important;
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -26,17 +26,18 @@
 
 .language-model.button .vertical-stack {
 	text-align: center;
+	gap: 0;
 }
 
 .language-model.icon {
-	height: 3rem;
-	width: 3rem;
+	height: 2.5rem;
+	width: 2.5rem;
 	margin: 0 15px;
 	align-self: center;
 }
 
 .language-model.icon.codicon.button-icon {
-	font-size: 3rem;
+	font-size: 2.5rem;
 }
 
 .language-model.button .content {
@@ -64,6 +65,11 @@
 	background: var(--vscode-positronIconButton-background);
 }
 
+.hc-black .language-model.button:hover,
+.hc-light .language-model.button:hover {
+	border: 1px dashed var(--vscode-focusBorder);
+}
+
 .language-model-container {
 	display: flex;
 	height: 3rem;
@@ -72,6 +78,7 @@
 .language-model-authentication-container {
 	display: flex;
 	width: 100%;
+	margin-right: 1rem;
 }
 
 .language-model.button.sign-in {
@@ -82,13 +89,20 @@
 	border-radius: 5px;
 	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
 	background: var(--vscode-positronModalDialog-buttonBackground);
+	width: 80px;
+	text-align: center !important;
 }
 
 /** layout the children of this container horizontally */
 .language-model-authentication-method-container .radio-group {
 	display: flex;
 	flex-direction: row;
-	column-gap: 10px;
+	column-gap: 15px;
+}
+
+.language-model-modal-dialog .content-area {
+	padding-bottom: 0;
+	bottom: 0;
 }
 
 .language-model-modal-dialog .content-area > .vertical-stack {
@@ -100,10 +114,12 @@
 }
 
 #model-tos {
-	margin-top: 1rem;
 	font-size: 0.7rem;
 }
 
 .language-model-modal-dialog .ok-action-bar.top-separator {
 	border-top: none;
+	padding-bottom: 16px;
+	padding-top: 0px;
+	height: 32px;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -178,6 +178,12 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const providers = props.sources
 		.filter(source => source.type === 'chat' || (source.type === 'completion' && source.provider.id === 'copilot'))
 		.sort((a, b) => {
+			if (a.provider.id === 'echo' || a.provider.id === 'error') {
+				return 1;
+			}
+			if (b.provider.id === 'echo' || b.provider.id === 'error') {
+				return -1;
+			}
 			return a.provider.displayName.localeCompare(b.provider.displayName);
 		})
 		.map(source => new DropDownListBoxItem({
@@ -378,7 +384,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			okButtonTitle={(() => localize('positron.languageModelModalDialog.done', "Done"))()}
 			renderer={props.renderer}
 			title={(() => localize('positron.languageModelModalDialog.title', "Add a Language Model Provider"))()}
-			width={540}
+			width={600}
 			onAccept={onAccept}
 		>
 			<VerticalStack>
@@ -388,7 +394,6 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				<div className='language-model button-container'>
 					{
 						providers.map(provider => {
-							console.log(provider.options.value.signedIn);
 							return <LanguageModelButton
 								key={provider.options.identifier}
 								displayName={provider.options.title ?? provider.options.identifier}


### PR DESCRIPTION
Fix high contrast hover and selection styles for buttons Adjust dialog to fit everything
Sort providers so test models come last
Change embedded link component to allow links without text


Address https://github.com/posit-dev/positron-builds/issues/241

Changes the styling of the button selection and hover to match the rest of the IDE. This also affected the New Project wizard. The high contrast themes were updated for buttons so that there is a dashed outline when hovering.

The provider dialog itself has changed several things:
* The dialog is a bit wider to accommodate the larger amount of text for the third party TOS and privacy policy.
* The icons are a bit smaller
* Adjusted spacing so that the controls aren't so tight
* The test models are now at the end of the list
* The embedded link component can also render a link without a label

Light:
![image](https://github.com/user-attachments/assets/58e313a6-ab1c-4de3-a900-65650692ee57)

Dark:
![image](https://github.com/user-attachments/assets/f830d585-2976-4b97-a96b-9f6fc63f743e)

HC Light:
![image](https://github.com/user-attachments/assets/ab530224-cf3c-49e1-bbd6-9ebb7d3db323)

HC Dark:
![image](https://github.com/user-attachments/assets/7f78c2d4-913d-41ee-b62a-fb6e60c59f41)

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
