### PR TITLE
Remove Data Explorer UI for AND / OR row filter conditions

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -19,10 +19,9 @@ import { DropDownListBoxItem } from '../../../../../positronComponents/dropDownL
 import { PositronModalPopup } from '../../../../../positronComponents/positronModalPopup/positronModalPopup.js';
 import { PositronModalReactRenderer } from '../../../../../positronModalReactRenderer/positronModalReactRenderer.js';
 import { DropDownListBoxSeparator } from '../../../../../positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
-import { DataExplorerClientInstance } from '../../../../../../services/languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { DropDownListBox, DropDownListBoxEntry } from '../../../../../positronComponents/dropDownListBox/dropDownListBox.js';
+import { DataExplorerClientInstance } from '../../../../../../services/languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { ColumnSchema, ColumnDisplayType, RowFilterCondition } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
-import { dataExplorerExperimentalFeatureEnabled } from '../../../../../../services/positronDataExplorer/common/positronDataExplorerExperimentalConfig.js';
 import { RangeRowFilterDescriptor, RowFilterDescriptor, RowFilterDescrType, RowFilterDescriptorComparison, RowFilterDescriptorIsBetween, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsNotBetween, RowFilterDescriptorIsNotEmpty, SingleValueRowFilterDescriptor, RowFilterDescriptorIsNotNull, RowFilterDescriptorIsNull, RowFilterDescriptorSearch, RowFilterDescriptorIsTrue, RowFilterDescriptorIsFalse } from './rowFilterDescriptor.js';
 
 /**
@@ -168,10 +167,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 	const [errorText, setErrorText] = useState<string | undefined>(
 		props.editRowFilter?.props.errorMessage
 	);
-	const [selectedCondition, setSelectedCondition] =
-		useState<RowFilterCondition>(
-			props.editRowFilter?.props.condition ?? RowFilterCondition.And
-		);
 
 	// This useEffect drives focus into the right component when the AddEditRowFilterModalPopup is mounted.
 	useEffect(() => {
@@ -626,16 +621,13 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			props.onApplyRowFilter(rowFilter);
 		};
 
-		const condition = props.isFirstFilter ? RowFilterCondition.And :
-			selectedCondition ?? RowFilterCondition.And;
-
 		// Validate the condition and row filter values. If things are valid, add the row filter.
 		switch (selectedFilterType) {
 			// Apply the is empty row filter.
 			case RowFilterDescrType.IS_EMPTY: {
 				applyRowFilter(new RowFilterDescriptorIsEmpty({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
@@ -644,7 +636,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case RowFilterDescrType.IS_NOT_EMPTY: {
 				applyRowFilter(new RowFilterDescriptorIsNotEmpty({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
@@ -653,7 +645,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case RowFilterDescrType.IS_NULL: {
 				applyRowFilter(new RowFilterDescriptorIsNull({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
@@ -662,7 +654,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case RowFilterDescrType.IS_NOT_NULL: {
 				applyRowFilter(new RowFilterDescriptorIsNotNull({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
@@ -671,14 +663,14 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case RowFilterDescrType.IS_TRUE: {
 				applyRowFilter(new RowFilterDescriptorIsTrue({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
 			case RowFilterDescrType.IS_FALSE: {
 				applyRowFilter(new RowFilterDescriptorIsFalse({
 					columnSchema: selectedColumnSchema,
-					condition
+					condition: RowFilterCondition.And
 				}));
 				break;
 			}
@@ -695,7 +687,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 				applyRowFilter(new RowFilterDescriptorSearch(
 					{
 						columnSchema: selectedColumnSchema,
-						condition
+						condition: RowFilterCondition.And
 					},
 					firstRowFilterValue,
 					selectedFilterType
@@ -714,7 +706,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorComparison(
-					{ columnSchema: selectedColumnSchema, condition },
+					{ columnSchema: selectedColumnSchema, condition: RowFilterCondition.And },
 					firstRowFilterValue,
 					selectedFilterType
 				));
@@ -730,7 +722,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorIsBetween(
-					{ columnSchema: selectedColumnSchema, condition },
+					{ columnSchema: selectedColumnSchema, condition: RowFilterCondition.And },
 					firstRowFilterValue,
 					secondRowFilterValue
 				));
@@ -746,7 +738,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorIsNotBetween(
-					{ columnSchema: selectedColumnSchema, condition },
+					{ columnSchema: selectedColumnSchema, condition: RowFilterCondition.And },
 					firstRowFilterValue,
 					secondRowFilterValue
 				));
@@ -764,10 +756,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		setErrorText(undefined);
 	};
 
-	// Get the supported features.
-	const supportedFeatures = props.dataExplorerClientInstance.getSupportedFeatures();
-	const supportsConditions = dataExplorerExperimentalFeatureEnabled(supportedFeatures.set_row_filters.supports_conditions, props.configurationService);
-
 	// Render.
 	return (
 		<PositronModalPopup
@@ -781,38 +769,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			width={275}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
-				{supportsConditions && !props.isFirstFilter &&
-					<DropDownListBox
-						entries={[
-							new DropDownListBoxItem({
-								identifier: RowFilterCondition.And,
-								title: localize(
-									'positron.addEditRowFilter.conditionAnd',
-									"and"
-								),
-								value: RowFilterCondition.And,
-							}),
-							new DropDownListBoxItem({
-								identifier: RowFilterCondition.Or,
-								title: localize(
-									'positron.addEditRowFilter.conditionOr',
-									"or"
-								),
-								value: RowFilterCondition.Or
-							})
-						]}
-						keybindingService={props.renderer.keybindingService}
-						layoutService={props.renderer.layoutService}
-						selectedIdentifier={selectedCondition}
-						title={(() => localize(
-							'positron.addEditRowFilter.selectCombiningOperator',
-							"Select Combining Operator"
-						))()}
-						onSelectionChanged={dropDownListBoxItem => {
-							setSelectedCondition(dropDownListBoxItem.options.identifier);
-						}}
-					/>
-				}
 				<DropDownColumnSelector
 					ref={dropDownColumnSelectorRef}
 					configurationService={props.configurationService}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -25,14 +25,12 @@ import {
 	RowFilterDescriptorIsTrue,
 	RowFilterDescriptorSearch
 } from '../../addEditRowFilterModalPopup/rowFilterDescriptor.js';
-import { RowFilterCondition } from '../../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 
 /**
  * RowFilterWidgetProps interface.
  */
 interface RowFilterWidgetProps {
 	rowFilter: RowFilterDescriptor;
-	booleanOperator?: RowFilterCondition;
 	onEdit: () => void;
 	onClear: () => void;
 }
@@ -141,14 +139,6 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 			className={buttonClass}
 			onPressed={() => props.onEdit()}
 		>
-			{props.booleanOperator &&
-				<div className='boolean-operator'>
-					{props.rowFilter.props.condition === RowFilterCondition.And ?
-						localize('positron.dataExplorer.rowFilterWidget.and', "and") :
-						localize('positron.dataExplorer.rowFilterWidget.or', "or")
-					}
-				</div>
-			}
 			<div className='title'>
 				{title}
 			</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -12,18 +12,18 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../../../nls.js';
 import * as DOM from '../../../../../../../base/browser/dom.js';
+import { RowFilterWidget } from './components/rowFilterWidget.js';
 import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { usePositronDataExplorerContext } from '../../../../positronDataExplorerContext.js';
 import { Button } from '../../../../../../../base/browser/ui/positronComponents/button/button.js';
+import { AddEditRowFilterModalPopup } from '../addEditRowFilterModalPopup/addEditRowFilterModalPopup.js';
 import { ColumnSchema } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 import { OKModalDialog } from '../../../../../positronComponents/positronModalDialog/positronOKModalDialog.js';
-import { usePositronDataExplorerContext } from '../../../../positronDataExplorerContext.js';
+import { getRowFilterDescriptor, RowFilterDescriptor } from '../addEditRowFilterModalPopup/rowFilterDescriptor.js';
 import { PositronModalReactRenderer } from '../../../../../positronModalReactRenderer/positronModalReactRenderer.js';
 import { CustomContextMenuItem } from '../../../../../positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuSeparator } from '../../../../../positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../../positronComponents/customContextMenu/customContextMenu.js';
-import { RowFilterWidget } from './components/rowFilterWidget.js';
-import { AddEditRowFilterModalPopup } from '../addEditRowFilterModalPopup/addEditRowFilterModalPopup.js';
-import { getRowFilterDescriptor, RowFilterDescriptor } from '../addEditRowFilterModalPopup/rowFilterDescriptor.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../../../../../services/positronDataExplorer/common/positronDataExplorerExperimentalConfig.js';
 
 /**
@@ -274,7 +274,6 @@ export const RowFilterBar = () => {
 								rowFilterWidgetRefs.current[index] = ref;
 							}
 						}}
-						booleanOperator={index === 0 ? undefined : rowFilter.props.condition}
 						rowFilter={rowFilter}
 						onClear={async () => await clearRowFilter(rowFilter.identifier)}
 						onEdit={() => {


### PR DESCRIPTION
This PR removes Data Explorer UI for AND / OR row filter conditions.

Tests:
@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #7473 Remove Data Explorer UI for AND / OR row filter conditions

### QA Notes

There was dead UI code in Data Explorer for AND / OR row filter conditions. This PR removes this code. A deeper removal in the comms layer and runtimes will need to be done at some point in the future.