### PR TITLE
e2e - expect as part of test.setup

### DIFF
--- a/test/e2e/tests/quarto/quarto-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-python.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, tags, expect } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, tags, expect } from '../_test.setup';
 
 test.use({
 	suiteId: __filename


### PR DESCRIPTION
This pull request includes a minor change to consolidate imports in end-to-end test files. The `expect` module is now imported from the same source as `test` and `tags` for consistency.

* [`test/e2e/tests/quarto/quarto-python.test.ts`](diffhunk://#diff-78cdaac7f5ade5ce9d8d1d3d79154fc96a9ce89328a8191a4e1975e5ff303e33L7-R7): Updated the import statement to include `expect` from `../_test.setup` instead of importing it separately from `@playwright/test`.
* [`test/e2e/tests/viewer/viewer.test.ts`](diffhunk://#diff-bf8cf9bac82100316644b307acdbdadc1b3b9d4c91e00b37b44213fd900d1bc1L6-R6): Similarly updated the import statement to include `expect` from `../_test.setup` for consistency.

### QA Notes

@:quarto @:web @:win