### PR TITLE
e2e test: update great-tables viewer test to include testing of clearing button functionality

### DIFF
--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename
@@ -23,23 +24,43 @@ test.describe('Viewer', { tag: [tags.VIEWER] }, () => {
 		await theDoc.waitFor({ state: 'attached' });
 	});
 
-	test('Python - Verify Viewer displays great-tables output', { tag: [tags.WEB] }, async function ({ app, logger, python }) {
-
-		// extra clean up - https://github.com/posit-dev/positron/issues/4604
-		// without this, on ubuntu, the Enter key send to the console
-		// won't work because the pasted code is out of view
-		await app.workbench.console.clearButton.click();
-
-		logger.log('Sending code to console');
-		await app.workbench.console.pasteCodeToConsole(pythonGreatTablesScript);
-		await app.workbench.console.sendEnterKey();
-
+	test('Python - Verify Viewer displays great-tables output and can be cleared', { tag: [tags.WEB] }, async function ({ app, logger, page, python }) {
+		// Clearing viewer output button has now been implemented. Hence, modifications herein ensure that the button functionality works.
+		// Locators
 		const apricot = app.workbench.viewer.getViewerLocator('td').filter({ hasText: 'apricot' });
-		await apricot.waitFor({ state: 'attached', timeout: 60000 });
+		const clearButton = page.locator('.positron-action-bar').getByRole('button', { name: 'Clear the content' });
 
-		// Note that there is not a control to clear the viewer at this point
+		// TestStep1: Initial viewer content should be displayed once user runs GreatTablesScript in Console
+		await test.step('Display initial viewer content', async () => {
+			await app.workbench.console.clearButton.click();
+			logger.log('Sending code to console');
+			await app.workbench.console.pasteCodeToConsole(pythonGreatTablesScript);
+			await app.workbench.console.sendEnterKey();
+			await expect(apricot).toBeVisible({ timeout: 30000 });
+		});
+
+		// TestStep2: User can click on the 'Clear the content' button in Positron action bar (under Viewer tab)
+		await test.step('Click the clear button', async () => {
+			await expect(clearButton).toBeVisible();
+			await clearButton.click();
+		});
+
+		// TestStep3: After user clicked the button, element is NOT present in the DOM, by using detached state.
+		await test.step('Verify content disappeared', async () => {
+			await apricot.waitFor({ state: 'detached', timeout: 30000 });
+		});
+
+		/* Additional comments: to be addressed in the future or limitations
+		- Extra clean up - https://github.com/posit-dev/positron/issues/4604
+		- Without this, on ubuntu, the Enter key sends to the console
+		- It won't work because the pasted code is out of view
+		- Additional points for discussion with team:
+		-- Is keeping the Python scripts in the end the best method?
+		-- Should we have a separate file containing scripts and importing them here?
+		-- Having the scripts in the end is a bit impractical, regarding visibility. Thoughts?
+		*/
+
 	});
-
 
 	test('R - Verify Viewer displays modelsummary output', { tag: [tags.WEB] }, async function ({ app, logger, r }) {
 		logger.log('Sending code to console');


### PR DESCRIPTION
- This test has been updated to include verification of the clearing button functionality in the Viewer tab.
- Additional changes included:
  - Placing locators in the top portion of the test for easier visibility
  - Introducing [TestSteps](https://playwright.dev/docs/api/class-teststep) for better organization and test reporting
  - Organization of additional comments/to-dos in the end of the test, for easier focus
- Addition of points for discussion with the team, concerning where to place the Python scripts for better visibility and workflow when updating related tests in the future.

### QA Notes

@:quarto @:web @:win
