### PR TITLE
Add posit jenkins bot to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -56,7 +56,7 @@ jobs:
             before we accept your contribution. You can sign the CLA by posting
             a comment on this PR saying:
 
-          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm
+          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, posit-jenkins-enterprise
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
I created a GitHub action to automatically update Positron and PWB Code server with the latest Workbench extension number when the extension successfully builds. This is set up and working and has created its first PR: https://github.com/posit-dev/positron/pull/7607

That PR is currently blocked because the bot hasn't signed the CLA. This PR adds the bot to our allowlist.