### PR TITLE
python: remove unnecessary handling for html urls on windows

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -264,7 +264,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         if self._comm is None:
             logger.warning("No comm available to send ShowHtmlFile event")
             return False
-        if os.name == "nt":
+        if os.name == "nt" and is_local_html_file(url):
             url = urlparse(url).netloc or urlparse(url).path
         self._comm.send_event(
             name=UiFrontendEvent.ShowHtmlFile,


### PR DESCRIPTION
We were stripping out part of the URL for plotly (eg, sending over `127.0.0.1:8888` instead of `http://127.0.0.1:8888`), which was causing a hang. We still want to use the netloc or path, but only if it is an html _file_ and not a url.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes bug where plotly infinitely hangs on windows #6033 


### QA Notes

Should produce a plot on windows. Worth trying for `pip install plotly==5.24.1` and `pip install plotly==6.0.1`

```python
import plotly.express as px
fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig
```

@:plots