### PR TITLE
Unified chat view only

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -252,6 +252,9 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.unifiedChatView', "Enables the unified view with Ask, Edit, and Agent modes in one view."),
 			default: true,
 			tags: ['preview'],
+			// --- Start Positron ---
+			deprecationMessage: nls.localize('chat.unifiedChatView.deprecated', "This setting must always be enabled.")
+			// --- End Positron ---
 		},
 		[ChatConfiguration.UseFileStorage]: {
 			type: 'boolean',


### PR DESCRIPTION
Address #6961 

Deprecate unified chat view option so it is not visible in the settings. The settings won't show this preference anymore and will default to `true`.

The `Open in Copilot Edits` only exists but only in the non-unified views. I'm unsure what will happen in the future with the unified view. 1.100.0 changed the behaviour with the chat mode switcher where you cannot continue the conversation in the new mode. So that may be the expected behaviour going forward.

![image](https://github.com/user-attachments/assets/322a14c0-1b75-4da7-8d56-ba53d971b6b1)

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
`chat.unifiedChatView` can still toggle the unified chat view when added as a hidden preference. The old non-unified views will not be supported if unified chat is disabled in this case. Fresh installs will have unified chat enabled.

Unified chat was introduced in upstream 1.99.0 and is still changing but is expected to be the UI.