### PR TITLE
Make the letters n and p work while searching history

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -345,6 +345,15 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 	const navigateHistoryDown = (e: IKeyboardEvent) => {
 
+		// If the history browser is up, update the selected index.
+		if (historyBrowserActiveRef.current) {
+			setHistoryBrowserSelectedIndex(Math.min(
+				historyItemsRef.current.length - 1,
+				historyBrowserSelectedIndexRef.current + 1));
+			consumeKbdEvent(e);
+			return;
+		}
+
 		// Get the position and text model. If it's on the last line, allow forward history
 		// navigation.
 		const position = codeEditorWidgetRef.current.getPosition();
@@ -520,9 +529,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
 						consumeEvent();
 						navigateHistoryUp(e);
-						break;
 					}
 				}
+				break;
 			}
 
 			case KeyCode.KeyN: {
@@ -532,9 +541,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
 						consumeEvent();
 						navigateHistoryDown(e);
-						break;
 					}
 				}
+				break;
 			}
 
 			// Tab processing.
@@ -569,18 +578,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 			// Down arrow processing.
 			case KeyCode.DownArrow: {
-
-				// If the history browser is up, update the selected index.
-				if (historyBrowserActiveRef.current) {
-					setHistoryBrowserSelectedIndex(Math.min(
-						historyItemsRef.current.length - 1,
-						historyBrowserSelectedIndexRef.current + 1));
-					consumeEvent();
-					break;
-				} else {
-					navigateHistoryDown(e);
-				}
-
+				navigateHistoryDown(e);
 				break;
 			}
 


### PR DESCRIPTION
Quick change to make <kbd>n</kbd> and <kbd>p</kbd> work correctly when searching history entries in the Console.

Addresses https://github.com/posit-dev/positron/issues/7619

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- Fix issue causing N and P keys to cancel history search in the Console (#7619)


### QA Notes

- The Ctrl+N and Ctrl+P keybindings are only applied on macOS
- Now Ctrl+N and Ctrl+P should behave like Up and Down -- that is, they should navigate the history search popup if it is visible, and the the console history if it is not

Test tags: `@:console`