### PR TITLE
Enhancement/improve add row filter focus handling

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -137,6 +137,8 @@ interface AddEditRowFilterModalPopupProps {
  */
 export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProps) => {
 	// Reference hooks.
+	const dropDownColumnSelectorRef = useRef<HTMLButtonElement>(undefined!);
+	const dropDownRowFilterRef = useRef<HTMLButtonElement>(undefined!);
 	const firstRowFilterParameterRef = useRef<HTMLInputElement>(undefined!);
 	const secondRowFilterParameterRef = useRef<HTMLInputElement>(undefined!);
 
@@ -171,7 +173,24 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			props.editRowFilter?.props.condition ?? RowFilterCondition.And
 		);
 
-	// useEffect for when the selectedFilterType changes.
+	// This useEffect drives focus into the right component when the AddEditRowFilterModalPopup is mounted.
+	useEffect(() => {
+		if (!props.schema) {
+			dropDownColumnSelectorRef.current.focus();
+		} else {
+			dropDownRowFilterRef.current.focus();
+		}
+	}, [props.schema]);
+
+	// This useEffect drives focus into the row filter drop down when the selected column schema changes.
+	useEffect(() => {
+		// When the selected column schema changes, drive focus into the row filter drop down.
+		if (selectedColumnSchema) {
+			dropDownRowFilterRef.current.focus();
+		}
+	}, [selectedColumnSchema]);
+
+	// This useEffect drives focus into the first row filter parameter when the selected filter type changes.
 	useEffect(() => {
 		// When there is a selected type, drive focus into the first row filter parameter.
 		if (selectedFilterType) {
@@ -795,6 +814,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					/>
 				}
 				<DropDownColumnSelector
+					ref={dropDownColumnSelectorRef}
 					configurationService={props.configurationService}
 					dataExplorerClientInstance={props.dataExplorerClientInstance}
 					keybindingService={props.renderer.keybindingService}
@@ -816,6 +836,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					}}
 				/>
 				<DropDownListBox
+					ref={dropDownRowFilterRef}
 					disabled={selectedColumnSchema === undefined}
 					entries={conditionEntries()}
 					keybindingService={props.renderer.keybindingService}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -166,7 +166,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 	const [errorText, setErrorText] = useState<string | undefined>(
 		props.editRowFilter?.props.errorMessage
 	);
-	const [selectedCondtion, setSelectedCondition] =
+	const [selectedCondition, setSelectedCondition] =
 		useState<RowFilterCondition>(
 			props.editRowFilter?.props.condition ?? RowFilterCondition.And
 		);
@@ -608,7 +608,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		};
 
 		const condition = props.isFirstFilter ? RowFilterCondition.And :
-			selectedCondtion ?? RowFilterCondition.And;
+			selectedCondition ?? RowFilterCondition.And;
 
 		// Validate the condition and row filter values. If things are valid, add the row filter.
 		switch (selectedFilterType) {
@@ -784,7 +784,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 						]}
 						keybindingService={props.renderer.keybindingService}
 						layoutService={props.renderer.layoutService}
-						selectedIdentifier={selectedCondtion}
+						selectedIdentifier={selectedCondition}
 						title={(() => localize(
 							'positron.addEditRowFilter.selectCombiningOperator',
 							"Select Combining Operator"

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
@@ -140,7 +140,7 @@ export const DropDownColumnSelector = forwardRef<HTMLButtonElement, DropDownColu
 		return () => {
 			el.removeEventListener('keydown', onKeyDown);
 		};
-	}, [buttonRef, onKeyDown]);
+	}, [onKeyDown]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
@@ -7,11 +7,14 @@
 import './dropDownColumnSelector.css';
 
 // React.
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../../../../nls.js';
 import * as DOM from '../../../../../../../../base/browser/dom.js';
+import { ColumnSelectorModalPopup } from './columnSelectorModalPopup.js';
+import { ColumnSelectorDataGridInstance } from './columnSelectorDataGridInstance.js';
+import { columnSchemaDataTypeIcon } from '../../../utility/columnSchemaUtilities.js';
 import { ILayoutService } from '../../../../../../../../platform/layout/browser/layoutService.js';
 import { Button } from '../../../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { IKeybindingService } from '../../../../../../../../platform/keybinding/common/keybinding.js';
@@ -21,9 +24,6 @@ import { OKModalDialog } from '../../../../../../positronComponents/positronModa
 import { VerticalStack } from '../../../../../../positronComponents/positronModalDialog/components/verticalStack.js';
 import { PositronModalReactRenderer } from '../../../../../../positronModalReactRenderer/positronModalReactRenderer.js';
 import { DataExplorerClientInstance } from '../../../../../../../services/languageRuntime/common/languageRuntimeDataExplorerClient.js';
-import { columnSchemaDataTypeIcon } from '../../../utility/columnSchemaUtilities.js';
-import { ColumnSelectorModalPopup } from './columnSelectorModalPopup.js';
-import { ColumnSelectorDataGridInstance } from './columnSelectorDataGridInstance.js';
 
 /**
  * DropDownColumnSelectorProps interface.
@@ -41,14 +41,17 @@ interface DropDownColumnSelectorProps {
 /**
  * DropDownColumnSelector component.
  * @param props The component properties.
+ * @param ref The component reference.
  * @returns The rendered component.
  */
-export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
+export const DropDownColumnSelector = forwardRef<HTMLButtonElement, DropDownColumnSelectorProps>((props, ref) => {
 	// Reference hooks.
-	const ref = useRef<HTMLButtonElement>(undefined!);
+	const buttonRef = useRef<HTMLButtonElement>(undefined!);
+
+	// Imperative handle to ref.
+	useImperativeHandle(ref, () => buttonRef.current);
 
 	// State hooks.
-	const [title, _setTitle] = useState(props.title);
 	const [selectedColumnSchema, setSelectedColumnSchema] = useState<ColumnSchema | undefined>(props.selectedColumnSchema);
 
 	const onPressed = useCallback(async (focusInput?: boolean) => {
@@ -58,7 +61,7 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 		);
 
 		// Get the container.
-		const container = props.layoutService.getContainer(DOM.getWindow(ref.current));
+		const container = props.layoutService.getContainer(DOM.getWindow(buttonRef.current));
 
 		// If the column selector data grid instance could not be created, alert the user.
 		// Otherwise, show the column selector modal popup.
@@ -102,14 +105,14 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 				disableCaptures: true, // permits the usage of the enter key where applicable
 				onDisposed: () => {
 					columnSelectorDataGridInstance.dispose();
-					ref.current.focus();
+					buttonRef.current.focus();
 				}
 			});
 
 			// Show the drop down list box modal popup.
 			renderer.render(
 				<ColumnSelectorModalPopup
-					anchorElement={ref.current}
+					anchorElement={buttonRef.current}
 					columnSelectorDataGridInstance={columnSelectorDataGridInstance}
 					configurationService={props.configurationService}
 					focusInput={focusInput}
@@ -132,22 +135,22 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 	}, [onPressed]);
 
 	useEffect(() => {
-		const el = ref.current;
+		const el = buttonRef.current;
 		el.addEventListener('keydown', onKeyDown);
 		return () => {
 			el.removeEventListener('keydown', onKeyDown);
 		};
-	}, [ref, onKeyDown]);
+	}, [buttonRef, onKeyDown]);
 
 	// Render.
 	return (
 		<Button
-			ref={ref}
+			ref={buttonRef}
 			className='drop-down-column-selector'
 			onPressed={() => onPressed()}
 		>
 			{!selectedColumnSchema ?
-				(<div className='title'>{title}</div>) :
+				(<div className='title'>{props.title}</div>) :
 				(
 					<div className='column-schema-title'>
 						<div className={`data-type-icon codicon ${columnSchemaDataTypeIcon(selectedColumnSchema)}`}></div>
@@ -162,4 +165,7 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 			</div>
 		</Button>
 	);
-};
+});
+
+// Set the display name.
+DropDownColumnSelector.displayName = 'DropDownColumnSelector';


### PR DESCRIPTION
## Description

This PR completes work on #4079 by:

- Driving focus into the column selector drop down when the `AddEditRowFilterModalPopup` component is shown by clicking on the **+** button in the` RowFilterBar` component.
- Driving focus to the filter type drop down whenever a selection is made in the column selector drop down.
- Driving focus into the filter type drop down when the `AddEditRowFilterModalPopup` component is shown via the column header **···** context menu.

Tests:
@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #4079 Improved focus management for keyboard users when adding row filters.

### QA Notes

See:


https://github.com/user-attachments/assets/829e3ebb-58ce-4c6f-bf37-22abb0c5f123



And:

https://github.com/user-attachments/assets/0f1c2540-5083-4dc2-a1f5-9bb845012535