### PR TITLE
Fix reh builds to not mangle when minified is false

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -42,6 +42,7 @@ const commit = getVersion(REPO_ROOT);
 const BUILD_ROOT = path.dirname(REPO_ROOT);
 const REMOTE_FOLDER = path.join(REPO_ROOT, 'remote');
 // --- Start Positron ---
+const { compileBuildWithoutManglingTask } = require('./gulpfile.compile');
 const REMOTE_REH_WEB_FOLDER = path.join(REPO_ROOT, 'remote', 'reh-web');
 // --- End Positron ---
 
@@ -557,7 +558,11 @@ function tweakProductForServerWeb(product) {
 			gulp.task(serverTaskCI);
 
 			const serverTask = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}`, task.series(
-				compileBuildWithManglingTask,
+				// --- Start Positron ---
+				// Only mangle when minified is true. This matches the behavior of gulpfile.vscode:628.
+				// minified ? compileBuildWithManglingTask,
+				minified ? compileBuildWithManglingTask : compileBuildWithoutManglingTask,
+				// --- End Positron ---
 				cleanExtensionsBuildTask,
 				compileNonNativeExtensionsBuildTask,
 				compileExtensionMediaBuildTask,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
     "precommit": "node build/hygiene.js",
     "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
-    "big-gulp": "DISABLE_MANGLE=true node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
     "electron": "node build/lib/electron",
     "7z": "7z",
     "update-grammars": "node build/npm/update-all-grammars.mjs",


### PR DESCRIPTION
## Description

This PR updates `gulpfile.reh.js` to match `gulpfile.vscode.js` so that only minified builds get mangled, saving ~10 minutes when building `reh` builds locally.

It also removes the `big-gulp` workaround from `package.json` as it is no longer needed.

You can test this using:

```
npm run gulp vscode-reh-web-linux-arm64
```

or

```
npm run gulp vscode-reh-linux-arm64
```

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A