### PR TITLE
Fix Python syntax highlighting during Remote SSH

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -70,6 +70,9 @@
         "Data Science",
         "Machine Learning"
     ],
+    "extensionDependencies": [
+        "positron.positron-supervisor"
+    ],
     "activationEvents": [
         "onCommand:python.createEnvironmentAndRegister",
         "onStartupFinished",

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -57,9 +57,6 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin MagicStack/MagicPython grammars/MagicPython.tmLanguage ./syntaxes/MagicPython.tmLanguage.json grammars/MagicRegExp.tmLanguage ./syntaxes/MagicRegExp.tmLanguage.json"
   },
-  "extensionDependencies": [
-    "positron.positron-supervisor"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/6420. One of the wildest issues I've worked on!

As discussed in that issue, I did a git bisect and narrowed down the commit that broke Remote SSH Python syntax highlighting to be the PR https://github.com/posit-dev/positron/pull/6210. This is weird because that PR touches neither the Python extension nor the Remote SSH extension. But I noticed that the `extensionDependencies` was added to the Microsoft Python extension `package.json`, not the Positron Python one, so I tried moving it back, and syntax highlighting started working again!

I assume there was some sort of race or out-of-order events that caused our Python extension to fail in this specific case, because it wasn't waiting for the supervisor. But I'm not positive. Either way, this works.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed Python syntax highlighting during Remote SSH sessions (#6420)


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
Part of what took me so long to find this was coming up with a reliable, fast-ish way to develop on Remote SSH. Posit employees can follow my instructions [here](https://connect.posit.it/positron-wiki/dev-notes/remote-ssh-dev.html).

Once you've done that, on the remote server, you can open a Python file. If you type something like `import datetime`, the word `import` should be colored.