### PR TITLE
E2E test: close R db connection at end of test

### DIFF
--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -108,6 +108,20 @@ test.describe('Postgres DB Connection', {
 
 			}).toPass({ timeout: 60000 });
 		});
+
+		await app.workbench.dataExplorer.closeDataExplorer();
+		await app.workbench.layouts.enterLayout('stacked');
+
+		await test.step('Remove connection', async () => {
+			await app.workbench.connections.openConnectionPane();
+
+			await app.code.driver.page.getByRole('button', { name: 'Disconnect' }).click();
+
+			await app.code.driver.page.locator('.col-name', { hasText: 'PqConnection' }).click();
+
+			await app.code.driver.page.getByRole('button', { name: 'Delete Connection' }).click();
+		});
+
 	});
 });
 


### PR DESCRIPTION
Forgot to close the db connection at the end of the R test

### QA Notes

@:web @:connections
