### PR TITLE
Adjust CSS to fix spacing in split ActionBarButton

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -110,12 +110,12 @@
 
 .action-bar-button-icon.enabled-split {
 	display: flex;
-	padding: 0 2px 0 3px;
+	padding: 0 4px 0 3px;
 }
 
 .action-bar-button-icon.enabled-split:hover {
 	border-radius: 4px;
-	padding: 0 2px 0 3px;
+	padding: 0 4px 0 3px;
 	filter: brightness(90%);
 	background: var(--positronActionBar-hoverBackground);
 }

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -110,7 +110,7 @@
 
 .action-bar-button-icon.enabled-split {
 	display: flex;
-	padding: 0 4px 0 3px;
+	padding: 0 4px;
 }
 
 .action-bar-button-icon.enabled-split:hover {


### PR DESCRIPTION
## Description

This PR makes a small adjustment to the `ActionBarButton` component for better spacing of the split codicon.

![image](https://github.com/user-attachments/assets/18d1ac15-1190-44c4-b2cd-9cc19f87f4d0)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A