### PR TITLE
Updates to support propagating session name updates

### DIFF
--- a/extensions/positron-javascript/src/session.ts
+++ b/extensions/positron-javascript/src/session.ts
@@ -194,6 +194,11 @@ export class JavaScriptLanguageRuntimeSession implements positron.LanguageRuntim
 
 	dispose() { }
 
+	updateSessionName(sessionName: string): void {
+		// Update the dynamic state of the session
+		this.dynState.sessionName = sessionName;
+	}
+
 	private emitOutput(parentId: string, output: string) {
 		this._onDidReceiveRuntimeMessage.fire({
 			id: randomUUID(),

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -711,6 +711,11 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
     }
 
+    updateSessionName(sessionName: string): void {
+        this.dynState.sessionName = sessionName;
+        this._kernel?.updateSessionName(sessionName);
+    }
+
     private async createKernel(): Promise<JupyterLanguageRuntimeSession> {
         const ext = vscode.extensions.getExtension('positron.positron-supervisor');
         if (!ext) {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -400,6 +400,12 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		await this._kernel?.showProfile?.();
 	}
 
+	updateSessionName(sessionName: string): void {
+		// Update the dynamic state of the session
+		this.dynState.sessionName = sessionName;
+		this._kernel?.updateSessionName(sessionName);
+	}
+
 	/**
 	 * Get the LANG env var and all categories of the locale, in R's Sys.getlocale() sense, from
 	 * the R session.

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -872,6 +872,10 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 	public dispose() {
 		return this.pythonSession.dispose();
 	}
+
+	public updateSessionName(sessionName: string): void {
+		this.pythonSession.updateSessionName(sessionName);
+	}
 }
 class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	extraRuntimeData: any = {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1465,6 +1465,11 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		}
 	}
 
+	updateSessionName(sessionName: string): void {
+		// Update the dynamic state with the new values
+		this.dynState.sessionName = sessionName;
+	}
+
 	/**
 	 * Gets the current runtime state of the kernel.
 	 */

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1267,6 +1267,11 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 
 	dispose(): void { }
 
+	updateSessionName(sessionName: string): void {
+		// Update the dynamic state with the new values.
+		this.dynState.sessionName = sessionName;
+	}
+
 	//#endregion LanguageRuntime Implementation
 
 	//#region Private Methods

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
@@ -379,6 +379,11 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 
 	dispose() {
 	}
+
+	updateSessionName(sessionName: string): void {
+		// Update the dynamic state of the session
+		this.dynState.sessionName = sessionName;
+	}
 }
 
 function testLanguageRuntimeMetadata(): positron.LanguageRuntimeMetadata {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1043,6 +1043,13 @@ declare module 'positron' {
 		forceQuit(): Thenable<void>;
 
 		/**
+		 * Update the runtime's dynamic state.
+		 *
+		 * @param sessionName The new dynamic state of the runtime
+		 */
+		updateSessionName(sessionName: string): void;
+
+		/**
 		 * Show runtime log in output panel.
 		 *
 		 * @param channel The channel to show the output in

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1043,9 +1043,9 @@ declare module 'positron' {
 		forceQuit(): Thenable<void>;
 
 		/**
-		 * Update the runtime's dynamic state.
+		 * Update the session name.
 		 *
-		 * @param sessionName The new dynamic state of the runtime
+		 * @param sessionName The new session name
 		 */
 		updateSessionName(sessionName: string): void;
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -566,6 +566,11 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		return await this._proxy.$listOutputChannelsLanguageRuntime(this.handle);
 	}
 
+	async updateSessionName(sessionName: string): Promise<void> {
+		this.dynState.sessionName = sessionName;
+		this._proxy.$updateSessionNameLanguageRuntime(this.handle, sessionName);
+	}
+
 	async showProfile(): Promise<void> {
 		return this._proxy.$showProfileLanguageRuntime(this.handle);
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -81,6 +81,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$showOutputLanguageRuntime(handle: number, channel?: LanguageRuntimeSessionChannel): void;
 	$listOutputChannelsLanguageRuntime(handle: number): Promise<LanguageRuntimeSessionChannel[]>;
+	$updateSessionNameLanguageRuntime(handle: number, sessionName: string): void;
 	$showProfileLanguageRuntime(handle: number): void;
 	$discoverLanguageRuntimes(disabledLanguageIds: string[]): void;
 	$recommendWorkspaceRuntimes(disabledLanguageIds: string[]): Promise<ILanguageRuntimeMetadata[]>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -660,10 +660,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 	$updateSessionNameLanguageRuntime(handle: number, sessionName: string): void {
 		if (handle >= this._runtimeSessions.length) {
-			throw new Error(`Cannot list output channels for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
-		}
-		if (!this._runtimeSessions[handle].listOutputChannels) {
-			throw new Error(`Cannot list output channels for runtime: language runtime session handle '${handle}'`);
+			throw new Error(`Cannot update session name for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
 		}
 		this._runtimeSessions[handle].updateSessionName(sessionName);
 	}

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -658,6 +658,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return this._runtimeSessions[handle].listOutputChannels();
 	}
 
+	$updateSessionNameLanguageRuntime(handle: number, sessionName: string): void {
+		if (handle >= this._runtimeSessions.length) {
+			throw new Error(`Cannot list output channels for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
+		}
+		if (!this._runtimeSessions[handle].listOutputChannels) {
+			throw new Error(`Cannot list output channels for runtime: language runtime session handle '${handle}'`);
+		}
+		this._runtimeSessions[handle].updateSessionName(sessionName);
+	}
+
 	$showProfileLanguageRuntime(handle: number): Thenable<void> {
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot show profile for runtime: language runtime session handle '${handle}' not found or no longer valid.`);

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -264,9 +264,9 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		return this._onWillStartSession;
 	}
 
-  watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable {
-      throw new Error('Method not implemented.');
-  }
+	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable {
+		throw new Error('Method not implemented.');
+	}
 }
 
 class TestRuntimeStartupService implements IRuntimeStartupService {
@@ -447,6 +447,9 @@ class TestLanguageRuntimeSession extends Disposable implements ILanguageRuntimeS
 		};
 		this.runtimeMetadata = TestLanguageRuntimeMetadata;
 		this.metadata = createSessionMetadata(sessionId);
+	}
+	updateSessionName(sessionName: string): void {
+		this.dynState.sessionName = sessionName;
 	}
 
 	cleanup(): Thenable<void> {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -978,7 +978,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			`Updating session name to ${validatedName} for session ${formatLanguageRuntimeSession(session)}'`);
 
 		// Update the sesion name in its dynamic state
-		session.dynState.sessionName = validatedName;
+		session.updateSessionName(validatedName);
 
 		// Log the end of the session name update
 		this._logService.info(
@@ -1657,9 +1657,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Save the new active session info.
 		const activeSession = new ActiveRuntimeSession(
 			session,
-		  manager,
+			manager,
 			this._commandService,
-	 	 	this._logService,
+			this._logService,
 			this._openerService,
 			this._configurationService,
 		);
@@ -1670,7 +1670,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		}));
 
 		// Forwad UI client to interested services once it's available
-	 	activeSession.register(activeSession.onUiClientStarted(uiClient => {
+		activeSession.register(activeSession.onUiClientStarted(uiClient => {
 			this._onDidStartUiClientEmitter.fire({ sessionId: session.sessionId, uiClient });
 		}));
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -226,6 +226,9 @@ export interface ILanguageRuntimeSession extends IDisposable {
 
 	/** Get the label associated with the session. This is a more human-readable name for the session. */
 	getLabel(): string;
+
+	/** Updates the session's name */
+	updateSessionName(sessionName: string): void;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -96,6 +96,10 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		this._register(this.onDidChangeRuntimeState(state => this._currentState = state));
 	}
 
+	updateSessionName(sessionName: string): void {
+		this.dynState.sessionName = sessionName;
+	}
+
 	getRuntimeState(): RuntimeState {
 		return this._currentState;
 	}


### PR DESCRIPTION
The Positron extension API exposes new Language Runtime method which allows the frontend to pass updates to the session name via the ExtHost proxy.

Before:
<img width="505" alt="Screenshot 2025-05-19 at 10 11 04 AM" src="https://github.com/user-attachments/assets/f977caa9-d7dd-429a-96b6-dac0e8167e95" />

After:
<img width="517" alt="Screenshot 2025-05-19 at 10 09 17 AM" src="https://github.com/user-attachments/assets/fc2ee6b0-b9b5-497e-aa47-1bfe54788ec0" />

To test:
- Start a new console session
- Rename the session
- Restart the session

The "Exited" messages should show the updated session name.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #7461

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:console
