### PR TITLE
e2e-test: import vs code settings test for windows

### DIFF
--- a/test/e2e/tests/import-vscode-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vscode-settings/import-vscode-settings.test.ts
@@ -28,7 +28,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
+test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] }, () => {
 	test.beforeAll(async ({ vscodeUserSettings, positronUserSettings, runCommand }) => {
 		await vscodeUserSettings.ensureExists();
 		await positronUserSettings.ensureExists();


### PR DESCRIPTION
### Summary
Tagging import vscode settings test to run agains Windows.

### QA Notes

@:vscode-settings @:win