### PR TITLE
update bundled version of workbench extension to latest in 2025.05

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -616,7 +616,7 @@
         "filename": "build/lib/stylelint/vscode-known-variables.json",
         "hashed_secret": "bebac042cf8ae1cf5954a7f233759a1373a1bd5b",
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 771,
         "is_secret": false
       }
     ],
@@ -923,7 +923,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d532234ad25d9767b98a089f00f0eb68ed18af4f",
+        "hashed_secret": "92bf36d24ad4f4b3afe20a1a789182e9f70ddcc8",
         "is_verified": false,
         "line_number": 112,
         "is_secret": false
@@ -1455,5 +1455,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-22T16:07:11Z"
+  "generated_at": "2025-05-02T14:53:27Z"
 }

--- a/product.json
+++ b/product.json
@@ -106,10 +106,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.29",
+			"version": "1.5.37",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "1c1854455074fd75352430ff8fbfcd20717f7895d4d5e6670b1ec2ba6b72d371",
+			"sha256": "b2cd1e78b46af0e4097d2fbd7f35a9618dac830d75ac11329e281eec8c4584b1",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Update Workbench Extension to latest build from: https://build.posit.it/blue/organizations/jenkins/IDE%2Fvscode-ext/detail/main/158/pipeline/
This includes some improvement from @atheriel: https://github.com/rstudio/rstudio-workbench-vscode-ext/commits/main/

It'd be good to see these in PTD when we update the Positron/Workbench versions there next week.
