### PR TITLE
Fix restart for Zed

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1199,7 +1199,6 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		}
 
 		// Go through the startup sequence again.
-		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Initializing);
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Starting);
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Ready);
 	}


### PR DESCRIPTION
Quick change to fix restart for Zed.

The issue is that Zed is not sending expected restart sequence, which includes the `Exited` => `Starting` state transition. When this state transition does not occur, the Console doesn't get a signal that the restarted runtime is coming back online. Since Zed currently does `Exited` => `Initializing` => `Starting`, the console did not detect that it had restarted. 

Addresses https://github.com/posit-dev/positron/issues/7432.