### PR TITLE
Focus console pane when changing foreground session

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -832,9 +832,9 @@ export function registerLanguageRuntimeActions() {
 
 		// If the user selected a specific session, set it as the active session if it still exists
 		if (newActiveSession) {
-			runtimeSessionService.foregroundSession = newActiveSession;
 			// Drive focus into the Positron console.
 			commandService.executeCommand('workbench.panel.positronConsole.focus');
+			runtimeSessionService.foregroundSession = newActiveSession;
 		}
 	});
 
@@ -876,6 +876,9 @@ export function registerLanguageRuntimeActions() {
 				return;
 			}
 
+			// Drive focus into the Positron console.
+			commandService.executeCommand('workbench.panel.positronConsole.focus');
+
 			// Duplicate the current session with the `startNewRuntimeSession` method.
 			await runtimeSessionService.startNewRuntimeSession(
 				currentSession.runtimeMetadata.runtimeId,
@@ -886,9 +889,6 @@ export function registerLanguageRuntimeActions() {
 				RuntimeStartMode.Starting,
 				true
 			);
-
-			// Drive focus into the Positron console.
-			commandService.executeCommand('workbench.panel.positronConsole.focus');
 		}
 	});
 
@@ -923,7 +923,10 @@ export function registerLanguageRuntimeActions() {
 
 			// If the user selected a runtime, set it as the active runtime
 			if (selectedRuntime?.runtimeId) {
-				const sessionId = await runtimeSessionService.startNewRuntimeSession(
+				// Drive focus into the Positron console.
+				commandService.executeCommand('workbench.panel.positronConsole.focus');
+
+				return await runtimeSessionService.startNewRuntimeSession(
 					selectedRuntime.runtimeId,
 					selectedRuntime.runtimeName,
 					LanguageRuntimeSessionMode.Console,
@@ -932,11 +935,6 @@ export function registerLanguageRuntimeActions() {
 					RuntimeStartMode.Starting,
 					true
 				);
-
-				// Drive focus into the Positron console.
-				commandService.executeCommand('workbench.panel.positronConsole.focus');
-
-				return sessionId;
 			}
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -833,8 +833,8 @@ export function registerLanguageRuntimeActions() {
 		// If the user selected a specific session, set it as the active session if it still exists
 		if (newActiveSession) {
 			runtimeSessionService.foregroundSession = newActiveSession;
-			// Focus the console pane after creating the new session
-			await commandService.executeCommand('workbench.panel.positronConsole.focus');
+			// Drive focus into the Positron console.
+			commandService.executeCommand('workbench.panel.positronConsole.focus');
 		}
 	});
 
@@ -884,11 +884,11 @@ export function registerLanguageRuntimeActions() {
 				undefined,
 				`Duplicated session: ${currentSession.dynState.sessionName}`,
 				RuntimeStartMode.Starting,
-				true
+				false
 			);
 
-			// Focus the console pane after creating the new session
-			await commandService.executeCommand('workbench.panel.positronConsole.focus');
+			// Drive focus into the Positron console.
+			commandService.executeCommand('workbench.panel.positronConsole.focus');
 		}
 	});
 
@@ -923,17 +923,20 @@ export function registerLanguageRuntimeActions() {
 
 			// If the user selected a runtime, set it as the active runtime
 			if (selectedRuntime?.runtimeId) {
-				// Focus the console pane after creating the new session
-				await commandService.executeCommand('workbench.panel.positronConsole.focus');
-				return await runtimeSessionService.startNewRuntimeSession(
+				const sessionId = await runtimeSessionService.startNewRuntimeSession(
 					selectedRuntime.runtimeId,
 					selectedRuntime.runtimeName,
 					LanguageRuntimeSessionMode.Console,
 					undefined,
 					'User selected runtime',
 					RuntimeStartMode.Starting,
-					true
+					false
 				);
+
+				// Drive focus into the Positron console.
+				commandService.executeCommand('workbench.panel.positronConsole.focus');
+
+				return sessionId;
 			}
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -884,7 +884,7 @@ export function registerLanguageRuntimeActions() {
 				undefined,
 				`Duplicated session: ${currentSession.dynState.sessionName}`,
 				RuntimeStartMode.Starting,
-				false
+				true
 			);
 
 			// Drive focus into the Positron console.
@@ -930,7 +930,7 @@ export function registerLanguageRuntimeActions() {
 					undefined,
 					'User selected runtime',
 					RuntimeStartMode.Starting,
-					false
+					true
 				);
 
 				// Drive focus into the Positron console.

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -824,6 +824,7 @@ export function registerLanguageRuntimeActions() {
 
 	registerLanguageRuntimeAction(LANGUAGE_RUNTIME_OPEN_ACTIVE_SESSIONS_ID, 'Session Selector', async accessor => {
 		// Access services.
+		const commandService = accessor.get(ICommandService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 		// Prompt the user to select a runtime to use.
@@ -832,6 +833,8 @@ export function registerLanguageRuntimeActions() {
 		// If the user selected a specific session, set it as the active session if it still exists
 		if (newActiveSession) {
 			runtimeSessionService.foregroundSession = newActiveSession;
+			// Focus the console pane after creating the new session
+			await commandService.executeCommand('workbench.panel.positronConsole.focus');
 		}
 	});
 
@@ -883,6 +886,9 @@ export function registerLanguageRuntimeActions() {
 				RuntimeStartMode.Starting,
 				true
 			);
+
+			// Focus the console pane after creating the new session
+			await commandService.executeCommand('workbench.panel.positronConsole.focus');
 		}
 	});
 
@@ -909,6 +915,7 @@ export function registerLanguageRuntimeActions() {
 
 		async run(accessor: ServicesAccessor) {
 			// Access services.
+			const commandService = accessor.get(ICommandService);
 			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 			// Prompt the user to select a runtime to start
@@ -916,6 +923,8 @@ export function registerLanguageRuntimeActions() {
 
 			// If the user selected a runtime, set it as the active runtime
 			if (selectedRuntime?.runtimeId) {
+				// Focus the console pane after creating the new session
+				await commandService.executeCommand('workbench.panel.positronConsole.focus');
 				return await runtimeSessionService.startNewRuntimeSession(
 					selectedRuntime.runtimeId,
 					selectedRuntime.runtimeName,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1657,9 +1657,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Save the new active session info.
 		const activeSession = new ActiveRuntimeSession(
 			session,
-		  manager,
+			manager,
 			this._commandService,
-	 	 	this._logService,
+			this._logService,
 			this._openerService,
 			this._configurationService,
 		);
@@ -1669,8 +1669,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			this._onDidReceiveRuntimeEventEmitter.fire(evt);
 		}));
 
-		// Forwad UI client to interested services once it's available
-	 	activeSession.register(activeSession.onUiClientStarted(uiClient => {
+		// Forward UI client to interested services once it's available
+		activeSession.register(activeSession.onUiClientStarted(uiClient => {
 			this._onDidStartUiClientEmitter.fire({ sessionId: session.sessionId, uiClient });
 		}));
 


### PR DESCRIPTION
Addresses #7522 

Updated the command palette actions that cause the foreground session to change. This includes the duplicate session, create session, and select session actions. The focus is moved to the console before the new session is ready for a snappier experience.


https://github.com/user-attachments/assets/d636a3f3-a616-4791-9a92-edbe1c7b8e0b



### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Focus console pane when foreground session changes via the interpreter command palette actions

### QA Notes

@:win @:sessions @:web
