### PR TITLE
e2e-test: skipping reload part of session rename test

### DIFF
--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -11,14 +11,17 @@ test.use({
 
 test.describe('Sessions: Rename', {
 	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7692' }],
+	annotation: [
+		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7692' },
+		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6843' }
+	],
 }, () => {
 
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.variables.togglePane('hide');
 	});
 
-	test('Validate can rename sessions and name persists', async function ({ sessions, runCommand }) {
+	test('Validate can rename sessions and name persists', async function ({ sessions }) {
 		const [pySession, pySessionAlt, rSession, rSessionAlt] = await sessions.start(['python', 'pythonAlt', 'r', 'rAlt']);
 
 		// Rename sessions
@@ -27,15 +30,16 @@ test.describe('Sessions: Rename', {
 		await sessions.rename(rSession.name, 'R Session 1');
 		await sessions.rename(rSessionAlt.name, 'R Session 2');
 
+		// Skipping rest of test due to issue 6843
 		// Reload window
-		await runCommand('workbench.action.reloadWindow');
-		await sessions.expectAllSessionsToBeReady();
+		// await runCommand('workbench.action.reloadWindow');
+		// await sessions.expectAllSessionsToBeReady();
 
-		// Verify session names persist
-		await sessions.expectSessionNameToBe(pySession.id, 'Python Session 1');
-		await sessions.expectSessionNameToBe(pySessionAlt.id, 'Python Session 2');
-		await sessions.expectSessionNameToBe(rSession.id, 'R Session 1');
-		await sessions.expectSessionNameToBe(rSessionAlt.id, 'R Session 2');
+		// // Verify session names persist
+		// await sessions.expectSessionNameToBe(pySession.id, 'Python Session 1');
+		// await sessions.expectSessionNameToBe(pySessionAlt.id, 'Python Session 2');
+		// await sessions.expectSessionNameToBe(rSession.id, 'R Session 1');
+		// await sessions.expectSessionNameToBe(rSessionAlt.id, 'R Session 2');
 	});
 
 	test('Validate can rename sessions via UI', { tag: [tags.WEB_ONLY] }, async function ({ sessions },) {

--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -30,6 +30,12 @@ test.describe('Sessions: Rename', {
 		await sessions.rename(rSession.name, 'R Session 1');
 		await sessions.rename(rSessionAlt.name, 'R Session 2');
 
+		// Verify session names have changed
+		await sessions.expectSessionNameToBe(pySession.id, 'Python Session 1');
+		await sessions.expectSessionNameToBe(pySessionAlt.id, 'Python Session 2');
+		await sessions.expectSessionNameToBe(rSession.id, 'R Session 1');
+		await sessions.expectSessionNameToBe(rSessionAlt.id, 'R Session 2');
+
 		// Skipping rest of test due to issue 6843
 		// Reload window
 		// await runCommand('workbench.action.reloadWindow');


### PR DESCRIPTION
### Summary
There is a known issue https://github.com/posit-dev/positron/issues/6843 that will cause this test to fail/flake sometimes. So updating the test to not validate session rename persists on reload.



### QA Notes

@:sessions