### PR TITLE
Assistant: Display file references in tool response output

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/filepaths.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/filepaths.md
@@ -1,7 +1,25 @@
-When the user mentions a file name, construct the full path to the file. You may need to invoke a tool to determine the path to the file, such as the project tree tool.
-
-When displaying file paths, if the paths are for files and directories in the workspace, display the paths as relative to the workspace root. If the paths are for files and directories outside of the workspace, display the paths as absolute paths.
-
-For example, if the workspace root is `/home/user/workspace` and the file path is `/home/user/workspace/src/file.txt`, display it as `src/file.txt`. If the file path is `/home/user/other/file.txt`, display it as `/home/user/other/file.txt`.
+When the user describes a file in the project or mentions a file name, you may need to invoke a tool to determine the path to the file, such as the project tree tool.
 
 Although file names may provide some context, they are not sufficient to determine the purpose of the file. Therefore, you should not use file names to infer the file type. Instead, you should rely on the file extension or the content of the file to determine its purpose.
+
+When displaying file paths, follow these strict rules:
+
+1. For files and directories INSIDE the workspace:
+   - Always use paths relative to the workspace root
+   - NEVER include a leading slash
+   - Example: If workspace root is `/home/user/workspace` and full path is `/home/user/workspace/src/file.txt`
+     - CORRECT: `src/file.txt`
+     - INCORRECT: `/src/file.txt`
+
+2. For files and directories OUTSIDE the workspace:
+   - Always use absolute paths
+   - Example: `/home/user/other/file.txt`
+
+Common mistakes to avoid:
+- Never include the workspace root in relative paths
+- Never add a leading slash to relative paths
+
+Example transformations:
+/home/user/workspace/docs/readme.md → docs/readme.md
+/home/user/workspace/src/lib/utils.py → src/lib/utils.py
+/home/user/external/config.json → /home/user/external/config.json

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -448,26 +448,13 @@ class PositronAssistantEditorParticipant extends PositronAssistantParticipant im
 			throw new Error('Editor participant only supports editor requests');
 		}
 
-		const prompts = [];
-
+		// If the user has not selected text, use the prompt for the whole document.
 		if (request.location2.selection.isEmpty) {
-			// If the user has not selected text, use the prompt for the whole document.
-			prompts.push(
-				await fs.promises.readFile(`${mdDir}/prompts/chat/editor.md`, 'utf8')
-			);
-		} else {
-			// If the user has selected text, generate a new version of the selection.
-			prompts.push(
-				await fs.promises.readFile(`${mdDir}/prompts/chat/selection.md`, 'utf8')
-			);
+			return await fs.promises.readFile(`${mdDir}/prompts/chat/editor.md`, 'utf8');
 		}
 
-		// Add filepaths handling to the system prompt.
-		prompts.push(
-			await fs.promises.readFile(`${mdDir}/prompts/chat/filepaths.md`, 'utf8')
-		);
-
-		return prompts.join('\n\n');
+		// If the user has selected text, generate a new version of the selection.
+		return await fs.promises.readFile(`${mdDir}/prompts/chat/selection.md`, 'utf8');
 	}
 
 	async getMessages(request: vscode.ChatRequest): Promise<vscode.LanguageModelChatMessage[]> {
@@ -506,6 +493,10 @@ class PositronAssistantNotebookParticipant extends PositronAssistantParticipant 
 /** The participant used in the chat pane in Edit mode. */
 class PositronAssistantEditParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
 	id = ParticipantID.Edit;
+
+	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string | undefined> {
+		return await fs.promises.readFile(`${mdDir}/prompts/chat/filepaths.md`, 'utf8');
+	}
 }
 
 export function registerParticipants(context: vscode.ExtensionContext) {

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -190,9 +190,11 @@ export function toLanguageModelChatMessage(turns: vscode.ChatContext['history'])
 					return acc + content.value.value;
 				} else if (content instanceof vscode.ChatResponseTextEditPart) {
 					return acc + `\n\nSuggested text edits: ${JSON.stringify(content.edits)}\n\n`;
+				} else if (content instanceof vscode.ChatResponseAnchorPart) {
+					return acc + `\n\nAnchor: ${content.title ? `${content.title} ` : ''}${JSON.stringify(content.value2)}\n\n`;
 				} else {
 					// TODO: Lower more history entry types to text.
-					throw new Error('Unsupported response kind when lowering chat agent response');
+					throw new Error(`Unsupported response kind when lowering chat agent response: ${content.constructor.name}`);
 				}
 			}, '');
 			return textValue === '' ? null : vscode.LanguageModelChatMessage.Assistant(textValue);

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -11,6 +11,8 @@ import { localize } from '../../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { ChatModel } from '../../common/chatModel.js';
+import { IChatService } from '../../common/chatService.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
 import { IToolInputProcessor } from '../../common/tools/tools.js';
 
@@ -44,6 +46,7 @@ export const FileContentsToolData: IToolData = {
 
 export class FileContentsTool implements IToolImpl {
 	constructor(
+		@IChatService private readonly _chatService: IChatService,
 		@ITextFileService private readonly _textFileService: ITextFileService,
 		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -76,6 +79,16 @@ export class FileContentsTool implements IToolImpl {
 
 		// The file is in the workspace, so grab the file contents
 		const { value, size, encoding } = await this._textFileService.read(uri);
+
+		// If we have a chat context, create a clickable file reference
+		if (invocation.context) {
+			const model = this._chatService.getSession(invocation.context?.sessionId) as ChatModel;
+			const request = model.getRequests().at(-1)!;
+			model.acceptResponseProgress(request, {
+				kind: 'inlineReference',
+				inlineReference: uri,
+			});
+		}
 
 		return {
 			content: [{ kind: 'text', value: JSON.stringify({ contents: value, size, encoding, }) }],

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -9,9 +9,11 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ITextQueryBuilderOptions, QueryBuilder } from '../../../../services/search/common/queryBuilder.js';
-import { IPatternInfo, ISearchConfigurationProperties, ISearchService } from '../../../../services/search/common/search.js';
+import { IPatternInfo, ISearchConfigurationProperties, ISearchService, resultIsMatch } from '../../../../services/search/common/search.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
 import { IToolInputProcessor } from '../../common/tools/tools.js';
+import { ChatModel } from '../../common/chatModel.js';
+import { IChatService } from '../../common/chatService.js';
 
 const findTextInProjectModelDescription = `
 This tool searches for the specified text inside files in the project and returns a set of files and their corresponding lines where the text is found,
@@ -76,6 +78,7 @@ export class TextSearchTool implements IToolImpl {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ISearchService private readonly _searchService: ISearchService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IChatService private readonly _chatService: IChatService,
 	) { }
 
 	private get searchConfig(): ISearchConfigurationProperties {
@@ -106,6 +109,38 @@ export class TextSearchTool implements IToolImpl {
 
 		// Search for the text
 		const { results, messages } = await this._searchService.textSearch(query, _token);
+
+		// If we have a chat context, include references for each result
+		if (invocation.context) {
+			const model = this._chatService.getSession(invocation.context.sessionId) as ChatModel;
+			const request = model.getRequests().at(-1)!;
+
+			for (const result of results) {
+				const { resource, results } = result;
+				if (!results || results.length === 0) {
+					continue; // No results for this file
+				}
+
+				results
+					.filter(resultIsMatch)
+					.flatMap(match => match.rangeLocations)
+					.forEach(loc => {
+						model.acceptResponseProgress(request, {
+							kind: 'reference',
+							reference: {
+								uri: resource,
+								// Adjust the range to be 1-based for display (ranges are 0-based in the results)
+								range: {
+									startLineNumber: loc.source.startLineNumber + 1,
+									startColumn: loc.source.startColumn + 1,
+									endLineNumber: loc.source.endLineNumber + 1,
+									endColumn: loc.source.endColumn + 1
+								}
+							}
+						});
+					});
+			}
+		}
 
 		return {
 			content: [{

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -116,12 +116,12 @@ export class TextSearchTool implements IToolImpl {
 			const request = model.getRequests().at(-1)!;
 
 			for (const result of results) {
-				const { resource, results } = result;
-				if (!results || results.length === 0) {
+				const { resource, results: fileMatches } = result;
+				if (!fileMatches?.length) {
 					continue; // No results for this file
 				}
 
-				results
+				fileMatches
 					.filter(resultIsMatch)
 					.flatMap(match => match.rangeLocations)
 					.forEach(loc => {


### PR DESCRIPTION
## Summary

- final PR for https://github.com/posit-dev/positron/issues/7110
- add file references to the tool response output for the file contents and text search tools
- rewrote the filepaths system prompt more effectively for the LLM
- fix where the filepaths prompt is appended for the edit chat participant (I accidentally appended it into the editor inline chat previously in https://github.com/posit-dev/positron/pull/7298)
- handle Anchor response parts to avoid `Unsupported response kind when lowering chat agent response` error

### demo

https://github.com/user-attachments/assets/d047c9bc-1adc-4e79-ba83-b7cfd0892bea

## QA Notes

@:assistant

File contents and text search tools should not have filepath-related errors and show display the references they used as shown in the video above, in both Edit and Ask modes.