### PR TITLE
Adjusts Data Explorer's percent missing background color to Posit orange

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1895,10 +1895,10 @@ export const POSITRON_DATA_EXPLORER_BORDER_COLOR = registerColor('positronDataEx
 
 // Positron data explorer missing values graph background fill color.
 export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_BACKGROUND_FILL_COLOR = registerColor('positronDataExplorer.columnNullPercentGraphBackgroundFill', {
-	dark: '#bc1a1b',
-	light: '#ea3d3d',
-	hcDark: '#ea3d3d',
-	hcLight: '#ea3d3d',
+	dark: '#ee6331',
+	light: '#ee6331',
+	hcDark: '#ee6331',
+	hcLight: '#ee6331',
 }, localize('positronDataExplorer.columnNullPercentGraphBackgroundFill', "Positron data explorer missing values graph background fill color."));
 
 // Positron data explorer missing values graph background stroke color.


### PR DESCRIPTION
## Description

Adjusts Data Explorer's percent missing background color to Posit orange.

Screenshots:

<img width="1029" alt="light" src="https://github.com/user-attachments/assets/b0cda2dd-0da3-4800-a090-b010b8f5613e" />

<img width="1029" alt="dark" src="https://github.com/user-attachments/assets/657c7f87-3575-4164-8549-9662a373bb31" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #2862 Adjust Data Explorer's percent missing background color to Posit orange.

### QA Notes

None