### PR TITLE
set model-specific `maxOutputTokens` so that larger text selections can be edited

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -9,11 +9,13 @@ import Anthropic from '@anthropic-ai/sdk';
 import { ModelConfig } from './config';
 import { isLanguageModelImagePart, LanguageModelImagePart } from './languageModelParts.js';
 import { hasNonEmptyContent, isChatImagePart } from './utils.js';
+import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 
 export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProvider {
 	name: string;
 	provider: string;
 	identifier: string;
+	maxOutputTokens: number;
 
 	capabilities = {
 		vision: true,
@@ -44,6 +46,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		this._client = new Anthropic({
 			apiKey: _config.apiKey,
 		});
+		this.maxOutputTokens = _config.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT;
 	}
 
 	async provideLanguageModelResponse(
@@ -61,8 +64,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		const tool_choice = options.toolMode && toAnthropicToolChoice(options.toolMode);
 		const stream = this._client.messages.stream({
 			model: this._config.model,
-			// TODO: How do we decide on default max tokens?
-			max_tokens: options.modelOptions?.maxTokens ?? 1024,
+			max_tokens: options.modelOptions?.maxTokens ?? this.maxOutputTokens,
 			messages: anthropicMessages,
 			tool_choice,
 			tools,

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -11,3 +11,6 @@ export const EXTENSION_ROOT_DIR = path.join(__dirname, '..');
 
 /** Selects all documents. */
 export const ALL_DOCUMENTS_SELECTOR: DocumentSelector = [{ scheme: '*' }];
+
+/** The default max token output if a model's maximum is unknown */
+export const DEFAULT_MAX_TOKEN_OUTPUT = 4_096;

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -12,7 +12,7 @@ import { registerParticipants } from './participants';
 import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { registerAssistantTools } from './tools.js';
 import { registerCopilotService } from './copilot.js';
-import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
+import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { registerCodeActionProvider } from './codeActions.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
@@ -131,6 +131,7 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 			modelsCopy.push({
 				name: modelConfig.name,
 				identifier: modelConfig.model,
+				maxOutputTokens: modelConfig.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT,
 			});
 		}
 
@@ -139,6 +140,7 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 				...modelConfig,
 				model: model.identifier,
 				name: model.name,
+				maxOutputTokens: model.maxOutputTokens,
 			};
 			const languageModel = newLanguageModel(newConfig);
 
@@ -150,7 +152,7 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 				version: context.extension.packageJSON.version,
 				capabilities: languageModel.capabilities,
 				maxInputTokens: 0,
-				maxOutputTokens: 0,
+				maxOutputTokens: languageModel.maxOutputTokens,
 				isUserSelectable: true,
 				isDefault: isDefault,
 			});

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -19,6 +19,7 @@ import { hasNonEmptyContent, toAIMessage } from './utils';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel } from './anthropic';
+import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 
 /**
  * Models used by chat participants and for vscode.lm.* API functionality.
@@ -29,6 +30,7 @@ class ErrorLanguageModel implements positron.ai.LanguageModelChatProvider {
 	readonly name = 'Error Language Model';
 	readonly provider = 'error';
 	readonly identifier = 'error-language-model';
+	readonly maxOutputTokens = DEFAULT_MAX_TOKEN_OUTPUT;
 	private readonly _message = 'This language model always throws an error message.';
 
 	static source = {
@@ -66,6 +68,7 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 	readonly name = 'Echo Language Model';
 	readonly provider = 'echo';
 	readonly identifier = 'echo-language-model';
+	readonly maxOutputTokens = DEFAULT_MAX_TOKEN_OUTPUT;
 
 	static source = {
 		type: positron.PositronLanguageModelType.Chat,
@@ -155,6 +158,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 	public readonly name;
 	public readonly provider;
 	public readonly identifier;
+	public readonly maxOutputTokens;
 	protected abstract model: ai.LanguageModelV1;
 
 	capabilities = {
@@ -167,6 +171,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		this.identifier = _config.id;
 		this.name = _config.name;
 		this.provider = _config.provider;
+		this.maxOutputTokens = _config.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT;
 	}
 
 	get providerName(): string {
@@ -234,6 +239,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			maxSteps: modelOptions.maxSteps ?? 50,
 			tools: this._config.toolCalls ? tools : undefined,
 			abortSignal: signal,
+			maxTokens: modelOptions.maxTokens ?? this.maxOutputTokens,
 		});
 
 		for await (const part of result.fullStream) {
@@ -600,44 +606,52 @@ class GoogleLanguageModel extends AILanguageModel implements positron.ai.Languag
 
 // Note: we don't query for available models using any provider API since it may return ones that are not
 // suitable for chat and we don't want the selection to be too large
-export const availableModels = new Map<string, { name: string; identifier: string }[]>(
+export const availableModels = new Map<string, { name: string; identifier: string; maxOutputTokens?: number }[]>(
 	[
 		['anthropic', [
 			{
 				name: 'Claude 3.7 Sonnet v1',
-				identifier: 'claude-3-7-sonnet-latest'
+				identifier: 'claude-3-7-sonnet-latest',
+				maxOutputTokens: 64_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 			{
 				name: 'Claude 3.5 Sonnet v2',
-				identifier: 'claude-3-5-sonnet-latest'
+				identifier: 'claude-3-5-sonnet-latest',
+				maxOutputTokens: 8_192, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 		]],
 		['google', [
 			{
 				name: 'Gemini 2.5 Flash',
 				identifier: 'gemini-2.5-pro-exp-03-25',
+				maxOutputTokens: 65_536, // reference: https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-preview
 			},
 			{
 				name: 'Gemini 2.0 Flash',
 				identifier: 'gemini-2.0-flash-exp',
+				maxOutputTokens: 8_192, // reference: https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash
 			},
 			{
 				name: 'Gemini 1.5 Flash 002',
 				identifier: 'gemini-1.5-flash-002',
+				maxOutputTokens: 8_192, // reference: https://ai.google.dev/gemini-api/docs/models#gemini-1.5-flash
 			},
 		]],
 		['bedrock', [
 			{
 				name: 'Claude 3.7 Sonnet v1 Bedrock',
 				identifier: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+				maxOutputTokens: 64_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 			{
 				name: 'Claude 3.5 Sonnet v2 Bedrock',
-				identifier: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0'
+				identifier: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+				maxOutputTokens: 8_192, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 			{
 				name: 'Claude 3.5 Sonnet v1 Bedrock',
 				identifier: 'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
+				maxOutputTokens: 8_192, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 		]]
 	]

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1780,7 +1780,8 @@ declare module 'positron' {
 			provider: string;
 			identifier: string;
 
-			get providerName(): string;
+			providerName: string;
+			maxOutputTokens: number;
 
 			readonly capabilities?: {
 				readonly vision?: boolean;
@@ -1883,6 +1884,7 @@ declare module 'positron' {
 			project?: string;
 			location?: string;
 			numCtx?: number;
+			maxOutputTokens?: number;
 		}
 
 		/**

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -71,6 +71,7 @@ export interface IPositronLanguageModelConfig {
 	project?: string;
 	location?: string;
 	numCtx?: number;
+	maxOutputTokens?: number;
 }
 
 //#endregion


### PR DESCRIPTION
### Summary

- addresses #7500 and maybe also #7675
- set a larger max output token limit for each model, based on the documented max output token limits for each model
- set the default limit to 4096 (only used for the Echo and Error test models at the moment), which is the max token output for Claude 3 Opus and Claude 3 Haiku (seemed like a reasonable default 🤷)
- note that it can take a long time to get suggested edits, but it does work now. We may need to do some form of paging of the content to achieve something a bit faster.

### Release Notes

#### Bug Fixes

- Positron Assistant: Increased the maximum token output to allow for edits to larger selections of text (#7500, #7675)

### QA Notes

@:assistant

The issue was consistently reproducible for me when using <kbd>Cmd+I</kbd> to invoke inline assistant edits, but only sometimes reproducible when using the Chat in both Ask and Edit modes.

Note that it is not the chat message that needs to be long, but the selection of text/code that should be quite long (2500+ characters seems to do the trick!).

1. Select 2500+ characters in a file
2. <kbd>Cmd+I</kbd> for inline assistant
3. Ask the assistant to modify all of the text in some way
4. It may take a moment, but should succeed and apply an edit. Previously, it would run and say it did something, but no edits would be provided.