### PR TITLE
Bump ark to 0.1.185

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -766,7 +766,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.184"
+      "ark": "0.1.185"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/803
- https://github.com/posit-dev/ark/pull/804
- https://github.com/posit-dev/ark/pull/772
- https://github.com/posit-dev/ark/pull/805


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R: Completions can now be requested at a bare R prompt or on an empty line (https://github.com/posit-dev/ark/pull/772)

#### Bug Fixes

- R: The pipe placeholder, `_`, is no longer flagged as a symbol not in scope (https://github.com/posit-dev/ark/pull/804)
- R: Diagnostics are now disabled while inside a `[` or `[[` scope, which should make using data.table in Positron more pleasant! (https://github.com/posit-dev/ark/pull/803)


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
