### PR TITLE
assistant: replace empty tool results with placeholder text

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import Anthropic from '@anthropic-ai/sdk';
 import { ModelConfig } from './config';
 import { isLanguageModelImagePart, LanguageModelImagePart } from './languageModelParts.js';
-import { hasNonEmptyContent, isChatImagePart } from './utils.js';
+import { ensureMessageContent, isChatImagePart } from './utils.js';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 
 export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProvider {
@@ -56,10 +56,9 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		progress: vscode.Progress<vscode.ChatResponseFragment2>,
 		token: vscode.CancellationToken
 	) {
-		// Filter out messages with empty text or empty tool response content
-		const filteredMessages = messages.filter(hasNonEmptyContent);
-
-		const anthropicMessages = filteredMessages.map(message => toAnthropicMessage(message));
+		const anthropicMessages = messages
+			.map(ensureMessageContent)
+			.map(toAnthropicMessage);
 		const tools = options.tools?.map(tool => toAnthropicTool(tool));
 		const tool_choice = options.toolMode && toAnthropicToolChoice(options.toolMode);
 		const stream = this._client.messages.stream({
@@ -133,21 +132,14 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 	}
 
 	async provideTokenCount(text: string | vscode.LanguageModelChatMessage, token: vscode.CancellationToken): Promise<number> {
-		// For empty string or message with only empty content, return 0 tokens
+		const messages: Anthropic.MessageParam[] = [];
 		if (typeof text === 'string') {
+			// For empty string, return 0 tokens
 			if (text.trim() === '') {
 				return 0;
 			}
-		} else {
-			// Check if message has any non-empty content
-			if (!hasNonEmptyContent(text)) {
-				return 0;
-			}
-		}
-
-		// Process non-empty content normally
-		const messages: Anthropic.MessageParam[] = typeof text === 'string' ?
-			[{
+			// Otherwise, treat it as a user message
+			messages.push({
 				role: 'user',
 				content: [
 					{
@@ -155,8 +147,13 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 						text,
 					},
 				],
-			}] :
-			[toAnthropicMessage(text)];
+			});
+		} else {
+			// For LanguageModelChatMessage, ensure it has non-empty message content
+			const transformedMessage = ensureMessageContent(text);
+			const anthropicMessage = toAnthropicMessage(transformedMessage);
+			messages.push(anthropicMessage);
+		}
 		const result = await this._client.messages.countTokens({
 			model: this._config.model,
 			messages,

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -15,7 +15,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createMistral } from '@ai-sdk/mistral';
 import { createOllama } from 'ollama-ai-provider';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-import { ensureMessageContent, toAIMessage } from './utils';
+import { processMessages, toAIMessage } from './utils';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel } from './anthropic';
@@ -218,12 +218,12 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		let tools: Record<string, ai.Tool> | undefined;
 
 		// Ensure all messages have content
-		const updatedMessages = messages.map(ensureMessageContent);
+		const processedMessages = processMessages(messages);
 		// Only Anthropic currently supports experimental_content in tool
 		// results.
 		const toolResultExperimentalContent = this.provider === 'anthropic';
 		// Convert messages to the Vercel AI format.
-		const aiMessages = toAIMessage(updatedMessages, toolResultExperimentalContent);
+		const aiMessages = toAIMessage(processedMessages, toolResultExperimentalContent);
 
 		if (options.tools && options.tools.length > 0) {
 			tools = options.tools.reduce((acc: Record<string, ai.Tool>, tool: vscode.LanguageModelChatTool) => {

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -217,7 +217,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 
 		let tools: Record<string, ai.Tool> | undefined;
 
-		// Filter out messages with empty text or empty tool response content
+		// Ensure all messages have content
 		const updatedMessages = messages.map(ensureMessageContent);
 		// Only Anthropic currently supports experimental_content in tool
 		// results.

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -15,7 +15,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createMistral } from '@ai-sdk/mistral';
 import { createOllama } from 'ollama-ai-provider';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-import { hasNonEmptyContent, toAIMessage } from './utils';
+import { ensureMessageContent, toAIMessage } from './utils';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel } from './anthropic';
@@ -218,12 +218,12 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		let tools: Record<string, ai.Tool> | undefined;
 
 		// Filter out messages with empty text or empty tool response content
-		const filteredMessages = messages.filter(hasNonEmptyContent);
+		const updatedMessages = messages.map(ensureMessageContent);
 		// Only Anthropic currently supports experimental_content in tool
 		// results.
 		const toolResultExperimentalContent = this.provider === 'anthropic';
 		// Convert messages to the Vercel AI format.
-		const aiMessages = toAIMessage(filteredMessages, toolResultExperimentalContent);
+		const aiMessages = toAIMessage(updatedMessages, toolResultExperimentalContent);
 
 		if (options.tools && options.tools.length > 0) {
 			tools = options.tools.reduce((acc: Record<string, ai.Tool>, tool: vscode.LanguageModelChatTool) => {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -369,6 +369,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		}
 
+		// Note if no workspace folders are open, which affects workspace-related tools.
+		if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+			prompts.push(xml.node('workspace', 'No workspace folders open.'));
+		}
+
 		// Add Positron IDE context to the prompt.
 		const positronContext = await positron.ai.getPositronChatContext(request);
 		const positronContextPrompts: string[] = [];

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -369,10 +369,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		}
 
-		// Note if no workspace folders are open, which affects workspace-related tools.
-		if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-			prompts.push(xml.node('workspace', 'No workspace folders open.'));
-		}
+		// Note if any folders are open in the workspace.
+		const areFoldersOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
+		prompts.push(xml.node('workspace', `Workspace folders are open: ${areFoldersOpen}`));
 
 		// Add Positron IDE context to the prompt.
 		const positronContext = await positron.ai.getPositronChatContext(request);

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -369,10 +369,6 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		}
 
-		// Note if any folders are open in the workspace.
-		const areFoldersOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
-		prompts.push(xml.node('workspace', `Workspace folders are open: ${areFoldersOpen}`));
-
 		// Add Positron IDE context to the prompt.
 		const positronContext = await positron.ai.getPositronChatContext(request);
 		const positronContextPrompts: string[] = [];
@@ -420,6 +416,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		if (customPrompt.length > 0) {
 			prompts.push(customPrompt);
 		}
+
+		// Add default context items to the prompt just before the prompts are joined.
+		// This ordering helps with verifying the context items in tests, as we can expect
+		// them to be at the end of the prompt.
+		prompts.push(...getDefaultContextItems());
 
 		const parts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [];
 		if (prompts.length > 0) {
@@ -617,4 +618,18 @@ async function openLlmsTextDocument(): Promise<vscode.TextDocument | undefined> 
 
 	const llmsDocument = await vscode.workspace.openTextDocument(fileUri);
 	return llmsDocument;
+}
+
+/**
+ * Retrieve the default context items to include in the prompt.
+ * @returns A list of default context items to include in the prompt.
+ */
+export function getDefaultContextItems(): string[] {
+	const defaultPrompts = [];
+
+	// Note if any folders are open in the workspace.
+	const areFoldersOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
+	defaultPrompts.push(xml.node('workspace', `Workspace folders are open: ${areFoldersOpen}`));
+
+	return defaultPrompts;
 }

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -65,9 +65,10 @@ suite('AnthropicLanguageModel', () => {
 	 */
 	test('provideLanguageModelResponse filters empty messages and different LanguageModelTextPart contents correctly', async () => {
 		// Create test messages with different combinations of empty/non-empty content
+		const nonEmptyText = 'Hello';
 		const emptyTextPart = new vscode.LanguageModelTextPart('');
 		const whitespaceTextPart = new vscode.LanguageModelTextPart('   \n  ');
-		const nonEmptyTextPart = new vscode.LanguageModelTextPart('Hello');
+		const nonEmptyTextPart = new vscode.LanguageModelTextPart(nonEmptyText);
 
 		// Define test messages with different combinations
 		const messagesWithVariousContent = [
@@ -114,12 +115,13 @@ suite('AnthropicLanguageModel', () => {
 		const streamCall = mockClient.messages.stream.getCall(0);
 		assert.ok(streamCall, 'Stream method was not called');
 
+		// We expect two messages with non-empty content to be passed to the Anthropic client
 		const messagesPassedToAnthropicClient = streamCall.args[0].messages;
 		assert.strictEqual(messagesPassedToAnthropicClient.length, numOfMessagesToKeep, 'Only non-empty messages should be passed to the Anthropic client');
 
-		// Verify specific message patterns that should be included vs filtered
-		const hasMessageWithNonEmptyContent = messagesPassedToAnthropicClient.some((msg: any) =>
-			msg.content.some((content: any) => content.type === 'text' && content.text === 'Hello')
+		// Verify each passed message has the non-empty content we expect
+		const hasMessageWithNonEmptyContent = messagesPassedToAnthropicClient.every((msg: any) =>
+			msg.content.some((content: any) => content.type === 'text' && content.text === nonEmptyText)
 		);
 		assert.strictEqual(hasMessageWithNonEmptyContent, true, 'Messages with non-empty content should be included');
 	});
@@ -129,9 +131,6 @@ suite('AnthropicLanguageModel', () => {
 		const toolCallId1 = 'test-tool-callId-1';
 		const toolCallEmptyPart = new vscode.LanguageModelToolCallPart(toolCallId1, `${toolCallId1}-tool`, {});
 		const emptyToolResultPartOriginal = new vscode.LanguageModelToolResultPart(toolCallId1, []);
-		const emptyToolResultPartExpected = new vscode.LanguageModelToolResultPart(toolCallId1, [
-			new vscode.LanguageModelTextPart(EMPTY_TOOL_RESULT_PLACEHOLDER),
-		]);
 
 		// 2nd tool call with non-empty result
 		const toolCallId2 = 'test-tool-callId-2';

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import { AnthropicLanguageModel } from '../anthropic';
 import { ModelConfig } from '../config';
+import { EMPTY_TOOL_RESULT_PLACEHOLDER } from '../utils.js';
 
 suite('AnthropicLanguageModel', () => {
 	let model: AnthropicLanguageModel;
@@ -58,61 +59,23 @@ suite('AnthropicLanguageModel', () => {
 		sinon.restore();
 	});
 
-	test('provideLanguageModelResponse should filter out messages with empty text content', async () => {
-		// Create test messages
-		const emptyTextPart = new vscode.LanguageModelTextPart('');
-		const nonEmptyTextPart = new vscode.LanguageModelTextPart('Hello');
-
-		const messagesWithEmpty = [
-			// Message with only empty text content
-			vscode.LanguageModelChatMessage.User([emptyTextPart]),
-			// Message with non-empty text content
-			vscode.LanguageModelChatMessage.User([nonEmptyTextPart]),
-			// Message with both empty and non-empty text content
-			vscode.LanguageModelChatMessage.Assistant([emptyTextPart, nonEmptyTextPart])
-		];
-
-		// Call the method under test
-		await model.provideLanguageModelResponse(
-			messagesWithEmpty,
-			{},
-			'test-extension',
-			mockProgress,
-			mockCancellationToken
-		);
-
-		// Check that messages were filtered before being passed to the Anthropic client
-		const streamCall = mockClient.messages.stream.getCall(0);
-		assert.ok(streamCall, 'Stream method was not called');
-
-		// The empty message should be filtered out
-		const messagesPassedToAnthropicClient = streamCall.args[0].messages;
-		assert.strictEqual(messagesPassedToAnthropicClient.length, 2, 'Only non-empty messages should be passed to the Anthropic client');
-
-		// Verify that the message with only empty content was filtered out
-		const hasEmptyMessage = messagesPassedToAnthropicClient.some((msg: any) => {
-			return msg.content.length === 0 ||
-				(msg.content.length === 1 &&
-					msg.content[0].type === 'text' &&
-					msg.content[0].text === '');
-		});
-		assert.strictEqual(hasEmptyMessage, false, 'Messages with only empty content should be filtered out');
-	});
-
 	/**
 	 * Test the filtering behavior by checking the messages passed to Anthropic
-	 * when a message with empty content is included.
+	 * when a message with empty LanguageModelTextPart content is included.
 	 */
-	test('provideLanguageModelResponse filters empty messages correctly with different content mixes', async () => {
+	test('provideLanguageModelResponse filters empty messages and different LanguageModelTextPart contents correctly', async () => {
 		// Create test messages with different combinations of empty/non-empty content
 		const emptyTextPart = new vscode.LanguageModelTextPart('');
 		const whitespaceTextPart = new vscode.LanguageModelTextPart('   \n  ');
 		const nonEmptyTextPart = new vscode.LanguageModelTextPart('Hello');
-		const toolCallPart = new vscode.LanguageModelToolCallPart('test-tool-callId', 'test-tool-name', {});
-		const emptyToolResultPart = new vscode.LanguageModelToolResultPart('test-tool-callId', []);
 
 		// Define test messages with different combinations
 		const messagesWithVariousContent = [
+			// Message with no content - should be filtered out
+			{
+				message: vscode.LanguageModelChatMessage.User([]),
+				keep: false
+			},
 			// Message with only empty text content - should be filtered out
 			{
 				message: vscode.LanguageModelChatMessage.User([emptyTextPart]),
@@ -133,16 +96,6 @@ suite('AnthropicLanguageModel', () => {
 				message: vscode.LanguageModelChatMessage.Assistant([emptyTextPart, nonEmptyTextPart]),
 				keep: true
 			},
-			// Message with tool call - should be kept
-			{
-				message: vscode.LanguageModelChatMessage.Assistant([toolCallPart]),
-				keep: true
-			},
-			// Message with empty tool result - should be filtered out
-			{
-				message: vscode.LanguageModelChatMessage.User([emptyToolResultPart]),
-				keep: false
-			}
 		];
 
 		const messages = messagesWithVariousContent.map(m => m.message);
@@ -169,5 +122,71 @@ suite('AnthropicLanguageModel', () => {
 			msg.content.some((content: any) => content.type === 'text' && content.text === 'Hello')
 		);
 		assert.strictEqual(hasMessageWithNonEmptyContent, true, 'Messages with non-empty content should be included');
+	});
+
+	test('provideLanguageModelResponse processes LanguageModelToolCallPart and LanguageModelToolResultPart contents correctly', async () => {
+		// 1st tool call with empty result
+		const toolCallId1 = 'test-tool-callId-1';
+		const toolCallEmptyPart = new vscode.LanguageModelToolCallPart(toolCallId1, `${toolCallId1}-tool`, {});
+		const emptyToolResultPartOriginal = new vscode.LanguageModelToolResultPart(toolCallId1, []);
+		const emptyToolResultPartExpected = new vscode.LanguageModelToolResultPart(toolCallId1, [
+			new vscode.LanguageModelTextPart(EMPTY_TOOL_RESULT_PLACEHOLDER),
+		]);
+
+		// 2nd tool call with non-empty result
+		const toolCallId2 = 'test-tool-callId-2';
+		const toolCallNonEmptyPart = new vscode.LanguageModelToolCallPart(toolCallId2, `${toolCallId2}-tool`, {});
+		const nonEmptyToolResultPart = new vscode.LanguageModelToolResultPart(toolCallId2, [
+			new vscode.LanguageModelTextPart('This is a non-empty tool result'),
+		]);
+
+		const messagesWithToolContent = [
+			// Tool call - should be passed
+			{
+				message: vscode.LanguageModelChatMessage.Assistant([toolCallEmptyPart]),
+			},
+			// Tool result with empty content - should be passed, but replaced with a placeholder
+			{
+				message: vscode.LanguageModelChatMessage.User([emptyToolResultPartOriginal]),
+				expectedText: EMPTY_TOOL_RESULT_PLACEHOLDER
+			},
+			// Tool call - should be passed
+			{
+				message: vscode.LanguageModelChatMessage.Assistant([toolCallNonEmptyPart]),
+			},
+			// Tool result with non-empty content - should be passed as is
+			{
+				message: vscode.LanguageModelChatMessage.User([nonEmptyToolResultPart]),
+			},
+		];
+
+		const messages = messagesWithToolContent.map(m => m.message);
+		const numOfMessagesToKeep = messagesWithToolContent.length;
+
+		// Call the method under test
+		await model.provideLanguageModelResponse(
+			messages,
+			{},
+			'test-extension',
+			mockProgress,
+			mockCancellationToken
+		);
+
+		// Check that messages were processed correctly
+		const streamCall = mockClient.messages.stream.getCall(0);
+		assert.ok(streamCall, 'Stream method was not called');
+
+		const messagesPassedToAnthropicClient = streamCall.args[0].messages;
+		assert.strictEqual(messagesPassedToAnthropicClient.length, numOfMessagesToKeep, 'All messages should be passed to the Anthropic client');
+
+		messagesWithToolContent.forEach((msg, index) => {
+			const expectedText = msg.expectedText;
+			if (!expectedText) {
+				return;
+			}
+			// sample actualContent: [{"type":"tool_result","tool_use_id":"test-tool-callId-1","content":[{"type":"text","text":"tool result is empty"}]}]
+			const actualText = messagesPassedToAnthropicClient[index].content[0].content[0].text;
+			assert.deepStrictEqual(actualText, expectedText, `Message text at index ${index} should match the expected text`);
+		});
 	});
 });

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -7,11 +7,14 @@ import * as assert from 'assert';
 import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { PositronAssistantChatParticipant, PositronAssistantEditorParticipant } from '../participants.js';
+import { getDefaultContextItems, PositronAssistantChatParticipant, PositronAssistantEditorParticipant } from '../participants.js';
 import { mock } from './utils.js';
 import { readFile } from 'fs/promises';
 import { MARKDOWN_DIR } from '../constants.js';
 import path = require('path');
+
+/** We expect 2 messages by default: 1 for the user's prompt, and 1 containing at least the default context */
+const DEFAULT_EXPECTED_MESSAGE_COUNT = 2;
 
 class TestLanguageModelChatResponse implements vscode.LanguageModelChatResponse {
 	stream: AsyncIterable<string> = {
@@ -111,25 +114,6 @@ suite('PositronAssistantParticipant', () => {
 		disposables.forEach((d) => d.dispose());
 	});
 
-	test('should not send context if none is available', async () => {
-		// Setup test inputs.
-		const request = makeChatRequest({ model, references: [] });
-		const context: vscode.ChatContext = { history: [] };
-		const sendRequestSpy = sinon.spy(model, 'sendRequest');
-		sinon.stub(positron.ai, 'getPositronChatContext').resolves({});
-
-		// Call the method under test.
-		await chatParticipant.requestHandler(request, context, response, token);
-
-		// There should be only one user message with the user's prompt,
-		// since there is no available context.
-		sinon.assert.calledOnce(sendRequestSpy);
-		const [messages,] = sendRequestSpy.getCall(0).args;
-		assert.strictEqual(messages.length, 1, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertMessageRole(messages[0], vscode.LanguageModelChatMessageRole.User);
-		assertMessageTextPart(messages[0].content[0], request.prompt);
-	});
-
 	test('should include positron session context', async () => {
 		// Setup test inputs.
 		const request = makeChatRequest({ model, references: [] });
@@ -174,7 +158,7 @@ suite('PositronAssistantParticipant', () => {
 		sinon.assert.calledOnce(sendRequestSpy);
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const c = positronChatContext;
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<context>
 <console description="Current active console" language="${c.console!.language}" version="${c.console!.version}" identifier="${c.console!.identifier}">
@@ -223,7 +207,7 @@ ${c.plots!.hasPlots ? 'A plot is visible.' : ''}
 		const document = await vscode.workspace.openTextDocument(referenceUri);
 		const filePath = vscode.workspace.asRelativePath(referenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<attachments>
 ${attachmentsText}
@@ -257,7 +241,7 @@ ${document.getText()}
 		const document = await vscode.workspace.openTextDocument(referenceUri);
 		const filePath = vscode.workspace.asRelativePath(referenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<attachments>
 ${attachmentsText}
@@ -293,7 +277,7 @@ ${document.getText()}
 		sinon.assert.calledOnce(sendRequestSpy);
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<attachments>
 ${attachmentsText}
@@ -329,7 +313,7 @@ It should be included in the chat message.`;
 		// The first user message should contain the formatted context.
 		sinon.assert.calledOnce(sendRequestSpy);
 		const [messages,] = sendRequestSpy.getCall(0).args;
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		assertContextMessage(messages[0],
 			`<instructions>
 ${llmsTxtContent}
@@ -353,7 +337,7 @@ ${llmsTxtContent}
 		// The first user message should contain the formatted context.
 		sinon.assert.calledOnce(sendRequestSpy);
 		const [messages,] = sendRequestSpy.getCall(0).args;
-		assert.strictEqual(messages.length, 2, `Unexpected messages: ${JSON.stringify(messages)}`);
+		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		const filePath = vscode.workspace.asRelativePath(referenceUri);
 		assertContextMessage(messages[0],
 			`<editor description="Current active editor" filePath="${filePath}" language="${document.languageId}" line="${selection.active.line + 1}" column="${selection.active.character + 1}" documentOffset="${document.offsetAt(selection.active)}">
@@ -425,7 +409,8 @@ function assertContextMessage(
 	assertMessageRole(message, vscode.LanguageModelChatMessageRole.User);
 
 	// The first part should be a text part with the formatted context.
-	assertMessageTextPart(message.content[0], expectedPrompt);
+	const fullPrompt = `${expectedPrompt}${expectedPrompt.length > 0 ? '\n\n' : ''}${getDefaultContextItems().join('\n')}`;
+	assertMessageTextPart(message.content[0], fullPrompt);
 
 	if (expectedImage) {
 		// If an image is expected, the second part should be a data part with the image.

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -256,19 +256,22 @@ export function isChatImageMimeType(mimeType: string): mimeType is vscode.ChatIm
 	return Object.values(vscode.ChatImageMimeType).includes(mimeType as vscode.ChatImageMimeType);
 }
 
-export const EMPTY_TOOL_RESULT_PLACEHOLDER = 'tool result is empty';
+export const EMPTY_TOOL_RESULT_PLACEHOLDER = '';
 
 /**
  * Processes a message to ensure it has non-empty tool result parts.
  * If a tool result part is empty, it replaces it with a placeholder.
  * This is a workaround for LLMs that don't handle empty tool result parts well.
+ * @todo: We may be able to remove this handling in the future, to save on token count,
+ * once LLMs are better at handling empty tool result parts.
  * @param message The message to process
  * @returns A new message with empty tool result parts replaced with a placeholder
  */
 function processEmptyToolResults(message: vscode.LanguageModelChatMessage2) {
 	let replacedEmptyToolResult = false;
 	const updatedContent = message.content.map(part => {
-		if (part instanceof vscode.LanguageModelToolResultPart && part.content.length === 0) {
+		const isToolResult = part instanceof vscode.LanguageModelToolResultPart || part instanceof vscode.LanguageModelToolResultPart2;
+		if (isToolResult && part.content.length === 0) {
 			replacedEmptyToolResult = true;
 			return new vscode.LanguageModelToolResultPart(
 				part.callId,

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -20,6 +20,7 @@ This tool returns the contents of the specified file in the project.
 The provided file path must be a path to a file in the workspace or a file that is currently open in the editor.
 The file path can be either absolute or relative to the workspace root.
 The tool will return the contents of the file as a string, along with its size and encoding.
+If the workspace is empty or no workspace folders are open, this tool cannot retrieve file contents.
 `;
 
 export const ExtensionFileContentsToolId = 'positron_getFileContents';

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -20,7 +20,7 @@ This tool returns the contents of the specified file in the project.
 The provided file path must be a path to a file in the workspace or a file that is currently open in the editor.
 The file path can be either absolute or relative to the workspace root.
 The tool will return the contents of the file as a string, along with its size and encoding.
-If the workspace is empty or no workspace folders are open, this tool cannot retrieve file contents.
+Do not use this tool when no workspace folders are open.
 `;
 
 export const ExtensionFileContentsToolId = 'positron_getFileContents';
@@ -60,13 +60,7 @@ export class FileContentsTool implements IToolImpl {
 		if (isAbsolute(filePath)) {
 			uri = URI.file(filePath);
 			if (!this.fileIsOpenOrInsideWorkspace(uri)) {
-				return {
-					content: [{
-						kind: 'text',
-						value: `File contents for '${filePath}' can't be retrieved because the file is not open or inside the current workspace`
-					}],
-					toolResultMessage: 'File is not available in the current workspace',
-				};
+				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace`);
 			}
 		} else {
 			// If the file path is relative, try to resolve it against the workspace folders
@@ -79,13 +73,7 @@ export class FileContentsTool implements IToolImpl {
 				}
 			}
 			if (!uri) {
-				return {
-					content: [{
-						kind: 'text',
-						value: `File contents for '${filePath}' can't be retrieved because the file is not open or inside the current workspace`
-					}],
-					toolResultMessage: 'File is not available in the current workspace',
-				};
+				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace`);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -59,7 +59,13 @@ export class FileContentsTool implements IToolImpl {
 		if (isAbsolute(filePath)) {
 			uri = URI.file(filePath);
 			if (!this.fileIsOpenOrInsideWorkspace(uri)) {
-				throw new Error(`File contents for ${filePath} can't be retrieved because the file is not open or inside the current workspace`);
+				return {
+					content: [{
+						kind: 'text',
+						value: `File contents for '${filePath}' can't be retrieved because the file is not open or inside the current workspace`
+					}],
+					toolResultMessage: 'File is not available in the current workspace',
+				};
 			}
 		} else {
 			// If the file path is relative, try to resolve it against the workspace folders
@@ -72,7 +78,13 @@ export class FileContentsTool implements IToolImpl {
 				}
 			}
 			if (!uri) {
-				throw new Error(`File contents for ${filePath} can't be retrieved because the file is not open or inside any folders in the current workspace`);
+				return {
+					content: [{
+						kind: 'text',
+						value: `File contents for '${filePath}' can't be retrieved because the file is not open or inside the current workspace`
+					}],
+					toolResultMessage: 'File is not available in the current workspace',
+				};
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -60,7 +60,7 @@ export class FileContentsTool implements IToolImpl {
 		if (isAbsolute(filePath)) {
 			uri = URI.file(filePath);
 			if (!this.fileIsOpenOrInsideWorkspace(uri)) {
-				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace`);
+				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace. Ensure the file is open in an editor or inside the workspace.`);
 			}
 		} else {
 			// If the file path is relative, try to resolve it against the workspace folders
@@ -73,7 +73,7 @@ export class FileContentsTool implements IToolImpl {
 				}
 			}
 			if (!uri) {
-				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace`);
+				throw new Error(`Can't retrieve file contents for ${filePath} because the file is not open or inside the current workspace. Ensure the file is open in an editor or inside the workspace.`);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -46,8 +46,11 @@ export class ProjectTreeTool implements IToolImpl {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
 			return {
-				content: [],
-				toolResultMessage: 'No workspace folders found.'
+				content: [{
+					kind: 'text',
+					value: `Project tree can't be constructed because no workspace folders are open`
+				}],
+				toolResultMessage: `Project tree is unavailable when no workspace folders are open`,
 			};
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -45,7 +45,7 @@ export class ProjectTreeTool implements IToolImpl {
 	async invoke(_invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
-			throw new Error(`Can't construct project tree because no workspace folders are open`);
+			throw new Error(`Can't construct project tree because no workspace folders are open. Open a workspace folder before using this tool.`);
 		}
 
 		const workspaceTrees: DirectoryItem[][] = [];

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -22,8 +22,7 @@ The project tree is represented as a nested array, where each entry can be eithe
 This tool ignores node_modules, __pycache__, dist directories, certain files like .DS_Store, Thumbs.db, and desktop.ini. and files with certain extensions like *.o, *.a, *.so, *.pyo.
 This tool does not provide information for specific files or directories, but rather gives an overview of the entire project structure.
 This tool is helpful for locating files and directories in the workspace.
-This tool only needs to be called once per conversation, unless files or directories are added, removed, moved, or renamed in the workspace.
-If the workspace is empty or no workspace folders are open, this tool cannot generate a project tree.
+Do not use this tool when no workspace folders are open.
 `;
 
 export const ExtensionProjectTreeId = 'positron_getProjectTree';
@@ -46,13 +45,7 @@ export class ProjectTreeTool implements IToolImpl {
 	async invoke(_invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
-			return {
-				content: [{
-					kind: 'text',
-					value: `Project tree can't be constructed because no workspace folders are open`
-				}],
-				toolResultMessage: `Project tree is unavailable when no workspace folders are open`,
-			};
+			throw new Error(`Can't construct project tree because no workspace folders are open`);
 		}
 
 		const workspaceTrees: DirectoryItem[][] = [];

--- a/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/projectTreeTool.ts
@@ -23,6 +23,7 @@ This tool ignores node_modules, __pycache__, dist directories, certain files lik
 This tool does not provide information for specific files or directories, but rather gives an overview of the entire project structure.
 This tool is helpful for locating files and directories in the workspace.
 This tool only needs to be called once per conversation, unless files or directories are added, removed, moved, or renamed in the workspace.
+If the workspace is empty or no workspace folders are open, this tool cannot generate a project tree.
 `;
 
 export const ExtensionProjectTreeId = 'positron_getProjectTree';

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -88,7 +88,7 @@ export class TextSearchTool implements IToolImpl {
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
-			throw new Error(`Can't search for text in project because no workspace folders are open`);
+			throw new Error(`Can't search for text in project because no workspace folders are open. Open a workspace folder before using this tool.`);
 		}
 
 		// Set up the text search query

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -88,8 +88,11 @@ export class TextSearchTool implements IToolImpl {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
 			return {
-				content: [],
-				toolResultMessage: 'No workspace folders found.'
+				content: [{
+					kind: 'text',
+					value: `Can't search for text in project because no workspace folders are open`
+				}],
+				toolResultMessage: 'Text search is unavailable when no workspace folders are open',
 			};
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -21,7 +21,7 @@ Do not use this tool to find files or directories in the workspace, as it is spe
 The search is performed across all files in the project, excluding files and directories that are ignored by the workspace settings.
 The provided pattern is interpreted as text unless indicated to be a regular expression.
 Other search options such as case sensitivity, whole word matching, and multiline matching can be specified.
-If the workspace is empty or no workspace folders are open, this tool cannot search for text.
+Do not use this tool when no workspace folders are open.
 `;
 
 export const ExtensionTextSearchToolId = 'positron_findTextInProject';
@@ -88,13 +88,7 @@ export class TextSearchTool implements IToolImpl {
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const workspaceFolders = this._workspaceContextService.getWorkspace().folders;
 		if (workspaceFolders.length === 0) {
-			return {
-				content: [{
-					kind: 'text',
-					value: `Can't search for text in project because no workspace folders are open`
-				}],
-				toolResultMessage: 'Text search is unavailable when no workspace folders are open',
-			};
+			throw new Error(`Can't search for text in project because no workspace folders are open`);
 		}
 
 		// Set up the text search query

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -21,6 +21,7 @@ Do not use this tool to find files or directories in the workspace, as it is spe
 The search is performed across all files in the project, excluding files and directories that are ignored by the workspace settings.
 The provided pattern is interpreted as text unless indicated to be a regular expression.
 Other search options such as case sensitivity, whole word matching, and multiline matching can be specified.
+If the workspace is empty or no workspace folders are open, this tool cannot search for text.
 `;
 
 export const ExtensionTextSearchToolId = 'positron_findTextInProject';


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7770
- improves message processing to handle empty content more effectively
    - we should not filter out _all_ empty responses
    - we can continue to filter out messages that have no content at all and messages that only contain empty text parts
    - however, we should not filter out tool results with empty content altogether
    - now, when a tool result part has empty content, we include placeholder content in place of the empty content, to ensure that tool calls will have corresponding tool results
- updates our workspace tools to return non-empty messages
    - throw an error when the tool criteria is not met
    - added text to tool descriptions to note that empty workspaces are not supported
- updates anthropic integration test to cover these cases
- adds whether workspace folders are open to the general context, so that LLMs are less likely to use the workspace tools when the workspace criteria is not met

### Release Notes

#### Bug Fixes

- Assistant: ensure tool calls have corresponding tool results (#7770)

### QA Notes

@:assistant

The easiest test case is running the project tree tool, file contents tool or text search tool when in a workspace-less window. The Assistant should not call any of these tools since no workspace folders are open. If you are able to sidestep this and get the Assistant to call the tools anyways, the tool should now throw a more user-friendly error, directing the user to ensure that a workspace folder is open.