### PR TITLE
Bump to ark 0.1.182

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -766,7 +766,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.181"
+      "ark": "0.1.182"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/782
Addresses #7234
Addresses #3108

### Release Notes

#### New Features

- R snippets are now handled in the conventional way for VS Code, i.e. via optional `.code-snippets` files at the user or workspace level or an R-specific `r.json` file. Newly configured snippet files contain examples for R and Python. The only R snippets that remain built-in are those relating to reserved words (#7234).

#### Bug Fixes

- It is now possible to get completions via `?` for functions, e.g., in the `apply()` family or for `switch()` (#3108).

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
