### PR TITLE
Python: Updates IPython tests to support versions >= 9.0.0

### DIFF
--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -18,7 +18,8 @@ hvplot==0.11.2
 ibis-framework[duckdb]==10.4.0; python_version >= '3.10'
 ipykernel==6.29.5
 ipython==8.18.1; python_version == '3.9'
-ipython==8.31.0; python_version >= '3.10'
+ipython==8.31.0; python_version == '3.10'
+ipython==9.2.0; python_version >= '3.11'
 ipywidgets==8.1.5
 lightning==2.5.1
 matplotlib==3.9.4; python_version == '3.9'

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -282,6 +282,9 @@ def test_console_traceback_ipy9(shell: PositronShell, test_traceback_result) -> 
     # Define a few OSC8 escape codes for convenience.
 
     # Convenient reference to colors from the active scheme.
+
+    # NOTE (here and below): Ignoring types related to `theme_table` and `ultratb.Token`
+    # as they will report undefined in Python<3.11.
     colors = ultratb.theme_table[shell.colors]  # type: ignore
 
     # This template matches the beginning of each traceback frame. We don't check each entire frame

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -183,7 +183,7 @@ def test_traceback_result(
     tmp_path: Path,
     mock_displayhook: Mock,
     monkeypatch,
-) -> tuple[str, Any]:
+) -> tuple[Path, Any]:
     # Ensure that we're in console mode.
     monkeypatch.setattr(shell, "session_mode", SessionMode.CONSOLE)
 
@@ -282,7 +282,7 @@ def test_console_traceback_ipy9(shell: PositronShell, test_traceback_result) -> 
     # Define a few OSC8 escape codes for convenience.
 
     # Convenient reference to colors from the active scheme.
-    colors = ultratb.theme_table[shell.colors]
+    colors = ultratb.theme_table[shell.colors]  # type: ignore
 
     # This template matches the beginning of each traceback frame. We don't check each entire frame
     # because syntax highlighted code is full of escape codes. For example, after removing
@@ -292,11 +292,11 @@ def test_console_traceback_ipy9(shell: PositronShell, test_traceback_result) -> 
     #
     traceback_frame_header = colors.format(
         [
-            (ultratb.Token.NormalEm, "File "),
-            (ultratb.Token.FilenameEm, f"{path}:{{line}}"),
-            (ultratb.Token.Normal, ", in "),
-            (ultratb.Token.VName, "{func}"),
-            (ultratb.Token.ValEm, "()"),
+            (ultratb.Token.NormalEm, "File "),  # type: ignore
+            (ultratb.Token.FilenameEm, f"{path}:{{line}}"),  # type: ignore
+            (ultratb.Token.Normal, ", in "),  # type: ignore
+            (ultratb.Token.VName, "{func}"),  # type: ignore
+            (ultratb.Token.ValEm, "()"),  # type: ignore
         ]
     )
 
@@ -314,7 +314,7 @@ def test_console_traceback_ipy9(shell: PositronShell, test_traceback_result) -> 
     # The exception value should include the top of the stack trace.
     assert_ansi_string_startswith(
         exc_content["evalue"],
-        "This is an error!\n" + colors.format([(ultratb.Token.NormalEm, "Cell")]),
+        "This is an error!\n" + colors.format([(ultratb.Token.NormalEm, "Cell")]),  # type: ignore
     )
 
 

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -5,7 +5,7 @@ holoviews
 hvplot
 ibis-framework[duckdb]; python_version >= '3.10'
 ipykernel
-ipython<=8.31.0  # see https://github.com/posit-dev/positron/issues/6604
+ipython
 ipywidgets
 lightning
 matplotlib


### PR DESCRIPTION
IPython 9.0.0 introduced breaking changes surrounding traceback colorization. This PR updates unit tests to support the new colorizing machinery. It retains the old test to ensure coverage when IPython < 9.0.0. 

Two tests are now testing for colorization, however, only one will succeed based on the current Python version. The other was marked with `pytest.xfail` to allow the suite to succeed. 

The test requirements were updated to pin IPython==9.2.0 when Python>=3.11.

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #6604


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Updates to unit tests only
