### PR TITLE
viewer: add action bar for console output

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './actionBars.css';
+
+// React.
+import React, { PropsWithChildren, useEffect, useState } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
+import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { kPaddingLeft, kPaddingRight, PreviewActionBarsProps } from './actionBars.js';
+import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
+import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { PreviewWebview } from '../previewWebview.js';
+
+const clear = localize('positron.preview.html.clear', "Clear the content");
+
+/**
+ * HtmlActionBarsProps interface.
+ */
+export interface BasicActionBarsProps extends PreviewActionBarsProps {
+
+	// The active preview.
+	readonly preview: PreviewWebview;
+}
+
+export const BasicActionBars = (props: PropsWithChildren<BasicActionBarsProps>) => {
+
+	const [title, setTitle] = useState(`${props.preview.name} output`);
+
+	// Handler for the clear button.
+	const clearHandler = () => {
+		props.positronPreviewService.clearAllPreviews();
+	};
+
+	// Main use effect.
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+		disposableStore.add(props.preview.webview.onDidLoad((title) => {
+			if (title) {
+				setTitle(title);
+			}
+		}));
+		return () => disposableStore.dispose();
+	}, [props.preview.webview]);
+
+	// Render.
+	return (
+		<PositronActionBarContextProvider {...props}>
+			<div className='action-bars preview-action-bar'>
+				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+					<ActionBarRegion location='left'>
+						<span className='codicon codicon-file'></span>
+					</ActionBarRegion>
+					<ActionBarRegion location='center'>
+						<span className='preview-title'>{title}</span>
+					</ActionBarRegion>
+					<ActionBarRegion location='right'>
+						<ActionBarButton
+							align='right'
+							ariaLabel={clear}
+							icon={ThemeIcon.fromId('clear-all')}
+							tooltip={clear}
+							onPressed={clearHandler} />
+					</ActionBarRegion>
+				</PositronActionBar>
+			</div>
+		</PositronActionBarContextProvider>
+	);
+};

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
@@ -33,6 +33,7 @@ import { PreviewHtml } from './previewHtml.js';
 import { HtmlActionBars } from './components/htmlActionBars.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { BasicActionBars } from './components/basicActionBars.js';
 
 /**
  * PositronPreviewProps interface.
@@ -106,7 +107,10 @@ export const PositronPreview = (props: PropsWithChildren<PositronPreviewProps>) 
 
 	const urlToolbar = activePreview && activePreview instanceof PreviewUrl;
 	const htmlToolbar = activePreview && activePreview instanceof PreviewHtml;
-	const showToolbar = urlToolbar || htmlToolbar;
+	const basicToolbar =
+		activePreview && activePreview.viewType === 'notebookRenderer';
+	const showToolbar = urlToolbar || htmlToolbar || basicToolbar;
+
 	// Render.
 	return (
 		<PositronPreviewContextProvider {...props}>
@@ -119,6 +123,9 @@ export const PositronPreview = (props: PropsWithChildren<PositronPreviewProps>) 
 			}
 			{htmlToolbar &&
 				<HtmlActionBars key={activePreview.previewId} preview={activePreview} {...props} />
+			}
+			{basicToolbar &&
+				<BasicActionBars key={activePreview.previewId} preview={activePreview} {...props} />
 			}
 			<PreviewContainer
 				height={height - (showToolbar ? 32 : 0)}


### PR DESCRIPTION
Creates a new toolbar for notebook/console output with a button to clear content.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #4601 Adds a toolbar for console output in viewer to enable clearing.

#### Bug Fixes

- N/A


### QA Notes

```
pip install great-tables polars
```

```python
from great_tables import GT
from great_tables.data import islands

islands_mini = islands.head(10)
GT(islands_mini)
```