### PR TITLE
Fix typo in console service error message

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -567,7 +567,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 			} else {
 				// There is no registered runtime for the language, so we can't execute code.
 				throw new Error(
-					`Cannot execute code because no there is no registered runtime for the '${languageId}' language.`);
+					`Cannot execute code because there is no registered runtime for the '${languageId}' language.`);
 			}
 		}
 


### PR DESCRIPTION
Addresses #7589 in the sense that it fixes the grammar of the error message but _not_ in the sense that it solves the real problem; I still have not been able to reproduce that failure.


### Release Notes


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Also N/A
