### PR TITLE
Assistant: Fix "Language model unavailable" issue

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -298,7 +298,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 
 	// Register the new model
 	try {
-		await registerModel(newConfig, context, storage);
+		// Make the model the default if it is the first one registered.
+		await registerModel(newConfig, context, storage, existingConfigs.length === 0);
 
 		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -30,7 +30,7 @@ function disposeParticipants() {
 	participantDisposables = [];
 }
 
-export async function registerModel(config: StoredModelConfig, context: vscode.ExtensionContext, storage: SecretStorage) {
+export async function registerModel(config: StoredModelConfig, context: vscode.ExtensionContext, storage: SecretStorage, isDefault: boolean) {
 	try {
 		const modelConfig = await getModelConfiguration(config.id, context, storage);
 
@@ -50,7 +50,7 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			throw new Error(vscode.l10n.t('Failed to register model configuration. The provider is disabled.'));
 		}
 
-		await registerModelWithAPI(modelConfig, context);
+		await registerModelWithAPI(modelConfig, context, isDefault);
 	} catch (e) {
 		vscode.window.showErrorMessage(
 			vscode.l10n.t('Positron Assistant: Failed to register model configuration. {0}', [e])

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -93,8 +93,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 /**
  * Test suite Positron Assistant actions from the chat interface.
  */
-// Skipped due to https://github.com/posit-dev/positron/issues/7391
-test.describe.skip('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
+test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
 	test.beforeAll('How to set User Settings', async function ({ app, userSettings }) {
 		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
 		await userSettings.set([['positron.assistant.enable', 'true'],


### PR DESCRIPTION
This change addresses an issue causing "Language model unavailable" errors when starting chats immediately after registering the first language model.

The problem is that we always need at least one default language model, but we only set a default language model when replaying existing registrations. Consequently the very first model registered doesn't get marked as a default until the next IDE load. 

The fix is to set the `isDefault` flag when the very first model is registered, so that it can accept requests immediately.

Addresses https://github.com/posit-dev/positron/issues/7391

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
