### PR TITLE
fix bots on CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -56,7 +56,7 @@ jobs:
             before we accept your contribution. You can sign the CLA by posting
             a comment on this PR saying:
 
-          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, posit-jenkins-enterprise
+          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, posit-jenkins-enterprise[bot], github-actions[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
Looks like I got this wrong on the [prior PR](https://github.com/posit-dev/positron/pull/7609) where I tried to fix this as we're still getting CLA errors on automation PRs: https://github.com/posit-dev/positron/pull/7742

This time I copied the the names directly from the commit https://github.com/posit-dev/positron/pull/7742/commits/aef9c10c6a063e7341383ba73a50352545498f60