### PR TITLE
Provide summary of code to be executed

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -182,6 +182,10 @@
             "language": {
               "type": "string",
               "description": "The programming language of the code."
+            },
+            "summary": {
+              "type": "string",
+              "description": "A very short summary of the task the code is performing, beginning with a verb and not to exceed 7 words. Shown to the user to help them understand what the code will do."
             }
           }
         },

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -122,7 +122,11 @@ export function registerAssistantTools(
 
 	context.subscriptions.push(selectionEditTool);
 
-	const executeCodeTool = vscode.lm.registerTool<{ code: string; language: string }>(PositronAssistantToolName.ExecuteCode, {
+	const executeCodeTool = vscode.lm.registerTool<{
+		code: string;
+		language: string;
+		summary: string;
+	}>(PositronAssistantToolName.ExecuteCode, {
 		/**
 		 * Called by Positron to prepare for tool invocation. We use this hook
 		 * to show the user the code that we are about to run, and ask for
@@ -145,7 +149,7 @@ export function registerAssistantTools(
 
 				/// The message shown to confirm that the user wants to run the code.
 				confirmationMessages: {
-					title: vscode.l10n.t('Run in Console'),
+					title: options.input.summary ?? vscode.l10n.t('Run in Console'),
 					message: ''
 				},
 			};

--- a/remote/reh-web/package.json
+++ b/remote/reh-web/package.json
@@ -55,7 +55,8 @@
 		"follow-redirects": "^1.15.4",
 		"node-gyp-build": "4.8.1",
 		"kerberos@2.1.1": {
-			"node-addon-api": "7.1.0"
+			"node-addon-api": "7.1.0",
+			"tar-fs": "^2.1.2"
 		}
 	},
 	"customEntryPoints": {


### PR DESCRIPTION
Quick change to replace the generic "Run in Console" label with a short summary generated by the model.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/9a939cbe-974a-49d0-8a8e-e870680dd7ba" />

Addresses https://github.com/posit-dev/positron/issues/7746. 