### PR TITLE
Fix auth method when switching between providers

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -156,10 +156,8 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	}, [source]);
 
 	useEffect(() => {
-		if (source.defaults.oauth !== undefined) {
-			const authMethod = source.defaults.oauth ? 'oauth' : 'apiKey';
-			setAuthMethod(authMethod);
-		}
+		const authMethod = source.defaults.oauth ? 'oauth' : 'apiKey';
+		setAuthMethod(authMethod);
 	}, [source.defaults.oauth]);
 
 	const authMethodRadioButtons: RadioButtonItem[] = [

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -7,7 +7,7 @@
 import { expect, test } from '@playwright/test';
 import { Code } from '../infra/code';
 
-const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label="Chat (Ctrl+Alt+I)"]';
+const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label^="Chat"]';
 const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
 const ADD_MODEL_BUTTON = 'a.action-label[aria-label="Add Language Model"]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
@@ -124,14 +124,12 @@ export class Assistant {
 	async verifyAuthMethod(type: 'oauth' | 'apiKey') {
 		switch (type) {
 			case 'oauth':
-				// ensure oauth radio is currently selected and apiKey is disabled
-				await this.code.driver.page.locator(OATH_RADIO).isChecked();
-				await this.code.driver.page.locator(APIKEY_RADIO).isDisabled();
+				await expect(this.code.driver.page.locator(OATH_RADIO)).toBeChecked();
+				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeDisabled();
 				break;
 			case 'apiKey':
-				// ensure apiKey radio is currently selected and oauth is disabled
-				await this.code.driver.page.locator(APIKEY_RADIO).isChecked();
-				await this.code.driver.page.locator(OATH_RADIO).isDisabled();
+				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeChecked();
+				await expect(this.code.driver.page.locator(OATH_RADIO)).toBeDisabled();
 				break;
 			default:
 				throw new Error(`Unsupported auth method: ${type}`);

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -22,7 +22,7 @@ const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-provider-button)';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
 const RUN_BUTTON = 'a.action-label.codicon.codicon-play[role="button"][aria-label="Run in Console"]';
-// const OATH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
+const OATH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
 const APIKEY_RADIO = '.language-model-authentication-method-container input#apiKey[type="radio"]';
 const CHAT_INPUT = '.chat-editor-container .interactive-input-editor textarea.inputarea';
 const SEND_MESSAGE_BUTTON = '.action-container .action-label.codicon-send[aria-label="Send and Dispatch (Enter)"]';
@@ -119,6 +119,23 @@ export class Assistant {
 	async verifySignInButtonVisible(timeout: number = 15000) {
 		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toBeVisible({ timeout });
 		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toHaveText('Sign in', { timeout });
+	}
+
+	async verifyAuthMethod(type: 'oauth' | 'apiKey') {
+		switch (type) {
+			case 'oauth':
+				// ensure oauth radio is currently selected and apiKey is disabled
+				await this.code.driver.page.locator(OATH_RADIO).isChecked();
+				await this.code.driver.page.locator(APIKEY_RADIO).isDisabled();
+				break;
+			case 'apiKey':
+				// ensure apiKey radio is currently selected and oauth is disabled
+				await this.code.driver.page.locator(APIKEY_RADIO).isChecked();
+				await this.code.driver.page.locator(OATH_RADIO).isDisabled();
+				break;
+			default:
+				throw new Error(`Unsupported auth method: ${type}`);
+		}
 	}
 
 	async enterChatMessage(message: string) {

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -22,7 +22,7 @@ const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-provider-button)';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
 const RUN_BUTTON = 'a.action-label.codicon.codicon-play[role="button"][aria-label="Run in Console"]';
-const OATH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
+const OAUTH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
 const APIKEY_RADIO = '.language-model-authentication-method-container input#apiKey[type="radio"]';
 const CHAT_INPUT = '.chat-editor-container .interactive-input-editor textarea.inputarea';
 const SEND_MESSAGE_BUTTON = '.action-container .action-label.codicon-send[aria-label="Send and Dispatch (Enter)"]';
@@ -124,12 +124,12 @@ export class Assistant {
 	async verifyAuthMethod(type: 'oauth' | 'apiKey') {
 		switch (type) {
 			case 'oauth':
-				await expect(this.code.driver.page.locator(OATH_RADIO)).toBeChecked();
+				await expect(this.code.driver.page.locator(OAUTH_RADIO)).toBeChecked();
 				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeDisabled();
 				break;
 			case 'apiKey':
 				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeChecked();
-				await expect(this.code.driver.page.locator(OATH_RADIO)).toBeDisabled();
+				await expect(this.code.driver.page.locator(OAUTH_RADIO)).toBeDisabled();
 				break;
 			default:
 				throw new Error(`Unsupported auth method: ${type}`);

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -93,7 +93,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.clickAddModelButton();
 		await app.workbench.assistant.selectModelProvider('Copilot');
-		await app.workbench.assistant.verifyAuthMethod('oauth')
+		await app.workbench.assistant.verifyAuthMethod('oauth');
 		await app.workbench.assistant.selectModelProvider('Anthropic');
 		await app.workbench.assistant.verifyAuthMethod('apiKey');
 		await app.workbench.assistant.clickDoneButton();

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -89,6 +89,16 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickDoneButton();
 	});
 
+	test('Verify Authentication Type When Switching Providers', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.clickAddModelButton();
+		await app.workbench.assistant.selectModelProvider('Copilot');
+		await app.workbench.assistant.verifyAuthMethod('oauth')
+		await app.workbench.assistant.selectModelProvider('Anthropic');
+		await app.workbench.assistant.verifyAuthMethod('apiKey');
+		await app.workbench.assistant.clickDoneButton();
+	});
+
 });
 /**
  * Test suite Positron Assistant actions from the chat interface.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #7335 

The initial auth method was not updating when switching from a provider that uses oauth.

The selector for the Chat view element has been updated so that the aria label only needs to start with `Chat` so it can run on Mac (the shortcut is different on Mac).

@:assistant
### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes authentication selection when switching from Copilot to Anthropic #7335


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
