### PR TITLE
Allow extensions to contribute views to the Connections container

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -30,6 +30,9 @@ import { ILogService } from '../../../platform/log/common/log.js';
 import { IExtensionFeatureTableRenderer, IRenderedData, ITableData, IRowData, IExtensionFeaturesRegistry, Extensions as ExtensionFeaturesRegistryExtensions } from '../../services/extensionManagement/common/extensionFeatures.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../base/common/htmlContent.js';
+// --- Start Positron ---
+import { POSITRON_CONNECTIONS_VIEW_ID } from '../../services/positronConnections/common/interfaces/positronConnectionsService.js';
+// --- End Positron ---
 
 export interface IUserFriendlyViewsContainerDescriptor {
 	id: string;
@@ -233,7 +236,15 @@ const viewsContribution: IJSONSchema = {
 			type: 'array',
 			items: remoteViewDescriptor,
 			default: []
+		},
+		// --- Start Positron ---
+		'connections': {
+			description: localize('views.connections', "Contributes views to Connections container in the Auxiliary sidebar"),
+			type: 'array',
+			items: viewDescriptor,
+			default: []
 		}
+		// --- End Positron ---
 	},
 	additionalProperties: {
 		description: localize('views.contributed', "Contributes views to contributed views container"),
@@ -627,6 +638,9 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 			case 'debug': return this.viewContainersRegistry.get(DEBUG);
 			case 'scm': return this.viewContainersRegistry.get(SCM);
 			case 'remote': return this.viewContainersRegistry.get(REMOTE);
+			// --- Start Positron ---
+			case 'connections': return this.viewContainersRegistry.get(POSITRON_CONNECTIONS_VIEW_ID);
+			// --- End Positron ---
 			default: return this.viewContainersRegistry.get(`workbench.view.extension.${value}`);
 		}
 	}


### PR DESCRIPTION
This commit wires up `contributes.views.connections` so that extensions can provide data source-related views of their own.

Addresses #7520.


### Release Notes

#### New Features

- Positron extensions can now contribute custom views to the `Connections` container (#7520)

#### Bug Fixes

- N/A

### QA Notes

You can verify this by having an extension contribute a custom view, e.g.

![Screenshot from 2025-05-02 16-35-51](https://github.com/user-attachments/assets/d8cf851f-c908-48ee-a1e7-924842cbce34)

this view should then appear alongside the built-in `Connections: Core` in the `Connections` container.
