### PR TITLE
Hide Chat panel when Assistant is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -81,20 +81,12 @@ const chatViewDescriptor: IViewDescriptor[] = [{
 		order: 1
 	},
 	ctorDescriptor: new SyncDescriptor(ChatViewPane, [{ location: ChatAgentLocation.Panel }]),
-	// --- Start Positron ---
-	// Do not show the Chat pane at all if there are no participants registered;
-	// this is the case when Assistant is disabled entirely.
-	//
-	// Old version:
-	/*
 	when: ContextKeyExpr.or(
 		ChatContextKeys.Setup.hidden.negate(),
 		ChatContextKeys.Setup.installed,
 		ChatContextKeys.panelParticipantRegistered,
 		ChatContextKeys.extensionInvalid
 	)
-	*/
-	when: ChatContextKeys.panelParticipantRegistered,
 	// --- End Positron ---
 }];
 Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews(chatViewDescriptor, chatViewContainer);

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -89,7 +89,6 @@ const chatViewDescriptor: IViewDescriptor[] = [{
 		ChatContextKeys.panelParticipantRegistered,
 		ChatContextKeys.extensionInvalid
 	)
-	// --- End Positron ---
 }];
 Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews(chatViewDescriptor, chatViewContainer);
 

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -81,12 +81,21 @@ const chatViewDescriptor: IViewDescriptor[] = [{
 		order: 1
 	},
 	ctorDescriptor: new SyncDescriptor(ChatViewPane, [{ location: ChatAgentLocation.Panel }]),
+	// --- Start Positron ---
+	// Do not show the Chat pane at all if there are no participants registered;
+	// this is the case when Assistant is disabled entirely.
+	//
+	// Old version:
+	/*
 	when: ContextKeyExpr.or(
 		ChatContextKeys.Setup.hidden.negate(),
 		ChatContextKeys.Setup.installed,
 		ChatContextKeys.panelParticipantRegistered,
 		ChatContextKeys.extensionInvalid
 	)
+	*/
+	when: ChatContextKeys.panelParticipantRegistered,
+	// --- End Positron ---
 }];
 Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews(chatViewDescriptor, chatViewContainer);
 

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -309,9 +309,15 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		let editingAgentRegistered = false;
 		let defaultAgentRegistered = false;
 		let toolsAgentRegistered = false;
+		// --- Start Positron ---
+		let testAgentRegistered = false;
+		// --- End Positron ---
 		for (const agent of this.getAgents()) {
 			if (agent.isDefault && agent.locations.includes(ChatAgentLocation.EditingSession)) {
 				// --- Start Positron ---
+				if (agent.extensionId.value === 'vscode.vscode-api-tests') {
+					testAgentRegistered = true;
+				}
 				defaultAgentRegistered = true;
 				// --- End Positron ---
 				editingAgentRegistered = true;
@@ -324,9 +330,10 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		}
 		this._editingAgentRegistered.set(editingAgentRegistered);
 		// --- Start Positron ---
-		// Do not register default agents when Assistant is disabled.
+		// Do not register default agents when Assistant is disabled, except for
+		// the API test agent from upstream.
 		// this._defaultAgentRegistered.set(defaultAgentRegistered);
-		if (this.configurationService.getValue('positron.assistant.enable')) {
+		if (testAgentRegistered || this.configurationService.getValue('positron.assistant.enable')) {
 			this._defaultAgentRegistered.set(defaultAgentRegistered);
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -313,11 +313,13 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		let testAgentRegistered = false;
 		// --- End Positron ---
 		for (const agent of this.getAgents()) {
+			// --- Start Positron ---
+			if (agent.extensionId.value === 'vscode.vscode-api-tests') {
+				testAgentRegistered = true;
+			}
+			// --- End Positron ---
 			if (agent.isDefault && agent.locations.includes(ChatAgentLocation.EditingSession)) {
 				// --- Start Positron ---
-				if (agent.extensionId.value === 'vscode.vscode-api-tests') {
-					testAgentRegistered = true;
-				}
 				defaultAgentRegistered = true;
 				// --- End Positron ---
 				editingAgentRegistered = true;

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -29,6 +29,10 @@ import { IRawChatCommandContribution } from './chatParticipantContribTypes.js';
 import { IChatFollowup, IChatLocationData, IChatProgress, IChatResponseErrorDetails, IChatTaskDto } from './chatService.js';
 import { ChatAgentLocation, ChatMode } from './constants.js';
 
+// --- Start Positron ---
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+// --- End Positron ---
+
 //#region agent service, commands etc
 
 export interface IChatAgentHistoryEntry {
@@ -243,6 +247,9 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 
 	constructor(
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		// --- Start Positron ---
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		// --- End Positron ---
 	) {
 		super();
 		this._hasDefaultAgent = ChatContextKeys.enabled.bindTo(this.contextKeyService);
@@ -316,7 +323,13 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 			}
 		}
 		this._editingAgentRegistered.set(editingAgentRegistered);
-		this._defaultAgentRegistered.set(defaultAgentRegistered);
+		// --- Start Positron ---
+		// Do not register default agents when Assistant is disabled.
+		// this._defaultAgentRegistered.set(defaultAgentRegistered);
+		if (this.configurationService.getValue('positron.assistant.enable')) {
+			this._defaultAgentRegistered.set(defaultAgentRegistered);
+		}
+		// --- End Positron ---
 		if (toolsAgentRegistered !== this._hasToolsAgentContextKey.get()) {
 			this._hasToolsAgentContextKey.set(toolsAgentRegistered);
 			this._onDidChangeAgents.fire(this.getDefaultAgent(ChatAgentLocation.EditingSession));

--- a/src/vs/workbench/contrib/chat/test/common/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatAgents.test.ts
@@ -51,6 +51,7 @@ suite('ChatAgents', function () {
 		// --- Start Positron ---
 		// Add configuration service to chat
 		configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('positron.assistant.enable', true);
 		chatAgentService = store.add(new ChatAgentService(contextKeyService, configurationService));
 		// --- End Positron ---
 	});

--- a/src/vs/workbench/contrib/chat/test/common/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatAgents.test.ts
@@ -10,6 +10,10 @@ import { ExtensionIdentifier } from '../../../../../platform/extensions/common/e
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { ChatAgentService, IChatAgentData, IChatAgentImplementation } from '../../common/chatAgents.js';
 
+// --- Start Positron ---
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+// --- End Positron ---
+
 const testAgentId = 'testAgent';
 const testAgentData: IChatAgentData = {
 	id: testAgentId,
@@ -39,9 +43,16 @@ suite('ChatAgents', function () {
 
 	let chatAgentService: ChatAgentService;
 	let contextKeyService: TestingContextKeyService;
+	// --- Start Positron ---
+	let configurationService: TestConfigurationService;
+	// --- End Positron ---
 	setup(() => {
 		contextKeyService = new TestingContextKeyService();
-		chatAgentService = store.add(new ChatAgentService(contextKeyService));
+		// --- Start Positron ---
+		// Add configuration service to chat
+		configurationService = new TestConfigurationService();
+		chatAgentService = store.add(new ChatAgentService(contextKeyService, configurationService));
+		// --- End Positron ---
 	});
 
 	test('registerAgent', async () => {


### PR DESCRIPTION
This change hides the Chat panel entirely when Positron Assistant is disabled. The approach taken is:

- Never show the Chat panel unless there are chat agents registered. The upstream configuration shows the panel in other contexts, such as when an incorrect version of Copilot is installed -- not something we need to worry about since we bundle Assistant.
- Do not register any chat agents when Assistant is disabled. This is necessary since the default agent comes from a built-in extension and is therefore always registered.

Addresses https://github.com/posit-dev/positron/issues/6828. 

### QA Notes

A reload or restart is required to apply the setting.