### PR TITLE
Another attempt to fix `positron-run-app` integration tests

### DIFF
--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { DebugAppOptions, RunAppOptions } from '../positron-run-app';
 import { raceTimeout } from '../utils';
 import { PositronRunAppApiImpl } from '../api';
+import { log } from '../extension.js';
 
 suite('PositronRunApp', () => {
 	// Use a test runtime with a runtimePath of `cat` so that executing a file
@@ -55,6 +56,13 @@ suite('PositronRunApp', () => {
 	let runAppApi: PositronRunAppApiImpl;
 
 	setup(async () => {
+		// Reroute log messages to the console.
+		for (const level of ['trace', 'debug', 'info', 'warn', 'error']) {
+			sinon.stub(log, level as keyof typeof log).callsFake((...args) => {
+				console.info('[PositronRunApp]', ...args);
+			});
+		}
+
 		// Open the test app. Assumes that the tests are run in the ../test-workspace workspace.
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 		assert(workspaceFolder, 'This test should be run from the ../test-workspace workspace');

--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -64,12 +64,11 @@ echo
 npm run test-extension -- -l positron-connections
 kill_app
 
-# TODO: Flaky test: https://github.com/posit-dev/positron/issues/5823.
-# echo
-# echo "### Positron Run App tests"
-# echo
-# npm run test-extension -- -l positron-run-app
-# kill_app
+echo
+echo "### Positron Run App tests"
+echo
+npm run test-extension -- -l positron-run-app
+kill_app
 
 echo
 echo "### Positron DuckDB tests"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -154,12 +154,11 @@ echo
 npm run test-extension -- -l positron-connections
 kill_app
 
-# TODO: Flaky test: https://github.com/posit-dev/positron/issues/5823.
-# echo
-# echo "### Positron Run App tests"
-# echo
-# npm run test-extension -- -l positron-run-app
-# kill_app
+echo
+echo "### Positron Run App tests"
+echo
+npm run test-extension -- -l positron-run-app
+kill_app
 
 echo
 echo "### Positron DuckDB tests"


### PR DESCRIPTION
**Hopefully** addresses #5823. The suspected issue is that we sometimes send text to the terminal before shell integration is "ready", so now we always `await` it first.

There's a slight complication if the user has an unsupported shell, then we don't them to wait for the timeout on every run.

### QA Notes

Integration tests should pass reliably.

@:apps