### PR TITLE
Rewrite file hyperlinks on web

### DIFF
--- a/src/vs/workbench/browser/positronAnsiRenderer/outputLine.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputLine.tsx
@@ -14,11 +14,15 @@ import { OutputRun } from './outputRun.js';
 import { ANSIOutputLine } from '../../../base/common/ansiOutput.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
+import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
+import { IPathService } from '../../services/path/common/pathService.js';
 
 // OutputLineProps interface.
 export interface OutputLineProps {
 	readonly openerService: IOpenerService;
 	readonly notificationService: INotificationService;
+	readonly pathService: IPathService;
+	readonly environmentService: IWorkbenchEnvironmentService;
 	readonly outputLine: ANSIOutputLine;
 }
 
@@ -39,9 +43,11 @@ export const OutputLine = (props: OutputLineProps) => {
 			{props.outputLine.outputRuns.map(outputRun =>
 				<OutputRun
 					key={outputRun.id}
+					environmentService={props.environmentService}
 					notificationService={props.notificationService}
 					openerService={props.openerService}
 					outputRun={outputRun}
+					pathService={props.pathService}
 				/>
 			)}
 		</div>

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputLines.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputLines.tsx
@@ -14,11 +14,15 @@ import { OutputLine } from './outputLine.js';
 import { ANSIOutputLine } from '../../../base/common/ansiOutput.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
+import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
+import { IPathService } from '../../services/path/common/pathService.js';
 
 // OutputLinesProps interface.
 export interface OutputLinesProps {
 	readonly openerService: IOpenerService;
 	readonly notificationService: INotificationService;
+	readonly environmentService: IWorkbenchEnvironmentService;
+	readonly pathService: IPathService;
 	readonly outputLines: readonly ANSIOutputLine[];
 }
 
@@ -34,9 +38,11 @@ export const OutputLines = (props: OutputLinesProps) => {
 			{props.outputLines.map(outputLine =>
 				<OutputLine
 					key={outputLine.id}
+					environmentService={props.environmentService}
 					notificationService={props.notificationService}
 					openerService={props.openerService}
 					outputLine={outputLine}
+					pathService={props.pathService}
 				/>
 			)}
 		</>

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
@@ -40,7 +40,7 @@ export interface OutputRunProps {
 }
 
 /**
- * ColorType enumeration.defaultUriAuthority
+ * ColorType enumeration.
  */
 enum ColorType {
 	Foreground,

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
@@ -18,7 +18,9 @@ import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { ANSIColor, ANSIOutputRun, ANSIStyle } from '../../../base/common/ansiOutput.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
 import { OutputRunWithLinks } from '../../contrib/positronConsole/browser/components/outputRunWithLinks.js';
-import * as DOM from '../../../base/browser/dom.js';
+import { toLocalResource } from '../../../base/common/resources.js';
+import { IPathService } from '../../services/path/common/pathService.js';
+import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 
 /**
  * Constants.
@@ -32,11 +34,13 @@ const fileURLWithLineAndColumn = /^(file:\/\/\/.+):(\d+):(\d+)$/;
 export interface OutputRunProps {
 	readonly openerService: IOpenerService;
 	readonly notificationService: INotificationService;
+	readonly pathService: IPathService;
+	readonly environmentService: IWorkbenchEnvironmentService;
 	readonly outputRun: ANSIOutputRun;
 }
 
 /**
- * ColorType enumeration.
+ * ColorType enumeration.defaultUriAuthority
  */
 enum ColorType {
 	Foreground,
@@ -89,10 +93,11 @@ export const OutputRun = (props: OutputRunProps) => {
 		// AFTER example:
 		// vscode-remote://localhost:8080/Users/jenny/rrr/positron-learning/testfun/DESCRIPTION
 		if (platform.isWeb) {
-			uri = uri.with({
-				scheme: Schemas.vscodeRemote,
-				authority: DOM.getActiveWindow().location.host
-			});
+			uri = toLocalResource(
+				uri,
+				props.environmentService.remoteAuthority,
+				props.pathService.defaultUriScheme
+			);
 			url = uri.toString();
 		}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -240,9 +240,11 @@ export const ActivityInput = (props: ActivityInputProps) => {
 						{outputLine.outputRuns.map(outputRun =>
 							<OutputRun
 								key={outputRun.id}
+								environmentService={positronConsoleContext.environmentService}
 								notificationService={positronConsoleContext.notificationService}
 								openerService={positronConsoleContext.openerService}
 								outputRun={outputRun}
+								pathService={positronConsoleContext.pathService}
 							/>
 						)}
 					</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -34,7 +34,7 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 	const inputRef = useRef<HTMLInputElement>(undefined!);
 
 	// Get services from the context.
-	const { openerService, notificationService, clipboardService } = usePositronConsoleContext();
+	const { openerService, notificationService, environmentService, pathService, clipboardService } = usePositronConsoleContext();
 
 	/**
 	 * Readies the input.
@@ -211,9 +211,11 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					outputLine.outputRuns.map(outputRun =>
 						<OutputRun
 							key={outputRun.id}
+							environmentService={environmentService}
 							notificationService={notificationService}
 							openerService={openerService}
 							outputRun={outputRun}
+							pathService={pathService}
 						/>
 					)
 				)}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleOutputLines.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleOutputLines.tsx
@@ -25,14 +25,16 @@ export interface ConsoleOutputLinesProps {
  */
 export const ConsoleOutputLines = (props: ConsoleOutputLinesProps) => {
 	// Get services from the context.
-	const { openerService, notificationService } = usePositronConsoleContext();
+	const { openerService, notificationService, environmentService, pathService } = usePositronConsoleContext();
 
 	// Render.
 	return (
 		<OutputLines
 			{...props}
+			environmentService={environmentService}
 			notificationService={notificationService}
 			openerService={openerService}
+			pathService={pathService}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
@@ -28,7 +28,7 @@ export interface RuntimePendingInputProps {
  */
 export const RuntimePendingInput = (props: RuntimePendingInputProps) => {
 	// Get services from the context.
-	const { openerService, notificationService } = usePositronConsoleContext();
+	const { openerService, notificationService, environmentService, pathService } = usePositronConsoleContext();
 
 	// Calculate the prompt width.
 	const promptWidth = Math.ceil(
@@ -47,9 +47,11 @@ export const RuntimePendingInput = (props: RuntimePendingInputProps) => {
 					{outputLine.outputRuns.map(outputRun =>
 						<OutputRun
 							key={outputRun.id}
+							environmentService={environmentService}
 							notificationService={notificationService}
 							openerService={openerService}
 							outputRun={outputRun}
+							pathService={pathService}
 						/>
 					)}
 				</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -27,6 +27,8 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron
@@ -37,6 +39,7 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly commandService: ICommandService;
 	readonly contextKeyService: IContextKeyService;
 	readonly editorService: IEditorService;
+	readonly environmentService: IWorkbenchEnvironmentService;
 	readonly executionHistoryService: IExecutionHistoryService;
 	readonly instantiationService: IInstantiationService;
 	readonly languageRuntimeService: ILanguageRuntimeService;
@@ -48,6 +51,7 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly modelService: IModelService;
 	readonly notificationService: INotificationService;
 	readonly openerService: IOpenerService;
+	readonly pathService: IPathService;
 	readonly positronConsoleService: IPositronConsoleService;
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly viewsService: IViewsService;

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -42,6 +42,8 @@ import { IPositronConsoleService } from '../../../services/positronConsole/brows
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 
 /**
  * PositronConsoleViewPane class.
@@ -220,6 +222,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		@IModelService private readonly modelService: IModelService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@IOpenerService openerService: IOpenerService,
+		@IPathService private readonly pathService: IPathService,
 		@IPositronConsoleService private readonly positronConsoleService: IPositronConsoleService,
 		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService,
 		@IRuntimeSessionService private readonly runtimeSessionService: IRuntimeSessionService,
@@ -227,6 +230,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
 		@IViewsService private readonly viewsService: IViewsService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super(
 			options,
@@ -286,6 +290,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				contextKeyService={this.contextKeyService}
 				contextMenuService={this.contextMenuService}
 				editorService={this.editorService}
+				environmentService={this.environmentService}
 				executionHistoryService={this.executionHistoryService}
 				hoverService={this.hoverService}
 				instantiationService={this.instantiationService}
@@ -297,6 +302,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				modelService={this.modelService}
 				notificationService={this.notificationService}
 				openerService={this.openerService}
+				pathService={this.pathService}
 				positronConsoleService={this.positronConsoleService}
 				positronPlotsService={this.positronPlotsService}
 				reactComponentContainer={this}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -59,6 +59,8 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { NotebookVisibilityProvider } from './NotebookVisibilityContext.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
 
 
 interface NotebookLayoutInfo {
@@ -129,6 +131,8 @@ export class PositronNotebookEditor extends EditorPane {
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+		@IPathService private readonly _pathService: IPathService,
 	) {
 		// Call the base class's constructor.
 		super(
@@ -478,6 +482,8 @@ export class PositronNotebookEditor extends EditorPane {
 						logService: this._logService,
 						openerService: this._openerService,
 						notificationService: this._notificationService,
+						environmentService: this._environmentService,
+						pathService: this._pathService,
 						sizeObservable: this._size,
 						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
 						editorService: this._editorService,

--- a/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -22,6 +22,8 @@ import { IWorkbenchLayoutService } from '../../../services/layout/browser/layout
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IWebviewService } from '../../webview/browser/webview.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
 
 /**
  * Bundle of services that are passed to React-Land in the form of context.
@@ -95,6 +97,15 @@ interface ServiceBundle {
 	 */
 	layoutService: IWorkbenchLayoutService;
 
+	/**
+	 * Service for retrieving workbench environment information
+	 */
+	environmentService: IWorkbenchEnvironmentService;
+
+	/**
+	 * Service for managing path-related operations
+	 */
+	pathService: IPathService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -88,24 +88,28 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 
 export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
-	const { openerService, notificationService, commandService } = useServices();
+	const { openerService, notificationService, commandService, environmentService, pathService } = useServices();
 	const { containerRef, truncation } = useLongOutputBehavior(content);
 
 	return <>
 		<div ref={containerRef} className={`notebook-${type} positron-notebook-text-output long-output-${truncation.mode}`}>
 			<OutputLines
+				environmentService={environmentService}
 				notificationService={notificationService}
 				openerService={openerService}
 				outputLines={ANSIOutput.processOutput(truncation.content)}
+				pathService={pathService}
 			/>
 			{
 				truncation.mode === 'truncate'
 					? <>
 						<TruncationMessage commandService={commandService} truncationResult={truncation} />
 						<OutputLines
+							environmentService={environmentService}
 							notificationService={notificationService}
 							openerService={openerService}
 							outputLines={ANSIOutput.processOutput(truncation.contentAfter)}
+							pathService={pathService}
 						/>
 					</>
 					: null

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -116,9 +116,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 	});
 
-	test('R - Verify file hyperlink', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7256' }],
-	}, async function ({ app, r }) {
+	test('R - Verify file hyperlink', async function ({ app, r }) {
 
 		await app.workbench.console.pasteCodeToConsole('library(cli)', true);
 		await app.workbench.console.pasteCodeToConsole('txt <- "Let\'s open a file {.file DESCRIPTION}"', true);

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -116,7 +116,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 	});
 
-	test.skip('R - Verify file hyperlink', {
+	test('R - Verify file hyperlink', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7256' }],
 	}, async function ({ app, r }) {
 
@@ -133,4 +133,3 @@ test.describe('Console Pane: R Hyperlinks', {
 	});
 
 });
-


### PR DESCRIPTION
Addresses #7256

File hyperlinks in the Console should now open the targetted file, in a web/workbench context.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- File hyperlinks in the R Console now open the relevant remote file when running on Workbench.

### QA Notes

@:web @:win @:console

The test that is being un-skipped here is a good manual test case. In an instance of Positron (Web), execute something like this:

``` r
library(cli)
cli_text("Let's open {.file DESCRIPTION:15:8}")
```

where `DESCRIPTION` is a path to a file that exists and the `:15` or `:15:8` part is an optional specification of line or line and column.