### PR TITLE
Fix that allows Enter to be used to select an item in a `DropDownListBox` component

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -35,14 +35,14 @@ export interface KeyboardModifiers {
  * ButtonProps interface.
  */
 interface ButtonProps {
-	readonly hoverManager?: IHoverManager;
+	readonly ariaLabel?: string;
 	readonly className?: string;
+	readonly disabled?: boolean;
+	readonly hoverManager?: IHoverManager;
+	readonly mouseTrigger?: MouseTrigger;
 	readonly style?: CSSProperties | undefined;
 	readonly tabIndex?: number;
-	readonly disabled?: boolean;
-	readonly ariaLabel?: string;
 	readonly tooltip?: string | (() => string | undefined);
-	readonly mouseTrigger?: MouseTrigger;
 	readonly onBlur?: () => void;
 	readonly onFocus?: () => void;
 	readonly onMouseEnter?: () => void;

--- a/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
+++ b/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
@@ -11,14 +11,14 @@ import React, { JSX, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
+import { DropDownListBoxItem } from './dropDownListBoxItem.js';
+import { DropDownListBoxSeparator } from './dropDownListBoxSeparator.js';
+import { PositronModalPopup } from '../positronModalPopup/positronModalPopup.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { DropDownListBoxItem } from './dropDownListBoxItem.js';
-import { PositronModalPopup } from '../positronModalPopup/positronModalPopup.js';
 import { PositronModalReactRenderer } from '../../positronModalReactRenderer/positronModalReactRenderer.js';
-import { DropDownListBoxSeparator } from './dropDownListBoxSeparator.js';
 
 /**
  * DropDownListBoxEntry type.
@@ -29,14 +29,14 @@ export type DropDownListBoxEntry<T extends NonNullable<any>, V extends NonNullab
  * DropDownListBoxProps interface.
  */
 interface DropDownListBoxProps<T extends NonNullable<any>, V extends NonNullable<any>> {
+	className?: string;
+	createItem?: (dropDownListBoxItem: DropDownListBoxItem<T, V>) => JSX.Element;
+	disabled?: boolean;
+	entries: DropDownListBoxEntry<T, V>[];
 	keybindingService: IKeybindingService;
 	layoutService: ILayoutService;
-	className?: string;
-	disabled?: boolean;
-	title: string;
-	entries: DropDownListBoxEntry<T, V>[];
-	createItem?: (dropDownListBoxItem: DropDownListBoxItem<T, V>) => JSX.Element;
 	selectedIdentifier?: T;
+	title: string;
 	onSelectionChanged: (dropDownListBoxItem: DropDownListBoxItem<T, V>) => void;
 }
 

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -89,7 +89,6 @@ export interface PositronModalPopupProps {
 	readonly fixedHeight?: boolean;
 	readonly focusableElementSelectors?: string;
 	readonly keyboardNavigationStyle: KeyboardNavigationStyle;
-	readonly onAccept?: () => void;
 }
 
 /**
@@ -357,13 +356,6 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 			// Handle the event.
 			switch (e.code) {
-				// Enter accepts the modal popup.
-				case 'Enter': {
-					consumeEvent();
-					props.onAccept?.();
-					break;
-				}
-
 				// Escape dismisses the modal popup.
 				case 'Escape': {
 					consumeEvent();

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -11,6 +11,8 @@ import React, { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../../../nls.js';
+import { RowFilterParameter } from './components/rowFilterParameter.js';
+import { DropDownColumnSelector } from './components/dropDownColumnSelector.js';
 import { Button } from '../../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { DropDownListBoxItem } from '../../../../../positronComponents/dropDownListBox/dropDownListBoxItem.js';
@@ -21,8 +23,6 @@ import { DataExplorerClientInstance } from '../../../../../../services/languageR
 import { DropDownListBox, DropDownListBoxEntry } from '../../../../../positronComponents/dropDownListBox/dropDownListBox.js';
 import { ColumnSchema, ColumnDisplayType, RowFilterCondition } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../../../../../services/positronDataExplorer/common/positronDataExplorerExperimentalConfig.js';
-import { RowFilterParameter } from './components/rowFilterParameter.js';
-import { DropDownColumnSelector } from './components/dropDownColumnSelector.js';
 import { RangeRowFilterDescriptor, RowFilterDescriptor, RowFilterDescrType, RowFilterDescriptorComparison, RowFilterDescriptorIsBetween, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsNotBetween, RowFilterDescriptorIsNotEmpty, SingleValueRowFilterDescriptor, RowFilterDescriptorIsNotNull, RowFilterDescriptorIsNull, RowFilterDescriptorSearch, RowFilterDescriptorIsTrue, RowFilterDescriptorIsFalse } from './rowFilterDescriptor.js';
 
 /**
@@ -760,7 +760,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			popupPosition='auto'
 			renderer={props.renderer}
 			width={275}
-			onAccept={applyRowFilter}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
 				{supportsConditions && !props.isFirstFilter &&

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -338,7 +338,7 @@ export const VariableItem = (props: VariableItemProps) => {
 					const text = await props.variableItem.formatForClipboard('text/plain');
 					positronVariablesContext.clipboardService.writeText(text);
 				}
-			} as IAction);
+			} satisfies IAction);
 
 			// Add the copy as HTML action.
 			actions.push({
@@ -398,8 +398,8 @@ export const VariableItem = (props: VariableItemProps) => {
 				<div className='right-column'>
 					<div
 						className={icon}
-						onMouseDown={viewerMouseDownHandler}
 						title={localize('positron.variables.clickToView', "Click to view")}
+						onMouseDown={viewerMouseDownHandler}
 					></div>
 				</div>
 			);


### PR DESCRIPTION
## Description

This PR contains a fix that allows Enter to be used to select an item in a `DropDownListBox` component.

Tests:
@:data-explorer
@:new-project-wizard

### Release Notes

#### New Features

- Partial fix for #4079 that allows Enter to be used to select an item in a `DropDownListBox` component.

#### Bug Fixes

- N/A

### QA Notes

You can see this in action in two places, in the New Project dialog, and when adding a row filter in the Data Explorer. This screen recording shows me adding a row filter using only the keyboard:

https://github.com/user-attachments/assets/900d9421-f9ba-4565-9427-b6fb9fb25b6c
