### PR TITLE
Fix background colour for Viewer pane

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
@@ -7,7 +7,7 @@
 	overflow: hidden;
 }
 
-.preview-container {
+.positron-preview-editor-container .preview-container {
 	/* A web page will have a transparent background by default and browsers commonly set a white background. */
 	/* This ensures consistency with light and dark themes where the webview content does not style the background. */
 	background: white;

--- a/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
@@ -6,3 +6,9 @@
 .preview-container iframe {
 	overflow: hidden;
 }
+
+.preview-container {
+	/* A web page will have a transparent background by default and browsers commonly set a white background. */
+	/* This ensures consistency with light and dark themes where the webview content does not style the background. */
+	background: white;
+}

--- a/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.css
@@ -6,9 +6,3 @@
 .preview-container iframe {
 	overflow: hidden;
 }
-
-.positron-preview-editor-container .preview-container {
-	/* A web page will have a transparent background by default and browsers commonly set a white background. */
-	/* This ensures consistency with light and dark themes where the webview content does not style the background. */
-	background: white;
-}

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.css
@@ -5,6 +5,9 @@
 
 .positron-preview-container {
 	position: relative;
+}
+
+.positron-preview-webview {
 	/*
 	 * A web page will have a transparent background by default and browsers commonly set a white background.
 	 * This ensures consistency with light and dark themes where the webview content does not style the background.

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.css
@@ -5,4 +5,9 @@
 
 .positron-preview-container {
 	position: relative;
+	/*
+	 * A web page will have a transparent background by default and browsers commonly set a white background.
+	 * This ensures consistency with light and dark themes where the webview content does not style the background.
+	 */
+	background: white;
 }

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -216,7 +216,8 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 			options: {
 				enableFindWidget: true,
 				retainContextWhenHidden: true,
-				externalUri: this.canPreviewExternalUri()
+				externalUri: this.canPreviewExternalUri(),
+				customClasses: 'positron-preview-webview',
 			},
 			contentOptions: {
 				allowScripts: true,


### PR DESCRIPTION
Address #3759 

Sets the background colour on the viewer. When a webview's content doesn't set the background colour on the `body` or `html` tags, the background becomes the theme's background colour. This didn't work well when the content assumes a light theme.

This forces the background to be white for these cases. If the content is a dark theme, it is assumed that it sets the background colour on the webview and will override the colour in the view. For other content that does not set a background, it becomes transparent and takes on the default white. Browsers commonly do this.

Preview in Viewer
![image](https://github.com/user-attachments/assets/afa92cd9-46cb-4d75-8222-329fd63736b0)

![image](https://github.com/user-attachments/assets/3da1572e-5d3a-4fa1-b1ef-4bfb7091ceb7)

Preview in editor
![image](https://github.com/user-attachments/assets/2ba6f51c-a237-43ec-92f7-160069c70d14)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix Viewer style in dark mode with content that does not set a background style #3759 


### QA Notes
Check the issue for code examples to reproduce the issue.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
