### PR TITLE
Assistant: Improve Execute Code ergonomics

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -7,8 +7,9 @@ Do not mention the context if it is irrelevant, but just keep it in mind when re
 
 You will be provided with a tool that executes code. Use this tool to help the
 user complete tasks when the user gives you an imperative statement, or asks a
-question that can be answered by executing code.
+question that can be answered by executing code. When you use this tool, the
+user can see the code you are executing, so you don't need to show it to them
+afterwards.
 
-However, if the user asks you *how* to do something, or asks for code rather
-than results, generate the code and return it directly without trying to
-execute it.
+If the user asks you _how_ to do something, or asks for code rather than
+results, generate the code and return it directly without trying to execute it.

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -132,24 +132,21 @@ export function registerAssistantTools(
 		 *
 		 * @returns A vscode.PreparedToolInvocation object
 		 */
-		prepareInvocation: async (options, token) => {
+		prepareInvocation2: async (options, token) => {
 
 			// Ask user for confirmation before proceeding
-			const result: vscode.PreparedToolInvocation = {
-				/// The message shown when the code is actually executing.
-				/// Positron appends '...' to this message.
-				invocationMessage: vscode.l10n.t('Running'),
+			const result: vscode.PreparedTerminalToolInvocation = {
+				// The command (code to run)
+				command: options.input.code,
+
+				// The language (used for syntax highlighting)
+				language: options.input.language,
 
 				/// The message shown to confirm that the user wants to run the code.
 				confirmationMessages: {
 					title: vscode.l10n.t('Execute Code'),
-					/// Generate a MarkdownString to show the code with syntax
-					/// highlighting
-					message: new vscode.MarkdownString(
-						'```' + options.input.language + '\n' +
-						options.input.code + '\n' +
-						'```'),
-				}
+					message: ''
+				},
 			};
 			return result;
 		},

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -356,7 +356,12 @@ class ChatToolInvocationSubPart extends Disposable {
 			{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
 		));
 		const codeBlockRenderOptions: ICodeBlockRenderOptions = {
-			hideToolbar: true,
+			// --- Start Positron ---
+			// Don't hide the toolbar on code blocks, so the user can still
+			// copy/integrate the code elsewhere
+			// hideToolbar: true,
+			hideToolbar: false,
+			// --- Start Positron ---
 			reserveWidth: 19,
 			verticalPadding: 5,
 			editorOptions: {

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -41,7 +41,9 @@ class PositronAssistantContribution extends Disposable implements IWorkbenchCont
 						id: MenuId.ChatCodeBlock,
 						group: 'navigation',
 						order: 5,
-						when: ContextKeyExpr.equals(ChatContextKeys.location.key, ChatAgentLocation.Panel)
+						when: ContextKeyExpr.and(
+							ContextKeyExpr.equals(ChatContextKeys.location.key, ChatAgentLocation.Panel),
+							ChatContextKeys.Editing.hasToolConfirmation.toNegated())
 					},
 				});
 			}


### PR DESCRIPTION
This change improves the Execute Code tool in Positron Assistant in a couple of key areas (detailed below). 

Addresses https://github.com/posit-dev/positron/issues/7040.

### Toolbar

The Execute Code tool now shows a code toolbar. This allows you to copy or paste the code if running it wasn't what you wanted.

<img width="321" alt="image" src="https://github.com/user-attachments/assets/3c4e2029-aa75-49ff-b35a-6c10647e4592" />

### Persistence

When the code is run, it doesn't disappear but instead stays in the chat history (several users pointed out that the disappearing code was confusing). You can even see the status while it's running, and a green check when it's done.

<img width="313" alt="image" src="https://github.com/user-attachments/assets/7ab38daa-50e9-4c66-b484-d8c0a0d15462" />

### Implementation

This turned out to be a lot easier than I thought, because it turns out that this problem was largely solved already upstream: lots of special casing exists for Terminal tool invocations, for all the same reasons we wanted to special case Console tool invocations. So most of this change is simply making our Execute Code tool look enough like a Terminal tool that we get the same UI. 

### QA Notes

Note that the "Run" button in the toolbar is not present on Execute Code blocks even though it _is_ present on regular code blocks. This is intentional because it's confusing to have two run gestures (toolbar + Continue button), and it would be difficult to make the toolbar button do the same thing as the Continue button.

The issue #7040 mentions streaming responses, but that isn't covered in this PR. I think it's less important and can be done separately.