### PR TITLE
Remove the `EditorActionsCenter` (`editor/actions/center`) extension point

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -78,7 +78,6 @@ export class MenuId {
 	static readonly EditorContextShare = new MenuId('EditorContextShare');
 	// --- Start Positron ---
 	static readonly EditorActionsLeft = new MenuId('EditorActionsLeft');
-	static readonly EditorActionsCenter = new MenuId('EditorActionsCenter');
 	static readonly EditorActionsRight = new MenuId('EditorActionsRight');
 	// --- End Positron ---
 	static readonly EditorTitle = new MenuId('EditorTitle');

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
@@ -38,3 +38,7 @@
 	font-size: 12px !important;
 	color: var(--positronActionBar-foreground);
 }
+
+.action-bar-checkbox .checkbox-label {
+	white-space: nowrap;
+}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
@@ -65,7 +65,7 @@ export const ActionBarCheckbox = forwardRef<
 			<button ref={buttonRef} aria-checked={checked} className='checkbox-button' id={id} role='checkbox' tabIndex={0} onClick={clickHandler}>
 				{checked && <div className='check-indicator codicon codicon-check' />}
 			</button>
-			<label htmlFor={id}>{props.label}</label>
+			<label className='checkbox-label' htmlFor={id}>{props.label}</label>
 		</div>
 	);
 });

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -129,7 +129,6 @@ export class EditorActionBarFactory extends Disposable {
 		 */
 		const createMenus = () => {
 			this.createMenu(MenuId.EditorActionsLeft);
-			this.createMenu(MenuId.EditorActionsCenter);
 			this.createMenu(MenuId.EditorActionsRight);
 			this.createMenu(MenuId.EditorTitle);
 		};
@@ -164,13 +163,6 @@ export class EditorActionBarFactory extends Disposable {
 		const leftActionBarElements = this.buildActionBarElements(
 			processedActions,
 			MenuId.EditorActionsLeft,
-			false
-		);
-
-		// Build the center action bar elements from the editor actions center menu.
-		const centerActionBarElements = this.buildActionBarElements(
-			processedActions,
-			MenuId.EditorActionsCenter,
 			false
 		);
 
@@ -215,11 +207,6 @@ export class EditorActionBarFactory extends Disposable {
 				{leftActionBarElements.length > 0 &&
 					<ActionBarRegion location='left'>
 						{leftActionBarElements}
-					</ActionBarRegion>
-				}
-				{centerActionBarElements.length > 0 &&
-					<ActionBarRegion location='center'>
-						{centerActionBarElements}
 					</ActionBarRegion>
 				}
 				{rightActionBarElements.length > 0 &&

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -75,11 +75,6 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('menus.editorActionsLeft', "The editor actions left menu")
 	},
 	{
-		key: 'editor/actions/center',
-		id: MenuId.EditorActionsCenter,
-		description: localize('menus.editorActionsCenter', "The editor actions center menu")
-	},
-	{
 		key: 'editor/actions/right',
 		id: MenuId.EditorActionsRight,
 		description: localize('menus.editorActionsRight', "The editor actions right menu")


### PR DESCRIPTION
## Description

This PR removes the `EditorActionsCenter` (`editor/actions/center`) extension point. It is not shipping.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #7663 Remove the the `EditorActionsCenter` (`editor/actions/center`) extension point.

### QA Notes

- N/A