### PR TITLE
Replace black with ruff

### DIFF
--- a/build/lib/bootstrapExtensions.ts
+++ b/build/lib/bootstrapExtensions.ts
@@ -180,7 +180,11 @@ function removeExtension(extensionName: string): void {
 	const matchingFiles = files.filter(f => regex.test(f));
 	for (const vsixPath of matchingFiles) {
 		log(`[extensions]`, `Removing extension ${vsixPath}`);
-		fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+		try {
+			fs.unlinkSync(path.join(bootstrapDir, vsixPath));
+		} catch (error) {
+			log(`[extensions]`, `Failed to remove extension ${vsixPath}: ${error.message}`);
+		}
 	}
 }
 

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -923,7 +923,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d532234ad25d9767b98a089f00f0eb68ed18af4f",
+        "hashed_secret": "92bf36d24ad4f4b3afe20a1a789182e9f70ddcc8",
         "is_verified": false,
         "line_number": 112,
         "is_secret": false
@@ -1447,5 +1447,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-30T11:18:41Z"
+  "generated_at": "2025-05-02T14:29:42Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -931,17 +931,9 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "3285718bc1c9d739ee089f65966ef334cfbccabf",
-        "is_verified": false,
-        "line_number": 122,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "product.json",
         "hashed_secret": "4ecc1a40769a784c894984448c2aa8fe7c6b6d9c",
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 136,
         "is_secret": false
       },
       {
@@ -949,7 +941,7 @@
         "filename": "product.json",
         "hashed_secret": "62bc923c10a3b051de823593ac7dd26a5d1a3fd1",
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 152,
         "is_secret": false
       },
       {
@@ -957,7 +949,7 @@
         "filename": "product.json",
         "hashed_secret": "a98c117e7ff47453ec91a18892f2158eee3391d1",
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 168,
         "is_secret": false
       },
       {
@@ -965,7 +957,7 @@
         "filename": "product.json",
         "hashed_secret": "55a2958461cccfebfa42b8b4218ab19c520986a1",
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 185,
         "is_secret": false
       },
       {
@@ -973,7 +965,7 @@
         "filename": "product.json",
         "hashed_secret": "38c2ef71b7eddafaafff83b53ac51c275aa8d6a9",
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 201,
         "is_secret": false
       },
       {
@@ -981,7 +973,7 @@
         "filename": "product.json",
         "hashed_secret": "ab3a55d44f93c550d1c2f4ec085d83dbbf85e5d6",
         "is_verified": false,
-        "line_number": 247,
+        "line_number": 245,
         "is_secret": false
       }
     ],

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -921,7 +921,8 @@
             "pyright.disableOrganizeImports": true,
             "pyright.disablePullDiagnostics": true,
             "python.analysis.autoImportCompletions": false,
-            "python.analysis.typeCheckingMode": "off"
+            "python.analysis.typeCheckingMode": "off",
+            "ruff.importStrategy": "useBundled"
         },
         "debuggers": [
             {

--- a/product.json
+++ b/product.json
@@ -106,10 +106,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.29",
+			"version": "1.5.37",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "1c1854455074fd75352430ff8fbfcd20717f7895d4d5e6670b1ec2ba6b72d371",
+			"sha256": "b2cd1e78b46af0e4097d2fbd7f35a9618dac830d75ac11329e281eec8c4584b1",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}

--- a/product.json
+++ b/product.json
@@ -117,19 +117,17 @@
 	],
 	"bootstrapExtensions": [
 		{
-			"name": "ms-python.black-formatter",
-			"version": "2024.6.0",
-			"sha256sum": "0f6c85ca346f9a32edbc304f330ab460b2c88c8dfc1a1f86a4506988e7a2faaa",
-			"repo": "https://github.com/microsoft/vscode-black-formatter",
+			"name": "charliermarsh.ruff",
+			"version": "2025.22.0",
+			"repo": "https://github.com/astral-sh/ruff-vscode",
 			"metadata": {
-				"id": "859e640c-c157-47da-8699-9080b81c8371",
 				"publisherId": {
-					"publisherId": "998b010b-e2af-44a5-a6cd-0b5fd3b9b6f8",
-					"publisherName": "ms-python",
-					"displayName": "Black Formatter",
+					"publisherName": "charliermarsh",
+					"displayName": "Ruff",
 					"flags": "verified"
 				},
-				"publisherDisplayName": "ms-python"
+				"publisherDisplayName": "charliermarsh",
+				"multiPlatformServiceUrl": "https://open-vsx.org/api"
 			}
 		},
 		{

--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -159,8 +159,7 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 	 * extension installed are severe enough to warrant us forcing an uninstall.
 	 */
 	private cleanupOldExtensions(lastKnownVersion: string): void {
-		// If lastKnownVersion is < 2025.06, check for the Black Formatter extension. While the 2025.05
-		// release includes Ruff, early builds of 2025.05 included Black
+		// If lastKnownVersion is < 2025.06, check for the Black Formatter extension.
 		if (/^2025\.0[0-5].*/.test(lastKnownVersion)) {
 			this.extensionManagementService.getInstalled()
 				.then(installedExtensions => {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6461

- Replace black with ruff
- Update bootstrap extension syncing logic to remove `.vsix` files that were previously configured to be bootstrapped but have since been removed. For dev runs, this will remove the `.vsix` from `positron/.build/bootstrappedExtensions/`.
- Update the bootstrap install service to detect if the user is upgrading from a version of positron < 2025.06 and if so, log a warning about removing the Black extension in the Shared process output pane.
   - Because bootstrapped extensions are only installed during an initial installation or upgrade, if a user has already installed a 2025.05.0 build, they will not have Ruff installed or see this warning until they upgrade to 2025.06. To work around this, users can modify the `.version` file at `<positron-data-dir>/extensions/.version` to contain `2025.04.0`. For dev builds, `<positron-data-dir>` is `~/.positron-dev` 
   - When upgrading from a Positron version < 2025.05 to a version of 2025.05 that includes this change, users will have Ruff installed and see this warning.
  
### Release Notes
#### New Features

- Added Ruff as a bootstrapped extension and remove Black Formatter. We highly recommend users uninstall Black Formatter.

#### Bug Fixes

- N/A


### QA Notes

Validation may require some file system manipulation based on the notes I provided above. I'm happy to discuss these live if necessary.