### PR TITLE
Address remaining issue in #550 by slowing down quickSuggestionsDelay from 10ms to 250ms

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -6230,7 +6230,10 @@ export const EditorOptions = {
 	quickSuggestions: register(new EditorQuickSuggestions()),
 	quickSuggestionsDelay: register(new EditorIntOption(
 		EditorOption.quickSuggestionsDelay, 'quickSuggestionsDelay',
-		10, 0, Constants.MAX_SAFE_SMALL_INTEGER,
+		// --- Start Positron ---
+		// Changed default of 10ms to 250ms to slow down the quick suggestions a bit for https://github.com/posit-dev/positron/issues/550.
+		250, 0, Constants.MAX_SAFE_SMALL_INTEGER,
+		// --- End Positron ---
 		{ description: nls.localize('quickSuggestionsDelay', "Controls the delay in milliseconds after which quick suggestions will show up.") }
 	)),
 	// --- Start Positron ---


### PR DESCRIPTION
## Description

This PR addresses the remaining issue in #550 by slowing down `quickSuggestionsDelay` from 10ms to 250ms.

Tests:
@:console

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #550 Slow down `quickSuggestionsDelay` from 10ms to 250ms.

### QA Notes

None