### PR TITLE
Reenable the `jupyter.interactiveWindow.cellMarker.default` setting

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -29,7 +29,8 @@ const IGNORED_JUPYTER_CONFIGURATION_PROPERTIES = new Set([
 	'jupyter.enableCellCodeLens',
 	'jupyter.interactiveWindow.cellMarker.codeRegex',
 	'jupyter.interactiveWindow.cellMarker.decorateCells',
-	'jupyter.interactiveWindow.cellMarker.default',
+	// The cell marker setting is needed for properly exporting notebooks to other formats (see #3903.)
+	// 'jupyter.interactiveWindow.cellMarker.default',
 	'jupyter.interactiveWindow.cellMarker.markdownRegex',
 	'jupyter.interactiveWindow.codeLens.commands',
 	'jupyter.interactiveWindow.codeLens.enable',


### PR DESCRIPTION
Addresses #3903 

In the past we had needed to remove a few jupyter settings from positron to avoid messing with positron's internals and how they interacted with the `vscode-jupyter` extension.  

The removing of these settings sometimes had unintended consequences, such as in #3903 where the fact we were removing the `jupyter.interactiveWindow.cellMarker.default` setting meant that when jupyter went to export a notebook to a python script, there was no commenting out of markdown cells (due to the default value falling back to an empty string rather than `"# %%"`.)

This PR simply re-enables the cell marker default setting so that exporting can go as planned. 

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Jupyter notebooks exported to python files now properly escape markdown cells.


### QA Notes

It's hard to be sure that all of these settings don't have adverse effects anymore. Hopefully our test suite will detect if they do. 