### PR TITLE
E2E test: capture server startup logs to console for debugging

### DIFF
--- a/test/e2e/infra/playwrightBrowser.ts
+++ b/test/e2e/infra/playwrightBrowser.ts
@@ -54,8 +54,8 @@ async function launchServer(options: LaunchOptions) {
 		const args = getServerArgs(currentPort, extensionsPath, agentFolder, serverLogsPath, options.verbose);
 		const serverLocation = resolveServerLocation(codeServerPath, logger);
 
-		logger.log(`Attempting to start server on port ${currentPort}`);
-		logger.log(`Command: '${serverLocation}' ${args.join(' ')}`);
+		console.log(`Attempting to start server on port ${currentPort}`);
+		console.log(`Command: '${serverLocation}' ${args.join(' ')}`);
 
 		try {
 			serverProcess = await startServer(serverLocation, args, env, logger);
@@ -209,7 +209,7 @@ function waitForEndpoint(server: ChildProcess, logger: Logger): Promise<string> 
 
 		server.stdout?.on('data', data => {
 			if (!endpointFound) {
-				logger.log(`[server] stdout: ${data}`); // log until endpoint found to diagnose issues
+				console.log(`[server] stdout: ${data}`); // log until endpoint found to diagnose issues
 			}
 
 			const matches = data.toString('ascii').match(/Web UI available at (.+)/);
@@ -222,7 +222,7 @@ function waitForEndpoint(server: ChildProcess, logger: Logger): Promise<string> 
 
 		server.stderr?.on('data', error => {
 			if (!endpointFound) {
-				logger.log(`[server] stderr: ${error}`); // log until endpoint found to diagnose issues
+				console.log(`[server] stderr: ${error}`); // log until endpoint found to diagnose issues
 			}
 
 			if (error.toString().indexOf('EADDRINUSE') !== -1) {


### PR DESCRIPTION
Log a handful of server startup messages to the console to help in debugging occasional errors with web runs.

### QA Notes

@:web
