### PR TITLE
ensure the windowConfig window dimensions uses `inherit`

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -414,6 +414,22 @@ export class WindowsStateHandler extends Disposable {
 				ensureNoOverlap = state.mode !== WindowMode.Fullscreen && windowConfig.newWindowDimensions === 'offset';
 			}
 		}
+		// --- Start Positron ---
+		else {
+			// If the windowConfig?.newWindowDimensions is undefined, our new default is to inherit the last active window's state.
+			if (lastActive) {
+				const lastActiveState = lastActive.serializeWindowState();
+				if (lastActiveState.mode === WindowMode.Fullscreen) {
+					state.mode = WindowMode.Fullscreen; // only take mode (fixes https://github.com/microsoft/vscode/issues/19331)
+				} else {
+					state = {
+						...lastActiveState,
+						zoomLevel: undefined // do not inherit zoom level
+					};
+				}
+			}
+		}
+		// --- End Positron ---
 
 		if (ensureNoOverlap) {
 			state = this.ensureNoOverlap(state);

--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -269,7 +269,10 @@ export class WindowsStateHandler extends Disposable {
 
 	getNewWindowState(configuration: INativeWindowConfiguration): INewWindowState {
 		const state = this.doGetNewWindowState(configuration);
-		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		// --- Start Positron ---
+		// const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		const windowConfig = this.getWindowSettingsConfig();
+		// --- End Positron --
 
 		// Fullscreen state gets special treatment
 		if (state.mode === WindowMode.Fullscreen) {
@@ -385,7 +388,10 @@ export class WindowsStateHandler extends Disposable {
 		state.y = Math.round(displayToUse.bounds.y + (displayToUse.bounds.height / 2) - (state.height! / 2));
 
 		// Check for newWindowDimensions setting and adjust accordingly
-		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		// --- Start Positron ---
+		// const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		const windowConfig = this.getWindowSettingsConfig();
+		// --- End Positron ---
 		let ensureNoOverlap = true;
 		if (windowConfig?.newWindowDimensions) {
 			if (windowConfig.newWindowDimensions === 'maximized') {
@@ -417,6 +423,30 @@ export class WindowsStateHandler extends Disposable {
 
 		return state;
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Retrieves the window settings configuration object from the configuration service and ensures
+	 * that the newWindowDimensions property is updated with Positron's default config changes.
+	 * @returns The window settings configuration object, or undefined if it doesn't exist.
+	 */
+	private getWindowSettingsConfig(): IWindowSettings | undefined {
+		let windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		if (!windowConfig) {
+			return undefined;
+		}
+
+		windowConfig = {
+			...windowConfig,
+			// We've changed the default value of newWindowDimensions to 'inherit' in Positron, so we need to
+			// set it to 'inherit' if it unset in the config, as we'll fallthrough to the default window state otherwise.
+			// Search for `window.newWindowDimensions` in src/vs/workbench/electron-sandbox/desktop.contribution.ts
+			// for the default configuration.
+			newWindowDimensions: windowConfig.newWindowDimensions || 'inherit',
+		};
+		return windowConfig;
+	}
+	// --- End Positron ---
 
 	private ensureNoOverlap(state: IWindowUIState): IWindowUIState {
 		if (this.windowsMainService.getWindows().length === 0) {

--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -414,22 +414,6 @@ export class WindowsStateHandler extends Disposable {
 				ensureNoOverlap = state.mode !== WindowMode.Fullscreen && windowConfig.newWindowDimensions === 'offset';
 			}
 		}
-		// --- Start Positron ---
-		else {
-			// If the windowConfig?.newWindowDimensions is undefined, our new default is to inherit the last active window's state.
-			if (lastActive) {
-				const lastActiveState = lastActive.serializeWindowState();
-				if (lastActiveState.mode === WindowMode.Fullscreen) {
-					state.mode = WindowMode.Fullscreen; // only take mode (fixes https://github.com/microsoft/vscode/issues/19331)
-				} else {
-					state = {
-						...lastActiveState,
-						zoomLevel: undefined // do not inherit zoom level
-					};
-				}
-			}
-		}
-		// --- End Positron ---
 
 		if (ensureNoOverlap) {
 			state = this.ensureNoOverlap(state);
@@ -446,21 +430,17 @@ export class WindowsStateHandler extends Disposable {
 	 * that the newWindowDimensions property is updated with Positron's default config changes.
 	 * @returns The window settings configuration object, or undefined if it doesn't exist.
 	 */
-	private getWindowSettingsConfig(): IWindowSettings | undefined {
-		let windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
-		if (!windowConfig) {
-			return undefined;
-		}
-
-		windowConfig = {
-			...windowConfig,
+	private getWindowSettingsConfig() {
+		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		const updatedWindowConfig = {
+			...(windowConfig ? windowConfig : {}),
 			// We've changed the default value of newWindowDimensions to 'inherit' in Positron, so we need to
 			// set it to 'inherit' if it unset in the config, as we'll fallthrough to the default window state otherwise.
 			// Search for `window.newWindowDimensions` in src/vs/workbench/electron-sandbox/desktop.contribution.ts
 			// for the default configuration.
-			newWindowDimensions: windowConfig.newWindowDimensions || 'inherit',
+			newWindowDimensions: windowConfig?.newWindowDimensions || 'inherit',
 		};
-		return windowConfig;
+		return updatedWindowConfig;
 	}
 	// --- End Positron ---
 


### PR DESCRIPTION
## Summary

- a follow-up to #7440 to address
    - https://github.com/posit-dev/positron/issues/3303
    - https://github.com/posit-dev/positron/issues/6277

I'll also cherry-pick this to `main` once merged.

### Implementation

We need to explicitly set the windowConfig to `window.newWindowDimensions = 'inherit'` because the default settings aren't read anywhere otherwise.

Similar handling can be found in:
- https://github.com/posit-dev/positron/blob/66236dbf0e9dd1739915979cdd152adc587810c6/src/vs/platform/launch/electron-main/launchMainService.ts#L159-L173
- https://github.com/posit-dev/positron/blob/83cc85cee46e2d53a1eadcb86f8cfb9704c1e5a4/src/vs/platform/windows/electron-main/windowsMainService.ts#L985-L999

## QA Notes

Please try this out on machines with different screen sizes and operating systems!

Make sure you don't already have `window.newWindowDimensions = inherit` set in your user settings JSON, to ensure that the setting is pulling in our new default value instead of pulling from your user setting (...not speaking from experience or anything 😅)

Please also try testing:
- with no user settings that are for `window`, e.g. comment out/remove any settings that start with `window.`
- with at least one user setting that is for `window`, such as `"window.openFoldersInNewWindow": "on"`