### PR TITLE
Overwrite style with theme colours

### DIFF
--- a/extensions/positron-proxy/resources/scripts_help.html
+++ b/extensions/positron-proxy/resources/scripts_help.html
@@ -19,19 +19,20 @@
 		-->
 		<style id="help-style-defaults">
 			::selection {
-				background: var(--vscode-editor-selectionBackground);
+				background: var(--vscode-editor-selectionBackground) !important;
 			}
 
 			body {
-				font-size: var(--vscode-font-size);
-				font-family: var(--vscode-font-family);
-				color: var(--vscode-editor-foreground);
-				background: var(--vscode-editor-background);
+				font-size: var(--vscode-font-size) !important;
+				font-family: var(--vscode-font-family) !important;
+				color: var(--vscode-editor-foreground) !important;
+				background: var(--vscode-editor-background) !important;
+				background-color: var(--vscode-editor-background) !important;
 				line-height: 1.5;
 			}
 
 			a {
-				color: var(--vscode-textLink-foreground);
+				color: var(--vscode-textLink-foreground) !important;
 			}
 		</style>
 		<style id="help-style-overrides">


### PR DESCRIPTION
Address #3759

The theme passed into the webview wasn't taking precedence over the styling from the vignette. Only some of the theme would be applied. So the font colour would apply, making it too light, and the background stayed white, making the contrast terrible. Adding `!important` for now will force the theme we want on the webview.

It's not perfect with this change but gets closer to making the vignette match Positron's theme. RStudio actually has to do the same thing and replaces the class names that apply the styling with the ACE editor styling. The Monaco editor generates its class names (prefixed by `mtk`) from the syntax highlighting rules for the language so it's not as easy as applying `mtk1` to `mtk10`. We don't know the mapping of the class names to the keywords so it wouldn't look the same in the vignette as in the editor.

![image](https://github.com/user-attachments/assets/6c975e03-edee-40ca-8627-7adea6a8f544)

![image](https://github.com/user-attachments/assets/fa0a9804-3f16-4aec-82a3-67ec2cca2a0d)


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix R vignette theming in dark mode


### QA Notes
The dark mode styling isn't perfect. Code blocks will remain in a light theme since we currently don't have a way to map the syntax colours for the code blocks.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
