### PR TITLE
E2E test: more waiting for postgres connection data setup

### DIFF
--- a/test/e2e/pages/connections.ts
+++ b/test/e2e/pages/connections.ts
@@ -81,13 +81,8 @@ export class Connections {
 		});
 	}
 
-	async connect(python: boolean = true) {
+	async connect() {
 		await test.step('Click connect button when ready', async () => {
-			if (python) {
-				await expect(this.code.driver.page.locator('.lines-content .view-line', { hasText: '%connection_show conn' })).toBeVisible();
-			} else {
-				await expect(this.code.driver.page.locator('.lines-content .view-line', { hasText: 'connections::connection_view(con)' })).toBeVisible();
-			}
 			await this.code.driver.page.locator('.button', { hasText: 'Connect' }).click();
 		});
 	}

--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -42,8 +42,8 @@ test.describe('Postgres DB Connection', {
 
 		await expect(app.code.driver.page.locator(viewLine, { hasText: '%connection_show conn' })).toBeVisible();
 		await expect(app.code.driver.page.locator(viewLine, { hasText: dbName })).toBeVisible();
-		await expect(app.code.driver.page.locator(viewLine, { hasText: user })).toBeVisible();
-		await expect(app.code.driver.page.locator(viewLine, { hasText: password })).toBeVisible();
+		await expect(app.code.driver.page.locator(`${viewLine}:has-text("username=\\"${user}\\"")`)).toBeVisible();
+		await expect(app.code.driver.page.locator(`${viewLine}:has-text("password=\\"${password}\\"")`)).toBeVisible();
 
 		await app.workbench.connections.connect();
 
@@ -94,8 +94,8 @@ test.describe('Postgres DB Connection', {
 
 		await expect(app.code.driver.page.locator(viewLine, { hasText: 'connections::connection_view(con)' })).toBeVisible();
 		await expect(app.code.driver.page.locator(viewLine, { hasText: dbName })).toBeVisible();
-		await expect(app.code.driver.page.locator(viewLine, { hasText: user })).toBeVisible();
-		await expect(app.code.driver.page.locator(viewLine, { hasText: password })).toBeVisible();
+		await expect(app.code.driver.page.locator(`${viewLine}:has-text("user = \\\'${user}\\\'")`)).toBeVisible();
+		await expect(app.code.driver.page.locator(`${viewLine}:has-text("password = \\\'${password}\\\'")`)).toBeVisible();
 
 		await app.workbench.connections.connect();
 

--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -18,6 +18,11 @@ test.use({
 // SELECT * FROM periodic_table;
 // exit
 
+const viewLine = '.lines-content .view-line';
+const dbName = process.env.E2E_POSTGRES_DB || 'testdb';
+const user = process.env.E2E_POSTGRES_USER || 'testuser';
+const password = process.env.E2E_POSTGRES_PASSWORD || 'testpassword';
+
 test.describe('Postgres DB Connection', {
 	tag: [tags.WEB, tags.CONNECTIONS]
 }, () => {
@@ -29,11 +34,16 @@ test.describe('Postgres DB Connection', {
 		await app.workbench.connections.initiateConnection('Python', 'PostgresSQL');
 
 		await app.workbench.connections.fillConnectionsInputs({
-			'Database Name': process.env.E2E_POSTGRES_DB || 'testdb',
+			'Database Name': dbName,
 			'Host': 'localhost',
-			'User': process.env.E2E_POSTGRES_USER || 'testuser',
-			'Password': process.env.E2E_POSTGRES_PASSWORD || 'testpassword',
+			'User': user,
+			'Password': password,
 		});
+
+		await expect(app.code.driver.page.locator(viewLine, { hasText: '%connection_show conn' })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: dbName })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: user })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: password })).toBeVisible();
 
 		await app.workbench.connections.connect();
 
@@ -82,7 +92,12 @@ test.describe('Postgres DB Connection', {
 			'Password': process.env.E2E_POSTGRES_PASSWORD || 'testpassword',
 		});
 
-		await app.workbench.connections.connect(false);
+		await expect(app.code.driver.page.locator(viewLine, { hasText: 'connections::connection_view(con)' })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: dbName })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: user })).toBeVisible();
+		await expect(app.code.driver.page.locator(viewLine, { hasText: password })).toBeVisible();
+
+		await app.workbench.connections.connect();
 
 		await test.step('Open periodic table connection', async () => {
 

--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -86,10 +86,10 @@ test.describe('Postgres DB Connection', {
 		await app.workbench.connections.initiateConnection('R', 'PostgresSQL');
 
 		await app.workbench.connections.fillConnectionsInputs({
-			'Database Name': process.env.E2E_POSTGRES_DB || 'testdb',
+			'Database Name': dbName,
 			'Host': 'localhost',
-			'User': process.env.E2E_POSTGRES_USER || 'testuser',
-			'Password': process.env.E2E_POSTGRES_PASSWORD || 'testpassword',
+			'User': user,
+			'Password': password,
 		});
 
 		await expect(app.code.driver.page.locator(viewLine, { hasText: 'connections::connection_view(con)' })).toBeVisible();


### PR DESCRIPTION
Test can try to connect before connections code block is ready. This changes aims to fix that.

@:web @:connections
