### PR TITLE
Settings Import: Fixes URI parsing on Windows

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -74,29 +74,29 @@ export async function getCodeSettingsPath(
 	const path = await pathService.path;
 	const homedir = await pathService.userHome();
 
-
-	let appDataPath: URI;
 	switch (os) {
 		case platform.OperatingSystem.Windows:
 			if (env['APPDATA']) {
-				appDataPath = URI.file(env['APPDATA']);
-			} else {
+				return URI.file(path.join(env['APPDATA'], 'Code', 'User', 'settings.json'));
+			} else if (env['USERPROFILE']) {
 				const userProfile = env['USERPROFILE'];
-				if (typeof userProfile !== 'string') {
-					throw new Error('Windows: Unexpected undefined %USERPROFILE% environment variable');
-				}
-
-				appDataPath = URI.file(path.join(userProfile, 'AppData', 'Roaming'));
+				return URI.file(path.join(userProfile, 'AppData', 'Roaming', 'Code', 'User', 'settings.json'));
+			} else {
+				return URI.joinPath(homedir, 'AppData', 'Roaming', 'Code', 'User', 'settings.json');
 			}
-			break;
+
 		case platform.OperatingSystem.Macintosh:
-			appDataPath = homedir.with({ path: path.join(homedir.path, 'Library', 'Application Support') });
-			break;
+			return URI.joinPath(homedir, 'Library', 'Application Support', 'Code', 'User', 'settings.json');
+
 		case platform.OperatingSystem.Linux:
-			appDataPath = env['XDG_CONFIG_HOME'] ? URI.file(env['XDG_CONFIG_HOME']) : homedir.with({ path: path.join(homedir.path, '.config') });
-			break;
+			return URI.joinPath(
+				(env['XDG_CONFIG_HOME'] ?
+					URI.file(env['XDG_CONFIG_HOME']) :
+					URI.joinPath(homedir, '.config')
+				), 'Code', 'User', 'settings.json'
+			);
+
 		default:
 			throw new Error('Platform not supported');
 	}
-	return appDataPath.with({ path: path.join(appDataPath.path, 'Code', 'User', 'settings.json') });
 }

--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -79,21 +79,21 @@ export async function getCodeSettingsPath(
 	switch (os) {
 		case platform.OperatingSystem.Windows:
 			if (env['APPDATA']) {
-				appDataPath = URI.parse(env['APPDATA']);
+				appDataPath = URI.file(env['APPDATA']);
 			} else {
 				const userProfile = env['USERPROFILE'];
 				if (typeof userProfile !== 'string') {
 					throw new Error('Windows: Unexpected undefined %USERPROFILE% environment variable');
 				}
 
-				appDataPath = URI.parse(path.join(userProfile, 'AppData', 'Roaming'));
+				appDataPath = URI.file(path.join(userProfile, 'AppData', 'Roaming'));
 			}
 			break;
 		case platform.OperatingSystem.Macintosh:
 			appDataPath = homedir.with({ path: path.join(homedir.path, 'Library', 'Application Support') });
 			break;
 		case platform.OperatingSystem.Linux:
-			appDataPath = env['XDG_CONFIG_HOME'] ? URI.parse(env['XDG_CONFIG_HOME']) : homedir.with({ path: path.join(homedir.path, '.config') });
+			appDataPath = env['XDG_CONFIG_HOME'] ? URI.file(env['XDG_CONFIG_HOME']) : homedir.with({ path: path.join(homedir.path, '.config') });
 			break;
 		default:
 			throw new Error('Platform not supported');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

The settings import feature did not properly parse the `USERPROFILE` and `APPDATA` URIs on Windows.

Addresses #7455
 
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:win