### PR TITLE
Fix "Apply in Editor" tool on Windows

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -84,7 +84,7 @@
         "isSticky": false,
         "isDefault": true,
         "locations": [
-          "editing-session"
+          "panel"
         ]
       }
     ],

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -39,8 +39,7 @@
           "panel"
         ],
         "modes": [
-          "ask",
-          "edit"
+          "ask"
         ]
       },
       {
@@ -85,6 +84,9 @@
         "isDefault": true,
         "locations": [
           "panel"
+        ],
+        "modes": [
+          "edit"
         ]
       }
     ],

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -674,7 +674,6 @@ declare module 'positron' {
 		Terminal = 'terminal',
 		Notebook = 'notebook',
 		Editor = 'editor',
-		EditingSession = 'editing-session',
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -371,7 +371,6 @@ export enum PositronChatAgentLocation {
 	Terminal = 'terminal',
 	Notebook = 'notebook',
 	Editor = 'editor',
-	EditingSession = 'editing-session',
 }
 
 /**


### PR DESCRIPTION
This change is the minimum needed to make _Apply in Editor_ work again.

In earlier iterations of the internal API, there was an `editing-session` agent location (corresponding to the Copilot Edits pane). This location doesn't exist any more; there's just a Chat pane. 

The fix here is to register the agent formerly used as the editing session agent for the "Edit" mode instead of trying to use the default agent for both Ask and Edit modes.

Addresses #7188. 
