### PR TITLE
Better naming for Execute tool

### DIFF
--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -144,7 +144,7 @@ export function registerAssistantTools(
 
 				/// The message shown to confirm that the user wants to run the code.
 				confirmationMessages: {
-					title: vscode.l10n.t('Run Code'),
+					title: vscode.l10n.t('Run in Console'),
 					message: ''
 				},
 			};

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -144,7 +144,7 @@ export function registerAssistantTools(
 
 				/// The message shown to confirm that the user wants to run the code.
 				confirmationMessages: {
-					title: vscode.l10n.t('Execute Code'),
+					title: vscode.l10n.t('Run Code'),
 					message: ''
 				},
 			};

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -332,7 +332,11 @@ class ChatToolInvocationSubPart extends Disposable {
 		}
 		const title = toolInvocation.confirmationMessages.title;
 		const message = toolInvocation.confirmationMessages.message;
-		const continueLabel = localize('continue', "Continue");
+		// --- Start Positron ---
+		// Show a clearer message for code to be executed in the Console
+		// const continueLabel = localize('continue', "Continue");
+		const continueLabel = localize('runInConsole', "Run in Console");
+		// --- End Positron ---
 		const continueKeybinding = this.keybindingService.lookupKeybinding(AcceptToolConfirmationActionId)?.getLabel();
 		const continueTooltip = continueKeybinding ? `${continueLabel} (${continueKeybinding})` : continueLabel;
 		const cancelLabel = localize('cancel', "Cancel");

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -335,7 +335,7 @@ class ChatToolInvocationSubPart extends Disposable {
 		// --- Start Positron ---
 		// Show a clearer message for code to be executed in the Console
 		// const continueLabel = localize('continue', "Continue");
-		const continueLabel = localize('runInConsole', "Run in Console");
+		const continueLabel = localize('runInConsole', "Run Code");
 		// --- End Positron ---
 		const continueKeybinding = this.keybindingService.lookupKeybinding(AcceptToolConfirmationActionId)?.getLabel();
 		const continueTooltip = continueKeybinding ? `${continueLabel} (${continueKeybinding})` : continueLabel;


### PR DESCRIPTION
Changes some wording on the Execute Code tool to make it clearer, based on user feedback that `Continue` doesn't make it clear what's going to happen next.

<img width="403" alt="image" src="https://github.com/user-attachments/assets/4c669f0d-5562-43dc-9512-c7b29858bc56" />

Addresses #7636.

Test tags: `@:assistant`