### PR TITLE
fix: override tar-fs to version >=2.1.2 for security vulnerability

### DIFF
--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -1357,9 +1357,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/remote/package.json
+++ b/remote/package.json
@@ -51,7 +51,8 @@
     "follow-redirects": "^1.15.4",
     "node-gyp-build": "4.8.1",
     "kerberos@2.1.1": {
-      "node-addon-api": "7.1.0"
+      "node-addon-api": "7.1.0",
+      "tar-fs": "^2.1.2"
     }
   }
 }


### PR DESCRIPTION
Addresses the final Positron specific tar-fs dependency ([#349](https://github.com/posit-dev/positron-builds/issues/349)) that I missed in #7600

Adds an additional override to the kerberos dependency. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
