### PR TITLE
Fix IntelliSense for viewsContainers.auxiliarybar contributions

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -70,7 +70,14 @@ export const viewsContainersContribution: IJSONSchema = {
 			description: localize('views.container.panel', "Contribute views containers to Panel"),
 			type: 'array',
 			items: viewsContainerSchema
+		},
+		// --- Start Positron ---
+		'auxiliarybar': {
+			description: localize('views.container.auxiliarybar', "Contribute views containers to the Auxiliary sidebar"),
+			type: 'array',
+			items: viewsContainerSchema
 		}
+		// --- End Positron ---
 	},
 	additionalProperties: false
 };


### PR DESCRIPTION
Since #2895 it's been possible (though undocumented) for Positron extensions to contribute views containers to the sidebar, unlike upstream VS Code.

This worked because upstream used to ignore additional keys in `contributes.viewsContainers`, but since
https://github.com/microsoft/vscode/pull/241700 they've explicitly prohibited them, so IntelliSense is starting to flag these keys as errors.

This commit fixes this by explicitly adding `contributes.viewsContainers.auxiliarybar` as a key in the JSON schema.

Addresses #7512.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- IntelliSense is no longer broken for Positron extensions that contribute views containers to the auxiliary sidebar (#7512)

### QA Notes

We should confirm that something like the following now shows to extension authors:

![Screenshot from 2025-05-02 14-42-17](https://github.com/user-attachments/assets/ecd053ce-c722-4cda-8185-7b7088e6421b)

(The above is from the built-in `positron-connections` extension.)
