### PR TITLE
e2e: Removed electron dependency from `nativeMenu` fixture

### DIFF
--- a/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
@@ -47,7 +47,7 @@ export function registerContextMenuListener(): void {
 
 		menu.on('menu-will-show', () => {
 			contextMenus.set(contextMenuId, menu);
-			app.emit('e2e:contextMenuShown', contextMenuId, menu.items);
+			app.emit('e2e:contextMenuShown', contextMenuId, menu.items.map(item => item.label));
 		});
 		menu.on('menu-will-close', () => {
 			contextMenus.delete(contextMenuId);

--- a/test/e2e/infra/nativeMenu.ts
+++ b/test/e2e/infra/nativeMenu.ts
@@ -3,10 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MenuItem } from 'electron';
 import { Code } from './code.js';
 import { Locator } from '@playwright/test';
-
 
 export class NativeMenu {
 
@@ -16,10 +14,10 @@ export class NativeMenu {
 
 	}
 
-	async showContextMenu(trigger: () => void): Promise<{ menuId: number; items: MenuItem[] } | undefined> {
-		const shownPromise: Promise<[number, MenuItem[]]> | undefined = this.code.electronApp?.evaluate(({ app }) => {
+	async showContextMenu(trigger: () => void): Promise<{ menuId: number; items: string[] } | undefined> {
+		const shownPromise: Promise<[number, string[]]> | undefined = this.code.electronApp?.evaluate(({ app }) => {
 			return new Promise((resolve) => {
-				const listener: any = (...args: [number, MenuItem[]]) => {
+				const listener: any = (...args: [number, string[]]) => {
 					app.removeListener('e2e:contextMenuShown' as any, listener);
 					resolve(args);
 				};
@@ -52,6 +50,9 @@ export class NativeMenu {
 		const menuItems = await this.showContextMenu(() => menuTrigger.click());
 
 		if (menuItems) {
+			if (!menuItems.items.includes(menuItemLabel)) {
+				throw new Error(`Context menu '${menuItemLabel}' not found. Available items: ${menuItems.items.join(', ')}`);
+			}
 			await this.selectContextMenuItem(menuItems.menuId, menuItemLabel);
 		} else {
 			throw new Error(`Context menu '${menuItemLabel}' did not appear or no menu items found.`);


### PR DESCRIPTION
Removes electron dependency from `nativeMenu` fixture to resolve nightly test failures.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #7687

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
