### PR TITLE
e2e tests: add rtools install to windows

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -143,6 +143,7 @@ jobs:
           rig add 4.4.0
           rig default 4.4.0
           rig ls
+          rig add rtools
 
       - name: Install R packages for 4.4.0
         run: |


### PR DESCRIPTION
Added rtools install to get arouind package build failures.


### QA Notes
@:win
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
