### PR TITLE
e2e-test: skip session reload test (known bug)

### DIFF
--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -109,10 +109,13 @@ test.describe('Sessions: Management', {
 		await sessions.expectActiveSessionListsToMatch();
 	});
 
-	test('Validate session, console, variables, and plots persist after reload',
+	test.skip('Validate session, console, variables, and plots persist after reload',
 		{
 			tag: [tags.VARIABLES, tags.PLOTS],
-			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6036' },]
+			annotation: [
+				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6036' },
+				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6843' } // <-- main issue for the test, session do not consistently restore
+				,]
 		}, async function ({ app, sessions, runCommand }) {
 			const { console, plots, variables } = app.workbench;
 


### PR DESCRIPTION
### Summary
Skipping the session reload test because it randomly fails to restore sessions as expected. See known issue: https://github.com/posit-dev/positron/issues/6843

### QA Notes

n/a
