### PR TITLE
e2e: update logger path and persist logs

### DIFF
--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -124,6 +124,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
           report-dir: ${{ env.REPORT_DIR }}
 
+      - name: Upload Test Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-electron
+          path: test-logs
+          if-no-files-found: ignore
+
   slack-notify:
     needs: [e2e-electron]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -17,6 +17,11 @@ on:
           - failure
           - always
           - never
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -125,7 +130,7 @@ jobs:
           report-dir: ${{ env.REPORT_DIR }}
 
       - name: Upload Test Logs
-        if: ${{ always() }}
+        if: ${{ inputs.upload_logs }}
         uses: actions/upload-artifact@v4
         with:
           name: logs-electron

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -269,6 +269,3 @@ jobs:
           path: test-logs
           if-no-files-found: ignore
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -260,3 +260,15 @@ jobs:
           TESTRAIL_TITLE: ${{ inputs.project }}
           TESTRAIL_PROJECT: "Positron"
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+
+      - name: Upload Test Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.project }}-logs
+          path: test-logs
+          if-no-files-found: ignore
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -53,6 +53,11 @@ on:
         description: "Comma-separated list of tags to skip."
         type: string
         default: ""
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -262,7 +267,7 @@ jobs:
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
 
       - name: Upload Test Logs
-        if: ${{ always() }}
+        if: ${{ inputs.upload_logs }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.project }}-logs

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -32,6 +32,11 @@ on:
         description: "Whether or not to report results to Currents."
         type: boolean
         default: true
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -211,7 +216,7 @@ jobs:
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
 
       - name: Upload Test Logs
-        if: ${{ always() }}
+        if: ${{ inputs.upload_logs }}
         uses: actions/upload-artifact@v4
         with:
           name: e2e-win-logs

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -209,3 +209,12 @@ jobs:
           TESTRAIL_TITLE: "e2e-windows"
           TESTRAIL_PROJECT: "Positron"
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+
+      - name: Upload Test Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-win-logs
+          path: test-logs
+          if-no-files-found: ignore
+

--- a/test/e2e/infra/logger.ts
+++ b/test/e2e/infra/logger.ts
@@ -6,10 +6,11 @@
 import { appendFileSync, writeFileSync, existsSync } from 'fs';
 import { format } from 'util';
 import { EOL } from 'os';
+import path from 'path';
 
 export interface Logger {
 	log(message: string, ...args: any[]): void;
-	setPath?(newPath: string): void;
+	setPath?(dir: string, filename?: string): void;
 }
 
 export class ConsoleLogger implements Logger {
@@ -27,8 +28,8 @@ export class FileLogger implements Logger {
 		this.ensureFileExists(this.path);
 	}
 
-	setPath(newPath: string): void {
-		this.path = newPath;
+	setPath(dir: string, filename = 'e2e-test-runner.log'): void {
+		this.path = path.join(dir, filename);
 		this.ensureFileExists(this.path);
 	}
 
@@ -52,6 +53,14 @@ export class FileLogger implements Logger {
 export class MultiLogger implements Logger {
 
 	constructor(private loggers: Logger[]) { }
+
+	setPath(dir: string, filename = 'e2e-test-runner.log'): void {
+		for (const logger of this.loggers) {
+			if (logger.setPath) {
+				logger.setPath(dir, filename);
+			}
+		}
+	}
 
 	log(message: string, ...args: any[]): void {
 		for (const logger of this.loggers) {

--- a/test/e2e/infra/logger.ts
+++ b/test/e2e/infra/logger.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { appendFileSync, writeFileSync } from 'fs';
+import { appendFileSync, writeFileSync, existsSync } from 'fs';
 import { format } from 'util';
 import { EOL } from 'os';
 
 export interface Logger {
 	log(message: string, ...args: any[]): void;
+	setPath?(newPath: string): void;
 }
 
 export class ConsoleLogger implements Logger {
@@ -19,9 +20,22 @@ export class ConsoleLogger implements Logger {
 }
 
 export class FileLogger implements Logger {
+	private path: string;
 
-	constructor(private path: string) {
-		writeFileSync(path, '');
+	constructor(initialPath: string) {
+		this.path = initialPath;
+		this.ensureFileExists(this.path);
+	}
+
+	setPath(newPath: string): void {
+		this.path = newPath;
+		this.ensureFileExists(this.path);
+	}
+
+	private ensureFileExists(path: string): void {
+		if (!existsSync(path)) {
+			writeFileSync(path, '');
+		}
 	}
 
 	log(message: string, ...args: any[]): void {

--- a/test/e2e/infra/playwrightBrowser.ts
+++ b/test/e2e/infra/playwrightBrowser.ts
@@ -54,8 +54,8 @@ async function launchServer(options: LaunchOptions) {
 		const args = getServerArgs(currentPort, extensionsPath, agentFolder, serverLogsPath, options.verbose);
 		const serverLocation = resolveServerLocation(codeServerPath, logger);
 
-		console.log(`Attempting to start server on port ${currentPort}`);
-		console.log(`Command: '${serverLocation}' ${args.join(' ')}`);
+		logger.log(`Attempting to start server on port ${currentPort}`);
+		logger.log(`Command: '${serverLocation}' ${args.join(' ')}`);
 
 		try {
 			serverProcess = await startServer(serverLocation, args, env, logger);
@@ -211,7 +211,7 @@ function waitForEndpoint(server: ChildProcess, logger: Logger): Promise<string> 
 
 		server.stdout?.on('data', data => {
 			if (!endpointFound) {
-				console.log(`[server] stdout: ${data}`); // log until endpoint found to diagnose issues
+				logger.log(`[server] stdout: ${data}`); // log until endpoint found to diagnose issues
 			}
 
 			const matches = data.toString('ascii').match(/Web UI available at (.+)/);
@@ -224,7 +224,7 @@ function waitForEndpoint(server: ChildProcess, logger: Logger): Promise<string> 
 
 		server.stderr?.on('data', error => {
 			if (!endpointFound) {
-				console.log(`[server] stderr: ${error}`); // log until endpoint found to diagnose issues
+				logger.log(`[server] stderr: ${error}`); // log until endpoint found to diagnose issues
 			}
 
 			if (error.toString().indexOf('EADDRINUSE') !== -1) {

--- a/test/e2e/infra/playwrightDriver.ts
+++ b/test/e2e/infra/playwrightDriver.ts
@@ -6,7 +6,7 @@
 import * as playwright from '@playwright/test';
 // eslint-disable-next-line local/code-import-patterns
 import type { Protocol } from 'playwright-core/types/protocol';
-import path, { dirname, join } from 'path';
+import { dirname, join } from 'path';
 import { promises } from 'fs';
 import { IWindowDriver } from './driver';
 // eslint-disable-next-line local/code-import-patterns
@@ -195,50 +195,16 @@ export class PlaywrightDriver {
 			}
 		}
 
-		// Web: exit via `close` method
-		if (this.options.web) {
-			try {
-				await measureAndLog(() => this.application.close(), 'playwright.close()', this.options.logger);
-			} catch (error) {
-				this.options.logger.log(`Error closing appliction (${error})`);
-			}
+		//  exit via `close` method
+		try {
+			await measureAndLog(() => this.application.close(), 'playwright.close()', this.options.logger);
+		} catch (error) {
+			this.options.logger.log(`Error closing application (${error})`);
 		}
 
-		// Desktop: exit via `driver.exitApplication`
-		else {
-
-			// Log all files in extensionsPath
-			const extensionsPath = this.options.extensionsPath;
-			this.options.logger.log(`Listing files in: ${extensionsPath}`);
-
-			const files = await promises.readdir(extensionsPath);
-			this.options.logger.log(`Files in extensionsPath: ${files.join(', ')}`);
-
-			// Read and log contents of extensions.json (if it exists)
-			const extensionsJsonPath = path.join(extensionsPath, 'extensions.json');
-			try {
-				const extensionsJsonContent = await promises.readFile(extensionsJsonPath, 'utf-8');
-				this.options.logger.log(`Contents of extensions.json:\n${extensionsJsonContent}`);
-			} catch (jsonError) {
-				this.options.logger.log(`extensions.json not found or cannot be read: ${jsonError}`);
-			}
-
-			try {
-				await measureAndLog(() => this.evaluateWithDriver(([driver]) => driver.exitApplication()), 'driver.exitApplication()', this.options.logger);
-			} catch (error) {
-				this.options.logger.log(`Error exiting application (${error})`);
-			}
-			//  exit via `close` method
-			try {
-				await measureAndLog(() => this.application.close(), 'playwright.close()', this.options.logger);
-			} catch (error) {
-				this.options.logger.log(`Error closing application (${error})`);
-			}
-
-			// Server: via `teardown`
-			if (this.serverProcess) {
-				await measureAndLog(() => teardown(this.serverProcess!, this.options.logger), 'teardown server process', this.options.logger);
-			}
+		// Server: via `teardown`
+		if (this.serverProcess) {
+			await measureAndLog(() => teardown(this.serverProcess!, this.options.logger), 'teardown server process', this.options.logger);
 		}
 	}
 

--- a/test/e2e/infra/test-runner/logger.ts
+++ b/test/e2e/infra/test-runner/logger.ts
@@ -16,8 +16,7 @@ const VERBOSE = process.env.VERBOSE === 'true';
  * @param logsRootPath the root path for the logs
  * @returns Logger instance
  */
-export function createLogger(logsRootPath: string): Logger {
-	const logsFileName = `e2e-test-runner.log`;
+export function createLogger(logsRootPath: string, logsFileName = 'e2e-test-runner.log'): Logger {
 	const loggers: Logger[] = [];
 
 	if (VERBOSE) {

--- a/test/e2e/infra/test-runner/logger.ts
+++ b/test/e2e/infra/test-runner/logger.ts
@@ -16,7 +16,7 @@ const VERBOSE = process.env.VERBOSE === 'true';
  * @param logsRootPath the root path for the logs
  * @returns Logger instance
  */
-export function createLogger(logsRootPath: string, logsFileName = 'e2e-test-runner.log'): Logger {
+export function createLogger(logsRootPath: string, logsFileName = 'e2e-test-runner.log'): MultiLogger {
 	const loggers: Logger[] = [];
 
 	if (VERBOSE) {

--- a/test/e2e/infra/test-runner/test-setup.ts
+++ b/test/e2e/infra/test-runner/test-setup.ts
@@ -22,9 +22,8 @@ const BUILD = process.env.BUILD;
  *   2. initializes the test environment
  *   3. prepares the test data directory
  */
-export function prepareTestEnv(rootPath = process.env.ROOT_PATH || 'ROOT_PATH not set prepareTestEnv') {
-	const logsRootPath = join(rootPath, '.build', 'logs', 'test-setup');
-	const logger = createLogger(logsRootPath);
+export function prepareTestEnv(rootPath: string, logsRootPath: string) {
+	const logger = createLogger(logsRootPath, 'prepare-test-env.log');
 
 	try {
 		initializeTestEnvironment(rootPath, logger);

--- a/test/e2e/tests/_global.setup.ts
+++ b/test/e2e/tests/_global.setup.ts
@@ -15,7 +15,7 @@ const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 
 async function globalSetup() {
 	fs.rmSync(LOGS_ROOT_PATH, { recursive: true, force: true });
-	prepareTestEnv(ROOT_PATH);
+	prepareTestEnv(ROOT_PATH, LOGS_ROOT_PATH);
 	cloneTestRepo(WORKSPACE_PATH);
 }
 

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,8 +21,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, ApplicationOptions, Quality } from '../infra';
-import { PackageManager } from '../pages/utils/packageManager';
+import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, FileLogger, ApplicationOptions, Quality } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
 
 // Constants
 const TEMP_DIR = `temp-${randomUUID()}`;
@@ -98,7 +97,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 		await use(app);
 	}, { scope: 'test', timeout: 60000 }],
 
-	app: [async ({ options, logsPath, }, use, workerInfo) => {
+	app: [async ({ options, logsPath, logger }, use, workerInfo) => {
 		const app = createApp(options);
 
 		try {
@@ -124,7 +123,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 
 			// rename the temp logs dir to the spec name (if available)
 			const specLogsPath = path.join(path.dirname(logsPath), SPEC_NAME || `worker-${workerInfo.workerIndex}`);
-			await moveAndOverwrite(logsPath, specLogsPath);
+			await moveAndOverwrite(logger, logsPath, specLogsPath);
 		}
 	}, { scope: 'worker', auto: true, timeout: 80000 }],
 
@@ -434,7 +433,7 @@ test.afterAll(async function ({ logger }, testInfo) {
 export { playwrightExpect as expect };
 export { TestTags as tags };
 
-async function moveAndOverwrite(sourcePath, destinationPath) {
+async function moveAndOverwrite(logger: Logger, sourcePath: string, destinationPath: string) {
 	try {
 		await access(sourcePath, constants.F_OK);
 	} catch {
@@ -455,7 +454,14 @@ async function moveAndOverwrite(sourcePath, destinationPath) {
 	// rename source to destination
 	try {
 		await rename(sourcePath, destinationPath);
-	} catch (err) { }
+		if (logger instanceof FileLogger) {
+			console.log('Marie! setting logger new path:', destinationPath);
+			logger.setPath(destinationPath);
+			logger.log('Logger path updated to:', destinationPath);
+		}
+	} catch (err) {
+		logger.log(`moveAndOverwrite: failed to move ${sourcePath} to ${destinationPath}:`, err);
+	}
 }
 
 interface TestFixtures {

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, FileLogger, ApplicationOptions, Quality, MultiLogger } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
+import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, ApplicationOptions, Quality, MultiLogger } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
 
 // Constants
 const TEMP_DIR = `temp-${randomUUID()}`;

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,8 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, ApplicationOptions, Quality, MultiLogger } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
+import { Application, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, ApplicationOptions, Quality, MultiLogger } from '../infra';
+import { PackageManager } from '../pages/utils/packageManager';
 
 // Constants
 const TEMP_DIR = `temp-${randomUUID()}`;
@@ -433,7 +434,7 @@ test.afterAll(async function ({ logger }, testInfo) {
 export { playwrightExpect as expect };
 export { TestTags as tags };
 
-async function moveAndOverwrite(logger: Logger, sourcePath: string, destinationPath: string) {
+async function moveAndOverwrite(logger: MultiLogger, sourcePath: string, destinationPath: string) {
 	try {
 		await access(sourcePath, constants.F_OK);
 	} catch {
@@ -454,7 +455,7 @@ async function moveAndOverwrite(logger: Logger, sourcePath: string, destinationP
 	// rename source to destination
 	try {
 		await rename(sourcePath, destinationPath);
-		(logger as MultiLogger).setPath(destinationPath);
+		logger.setPath(destinationPath);
 		logger.log('Logger path updated to:', destinationPath);
 	} catch (err) {
 		logger.log(`moveAndOverwrite: failed to move ${sourcePath} to ${destinationPath}:`, err);
@@ -494,7 +495,7 @@ interface WorkerFixtures {
 	userDataDir: string;
 	app: Application;
 	logsPath: string;
-	logger: Logger;
+	logger: MultiLogger;
 	userSettings: {
 		set: (settings: Setting[], restartApp?: boolean) => Promise<void>;
 	};

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, FileLogger, ApplicationOptions, Quality } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
+import { Application, Logger, Setting, SettingsFixture, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, getRandomUserDataDir, createPositronSettingsManager, vsCodeSettings, FileLogger, ApplicationOptions, Quality, MultiLogger } from '../infra'; import { PackageManager } from '../pages/utils/packageManager';
 
 // Constants
 const TEMP_DIR = `temp-${randomUUID()}`;
@@ -454,11 +454,8 @@ async function moveAndOverwrite(logger: Logger, sourcePath: string, destinationP
 	// rename source to destination
 	try {
 		await rename(sourcePath, destinationPath);
-		if (logger instanceof FileLogger) {
-			console.log('Marie! setting logger new path:', destinationPath);
-			logger.setPath(destinationPath);
-			logger.log('Logger path updated to:', destinationPath);
-		}
+		(logger as MultiLogger).setPath(destinationPath);
+		logger.log('Logger path updated to:', destinationPath);
 	} catch (err) {
 		logger.log(`moveAndOverwrite: failed to move ${sourcePath} to ${destinationPath}:`, err);
 	}

--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -17,7 +17,7 @@ test.describe('Large Python Notebook', {
 
 	test.afterAll(async function ({ hotKeys }) {
 		// If we don't close the editor, the test teardown fails
-		await hotKeys.closeAllEditors()
+		await hotKeys.closeAllEditors();
 	});
 
 	test('Python - Large notebook execution', async function ({ app, python }) {


### PR DESCRIPTION
### Summary

This updates the logger to support dynamically updating its file path. The log files are renamed in the app fixture after the app shuts down, so this ensures that if a test hangs (for any reason), logs continue to be written to the correct file.

Also uploading `test-logs` dir in CI. Not sure we need this, I can put it behind a flag so we can toggle. Thoughts? It is currently disabled.

### QA Notes

Verified using the large-python-notebook test: by toggling the afterAll hook, I confirmed that trailing logs (which previously failed to write) now correctly appear in the updated log file.

<img width="1815" alt="Screenshot 2025-05-21 at 11 42 00 AM" src="https://github.com/user-attachments/assets/e5e9b32c-919c-4e7a-9ad3-d2e89090623e" />


