### PR TITLE
Revamp how plots are named and saved

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -138,7 +138,7 @@ interface DirectoryState {
 
 const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 	const [directory, setDirectory] = React.useState<DirectoryState>({ value: props.suggestedPath ?? URI.file(''), valid: true });
-	const [name, setName] = React.useState({ value: 'plot', valid: true });
+	const [name, setName] = React.useState({ value: props.plotClient.metadata.suggested_file_name ?? 'plot', valid: true });
 	const [format, setFormat] = React.useState(PlotRenderFormat.Png);
 	const [enableIntrinsicSize, setEnableIntrinsicSize] = React.useState(props.enableIntrinsicSize);
 	const [width, setWidth] = React.useState({ value: props.plotSize?.width ?? 100, valid: true });

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -30,7 +30,7 @@ import { EditorPlotsContainer } from './editorPlotsContainer.js';
 import { PositronPlotsEditorInput } from './positronPlotsEditorInput.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { IPositronPlotClient, IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
+import { createSuggestedFileNameForPlot, IPositronPlotClient, IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 
@@ -109,7 +109,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
-		@IStorageService storageService: IStorageService,
+		@IStorageService private readonly storageService: IStorageService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService private readonly _layoutService: ILayoutService,
@@ -177,7 +177,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 			throw new Error('Plot client not found');
 		}
 
-		input.setName(`Plot: ${this._plotClient.id}`);
+		input.setName(this._plotClient.metadata.suggested_file_name ?? createSuggestedFileNameForPlot(this.storageService));
 
 		this.renderContainer(this._plotClient);
 		this.onSizeChanged((event: ISize) => {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -66,6 +66,9 @@ export interface IPositronPlotMetadata {
 
 	/** The pre-rendering of the plot for initial display, if any. */
 	pre_render?: PlotResult;
+
+	/** The suggested file name of the plot. */
+	suggested_file_name?: string;
 }
 
 /**

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -8,6 +8,7 @@ import { Event } from '../../../../base/common/event.js';
 import { IPlotSize, IPositronPlotSizingPolicy } from './sizingPolicy.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IPositronPlotMetadata } from '../../languageRuntime/common/languageRuntimePlotClient.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
 export const POSITRON_PLOTS_VIEW_ID = 'workbench.panel.positronPlots';
 
@@ -66,6 +67,18 @@ export enum DarkFilter {
 	/** The dark filter follows the current theme (i.e. it's on in dark themes and off in light themes) */
 	Auto = 'auto'
 }
+
+/**
+ * Creates a suggested file name for a plot.
+ * @param storageService The storage service to use.
+ * @returns A suggested file name for the plot.
+ */
+export const createSuggestedFileNameForPlot = (storageService: IStorageService) => {
+	const key = 'positron.plotNumber';
+	const plotNumber = storageService.getNumber(key, StorageScope.APPLICATION, 0) + 1;
+	storageService.store(key, plotNumber, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	return `plot-${plotNumber}`;
+};
 
 /**
  * IPositronPlotsService interface.

--- a/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
+++ b/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
@@ -1,12 +1,13 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IPositronPlotMetadata } from '../../languageRuntime/common/languageRuntimePlotClient.js';
 import { ILanguageRuntimeMessageOutput } from '../../languageRuntime/common/languageRuntimeService.js';
-import { IPositronPlotClient } from './positronPlots.js';
+import { createSuggestedFileNameForPlot, IPositronPlotClient } from './positronPlots.js';
 
 /**
  * Creates a static plot client from a language runtime message.
@@ -16,7 +17,7 @@ export class StaticPlotClient extends Disposable implements IPositronPlotClient 
 	public readonly mimeType;
 	public readonly data;
 
-	constructor(sessionId: string, message: ILanguageRuntimeMessageOutput,
+	constructor(storageService: IStorageService, sessionId: string, message: ILanguageRuntimeMessageOutput,
 		public readonly code?: string) {
 		super();
 
@@ -27,6 +28,7 @@ export class StaticPlotClient extends Disposable implements IPositronPlotClient 
 			created: Date.parse(message.when),
 			session_id: sessionId,
 			code: code ? code : '',
+			suggested_file_name: createSuggestedFileNameForPlot(storageService),
 		};
 
 		// Find the image MIME type. This is guaranteed to exist since we only create this object if


### PR DESCRIPTION
## Description

This PR addresses #5872 by revamping how plots are named and saved.

Now, when you open a plot, it will be named "plot-1", "plot-2", and so on, across sessions. If you open the plot in an editor window, you will see its name:

<img width="1776" alt="image" src="https://github.com/user-attachments/assets/6fe5c1f5-14eb-4664-ab76-91127f4f5f70" />

&nbsp;
Instead of the unsightly UUID, as outlined in the original issue.

Additionally, when you save a plot, you will now see the plot name in the save dialogs. For example:

<img width="514" alt="image" src="https://github.com/user-attachments/assets/80523e56-6b1b-4db7-b910-32a6eba1d33e" />

&nbsp;
<img width="834" alt="image" src="https://github.com/user-attachments/assets/92bdc20f-d538-475e-bcfe-113587b210cb" />

&nbsp;
Which will help users not have to deal with coming up with a unique file name each time they save a plot.

Tests:
@:plots

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #5872 Revamp how plots are named and saved. Now plots are named, "plot-1", "plot-2", and so on.

### QA Notes

