### PR TITLE
Repaint Editor Action Bar when the theme changes

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -107,9 +107,9 @@ export const ActionBarButton = forwardRef<
 
 			// Determine the css background image based on the color theme type and icon.
 			let icon: URI | undefined;
-			if (colorThemeType === ColorScheme.LIGHT && props.icon.light) {
+			if ((colorThemeType === ColorScheme.LIGHT || colorThemeType === ColorScheme.HIGH_CONTRAST_LIGHT) && props.icon.light) {
 				icon = props.icon.light;
-			} else if (colorThemeType === ColorScheme.DARK && props.icon.dark) {
+			} else if ((colorThemeType === ColorScheme.DARK || colorThemeType === ColorScheme.HIGH_CONTRAST_DARK) && props.icon.dark) {
 				icon = props.icon.dark;
 			} else {
 				// Fallback to the dark icon if the light icon is not available.

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -105,7 +105,7 @@ export const ActionBarButton = forwardRef<
 			// Get the color theme type.
 			const colorThemeType = context.themeService.getColorTheme().type;
 
-			// Determine the css background image based on the color theme type and icon.
+			// Determine the CSS background image based on the color theme type and icon.
 			let icon: URI | undefined;
 			if ((colorThemeType === ColorScheme.LIGHT || colorThemeType === ColorScheme.HIGH_CONTRAST_LIGHT) && props.icon.light) {
 				icon = props.icon.light;

--- a/src/vs/workbench/browser/parts/editor/editorActionBar.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBar.tsx
@@ -52,9 +52,15 @@ export const EditorActionBar = (props: EditorActionBarProps) => {
 			setRenderMarker(renderCounter => renderCounter + 1);
 		}));
 
+		// Add the onDidColorThemeChange event handler.
+		disposableStore.add(props.themeService.onDidColorThemeChange(() => {
+			// Re-render the component.
+			setRenderMarker(renderCounter => renderCounter + 1);
+		}));
+
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
-	}, [props.editorActionBarFactory]);
+	}, [props.editorActionBarFactory, props.themeService]);
 
 	// Determine whether the window is an auxiliary window.
 	const auxiliaryWindow = ref.current ? isAuxiliaryWindow(DOM.getWindow(ref.current)) : undefined;

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -10,24 +10,24 @@ import './editorActionBarControl.css';
 import React from 'react';
 
 // Other dependencies.
+import { IEditorGroupView } from './editor.js';
+import { EditorActionBar } from './editorActionBar.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { EditorActionBarFactory } from './editorActionBarFactory.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { IEditorGroupView } from './editor.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-import { EditorActionBar } from './editorActionBar.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { EditorActionBarFactory } from './editorActionBarFactory.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
-import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
-import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 
 /**
  * Constants.


### PR DESCRIPTION
## Description

This PR addresses #7509 by repainting the Editor Action Bar when the theme changes.

Here's a video:

https://github.com/user-attachments/assets/9609d0d0-6a12-4fa6-8268-e714eeaee5b1


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #7509 Repaint the Editor Action Bar when the theme changes.

### QA Notes

None