### PR TITLE
remove copilot commands from command palette

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -110,18 +110,6 @@
         "title": "%commands.configureModels.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable"
-      },
-      {
-        "command": "positron-assistant.copilot.signin",
-        "title": "%commands.copilot.signin.title%",
-        "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
-      },
-      {
-        "command": "positron-assistant.copilot.signout",
-        "title": "%commands.copilot.signout.title%",
-        "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable && config.positron.assistant.copilot.enable"
       }
     ],
     "languageModels": [

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { getLanguageModels } from './models';
 import { completionModels } from './completion';
 import { registerModel, registerModels } from './extension';
-import { COPILOT_SIGNIN_COMMAND, COPILOT_SIGNOUT_COMMAND } from './copilot.js';
+import { CopilotService } from './copilot.js';
 
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
@@ -343,7 +343,7 @@ async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources:
 	try {
 		switch (userConfig.provider) {
 			case 'copilot':
-				oauthCompleted = await vscode.commands.executeCommand(COPILOT_SIGNIN_COMMAND);
+				oauthCompleted = await CopilotService.instance().signIn();
 				break;
 			default:
 				throw new Error(vscode.l10n.t('OAuth sign-in is not supported for provider {0}', userConfig.provider));
@@ -366,7 +366,7 @@ async function oauthSignout(userConfig: positron.ai.LanguageModelConfig, sources
 	try {
 		switch (userConfig.provider) {
 			case 'copilot':
-				oauthCompleted = await vscode.commands.executeCommand(COPILOT_SIGNOUT_COMMAND);
+				oauthCompleted = await CopilotService.instance().signOut();
 				break;
 			default:
 				throw new Error(vscode.l10n.t('OAuth sign-out is not supported for provider {0}', userConfig.provider));

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -92,9 +92,6 @@ export function registerCopilotService(context: ExtensionContext) {
 	context.subscriptions.push(copilotService);
 }
 
-export const COPILOT_SIGNIN_COMMAND = 'positron-assistant.copilot.signin';
-export const COPILOT_SIGNOUT_COMMAND = 'positron-assistant.copilot.signout';
-
 export class CopilotService implements vscode.Disposable {
 	private readonly _disposables: vscode.Disposable[] = [];
 
@@ -122,21 +119,7 @@ export class CopilotService implements vscode.Disposable {
 
 	private constructor(
 		private readonly _context: vscode.ExtensionContext,
-	) {
-		this.registerCommands();
-	}
-
-	/** Register Copilot commands. */
-	private registerCommands() {
-		this._disposables.push(
-			vscode.commands.registerCommand(COPILOT_SIGNIN_COMMAND, async () => {
-				return await this.signIn();
-			}),
-			vscode.commands.registerCommand(COPILOT_SIGNOUT_COMMAND, async () => {
-				return await this.signOut();
-			})
-		);
-	}
+	) { }
 
 	/** Get the Copilot language client. */
 	private client(): CopilotLanguageClient {
@@ -162,7 +145,7 @@ export class CopilotService implements vscode.Disposable {
 	/**
 	 * Prompt the user to sign in to Copilot if they aren't already signed in.
 	 */
-	private async signIn(): Promise<boolean> {
+	async signIn(): Promise<boolean> {
 		const client = this.client();
 		const response = await client.sendRequest(SignInRequest.type, {});
 
@@ -187,7 +170,7 @@ export class CopilotService implements vscode.Disposable {
 	}
 
 	/** Sign out of Copilot. */
-	private async signOut(): Promise<boolean> {
+	async signOut(): Promise<boolean> {
 		const client = this.client();
 
 		try {


### PR DESCRIPTION
addresses https://github.com/posit-dev/positron/issues/7320 by removing the commands from the command palette

### QA Notes

- the copilot sign in/out commands should no longer appear in the Command Palette
   <img width="609" alt="image" src="https://github.com/user-attachments/assets/92608bd9-d87d-47a8-be73-26f04b4bb57a" />
- signing in/out to copilot via the language model provider modal should continue to work
   <img width="546" alt="image" src="https://github.com/user-attachments/assets/03a468bc-e70c-4206-9dd0-8d0b2847ea4c" />
