### PR TITLE
e2e-test: add r-debugger current line focused test

### DIFF
--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -137,4 +137,25 @@ export class Debug {
 			await expect(this.code.driver.page.getByText(`Browse[${number}]>`)).toBeVisible();
 		});
 	}
+
+	/**
+	 * Verify: the current line is the specified line number
+	 *
+	 * @param lineNumber
+	 */
+	async expectCurrentLineToBe(lineNumber: number): Promise<void> {
+		await test.step(`Verify current line is: ${lineNumber}`, async () => {
+			await expect(this.code.driver.page.locator('[id="workbench.parts.editor"]').locator('.line-numbers.active-line-number')).toHaveText(lineNumber.toString());
+		});
+	}
+
+	/**
+	 * Verify: the current line indicator is visible
+	 * Note: This does not check the line number, only that the indicator is present
+	 */
+	async expectCurrentLineIndicatorVisible(): Promise<void> {
+		await test.step('Verify current line indicator is visible', async () => {
+			await expect(this.code.driver.page.locator('.codicon-debug-stackframe')).toBeVisible();
+		});
+	}
 }

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -108,6 +108,48 @@ test.describe('R Debugging', {
 		await console.waitForConsoleContents('Found 2 fruits!');
 	});
 
+
+	test('R - Verify debugger indicator/highlight maintains focus', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7667' }] // uncomment starting at lin 130 when fixed
+	},
+		async ({ app, page, openFile, runCommand, executeCode }) => {
+			const { debug, console } = app.workbench;
+
+			await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
+			await runCommand('r.sourceCurrentFile');
+
+			// Trigger the breakpoint
+			await executeCode('R', `fruit_avg(dat, "berry")`, { waitForReady: false });
+			await debug.expectBrowserModeFrame(1);
+
+			// Verify current line indicator is visible
+			await page.getByRole('button', { name: 'Restore Panel' }).click();
+			await debug.expectCurrentLineIndicatorVisible();
+			await debug.expectCurrentLineToBe(2);
+
+			// Run random code in the console
+			// await executeCode('R', '100 + 100', { waitForReady: false });
+			// await console.waitForConsoleContents('200');
+			// // await page.getByRole('button', { name: 'Restore Panel' }).click(); <--- i don't think we should need this, but we do
+			// await debug.expectCurrentLineIndicatorVisible();
+			// await debug.expectCurrentLineToBe(2);
+
+			// Step over and check current line
+			await debug.stepOver();
+			await debug.expectCurrentLineIndicatorVisible();
+			await debug.expectCurrentLineToBe(3);
+
+			// Step into and check current line
+			await debug.stepInto();
+			await debug.stepOut();
+			await debug.expectCurrentLineToBe(4);
+
+			// Continue execution and check final message
+			await debug.continue();
+			await console.waitForConsoleContents('Found 2 fruits!');
+		});
+
+
 	test('R - Verify debugging with `debugonce()` pauses only once', async ({ app, page, executeCode, openFile, runCommand }) => {
 		const { debug, console } = app.workbench;
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -123,7 +123,7 @@ test.describe('R Debugging', {
 			await debug.expectBrowserModeFrame(1);
 
 			// Verify current line indicator is visible
-			await page.getByRole('button', { name: 'Restore Panel' }).click();
+			await page.getByRole('button', { name: 'Restore Panel' }).click(); // <-- i shouldn't have to do this, right?
 			await debug.expectCurrentLineIndicatorVisible();
 			await debug.expectCurrentLineToBe(2);
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -110,27 +110,26 @@ test.describe('R Debugging', {
 
 
 	test('R - Verify debugger indicator/highlight maintains focus', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7667' }] // uncomment line 134 when fixed
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7667' }] // uncomment line 133 when fixed
 	},
 		async ({ app, page, openFile, runCommand, executeCode }) => {
 			const { debug, console } = app.workbench;
 
 			await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
 			await runCommand('r.sourceCurrentFile');
+			await page.waitForTimeout(500); // not sure why but in browser only this is needed to allow source to load
 
 			// Trigger the breakpoint
-			await executeCode('R', `fruit_avg(dat, "berry")`, { waitForReady: false });
+			await console.pasteCodeToConsole(`fruit_avg(dat, "berry")`, true);
 			await debug.expectBrowserModeFrame(1);
 
 			// Verify current line indicator is visible
-			await page.getByRole('button', { name: 'Restore Panel' }).click(); // <-- i shouldn't have to do this, right?
 			await debug.expectCurrentLineIndicatorVisible();
 			await debug.expectCurrentLineToBe(2);
 
 			// Run random code in the console
-			await executeCode('R', '100 + 100', { waitForReady: false });
+			await console.pasteCodeToConsole('100 + 100', true);
 			await console.waitForConsoleContents('[1] 200');
-			await page.getByRole('button', { name: 'Restore Panel' }).click(); // <--- i shouldn't have to do this, right?
 			// await debug.expectCurrentLineIndicatorVisible();
 			await debug.expectCurrentLineToBe(2);
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -110,7 +110,7 @@ test.describe('R Debugging', {
 
 
 	test('R - Verify debugger indicator/highlight maintains focus', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7667' }] // uncomment starting at lin 130 when fixed
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7667' }] // uncomment line 134 when fixed
 	},
 		async ({ app, page, openFile, runCommand, executeCode }) => {
 			const { debug, console } = app.workbench;
@@ -128,20 +128,21 @@ test.describe('R Debugging', {
 			await debug.expectCurrentLineToBe(2);
 
 			// Run random code in the console
-			// await executeCode('R', '100 + 100', { waitForReady: false });
-			// await console.waitForConsoleContents('200');
-			// // await page.getByRole('button', { name: 'Restore Panel' }).click(); <--- i don't think we should need this, but we do
+			await executeCode('R', '100 + 100', { waitForReady: false });
+			await console.waitForConsoleContents('[1] 200');
+			await page.getByRole('button', { name: 'Restore Panel' }).click(); // <--- i shouldn't have to do this, right?
 			// await debug.expectCurrentLineIndicatorVisible();
-			// await debug.expectCurrentLineToBe(2);
+			await debug.expectCurrentLineToBe(2);
 
 			// Step over and check current line
 			await debug.stepOver();
 			await debug.expectCurrentLineIndicatorVisible();
 			await debug.expectCurrentLineToBe(3);
 
-			// Step into and check current line
+			// Step into and out and check current line
 			await debug.stepInto();
 			await debug.stepOut();
+			await debug.expectCurrentLineIndicatorVisible();
 			await debug.expectCurrentLineToBe(4);
 
 			// Continue execution and check final message


### PR DESCRIPTION
### Summary

Expanding the r debugger test to verify the current line in the debugger has focus and is correct. Inspired by issue: https://github.com/posit-dev/positron/issues/7667.

### QA Notes

@:debug @:web @:win