### PR TITLE
E2E test: re-enable R plot baseline comparison

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -292,17 +292,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('R - Verify basic plot functionality', {
-			tag: [tags.CRITICAL, tags.WEB, tags.WIN],
-			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5954 (see comment)' }]
-		}, async function ({ app, logger, headless }) {
+			tag: [tags.CRITICAL, tags.WEB, tags.WIN]
+		}, async function ({ app, logger, headless }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('R', rBasicPlot);
 			await app.workbench.plots.waitForCurrentPlot();
 
-			// https://github.com/posit-dev/positron/issues/5954
-			// when the "Error rendering plot to `Auto' Size: RPC timeout... " message appears
-			// this comparison fails
-			/*
 			await app.workbench.popups.closeAllToasts();
 
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
@@ -313,7 +308,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 				masterScreenshotName: `autos-${process.platform}`,
 				testInfo
 			});
-			*/
 
 			if (!headless) {
 				await app.workbench.plots.copyCurrentPlotToClipboard();


### PR DESCRIPTION
Add baseline plot comparison back in for R.

Working under the assumption that https://github.com/posit-dev/positron/issues/7449 will result in less phantom error toasts.

### QA Notes

@:plots @:web @:win
