### PR TITLE
Fix inline chat size

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -165,7 +165,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private readonly welcomePart: MutableDisposable<ChatViewWelcomePart> = this._register(new MutableDisposable());
 
 	// --- Start Positron ---
-	private actionBarContainer!: ChatActionBarControl;
+	private actionBarContainer?: ChatActionBarControl;
 	// --- End Positron ---
 
 	private bodyDimension: dom.Dimension | undefined;
@@ -523,9 +523,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.onDidStyleChange();
 
 		// --- Start Positron ---
-		this.actionBarContainer = this._register(this.instantiationService.createInstance(ChatActionBarControl, this.inputPart));
-		this.actionBarContainer.render(this.container);
-		this.actionBarContainer.onProviderSelected((provider) => this.inputPart.currentProvider = provider);
+		if (this.location === ChatAgentLocation.Panel) {
+			this.actionBarContainer = this._register(this.instantiationService.createInstance(ChatActionBarControl, this.inputPart));
+			this.actionBarContainer.render(this.container);
+			this.actionBarContainer.onProviderSelected((provider) => this.inputPart.currentProvider = provider);
+		}
 		// --- End Positron ---
 
 		// Do initial render
@@ -1295,7 +1297,7 @@ Always verify results. AI assistants can sometimes produce incorrect code.`);
 
 	layout(height: number, width: number): void {
 		// --- Start Positron ---
-		const actionBarHeight = this.actionBarContainer.height;
+		const actionBarHeight = this.actionBarContainer?.height ?? 0;
 		// --- End Positron ---
 		width = Math.min(width, 850);
 		this.bodyDimension = new dom.Dimension(width, height);

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -27,6 +27,7 @@ const APIKEY_RADIO = '.language-model-authentication-method-container input#apiK
 const CHAT_INPUT = '.chat-editor-container .interactive-input-editor textarea.inputarea';
 const SEND_MESSAGE_BUTTON = '.action-container .action-label.codicon-send[aria-label="Send and Dispatch (Enter)"]';
 const NEW_CHAT_BUTTON = '.composite.title .actions-container[aria-label="Chat actions"] .action-item .action-label.codicon-plus[aria-label="New Chat (Ctrl+L)"]';
+const INLINE_CHAT_TOOLBAR = '.interactive-input-part.compact .chat-input-toolbars';
 /*
  *  Reuseable Positron Assistant functionality for tests to leverage.
  */
@@ -64,6 +65,11 @@ export class Assistant {
 	async verifyAddModelButtonVisible() {
 		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toBeVisible();
 		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toHaveText('Add Language Model');
+	}
+
+	async verifyInlineChatInputsVisible() {
+		await expect(this.code.driver.page.locator(INLINE_CHAT_TOOLBAR)).toBeVisible();
+		await expect(this.code.driver.page.locator(INLINE_CHAT_TOOLBAR)).toBeInViewport({ ratio: 1 });
 	}
 
 	async selectModelProvider(provider: string) {

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -81,8 +81,10 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickDoneButton();
 		await openFile(join('workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 		await app.workbench.editor.clickOnTerm('chinook-sqlite.py', 'data_file_path', 4);
-		await app.code.driver.page.keyboard.press('Control+I');
+		const inlineChatShortcut = process.platform === 'darwin' ? 'Meta+I' : 'Control+I';
+		await app.code.driver.page.keyboard.press(inlineChatShortcut);
 		await app.code.driver.page.locator('.chat-widget > .interactive-session').isVisible();
+		await app.workbench.assistant.verifyInlineChatInputsVisible();
 		await app.workbench.quickaccess.runCommand('positron-assistant.addModelConfiguration');
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignOutButton();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #7468 

Removes the model provider selector from inline chat. This was inadvertently added since the `ChatWidget` is used for inline chat and the chat view.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
Added to the e2e test that checks whether the chat input actions are fully visible in the inline chat.


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
