### PR TITLE
Fix localization compile error

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -21,7 +21,7 @@ interface LanguageModelConfigComponentProps {
 
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	function getTos(provider: string): string {
-		let providerConfig = [];
+		let providerConfig = new Array<string>();
 
 		switch (provider) {
 			case 'anthropic':

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -21,7 +21,7 @@ interface LanguageModelConfigComponentProps {
 
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	function getTos(provider: string): string {
-		let providerConfig = new Array<string>();
+		const providerConfig = new Array<string>();
 
 		switch (provider) {
 			case 'anthropic':

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -19,33 +19,34 @@ interface LanguageModelConfigComponentProps {
 	onSignIn: () => void,
 }
 
-const TOS_TEMPLATE = `{0} is considered "Third Party Materials" as defined in the [Posit EULA](https://posit.co/about/eula/)
-and subject to the {0} terms of service at {1} and privacy policy at {2}.\n\n
-Your use of {0} is optional and at your sole risk.`
-
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
-	function getTos(provider: string) {
+	function getTos(provider: string): string {
+		let providerConfig = [];
+
 		switch (provider) {
 			case 'anthropic':
-				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
-					'Anthropic',
-					'[Terms of Service](https://www.anthropic.com/legal/consumer-terms)',
-					'[Privacy Policy](https://www.anthropic.com/legal/privacy)');
+				providerConfig.push('Anthropic');
+				providerConfig.push('[Terms of Service](https://www.anthropic.com/legal/consumer-terms)');
+				providerConfig.push('[Privacy Policy](https://www.anthropic.com/legal/privacy)');
+				break;
 			case 'google':
-				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
-					'Google Gemini',
-					'[Terms of Service](https://policies.google.com/terms)',
-					'[Privacy Policy](https://policies.google.com/privacy)'
-				);
+				providerConfig.push('Google Gemini');
+				providerConfig.push('[Terms of Service](https://cloud.google.com/terms/service-terms)');
+				providerConfig.push('[Privacy Policy](https://policies.google.com/privacy)');
+				break;
 			case 'copilot':
-				return localize('positron.newConnectionModalDialog.tos', TOS_TEMPLATE,
-					'Copilot',
-					'[Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)',
-					'[Privacy Policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)'
-				);
+				providerConfig.push('GitHub Copilot');
+				providerConfig.push('[Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)');
+				providerConfig.push('[Privacy Policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)');
+				break;
 			default:
 				return '';
 		}
+
+		return localize('positron.newConnectionModalDialog.tos',
+			'{0} is considered "Third Party Materials" as defined in the [Posit EULA](https://posit.co/about/eula/) and subject to the {0} terms of service at {1} and privacy policy at {2}.\n\nYour use of {0} is optional and at your sole risk.',
+			...providerConfig
+		);
 	}
 
 	return (<>


### PR DESCRIPTION
The localization call during the build cannot resolve the string template. Refactoring it to a single localization call and using an array for the replacements allows for a single instance of the string.

A local build gets past the `compile-src` stage.

```bash
➜ npm run gulp vscode-darwin-arm64
> code-oss-dev@1.99.0 gulp
> node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-darwin-arm64

[10:24:41] Using gulpfile ~/source/positron/gulpfile.js
[10:24:41] Starting 'vscode-darwin-arm64'...
[10:24:41] Starting clean-out-build ...
[10:24:41] Finished clean-out-build after 508 ms
[10:24:41] Starting build-date-file ...
[10:24:41] Finished build-date-file after 0 ms
[10:24:41] Starting compile-api-proposal-names ...
[10:24:41] Starting compilation api-proposal-names...
[10:24:41] Finished compilation api-proposal-names with 0 errors after 58 ms
[10:24:41] Finished compile-api-proposal-names after 62 ms
[10:24:41] Starting compile-src ...
[10:24:42] Starting compilation...
[10:26:04] Finished compilation with 0 errors after 82425 ms
[10:26:04] Finished compile-src after 82987 ms
[10:26:04] Starting compile-build-without-mangling ...
[10:26:04] Finished compile-build-without-mangling after 0 ms
[10:26:04] Starting clean-extensions-build ...
[10:26:04] Finished clean-extensions-build after 21 ms
[10:26:04] Starting bundle-marketplace-extensions-build ...
[10:26:04] [extensions] ms-vscode.js-debug-companion@1.1.3 up to date ✔︎
[10:26:04] [extensions] ms-vscode.js-debug@1.97.1 up to date ✔︎
[10:26:04] [extensions] ms-vscode.vscode-js-profile-table@1.0.10 up to date ✔︎
[10:26:04] [extensions] ms-toolsai.jupyter-renderers@1.0.19 up to date ✔︎
[10:26:04] Downloading extension from Posit CDN: rstudio.rstudio-workbench@1.5.29 ...
[10:26:05] Finished bundle-marketplace-extensions-build after 911 ms
[10:26:05] Starting bundle-bootstrap-extensions-build ...
[10:26:05] [extensions] ms-python.black-formatter@2024.6.0 up to date ✔︎
[10:26:05] [extensions] ms-toolsai.vscode-jupyter-cell-tags@0.1.9 up to date ✔︎
[10:26:05] [extensions] ms-toolsai.jupyter-keymap@1.1.2 up to date ✔︎
[10:26:05] [extensions] ms-toolsai.vscode-jupyter-slideshow@0.1.6 up to date ✔︎
[10:26:05] [extensions] ms-toolsai.jupyter@2024.11.0 up to date ✔︎
[10:26:05] [extensions] ms-pyright.pyright@1.1.397 up to date ✔︎
[10:26:05] [extensions] Architecture folder /Users/tmok/source/positron/.build/bootstrapExtensions/arm64 does not exist
[10:26:05] Downloading multi-platform extension: ms-python.debugpy@2025.0.1 for darwin-x64, darwin-arm64...
[10:26:05] [extensions] Architecture folder /Users/tmok/source/positron/.build/bootstrapExtensions/arm64 does not exist
[10:26:05] Downloading multi-platform extension: posit.publisher@1.12.1 for darwin-x64, darwin-arm64...
[10:26:05] [extensions] quarto.quarto@1.120.0 up to date ✔︎
[10:26:05] [extensions] Architecture folder /Users/tmok/source/positron/.build/bootstrapExtensions/arm64 does not exist
[10:26:05] Downloading multi-platform extension: posit.air-vscode@0.10.0 for darwin-x64, darwin-arm64...
[10:26:15] Finished bundle-bootstrap-extensions-build after 9974 ms
[10:26:15] Starting bundle-non-native-extensions-build ...
[10:26:18] Bundled extension: configuration-editing/extension.webpack.config.js...
[10:26:22] Bundled extension: css-language-features/server/extension.webpack.config.js...
[10:26:22] Bundled extension: css-language-features/extension.webpack.config.js...
[10:26:22] Bundled extension: debug-auto-launch/extension.webpack.config.js...
[10:26:23] Bundled extension: debug-server-ready/extension.webpack.config.js...
[10:26:25] Bundled extension: emmet/extension.webpack.config.js...
[10:26:26] Bundled extension: extension-editing/extension.webpack.config.js...
[10:26:27] Bundled extension: git-base/extension.webpack.config.js...
[10:26:31] Bundled extension: git/extension.webpack.config.js...
[10:26:32] Bundled extension: github-authentication/extension.webpack.config.js...
[10:26:34] Bundled extension: github/extension.webpack.config.js...
[10:26:35] Bundled extension: grunt/extension.webpack.config.js...
[10:26:35] Bundled extension: gulp/extension.webpack.config.js...
[10:26:40] Bundled extension: html-language-features/server/extension.webpack.config.js...
[10:26:40] Bundled extension: html-language-features/extension.webpack.config.js...
[10:26:44] Bundled extension: ipynb/extension.webpack.config.js...
[10:26:44] Bundled extension: jake/extension.webpack.config.js...
[10:26:47] Bundled extension: json-language-features/server/extension.webpack.config.js...
[10:26:48] Bundled extension: json-language-features/extension.webpack.config.js...
[10:26:56] Bundled extension: markdown-language-features/extension.webpack.config.js...
[10:26:57] Bundled extension: markdown-math/extension.webpack.config.js...
[10:26:58] Bundled extension: media-preview/extension.webpack.config.js...
[10:27:00] Bundled extension: merge-conflict/extension.webpack.config.js...
[10:27:02] Bundled extension: npm/extension.webpack.config.js...
[10:27:05] Bundled extension: open-remote-ssh/extension.webpack.config.js...
[10:27:06] Bundled extension: php-language-features/extension.webpack.config.js...
[10:27:14] Bundled extension: positron-assistant/extension.webpack.config.js...
[10:27:14] Bundled extension: positron-code-cells/extension.webpack.config.js...
[10:27:15] Bundled extension: positron-connections/extension.webpack.config.js...
[10:27:16] Bundled extension: positron-duckdb/extension.webpack.config.js...
[10:27:17] Bundled extension: positron-environment/extension.webpack.config.js...
[10:27:18] Bundled extension: positron-notebook-controllers/extension.webpack.config.js...
[10:27:18] Bundled extension: positron-notebooks/extension.webpack.config.js...
[10:27:20] Bundled extension: positron-proxy/extension.webpack.config.js...
Webpack Bundle Analyzer saved report to /Users/tmok/source/positron/extensions/positron-python/dist/client/extension.analyzer.html
Webpack Bundle Analyzer saved stats file to /Users/tmok/source/positron/extensions/positron-python/dist/client/extension.stats.json
[10:27:42] Bundled extension: positron-python/extension.webpack.config.js...
[10:27:44] Bundled extension: positron-r/extension.webpack.config.js...
[10:27:45] Bundled extension: positron-reticulate/extension.webpack.config.js...
[10:27:46] Bundled extension: positron-run-app/extension.webpack.config.js...
[10:27:49] Bundled extension: positron-supervisor/extension.webpack.config.js...
[10:27:49] Bundled extension: positron-viewer/extension.webpack.config.js...
[10:27:51] Bundled extension: references-view/extension.webpack.config.js...
[10:27:52] Bundled extension: search-result/extension.webpack.config.js...
[10:27:53] Bundled extension: simple-browser/extension.webpack.config.js...
[10:27:57] Bundled extension: terminal-suggest/extension.webpack.config.js...
[10:28:00] Bundled extension: tunnel-forwarding/extension.webpack.config.js...
[10:28:04] Bundled extension: typescript-language-features/extension.webpack.config.js...
(node:93531) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 101 error listeners added to [Stream]. MaxListeners is 100. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
(node:93531) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 101 close listeners added to [Stream]. MaxListeners is 100. Use emitter.setMaxListeners() to increase limit
(node:93531) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 101 drain listeners added to [Stream]. MaxListeners is 100. Use emitter.setMaxListeners() to increase limit
[10:28:05] Finished bundle-non-native-extensions-build after 110031 ms
[10:28:05] Starting compile-non-native-extensions-build ...
[10:28:05] Finished compile-non-native-extensions-build after 0 ms
[10:28:05] Starting compile-extension-media-build ...
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/markdown-language-features/esbuild-preview.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/ipynb/esbuild.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/markdown-language-features/esbuild-notebook.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/simple-browser/esbuild-preview.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/notebook-renderers/esbuild.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/markdown-math/esbuild.js with 0 errors.
[10:28:05] Finished esbuilding extension media /Users/tmok/source/positron/extensions/positron-ipywidgets/renderer/esbuild.js with 0 errors.
[10:28:05] Finished compile-extension-media-build after 187 ms
[10:28:05] Starting copy-extension-binaries ...
[10:28:05] Copying 8 binary sets for built-in Positron extensions
[10:28:05] Finished copy-extension-binaries after 6 ms
[10:28:05] Starting clean-out-vscode ...
[10:28:05] Finished clean-out-vscode after 1 ms
[10:28:05] Starting bundle-vscode ...
[10:28:05] Bundled entry point: vs/editor/common/services/editorWebWorkerMain...
[10:28:05] Bundled entry point: vs/workbench/api/worker/extensionHostWorkerMain...
[10:28:05] Bundled entry point: vs/workbench/contrib/notebook/common/services/notebookWebWorkerMain...
[10:28:05] Bundled entry point: vs/workbench/services/languageDetection/browser/languageDetectionWebWorkerMain...
[10:28:05] Bundled entry point: vs/workbench/services/search/worker/localFileSearchMain...
[10:28:05] Bundled entry point: vs/platform/profiling/electron-sandbox/profileAnalysisWorkerMain...
[10:28:05] Bundled entry point: vs/workbench/contrib/output/common/outputLinkComputerMain...
[10:28:05] Bundled entry point: vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.workerMain...
[10:28:05] Bundled entry point: vs/workbench/contrib/debug/node/telemetryApp...
[10:28:05] Bundled entry point: vs/platform/files/node/watcher/watcherMain...
[10:28:05] Bundled entry point: vs/platform/terminal/node/ptyHostMain...
[10:28:05] Bundled entry point: vs/workbench/api/node/extensionHostProcess...
[10:28:05] Bundled entry point: vs/workbench/workbench.desktop.main...
[10:28:05] Bundled entry point: vs/code/node/cliProcessMain...
[10:28:05] Bundled entry point: vs/code/electron-utility/sharedProcess/sharedProcessMain...
[10:28:05] Bundled entry point: vs/code/electron-sandbox/processExplorer/processExplorerMain...
[10:28:05] Bundled entry point: vs/code/electron-sandbox/workbench/workbench...
[10:28:05] Bundled entry point: vs/code/electron-sandbox/processExplorer/processExplorer...
[10:28:05] Bundled entry point: main...
[10:28:05] Bundled entry point: cli...
[10:28:05] Bundled entry point: bootstrap-fork...
[10:28:09] Finished bundle-vscode after 4005 ms
[10:28:09] Starting compile-native-extensions-build ...
[10:28:13] Bundled extension: microsoft-authentication/extension.webpack.config.js...
[10:28:13] Finished compile-native-extensions-build after 3765 ms
[10:28:13] Starting clean-vscode-darwin-arm64 ...
[10:28:13] Finished clean-vscode-darwin-arm64 after 0 ms
[10:28:13] Starting vscode-darwin-arm64-ci ...
[10:28:13] Synchronizing quarto 1.6.40...
[10:28:14] [Fetch queue] start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-macos.tar.gz (0 remaining)
[10:28:14] Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-macos.tar.gz
[10:28:15] Fetch completed: Status 200. Took 1262 ms
[10:28:32] Skipping checksum verification for https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-macos.tar.gz because no expected checksum was provided
[10:28:32] Fetched response body buffer: 209138529 bytes
[10:28:32] [Fetch queue] completed fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.40/quarto-1.6.40-macos.tar.gz (0 remaining)
[10:28:38] Finished vscode-darwin-arm64-ci after 24665 ms
[10:28:38] Starting vscode-darwin-arm64 ...
[10:28:38] Finished vscode-darwin-arm64 after 0 ms
[10:28:38] Finished 'vscode-darwin-arm64' after 3.95 min
```