### PR TITLE
Use XML in Assistant context message

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -65,7 +65,7 @@ const extensions = [
 	// --- Start Positron ---
 	{
 		label: 'positron-assistant',
-		workspaceFolder: path.join(os.tmpdir(), `positron-assistant-${Math.floor(Math.random() * 100000)}`),
+		workspaceFolder: 'extensions/positron-assistant/test-workspace',
 		mocha: { timeout: 60_000 }
 	},
 	{

--- a/extensions/positron-assistant/src/commands/quarto.ts
+++ b/extensions/positron-assistant/src/commands/quarto.ts
@@ -30,7 +30,7 @@ export async function quartoHandler(
 	});
 	const editor = await vscode.window.showTextDocument(document);
 
-	const messages: vscode.LanguageModelChatMessage[] = toLanguageModelChatMessage(context.history);
+	const messages = toLanguageModelChatMessage(context.history);
 	messages.push(...[
 		vscode.LanguageModelChatMessage.User(vscode.l10n.t('Convert to Qmd.')),
 	]);

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -9,6 +9,9 @@ import { DocumentSelector } from 'vscode-languageclient';
 /** The extension root directory. */
 export const EXTENSION_ROOT_DIR = path.join(__dirname, '..');
 
+/** Directory containing markdown files (e.g. prompt templates). */
+export const MARKDOWN_DIR = path.join(EXTENSION_ROOT_DIR, 'src', 'md');
+
 /** Selects all documents. */
 export const ALL_DOCUMENTS_SELECTOR: DocumentSelector = [{ scheme: '*' }];
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -382,6 +382,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					description: 'Current active console',
 					language: positronContext.console.language,
 					version: positronContext.console.version,
+					identifier: positronContext.console.identifier,
 				})
 			);
 		}

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -6,6 +6,7 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as xml from './xml.js';
 
 import { EXTENSION_ROOT_DIR } from './constants';
 import { isChatImageMimeType, toLanguageModelChatMessage } from './utils';
@@ -223,8 +224,17 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		);
 
-		// Construct the language model request.
-		const messages = await this.getDefaultMessages(request, context, response);
+		// Construct the transient message thread sent to the language model.
+		// Note that this is not the same as the chat history shown in the UI.
+		const messages = [
+			// Start with the chat history.
+			// Note that context.history excludes tool calls and results.
+			...toLanguageModelChatMessage(context.history),
+			// Add a user message containing context about the request, workspace, running sessions, etc.
+			await this.getContextMessage(request, response),
+			// Add the user's prompt.
+			vscode.LanguageModelChatMessage.User(request.prompt),
+		];
 
 		// Send the request to the language model.
 		await this.sendLanguageModelRequest(request, response, token, messages, tools, system);
@@ -248,17 +258,18 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		return undefined;
 	}
 
-	private async getDefaultMessages(
+	private async getContextMessage(
 		request: vscode.ChatRequest,
-		context: vscode.ChatContext,
 		response: vscode.ChatResponseStream,
-	) {
-		// The transient message thread sent to the language model.
-		// This will include messages from the persisted chat history,
-		// but this message thread will not be persisted.
-		const messages: vscode.LanguageModelChatMessage2[] = [];
+	): Promise<vscode.LanguageModelChatMessage2> {
+		// This function returns a single user message containing all context
+		// relevant to a request, including:
+		// 1. A text prompt.
+		const prompts: string[] = [];
+		// 2. Binary data (e.g. image attachments).
+		const userDataParts: vscode.LanguageModelDataPart[] = [];
 
-		// If the workspace has an llms.txt document, add it's current value to the message thread.
+		// If the workspace has an llms.txt document, add it's current value to the prompt.
 		const llmsDocument = await openLlmsTextDocument();
 		if (llmsDocument) {
 			const llmsText = llmsDocument.getText();
@@ -266,102 +277,160 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				// Add the file as a reference in the response.
 				response.reference(llmsDocument.uri);
 
-				// Add the contents of the file to the message thread.
-				messages.push(
-					vscode.LanguageModelChatMessage.User(llmsText),
-					vscode.LanguageModelChatMessage.Assistant('Acknowledged.'),
-				);
+				// Add the contents of the file to the prompt
+				prompts.push(xml.node('instructions', llmsText));
 			}
 		}
 
-		// Add the persisted chat history to the message thread.
-		const historyMessages: vscode.LanguageModelChatMessage[] = toLanguageModelChatMessage(context.history);
-		messages.push(...historyMessages);
-
-		// Add Positron specific context to the message thread.
-		const positronContext = await positron.ai.getPositronChatContext(request);
-		messages.push(
-			vscode.LanguageModelChatMessage.User(JSON.stringify(positronContext)),
-			vscode.LanguageModelChatMessage.Assistant('Acknowledged.'),
-		);
-
-		// If the user has explicitly attached files as context, add them to the message thread.
+		// If the user has explicitly attached files as context, add them to the prompt.
 		if (request.references.length > 0) {
-			const attachmentsText = await fs.promises.readFile(`${mdDir}/prompts/chat/attachments.md`, 'utf8');
-			const userParts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [
-				new vscode.LanguageModelTextPart(attachmentsText)
-			];
+			const referencesPrompts: string[] = [];
 			for (const reference of request.references) {
 				const value = reference.value;
 				if (value instanceof vscode.Location) {
-					const description = reference.modelDescription;
+					// The user attached a range of a file -
+					// usually the automatically attached visible region of the active file.
+
 					const document = await vscode.workspace.openTextDocument(value.uri);
+					const path = vscode.workspace.asRelativePath(value.uri);
 					const documentText = document.getText();
-					const selectionText = document.getText(value.range);
-					const ref = {
-						id: reference.id,
-						uri: value.uri.toString(),
-						description,
-						documentText,
-						selectionText,
-					};
+					const visibleText = document.getText(value.range);
+
 					// Add the file as a reference in the response.
 					// Although the reference includes a range, we provide the full document text as context
 					// and can't distinguish which part the model uses, so we don't include the range in the
 					// response reference.
 					response.reference(value.uri);
-					userParts.push(new vscode.LanguageModelTextPart(`\n\n${JSON.stringify(ref)}`));
+
+					// Add the visible region prompt.
+					referencesPrompts.push(xml.node('reference', visibleText, {
+						filePath: path,
+						description: 'Visible region of the active file',
+						language: document.languageId,
+						startLine: value.range.start.line + 1,
+						endLine: value.range.end.line + 1,
+					}));
+
+					// Add the full document text prompt.
+					referencesPrompts.push(xml.node('reference', documentText, {
+						filePath: path,
+						description: 'Full contents of the active file',
+						language: document.languageId,
+					}));
 				} else if (value instanceof vscode.Uri) {
+					// The user attached a file - usually a manually attached file in the workspace.
 					const document = await vscode.workspace.openTextDocument(value);
+					const path = vscode.workspace.asRelativePath(value);
 					const documentText = document.getText();
-					const ref = { id: reference.id, uri: value.toString(), documentText };
+
 					// Add the file as a reference in the response.
 					response.reference(value);
-					userParts.push(new vscode.LanguageModelTextPart(`\n\n${JSON.stringify(ref)}`));
+
+					// Attach the full document text.
+					referencesPrompts.push(xml.node('reference', documentText, {
+						filePath: path,
+						description: 'Full contents of the file',
+						language: document.languageId,
+					}));
 				} else if (value instanceof vscode.ChatReferenceBinaryData) {
 					if (isChatImageMimeType(value.mimeType)) {
+						// The user attached an image - usually a pasted image or screenshot of the IDE.
 						const data = await value.data();
+
+						// If the binary data is associated with a file, add it as a reference in the response.
 						if (value.reference) {
-							// If the binary data is associated with a file, add it as a reference in the response.
 							response.reference(value.reference);
 						}
-						userParts.push(
-							new vscode.LanguageModelTextPart(`Attached image name: ${reference.name}`),
-							new vscode.LanguageModelDataPart(data, value.mimeType),
+
+						// Attach the image.
+						referencesPrompts.push(xml.leaf('img', {
+							src: reference.name,
+							alt: `Attached image ${reference.name}`,
+						}));
+
+						userDataParts.push(
+							vscode.LanguageModelDataPart.image(data, value.mimeType),
 						);
 					} else {
-						console.warn(`Positron Assistant: Unsupported chat reference binary data type: ${typeof value}`);
+						console.warn(`Positron Assistant: Unsupported chat reference binary data type: ${typeof value} `);
 					}
 				} else {
-					console.warn(`Positron Assistant: Unsupported reference type: ${typeof value}`);
+					console.warn(`Positron Assistant: Unsupported reference type: ${typeof value} `);
 				}
 			}
-			messages.push(
-				vscode.LanguageModelChatMessage2.User(userParts),
-				vscode.LanguageModelChatMessage.Assistant('Acknowledged.'),
-			);
+
+			if (referencesPrompts.length > 0) {
+				// Add the references to the prompt.
+				const content = referencesPrompts.join('\n');
+				prompts.push(xml.node('references', content));
+			}
 		}
 
-		// Subclasses can override `getMessages` to add custom messages before the user prompt.
-		const customMessages = await this.getMessages(request);
-		messages.push(...customMessages);
+		// Add Positron IDE context to the prompt.
+		const positronContext = await positron.ai.getPositronChatContext(request);
+		const positronContextPrompts: string[] = [];
+		if (positronContext.console) {
+			const executions = positronContext.console.executions
+				.map((e) => xml.node('execution', JSON.stringify(e)))
+				.join('\n');
+			positronContextPrompts.push(
+				xml.node('console',
+					xml.node('executions', executions ?? '', {
+						description: 'Current active console',
+						language: positronContext.console.language,
+						version: positronContext.console.version,
+					})
+				)
+			);
+		}
+		if (positronContext.variables) {
+			positronContextPrompts.push(
+				xml.node('variables', positronContext.variables
+					.map((v) => xml.node('variable', JSON.stringify(v)))
+					.join('\n'), {
+					description: 'Variables defined in the current session',
+				})
+			);
+		}
+		if (positronContext.shell) {
+			positronContextPrompts.push(
+				xml.node('shell', positronContext.shell, {
+					description: `Current active shell`,
+				})
+			);
+		}
+		if (positronContext.plots && positronContext.plots.hasPlots) {
+			positronContextPrompts.push(
+				xml.node('plots', `A plot is visible.`)
+			);
+		}
+		if (positronContextPrompts.length > 0) {
+			prompts.push(xml.node('context', positronContextPrompts.join('\n\n')));
+		}
 
-		// User prompt
-		messages.push(vscode.LanguageModelChatMessage.User(request.prompt));
+		// Subclasses can override `getCustomPrompt` to append to the context message prompt.
+		const customPrompt = await this.getCustomPrompt(request);
+		if (customPrompt.length > 0) {
+			prompts.push(customPrompt);
+		}
 
-		return messages;
+		const prompt = prompts.join('\n\n');
+		return vscode.LanguageModelChatMessage2.User([
+			new vscode.LanguageModelTextPart(prompt),
+			...userDataParts,
+		]);
 	}
 
-	/** Custom language model messages for this participant, added before the user prompt. */
-	protected async getMessages(request: vscode.ChatRequest): Promise<vscode.LanguageModelChatMessage[]> {
-		return [];
+	/** Custom prompt for this participant, added before the user prompt. */
+	protected async getCustomPrompt(request: vscode.ChatRequest): Promise<string> {
+		return '';
 	}
 
 	private async sendLanguageModelRequest(
 		request: vscode.ChatRequest,
 		response: vscode.ChatResponseStream,
 		token: vscode.CancellationToken,
-		messages: vscode.LanguageModelChatMessage2[],
+		messages: (vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2)[],
 		tools: vscode.LanguageModelChatTool[],
 		system: string,
 	): Promise<void> {
@@ -455,31 +524,38 @@ class PositronAssistantEditorParticipant extends PositronAssistantParticipant im
 		return await fs.promises.readFile(`${mdDir}/prompts/chat/selection.md`, 'utf8');
 	}
 
-	async getMessages(request: vscode.ChatRequest): Promise<vscode.LanguageModelChatMessage[]> {
+	async getCustomPrompt(request: vscode.ChatRequest): Promise<string> {
 		if (!(request.location2 instanceof vscode.ChatRequestEditorData)) {
 			throw new Error('Editor participant only supports editor requests');
 		}
+
+		// Note: in this case, the current visible region of the document is not
+		// included as an attachment in the request.
 
 		// When invoked from the editor, add document and selection context
 		const document = request.location2.document;
 		const selection = request.location2.selection;
 		const selectedText = document.getText(selection);
 		const documentText = document.getText();
-		const ref = {
-			id: document.uri.toString(),
-			documentText,
-			selectedText,
-			line: selection.active.line + 1, // 1-based line numbering for the model
-			column: selection.active.character,
-			documentOffset: document.offsetAt(selection.active)
-		};
-		const textParts: vscode.LanguageModelTextPart[] = [
-			new vscode.LanguageModelTextPart(`\n\n${JSON.stringify(ref)}`)
-		];
-		return [
-			vscode.LanguageModelChatMessage.User(textParts),
-			vscode.LanguageModelChatMessage.Assistant('Acknowledged.'),
-		];
+		const filePath = vscode.workspace.asRelativePath(document.uri);
+		return xml.node('editor',
+			[
+				xml.node('document', documentText, {
+					description: 'Full contents of the active file',
+				}),
+				xml.node('selection', selectedText, {
+					description: 'Selected text in the active file',
+				})
+			].join('\n'),
+			{
+				description: 'Current active editor',
+				filePath,
+				language: document.languageId,
+				line: selection.active.line + 1,
+				column: selection.active.character,
+				documentOffset: document.offsetAt(selection.active),
+			},
+		);
 	}
 }
 

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -379,7 +379,8 @@ function makeChatRequest(
 		prompt: 'Hello, world!',
 		command: undefined,
 		references: options.references,
-		tools: [],
+		tools: new Map(),
+		toolSelection: undefined,
 		toolReferences: [],
 		toolInvocationToken: undefined as vscode.ChatParticipantToolToken,
 		model: options.model,
@@ -411,8 +412,8 @@ function assertMessageDataPart(
 	expectedData: Uint8Array,
 ) {
 	assert.ok(part instanceof vscode.LanguageModelDataPart, `Expected a data part, got: ${JSON.stringify(part)}`);
-	assert.strictEqual(part.value.mimeType, expectedMimeType, 'Unexpected data part mime type');
-	assert.strictEqual(part.value.data, expectedData, 'Unexpected data part value');
+	assert.strictEqual(part.mimeType, expectedMimeType, 'Unexpected data part mime type');
+	assert.strictEqual(part.data, expectedData, 'Unexpected data part value');
 }
 
 function assertContextMessage(

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { PositronAssistantChatParticipant } from '../participants.js';
+import { mock } from './utils.js';
+
+class TestLanguageModelChatResponse implements vscode.LanguageModelChatResponse {
+	stream: AsyncIterable<string> = {
+		[Symbol.asyncIterator]: async function* () {
+			yield "This is a test response from the language model.";
+		}
+	};
+	text: AsyncIterable<string> = this.stream;
+}
+
+class TestLanguageModelChat implements vscode.LanguageModelChat {
+	id = 'test-language-model-chat';
+	name = 'TestLanguageModelChat';
+	vendor = 'TestVendor';
+	family = 'TestFamily';
+	version = '1.0.0';
+	maxInputTokens = 2048;
+	async sendRequest(
+		messages: (vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2)[],
+		options?: vscode.LanguageModelChatRequestOptions,
+		token?: vscode.CancellationToken,
+	): Promise<vscode.LanguageModelChatResponse> {
+		return new TestLanguageModelChatResponse();
+	}
+	async countTokens(
+		text: string | vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2,
+		token?: vscode.CancellationToken,
+	): Promise<number> {
+		const textString = typeof text === 'string' ? text : JSON.stringify(text);
+		return Promise.resolve(textString.length);
+	}
+}
+
+class TestChatResponseStream implements vscode.ChatResponseStream {
+	progress(value: unknown, task?: unknown): void {
+	}
+	textEdit(target: unknown, isDone: unknown): void {
+	}
+	notebookEdit(target: unknown, isDone: unknown): void {
+	}
+	markdownWithVulnerabilities(value: string | vscode.MarkdownString, vulnerabilities: vscode.ChatVulnerability[]): void {
+	}
+	codeblockUri(uri: vscode.Uri, isEdit?: boolean): void {
+	}
+	push(part: unknown): void {
+	}
+	confirmation(title: string, message: string, data: any, buttons?: string[]): void {
+	}
+	warning(message: string | vscode.MarkdownString): void {
+	}
+	reference(value: unknown, iconPath?: unknown): void {
+	}
+	reference2(value: vscode.Uri | vscode.Location | string | { variableName: string; value?: vscode.Uri | vscode.Location }, iconPath?: vscode.Uri | vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri }, options?: { status?: { description: string; kind: vscode.ChatResponseReferencePartStatusKind } }): void {
+	}
+	codeCitation(value: vscode.Uri, license: string, snippet: string): void {
+	}
+	markdown(value: string | vscode.MarkdownString): void {
+	}
+	anchor(value: vscode.Uri | vscode.Location, title?: string): void {
+	}
+	button(command: vscode.Command): void {
+	}
+	filetree(value: vscode.ChatResponseFileTree[], baseUri: vscode.Uri): void {
+	}
+}
+
+suite('PositronAssistantParticipant', () => {
+	let model: TestLanguageModelChat;
+	let response: TestChatResponseStream;
+	let tokenSource: vscode.CancellationTokenSource;
+	let token: vscode.CancellationToken;
+	let referenceUri: vscode.Uri;
+	let participant: PositronAssistantChatParticipant;
+	setup(() => {
+		model = new TestLanguageModelChat();
+		response = new TestChatResponseStream();
+		tokenSource = new vscode.CancellationTokenSource();
+		token = tokenSource.token;
+
+		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+		assert.ok(workspaceFolder, 'This test should be run from the ../test-workspace workspace');
+		referenceUri = vscode.Uri.joinPath(workspaceFolder.uri, 'reference.ts');
+
+		const extensionContext = mock<vscode.ExtensionContext>({});
+		participant = new PositronAssistantChatParticipant(extensionContext);
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	test('should not send context if none is available', async () => {
+		// Setup test inputs.
+		const request = makeChatRequest({ model, references: [] });
+		const context: vscode.ChatContext = { history: [] };
+		const sendRequestSpy = sinon.spy(model, 'sendRequest');
+		sinon.stub(positron.ai, 'getPositronChatContext').resolves({});
+
+		// Call the method under test.
+		await participant.requestHandler(request, context, response, token);
+
+		// There should be only one user message with the user's prompt,
+		// since there is no available context.
+		sinon.assert.calledOnce(sendRequestSpy);
+		const [messages,] = sendRequestSpy.getCall(0).args;
+		assert.strictEqual(messages.length, 1, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages[0].role, vscode.LanguageModelChatMessageRole.User);
+		assertMessageTextEqual(messages[0], request.prompt);
+	});
+
+	test('should include positron session context', async () => {
+		// Setup test inputs.
+		const request = makeChatRequest({ model, references: [] });
+		const context: vscode.ChatContext = { history: [] };
+		const sendRequestSpy = sinon.spy(model, 'sendRequest');
+		const positronChatContext: positron.ai.ChatContext = {
+			console: {
+				language: 'python',
+				version: '3.12.0',
+				executions: [
+					{
+						input: 'x = 1',
+						output: '',
+						error: undefined,
+					},
+				],
+			},
+			plots: {
+				hasPlots: true,
+			},
+			variables: [
+				{
+					name: 'x',
+					value: '1',
+					type: 'number',
+				},
+			],
+			shell: 'bash',
+		};
+		sinon.stub(positron.ai, 'getPositronChatContext').resolves(positronChatContext);
+
+		// Call the method under test.
+		await participant.requestHandler(request, context, response, token);
+
+		// The first user message should contain the formatted context.
+		sinon.assert.calledOnce(sendRequestSpy);
+		const [messages,] = sendRequestSpy.getCall(0).args;
+		assert.ok(messages.length > 0, `Unexpected messages: ${JSON.stringify(messages)}`);
+		const message = messages[0];
+		assert.strictEqual(message.role, vscode.LanguageModelChatMessageRole.User);
+		const c = positronChatContext;
+		assertMessageTextEqual(message,
+			`<context>
+<console>
+<executions description="Current active console" language="${c.console!.language}" version="${c.console!.version}">
+<execution>
+${JSON.stringify(c.console!.executions[0])}
+</execution>
+</executions>
+</console>
+
+<variables description="Variables defined in the current session">
+<variable>
+${JSON.stringify(c.variables![0])}
+</variable>
+</variables>
+
+<shell description="Current active shell">
+${c.shell}
+</shell>
+
+<plots>
+${c.plots!.hasPlots ? 'A plot is visible.' : ''}
+</plots>
+</context>`);
+	});
+
+	test('should include file reference', async () => {
+		// Setup test inputs.
+		const references: vscode.ChatPromptReference[] = [{
+			id: 'test-file-reference',
+			name: 'Test File',
+			value: referenceUri,
+			modelDescription: 'Test file description',
+		}];
+		const request = makeChatRequest({ model, references });
+		const context: vscode.ChatContext = { history: [] };
+		sinon.stub(positron.ai, 'getPositronChatContext').resolves({});
+		const sendRequestSpy = sinon.spy(model, 'sendRequest');
+
+		// Call the method under test.
+		await participant.requestHandler(request, context, response, token);
+
+		// The first user message should contain the formatted context.
+		sinon.assert.calledOnce(sendRequestSpy);
+		const [messages,] = sendRequestSpy.getCall(0).args;
+		assert.ok(messages.length > 0, `Unexpected messages: ${JSON.stringify(messages)}`);
+		const message = messages[0];
+		assert.strictEqual(message.role, vscode.LanguageModelChatMessageRole.User);
+		const document = await vscode.workspace.openTextDocument(referenceUri);
+		const filePath = vscode.workspace.asRelativePath(referenceUri);
+		assertMessageTextEqual(message,
+			`<references>
+<reference filePath="${filePath}" description="Full contents of the file" language="${document.languageId}">
+${document.getText()}
+</reference>
+</references>`);
+	});
+
+	test('should include file range reference', async () => {
+		// Setup test inputs.
+		const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(1, 0));
+		const location = new vscode.Location(referenceUri, range);
+		const references: vscode.ChatPromptReference[] = [{
+			id: 'test-file-reference',
+			name: 'Test File',
+			value: location,
+			modelDescription: 'Test file description',
+		}];
+		const request = makeChatRequest({ model, references });
+		const context: vscode.ChatContext = { history: [] };
+		sinon.stub(positron.ai, 'getPositronChatContext').resolves({});
+		const sendRequestSpy = sinon.spy(model, 'sendRequest');
+
+		// Call the method under test.
+		await participant.requestHandler(request, context, response, token);
+
+		// The first user message should contain the formatted context.
+		sinon.assert.calledOnce(sendRequestSpy);
+		const [messages,] = sendRequestSpy.getCall(0).args;
+		assert.ok(messages.length > 0, `Unexpected messages: ${JSON.stringify(messages)}`);
+		const message = messages[0];
+		assert.strictEqual(message.role, vscode.LanguageModelChatMessageRole.User);
+		const document = await vscode.workspace.openTextDocument(referenceUri);
+		const filePath = vscode.workspace.asRelativePath(referenceUri);
+		assertMessageTextEqual(message,
+			`<references>
+<reference filePath="${filePath}" description="Visible region of the active file" language="${document.languageId}" startLine="${range.start.line + 1}" endLine="${range.end.line + 1}">
+${document.getText(range)}
+</reference>
+<reference filePath="${filePath}" description="Full contents of the active file" language="${document.languageId}">
+${document.getText()}
+</reference>
+</references>`);
+	});
+
+	// TODO: Continue here...
+	test('should include llms.txt instructions', async () => {
+	});
+
+	test('should include image reference', async () => {
+	});
+
+	test('should include editor information', async () => {
+	});
+});
+
+function makeChatRequest(
+	options: {
+		model: vscode.LanguageModelChat;
+		references: vscode.ChatPromptReference[];
+	},
+): vscode.ChatRequest {
+	return {
+		id: 'test-request-id',
+		prompt: 'Hello, world!',
+		command: undefined,
+		references: options.references,
+		tools: [],
+		toolReferences: [],
+		toolInvocationToken: undefined as vscode.ChatParticipantToolToken,
+		model: options.model,
+		attempt: 0,
+		location: vscode.ChatLocation.Panel,
+		location2: undefined,
+		enableCommandDetection: false,
+		isParticipantDetected: false,
+	};
+}
+
+function assertMessageTextEqual(
+	message: vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2,
+	expected: string,
+): void {
+	assert.strictEqual(message.content.length, 1);
+	assert.ok(message.content[0] instanceof vscode.LanguageModelTextPart);
+	assert.strictEqual(message.content[0].value, expected);
+}

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -139,6 +139,7 @@ suite('PositronAssistantParticipant', () => {
 			console: {
 				language: 'python',
 				version: '3.12.0',
+				identifier: 'test-console',
 				executions: [
 					{
 						input: 'x = 1',
@@ -152,9 +153,14 @@ suite('PositronAssistantParticipant', () => {
 			},
 			variables: [
 				{
-					name: 'x',
-					value: '1',
-					type: 'number',
+					access_key: 'x',
+					display_name: 'x',
+					display_type: 'number',
+					display_value: '1',
+					has_children: false,
+					length: 1,
+					size: 1,
+					type_info: 'int',
 				},
 			],
 			shell: 'bash',
@@ -171,7 +177,7 @@ suite('PositronAssistantParticipant', () => {
 		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<context>
-<console description="Current active console" language="${c.console!.language}" version="${c.console!.version}">
+<console description="Current active console" language="${c.console!.language}" version="${c.console!.version}" identifier="${c.console!.identifier}">
 <executions>
 <execution>
 ${JSON.stringify(c.console!.executions[0])}

--- a/extensions/positron-assistant/src/test/utils.ts
+++ b/extensions/positron-assistant/src/test/utils.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function mock<T>(obj: Partial<T>): T {
+	return obj as T;
+}

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -220,7 +220,7 @@ function getPlotToolResultToAiMessage(part: vscode.LanguageModelToolResultPart):
 /**
  * Convert chat participant history into an array of VSCode language model messages.
  */
-export function toLanguageModelChatMessage(turns: vscode.ChatContext['history']): vscode.LanguageModelChatMessage[] {
+export function toLanguageModelChatMessage(turns: vscode.ChatContext['history']): (vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2)[] {
 	return turns.map((turn) => {
 		if (turn instanceof vscode.ChatRequestTurn) {
 			let textValue = turn.prompt;

--- a/extensions/positron-assistant/src/xml.ts
+++ b/extensions/positron-assistant/src/xml.ts
@@ -3,6 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * NOTE: The goal of this module is to use XML-like syntax to structure information
+ *       in LLM conversations, NOT to create valid XML. We may drift significantly
+ *       from XML syntax if it produces better LLM results. This is also why we decided
+ *       to not use a third party library.
+ */
+
 function xmlAttributes(attributes: Record<string, any>): string {
 	return Object.entries(attributes)
 		.map(([key, val]) => `${key}="${val}"`)
@@ -10,7 +17,9 @@ function xmlAttributes(attributes: Record<string, any>): string {
 }
 
 /**
- * Create an XML node.
+ * Create an XML-like node for structuring information in LLM prompts.
+ *
+ * NOTE: Do not use this function where valid XML is required.
  *
  * @param name The name of the node.
  * @param content The content of the node.
@@ -31,7 +40,9 @@ export function node(name: string, content?: string, attributes?: Record<string,
 }
 
 /**
- * Create a self-closing XML node.
+ * Create a self-closing XML node for structuring information in LLM prompts.
+ *
+ * NOTE: Do not use this function where valid XML is required.
  *
  * @param name The name of the node.
  * @param attributes The attributes of the node.

--- a/extensions/positron-assistant/src/xml.ts
+++ b/extensions/positron-assistant/src/xml.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+function xmlAttributes(attributes: Record<string, any>): string {
+	return Object.entries(attributes)
+		.map(([key, val]) => `${key}="${val}"`)
+		.join(' ');
+}
+
+/**
+ * Create an XML node.
+ *
+ * @param name The name of the node.
+ * @param content The content of the node.
+ * @param attributes The attributes of the node.
+ * @returns The XML string representation of the node.
+ */
+export function node(name: string, content?: string, attributes?: Record<string, any>): string {
+	let result = `<${name}`;
+	if (attributes && Object.keys(attributes).length) {
+		result += ` ${xmlAttributes(attributes)}`;
+	}
+	result += `>`;
+	if (content && content.length > 0) {
+		result += `\n${content}\n`;
+	}
+	result += `</${name}>`;
+	return result;
+}
+
+/**
+ * Create a self-closing XML node.
+ *
+ * @param name The name of the node.
+ * @param attributes The attributes of the node.
+ * @returns The XML string representation of the self-closing node.
+ */
+export function leaf(name: string, attributes?: Record<string, any>): string {
+	let result = `<${name}`;
+	if (attributes && Object.keys(attributes).length) {
+		result += ` ${xmlAttributes(attributes)}`;
+	}
+	result += ` />`;
+	return result;
+}

--- a/extensions/positron-assistant/test-workspace/reference.ts
+++ b/extensions/positron-assistant/test-workspace/reference.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+console.log('Hello from reference.ts');

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2053,6 +2053,9 @@ declare module 'positron' {
 					error?: any;
 				}[];
 			};
+			plots?: {
+				hasPlots: boolean;
+			};
 			variables?: RuntimeVariable[];
 			shell?: string;
 		}


### PR DESCRIPTION
Addresses a few issues raised in https://github.com/posit-dev/positron/issues/7596#issuecomment-2882237326 related to the context message we construct:

1. [Use XML tags](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-tags).
2. Use a single user message for the context.

Might be best to look at the tests to see what the new context messages look like.

I'm not sure what prompting best practices are, and whether I used XML in the best way.

### QA Notes

I added extension tests to check that the context message is generated as expected. I think it's a useful thing to test and don't think there's a good way to do that via e2e tests cc @jonvanausdeln.