### PR TITLE
Updates Console view to track disposables

### DIFF
--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -117,7 +117,8 @@ suite('PositronRunApp', () => {
 		assert(terminal, 'Terminal not found');
 	}
 
-	test('appLauncher: shell integration supported', async () => {
+	// TODO: Flaky test: https://github.com/posit-dev/positron/issues/5823.
+	test.skip('appLauncher: shell integration supported', async () => {
 		// Run the application.
 		await verifyRunTestApplication();
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -376,7 +376,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				const dropdownAction = new Action('console.session.quickLaunch', localize('console.session.quickLaunch', 'Quick Launch Session...'), 'codicon-chevron-down', true);
 				this._register(dropdownAction);
 
-				this._sessionDropdown.value = new DropdownWithPrimaryActionViewItem(action, dropdownAction, [], 'console-test-dropdown', {}, this.contextMenuService, this.keybindingService, this.notificationService, this.contextKeyService, this.themeService, this.accessibilityService);
+				this._sessionDropdown.value = new DropdownWithPrimaryActionViewItem(action, dropdownAction, [], '', {}, this.contextMenuService, this.keybindingService, this.notificationService, this.contextKeyService, this.themeService, this.accessibilityService);
 				this.updateSessionDropdown(dropdownAction);
 
 				return this._sessionDropdown.value;


### PR DESCRIPTION
New console split button introduced excessive disposable warnings in the console output. This PR updates logic to track disposables properly.

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #7776


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:console

cc: @midleman 
