### PR TITLE
Update "Interpreter" command palette actions

### DIFF
--- a/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
@@ -126,7 +126,7 @@ export class UnsupportedPythonVersionService extends BaseDiagnosticsService {
                         prompt: Common.selectNewSession,
                         command: commandFactory.createCommand(diagnostic, {
                             type: 'executeVSCCommand',
-                            options: 'workbench.action.language.runtime.openActivePicker',
+                            options: 'workbench.action.language.runtime.selectSession',
                         }),
                     },
                     {

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -44,7 +44,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     // --- Start Positron ---
     [Commands.Show_Interpreter_Debug_Info]: [];
     // New command that opens the multisession interpreter picker
-    ['workbench.action.language.runtime.openActivePicker']: [];
+    ['workbench.action.language.runtime.selectSession']: [];
     // --- End Positron ---
 }
 
@@ -63,10 +63,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                  installPreReleaseVersion?: boolean;
-                  donotSync?: boolean;
-              }
+                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                installPreReleaseVersion?: boolean;
+                donotSync?: boolean;
+            }
             | undefined
         ),
     ];

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -63,10 +63,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                installPreReleaseVersion?: boolean;
-                donotSync?: boolean;
-            }
+                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                  installPreReleaseVersion?: boolean;
+                  donotSync?: boolean;
+              }
             | undefined
         ),
     ];

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -17,6 +17,7 @@ import { ActionBarCommandButton } from '../../../../../platform/positronActionBa
 import { CommandCenter } from '../../../../../platform/commandCenter/common/commandCenter.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { localize } from '../../../../../nls.js';
+import { LANGUAGE_RUNTIME_SELECT_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../../../contrib/languageRuntime/browser/languageRuntimeActions.js';
 
 const startSession = localize('positron.console.startSession', "Start Session");
 
@@ -38,8 +39,8 @@ export const TopActionBarSessionManager = () => {
 	const hasActiveConsoleSessions = context.runtimeSessionService.activeSessions.find(
 		session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
 	const command = hasActiveConsoleSessions
-		? 'workbench.action.language.runtime.openActivePicker'
-		: 'workbench.action.language.runtime.openStartPicker';
+		? LANGUAGE_RUNTIME_SELECT_SESSION_ID
+		: LANGUAGE_RUNTIME_START_NEW_SESSION_ID;
 
 	// Main useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -128,6 +128,7 @@ export const PositronTopActionBarFocused = new RawContextKey<boolean>('positronT
 export const PositronTopActionBarVisibleContext = new RawContextKey<boolean>('positronTopActionBarVisible', true, localize('positronTopActionBarVisible', "Whether Positron Top Action Bar is visible"));
 export const PositronConsoleFocused = new RawContextKey<boolean>('positronConsoleFocused', false, localize('positronConsoleFocused', "Whether Positron Console has keyboard focus"));
 export const PositronConsoleTabFocused = new RawContextKey<boolean>('positronConsoleTabFocused', false, localize('positronConsoleTabFocused', "Whether Positron Console Tab has keyboard focus"));
+export const PositronConsoleInstancesExistContext = new RawContextKey<boolean>('positronConsoleInstancesExist', false, localize('positronConsoleInstancesExist', "Whether any Positron Console instances exist"));
 export const PositronVariablesFocused = new RawContextKey<boolean>('positronVariablesFocused', false, localize('positronVariablesFocused', "Whether Positron Variables has keyboard focus"));
 export const PositronHelpFocused = new RawContextKey<boolean>('positronHelpFocused', false, localize('positronHelpFocused', "Whether Positron Help has keyboard focus"));
 export const PositronDataExplorerFocused = new RawContextKey<boolean>('positronDataExplorerFocused', false, localize('positronDataExplorerFocused', "Whether Positron Data Explorer has keyboard focus"));

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -40,7 +40,7 @@ interface RuntimeClientInstanceQuickPickItem extends IQuickPickItem { runtimeCli
 // Action IDs
 export const LANGUAGE_RUNTIME_SELECT_SESSION_ID = 'workbench.action.language.runtime.selectSession';
 export const LANGUAGE_RUNTIME_START_NEW_SESSION_ID = 'workbench.action.language.runtime.startNewSession';
-export const LANGUAGE_RUNTIME_RESTART_SESSION_ID = 'workbench.action.language.runtime.restartSession';
+export const LANGUAGE_RUNTIME_RESTART_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.restartActiveSession';
 export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
 export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveSession';
@@ -777,20 +777,21 @@ export function registerLanguageRuntimeActions() {
 	 * Action that allows the user to restart an active session.
 	 */
 	registerLanguageRuntimeAction(
-		LANGUAGE_RUNTIME_RESTART_SESSION_ID,
-		'Restart Interpreter Session',
+		LANGUAGE_RUNTIME_RESTART_ACTIVE_SESSION_ID,
+		'Restart Active Interpreter Session',
 		async accessor => {
 			const sessionService = accessor.get(IRuntimeSessionService);
 
-			// Prompt the user to select a language runtime session to restart.
-			const session = await selectLanguageRuntimeSession(
-				accessor, { title: 'Select Interpreter Session To Restart' });
+			// Get the active session
+			const session = sessionService.foregroundSession;
+			if (!session) {
+				return;
+			}
 
 			// Restart the session
-			if (session?.sessionId) {
-				sessionService.restartSession(session.sessionId,
-					`'Restart Interpreter Session' command invoked`);
-			}
+			sessionService.restartSession(session.sessionId,
+				`'Restart Active Interpreter Session' command invoked`);
+
 		},
 		[
 			{

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -950,7 +950,7 @@ export function registerLanguageRuntimeActions() {
 			super({
 				id: 'workbench.action.executeCode.console',
 				title: nls.localize2('positron.command.executeCode.console', "Execute Code in Console"),
-				f1: true,
+				f1: false,
 				category
 			});
 		}
@@ -1043,6 +1043,8 @@ export function registerLanguageRuntimeActions() {
 	 *
 	 * Typically used to for code that is executed for its side effects, rather
 	 * than for its output. Doesn't auto-start sessions.
+	 *
+	 * Commonly used by users by creating a keyboard shortcut for this action.
 	 */
 	registerAction2(class ExecuteSilentlyAction extends Action2 {
 		private static _counter = 0;

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -27,7 +27,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { Codicon } from '../../../../base/common/codicons.js';
 import { localize } from '../../../../nls.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
-import { PositronConsoleTabFocused } from '../../../common/contextkeys.js';
+import { PositronConsoleInstancesExistContext, PositronConsoleTabFocused } from '../../../common/contextkeys.js';
 
 // The category for language runtime actions.
 const category: ILocalizedString = { value: LANGUAGE_RUNTIME_ACTION_CATEGORY, original: 'Interpreter' };
@@ -593,6 +593,15 @@ export function registerLanguageRuntimeActions() {
 				},
 				category,
 				f1: true,
+				menu: [{
+					group: 'navigation',
+					id: MenuId.ViewTitle,
+					order: 1,
+					when: ContextKeyExpr.and(
+						ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
+						PositronConsoleInstancesExistContext.negate()
+					),
+				}],
 				keybinding: {
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
 					mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Slash },
@@ -647,7 +656,10 @@ export function registerLanguageRuntimeActions() {
 					group: 'navigation',
 					id: MenuId.ViewTitle,
 					order: 1,
-					when: ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
+					when: ContextKeyExpr.and(
+						ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
+						PositronConsoleInstancesExistContext
+					),
 				}],
 			});
 		}
@@ -661,7 +673,6 @@ export function registerLanguageRuntimeActions() {
 			// Get the current foreground session.
 			const currentSession = runtimeSessionService.foregroundSession;
 			if (!currentSession) {
-				await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
 				return;
 			}
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -638,7 +638,7 @@ export function registerLanguageRuntimeActions() {
 				icon: Codicon.plus,
 				id: LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID,
 				title: {
-					value: localize('positron.languageRuntime.duplicate.title', 'Duplicate Interpreter Session'),
+					value: localize('positron.languageRuntime.duplicateSession.title', 'Duplicate Active Interpreter Session'),
 					original: 'Duplicate Session'
 				},
 				category,

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -821,15 +821,6 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	/**
-	 * Action that allows the user to shutdown an active session.
-	 */
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Interpreter Session', async accessor => {
-		(await selectLanguageRuntimeSession(
-			accessor,
-			{ title: 'Select Interpreter Session To Shutdown' }))?.shutdown();
-	});
-
-	/**
 	 * Action that allows the user to force-quit the active session.
 	 */
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Active Interpreter Session', async accessor => {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -992,7 +992,7 @@ export function registerLanguageRuntimeActions() {
 			super({
 				id: 'workbench.action.executeCode.console',
 				title: nls.localize2('positron.command.executeCode.console', "Execute Code in Console"),
-				f1: false,
+				f1: true,
 				category
 			});
 		}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -9,7 +9,7 @@ import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem, QuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IKeybindingRule, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from '../common/languageRuntime.js';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
@@ -17,7 +17,6 @@ import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessi
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
-import { groupBy } from '../../../../base/common/collections.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
@@ -39,11 +38,14 @@ interface RuntimeClientTypeQuickPickItem extends IQuickPickItem { runtimeClientT
 interface RuntimeClientInstanceQuickPickItem extends IQuickPickItem { runtimeClientInstance: IRuntimeClientInstance<any, any> }
 
 // Action IDs
-export const LANGUAGE_RUNTIME_OPEN_ACTIVE_SESSIONS_ID = 'workbench.action.language.runtime.openActivePicker';
-export const LANGUAGE_RUNTIME_START_SESSION_ID = 'workbench.action.language.runtime.openStartPicker';
+export const LANGUAGE_RUNTIME_SELECT_SESSION_ID = 'workbench.action.language.runtime.selectSession';
+export const LANGUAGE_RUNTIME_START_NEW_SESSION_ID = 'workbench.action.language.runtime.startNewSession';
+export const LANGUAGE_RUNTIME_RESTART_SESSION_ID = 'workbench.action.language.runtime.restartSession';
 export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
-export const LANGUAGE_RUNTIME_DUPLICATE_SESSION_ID = 'workbench.action.language.runtime.duplicateSession';
+export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveSession';
+
+export const LANGUAGE_RUNTIME_SELECT_RUNTIME_ID = 'workbench.action.languageRuntime.selectRuntime';
 
 /**
  * Helper function that askses the user to select a language from the list of registered language
@@ -103,18 +105,18 @@ async function selectLanguage(accessor: ServicesAccessor) {
 
 /**
  * Helper function that asks the user to select a language runtime session from
- * an array of language runtime sessions.
+ * an array of existing language runtime sessions.
  *
- * @param quickInputService The quick input service.
- * @param sessions The language runtime sessions the user can select from.
- * @param placeHolder The placeholder for the quick input.
+ * @param accessor The service accessor.
+ * @param options The options for the quick pick.
+ * @param options.allowStartSession Whether to allow the user to start a new session.
  * @returns The runtime session the user selected, or undefined, if the user canceled the operation.
  */
-export const selectLanguageRuntimeSession = async (
+const selectLanguageRuntimeSession = async (
 	accessor: ServicesAccessor,
 	options?: {
-		placeholder?: string;
 		allowStartSession?: boolean;
+		placeholder?: string;
 	}): Promise<ILanguageRuntimeSession | undefined> => {
 
 	// Constants
@@ -184,7 +186,7 @@ export const selectLanguageRuntimeSession = async (
 		});
 	}
 	const result = await quickInputService.pick(quickPickItems, {
-		title: localize('positron.languageRuntime.selectSession', 'Select a Session'),
+		title: options?.placeholder || localize('positron.languageRuntime.selectSession', 'Select a Session'),
 		canPickMany: false,
 		activeItem: activeRuntimeItems.filter(item => item.picked)[0]
 	});
@@ -192,7 +194,7 @@ export const selectLanguageRuntimeSession = async (
 	// Handle the user's selection.
 	if (result?.id === startNewRuntimeId) {
 		// If the user selected "All Runtimes...", execute the command to show all runtimes.
-		const sessionId: string | undefined = await commandService.executeCommand(LANGUAGE_RUNTIME_START_SESSION_ID);
+		const sessionId: string | undefined = await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
 		if (sessionId) {
 			return runtimeSessionService.activeSessions.find(session => session.sessionId === sessionId);
 		}
@@ -202,123 +204,6 @@ export const selectLanguageRuntimeSession = async (
 		return session;
 	}
 	return undefined;
-};
-
-/**
- * Helper function that asks the user to select a registered language runtime for a language.
- *
- * @param accessor The service accessor.
- * @param languageId The language ID of the language runtimes to select from.
- *
- * @returns The language runtime the user selected, or undefined, if the user canceled the operation.
- */
-const selectLanguageRuntime = async (
-	accessor: ServicesAccessor,
-	languageId: string,
-	preferredRuntime: ILanguageRuntimeMetadata | undefined,
-): Promise<ILanguageRuntimeMetadata | undefined> => {
-
-	const quickInputService = accessor.get(IQuickInputService);
-	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
-	const languageService = accessor.get(ILanguageService);
-
-	// Prompt the user to select a language runtime.
-	return new Promise((resolve) => {
-		const input = quickInputService.createQuickPick<LanguageRuntimeQuickPickItem>(
-			{ useSeparators: true }
-		);
-		const runtimePicks = new Map<string, LanguageRuntimeQuickPickItem>();
-
-		const addRuntime = (runtimeMetadata: ILanguageRuntimeMetadata) => {
-			runtimePicks.set(runtimeMetadata.runtimeId, {
-				id: runtimeMetadata.runtimeId,
-				label: runtimeMetadata.runtimeName,
-				description: runtimeMetadata.runtimePath,
-				runtime: runtimeMetadata
-			});
-
-			// Update the quick pick items.
-			const runtimePicksBySource = groupBy(Array.from(runtimePicks.values()), pick => pick.runtime.runtimeSource);
-			const sortedSources = Object.keys(runtimePicksBySource).sort();
-			const picks = new Array<IQuickPickSeparator | LanguageRuntimeQuickPickItem>();
-			for (const source of sortedSources) {
-				picks.push({ label: source, type: 'separator' }, ...runtimePicksBySource[source]);
-			}
-			input.items = picks;
-		};
-
-		const disposables = [
-			input,
-			input.onDidAccept(() => {
-				resolve(input.activeItems[0]?.runtime);
-				input.hide();
-			}),
-			input.onDidHide(() => {
-				dispose(disposables);
-				resolve(undefined);
-			}),
-			languageRuntimeService.onDidRegisterRuntime((runtimeMetadata) => {
-				if (runtimeMetadata.languageId === languageId) {
-					addRuntime(runtimeMetadata);
-				}
-			}),
-		];
-
-		input.canSelectMany = false;
-		const languageName = languageService.getLanguageName(languageId);
-		input.title = nls.localize('positron.languageRuntime.select.selectInterpreter', 'Select {0} Interpreter', languageName);
-		input.matchOnDescription = true;
-
-		for (const runtimeMetadata of languageRuntimeService.registeredRuntimes) {
-			if (runtimeMetadata.languageId === languageId) {
-				addRuntime(runtimeMetadata);
-			}
-		}
-
-		if (preferredRuntime) {
-			input.placeholder = nls.localize('positron.languageRuntime.select.selectedInterpreer', 'Selected Interpreter: {0}', preferredRuntime.runtimeName);
-			const activeItem = runtimePicks.get(preferredRuntime.runtimeId);
-			if (activeItem) {
-				input.activeItems = [activeItem];
-			}
-		}
-
-		input.show();
-
-	});
-};
-
-/**
- * Helper function that asks the user to select a running language runtime, if no runtime is
- * currently marked as the active runtime.
- *
- * @param accessor The service accessor.
- * @param placeholder The placeholder for the quick input.
- * @returns The language runtime the user selected, or undefined, if there are no running language runtimes or the user canceled the operation.
- */
-const selectRunningLanguageRuntime = async (
-	accessor: ServicesAccessor,
-	placeholder: string): Promise<ILanguageRuntimeSession | undefined> => {
-
-	// If there's an active language runtime, use that.
-	// NOTE @samclark2015: Does this even do anything with Multisession???
-	// e.g. when would we have sessions running but without an active foreground session?
-	const runtimeSessionService = accessor.get(IRuntimeSessionService);
-	const activeSession = runtimeSessionService.foregroundSession;
-	if (activeSession) {
-		return activeSession;
-	}
-
-	// If there isn't an active language runtime, but there are running
-	// runtimes, ask the user to select one.
-	const activeSessions = runtimeSessionService.activeSessions;
-	if (!activeSessions.length) {
-		alert('No interpreters are currently running.');
-		return undefined;
-	}
-
-	// As the user to select the running language runtime.
-	return await selectLanguageRuntimeSession(accessor, { placeholder });
 };
 
 /**
@@ -381,6 +266,15 @@ const createInterpreterGroups = (
 	});
 };
 
+/**
+ * Helper function that askses the user to select a language runtime from
+ * the list of registered language runtimes.
+ *
+ * This can be used to start a session for a registered language runtime.
+ *
+ * @param accessor The service accessor.
+ * @returns
+ */
 const selectNewLanguageRuntime = async (
 	accessor: ServicesAccessor
 ): Promise<ILanguageRuntimeMetadata | undefined> => {
@@ -517,12 +411,51 @@ const selectNewLanguageRuntime = async (
 		}
 	);
 
-	// If the user selected a runtime, set it as the active runtime
+	// If the user selected a runtime, return the runtime metadata.
 	if (selectedRuntime?.id) {
 		return languageRuntimeService.getRegisteredRuntime(selectedRuntime.id);
 	}
 
 	return undefined;
+};
+
+/**
+ * Helper function to rename a session.
+ *
+ * @param accessor The service accessor.
+ * @param sessionId The ID of the session to rename.
+ */
+const renameLanguageRuntimeSession = async (
+	sessionService: IRuntimeSessionService,
+	notificationService: INotificationService,
+	quickInputService: IQuickInputService,
+	sessionId: string
+) => {
+	// Prompt the user to enter the new session name.
+	const sessionName = await quickInputService.input({
+		value: '',
+		placeHolder: '',
+		prompt: nls.localize('positron.console.renameSession.prompt', "Enter the new session name"),
+	});
+
+	// Validate the new session name
+	const newSessionName = sessionName?.trim();
+	if (!newSessionName?.trim()) {
+		return;
+	}
+
+	// Attempt to rename the session.
+	try {
+		sessionService.updateSessionName(sessionId, newSessionName);
+	} catch (error) {
+		notificationService.error(
+			localize('positron.console.renameSession.error',
+				"Failed to rename session {0}: {1}",
+				sessionId,
+				error
+			)
+		);
+	}
 };
 
 /**
@@ -563,11 +496,17 @@ export function registerLanguageRuntimeActions() {
 		});
 	};
 
+	/**
+	 * Action used to select a registered language runtime (aka interpreter).
+	 *
+	 * NOTE: This is a convenience action that is used by the notebook controller
+	 * and service.
+	 */
 	registerAction2(class PickInterpreterAction extends Action2 {
 		constructor() {
 			super({
-				id: 'workbench.action.languageRuntime.pick',
-				title: nls.localize2('positron.command.pickInterpreter', "Pick Interpreter"),
+				id: LANGUAGE_RUNTIME_SELECT_RUNTIME_ID,
+				title: nls.localize2('positron.command.selectInterpreter', "Select Interpreter"),
 				f1: false,
 				category,
 			});
@@ -579,148 +518,10 @@ export function registerLanguageRuntimeActions() {
 		}
 	});
 
-	// Registers the start language runtime action.
-	registerAction2(class SelectInterpreterAction extends Action2 {
-		constructor() {
-			super({
-				id: 'workbench.action.languageRuntime.select',
-				title: nls.localize2('positron.command.selectInterpreter', "Select Interpreter"),
-				f1: false,
-				category,
-			});
-		}
-
-		async run(accessor: ServicesAccessor, languageId: string) {
-			// Access services.
-			const commandService = accessor.get(ICommandService);
-			const runtimeSessionService = accessor.get(IRuntimeSessionService);
-			const runtimeStartupService = accessor.get(IRuntimeStartupService);
-
-			// Ask the user to select the language runtime to start. If they selected one, start it.
-			let preferredRuntime: ILanguageRuntimeMetadata | undefined;
-			try {
-				preferredRuntime = runtimeStartupService.getPreferredRuntime(languageId);
-			} catch {
-				// getPreferredRuntime can error if a workspace-affiliated runtime is not
-				// yet registered. Do nothing.
-			}
-			const languageRuntime = await selectLanguageRuntime(accessor, languageId, preferredRuntime);
-
-			if (languageRuntime) {
-				// Start the language runtime.
-				runtimeSessionService.selectRuntime(languageRuntime.runtimeId, `'Select Interpreter' command invoked`);
-
-				// Drive focus into the Positron console.
-				commandService.executeCommand('workbench.panel.positronConsole.focus');
-			}
-		}
-	});
-
-	// Registers the set active language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.setActive', 'Set Active Interpreter', async accessor => {
-		// Get the language runtime service.
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
-
-		// Have the user select the language runtime they wish to set as the active language runtime.
-		const session = await selectRunningLanguageRuntime(
-			accessor,
-			localize('positron.lanuageRuntime.setActive', 'Set the active language runtime'));
-
-		// If the user selected a language runtime, set it as the active language runtime.
-		if (session) {
-			runtimeSessionService.foregroundSession = session;
-		}
-	});
-
-	// Registers the restart language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Interpreter', async accessor => {
-		// Access services.
-		const consoleService = accessor.get(IPositronConsoleService);
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
-
-		// The runtime we'll try to restart.
-		let session: ILanguageRuntimeSession | undefined = undefined;
-
-		// Typically, the restart command should act on the language runtime
-		// that's active in the Console, so try that first.
-		const activeConsole = consoleService.activePositronConsoleInstance;
-		if (activeConsole) {
-			session = activeConsole.attachedRuntimeSession;
-		}
-
-		// If there's no active console, try the active language runtime.
-		if (!session) {
-			session = runtimeSessionService.foregroundSession;
-		}
-
-		// If we still don't have an active language runtime, ask the user to
-		// pick one.
-		if (!session) {
-			session = await selectRunningLanguageRuntime(
-				accessor,
-				localize(
-					'positron.languageRuntime.selectInterpreterRestart',
-					'Select the interpreter to restart'
-				)
-			);
-			if (!session) {
-				throw new Error('No interpreter selected');
-			}
-		}
-
-		// Restart the language runtime.
-		runtimeSessionService.restartSession(session.sessionId,
-			`'Restart Interpreter' command invoked`);
-	},
-		[
-			{
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Numpad0,
-				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10]
-			},
-			{
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit0
-			},
-		]
-	);
-
-	// Registers the interrupt language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Interpreter', async accessor => {
-		(await selectRunningLanguageRuntime(
-			accessor,
-			'Select the interpreter to interrupt'))?.interrupt();
-	});
-
-	// Registers the shutdown language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Interpreter', async accessor => {
-		(await selectRunningLanguageRuntime(
-			accessor,
-			'Select the interpreter to shutdown'))?.shutdown();
-	});
-
-	// Registers the force quit language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Interpreter', async accessor => {
-		(await selectRunningLanguageRuntime(
-			accessor,
-			'Select the interpreter to force-quit'))?.forceQuit();
-	});
-
-	// Registers the show output language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show interpreter output', async accessor => {
-		(await selectRunningLanguageRuntime(
-			accessor,
-			'Select the interpreter for which to show output'))?.showOutput();
-	});
-
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show interpreter profile report', async accessor => {
-		(await selectRunningLanguageRuntime(
-			accessor,
-			'Select the interpreter for which to show profile output'))?.showProfile();
-	});
-
-	// Registers the clear affiliated language runtime / clear saved interpreter action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.clearAffiliation', 'Clear Saved Interpreter', async accessor => {
+	/**
+	 * Action that allows the user to remove a runtime from the list of offiliated runtimes.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.clearAffiliatedRuntime', 'Clear Saved Interpreter', async accessor => {
 		const runtimeSessionService = accessor.get(IRuntimeStartupService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
@@ -756,74 +557,10 @@ export function registerLanguageRuntimeActions() {
 		notificationService.info(nls.localize('interpreterCleared', 'The {0} interpreter has been cleared from this workspace.', quickPickItem.runtime.runtimeName));
 	});
 
-	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
-		// Access services.
-		const quickInputService = accessor.get(IQuickInputService);
-
-		// Ask the user to select a running language runtime.
-		const languageRuntime = await selectRunningLanguageRuntime(
-			accessor,
-			localize('positron.languageRuntime.selectRuntime', 'Select the language runtime')
-		);
-		if (!languageRuntime) {
-			return;
-		}
-
-		// Prompt the user to select the runtime client type.
-		const selection = await quickInputService.pick<RuntimeClientTypeQuickPickItem>([{
-			id: generateUuid(),
-			label: 'Environment Pane',
-			runtimeClientType: RuntimeClientType.Variables,
-		}], {
-			canPickMany: false,
-			placeHolder: `Select runtime client for ${languageRuntime.runtimeMetadata.runtimeName}`
-		});
-
-		// If the user selected a runtime client type, create the client for it.
-		if (selection) {
-			languageRuntime.createClient(selection.runtimeClientType, null);
-		}
-	});
-
-	registerLanguageRuntimeAction('workbench.action.language.runtime.closeClient', 'Close Runtime Client Widget', async accessor => {
-		// Access services.
-		// const runtimeSessionService = accessor.get(IRuntimeSessionService);
-		const quickInputService = accessor.get(IQuickInputService);
-
-		// Ask the user to select a running language runtime.
-		const languageRuntime = await selectRunningLanguageRuntime(accessor, 'Select the language runtime');
-		if (!languageRuntime) {
-			return;
-		}
-
-		// Get the runtime client instances for the language runtime.
-		const runtimeClientInstances = await languageRuntime.listClients();
-		if (!runtimeClientInstances.length) {
-			alert('No clients are currently started.');
-			return;
-		}
-
-		// Create runtime client instance quick pick items.
-		const runtimeClientInstanceQuickPickItems = runtimeClientInstances.map<RuntimeClientInstanceQuickPickItem>(runtimeClientInstance => ({
-			id: generateUuid(),
-			label: runtimeClientInstance.getClientType(),
-			runtimeClientInstance,
-		} satisfies RuntimeClientInstanceQuickPickItem));
-
-		// Prompt the user to select a runtime client instance.
-		const selection = await quickInputService.pick<RuntimeClientInstanceQuickPickItem>(runtimeClientInstanceQuickPickItems, {
-			canPickMany: false,
-			placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', languageRuntime.runtimeMetadata.runtimeName)
-		});
-
-		// If the user selected a runtime client instance, dispose it.
-		if (selection) {
-			selection.runtimeClientInstance.dispose();
-		}
-	});
-
-
-	registerLanguageRuntimeAction(LANGUAGE_RUNTIME_OPEN_ACTIVE_SESSIONS_ID, 'Session Selector', async accessor => {
+	/**
+	 * Action that allows the user to change the foreground session.
+	 */
+	registerLanguageRuntimeAction(LANGUAGE_RUNTIME_SELECT_SESSION_ID, 'Select Interpreter Session', async accessor => {
 		// Access services.
 		const commandService = accessor.get(ICommandService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
@@ -839,60 +576,9 @@ export function registerLanguageRuntimeActions() {
 		}
 	});
 
-	registerAction2(class extends Action2 {
-		constructor() {
-			super({
-				icon: Codicon.plus,
-				id: LANGUAGE_RUNTIME_DUPLICATE_SESSION_ID,
-				title: {
-					value: localize('positron.languageRuntime.duplicate.title', 'Duplicate Session'),
-					original: 'Duplicate Session'
-				},
-				category,
-				f1: true,
-				menu: [{
-					group: 'navigation',
-					id: MenuId.ViewTitle,
-					order: 1,
-					when: ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
-				}],
-			});
-		}
-
-		async run(accessor: ServicesAccessor) {
-			// Access services
-			const commandService = accessor.get(ICommandService);
-			const runtimeSessionService = accessor.get(IRuntimeSessionService);
-			const notificationService = accessor.get(INotificationService);
-
-			// Get the current foreground session.
-			const currentSession = runtimeSessionService.foregroundSession;
-			if (!currentSession) {
-				await commandService.executeCommand(LANGUAGE_RUNTIME_START_SESSION_ID);
-				return;
-			}
-
-			if (currentSession.metadata.sessionMode !== LanguageRuntimeSessionMode.Console) {
-				notificationService.error(localize('positron.languageRuntime.duplicate.notConsole', 'Cannot duplicate session. The current session is not a console session.'));
-				return;
-			}
-
-			// Drive focus into the Positron console.
-			commandService.executeCommand('workbench.panel.positronConsole.focus');
-
-			// Duplicate the current session with the `startNewRuntimeSession` method.
-			await runtimeSessionService.startNewRuntimeSession(
-				currentSession.runtimeMetadata.runtimeId,
-				currentSession.dynState.sessionName,
-				currentSession.metadata.sessionMode,
-				undefined,
-				`Duplicated session: ${currentSession.dynState.sessionName}`,
-				RuntimeStartMode.Starting,
-				true
-			);
-		}
-	});
-
+	/**
+	 * Action that allows the user to create a new session from a list of registered runtimes.
+	 */
 	registerAction2(class extends Action2 {
 		/**
 		 * Constructor.
@@ -900,12 +586,13 @@ export function registerLanguageRuntimeActions() {
 		constructor() {
 			super({
 				icon: Codicon.plus,
-				id: LANGUAGE_RUNTIME_START_SESSION_ID,
+				id: LANGUAGE_RUNTIME_START_NEW_SESSION_ID,
 				title: {
-					value: localize('workbench.action.language.runtime.openStartPicker', "Start a New Session"),
-					original: 'Start a New Session'
+					value: localize('workbench.action.language.runtime.startSession', "Start New Interpreter Session"),
+					original: 'Start New Interpreter Session'
 				},
 				category,
+				f1: true,
 				keybinding: {
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
 					mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Slash },
@@ -938,6 +625,292 @@ export function registerLanguageRuntimeActions() {
 				);
 			}
 			return undefined;
+		}
+	});
+
+	/**
+	 * Action that allows the user to create a new session based off the current active session.
+	 * This utilizes the runtime data from the current session to create a new session.
+	 */
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				icon: Codicon.plus,
+				id: LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID,
+				title: {
+					value: localize('positron.languageRuntime.duplicate.title', 'Duplicate Interpreter Session'),
+					original: 'Duplicate Session'
+				},
+				category,
+				f1: true,
+				menu: [{
+					group: 'navigation',
+					id: MenuId.ViewTitle,
+					order: 1,
+					when: ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
+				}],
+			});
+		}
+
+		async run(accessor: ServicesAccessor) {
+			// Access services
+			const commandService = accessor.get(ICommandService);
+			const runtimeSessionService = accessor.get(IRuntimeSessionService);
+			const notificationService = accessor.get(INotificationService);
+
+			// Get the current foreground session.
+			const currentSession = runtimeSessionService.foregroundSession;
+			if (!currentSession) {
+				await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
+				return;
+			}
+
+			if (currentSession.metadata.sessionMode !== LanguageRuntimeSessionMode.Console) {
+				notificationService.error(localize('positron.languageRuntime.duplicate.notConsole', 'Cannot duplicate session. The current session is not a console session.'));
+				return;
+			}
+
+			// Drive focus into the Positron console.
+			commandService.executeCommand('workbench.panel.positronConsole.focus');
+
+			// Duplicate the current session with the `startNewRuntimeSession` method.
+			await runtimeSessionService.startNewRuntimeSession(
+				currentSession.runtimeMetadata.runtimeId,
+				currentSession.dynState.sessionName,
+				currentSession.metadata.sessionMode,
+				undefined,
+				`Duplicated session: ${currentSession.dynState.sessionName}`,
+				RuntimeStartMode.Starting,
+				true
+			);
+		}
+	});
+
+	/**
+	 * Action that allows the user to rename an active session.
+	 */
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				id: LANGUAGE_RUNTIME_RENAME_SESSION_ID,
+				title: nls.localize2('positron.console.renameSesison', "Rename Interpreter Session"),
+				category,
+				f1: true,
+			});
+		}
+
+		/**
+		 * Renames a session
+		 *
+		 * @param accessor The service accessor
+		 * @returns A promise that resolves when the session has been renamed
+		 */
+		async run(accessor: ServicesAccessor) {
+			const sessionService = accessor.get(IRuntimeSessionService);
+			const notificationService = accessor.get(INotificationService);
+			const quickInputService = accessor.get(IQuickInputService);
+
+			// Prompt the user to select a session they want to rename.
+			const session = await selectLanguageRuntimeSession(
+				accessor, { placeholder: 'Select Interpreter Session To Rename' });
+			if (!session) {
+				return;
+			}
+
+			await renameLanguageRuntimeSession(
+				sessionService,
+				notificationService,
+				quickInputService,
+				session.sessionId
+			);
+		}
+	});
+
+	/**
+	 * Action that allows the user to rename the foreground session.
+	 *
+	 * Note: This is a convenience action that is used to allow the user to rename
+	 * the currently active session without having to select it via the UI.
+	 */
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				id: LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID,
+				title: nls.localize2('positron.console.renameActiveSesison', "Rename Active Interpreter Session"),
+				category,
+				f1: true,
+				keybinding: {
+					primary: KeyCode.Enter,
+					when: PositronConsoleTabFocused,
+					weight: KeybindingWeight.WorkbenchContrib
+				}
+			});
+		}
+
+		/**
+		 * Renames the currently active session
+		 *
+		 * @param accessor The service accessor
+		 * @returns A promise that resolves when the session has been renamed
+		 */
+		async run(accessor: ServicesAccessor) {
+			const sessionService = accessor.get(IRuntimeSessionService);
+			const notificationService = accessor.get(INotificationService);
+			const quickInputService = accessor.get(IQuickInputService);
+
+			// Get the active session
+			const session = sessionService.foregroundSession;
+			if (!session) {
+				return;
+			}
+
+			await renameLanguageRuntimeSession(
+				sessionService,
+				notificationService,
+				quickInputService,
+				session.sessionId
+			);
+		}
+	});
+
+	/**
+	 * Action that allows the user to restart an active session.
+	 */
+	registerLanguageRuntimeAction(LANGUAGE_RUNTIME_RESTART_SESSION_ID, 'Restart Interpreter Session', async accessor => {
+		// Access services.
+		const sessionService = accessor.get(IRuntimeSessionService);
+
+		// Prompt the user to select a language runtime session to restart.
+		const session = await selectLanguageRuntimeSession(
+			accessor, { placeholder: 'Select Interpreter Session To Restart' });
+
+		// Restart the session
+		if (session?.sessionId) {
+			sessionService.restartSession(session.sessionId,
+				`'Restart Interpreter Session' command invoked`);
+		}
+	},
+		[
+			{
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Numpad0,
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10]
+			},
+			{
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit0
+			},
+		]
+	);
+
+	/**
+	 * Action that allows the user to interrupt an active session.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Interpreter Session', async accessor => {
+		(await selectLanguageRuntimeSession(
+			accessor,
+			{ placeholder: 'Select Interpreter Session To Interrupt' }))?.interrupt();
+	});
+
+	/**
+	 * Action that allows the user to shutdown an active session.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Interpreter Session', async accessor => {
+		(await selectLanguageRuntimeSession(
+			accessor,
+			{ placeholder: 'Select Interpreter Session To Shutdown' }))?.shutdown();
+	});
+
+	/**
+	 * Action that allows the user to force-quit an active session.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Interpreter Session', async accessor => {
+		(await selectLanguageRuntimeSession(
+			accessor,
+			{ placeholder: 'Select Interpreter Session To Force Quit' }))?.forceQuit();
+	});
+
+	/**
+	 * Action that allows the user to show the output channel for an active session.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show Interpreter Session Output', async accessor => {
+		(await selectLanguageRuntimeSession(
+			accessor,
+			{ placeholder: 'Select Interpreter Session To Show Output' }))?.showOutput();
+	});
+
+	/**
+	 * Action that allows the user to show the profile report for an active session.
+	 */
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show Interpreter Session Profile Report', async accessor => {
+		(await selectLanguageRuntimeSession(
+			accessor,
+			{ placeholder: 'Select Interpreter Session To Show Profile Report' }))?.showProfile();
+	});
+
+	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
+		// Access services.
+		const quickInputService = accessor.get(IQuickInputService);
+
+		// Prompt the user to select a session
+		const session = await selectLanguageRuntimeSession(accessor);
+		if (!session) {
+			return;
+		}
+
+		// Prompt the user to select the runtime client type.
+		const selection = await quickInputService.pick<RuntimeClientTypeQuickPickItem>(
+			[
+				{
+					id: generateUuid(),
+					label: 'Environment Pane',
+					runtimeClientType: RuntimeClientType.Variables,
+				}
+			],
+			{
+				canPickMany: false,
+				placeHolder: `Select runtime client for ${session.runtimeMetadata.runtimeName}`
+			}
+		);
+
+		// If the user selected a runtime client type, create the client for it.
+		if (selection) {
+			session.createClient(selection.runtimeClientType, null);
+		}
+	});
+
+	registerLanguageRuntimeAction('workbench.action.language.runtime.closeClient', 'Close Runtime Client Widget', async accessor => {
+		const quickInputService = accessor.get(IQuickInputService);
+
+		// Prompt the user to select a session
+		const session = await selectLanguageRuntimeSession(accessor);
+		if (!session) {
+			return;
+		}
+
+		// Get the runtime client instances for the session.
+		const runtimeClientInstances = await session.listClients();
+		if (!runtimeClientInstances.length) {
+			alert('No clients are currently started.');
+			return;
+		}
+
+		// Create runtime client instance quick pick items.
+		const runtimeClientInstanceQuickPickItems = runtimeClientInstances.map<RuntimeClientInstanceQuickPickItem>(runtimeClientInstance => ({
+			id: generateUuid(),
+			label: runtimeClientInstance.getClientType(),
+			runtimeClientInstance,
+		} satisfies RuntimeClientInstanceQuickPickItem));
+
+		// Prompt the user to select a runtime client instance.
+		const selection = await quickInputService.pick<RuntimeClientInstanceQuickPickItem>(runtimeClientInstanceQuickPickItems, {
+			canPickMany: false,
+			placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', session.runtimeMetadata.runtimeName)
+		});
+
+		// If the user selected a runtime client instance, dispose it.
+		if (selection) {
+			selection.runtimeClientInstance.dispose();
 		}
 	});
 
@@ -993,7 +966,7 @@ export function registerLanguageRuntimeActions() {
 			const quickInputService = accessor.get(IQuickInputService);
 			let fromPrompt = false;
 
-			// TODO: Should this be in a "Developer: " command?
+			// TODO: Should this be a "Developer: " command?
 			// If no arguments are passed, prompt the user.
 			if (!args) {
 				// Prompt the user to select a language.
@@ -1160,7 +1133,7 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 		if (!session) {
 			notificationService.info(
 				nls.localize('positron.setWorkingDirectory.noSession',
-					"No active interpreter session; open the Console and select an interpreter before setting the working directory."));
+					"No active interpreter session; open the Console and select an interpreter session before setting the working directory."));
 			return;
 		}
 		// If no resource was provided, ask the user to select a folder.
@@ -1193,121 +1166,5 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 		} catch (e) {
 			notificationService.error(e);
 		}
-	}
-});
-
-/**
- * Helper function to rename a language runtime session.
- *
- * @param accessor The service accessor.
- * @param sessionId The ID of the session to rename.
- */
-const renameLanguageRuntimeSession = async (
-	sessionService: IRuntimeSessionService,
-	notificationService: INotificationService,
-	quickInputService: IQuickInputService,
-	sessionId: string
-) => {
-	// Prompt the user to enter the new session name.
-	const sessionName = await quickInputService.input({
-		value: '',
-		placeHolder: '',
-		prompt: nls.localize('positron.console.renameSession.prompt', "Enter the new session name"),
-	});
-
-	// Validate the new session name
-	const newSessionName = sessionName?.trim();
-	if (!newSessionName?.trim()) {
-		return;
-	}
-
-	// Attempt to rename the session.
-	try {
-		sessionService.updateSessionName(sessionId, newSessionName);
-	} catch (error) {
-		notificationService.error(
-			localize('positron.console.renameSession.error',
-				"Failed to rename session {0}: {1}",
-				sessionId,
-				error
-			)
-		);
-	}
-};
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: LANGUAGE_RUNTIME_RENAME_SESSION_ID,
-			title: nls.localize2('positron.console.renameSesison', "Rename Session"),
-			category,
-			f1: true,
-		});
-	}
-
-	/**
-	 * Renames a session
-	 *
-	 * @param accessor The service accessor
-	 * @returns A promise that resolves when the session has been renamed
-	 */
-	async run(accessor: ServicesAccessor) {
-		const sessionService = accessor.get(IRuntimeSessionService);
-		const notificationService = accessor.get(INotificationService);
-		const quickInputService = accessor.get(IQuickInputService);
-
-		// Prompt the user to select a session they want to rename.
-		const session = await selectLanguageRuntimeSession(accessor);
-		if (!session) {
-			return;
-		}
-
-		await renameLanguageRuntimeSession(
-			sessionService,
-			notificationService,
-			quickInputService,
-			session.sessionId
-		);
-	}
-});
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID,
-			title: nls.localize2('positron.console.renameActiveSesison', "Rename the Currently Active Session"),
-			category,
-			f1: true,
-			keybinding: {
-				primary: KeyCode.Enter,
-				when: PositronConsoleTabFocused,
-				weight: KeybindingWeight.WorkbenchContrib
-			}
-		});
-	}
-
-	/**
-	 * Renames the currently active session
-	 *
-	 * @param accessor The service accessor
-	 * @returns A promise that resolves when the session has been renamed
-	 */
-	async run(accessor: ServicesAccessor) {
-		const sessionService = accessor.get(IRuntimeSessionService);
-		const notificationService = accessor.get(INotificationService);
-		const quickInputService = accessor.get(IQuickInputService);
-
-		// Get the active session
-		const session = sessionService.foregroundSession;
-		if (!session) {
-			return;
-		}
-
-		await renameLanguageRuntimeSession(
-			sessionService,
-			notificationService,
-			quickInputService,
-			session.sessionId
-		);
 	}
 });

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -110,13 +110,14 @@ async function selectLanguage(accessor: ServicesAccessor) {
  * @param accessor The service accessor.
  * @param options The options for the quick pick.
  * @param options.allowStartSession Whether to allow the user to start a new session.
+ * @param options.title The title of the quick pick.
  * @returns The runtime session the user selected, or undefined, if the user canceled the operation.
  */
 const selectLanguageRuntimeSession = async (
 	accessor: ServicesAccessor,
 	options?: {
 		allowStartSession?: boolean;
-		placeholder?: string;
+		title?: string;
 	}): Promise<ILanguageRuntimeSession | undefined> => {
 
 	// Constants
@@ -186,7 +187,7 @@ const selectLanguageRuntimeSession = async (
 		});
 	}
 	const result = await quickInputService.pick(quickPickItems, {
-		title: options?.placeholder || localize('positron.languageRuntime.selectSession', 'Select a Session'),
+		title: options?.title || localize('positron.languageRuntime.selectSession', 'Select a Session'),
 		canPickMany: false,
 		activeItem: activeRuntimeItems.filter(item => item.picked)[0]
 	});
@@ -711,7 +712,7 @@ export function registerLanguageRuntimeActions() {
 
 			// Prompt the user to select a session they want to rename.
 			const session = await selectLanguageRuntimeSession(
-				accessor, { placeholder: 'Select Interpreter Session To Rename' });
+				accessor, { title: 'Select Interpreter Session To Rename' });
 			if (!session) {
 				return;
 			}
@@ -781,7 +782,7 @@ export function registerLanguageRuntimeActions() {
 
 		// Prompt the user to select a language runtime session to restart.
 		const session = await selectLanguageRuntimeSession(
-			accessor, { placeholder: 'Select Interpreter Session To Restart' });
+			accessor, { title: 'Select Interpreter Session To Restart' });
 
 		// Restart the session
 		if (session?.sessionId) {
@@ -808,7 +809,7 @@ export function registerLanguageRuntimeActions() {
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Interpreter Session', async accessor => {
 		(await selectLanguageRuntimeSession(
 			accessor,
-			{ placeholder: 'Select Interpreter Session To Interrupt' }))?.interrupt();
+			{ title: 'Select Interpreter Session To Interrupt' }))?.interrupt();
 	});
 
 	/**
@@ -817,7 +818,7 @@ export function registerLanguageRuntimeActions() {
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Interpreter Session', async accessor => {
 		(await selectLanguageRuntimeSession(
 			accessor,
-			{ placeholder: 'Select Interpreter Session To Shutdown' }))?.shutdown();
+			{ title: 'Select Interpreter Session To Shutdown' }))?.shutdown();
 	});
 
 	/**
@@ -826,7 +827,7 @@ export function registerLanguageRuntimeActions() {
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Interpreter Session', async accessor => {
 		(await selectLanguageRuntimeSession(
 			accessor,
-			{ placeholder: 'Select Interpreter Session To Force Quit' }))?.forceQuit();
+			{ title: 'Select Interpreter Session To Force Quit' }))?.forceQuit();
 	});
 
 	/**
@@ -835,7 +836,7 @@ export function registerLanguageRuntimeActions() {
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show Interpreter Session Output', async accessor => {
 		(await selectLanguageRuntimeSession(
 			accessor,
-			{ placeholder: 'Select Interpreter Session To Show Output' }))?.showOutput();
+			{ title: 'Select Interpreter Session To Show Output' }))?.showOutput();
 	});
 
 	/**
@@ -844,7 +845,7 @@ export function registerLanguageRuntimeActions() {
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show Interpreter Session Profile Report', async accessor => {
 		(await selectLanguageRuntimeSession(
 			accessor,
-			{ placeholder: 'Select Interpreter Session To Show Profile Report' }))?.showProfile();
+			{ title: 'Select Interpreter Session To Show Profile Report' }))?.showProfile();
 	});
 
 	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -268,7 +268,7 @@ const createInterpreterGroups = (
 };
 
 /**
- * Helper function that askses the user to select a language runtime from
+ * Helper function that asks the user to select a language runtime from
  * the list of registered language runtimes.
  *
  * This can be used to start a session for a registered language runtime.

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -776,20 +776,22 @@ export function registerLanguageRuntimeActions() {
 	/**
 	 * Action that allows the user to restart an active session.
 	 */
-	registerLanguageRuntimeAction(LANGUAGE_RUNTIME_RESTART_SESSION_ID, 'Restart Interpreter Session', async accessor => {
-		// Access services.
-		const sessionService = accessor.get(IRuntimeSessionService);
+	registerLanguageRuntimeAction(
+		LANGUAGE_RUNTIME_RESTART_SESSION_ID,
+		'Restart Interpreter Session',
+		async accessor => {
+			const sessionService = accessor.get(IRuntimeSessionService);
 
-		// Prompt the user to select a language runtime session to restart.
-		const session = await selectLanguageRuntimeSession(
-			accessor, { title: 'Select Interpreter Session To Restart' });
+			// Prompt the user to select a language runtime session to restart.
+			const session = await selectLanguageRuntimeSession(
+				accessor, { title: 'Select Interpreter Session To Restart' });
 
-		// Restart the session
-		if (session?.sessionId) {
-			sessionService.restartSession(session.sessionId,
-				`'Restart Interpreter Session' command invoked`);
-		}
-	},
+			// Restart the session
+			if (session?.sessionId) {
+				sessionService.restartSession(session.sessionId,
+					`'Restart Interpreter Session' command invoked`);
+			}
+		},
 		[
 			{
 				weight: KeybindingWeight.WorkbenchContrib,
@@ -804,12 +806,18 @@ export function registerLanguageRuntimeActions() {
 	);
 
 	/**
-	 * Action that allows the user to interrupt an active session.
+	 * Action that allows the user to interrupt the active session.
 	 */
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Interpreter Session', async accessor => {
-		(await selectLanguageRuntimeSession(
-			accessor,
-			{ title: 'Select Interpreter Session To Interrupt' }))?.interrupt();
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Active Interpreter Session', async accessor => {
+		const sessionService = accessor.get(IRuntimeSessionService);
+
+		// Get the active session
+		const session = sessionService.foregroundSession;
+		if (!session) {
+			return;
+		}
+
+		session.interrupt();
 	});
 
 	/**
@@ -822,30 +830,48 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	/**
-	 * Action that allows the user to force-quit an active session.
+	 * Action that allows the user to force-quit the active session.
 	 */
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Interpreter Session', async accessor => {
-		(await selectLanguageRuntimeSession(
-			accessor,
-			{ title: 'Select Interpreter Session To Force Quit' }))?.forceQuit();
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Active Interpreter Session', async accessor => {
+		const sessionService = accessor.get(IRuntimeSessionService);
+
+		// Get the active session
+		const session = sessionService.foregroundSession;
+		if (!session) {
+			return;
+		}
+
+		session.forceQuit();
 	});
 
 	/**
-	 * Action that allows the user to show the output channel for an active session.
+	 * Action that allows the user to show the output channel for the active session.
 	 */
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show Interpreter Session Output', async accessor => {
-		(await selectLanguageRuntimeSession(
-			accessor,
-			{ title: 'Select Interpreter Session To Show Output' }))?.showOutput();
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show Active Interpreter Session Output', async accessor => {
+		const sessionService = accessor.get(IRuntimeSessionService);
+
+		// Get the active session
+		const session = sessionService.foregroundSession;
+		if (!session) {
+			return;
+		}
+
+		session.showOutput();
 	});
 
 	/**
 	 * Action that allows the user to show the profile report for an active session.
 	 */
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show Interpreter Session Profile Report', async accessor => {
-		(await selectLanguageRuntimeSession(
-			accessor,
-			{ title: 'Select Interpreter Session To Show Profile Report' }))?.showProfile();
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show Active Interpreter Session Profile Report', async accessor => {
+		const sessionService = accessor.get(IRuntimeSessionService);
+
+		// Get the active session
+		const session = sessionService.foregroundSession;
+		if (!session) {
+			return;
+		}
+
+		session.showProfile();
 	});
 
 	registerAction2(class ExecuteCodeInConsoleAction extends Action2 {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -170,7 +170,7 @@ const selectLanguageRuntimeSession = async (
 	// Show quick pick to select an active runtime or show all runtimes.
 	const quickPickItems: QuickPickItem[] = [
 		{
-			label: localize('positron.languageRuntime.activeSessions', 'Active Sessions'),
+			label: localize('positron.languageRuntime.activeSessions', 'Active Interpreter Sessions'),
 			type: 'separator',
 		},
 		...activeRuntimeItems,
@@ -181,13 +181,13 @@ const selectLanguageRuntimeSession = async (
 
 	if (options?.allowStartSession) {
 		quickPickItems.push({
-			label: localize('positron.languageRuntime.newSession', 'New Session...'),
+			label: localize('positron.languageRuntime.newSession', 'New Interpreter Session...'),
 			id: startNewRuntimeId,
 			alwaysShow: true
 		});
 	}
 	const result = await quickInputService.pick(quickPickItems, {
-		title: options?.title || localize('positron.languageRuntime.selectSession', 'Select a Session'),
+		title: options?.title || localize('positron.languageRuntime.selectSession', 'Select Interpreter Session'),
 		canPickMany: false,
 		activeItem: activeRuntimeItems.filter(item => item.picked)[0]
 	});
@@ -407,7 +407,7 @@ const selectNewLanguageRuntime = async (
 	const selectedRuntime = await quickInputService.pick(
 		runtimeItems,
 		{
-			title: localize('positron.languageRuntime.startSession', 'Start a New Session'),
+			title: localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
 			canPickMany: false
 		}
 	);
@@ -588,7 +588,7 @@ export function registerLanguageRuntimeActions() {
 				icon: Codicon.plus,
 				id: LANGUAGE_RUNTIME_START_NEW_SESSION_ID,
 				title: {
-					value: localize('workbench.action.language.runtime.startSession', "Start New Interpreter Session"),
+					value: localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
 					original: 'Start New Interpreter Session'
 				},
 				category,

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -848,69 +848,93 @@ export function registerLanguageRuntimeActions() {
 			{ title: 'Select Interpreter Session To Show Profile Report' }))?.showProfile();
 	});
 
-	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
-		// Access services.
-		const quickInputService = accessor.get(IQuickInputService);
+	registerAction2(class ExecuteCodeInConsoleAction extends Action2 {
 
-		// Prompt the user to select a session
-		const session = await selectLanguageRuntimeSession(accessor);
-		if (!session) {
-			return;
+		constructor() {
+			super({
+				id: 'workbench.action.language.runtime.openClient',
+				title: nls.localize2('positron.command.openClient', "Create Runtime Client Widget"),
+				f1: false,
+				category
+			});
 		}
 
-		// Prompt the user to select the runtime client type.
-		const selection = await quickInputService.pick<RuntimeClientTypeQuickPickItem>(
-			[
-				{
-					id: generateUuid(),
-					label: 'Environment Pane',
-					runtimeClientType: RuntimeClientType.Variables,
-				}
-			],
-			{
-				canPickMany: false,
-				placeHolder: `Select runtime client for ${session.runtimeMetadata.runtimeName}`
-			}
-		);
+		async run(accessor: ServicesAccessor) {
+			// Access services.
+			const quickInputService = accessor.get(IQuickInputService);
 
-		// If the user selected a runtime client type, create the client for it.
-		if (selection) {
-			session.createClient(selection.runtimeClientType, null);
+			// Prompt the user to select a session
+			const session = await selectLanguageRuntimeSession(accessor);
+			if (!session) {
+				return;
+			}
+
+			// Prompt the user to select the runtime client type.
+			const selection = await quickInputService.pick<RuntimeClientTypeQuickPickItem>(
+				[
+					{
+						id: generateUuid(),
+						label: 'Environment Pane',
+						runtimeClientType: RuntimeClientType.Variables,
+					}
+				],
+				{
+					canPickMany: false,
+					placeHolder: `Select runtime client for ${session.runtimeMetadata.runtimeName}`
+				}
+			);
+
+			// If the user selected a runtime client type, create the client for it.
+			if (selection) {
+				session.createClient(selection.runtimeClientType, null);
+			}
 		}
 	});
 
-	registerLanguageRuntimeAction('workbench.action.language.runtime.closeClient', 'Close Runtime Client Widget', async accessor => {
-		const quickInputService = accessor.get(IQuickInputService);
+	registerAction2(class ExecuteCodeInConsoleAction extends Action2 {
 
-		// Prompt the user to select a session
-		const session = await selectLanguageRuntimeSession(accessor);
-		if (!session) {
-			return;
+		constructor() {
+			super({
+				id: 'workbench.action.language.runtime.closeClient',
+				title: nls.localize2('positron.command.closeClient', "Close Runtime Client Widget"),
+				f1: false,
+				category
+			});
 		}
 
-		// Get the runtime client instances for the session.
-		const runtimeClientInstances = await session.listClients();
-		if (!runtimeClientInstances.length) {
-			alert('No clients are currently started.');
-			return;
-		}
+		async run(accessor: ServicesAccessor) {
+			const quickInputService = accessor.get(IQuickInputService);
 
-		// Create runtime client instance quick pick items.
-		const runtimeClientInstanceQuickPickItems = runtimeClientInstances.map<RuntimeClientInstanceQuickPickItem>(runtimeClientInstance => ({
-			id: generateUuid(),
-			label: runtimeClientInstance.getClientType(),
-			runtimeClientInstance,
-		} satisfies RuntimeClientInstanceQuickPickItem));
+			// Prompt the user to select a session
+			const session = await selectLanguageRuntimeSession(accessor);
+			if (!session) {
+				return;
+			}
 
-		// Prompt the user to select a runtime client instance.
-		const selection = await quickInputService.pick<RuntimeClientInstanceQuickPickItem>(runtimeClientInstanceQuickPickItems, {
-			canPickMany: false,
-			placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', session.runtimeMetadata.runtimeName)
-		});
+			// Get the runtime client instances for the session.
+			const runtimeClientInstances = await session.listClients();
+			if (!runtimeClientInstances.length) {
+				alert('No clients are currently started.');
+				return;
+			}
 
-		// If the user selected a runtime client instance, dispose it.
-		if (selection) {
-			selection.runtimeClientInstance.dispose();
+			// Create runtime client instance quick pick items.
+			const runtimeClientInstanceQuickPickItems = runtimeClientInstances.map<RuntimeClientInstanceQuickPickItem>(runtimeClientInstance => ({
+				id: generateUuid(),
+				label: runtimeClientInstance.getClientType(),
+				runtimeClientInstance,
+			} satisfies RuntimeClientInstanceQuickPickItem));
+
+			// Prompt the user to select a runtime client instance.
+			const selection = await quickInputService.pick<RuntimeClientInstanceQuickPickItem>(runtimeClientInstanceQuickPickItems, {
+				canPickMany: false,
+				placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', session.runtimeMetadata.runtimeName)
+			});
+
+			// If the user selected a runtime client instance, dispose it.
+			if (selection) {
+				selection.runtimeClientInstance.dispose();
+			}
 		}
 	});
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -499,8 +499,7 @@ export function registerLanguageRuntimeActions() {
 	/**
 	 * Action used to select a registered language runtime (aka interpreter).
 	 *
-	 * NOTE: This is a convenience action that is used by the notebook controller
-	 * and service.
+	 * NOTE: This is a convenience action that is used by the notebook services
 	 */
 	registerAction2(class PickInterpreterAction extends Action2 {
 		constructor() {

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -40,6 +40,7 @@ import { areSameExtensions } from '../../../../../platform/extensionManagement/c
 // eslint-disable-next-line no-duplicate-imports
 import { DeferredPromise } from '../../../../../base/common/async.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
+import { LANGUAGE_RUNTIME_SELECT_RUNTIME_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
 // --- End Positron ---
 type KernelPick = IQuickPickItem & { kernel: INotebookKernel };
 function isKernelPick(item: QuickPickInput<IQuickPickItem>): item is KernelPick {
@@ -566,7 +567,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 		// 	return this.displaySelectAnotherQuickPick(editor, items.length === 1 && items[0] === pick);
 		// }
 
-		if (pick.id === 'workbench.action.languageRuntime.pick') {
+		if (pick.id === LANGUAGE_RUNTIME_SELECT_RUNTIME_ID) {
 			this._handleKernelQuickPick(pick, editor);
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { localize } from '../../../../../nls.js';
 import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
-import { LANGUAGE_RUNTIME_START_SESSION_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
 
 // Load localized copy for control.
 const noSessionRunning = localize('positron.console.empty.noSessionRunning', "There is no session running.");
@@ -30,7 +30,7 @@ export const EmptyConsole = () => {
 	const positronConsoleContext = usePositronConsoleContext();
 
 	const handlePressed = () => {
-		positronConsoleContext.commandService.executeCommand(LANGUAGE_RUNTIME_START_SESSION_ID);
+		positronConsoleContext.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
 	};
 
 	// Render.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -47,7 +47,7 @@ import { IWorkbenchEnvironmentService } from '../../../services/environment/comm
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IDropdownMenuActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
 import { Action, IAction } from '../../../../base/common/actions.js';
-import { LANGUAGE_RUNTIME_DUPLICATE_SESSION_ID, LANGUAGE_RUNTIME_START_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { DropdownWithPrimaryActionViewItem } from '../../../../platform/actions/browser/dropdownWithPrimaryActionViewItem.js';
 import { MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { localize } from '../../../../nls.js';
@@ -371,7 +371,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 	}
 
 	override createActionViewItem(action: IAction, options?: IDropdownMenuActionViewItemOptions): IActionViewItem | undefined {
-		if (action.id === LANGUAGE_RUNTIME_DUPLICATE_SESSION_ID) {
+		if (action.id === LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID) {
 			if (action instanceof MenuItemAction) {
 				const dropdownAction = new Action('console.session.quickLaunch', localize('console.session.quickLaunch', 'Quick Launch Session...'), 'codicon-chevron-down', true);
 				this._register(dropdownAction);
@@ -443,7 +443,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 			undefined,
 			true,
 			() => {
-				this.commandService.executeCommand(LANGUAGE_RUNTIME_START_SESSION_ID);
+				this.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
 			})
 		);
 

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -23,6 +23,7 @@ import { NotebookExecutionStatus } from './notebookExecutionStatus.js';
 import { RuntimeNotebookKernel } from './runtimeNotebookKernel.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
+import { LANGUAGE_RUNTIME_SELECT_RUNTIME_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 
 /**
  * The affinity of a kernel for a notebook.
@@ -134,7 +135,7 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 					{
 						label: 'Select Environment...',
 						command: {
-							id: 'workbench.action.languageRuntime.pick',
+							id: LANGUAGE_RUNTIME_SELECT_RUNTIME_ID,
 							title: 'Select Environment',
 						},
 					}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ActionButton } from '../../positronNotebook/browser/utilityComponents/ActionButton.js';
-import { LANGUAGE_RUNTIME_START_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 
 interface WelcomeConsoleButtonProps {
 	commandService: ICommandService;
@@ -18,7 +18,7 @@ interface WelcomeConsoleButtonProps {
 
 export function WelcomeConsoleButton(props: WelcomeConsoleButtonProps) {
 	const handlePressed = () => {
-		props.commandService.executeCommand(LANGUAGE_RUNTIME_START_SESSION_ID);
+		props.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
 	}
 
 	// Render.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -756,8 +756,6 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 			return;
 		}
 
-		this._onDidDeletePositronConsoleInstanceEmitter.fire(consoleInstance);
-
 		// Update the foreground session.
 		// First try to use the last created console session for the runtime.
 		let runtimeSession = this._runtimeSessionService.getConsoleSessionForRuntime(
@@ -776,6 +774,8 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		this._positronConsoleInstancesBySessionId.delete(sessionId);
 
 		consoleInstance.dispose();
+
+		this._onDidDeletePositronConsoleInstanceEmitter.fire(consoleInstance);
 	}
 
 	/**

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -41,6 +41,7 @@ export class Console {
 		this.restartButton = this.code.driver.page.getByLabel('Restart console');
 		this.clearButton = this.code.driver.page.getByLabel('Clear console');
 		this.trashButton = this.code.driver.page.getByTestId('trash-session');
+		// TODO @dhruvisompura: This needs to be updated since this now creates or duplicates a session
 		this.newSessionButton = this.code.driver.page.getByRole('toolbar', { name: 'Console actions' }).getByRole('button', { name: 'Start a New Session' });
 		this.activeConsole = this.code.driver.page.locator(ACTIVE_CONSOLE_INSTANCE);
 		this.suggestionList = this.code.driver.page.locator(SUGGESTION_LIST);

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1008,7 +1008,7 @@ export class SessionQuickPick {
 
 			// Filter out the one with "New Session..."
 			const filteredSessions = activeSessions
-				.filter(session => !session.name.includes('New Session...'));
+				.filter(session => !session.name.includes('New Interpreter Session...'));
 
 			await this.closeSessionQuickPickMenu();
 			return filteredSessions;

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -940,8 +940,8 @@ export class Sessions {
  */
 export class SessionQuickPick {
 	private quickInputTitleBar = this.code.driver.page.locator('.quick-input-titlebar');
-	private sessionQuickMenu = this.quickInputTitleBar.getByText(/(Select a Session)|(Start a New Session)/);
-	allSessionsMenu = this.quickInputTitleBar.getByText(/Start a New Session/);
+	private sessionQuickMenu = this.quickInputTitleBar.getByText(/(Select Interpreter Session)|(Start New Interpreter Session)/);
+	allSessionsMenu = this.quickInputTitleBar.getByText(/Start New Interpreter Session/);
 
 	constructor(private code: Code, private sessions: Sessions) { }
 
@@ -960,9 +960,9 @@ export class SessionQuickPick {
 				}
 
 				if (viewAllRuntimes) {
-					await this.code.driver.page.getByRole('textbox', { name: /(Select a Session|New Session)/ }).fill('New Session');
+					await this.code.driver.page.getByRole('textbox', { name: /(Select Interpreter Session|New Interpreter Session)/ }).fill('New Session');
 					await this.code.driver.page.keyboard.press('Enter');
-					await expect(this.code.driver.page.getByText(/Start a New Session/)).toBeVisible({ timeout: 1000 });
+					await expect(this.code.driver.page.getByText(/Start New Interpreter Session/)).toBeVisible({ timeout: 1000 });
 				}
 			}, 'Open Session QuickPick Menu').toPass({ intervals: [500], timeout: 10000 });
 		});

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -89,11 +89,13 @@ test.describe('Python - New Project Wizard', { tag: [tags.MODAL, tags.NEW_PROJEC
 		await expect(notebookEditorTab).toBeVisible();
 
 		// Get the Python version from the session selector button
-		const sessionSelectorButton = app.code.driver.page.getByRole('button', { name: 'Session Selector' });
+		const sessionSelectorButton = app.code.driver.page.getByRole('button', { name: 'Select Interpreter Session' });
 		const sessionSelectorText = await sessionSelectorButton.textContent();
+
 		// Extract the version number (e.g., '3.10.12') from the button text
 		const versionMatch = sessionSelectorText && sessionSelectorText.match(/Python ([0-9]+\.[0-9]+\.[0-9]+)/);
 		const pythonVersion = versionMatch ? versionMatch[1] : undefined;
+
 		// Fail the test if we can't extract the version
 		expect(pythonVersion, 'Python version should be present in session selector').toBeTruthy();
 


### PR DESCRIPTION
Addresses #7189 

This PR goes through all the interpreter commands we expose to users in the command palette and updates them so the naming scheme is consistent and works better with multiple interpreter sessions. This also updates a couple other UI element labels that trigger the command palette actions so labels match across the board.

Note: The diff is a bit messy looking because I reordered a bunch of the actions, so hiding whitespace is recommended. I am also commenting the actions that were renamed/removed so its easier to find the destructive changes.

For most of the actions, a user is now prompted to select an interpreter session they want to take the action on. There are a couple actions that specifically act on the foreground session/active console, and those now specify that by using the term "Active Interpreter Session/ Active Console".

There’s a few actions in this list that I wasn’t sure what to do with and would love feedback on:
* Create/Close Runtime Client Widget: This action gets exposed in the command palette and I wanted to ask if this should be shown to users. I don’t know what the use case is for this. Alternatively, do we want to move this into the “Developer” category?
* Execute Code in Console/Execute Code Silently: from the comments it looks like this command is mainly used by QA. Can this be moved into the “Developer” category? I don’t love providing this as a path for users to run code because it’s a pretty odd experience.

Here's the new list of interpreter actions after the cleanup:

<img width="621" alt="Screenshot 2025-05-21 at 2 47 41 PM" src="https://github.com/user-attachments/assets/cfc18351-4cf1-4fa1-8071-6330a9090f04" />

The plus button in the console pane was also updated so the hover label matches the action being triggered. Prior to the fix, the button always. showed the "Duplicate Session" label - even when the action being triggered was the create new session action.

https://github.com/user-attachments/assets/29d5c067-e3de-4452-919b-0be833206ec8

### Release Notes

#### New Features

- Updated "Interpreter" command palette actions to work better with multiple interpreter sessions.
- Fixed incorrect hover label for "+" button in console pane

#### Bug Fixes

- N/A


### QA Notes

@:sessions @:web @:win @:console