### PR TITLE
7285 in new jupyter projects the starting notebook doesnt connect to the runtime automatically

### DIFF
--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -626,9 +626,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			}
 
 			// Select kernel
-			if (!this._selectKernelForNotebook(model)) {
-				this._logService.error(`${this._nbLogPrefix} No suitable kernel found for notebook.`);
-			}
+			this._selectKernelForNotebook(model);
 		} catch (error) {
 			this._logService.error(`${this._nbLogPrefix} Error during post-init notebook setup: ${String(error)}`);
 			this._notificationService.error(localize('positronNewProjectService.postInitNotebookError', 'Error setting up notebook for new project: {0}', String(error)));
@@ -644,9 +642,8 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * If no suitable kernel is found, a user-facing error notification is shown, but the flow continues.
 	 *
 	 * @param notebookTextModel The notebook text model to select a kernel for
-	 * @returns True if kernel was successfully selected, false otherwise
 	 */
-	private _selectKernelForNotebook(notebookTextModel: INotebookTextModel): boolean {
+	private _selectKernelForNotebook(notebookTextModel: INotebookTextModel) {
 		const matchingKernels = this._notebookKernelService.getMatchingKernel(notebookTextModel);
 		const runtimePath: string | undefined = this._runtimeMetadata?.runtimePath;
 		const languageId = this._runtimeMetadata?.languageId;
@@ -679,12 +676,12 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			// Show a user-facing error toast, but do not break the flow
 			this._notificationService.error('No matching Jupyter kernel was found for the new environment. You will need to select a kernel manually in the notebook.');
 			this._logService.debug(`[New project startup] No suitable kernel found for notebook`);
-			return false;
+			return;
 		}
 
 		this._notebookKernelService.selectKernelForNotebook(kernelToSelect, notebookTextModel);
 		this._logService.debug(`[New project startup] Selected kernel ${kernelToSelect.id} for notebook`);
-		return true;
+		return;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -484,8 +484,8 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 
 				// Check if the newly created runtime metadata was returned
 				if (!result.metadata) {
-					// Warn the user, but don't exit early. We'll still try to continue since the
-					// environment creation was successful.
+					// Warn the user, but don't exit early. We'll still try to
+					// continue since the environment creation was successful.
 					const message = this._failedPythonEnvMessage(`Could not determine interpreter metadata returned from ${createEnvCommand} command. The interpreter may need to be selected manually.`);
 					this._logService.error(message);
 					this._notificationService.warn(message);

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -72,6 +72,38 @@ test.describe('Python - New Project Wizard', { tag: [tags.MODAL, tags.NEW_PROJEC
 		await verifyProjectCreation(app, projectTitle);
 		await verifyVenEnvStarts(app);
 	});
+
+	test('Python Notebook Project - connects notebook to runtime on startup', async function ({ app }) {
+		const projectTitle = `python-notebook-runtime-${Math.floor(Math.random() * 1000000)}`;
+
+		// Create a new Python notebook project
+		await app.workbench.newProjectWizard.createNewProject({
+			type: ProjectType.JUPYTER_NOTEBOOK,
+			title: projectTitle,
+			status: 'new',
+			pythonEnv: 'venv', // or 'conda' if that's your default
+		});
+
+		// Wait for the notebook editor to be visible
+		const notebookEditorTab = app.code.driver.page.getByText('Untitled-1.ipynb', { exact: true });
+		await expect(notebookEditorTab).toBeVisible();
+
+		// Get the Python version from the session selector button
+		const sessionSelectorButton = app.code.driver.page.getByRole('button', { name: 'Session Selector' });
+		const sessionSelectorText = await sessionSelectorButton.textContent();
+		// Extract the version number (e.g., '3.10.12') from the button text
+		const versionMatch = sessionSelectorText && sessionSelectorText.match(/Python ([0-9]+\.[0-9]+\.[0-9]+)/);
+		const pythonVersion = versionMatch ? versionMatch[1] : undefined;
+		// Fail the test if we can't extract the version
+		expect(pythonVersion, 'Python version should be present in session selector').toBeTruthy();
+
+		// After the runtime starts up the kernel status should be replaced with the kernel name.
+		// The kernel name should contain the Python version from the session selector
+		// Only look within an 'a' tag with class 'kernel-label' to avoid false positives
+		const kernelLabel = app.code.driver.page.locator('a.kernel-label');
+		await expect(kernelLabel).toContainText(`Python ${pythonVersion}`);
+		await expect(kernelLabel).toContainText('(Venv: .venv)');
+	});
 });
 
 // Helper functions

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -85,7 +85,7 @@ test.describe('Python - New Project Wizard', { tag: [tags.MODAL, tags.NEW_PROJEC
 		});
 
 		// Wait for the notebook editor to be visible
-		const notebookEditorTab = app.code.driver.page.getByText('Untitled-1.ipynb', { exact: true });
+		const notebookEditorTab = app.code.driver.page.locator('[id="workbench.parts.editor"]').getByText('Untitled-1.ipynb', { exact: true });
 		await expect(notebookEditorTab).toBeVisible();
 
 		// Get the Python version from the session selector button

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -102,7 +102,7 @@ test.describe('Python - New Project Wizard', { tag: [tags.MODAL, tags.NEW_PROJEC
 		// Only look within an 'a' tag with class 'kernel-label' to avoid false positives
 		const kernelLabel = app.code.driver.page.locator('a.kernel-label');
 		await expect(kernelLabel).toContainText(`Python ${pythonVersion}`);
-		await expect(kernelLabel).toContainText('(Venv: .venv)');
+		await expect(kernelLabel).toContainText('.venv');
 	});
 });
 


### PR DESCRIPTION
@:new-project-wizard

This PR fixes addresses #7285 where newly created Jupyter notebook projects didn't automatically connect to their runtime. 

When starting a new notebook project, users previously had to manually connect it to the runtime, which was confusing and unexpected. Now, the notebook automatically connects once the runtime becomes available.

The implementation uses a few key approaches:
1. Listens for runtime initialization and reacts when it's ready
2. Finds and connects the notebook to the appropriate runtime
3. Selects the best kernel based on the project's runtime
4. Cleans up event listeners once the connection is established

  ### Release Notes

  #### Bug Fixes

  - Fixed issue where new Jupyter notebook projects didn't automatically connect to their runtime

  ### QA Notes

  To test this change:
  1. Create a new Jupyter notebook project
  2. Verify the notebook automatically connects to the runtime after it has started up (no manual connection required)
  3. Confirm you can execute notebook cells without having to manually select a kernel
  4. This change affects the notebook project creation workflow, but shouldn't impact other project types