### PR TITLE
Add support for github refs when downloading Ark

### DIFF
--- a/.github/workflows/prevent-repo-references.yml
+++ b/.github/workflows/prevent-repo-references.yml
@@ -2,11 +2,11 @@ name: Prevent GitHub Repo References in Package.json
 
 on:
   pull_request:
-    branches: [main, release/*]
+    branches: [main, release/*, prerelease/*]
     paths:
       - "extensions/positron-r/package.json"
   push:
-    branches: [main, release/*]
+    branches: [main, release/*, prerelease/*]
     paths:
       - "extensions/positron-r/package.json"
 

--- a/.github/workflows/prevent-repo-references.yml
+++ b/.github/workflows/prevent-repo-references.yml
@@ -1,0 +1,35 @@
+name: Prevent GitHub Repo References in Package.json
+
+on:
+  pull_request:
+    branches: [main, release/*]
+    paths:
+      - "extensions/positron-r/package.json"
+  push:
+    branches: [main, release/*]
+    paths:
+      - "extensions/positron-r/package.json"
+
+jobs:
+  check-repo-references:
+    name: Check for GitHub Repo References in Ark Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for repo references in package.json
+        run: |
+          echo "Checking for GitHub repo references in package.json"
+
+          # Extract the Ark version from package.json using jq
+          ARK_VERSION=$(jq -r '.positron.binaryDependencies.ark // empty' extensions/positron-r/package.json)
+
+          # Check if the extracted version follows the GitHub reference pattern
+          if [[ "$ARK_VERSION" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@[a-zA-Z0-9._\/-]+ ]] then
+            echo "::error::GitHub repo reference found in extensions/positron-r/package.json: $ARK_VERSION"
+            echo "GitHub repo references (org/repo@revision format) are only for development and should not be used in main or release branches."
+            exit 1
+          else
+            echo "No GitHub repo references found in extensions/positron-r/package.json"
+          fi

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -966,7 +966,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.201"
+      "ark": "posit-dev/ark@0.1.201"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -966,7 +966,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "posit-dev/ark@0.1.201"
+      "ark": "0.1.201"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/scripts/README.md
+++ b/extensions/positron-r/scripts/README.md
@@ -1,0 +1,68 @@
+# Positron R Extension Scripts
+
+## `install-kernel.ts`
+
+This script handles downloading and installing the Ark R kernel, which is used by the Positron R extension to execute R code.
+
+
+### Installation Methods
+
+#### Release Mode (Production Use)
+
+- Downloads pre-built binaries from GitHub releases
+- Uses a semantic version number like `"0.1.182"`
+- Example in package.json:
+  ```json
+  "positron": {
+    "binaryDependencies": {
+      "ark": "0.1.182"
+    }
+  }
+  ```
+
+
+#### Local development mode
+
+For kernel developers working directly on the Ark kernel, the script will check for locally built versions in a sibling `ark` directory before attempting to download or build from source.
+
+Note that this has precedence over downloading Ark based on the version specified in `package.json` (both release and github references).
+
+
+#### CI development Mode
+
+- Clones and builds the Ark kernel from source using a GitHub repositoryreference
+- Uses the format `"org/repo@branch_or_revision"`
+- Examples in package.json:
+  ```json
+  "positron": {
+    "binaryDependencies": {
+      "ark": "posit-dev/ark@main"                  // Use the main branch
+      "ark": "posit-dev/ark@experimental-feature"  // Use a feature branch
+      "ark": "posit-dev/ark@a1b2c3d"               // Use a specific commit
+      "ark": "posit-dev/ark@v0.1.183"              // Use a specific tag
+    }
+  }
+  ```
+
+The repository reference format (`org/repo@branch_or_revision`) should only be used during development and never be merged into main or release branches. A GitHub Action (`prevent-repo-references.yml`) enforces this restriction by checking pull requests to main and release branches for this pattern.
+
+
+### Authentication
+
+When accessing GitHub repositories or releases, the script attempts to find a GitHub Personal Access Token (PAT) in the following order:
+
+1. The `GITHUB_PAT` environment variable
+2. The `POSITRON_GITHUB_PAT` environment variable
+3. The git config setting `credential.https://api.github.com.token`
+
+Providing a PAT is recommended to avoid rate limiting and to access private repositories.
+
+
+## `compile-syntax.ts`
+
+This script compiles TextMate grammar files for syntax highlighting.
+
+
+## `post-install.ts`
+
+This script performs additional setup steps after the extension is installed.


### PR DESCRIPTION
Written with the help of Claude as agent.

Adds support for specifying Ark versions as github refs in `package.json`:

```ts
  "positron": {
    "binaryDependencies": {
      "ark": "posit-dev/ark@main"                  // Use the main branch
      "ark": "posit-dev/ark@experimental-feature"  // Use a feature branch
      "ark": "posit-dev/ark@a1b2c3d"               // Use a specific commit
      "ark": "posit-dev/ark@v0.1.183"              // Use a specific tag
    }
  }
```

The github revision is downloaded, built, and installed.

This allows CI-testing a branch in the Positron repo against a branch in the Ark repo without having to release Ark first. Releasing just for the purpose of testing is really not ideal as the feature might not be working well yet and other developers might need to do further Ark releases to make progress with their own work.

To prevent committing a dev ref that might have been forgotten in the `package.json` file, a github action watches changes to this file and checks that a release version is used. 

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
