### PR TITLE
e2e-test: adjust locator for `add language model` button

### DIFF
--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -9,7 +9,7 @@ import { Code } from '../infra/code';
 
 const CHATBUTTON = '.action-label.codicon-comment-discussion[aria-label^="Chat"]';
 const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
-const ADD_MODEL_BUTTON = 'a.action-label[aria-label="Add Language Model"]';
+const ADD_MODEL_BUTTON = '[id="workbench.panel.chat"] a.action-label[aria-label="Add Language Model"]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
 const DONE_BUTTON = 'button.positron-button.action-bar-button.default';
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';


### PR DESCRIPTION
### Summary
Improving locator so it avoids multi-match. Honestly, the real issue is an auth error, but improving this to prevent other problems.

### QA Notes

@:assistant
