### PR TITLE
e2e: Flake fix for DuckDB data explorer tests on web

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -94,6 +94,8 @@ async function verifyDataIsPresent(app: Application) {
 async function verifyCanOpenAsPlaintext(app: Application, searchString: string | RegExp) {
 	await app.workbench.editorActionBar.clickButton('Open as Plain Text File');
 
+	// Check if the "Open Anyway" button is visible. This is needed on web only as it warns
+	// that the file is large and may take a while to open. This is due to a vs code behavior and file size limit.
 	const openAnyway = app.code.driver.page.getByText("Open Anyway");
 
 	if (await openAnyway.waitFor({ state: "visible", timeout: 3000 }).then(() => true).catch(() => false)) {

--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -97,6 +97,7 @@ async function verifyCanOpenAsPlaintext(app: Application, searchString: string |
 	const openAnyway = app.code.driver.page.getByText("Open Anyway");
 
 	if (await openAnyway.waitFor({ state: "visible", timeout: 3000 }).then(() => true).catch(() => false)) {
+		await app.code.wait(1000);
 		await openAnyway.click();
 	}
 


### PR DESCRIPTION
### Intent

Occasionally, this headless test fails on Web becuase it doesn't click the button to go ahead and open the csv file.  This warning only shows on web due to the file size limits hardcoded into VS Code.

### Approach

While not ideal, I just added a small wait before clicking the button if it's found. I coudn't find a better way.

### QA Notes
@:web @:duck-db
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
