### PR TITLE
change `window.newWindowDimensions` default config to `inherit`

### DIFF
--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -216,7 +216,10 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 					localize('window.newWindowDimensions.maximized', "Open new windows maximized."),
 					localize('window.newWindowDimensions.fullscreen', "Open new windows in full screen mode.")
 				],
-				'default': 'default',
+				// --- Start Positron ---
+				// 'default': 'default',
+				'default': 'inherit',
+				// --- End Positron ---
 				'scope': ConfigurationScope.APPLICATION,
 				'description': localize('newWindowDimensions', "Controls the dimensions of opening a new window when at least one window is already opened. Note that this setting does not have an impact on the first window that is opened. The first window will always restore the size and location as you left it before closing.")
 			},


### PR DESCRIPTION
## Summary

- addresses #6277 to an extent, possibly addresses #3303 more though?
- we are taking the opinion that `inherit` is the more satisfactory default window size configuration
- users can opt for the `default` or any other available setting if preferred, by configuring the `window.newWindowDimensions` setting
    ![image](https://github.com/user-attachments/assets/a3af849d-d0ca-4a0a-989f-88f7ab8f457a)
- a possible further improvement to the new window experience has been written up here: https://github.com/posit-dev/positron/issues/7452

### Release Notes

#### New Features

- Once Positron has been opened, new windows now inherit the window size of the last active window (#3303, #6277)

### QA Notes

Please try this out on machines with different screen sizes and operating systems!