### PR TITLE
Update Chat view icon

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -47,7 +47,9 @@ import { CHAT_EDITING_SIDEBAR_PANEL_ID, CHAT_SIDEBAR_PANEL_ID, ChatViewPane } fr
 const chatViewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
 	id: CHAT_SIDEBAR_PANEL_ID,
 	title: localize2('chat.viewContainer.label', "Chat"),
-	icon: Codicon.commentDiscussion,
+	// --- Start Positron ---
+	icon: Codicon.positronAssistant,
+	// --- End Positron ---
 	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [CHAT_SIDEBAR_PANEL_ID, { mergeViewWithContainerWhenSingleView: true }]),
 	storageId: CHAT_SIDEBAR_PANEL_ID,
 	hideIfEmpty: true,

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -7,7 +7,7 @@
 import { expect, test } from '@playwright/test';
 import { Code } from '../infra/code';
 
-const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label^="Chat"]';
+const CHATBUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
 const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
 const ADD_MODEL_BUTTON = 'a.action-label[aria-label="Add Language Model"]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Address #6984 

Update the branding on the Chat view. The 1.99 update turns on the unified view so now Edits is accessible in Chat via the mode selector.

The Copilot branding that was around has also been hidden due to the 1.99 update. It would only appear if the Copilot extension is available.

All that needed to be updated is the view icon, which is now the Positron Assistant image. There are still places where the Copilot icon is used but those parts are disabled in Code OSS. I expect more refactoring from upstream to move references to Copilot out of Code OSS when possible.


![image](https://github.com/user-attachments/assets/975f626d-b407-46b0-8d04-2b1fc1a4f4b8)


@:assistant

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Update Chat view icon #6984


### QA Notes

The automated test has been updated so it can click on the view.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
