### PR TITLE
Data Explorer: Preserve non-file URIs when creating DuckDB clients

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -99,7 +99,7 @@ class PositronDataExplorerContribution extends Disposable {
 
 					// We create a data explorer URI that will use the DuckDB client
 					// that we just created.
-					const newResource = PositronDataExplorerUri.generate(`duckdb:${resource.path}`);
+					const newResource = PositronDataExplorerUri.generate(`duckdb:${resource.toString()}`);
 					return createDataExplorerEditor({
 						resource: newResource,
 						options

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -36,7 +36,6 @@ import { IPositronDataExplorerService, PositronDataExplorerLayout } from '../../
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
 import { PositronDataExplorerClosed, PositronDataExplorerClosedStatus } from '../../../browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.js';
 import { POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING, POSITRON_DATA_EXPLORER_IS_PLAINTEXT, POSITRON_DATA_EXPLORER_LAYOUT } from './positronDataExplorerContextKeys.js';
-import { URI } from '../../../../base/common/uri.js';
 
 /**
  * IPositronDataExplorerEditorOptions interface.
@@ -362,8 +361,8 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 					positronDataExplorerInstance.tableDataDataGridInstance.isColumnSorting
 				);
 
-				const uri = URI.parse(this._identifier);
-				if (uri.scheme === 'duckdb') {
+				const uri = PositronDataExplorerUri.backingUri(input.resource);
+				if (uri) {
 					this._isPlaintextContextKey.set(PLAINTEXT_EXTS.some(ext => uri.path.endsWith(ext)));
 				} else {
 					this._isPlaintextContextKey.reset();

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -97,7 +97,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		private readonly uri: URI
 	) {
 		super();
-		this.clientId = `duckdb:${this.uri.path}`;
+		this.clientId = `duckdb:${this.uri.toString()}`;
 		this.initialSetup = this.openDataset();
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri.ts
@@ -56,4 +56,19 @@ export class PositronDataExplorerUri {
 			return undefined;
 		}
 	}
+
+	/**
+	 * Parses a Positron data explorer URI and retrieves the URI of the backing file, if any.
+	 * @param resource The data explorer resource.
+	 * @returns A URI for the backing file, if any.
+	 */
+	public static backingUri(resource: URI): URI | undefined {
+		const identifier = PositronDataExplorerUri.parse(resource);
+		// Runtime comm IDs have no originating URIs.
+		if (!identifier || !identifier.startsWith('duckdb:')) {
+			return undefined;
+		}
+		// This will be something like "duckdb:file:///path/to/file.csv".
+		return URI.parse(identifier.replace('duckdb:', ''));
+	}
 }


### PR DESCRIPTION
Previously we encoded only the original path in the data explorer, losing the scheme (and other URI attributes) and fundamentally assuming that we could only open local files.

This commit instead encodes the original URI in its entirety and adds a helper to retrieve it, which makes it possible to use the `Open as Plain Text` button even with files backed by a virtual filesystem provider.

Double-encoding the URI here is pretty gross, of course, but it's consistent with what we were already doing.

This is the last piece of #7351.

e2e: @:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

We should ideally confirm that `Open as Plain Text` works when the data explorer is opened with a file backed by a virtual filesystem provider.