### PR TITLE
Use title case in console tooltips/UI

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -52,13 +52,13 @@ const stateLabelReconecting = localize('positronConsoleState.Reconnecting', "Rec
 /**
  * Localized strings for UI.
  */
-const positronInterruptExecution = localize('positronInterruptExecution', "Interrupt execution");
-const positronToggleTrace = localize('positronToggleTrace', "Toggle trace");
-const positronToggleWordWrap = localize('positronToggleWordWrap', "Toggle word wrap");
-const positronClearConsole = localize('positronClearConsole', "Clear console");
-const positronRestartConsole = localize('positronRestartConsole', "Restart console");
-const positronDeleteConsole = localize('positronDeleteConsole', "Delete console");
-const positronOpenInEditor = localize('positronOpenInEditor', "Open in editor");
+const positronInterruptExecution = localize('positronInterruptExecution', "Interrupt Execution");
+const positronToggleTrace = localize('positronToggleTrace', "Toggle Trace");
+const positronToggleWordWrap = localize('positronToggleWordWrap', "Toggle Word Wrap");
+const positronClearConsole = localize('positronClearConsole', "Clear Console");
+const positronRestartConsole = localize('positronRestartConsole', "Restart Console");
+const positronDeleteConsole = localize('positronDeleteConsole', "Delete Console");
+const positronOpenInEditor = localize('positronOpenInEditor', "Open in Editor");
 
 /**
  * Provides a localized label for the given runtime state. Only the transient

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -21,7 +21,7 @@ import { PositronModalPopup } from '../../../../browser/positronComponents/posit
 import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
 import { ILanguageRuntimeSession, LanguageRuntimeSessionChannel } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 
-const positronConsoleInfo = localize('positron.console.info.label', "Console information");
+const positronConsoleInfo = localize('positron.console.info.label', "Console Information");
 const localizeShowKernelOutputChannel = (channelName: string) => localize('positron.console.info.showKernelOutputChannel', "Show {0} Output Channel", channelName);
 
 const OutputChannelNames = {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7095

I did a bit of poking around files in this part of the codebase and the console UI in general, and these are the only ones I found on my current perusal.