### PR TITLE
change to env so it works on all platforms

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -288,7 +288,12 @@
 		},
 		{
 			"type": "shell",
-			"command": "VSCODE_DEV=1 node build/lib/preLaunch.js",
+			"command": "node build/lib/preLaunch.js",
+			"options": {
+				"env": {
+					"VSCODE_DEV": "1"
+				}
+			},
 			"label": "Ensure Prelaunch Dependencies",
 			"presentation": {
 				"reveal": "silent",


### PR DESCRIPTION
A recent change to add a VSCODE_DEV env variable didn't work on windows.  This changes to use an env options instead of having it as part of the command line


### QA Notes

A dev build should start from VSCode