### PR TITLE
python: clear app framework for non-python files

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -20,6 +20,10 @@ function getSupportedLibraries(): string[] {
 }
 
 export function detectWebApp(document: vscode.TextDocument): void {
+    if (document.languageId !== 'python') {
+        executeCommand('setContext', 'pythonAppFramework', undefined);
+        return;
+    }
     const text = document.getText();
     const framework = getFramework(text);
     executeCommand('setContext', 'pythonAppFramework', framework);
@@ -78,7 +82,7 @@ export function activateAppDetection(disposables: vscode.Disposable[]): void {
     disposables.push(
         // Trigger when the active editor changes
         vscode.window.onDidChangeActiveTextEditor((editor) => {
-            if (editor && editor.document.languageId === 'python') {
+            if (editor) {
                 activeEditor = editor;
                 triggerUpdateApp();
             }

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -20,6 +20,7 @@ suite('Discover Web app frameworks', () => {
         executeCommandStub = sinon.stub(cmdApis, 'executeCommand');
         document = {
             getText: () => '',
+            languageId: 'python',
         } as vscode.TextDocument;
         getExtensionStub = sinon.stub(vscode.extensions, 'getExtension');
     });


### PR DESCRIPTION
We were not clearing the app framework context for non-Python files. Updated to fix!

#### New Features

- N/A

#### Bug Fixes

- Fixed bug where "Run App" prompts linger for non-Python files #6883 #5323


### QA Notes

- Open up a Python file that, minimally, has `import shiny` in it. 
- See the `Run Shiny App in Terminal` command on play button
- Open up a Quarto file. 
- You should no longer see any `Run App...` play buttons, even if you include `import shiny` in the Quarto doc