### PR TITLE
Update branding in settings

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -142,14 +142,20 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize('extensions.autoUpdate.enabled', 'Download and install updates automatically only for enabled extensions.'),
 					localize('extensions.autoUpdate.false', 'Extensions are not automatically updated.'),
 				],
-				description: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
+				// --- Start Positron ---
+				// description: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
+				description: localize('positron.extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from the Open VSX Registry."),
+				// --- End Positron ---
 				default: true,
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['usesOnlineServices']
 			},
 			'extensions.autoCheckUpdates': {
 				type: 'boolean',
-				description: localize('extensionsCheckUpdates', "When enabled, automatically checks extensions for updates. If an extension has an update, it is marked as outdated in the Extensions view. The updates are fetched from a Microsoft online service."),
+				// --- Start Positron ---
+				// description: localize('extensionsCheckUpdates', "When enabled, automatically checks extensions for updates. If an extension has an update, it is marked as outdated in the Extensions view. The updates are fetched from a Microsoft online service."),
+				description: localize('positron.extensionsCheckUpdates', "When enabled, automatically checks extensions for updates. If an extension has an update, it is marked as outdated in the Extensions view. The updates are fetched from the Open VSX Registry."),
+				// --- End Positron ---
 				default: true,
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['usesOnlineServices']

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -108,16 +108,15 @@ const registry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 registry.registerConfiguration({
 	...workbenchConfigurationNodeBase,
 	'properties': {
-		'workbench.settings.enableNaturalLanguageSearch': {
-			'type': 'boolean',
-			'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service."),
-			// --- Start Positron ---
-			// 'default': true,
-			'default': false,
-			// --- End Positron ---
-			'scope': ConfigurationScope.WINDOW,
-			'tags': ['usesOnlineServices']
-		},
+		// --- Start Positron ---
+		// 'workbench.settings.enableNaturalLanguageSearch': {
+		// 	'type': 'boolean',
+		// 	'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service."),
+		// 	'default': true,
+		// 	'scope': ConfigurationScope.WINDOW,
+		// 	'tags': ['usesOnlineServices']
+		// },
+		// --- End Positron ---
 		'workbench.settings.settingsSearchTocBehavior': {
 			'type': 'string',
 			'enum': ['hide', 'filter'],

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../../../nls.js';
+// --- Start Positron ---
+// import { localize } from '../../../../nls.js';
+// --- End Positron ---
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import type { IKeyValueStorage, IExperimentationTelemetry } from 'tas-client-umd';
 import { MementoObject, Memento } from '../../../common/memento.js';
@@ -17,7 +19,10 @@ import { IAssignmentService } from '../../../../platform/assignment/common/assig
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { BaseAssignmentService } from '../../../../platform/assignment/common/assignmentService.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
+// --- Start Positron ---
+// import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+// --- End Positron ---
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 
 export const IWorkbenchAssignmentService = createDecorator<IWorkbenchAssignmentService>('WorkbenchAssignmentService');
@@ -142,14 +147,16 @@ registerSingleton(IWorkbenchAssignmentService, WorkbenchAssignmentService, Insta
 const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 registry.registerConfiguration({
 	...workbenchConfigurationNodeBase,
-	'properties': {
-		'workbench.enableExperiments': {
-			'type': 'boolean',
-			'description': localize('workbench.enableExperiments', "Fetches experiments to run from a Microsoft online service."),
-			'default': true,
-			'scope': ConfigurationScope.APPLICATION,
-			'restricted': true,
-			'tags': ['usesOnlineServices']
-		}
-	}
+	// --- Start Positron ---
+	// 'properties': {
+	// 	'workbench.enableExperiments': {
+	// 		'type': 'boolean',
+	// 		'description': localize('workbench.enableExperiments', "Fetches experiments to run from a Microsoft online service."),
+	// 		'default': true,
+	// 		'scope': ConfigurationScope.APPLICATION,
+	// 		'restricted': true,
+	// 		'tags': ['usesOnlineServices']
+	// 	}
+	// }
+	// --- End Positron ---
 });


### PR DESCRIPTION
Addresses #6198


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

We should no longer see references to "a Microsoft online service" in the settings.
