### PR TITLE
Refine Assistant follow-ups prompt

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/followups.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/followups.md
@@ -1,6 +1,3 @@
-Based on the conversation so far, suggest some follow-up data science questions or directions.
-They should be written like user commands, but keep them short.
+Based on what I have asked so far, suggest 2-3 follow-up steps, keeping them to a maximum length of one sentence. If I haven’t asked anything, or there aren’t any obvious next steps, don’t provide any suggestions.
 
-Return 2 or 3 suggestions only if they are relevant to the chat history. If you can't think of anything useful, just return an empty array.
-
-Return a JSON array of strings, and nothing else.
+You MUST return only JSON in the output, and nothing else. If present, format the suggestions as an array of strings. If not present, return an empty array.


### PR DESCRIPTION
The existing prompt may have led models on tangents by specifying "data science questions or directions". @hadley proposed this streamlined prompt that does seem to reduce the number of irrelevant follow-ups when they are suggested. We can monitor and continue to refine these going forward.

Addresses #7637

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Let's continue to monitor this and work on an evaluation test for the quality of this prompt.