### PR TITLE
Rework console interrupt so that Ctrl-C and the interrupt action bar button do the same thing

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -262,7 +262,7 @@ export const ActionBar = (props: ActionBarProps) => {
 		setInterrupting(true);
 
 		// Interrupt the active Positron console instance.
-		activePositronConsoleInstance?.attachedRuntimeSession?.interrupt();
+		activePositronConsoleInstance?.interrupt();
 	};
 
 	// Toggle trace event handler.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -100,10 +100,8 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					// Consume the event.
 					consumeEvent();
 
-					// Update the prompt state and reply to it.
-					props.positronConsoleInstance.replyToPrompt(
-						props.activityItemPrompt, inputRef.current?.value
-					);
+					// Reply to the prompt.
+					props.positronConsoleInstance.replyToPrompt(inputRef.current?.value);
 					return;
 				}
 
@@ -118,9 +116,7 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 				// C key.
 				case 'c': {
 					consumeEvent();
-
-					// Update the prompt state and interrupt it.
-					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt);
+					props.positronConsoleInstance.interrupt();
 					return;
 				}
 

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -6,7 +6,6 @@
 import { RuntimeItem } from '../classes/runtimeItem.js';
 import { Event } from '../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
-import { ActivityItemPrompt } from '../classes/activityItemPrompt.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IExecutionHistoryEntry } from '../../../positronHistory/common/executionHistoryService.js';
@@ -410,8 +409,9 @@ export interface IPositronConsoleInstance {
 
 	/**
 	 * Interrupts the console.
+	 * @param code The optional code to interrupt.
 	 */
-	interrupt(code: string): void;
+	interrupt(code?: string): void;
 
 	/**
 	 * Gets the clipboard representation of the console instance.
@@ -467,17 +467,10 @@ export interface IPositronConsoleInstance {
 		executionId?: string): void;
 
 	/**
-	 * Replies to a prompt.
-	 * @param activityItemPrompt The prompt activity item.
+	 * Replies to the active prompt.
 	 * @param value The value.
 	 */
-	replyToPrompt(activityItemPrompt: ActivityItemPrompt, value: string): void;
-
-	/**
-	 * Interrupts prompt.
-	 * @param activityItemPrompt The prompt activity item.
-	 */
-	interruptPrompt(activityItemPrompt: ActivityItemPrompt): void;
+	replyToPrompt(value: string): void;
 
 	/**
 	 * Attaches a runtime session to the console.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1992,7 +1992,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
-			// Set the acctive activity item prompt.
+			// Set the active activity item prompt.
 			this._activeActivityItemPrompt = new ActivityItemPrompt(
 				languageRuntimeMessagePrompt.id,
 				languageRuntimeMessagePrompt.parent_id,

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -871,9 +871,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _runtimeItemActivities = new Map<string, RuntimeItemActivity>();
 
 	/**
-	 * Gets or sets a value which indicates whether a prompt is active.
+	 * Gets or sets the active activity item prompt.
 	 */
-	private _promptActive = false;
+	private _activeActivityItemPrompt?: ActivityItemPrompt;
 
 	/**
 	 * Gets or sets the scrollback size.
@@ -1155,7 +1155,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Gets a value which indicates whether a prompt is active.
 	 */
 	get promptActive(): boolean {
-		return this._promptActive;
+		return this._activeActivityItemPrompt !== undefined;
 	}
 
 	/**
@@ -1307,7 +1307,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	clearConsole() {
 		// When a prompt is active, we cannot clear the console.
-		if (this._promptActive) {
+		if (this._activeActivityItemPrompt) {
 			// Notify the user that we cannot clear the console.
 			this._notificationService.notify({
 				severity: Severity.Info,
@@ -1333,7 +1333,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Interrupts the console.
 	 */
-	interrupt(code: string) {
+	interrupt(code?: string) {
 		// No session to interrupt.
 		if (!this._session) {
 			return;
@@ -1342,6 +1342,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// Get the runtime state.
 		const runtimeState = this._session.getRuntimeState();
 
+		// If there's a prompt active, interrupt it.
+		if (this._activeActivityItemPrompt) {
+			this._activeActivityItemPrompt.state = ActivityItemPromptState.Interrupted;
+			this._onDidChangeRuntimeItemsEmitter.fire();
+			this._activeActivityItemPrompt = undefined;
+		}
+
+		// Interrupt the runtime session.
 		this._session.interrupt();
 
 		// Clear pending input and pending code.
@@ -1361,10 +1369,15 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					ActivityItemInputState.Cancelled,
 					this._session.dynState.inputPrompt,
 					this._session.dynState.continuationPrompt,
-					code,
+					code ?? '',
 				)
 			);
 		}
+
+		// Drive focus to the input.
+		setTimeout(() => {
+			this.focusInput();
+		}, 0);
 	}
 
 	/**
@@ -1543,35 +1556,22 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 	/**
 	 * Replies to a prompt.
-	 * @param activityItemPrompt The prompt activity item.
 	 * @param value The value.
 	 */
-	replyToPrompt(activityItemPrompt: ActivityItemPrompt, value: string) {
-		// Update the prompt state.
-		activityItemPrompt.state = ActivityItemPromptState.Answered;
-		activityItemPrompt.answer = !activityItemPrompt.password ? value : '';
-		this._onDidChangeRuntimeItemsEmitter.fire();
+	replyToPrompt(value: string) {
+		// If there is a session and a prompt, reply to the prompt.
+		if (this._session && this._activeActivityItemPrompt) {
+			// Get the ID of the prompt.
+			const id = this._activeActivityItemPrompt.id;
 
-		// Reply to the prompt.
-		if (this._promptActive && this._session) {
-			this._promptActive = false;
-			this._session.replyToPrompt(activityItemPrompt.id, value);
-		}
-	}
+			// Update the prompt state.
+			this._activeActivityItemPrompt.state = ActivityItemPromptState.Answered;
+			this._activeActivityItemPrompt.answer = !this._activeActivityItemPrompt.password ? value : '';
+			this._activeActivityItemPrompt = undefined;
+			this._onDidChangeRuntimeItemsEmitter.fire();
 
-	/**
-	 * Interrupts a prompt.
-	 * @param activityItemPrompt The prompt activity item.
-	 */
-	interruptPrompt(activityItemPrompt: ActivityItemPrompt) {
-		// Update the prompt state.
-		activityItemPrompt.state = ActivityItemPromptState.Interrupted;
-		this._onDidChangeRuntimeItemsEmitter.fire();
-
-		// Reply to the prompt.
-		if (this._promptActive && this._session) {
-			this._promptActive = false;
-			this._session.interrupt();
+			// Reply to the prompt.
+			this._session.replyToPrompt(id, value);
 		}
 	}
 
@@ -1992,19 +1992,19 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
-			// Set the prompt active flag.
-			this._promptActive = true;
+			// Set the acctive activity item prompt.
+			this._activeActivityItemPrompt = new ActivityItemPrompt(
+				languageRuntimeMessagePrompt.id,
+				languageRuntimeMessagePrompt.parent_id,
+				new Date(languageRuntimeMessagePrompt.when),
+				languageRuntimeMessagePrompt.prompt,
+				languageRuntimeMessagePrompt.password
+			);
 
 			// Add or update the runtime item activity.
 			this.addOrUpdateUpdateRuntimeItemActivity(
 				languageRuntimeMessagePrompt.parent_id,
-				new ActivityItemPrompt(
-					languageRuntimeMessagePrompt.id,
-					languageRuntimeMessagePrompt.parent_id,
-					new Date(languageRuntimeMessagePrompt.when),
-					languageRuntimeMessagePrompt.prompt,
-					languageRuntimeMessagePrompt.password
-				)
+				this._activeActivityItemPrompt
 			);
 		}));
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1332,6 +1332,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 	/**
 	 * Interrupts the console.
+	 * @param code The optional code to interrupt.
 	 */
 	interrupt(code?: string) {
 		// No session to interrupt.

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -8,7 +8,6 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { CodeAttributionSource, IConsoleCodeAttribution, ILanguageRuntimeCodeExecutedEvent, IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState, SessionAttachMode } from '../../browser/interfaces/positronConsoleService.js';
 import { RuntimeItem } from '../../browser/classes/runtimeItem.js';
-import { ActivityItemPrompt } from '../../browser/classes/activityItemPrompt.js';
 import { ILanguageRuntimeMetadata, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata } from '../../../runtimeSession/common/runtimeSessionService.js';
 import { IExecutionHistoryEntry } from '../../../positronHistory/common/executionHistoryService.js';
@@ -535,14 +534,7 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 	/**
 	 * Replies to a prompt.
 	 */
-	replyToPrompt(activityItemPrompt: ActivityItemPrompt, value: string): void {
-		// No-op for test implementation
-	}
-
-	/**
-	 * Interrupts prompt.
-	 */
-	interruptPrompt(activityItemPrompt: ActivityItemPrompt): void {
+	replyToPrompt(value: string): void {
 		// No-op for test implementation
 	}
 


### PR DESCRIPTION
## Description

This PR addresses the remaining issue in #697 so that pressing Ctrl-C and using the interrupt action bar button behave exactly the same and interrupt the console, whether there is an active prompt or not. Additionally, after interrupt, focus is now driven into the code editor widget. Previously, focus went (seemingly) nowhere when interrupting a prompt.

Tests:
@:console

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #697


### QA Notes

Now, regardless of state, pressing Ctrl-C or using the interrupt action bar button do the exact same thing. The Console's `interruptPrompt` method has been removed. Now, the `interrupt` method can be called at any time to interrupt whatever's going on in the Console.