### PR TITLE
E2E test: wait a little after db disconnect

### DIFF
--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -76,6 +76,8 @@ test.describe('Postgres DB Connection', {
 			await app.code.driver.page.locator('.col-name', { hasText: 'SQLAlchemy (postgresql)' }).click();
 
 			await app.code.driver.page.getByRole('button', { name: 'Delete Connection' }).click();
+
+			await app.code.wait(3000);  // small sleep to ensure everything is truly closed
 		});
 	});
 
@@ -135,6 +137,8 @@ test.describe('Postgres DB Connection', {
 			await app.code.driver.page.locator('.col-name', { hasText: 'PqConnection' }).click();
 
 			await app.code.driver.page.getByRole('button', { name: 'Delete Connection' }).click();
+
+			await app.code.wait(3000);  // small sleep to ensure everything is truly closed
 		});
 
 	});


### PR DESCRIPTION
Trying a little wait at the end of the postgres tests to see if it resolves issues in CI (web) where it looks like all the cases that follow the postgres tests end up unable to launch electron.

### QA Notes

@:web @:connections
