### PR TITLE
Enable settings import for Workbench

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
@@ -7,7 +7,6 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { localize } from '../../../../nls.js';
 import { Action2 } from '../../../../platform/actions/common/actions.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -17,8 +16,7 @@ import { IStorageService } from '../../../../platform/storage/common/storage.js'
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
-import { COMPARE_WITH_SAVED_COMMAND_ID } from '../../files/browser/fileConstants.js';
-import { getCodeSettingsPath, setImportWasPrompted } from './helpers.js';
+import { getCodeSettingsPath, mergeSettingsJson, setImportWasPrompted } from './helpers.js';
 
 export class PositronImportSettings extends Action2 {
 	/**
@@ -48,7 +46,6 @@ export class PositronImportSettings extends Action2 {
 	 */
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const pathService = accessor.get(IPathService);
-		const commandService = accessor.get(ICommandService);
 		const prefService = accessor.get(IPreferencesService);
 		const fileService = accessor.get(IFileService);
 		const editorService = accessor.get(IEditorService);
@@ -67,27 +64,27 @@ export class PositronImportSettings extends Action2 {
 			return;
 		}
 
-		const codeSettingsContent = await fileService
-			.readFile(codeSettingsPath)
-			.then(content => content.value.toString());
+		const mergedSettings = await mergeSettingsJson(
+			fileService,
+			positronSettingsPath,
+			codeSettingsPath,
+		);
 
 
-		if (await fileService.exists(positronSettingsPath)) {
-			await commandService.executeCommand(COMPARE_WITH_SAVED_COMMAND_ID, positronSettingsPath);
-		} else {
+		if (!await fileService.exists(positronSettingsPath)) {
 			await fileService.createFile(positronSettingsPath);
-			await editorService.openEditor({
-				resource: positronSettingsPath
-			});
 		}
+
+		await editorService.openEditor({
+			resource: positronSettingsPath,
+		});
 
 		const editor = editorService.activeEditor;
 		const model = editorService.activeTextEditorControl?.getModel();
 
-		if (model && 'original' in model && 'modified' in model) {
-			model.modified.setValue('// Settings imported from Visual Studio Code\n' + codeSettingsContent);
-		} else if (model && 'setValue' in model) {
-			model.setValue('// Settings imported from Visual Studio Code\n' + codeSettingsContent);
+		if (model && 'setValue' in model) {
+			model.setLanguage('jsonl');
+			model.setValue('// Settings imported from Visual Studio Code\n' + mergedSettings);
 		}
 
 		const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -6,7 +6,7 @@
 import { URI } from '../../../../base/common/uri.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope, StorageTarget, WillSaveStateReason } from '../../../../platform/storage/common/storage.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { PositronImportSettings } from './actions.js';
 import * as platform from '../../../../base/common/platform.js';
@@ -25,11 +25,12 @@ export async function getImportWasPrompted(
 	return storageService.getBoolean(WAS_PROMPTED_KEY, StorageScope.PROFILE, false);
 }
 
-export function setImportWasPrompted(
+export async function setImportWasPrompted(
 	storageService: IStorageService,
 	state: boolean = true
 ) {
 	storageService.store(WAS_PROMPTED_KEY, state, StorageScope.PROFILE, StorageTarget.MACHINE);
+	await storageService.flush(WillSaveStateReason.SHUTDOWN);
 }
 
 export async function promptImport(

--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -12,6 +12,8 @@ import { PositronImportSettings } from './actions.js';
 import * as platform from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { env } from '../../../../base/common/process.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { parse } from '../../../../base/common/jsonc.js';
 
 const WAS_PROMPTED_KEY = 'positron.welcome.promptedImport';
 
@@ -99,4 +101,159 @@ export async function getCodeSettingsPath(
 		default:
 			throw new Error('Platform not supported');
 	}
+
+	// TODO @samclark2015: workbench
+	// Check ENV variable for the path to the settings file
+	// Also check default location (~/.vscode-server/User/settings.json)
+}
+
+/**
+ * Merge two JSON settings files.
+ * Returns the merged settings as a string with git merge conflict markers.
+ *
+ * @param fileService File service to read the files
+ * @param existing URI to existing settings file
+ * @param incoming URI to incoming settings file
+ * @returns Merged settings JSON as a string
+ */
+export async function mergeSettingsJson(
+	fileService: IFileService,
+	existing: URI,
+	incoming: URI
+): Promise<string> {
+	// Read the contents of the existing and incoming settings files
+	const existingContents = await fileService.readFile(existing);
+	const incomingContents = await fileService.readFile(incoming);
+
+	// Parse the contents as JSON
+	// Using the `jsonc.parse` function to handle comments and trailing commas
+	const existingJson = parse<Record<string, any>>(existingContents.value.toString());
+	const incomingJson = parse<Record<string, any>>(incomingContents.value.toString());
+
+	// Merge the two JSON objects
+	const mergedJson = mergeObjects(existingJson, incomingJson);
+	// Serialize the merged JSON object to a string with git merge conflict markers
+	const serializedOutput = serializeWithMergeMarkers(mergedJson);
+	return serializedOutput;
+}
+
+/**
+ * Merges two objects, optionally handling nested objects recursively.
+ * In case of conflicts, it marks them using a special structure for later serialization.
+ *
+ * @param existing The existing object to merge.
+ * @param incoming The incoming object to merge.
+ * @returns The merged object with conflicts marked.
+ */
+function mergeObjects(existing: Record<string, any>, incoming: Record<string, any>): Record<string, any> {
+	const merged: Record<string, any> = {};
+	// Create a set of all keys from both objects
+	const allKeys = new Set([...Object.keys(existing), ...Object.keys(incoming)]);
+
+	for (const key of allKeys) {
+		if (key in existing && key in incoming) {
+			// The key exists in both objects
+			if (
+				typeof existing[key] === 'object' &&
+				typeof incoming[key] === 'object' &&
+				!Array.isArray(existing[key]) &&
+				!Array.isArray(incoming[key]) &&
+				existing[key] !== null &&
+				incoming[key] !== null
+			) {
+				// Both values are objects, so we need to merge them recursively
+				// and mark the conflict if it exists
+				merged[key] = mergeObjects(existing[key], incoming[key]);
+			} else if (
+				JSON.stringify(existing[key]) !== JSON.stringify(incoming[key])
+			) {
+				// Otherwise, if a scalar or array with different values, mark as conflict
+				merged[key] = {
+					conflict: true,
+					existing: existing[key],
+					incoming: incoming[key]
+				};
+			} else {
+				// If the values are the same, just take one of them
+				merged[key] = existing[key];
+			}
+		} else if (key in existing) {
+			// The key exists only in the existing object
+			merged[key] = existing[key];
+		} else if (key in incoming) {
+			// The key exists only in the incoming object
+			merged[key] = incoming[key];
+		}
+	}
+
+	return merged;
+}
+
+/**
+ * Serializes a JSON object to a string, adding git merge conflict markers
+ * for conflicting keys.
+ *
+ * @param json The JSON object to serialize.
+ * @param level The current indentation level (used for nested objects).
+ * @returns The serialized JSON string with merge markers.
+ */
+function serializeWithMergeMarkers(json: Record<string, any>, level: number = 1): string {
+	// Start with opening brace for the top level
+	let result = (level === 1) ? '{\n' : '';
+	// Get all keys in the object
+	const keys = Object.keys(json);
+
+	// The proper indentation for all keys, including top-level
+	const keyIndent = '\t'.repeat(level);
+
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		const value = json[key];
+
+		// Serialize the key back into JSON-friendly format
+		const serializedKey = JSON.stringify(key);
+		const isLastKey = i === keys.length - 1;
+		// End with a comma if not the last line
+		const lineEnd = isLastKey ? '' : ',';
+
+		if (typeof value === 'object' && value !== null && value.conflict) {
+			// This is a conflict, so we need to serialize it with merge markers
+			// Serialize the existing and incoming values
+			// making sure to indent them properly
+			const serializedExisting = JSON.stringify(value.existing, null, '\t')
+				.replace(
+					/\n/g,
+					'\n' + '\t'.repeat(level)
+				);
+			const serializedIncoming = JSON.stringify(value.incoming, null, '\t')
+				.replace(
+					/\n/g,
+					'\n' + '\t'.repeat(level)
+				);
+
+			// Add the merge markers
+			result += `<<<<<<< Existing\n`;
+			result += `${keyIndent}${serializedKey}: ${serializedExisting}${lineEnd}\n`;
+			result += `=======\n`;
+			result += `${keyIndent}${serializedKey}: ${serializedIncoming}${lineEnd}\n`;
+			result += `>>>>>>> Incoming\n`;
+		} else if (Array.isArray(value) || typeof value !== 'object') {
+			// This is a simple value or an array, so we can serialize it directly
+			const serializedValue = JSON.stringify(value, null, '\t')
+				.replace(
+					/\n/g,
+					'\n' + '\t'.repeat(level)
+				);
+			result += `${keyIndent}${serializedKey}: ${serializedValue}${lineEnd}\n`;
+		} else {
+			// This is a nested object, so we need to serialize it recursively
+			result += `${keyIndent}${serializedKey}: {\n`;
+			result += serializeWithMergeMarkers(value, level + 1);
+			result += `${keyIndent}}${lineEnd}\n`;
+		}
+	}
+
+
+	// Add closing brace with proper indentation for top level
+	return (level === 1) ? result + '}' : result;
 }

--- a/src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { isWeb } from '../../../../base/common/platform.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -32,10 +31,6 @@ class PositronWelcomeContribution extends Disposable implements IWorkbenchContri
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
-
-		if (isWeb) {
-			return;
-		}
 
 		const enabledGlobally = this.configurationService.getValue<boolean>(POSITRON_SETTINGS_IMPORT_ENABLE_KEY);
 

--- a/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
+++ b/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
@@ -3,18 +3,17 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import { IPathService } from '../../../../services/path/common/pathService.js';
-import { getCodeSettingsPath } from "../../browser/helpers.js";
+import { getCodeSettingsPathNative } from "../../browser/helpers.js";
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestPathService } from '../../../../test/browser/workbenchTestServices.js';
 import { URI } from '../../../../../base/common/uri.js';
 import assert from 'assert';
-import { isLinux, isMacintosh, isWeb, isWindows, OperatingSystem } from '../../../../../base/common/platform.js';
-import { env } from '../../../../../base/common/process.js';
+import { isLinux, isMacintosh, isWindows, OperatingSystem } from '../../../../../base/common/platform.js';
 
 suite('Positron - PositronWelcome Contribution Helpers', () => {
 	const testPosix = isMacintosh || isLinux ? test : test.skip;
 	const testWindows = isWindows ? test : test.skip;
-	const testWeb = isWeb ? test : test.skip;
+	// const testWeb = isWeb ? test : test.skip;
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -22,7 +21,7 @@ suite('Positron - PositronWelcome Contribution Helpers', () => {
 		const pathService: IPathService = new TestPathService(
 			URI.parse('/home/test')
 		);
-		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
+		const path = await getCodeSettingsPathNative(pathService, OperatingSystem.Linux);
 		assert.deepEqual(path, URI.parse('/home/test/.config/Code/User/settings.json'));
 	});
 
@@ -30,7 +29,7 @@ suite('Positron - PositronWelcome Contribution Helpers', () => {
 		const pathService: IPathService = new TestPathService(
 			URI.parse('/Users/test')
 		);
-		const path = await getCodeSettingsPath(pathService, OperatingSystem.Macintosh);
+		const path = await getCodeSettingsPathNative(pathService, OperatingSystem.Macintosh);
 		assert.deepEqual(path, URI.parse('/Users/test/Library/Application Support/Code/User/settings.json'));
 	});
 
@@ -38,25 +37,26 @@ suite('Positron - PositronWelcome Contribution Helpers', () => {
 		const pathService: IPathService = new TestPathService(
 			URI.file('C:\\Users\\test')
 		);
-		const path = await getCodeSettingsPath(pathService, OperatingSystem.Windows);
+		const path = await getCodeSettingsPathNative(pathService, OperatingSystem.Windows);
 		assert.deepEqual(path, URI.file('C:\\Users\\test\\AppData\\Roaming\\Code\\User\\settings.json'));
 	});
 
-	testWeb('VSCode settings path: ensure correct Workbench - with env var', async () => {
-		env['RS_VSCODE_USER_DATA_DIR'] = '/workbench/test';
+	// testWeb('VSCode settings path: ensure correct Workbench - with env var', async () => {
+	// 	env['RS_VSCODE_USER_DATA_DIR'] = '/workbench/test';
 
-		const pathService: IPathService = new TestPathService(
-			URI.parse('/should/not/use')
-		);
-		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
-		assert.deepEqual(path, URI.parse('/workbench/test/User/settings.json'));
-	});
+	// 	const pathService: IPathService = new TestPathService(
+	// 		URI.parse('/should/not/use')
+	// 	);
+	// 	const path = await getCodeSettingsPathWeb(pathService, OperatingSystem.Linux);
+	// 	assert.deepEqual(path, URI.parse('/workbench/test/User/settings.json'));
+	// });
 
-	testWeb('VSCode settings path: ensure correct Workbench - without env var', async () => {
-		const pathService: IPathService = new TestPathService(
-			URI.parse('/workbench/test-novar')
-		);
-		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
-		assert.deepEqual(path, URI.parse('/workbench/test-novar/User/settings.json'));
-	});
+	// testWeb('VSCode settings path: ensure correct Workbench - without env var', async () => {
+	// 	const pathService: IPathService = new TestPathService(
+	// 		URI.parse('/workbench/test-novar')
+	// 	);
+
+	// 	const path = await getCodeSettingsPathWeb(pathService, OperatingSystem.Linux);
+	// 	assert.deepEqual(path, URI.parse('/workbench/test-novar/User/settings.json'));
+	// });
 });

--- a/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
+++ b/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
@@ -9,6 +9,7 @@ import { TestPathService } from '../../../../test/browser/workbenchTestServices.
 import { URI } from '../../../../../base/common/uri.js';
 import assert from 'assert';
 import { isLinux, isMacintosh, isWindows, OperatingSystem } from '../../../../../base/common/platform.js';
+import { env } from '../../../../../base/common/process.js';
 
 suite('Positron - PositronWelcome Contribution Helpers', () => {
 	const testPosix = isMacintosh || isLinux ? test : test.skip;
@@ -18,11 +19,15 @@ suite('Positron - PositronWelcome Contribution Helpers', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	testPosix('VSCode settings path: ensure correct Linux', async () => {
+		const oldXdgConfig = process.env.XDG_CONFIG_HOME;
+		delete env.XDG_CONFIG_HOME;
+
 		const pathService: IPathService = new TestPathService(
 			URI.parse('/home/test')
 		);
 		const path = await getCodeSettingsPathNative(pathService, OperatingSystem.Linux);
 		assert.deepEqual(path, URI.parse('/home/test/.config/Code/User/settings.json'));
+		env.XDG_CONFIG_HOME = oldXdgConfig;
 	});
 
 	testPosix('VSCode settings path: ensure correct MacOS', async () => {

--- a/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
+++ b/src/vs/workbench/contrib/positronWelcome/test/browser/helpers.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { getCodeSettingsPath } from "../../browser/helpers.js";
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestPathService } from '../../../../test/browser/workbenchTestServices.js';
+import { URI } from '../../../../../base/common/uri.js';
+import assert from 'assert';
+import { isLinux, isMacintosh, isWeb, isWindows, OperatingSystem } from '../../../../../base/common/platform.js';
+import { env } from '../../../../../base/common/process.js';
+
+suite('Positron - PositronWelcome Contribution Helpers', () => {
+	const testPosix = isMacintosh || isLinux ? test : test.skip;
+	const testWindows = isWindows ? test : test.skip;
+	const testWeb = isWeb ? test : test.skip;
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	testPosix('VSCode settings path: ensure correct Linux', async () => {
+		const pathService: IPathService = new TestPathService(
+			URI.parse('/home/test')
+		);
+		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
+		assert.deepEqual(path, URI.parse('/home/test/.config/Code/User/settings.json'));
+	});
+
+	testPosix('VSCode settings path: ensure correct MacOS', async () => {
+		const pathService: IPathService = new TestPathService(
+			URI.parse('/Users/test')
+		);
+		const path = await getCodeSettingsPath(pathService, OperatingSystem.Macintosh);
+		assert.deepEqual(path, URI.parse('/Users/test/Library/Application Support/Code/User/settings.json'));
+	});
+
+	testWindows('VSCode settings path: ensure correct Windows', async () => {
+		const pathService: IPathService = new TestPathService(
+			URI.file('C:\\Users\\test')
+		);
+		const path = await getCodeSettingsPath(pathService, OperatingSystem.Windows);
+		assert.deepEqual(path, URI.file('C:\\Users\\test\\AppData\\Roaming\\Code\\User\\settings.json'));
+	});
+
+	testWeb('VSCode settings path: ensure correct Workbench - with env var', async () => {
+		env['RS_VSCODE_USER_DATA_DIR'] = '/workbench/test';
+
+		const pathService: IPathService = new TestPathService(
+			URI.parse('/should/not/use')
+		);
+		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
+		assert.deepEqual(path, URI.parse('/workbench/test/User/settings.json'));
+	});
+
+	testWeb('VSCode settings path: ensure correct Workbench - without env var', async () => {
+		const pathService: IPathService = new TestPathService(
+			URI.parse('/workbench/test-novar')
+		);
+		const path = await getCodeSettingsPath(pathService, OperatingSystem.Linux);
+		assert.deepEqual(path, URI.parse('/workbench/test-novar/User/settings.json'));
+	});
+});


### PR DESCRIPTION
### Release Notes

Upon launching Workbench, Positron now prompts users to import VSCode settings, if they exist.

https://github.com/user-attachments/assets/c226e49a-3314-48f7-ba41-a67f5cd32378


#### New Features

- #7428


#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
