### PR TITLE
Add plot thumbnail cache feature so plots pane shows thumbnails after a reload

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -39,9 +39,11 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 	useEffect(() => {
 		// When the plot is rendered, update the URI. This can happen multiple times if the plot
 		// is resized.
-		props.plotClient.onDidCompleteRender(result => {
+		const disposable = props.plotClient.onDidCompleteRender(result => {
 			setUri(result.uri);
 		});
+
+		return () => disposable.dispose();
 	}, [props.plotClient]);
 
 	// If the plot is not yet rendered yet (no URI), show a placeholder;

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { PlaceholderThumbnail } from './placeholderThumbnail.js';
+import { usePositronPlotsContext } from '../positronPlotsContext.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 
 /**
@@ -24,19 +25,21 @@ interface DynamicPlotThumbnailProps {
  * @returns The rendered component.
  */
 export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
-
-	const [uri, setUri] = useState('');
+	const context = usePositronPlotsContext();
+	const [uri, setUri] = useState(() => {
+		// If the plot is already rendered, set the URI; otherwise, try to use the cached URI until
+		// the plot is rendered.
+		if (props.plotClient.lastRender) {
+			return props.plotClient.lastRender.uri;
+		} else {
+			return context.positronPlotsService.getCachedPlotThumbnailURI(props.plotClient.id);
+		}
+	});
 
 	useEffect(() => {
-		// If the plot is already rendered, show the URI; otherwise, wait for
-		// the plot to render.
-		if (props.plotClient.lastRender) {
-			setUri(props.plotClient.lastRender.uri);
-		}
-
 		// When the plot is rendered, update the URI. This can happen multiple times if the plot
 		// is resized.
-		props.plotClient.onDidCompleteRender((result) => {
+		props.plotClient.onDidCompleteRender(result => {
 			setUri(result.uri);
 		});
 	}, [props.plotClient]);

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -165,6 +165,13 @@ export interface IPositronPlotsService {
 	readonly onDidChangeSizingPolicy: Event<IPositronPlotSizingPolicy>;
 
 	/**
+	 * Gets the cached plot thumbnail URI for a given plot ID.
+	 * @param plotId The plot ID to get the thumbnail URI for.
+	 * @returns The thumbnail URI for the plot, or undefined if not found.
+	 */
+	getCachedPlotThumbnailURI(plotId: string): string | undefined;
+
+	/**
 	 * Selects the plot with the specified ID.
 	 *
 	 * @param id The ID of the plot to select.

--- a/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
+++ b/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
@@ -208,6 +208,15 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	 */
 	readonly onDidChangeSizingPolicy = this._onDidChangeSizingPolicyEmitter.event;
 
+	/**
+	 * Gets the cached plot thumbnail URI for a given plot ID.
+	 * @param plotId The plot ID to get the thumbnail URI for.
+	 * @returns The thumbnail URI for the plot, or undefined if not found.
+	 */
+	getCachedPlotThumbnailURI(plotId: string) {
+		// Noop in test implementation. In a real implementation, this would return the URI of the cached thumbnail.
+		return undefined;
+	}
 
 	/**
 	 * Selects the plot with the specified ID.


### PR DESCRIPTION
## Description

This PR addresses #397 by adding a thumbnail cache feature to plots. Now, when Positron is reloaded, the Plots pane will show thumbnails for all the current plots.

Here's a screen recording of this in action:

https://github.com/user-attachments/assets/df2d7fb5-cce9-4af0-a738-fbe38c5d4387

Tests:
@:plots

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #397 Add plot thumbnail cache feature so plots pane shows thumbnails after a reload.

### QA Notes

Please note that #7584 has not been addressed yet. It is a separate bug unrelated to this PR.