### PR TITLE
Update posit publisher extension to 1.12.1

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -944,7 +944,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d063388a2bf45836401d99e6011749c61836ea1f",
+        "hashed_secret": "14ce128c6c67ad3500ec7912d66d20b869bfd923",
         "is_verified": false,
         "line_number": 234,
         "is_secret": false
@@ -1412,5 +1412,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-25T14:08:52Z"
+  "generated_at": "2025-04-28T19:52:09Z"
 }

--- a/product.json
+++ b/product.json
@@ -230,8 +230,8 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.12.0",
-			"sha256sum": "eb642fa964eb1a7efa03ba0fceec853ad00f28fedb0ed274ef49d9d15f349614",
+			"version": "1.12.1",
+			"sha256sum": "f537777bd06a6fa83a548abfa82f0ab534c46d5a5748c96a79976d5cf878346b",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",


### PR DESCRIPTION
Used the linux x64 vsix for the sha256sum, though this is a multi-platform asset.

https://open-vsx.org/extension/posit/publisher/changes#%5B1.12.1%5D