### PR TITLE
e2e test - Quarto Python test

### DIFF
--- a/test/e2e/tests/quarto/quarto-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-python.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+// This test group aims to verify basic functionalities of Quarto for Python users
+test.describe('Quarto - Python', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () => {
+
+	test('Verify Quarto app can render correctly with Python script', async function ({ app, openFile, python }, testInfo) {
+		// This test verifies basic rendering of report in PDF after user clicks 'Preview'
+		await openFile(join('workspaces', 'quarto_python', 'report.qmd'));
+		await app.code.driver.page.locator('.positron-action-bar').getByRole('button', { name: 'Preview' }).click();
+
+		const title = app.workbench.viewer.getViewerFrame().frameLocator('iframe').getByText('Example Report');
+
+		// Viewer tab is targeted by corresponding iframe. It is assumed that the report fully loads once title 'Example Report' appears
+		await expect(title).toBeVisible({ timeout: 30000 });
+
+	});
+});

--- a/test/e2e/tests/quarto/quarto-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-python.test.ts
@@ -15,14 +15,13 @@ test.use({
 test.describe('Quarto - Python', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () => {
 
 	test('Verify Quarto app can render correctly with Python script', async function ({ app, openFile, python }, testInfo) {
+
 		// This test verifies basic rendering of report in PDF after user clicks 'Preview'
 		await openFile(join('workspaces', 'quarto_python', 'report.qmd'));
 		await app.code.driver.page.locator('.positron-action-bar').getByRole('button', { name: 'Preview' }).click();
 
-		const title = app.workbench.viewer.getViewerFrame().frameLocator('iframe').getByText('Example Report');
-
 		// Viewer tab is targeted by corresponding iframe. It is assumed that the report fully loads once title 'Example Report' appears
+		const title = app.workbench.viewer.getViewerFrame().frameLocator('iframe').getByText('Example Report');
 		await expect(title).toBeVisible({ timeout: 30000 });
-
 	});
 });


### PR DESCRIPTION
- This test group (Quarto - Python) aims to verify basic functionalities of Quarto for Python users
- This test verifies basic rendering of report in PDF after user clicks 'Preview'
- Viewer tab is targeted by corresponding iframe. It is assumed that the report fully loads once title 'Example Report' appears

### QA Notes

@:quarto @:web @:win
