### PR TITLE
python: fix bug where all packages are considered protected

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -183,7 +183,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         const protectedPackages = (this._ipykernelBundle.paths ?? [])
             .flatMap((path) => fs.readdirSync(path).map((name) => ({ parent: path, name })))
             .filter(({ name }) => code.includes(name));
-        if (protectedPackages.length === 0) {
+        if (protectedPackages.length === 0 || !protectedPackages) {
             return false;
         }
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -183,7 +183,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         const protectedPackages = (this._ipykernelBundle.paths ?? [])
             .flatMap((path) => fs.readdirSync(path).map((name) => ({ parent: path, name })))
             .filter(({ name }) => code.includes(name));
-        if (!protectedPackages) {
+        if (protectedPackages.length === 0) {
             return false;
         }
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -183,7 +183,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         const protectedPackages = (this._ipykernelBundle.paths ?? [])
             .flatMap((path) => fs.readdirSync(path).map((name) => ({ parent: path, name })))
             .filter(({ name }) => code.includes(name));
-        if (protectedPackages.length === 0 || !protectedPackages) {
+        if (protectedPackages.length === 0) {
             return false;
         }
 

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -11,6 +11,7 @@ import { interfaces } from 'inversify';
 import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
+import * as fs from '../../client/common/platform/fs-paths';
 import { ILanguageServerOutputChannel } from '../../client/activation/types';
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import {
@@ -231,8 +232,13 @@ suite('Python Runtime Session', () => {
     });
 
     test('Execute: dont uninstall bundled packages', async () => {
-        // Start a console session.
-        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        // Mock ipykernelBundle to include fake paths and simulate fs functionality.
+        const _ipykernelBundle: IpykernelBundle = {
+            paths: ['/path/to/ipykernel'],
+        };
+        sinon.stub(fs, 'readdirSync').returns(['ipykernel']);
+
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console, _ipykernelBundle);
         await session.start();
 
         // Spy on the kernel execute method.


### PR DESCRIPTION
`protectedPackages` is always an array, but will return length zero if it is not a protected package

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #7576 Fixes bug where packages can't be uninstalled in the console


### QA Notes

- try `pip uninstall xyz` in console, should give a "can't uninstall because no package is installed" sort of error
- try `pip uninstall ipykernel` in console, should tell you to uninstall in the Terminal
