### PR TITLE
Add support for images in tool call results for vercel-anthropic

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -214,8 +214,11 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 
 		// Filter out messages with empty text or empty tool response content
 		const filteredMessages = messages.filter(hasNonEmptyContent);
-		// Convert messages to the Vercel AI format
-		const aiMessages = toAIMessage(filteredMessages);
+		// Only Anthropic currently supports experimental_content in tool
+		// results.
+		const toolResultExperimentalContent = this.provider === 'anthropic';
+		// Convert messages to the Vercel AI format.
+		const aiMessages = toAIMessage(filteredMessages, toolResultExperimentalContent);
 
 		if (options.tools && options.tools.length > 0) {
 			tools = options.tools.reduce((acc: Record<string, ai.Tool>, tool: vscode.LanguageModelChatTool) => {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

This addresses  #7705. The purpose of this change is for a modified version of the `executeCode` tool, which can return a result object that contains both text and images.

When Anthropic is used via the Vercel back end, it can now send images in tool call results. Also:

- When this is used, it is no longer necessary to special-case handling of `getPlot` tool call results, where it replaces the tool call message and the tool result message with normal Assistant and User messages.
- This can handle tool results where the `content` includes both text and image parts.

This PR does not affect providers other than Anthropic.

Note that this also probably should be used in conjunction with the base64 padding fix mentioned here:
https://github.com/posit-dev/positron/issues/7510#issuecomment-2882149754

I didn't know whether or not that should go in a separate PR, so I left it out for now.

This is my first PR to Positron, so I don't know all the conventions and I'm happy to make whatever changes are needed.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
