### PR TITLE
python: do not override root logger

### DIFF
--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -90,11 +90,11 @@ if __name__ == "__main__":
     handlers = ["console"] if args.logfile is None else ["file"]
     logging_config = {
         "loggers": {
-            "": {
+            "PositronIPKernelApp": {
                 "level": args.loglevel,
                 "handlers": handlers,
             },
-            "PositronIPKernelApp": {
+            "positron._vendor.pygls.protocol.json_rpc": {
                 "level": args.loglevel,
                 "handlers": handlers,
             },

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
                 "level": args.loglevel,
                 "handlers": handlers,
             },
-            "positron._vendor.pygls.protocol.json_rpc": {
+            "positron": {
                 "level": args.loglevel,
                 "handlers": handlers,
             },

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -94,6 +94,10 @@ if __name__ == "__main__":
                 "level": args.loglevel,
                 "handlers": handlers,
             },
+            "Comm": {
+                "level": args.loglevel,
+                "handlers": handlers,
+            },
             "positron._vendor.pygls.protocol.json_rpc": {
                 "level": args.loglevel,
                 "handlers": handlers,


### PR DESCRIPTION
By adding a handler for `""`, we were effectively pushing all logs to a file, including the user's. I've removed the root logger and instead added a few other handlers to capture logs. 

**_This change does expose us to a much higher likelihood of our logs leaking into the console._** 

Eg, the added handlers were after observing `positron._vendor.pygls.protocol.json_rpc` will send out logs if you run something like `import xyzabc`, and the `Comm` logs were leaking if there is an error in the comms.

Related issue in Jupyter, where they needed to handle `tornado` logs https://github.com/jupyter/notebook/issues/1397

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #4182 Python users' logs are now sent to console.


### QA Notes

```python

import logging
logging.warning("should show")
```

it's worth it to try to force a few other errors, to make sure we don't need to add other handlers.