### PR TITLE
Multi Session Accessibility Bugfixes

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -99,8 +99,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 	const keyDownHandler = (e: KeyboardEvent<HTMLButtonElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space triggers the onPressed event. Note: Do not add 'Enter' here. Enter is reserved
-			// for clicking the default button in modal popups and modal dialogs.
+			case 'Enter':
 			case 'Space':
 				sendOnPressed(e);
 				break;

--- a/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
@@ -51,10 +51,8 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Props
 	const keyDownHandler = (e: KeyboardEvent<HTMLDivElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space triggers the onPressed event. Note: Do not add 'Enter' here. Enter is reserved
-			// for clicking the default button in modal popups and modal dialogs.
 			case 'Space':
-				// Consume the event.
+			case 'Enter':
 				e.preventDefault();
 				e.stopPropagation();
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1279,10 +1279,7 @@ registerAction2(class extends Action2 {
 			category,
 			f1: true,
 			keybinding: {
-				primary: KeyCode.F2,
-				mac: {
-					primary: KeyCode.Enter
-				},
+				primary: KeyCode.Enter,
 				when: PositronConsoleTabFocused,
 				weight: KeybindingWeight.WorkbenchContrib
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -247,7 +247,7 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 	 * If the user presses Escape, the rename operation is cancelled.
 	 * Supports copy, cut, paste, and select all operations using Ctrl/Cmd + C/X/V/A.
 	 */
-	const handleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
+	const handleInputKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === 'Enter') {
 			e.preventDefault();
 			handleRenameSubmit();
@@ -336,7 +336,7 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 					onBlur={handleRenameSubmit}
 					onChange={e => setSessionName(e.target.value)}
 					onClick={e => e.stopPropagation()} // Keeps the input field open when clicked
-					onKeyDown={handleKeyDown}
+					onKeyDown={handleInputKeyDown}
 					onMouseDown={e => e.stopPropagation()} // Allows text selection in the input field
 				/>
 			) : (


### PR DESCRIPTION
Addresses #7722 and #7726 

* Updates our button components so `Enter` or `Space` activate the button as per https://www.w3.org/WAI/ARIA/apg/patterns/button/. This fix is what resolves the "start session" button from activating on `Enter`.
* Changed the keybinding for the "Rename Session" action to be "Enter" in all cases. Previously, the "F2" key was what kicked off the rename action on Windows/Ubuntu.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Button components now activate on "Enter"
- Pressing "Enter" (instead of "F2") on Windows/Ubuntu triggers rename interpreter session action when focused on a console tab

### QA Notes

@:sessions @:win @:web