### PR TITLE
Enable tool calling with Gemini

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -573,6 +573,7 @@ class GoogleLanguageModel extends AILanguageModel implements positron.ai.Languag
 			model: 'gemini-2.0-flash-exp',
 			baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
 			apiKey: undefined,
+			toolCalls: true,
 		},
 	};
 


### PR DESCRIPTION
Gemini wasn't calling any of the tools and it's due to it being created with the option off. After enabling it, Gemini seems to use it and I don't see why we shouldn't have it enabled.

<img width="258" alt="image" src="https://github.com/user-attachments/assets/4614b2d4-89af-4643-8ddf-789d9dfda5d1" />
