### PR TITLE
Bump to Air 0.12.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -257,7 +257,7 @@
 		},
 		{
 			"name": "posit.air-vscode",
-			"version": "0.10.0",
+			"version": "0.12.0",
 			"repo": "https://github.com/posit-dev/air",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",


### PR DESCRIPTION
Is this all we need to do to bump the bundled version of Air?


### Release Notes



#### New Features

- Updated bundled version of Air to [0.12.0](https://github.com/posit-dev/air/blob/main/editors/code/CHANGELOG.md#0120). This includes a fix that caused a bad interaction with Positron's Test Explorer.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
