### PR TITLE
E2E test: fix windows CI

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
           Rscript -e "install.packages('pak')"
-          Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
+          Rscript -e "pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"
 
       # Install R 4.4.2 using rig
       - name: Install R 4.4.2


### PR DESCRIPTION
Attempt to fix windows CI.  Instruct pak to not use the newest version if it is in source form

### QA Notes

@:win
