### PR TITLE
e2e-test: add r debug test

### DIFF
--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { Code } from '../infra/code';
 
 
@@ -36,14 +36,18 @@ export class Debug {
 	}
 
 	async setBreakpointOnLine(lineNumber: number): Promise<void> {
-		await expect(this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`)).toBeVisible();
-		await this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`).click({ position: { x: 5, y: 5 } });
-		await expect(this.code.driver.page.locator(BREAKPOINT_GLYPH)).toBeVisible();
+		await test.step(`Debug: Set breakpoint on line ${lineNumber}`, async () => {
+			await expect(this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`)).toBeVisible();
+			await this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`).click({ position: { x: 5, y: 5 } });
+			await expect(this.code.driver.page.locator(BREAKPOINT_GLYPH)).toBeVisible();
+		});
 	}
 
 	async startDebugging(): Promise<void> {
-		await this.code.driver.page.keyboard.press('F5');
-		await expect(this.code.driver.page.locator(STOP)).toBeVisible();
+		await test.step('Debug: Start', async () => {
+			await this.code.driver.page.keyboard.press('F5');
+			await expect(this.code.driver.page.locator(STOP)).toBeVisible();
+		});
 	}
 
 	async getVariables(): Promise<string[]> {
@@ -61,19 +65,27 @@ export class Debug {
 	}
 
 	async stepOver(): Promise<any> {
-		await this.code.driver.page.locator(STEP_OVER).click();
+		await test.step('Debug: Step over', async () => {
+			await this.code.driver.page.locator(STEP_OVER).click();
+		});
 	}
 
 	async stepInto(): Promise<any> {
-		await this.code.driver.page.locator(STEP_INTO).click();
+		await test.step('Debug: Step into', async () => {
+			await this.code.driver.page.locator(STEP_INTO).click();
+		});
 	}
 
 	async stepOut(): Promise<any> {
-		await this.code.driver.page.locator(STEP_OUT).click();
+		await test.step('Debug: Step out', async () => {
+			await this.code.driver.page.locator(STEP_OUT).click();
+		});
 	}
 
 	async continue(): Promise<any> {
-		await this.code.driver.page.locator(CONTINUE).click();
+		await test.step('Debug: Continue', async () => {
+			await this.code.driver.page.locator(CONTINUE).click();
+		});
 	}
 
 	async getStack(): Promise<IStackFrame[]> {
@@ -88,5 +100,41 @@ export class Debug {
 		}
 
 		return stack;
+	}
+
+	/**
+	 * Verify: The debug pane is visible and contains the specified variable
+	 *
+	 * @param variableLabel The label of the variable to check in the debug pane
+	 */
+	async expectDebugPaneToContain(variableLabel: string): Promise<void> {
+		await test.step(`Verify debug pane contains: ${variableLabel}`, async () => {
+			await expect(this.code.driver.page.getByRole('button', { name: 'Debug Variables Section' })).toBeVisible();
+			await expect(this.code.driver.page.getByLabel(variableLabel)).toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: The call stack is visible and contains the specified item
+	 *
+	 * @param item The item to check in the call stack
+	 */
+	async expectCallStackToContain(item: string): Promise<void> {
+		await test.step(`Verify call stack contains: ${item}`, async () => {
+			await expect(this.code.driver.page.getByRole('button', { name: 'Call Stack Section' })).toBeVisible();
+			const debugCallStack = this.code.driver.page.locator('.debug-call-stack');
+			await expect(debugCallStack.getByText(item)).toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: In browser mode at the specified frame
+	 *
+	 * @param number The frame number to check in the browser mode
+	 */
+	async expectBrowserModeFrame(number: number): Promise<void> {
+		await test.step(`Verify in browser mode: frame ${number}`, async () => {
+			await expect(this.code.driver.page.getByText(`Browse[${number}]>`)).toBeVisible();
+		});
 	}
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -209,8 +209,12 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 
 	// ex: await executeCode('Python', 'print("Hello, world!")');
 	executeCode: async ({ app }, use) => {
-		await use(async (language: 'Python' | 'R', code: string) => {
-			await app.workbench.console.executeCode(language, code);
+		await use(async (language: 'Python' | 'R', code: string, options?: {
+			timeout?: number;
+			waitForReady?: boolean;
+			maximizeConsole?: boolean;
+		}) => {
+			await app.workbench.console.executeCode(language, code, options);
 		});
 	},
 
@@ -470,7 +474,11 @@ interface TestFixtures {
 	openDataFile: (filePath: string) => Promise<void>;
 	openFolder: (folderPath: string) => Promise<void>;
 	runCommand: (command: string, options?: { keepOpen?: boolean; exactMatch?: boolean }) => Promise<void>;
-	executeCode: (language: 'Python' | 'R', code: string) => Promise<void>;
+	executeCode: (language: 'Python' | 'R', code: string, options?: {
+		timeout?: number;
+		waitForReady?: boolean;
+		maximizeConsole?: boolean;
+	}) => Promise<void>;
 	hotKeys: HotKeys;
 	cleanup: TestTeardown;
 }

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -47,9 +47,10 @@ test.describe('R Debugging', {
 	test('R - Verify debugging with `browser()` via console', async ({ app, page, openFile, runCommand, executeCode }) => {
 		const { debug, console } = app.workbench;
 
-		// Load the file and trigger the breakpoint
 		await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
 		await runCommand('r.sourceCurrentFile');
+
+		// Trigger the breakpoint
 		await executeCode('R', `fruit_avg(dat, "berry")`, { waitForReady: false });
 		await debug.expectBrowserModeFrame(1);
 
@@ -78,9 +79,10 @@ test.describe('R Debugging', {
 	test('R - Verify debugging with `browser()` via debugging UI tools', async ({ app, page, openFile, runCommand, executeCode }) => {
 		const { debug, console } = app.workbench;
 
-		// Load the file and trigger the breakpoint
 		await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
 		await runCommand('r.sourceCurrentFile');
+
+		// Trigger the breakpoint
 		await executeCode('R', `fruit_avg(dat, "berry")`, { waitForReady: false });
 		await debug.expectBrowserModeFrame(1);
 
@@ -135,14 +137,14 @@ test.describe('R Debugging', {
 		// Enable recovery mode so errors trigger the interactive debugger
 		await executeCode('R', 'options(error = recover)');
 
-		// This should throw an error inside rowMeans(mini_dat)
+		// Trigger an error: this should throw an error inside rowMeans(mini_dat)
 		await executeCode('R', 'fruit_avg(dat, "black")', { waitForReady: false });
 
 		// Confirm recovery prompt appears and frame selection is offered
 		await console.waitForConsoleContents('Enter a frame number, or 0 to exit');
 		await console.waitForConsoleContents('1: fruit_avg(dat, "black")');
 
-		// Select the inner function frame to inspect local variables
+		// Select the inner function frame
 		await console.waitForConsoleContents('Selection:');
 		await page.keyboard.type('1');
 		await page.keyboard.press('Enter');
@@ -150,11 +152,11 @@ test.describe('R Debugging', {
 		// Confirm error message appears in sidebar
 		await console.expectConsoleToContainError("'x' must be an array of at least two dimensions");
 
-		// Check the contents of mini_dat (only one column matched)
+		// Check the contents of mini_dat in the console
 		await console.focus();
 		await verifyVariableInConsole(page, 'mini_dat', '[1] 4 9 6');
 
-		// Quit the debugger and confirm REPL is ready
+		// Quit the debugger
 		await page.keyboard.type('Q');
 		await page.keyboard.press('Enter');
 		await console.waitForReady('>');

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('R Debugging', {
+	tag: [tags.DEBUG, tags.WEB, tags.WIN]
+}, () => {
+
+	test('R - Verify manual break point and debugging with browser()', async function ({ page, sessions, executeCode }) {
+		await sessions.start(['r']);
+		await executeCode('R', script);
+
+		// Call the function and hit the breakpoint
+		await executeCode('R', 'fruit_avg(dat, "berry")', { waitForReady: false });
+		await expect(page.getByText('Browse[1]>')).toBeVisible();
+
+		// Verify debug variables section is visible
+		await expect(page.getByRole('button', { name: 'Debug Variables Section' })).toBeVisible();
+		await expect(page.getByLabel('pattern, value "berry"')).toBeVisible();
+		await expect(page.getByLabel('dat, value dat')).toBeVisible();
+
+		// Verify the call stack section is visible
+		await expect(page.getByRole('button', { name: 'Call Stack Section' })).toBeVisible();
+		const debugCallStack = page.locator('.debug-call-stack');
+		await expect(debugCallStack.getByText('fruit_avg()fruit_avg()2:')).toBeVisible();
+		await expect(debugCallStack.getByText('<global>fruit_avg(dat, "berry")')).toBeVisible();
+
+		// Inspect the pattern variable
+		await page.keyboard.type('pattern');
+		await page.keyboard.press('Enter');
+		await expect(page.getByText('[1] "berry"')).toBeVisible();
+
+		// Inspect the structure of dat
+		await page.keyboard.type('names(dat)');
+		await page.keyboard.press('Enter');
+		await expect(page.getByText('[1] "blackberry" "blueberry"  "peach" "plum"')).toBeVisible({ timeout: 30000 });
+
+		// Step to the next line with 'n'
+		await page.keyboard.type('n');
+		await page.keyboard.press('Enter');
+		await expect(page.getByText('debug at #3: cols <- grep(pattern, names(dat))')).toBeVisible();
+
+		// Finally, continue
+		await page.keyboard.type('c');
+		await page.keyboard.press('Enter');
+
+		// Confirm expected message appears
+		await expect(page.getByText('Found 2 fruits!')).toBeVisible();
+	});
+});
+
+
+const script = `dat <- data.frame(
+blackberry = c(4, 9, 6),
+blueberry = c(1, 2, 8),
+peach = c(59, 150, 10),
+plum = c(30, 78, 5)
+)
+rownames(dat) <- c("calories", "weight", "yumminess")
+
+fruit_avg <- function(dat, pattern) {
+browser()
+cols <- grep(pattern, names(dat))
+mini_dat <- dat[ , cols]
+message("Found ", ncol(mini_dat), " fruits!")
+rowMeans(mini_dat)
+}`;

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -3,6 +3,22 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * R Debugging Feature
+ *
+ * This feature supports multiple debugging mechanisms for R-based code:
+ * - Browser-based debugging with `browser()` and `debugonce()`
+ * - Error recovery with `options(error = recover)`
+ * - Full integration with Positron's debugging UI, call stack, and variables view
+ *
+ * Debugging flow:
+ * 1. User sets breakpoints using R's native debugging functions (`browser()`, `debugonce()`, etc.)
+ * 2. When execution reaches these points, Positron enters debug mode
+ * 3. User can inspect variables, step through code, and control execution flow
+ * 4. Debugging can be controlled via console commands (s/n/c/Q) or Positron's debugging UI
+ * 5. Variables can be inspected in the console or in the Variables debugging pane
+ */
+
 import { Page } from '@playwright/test';
 import { Application } from '../../infra/index.js';
 import { test, tags, expect } from '../_test.setup';

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { exec } from 'child_process';
 import { test, tags, expect } from '../_test.setup';
 
 test.use({

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { exec } from 'child_process';
 import { test, tags, expect } from '../_test.setup';
 
 test.use({
@@ -13,49 +14,102 @@ test.describe('R Debugging', {
 	tag: [tags.DEBUG, tags.WEB, tags.WIN]
 }, () => {
 
-	test('R - Verify manual break point and debugging with browser()', async function ({ page, sessions, executeCode }) {
-		await sessions.start(['r']);
+	test('R - Verify manual break point and debugging with `browser()`',
+		async ({ r, page, executeCode }) => {
+			await executeCode('R', scriptWithBrowser);
+
+			// Call the function and hit the breakpoint
+			await executeCode('R', 'fruit_avg(dat, "berry")', { waitForReady: false });
+			await expect(page.getByText('Browse[1]>')).toBeVisible();
+
+			// Verify debug variables section is visible
+			await expect(page.getByRole('button', { name: 'Debug Variables Section' })).toBeVisible();
+			await expect(page.getByLabel('pattern, value "berry"')).toBeVisible();
+			await expect(page.getByLabel('dat, value dat')).toBeVisible();
+
+			// Verify the call stack section is visible
+			await expect(page.getByRole('button', { name: 'Call Stack Section' })).toBeVisible();
+			const debugCallStack = page.locator('.debug-call-stack');
+			await expect(debugCallStack.getByText('fruit_avg()fruit_avg()2:')).toBeVisible();
+			await expect(debugCallStack.getByText('<global>fruit_avg(dat, "berry")')).toBeVisible();
+
+			// Inspect the pattern variable
+			await page.keyboard.type('pattern');
+			await page.keyboard.press('Enter');
+			await expect(page.getByText('[1] "berry"')).toBeVisible();
+
+			// Inspect the structure of dat
+			await page.keyboard.type('names(dat)');
+			await page.keyboard.press('Enter');
+			await expect(page.getByText('[1] "blackberry" "blueberry"  "peach" "plum"')).toBeVisible({ timeout: 30000 });
+
+			// Step to the next line with 'n'
+			await page.keyboard.type('n');
+			await page.keyboard.press('Enter');
+			await expect(page.getByText('debug at #3: cols <- grep(pattern, names(dat))')).toBeVisible();
+
+			// Finally, continue
+			await page.keyboard.type('c');
+			await page.keyboard.press('Enter');
+
+			// Confirm expected message appears
+			await expect(page.getByText('Found 2 fruits!')).toBeVisible();
+		});
+
+	test('R - Verify interactive recovery mode using `options(error = recover)`', async ({ r, page, app, executeCode }) => {
+		// Set up the R environment and define the function with an intentional bug
 		await executeCode('R', script);
 
-		// Call the function and hit the breakpoint
-		await executeCode('R', 'fruit_avg(dat, "berry")', { waitForReady: false });
-		await expect(page.getByText('Browse[1]>')).toBeVisible();
+		// Enable interactive recovery mode for errors
+		await executeCode('R', 'options(error = recover)');
 
-		// Verify debug variables section is visible
-		await expect(page.getByRole('button', { name: 'Debug Variables Section' })).toBeVisible();
-		await expect(page.getByLabel('pattern, value "berry"')).toBeVisible();
-		await expect(page.getByLabel('dat, value dat')).toBeVisible();
+		// Trigger an error by passing a pattern that matches only one column
+		// This causes `rowMeans(mini_dat)` to fail since it's not a matrix
+		await executeCode('R', 'fruit_avg(dat, "black")', { waitForReady: false });
 
-		// Verify the call stack section is visible
-		await expect(page.getByRole('button', { name: 'Call Stack Section' })).toBeVisible();
-		const debugCallStack = page.locator('.debug-call-stack');
-		await expect(debugCallStack.getByText('fruit_avg()fruit_avg()2:')).toBeVisible();
-		await expect(debugCallStack.getByText('<global>fruit_avg(dat, "berry")')).toBeVisible();
+		// Verify the interactive recovery prompt is displayed
+		await expect(page.getByText('Enter a frame number, or 0 to exit')).toBeVisible();
+		await expect(page.getByText('1: fruit_avg(dat, "black")')).toBeVisible();
 
-		// Inspect the pattern variable
-		await page.keyboard.type('pattern');
-		await page.keyboard.press('Enter');
-		await expect(page.getByText('[1] "berry"')).toBeVisible();
-
-		// Inspect the structure of dat
-		await page.keyboard.type('names(dat)');
-		await page.keyboard.press('Enter');
-		await expect(page.getByText('[1] "blackberry" "blueberry"  "peach" "plum"')).toBeVisible({ timeout: 30000 });
-
-		// Step to the next line with 'n'
-		await page.keyboard.type('n');
-		await page.keyboard.press('Enter');
-		await expect(page.getByText('debug at #3: cols <- grep(pattern, names(dat))')).toBeVisible();
-
-		// Finally, continue
-		await page.keyboard.type('c');
+		// Select the first frame in the call stack (inside the function)
+		await page.keyboard.type('1');
 		await page.keyboard.press('Enter');
 
-		// Confirm expected message appears
-		await expect(page.getByText('Found 2 fruits!')).toBeVisible();
+		// Validate the error message
+		await expect(page.locator('.activity-error-message'))
+			.toContainText("'x' must be an array of at least two dimensions");
+
+		// Inspect a local variable in the selected frame
+		await app.workbench.console.focus();
+		await page.keyboard.type('mini_dat');
+		await page.keyboard.press('Enter');
+
+		// Confirm that `mini_dat` contains the expected values (only blackberry column)
+		await expect(page.getByText('[1] 4 9 6')).toBeVisible();
+
+		// Exit recovery mode
+		await page.keyboard.type('Q');
+		await page.keyboard.press('Enter');
+		await app.workbench.console.waitForReady('>');
 	});
 });
 
+
+const scriptWithBrowser = `dat <- data.frame(
+blackberry = c(4, 9, 6),
+blueberry = c(1, 2, 8),
+peach = c(59, 150, 10),
+plum = c(30, 78, 5)
+)
+rownames(dat) <- c("calories", "weight", "yumminess")
+
+fruit_avg <- function(dat, pattern) {
+browser()
+cols <- grep(pattern, names(dat))
+mini_dat <- dat[ , cols]
+message("Found ", ncol(mini_dat), " fruits!")
+rowMeans(mini_dat)
+}`;
 
 const script = `dat <- data.frame(
 blackberry = c(4, 9, 6),
@@ -66,7 +120,6 @@ plum = c(30, 78, 5)
 rownames(dat) <- c("calories", "weight", "yumminess")
 
 fruit_avg <- function(dat, pattern) {
-browser()
 cols <- grep(pattern, names(dat))
 mini_dat <- dat[ , cols]
 message("Found ", ncol(mini_dat), " fruits!")


### PR DESCRIPTION
### Summary
Adds baseline R debugging test:
* `browser()` via console interaction
* `browser()` via debugger UI controls
* `options(error = recover)` for error-triggered frame selection
* `debugonce()` to validate single-use breakpoint behavior

### QA Notes

@:debug @:win @:web
