### PR TITLE
Add preference for release channel

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -49,6 +49,19 @@ configurationRegistry.registerConfiguration({
 			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			deprecationMessage: localize('deprecated', "This setting is deprecated, please use '{0}' instead.", 'update.mode')
 		},
+		'update.positron.channel': {
+			type: 'string',
+			default: 'prereleases',
+			enum: ['dailies', 'prereleases'],
+			enumDescriptions: [
+				localize('dailies', "The latest daily build. This is the most up-to-date version of Positron."),
+				localize('prereleases', "Receive pre-release updates.")
+			],
+			scope: ConfigurationScope.APPLICATION,
+			description: localize('update.positron.channel', "Configure the release stream for receiving updates. Requires a restart after change to take effect."),
+			tags: ['usesOnlineServices'],
+			included: !isWeb
+		},
 		'update.primaryLanguageReporting': {
 			type: 'boolean',
 			default: true,

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -22,13 +22,6 @@ import { IUpdate } from '../common/update.js';
 import { hasUpdate } from '../electron-main/positronVersion.js';
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
 
-export const enum UpdateChannel {
-	Releases = 'releases',
-	Prereleases = 'prereleases',
-	Dailies = 'dailies',
-	Staging = 'staging',
-}
-
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
 	return `${productService.updateUrl}/${channel}/${platform}`;
 	//--- End Positron ---
@@ -93,7 +86,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	*/
 	protected async initialize(): Promise<void> {
 		// --- Start Positron ---
-		const updateChannel = process.env.POSITRON_UPDATE_CHANNEL ?? UpdateChannel.Prereleases;
+		const updateChannel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
 		this.enableAutoUpdate = this.configurationService.getValue<boolean>('update.autoUpdate');
 
 		if (this.environmentMainService.disableUpdates) {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -87,6 +87,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	protected async initialize(): Promise<void> {
 		// --- Start Positron ---
 		const updateChannel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
+		if (process.env.POSITRON_UPDATE_CHANNEL) {
+			this.logService.info('update#ctor - using update channel from environment variable', process.env.POSITRON_UPDATE_CHANNEL);
+		}
 		this.enableAutoUpdate = this.configurationService.getValue<boolean>('update.autoUpdate');
 
 		if (this.environmentMainService.disableUpdates) {

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -26,7 +26,7 @@ import { ChatConfiguration } from '../../chat/common/constants.js';
 
 interface IConfiguration extends IWindowsConfiguration {
 	// --- Start Positron ---
-	update?: { mode?: string; autoUpdate?: boolean };
+	update?: { mode?: string; autoUpdate?: boolean; positron: { channel?: string } };
 	// --- End Positron ---
 	debug?: { console?: { wordWrap?: boolean } };
 	editor?: { accessibilitySupport?: 'on' | 'off' | 'auto' };
@@ -55,6 +55,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		'security.restrictUNCAccess',
 		// --- Start Positron ---
 		'update.autoUpdate',
+		'update.positron.channel',
 		// --- End Positron ---
 		'accessibility.verbosity.debug',
 		ChatConfiguration.UnifiedChatView,
@@ -80,6 +81,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 	// --- Start Positron ---
 	private readonly autoUpdate = new ChangeObserver('boolean');
+	private readonly updateChannel = new ChangeObserver('string');
 	// --- End Positron ---
 
 	constructor(
@@ -145,6 +147,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 			// --- Start Positron ---
 			processChanged(this.autoUpdate.handleChange(config.update?.autoUpdate));
+			processChanged(this.updateChannel.handleChange(config.update?.positron.channel));
 			// --- End Positron ---
 
 			// On linux turning on accessibility support will also pass this flag to the chrome renderer, thus a restart is required


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #6489

Adds a preference for choosing where to get updates. The environment variable can still override the preference.

This allows users to switch to getting updates from the dailies.

Altering the preference will prompt the user to restart for the changes to take effect.

<img width="572" alt="image" src="https://github.com/user-attachments/assets/58605af8-00b8-4c6d-be75-b47861d17d03" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add release channel preference #6489 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
