### PR TITLE
e2e: Another fix for headless tests flake on web

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -53,11 +53,7 @@ test.describe('Headless Data Explorer', {
 	plainTextTestCases.forEach(({ name, file, searchString }) => {
 		test(`Verify can open ${name} file as plaintext`,
 			{ tag: [TestTags.EDITOR_ACTION_BAR] }, async function ({ app, openDataFile }) {
-				if (process.env.WEB && file === 'flights.csv') {
-					await openDataFile(join(`data-files/flights/small_file.csv`));
-				} else {
-					await openDataFile(join(`data-files/flights/${file}`));
-				}
+				await openDataFile(join(`data-files/flights/${file}`));
 				await verifyPlainTextButtonInActionBar(app, true);
 				await verifyCanOpenAsPlaintext(app, searchString);
 			});
@@ -102,8 +98,7 @@ async function verifyCanOpenAsPlaintext(app: Application, searchString: string |
 	// that the file is large and may take a while to open. This is due to a vs code behavior and file size limit.
 	const openAnyway = app.code.driver.page.getByText("Open Anyway");
 
-	if (await openAnyway.waitFor({ state: "visible", timeout: 3000 }).then(() => true).catch(() => false)) {
-		await app.code.wait(1000);
+	if (await openAnyway.waitFor({ state: "visible", timeout: 5000 }).then(() => true).catch(() => false)) {
 		await openAnyway.click();
 	}
 

--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -53,7 +53,11 @@ test.describe('Headless Data Explorer', {
 	plainTextTestCases.forEach(({ name, file, searchString }) => {
 		test(`Verify can open ${name} file as plaintext`,
 			{ tag: [TestTags.EDITOR_ACTION_BAR] }, async function ({ app, openDataFile }) {
-				await openDataFile(join(`data-files/flights/${file}`));
+				if (process.env.WEB && file === 'flights.csv') {
+					await openDataFile(join(`data-files/flights/small_file.csv`));
+				} else {
+					await openDataFile(join(`data-files/flights/${file}`));
+				}
 				await verifyPlainTextButtonInActionBar(app, true);
 				await verifyCanOpenAsPlaintext(app, searchString);
 			});


### PR DESCRIPTION
Needed to bump the timout for the file to be opened. It was at 3 seconds.. I saw it take over 4 to open.

### QA Notes
@:web @:duck-db
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
