### PR TITLE
E2E test: unskip reticulate tests

### DIFF
--- a/test/e2e/pages/popups.ts
+++ b/test/e2e/pages/popups.ts
@@ -75,7 +75,7 @@ export class Popups {
 			// TODO: make this smart later, perhaps by getting the console state from the API
 			await this.code.wait(5000);
 		} catch {
-			this.code.logger.log('Did not find modal dialog box');
+			this.code.logger.log('Did not find modal dialog box for ipykernel install');
 		}
 	}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -675,6 +675,22 @@ export class Sessions {
 	}
 
 	/**
+	 * Helper: Rename a session
+	 *
+	 * @param oldName - Name of the session to rename (or part of the name)
+	 * @param newName - New session name
+	 */
+	async renameSession(oldName: string, newName: string) {
+		await this.quickaccess.runCommand('workbench.action.language.runtime.renameSession', { keepOpen: true });
+		await this.quickinput.waitForQuickInputOpened();
+		await this.quickinput.type(oldName);
+		await this.quickinput.waitForQuickInputElements(e => e.length === 1 && e[0].includes(oldName));
+		await this.quickinput.quickInputList.getByText(oldName).first().click();
+		await this.quickinput.type(newName);
+		await this.code.driver.page.keyboard.press('Enter');
+	}
+
+	/**
 	* Action: Open the metadata dialog for the current session
 	*/
 	async openMetadataDialog() {

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -35,18 +35,6 @@ test.describe('Reticulate', {
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
 
-		if (process.env.GITHUB_ACTIONS) {
-			try {
-				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-				await app.workbench.console.typeToConsole('no');
-				await app.workbench.console.sendEnterKey();
-			} catch {
-				logger.log('Prompt did not appear');
-			}
-
-			await app.workbench.popups.installIPyKernel();
-		}
-
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 
 		await app.workbench.sessions.renameSession('reticulate', 'sessionOne');
@@ -56,18 +44,6 @@ test.describe('Reticulate', {
 		const rSessionMetaData2 = await sessions.start('r', { reuse: false });
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
-
-		if (process.env.GITHUB_ACTIONS) {
-			try {
-				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-				await app.workbench.console.typeToConsole('no');
-				await app.workbench.console.sendEnterKey();
-			} catch {
-				logger.log('Prompt did not appear');
-			}
-
-			await app.workbench.popups.installIPyKernel();
-		}
 
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
 	test.beforeAll(async function ({ app, workspaceSettings }) {
@@ -29,43 +29,51 @@ test.describe.skip('Reticulate', {
 		}
 	});
 
-	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', async function ({ app, sessions }) {
+	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', async function ({ app, sessions, logger }) {
 
 		const rSessionMetaData = await sessions.start('r');
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
 
-		try {
-			await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-			await app.workbench.console.typeToConsole('no');
-			await app.workbench.console.sendEnterKey();
-		} catch {
-			// Prompt did not appear
-		}
+		if (process.env.GITHUB_ACTIONS) {
+			try {
+				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
+				await app.workbench.console.typeToConsole('no');
+				await app.workbench.console.sendEnterKey();
+			} catch {
+				logger.log('Prompt did not appear');
+			}
 
-		await app.workbench.popups.installIPyKernel();
+			await app.workbench.popups.installIPyKernel();
+		}
 
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 
-		await verifyReticulateFunctionality(app, rSessionMetaData.id);
+		await app.workbench.sessions.renameSession('reticulate', 'sessionOne');
+
+		await verifyReticulateFunctionality(app, rSessionMetaData.id, 'sessionOne');
 
 		const rSessionMetaData2 = await sessions.start('r', { reuse: false });
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
 
-		try {
-			await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-			await app.workbench.console.typeToConsole('no');
-			await app.workbench.console.sendEnterKey();
-		} catch {
-			// Prompt did not appear
-		}
+		if (process.env.GITHUB_ACTIONS) {
+			try {
+				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
+				await app.workbench.console.typeToConsole('no');
+				await app.workbench.console.sendEnterKey();
+			} catch {
+				logger.log('Prompt did not appear');
+			}
 
-		await app.workbench.popups.installIPyKernel();
+			await app.workbench.popups.installIPyKernel();
+		}
 
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 
-		await verifyReticulateFunctionality(app, rSessionMetaData2.id, 'Python (reticulate)', '300', '500', '7');
+		await app.workbench.sessions.renameSession('reticulate', 'sessionTwo');
+
+		await verifyReticulateFunctionality(app, rSessionMetaData2.id, 'sessionTwo', '300', '500', '7');
 
 	});
 });

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -35,18 +35,6 @@ test.describe('Reticulate', {
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
 
-		if (process.env.GITHUB_ACTIONS) {
-			try {
-				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-				await app.workbench.console.typeToConsole('no');
-				await app.workbench.console.sendEnterKey();
-			} catch {
-				logger.log('Prompt did not appear');
-			}
-
-			await app.workbench.popups.installIPyKernel();
-		}
-
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 
 		await verifyReticulateFunctionality(app, rSessionMetaData.id);

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -29,21 +29,23 @@ test.describe('Reticulate', {
 		}
 	});
 
-	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions }) {
+	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions, logger }) {
 
 		const rSessionMetaData = await sessions.start('r');
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()', true);
 
-		try {
-			await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
-			await app.workbench.console.typeToConsole('no');
-			await app.workbench.console.sendEnterKey();
-		} catch {
-			// Prompt did not appear
-		}
+		if (process.env.GITHUB_ACTIONS) {
+			try {
+				await app.workbench.console.waitForConsoleContents('Yes/no/cancel');
+				await app.workbench.console.typeToConsole('no');
+				await app.workbench.console.sendEnterKey();
+			} catch {
+				logger.log('Prompt did not appear');
+			}
 
-		await app.workbench.popups.installIPyKernel();
+			await app.workbench.popups.installIPyKernel();
+		}
 
 		await app.workbench.console.waitForReadyAndStarted('>>>');
 

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
 	test.beforeAll(async function ({ app, workspaceSettings }) {
@@ -49,7 +49,9 @@ test.describe.skip('Reticulate', {
 
 		await app.workbench.console.waitForReadyAndStarted('>>>', 30000);
 
-		await verifyReticulateFunctionality(app, `R ${process.env.POSITRON_R_VER_SEL!}`, 'Python (reticulate)');
+		await app.workbench.sessions.renameSession('reticulate', 'reticulateNew');
+
+		await verifyReticulateFunctionality(app, `R ${process.env.POSITRON_R_VER_SEL!}`, 'reticulateNew');
 
 	});
 


### PR DESCRIPTION
Reticulate tests were temporarily skipped when the session renaming functionality was merged.  This gets them back into the suite.

### QA Notes

@:web @:reticulate
