### PR TITLE
e2e test - Publisher Test with Shiny App

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -104,6 +104,8 @@ jobs:
       E2E_POSTGRES_USER: ${{ secrets.E2E_POSTGRES_USER }}
       E2E_POSTGRES_PASSWORD: ${{ secrets.E2E_POSTGRES_PASSWORD }}
       E2E_POSTGRES_DB: ${{ secrets.E2E_POSTGRES_DB }}
+      E2E_CONNECT_SERVER: ${{ secrets.E2E_CONNECT_SERVER}}
+      E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY}}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -60,6 +60,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
       AWS_S3_BUCKET: positron-test-reports
+      E2E_CONNECT_SERVER: ${{ secrets.E2E_CONNECT_SERVER}}
+      E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY}}
 
     steps:
       - uses: actions/checkout@v4

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -42,6 +42,7 @@ export enum TestTags {
 	OUTPUT = '@:output',
 	PLOTS = '@:plots',
 	PROBLEMS = '@:problems',
+	PUBLISHER = '@:publisher',
 	REFERENCES = '@:references',
 	R_MARKDOWN = '@:r-markdown',
 	R_PKG_DEVELOPMENT = '@:r-pkg-development',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -39,7 +39,7 @@ import { Sessions } from '../pages/sessions';
 import { Search } from '../pages/search.js';
 import { Assistant } from '../pages/positronAssistant.js';
 import { HotKeys } from '../pages/hotKeys.js';
-// add the import with class here for the connect.ts file
+import { PositConnect } from '../pages/connect.js';
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -82,6 +82,7 @@ export class Workbench {
 	readonly search: Search;
 	readonly assistant: Assistant;
 	readonly hotKeys: HotKeys;
+	readonly positConnect: PositConnect;
 
 	constructor(code: Code) {
 		this.hotKeys = new HotKeys(code);
@@ -119,6 +120,6 @@ export class Workbench {
 		this.scm = new SCM(code, this.layouts);
 		this.search = new Search(code);
 		this.assistant = new Assistant(code);
-		// add to the constructor the creator of the instance of this class
+		this.positConnect = new PositConnect();
 	}
 }

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -39,6 +39,7 @@ import { Sessions } from '../pages/sessions';
 import { Search } from '../pages/search.js';
 import { Assistant } from '../pages/positronAssistant.js';
 import { HotKeys } from '../pages/hotKeys.js';
+// add the import with class here for the connect.ts file
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -118,5 +119,6 @@ export class Workbench {
 		this.scm = new SCM(code, this.layouts);
 		this.search = new Search(code);
 		this.assistant = new Assistant(code);
+		// add to the constructor the creator of the instance of this class
 	}
 }

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -120,6 +120,6 @@ export class Workbench {
 		this.scm = new SCM(code, this.layouts);
 		this.search = new Search(code);
 		this.assistant = new Assistant(code);
-		this.positConnect = new PositConnect();
+		this.positConnect = new PositConnect(code);
 	}
 }

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -17,14 +17,20 @@ export class PositConnect {
 		const contentGuids: string[] = [];
 		for (const app of appInfo) {
 			contentGuids.push(app['guid'] as string);
+
+			console.log(contentGuids);
+			if (contentGuids.length > 0) {
+				for (const guid of contentGuids) {
+					const response = await fetch(`${connectApiUrl}content/${guid}`, {
+						method: 'DELETE',
+						headers: headers
+					});
+					// 204 response = app deleted
+					if (response.status !== 204) {
+						throw new Error(`Failed to delete content with GUID: ${guid}`);
+					}
+				}
+			}
 		}
-
-		console.log(contentGuids);
-
 	}
 };
-
-
-// make a clean up for the shiny app, look at clipboard to get an example of what a cleanup for a page looks like
-
-// after this is added, go to workbench.ts and add an instance of this so that I can use it through the workbench

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export class ConnectPage { };
+
+// make a clean up for the shiny app, look at clipboard to get an example of what a cleanup for a page looks like
+
+// after this is added, go to workbench.ts and add an instance of this so that I can use it through the workbench

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -3,7 +3,20 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export class ConnectPage { };
+export class PositConnect {
+	constructor() {
+
+	}
+	async deleteUserContent() {
+		console.log('Deleting user content');
+		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`
+		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
+		const userGuid = await fetch(connectApiUrl + 'user', { headers: headers })['guid'];
+		console.log('User GUID:', userGuid);
+
+	}
+};
+
 
 // make a clean up for the shiny app, look at clipboard to get an example of what a cleanup for a page looks like
 

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -34,9 +34,10 @@ export class PositConnect {
 		}
 	}
 
+	// To prevent flakiness, this function always add the file name after app.py, which is guaranteed to be present
 	async selectFilesForDeploy(files: string[]) {
 		const editorContainer = this.code.driver.page.locator('[id="workbench.parts.editor"]');
-		const dynamicTomlLineRegex = /deployment-.*?\.toml/;
+		const dynamicTomlLineRegex = 'app.py';
 		const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
 
 		await targetLine.scrollIntoViewIfNeeded({ timeout: 20000 });
@@ -44,13 +45,13 @@ export class PositConnect {
 
 		await targetLine.click();
 		await this.code.driver.page.keyboard.press('End');
-		await this.code.driver.page.keyboard.type(',');
 
-		for (const file of files) {
-			await this.code.driver.page.keyboard.press('Enter');
-			await this.code.driver.page.keyboard.type(`'/${file}'${file === files[files.length - 1] ? '' : ','}`);
+		for (let i = 0; i < files.length; i++) {
+			if (i > 0) {
+				await this.code.driver.page.keyboard.press('Enter');
+			}
+			await this.code.driver.page.keyboard.type(`'/${files[i]}',`);
 		}
-
 		const saveButton = this.code.driver.page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
 		await saveButton.click();
 	}

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -14,7 +14,7 @@ export class PositConnect {
 		if (!process.env.E2E_CONNECT_SERVER || !process.env.E2E_CONNECT_APIKEY) {
 			throw new Error('Missing E2E_CONNECT_SERVER or E2E_CONNECT_APIKEY env vars.');
 		}
-		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`
+		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`;
 		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
 		const userGuid = (await (await fetch(connectApiUrl + 'user', { headers: headers })).json()).guid;
 

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -11,8 +11,15 @@ export class PositConnect {
 		console.log('Deleting user content');
 		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`
 		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
-		const userGuid = await fetch(connectApiUrl + 'user', { headers: headers })['guid'];
-		console.log('User GUID:', userGuid);
+		const userGuid = (await (await fetch(connectApiUrl + 'user', { headers: headers })).json()).guid;
+
+		const appInfo = await (await fetch(connectApiUrl + `content?owner_guid=${userGuid}`, { headers: headers })).json();
+		const contentGuids: string[] = [];
+		for (const app of appInfo) {
+			contentGuids.push(app['guid'] as string);
+		}
+
+		console.log(contentGuids);
 
 	}
 };

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -3,34 +3,55 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
+import { Code } from '../infra/code.js';
 export class PositConnect {
-	constructor() {
 
+	constructor(private code: Code) {
+		this.code = code;
 	}
 	async deleteUserContent() {
-		console.log('Deleting user content');
+		if (!process.env.E2E_CONNECT_SERVER || !process.env.E2E_CONNECT_APIKEY) {
+			throw new Error('Missing E2E_CONNECT_SERVER or E2E_CONNECT_APIKEY env vars.');
+		}
 		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`
 		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
 		const userGuid = (await (await fetch(connectApiUrl + 'user', { headers: headers })).json()).guid;
 
 		const appInfo = await (await fetch(connectApiUrl + `content?owner_guid=${userGuid}`, { headers: headers })).json();
-		const contentGuids: string[] = [];
-		for (const app of appInfo) {
-			contentGuids.push(app['guid'] as string);
 
-			console.log(contentGuids);
-			if (contentGuids.length > 0) {
-				for (const guid of contentGuids) {
-					const response = await fetch(`${connectApiUrl}content/${guid}`, {
-						method: 'DELETE',
-						headers: headers
-					});
-					// 204 response = app deleted
-					if (response.status !== 204) {
-						throw new Error(`Failed to delete content with GUID: ${guid}`);
-					}
-				}
+		for (const app of appInfo) {
+			const guid = app.guid as string;
+
+			const response = await fetch(`${connectApiUrl}content/${guid}`, {
+				method: 'DELETE',
+				headers,
+			});
+
+			if (response.status !== 204) {
+				throw new Error(`Failed to delete content with GUID: ${guid}`);
 			}
 		}
 	}
-};
+
+	async selectFilesForDeploy(files: string[]) {
+		const editorContainer = this.code.driver.page.locator('[id="workbench\\.parts\\.editor"]');
+		const dynamicTomlLineRegex = /deployment-.*?\.toml/;
+		const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
+
+		await targetLine.scrollIntoViewIfNeeded({ timeout: 20000 });
+		await expect(targetLine).toBeVisible({ timeout: 10000 });
+
+		await targetLine.click();
+		await this.code.driver.page.keyboard.press('End');
+		await this.code.driver.page.keyboard.type(',');
+
+		for (const file of files) {
+			await this.code.driver.page.keyboard.press('Enter');
+			await this.code.driver.page.keyboard.type(`'/${file}'${file === files[files.length - 1] ? '' : ','}`);
+		}
+
+		const saveButton = this.code.driver.page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
+		await saveButton.click();
+	}
+}

--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -35,7 +35,7 @@ export class PositConnect {
 	}
 
 	async selectFilesForDeploy(files: string[]) {
-		const editorContainer = this.code.driver.page.locator('[id="workbench\\.parts\\.editor"]');
+		const editorContainer = this.code.driver.page.locator('[id="workbench.parts.editor"]');
 		const dynamicTomlLineRegex = /deployment-.*?\.toml/;
 		const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
 

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -23,7 +23,7 @@ export class EditorActionBar {
 	 * @param button - Name of the button to click in the editor action bar.
 	 */
 	async clickButton(
-		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer' | 'Move into new window' | 'Open as Plain Text File'
+		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer' | 'Move into new window' | 'Open as Plain Text File' | 'Deploy with Posit Publisher'
 	): Promise<void> {
 		const buttonLocator = this.page.getByLabel(button, { exact: true });
 

--- a/test/e2e/pages/popups.ts
+++ b/test/e2e/pages/popups.ts
@@ -141,6 +141,20 @@ export class Popups {
 		}
 	}
 
+	// To implement in a test, use await app.workbench.popups.closeSpecificToast('messageText');
+	async closeSpecificToast(messageText: string) {
+		this.code.logger.log(`Closing specific toast with message: ${messageText}`);
+		try {
+			const toast = this.toastLocator.filter({ hasText: messageText });
+			// await toast.waitFor({ state: 'visible'});
+			await toast.hover();
+			await this.code.driver.page.locator(`${NOTIFICATION_TOAST} .codicon-notifications-clear`).click();
+			this.code.logger.log(`Closed toast containing: ${messageText}`);
+		} catch (error) {
+			this.code.logger.log('Toast not found or already closed');
+		}
+	}
+
 	async waitForModalDialogBox() {
 		await expect(this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX)).toBeVisible({ timeout: 30000 });
 	}
@@ -176,7 +190,6 @@ export class Popups {
 			expect(textContent).toContain(title);
 		}).toPass({ timeout: 10000 });
 	}
-
 
 	/**
 	 * Right clicks and selects a menu item, waiting for menu dismissal.

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -40,8 +40,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 		});
 
 		await test.step('Click on Publish button', async () => {
-			const deployPublisherButton = page.getByRole('button', { name: 'Deploy with Posit Publisher' });
-			await deployPublisherButton.click();
+			await app.workbench.editorActionBar.clickButton('Deploy with Posit Publisher');
 		});
 
 		await test.step('Enter title for application through quick-input', async () => {

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// This test aims to verify basic Publisher's functionality
+test('Verify Publisher functionality in Positron with Shiny app deployment as example', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, async function ({ app, openFile, logger, page, python }, testInfo) {
+
+	await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
+
+	const deployPublisherButton = page.getByRole('button', { name: 'Deploy with Posit Publisher' });
+	await deployPublisherButton.click();
+
+	await app.workbench.quickInput.waitForQuickInputOpened();
+	await app.workbench.quickInput.type('shiny-py-example');
+	await page.keyboard.press('Enter');
+
+	await app.workbench.quickInput.type(process.env.E2E_CONNECT_SERVER!);
+	await page.keyboard.press('Enter');
+
+	await app.workbench.quickInput.type(process.env.E2E_CONNECT_APIKEY!);
+	await page.keyboard.press('Enter');
+
+	await app.workbench.quickInput.type('shiny-py-example');
+	await page.keyboard.press('Enter');
+
+	// shadow dom note
+
+	const editorContainer = page.locator('[id="workbench\\.parts\\.editor"]');
+	const dynamicTomlLineRegex = /deployment-.*?\.toml/;
+	// if someone changes the structure of the toml file, this regex will not work
+	const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
+
+	await targetLine.scrollIntoViewIfNeeded({ timeout: 20000 });
+	await expect(targetLine).toBeVisible({ timeout: 10000 });
+
+	await targetLine.click();
+
+	await page.keyboard.press('End');
+	await page.keyboard.type(',')
+
+	await page.keyboard.press('Enter');
+	await page.keyboard.type("'/shared.py',");
+	await page.keyboard.press('Enter');
+	await page.keyboard.type("'/styles.css',");
+	await page.keyboard.press('Enter');
+	await page.keyboard.type("'/tips.csv'");
+
+	const saveButton = page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
+	await saveButton.click(); // up to here it works
+
+	// below doesn't work: I've tried multiple ways to click the button
+	const frame = page.frameLocator('iframe[src*="vscode-webview://"][src*="index.html"]');
+	await frame.locator('vscode-button[data-automation="deploy-button"] >>> button.control').click();
+
+
+
+});

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -35,7 +35,6 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 	});
 	*/
 	test('Verify Publisher functionality in Positron with Shiny app deployment as example', async function ({ app, page, openFile }) {
-		test.slow();
 		await test.step('Open file', async () => {
 			await openFile('workspaces/shiny-py-example/app.py');
 		});

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -5,15 +5,17 @@
 
 import { test, tags, expect } from '../_test.setup';
 
-
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER] }, () => {
+	/*
+	Temporarily disabled file deletion from Connect after test runs for the same reason below.
 	test.afterAll('Delete file from Posit Connect', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
 	});
+	*/
 
 	test('Verify Publisher functionality in Positron with Shiny app deployment as example', async function ({ app, page, openFile }) {
 		test.slow();
@@ -49,30 +51,41 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			await app.workbench.positConnect.selectFilesForDeploy(files);
 		});
 
-		// This step was tricky due to button being inside iframe --> iframe --> shadow DOM (for any left pane interactivity, check this approach)
 		const outerFrame = page.frameLocator('iframe.webview.ready');
 		const innerFrame = outerFrame.frameLocator('iframe#active-frame');
 		const deployButton = innerFrame.locator('vscode-button[data-automation="deploy-button"] >>> button');
 
-		await test.step('Click on Deploy Your Project button', async () => {
-			await deployButton.click();
-		});
-
-		await test.step('Click on View Log', async () => {
-			const viewLogLink = innerFrame.locator('a.webview-link', { hasText: 'View Log' });
-			await viewLogLink.waitFor({ state: 'visible' });
-			await viewLogLink.click();
-		});
-
-		// This step verifies deployment process kicks in. See discussion in #connect channel, posted 05/23.
-		await test.step('Verify deployments process gets kicked in by Publisher (out of scope: whether deployment succeeds', async () => {
-			// Not needed thanks to PR 7840, but this is an example of implementation
-			// await app.workbench.popups.closeSpecificToast('Import your settings from Visual Studio Code into Positron?');
-			await page.getByRole('button', { name: 'Maximize Panel' }).click();
-			// The next two await expects are a bit redundant on purpose. If "Deploy Bundle" isn't visible, test should quickly fail (5secs).
-			await expect(page.locator('span.monaco-highlighted-label:has-text("Deploy Bundle")')).toBeVisible({ timeout: 5000 });
-			// Then, checkmark next to it might take a bit long to appear, which is expected.
-			await expect(page.locator('.monaco-list-row:has-text("Deploy Bundle") .custom-view-tree-node-item-icon.codicon.codicon-check')).toBeVisible({ timeout: 90000 });
+		await test.step('Expect Deploy button to appear', async () => {
+			await expect(deployButton).toBeVisible();
 		});
 	});
 });
+
+/*
+Temporarily commenting this out, but keeping the code because later we may have a more feature-rich integration with Publisher.
+// This step was tricky due to button being inside iframe --> iframe --> shadow DOM (for any left pane interactivity, check this approach)
+const outerFrame = page.frameLocator('iframe.webview.ready');
+const innerFrame = outerFrame.frameLocator('iframe#active-frame');
+const deployButton = innerFrame.locator('vscode-button[data-automation="deploy-button"] >>> button');
+
+await test.step('Click on Deploy Your Project button', async () => {
+	await deployButton.click();
+});
+
+await test.step('Click on View Log', async () => {
+	const viewLogLink = innerFrame.locator('a.webview-link', { hasText: 'View Log' });
+	await viewLogLink.waitFor({ state: 'visible' });
+	await viewLogLink.click();
+});
+
+// This step verifies deployment process kicks in. See discussion in #connect channel, posted 05/23.
+await test.step('Verify deployments process gets kicked in by Publisher (out of scope: whether deployment succeeds', async () => {
+	// Not needed thanks to PR 7840, but this is an example of implementation
+	// await app.workbench.popups.closeSpecificToast('Import your settings from Visual Studio Code into Positron?');
+	await page.getByRole('button', { name: 'Maximize Panel' }).click();
+	// The next two await expects are a bit redundant on purpose. If "Deploy Bundle" isn't visible, test should quickly fail (5secs).
+	await expect(page.locator('span.monaco-highlighted-label:has-text("Deploy Bundle")')).toBeVisible({ timeout: 5000 });
+	// Then, checkmark next to it might take a bit long to appear, which is expected.
+	await expect(page.locator('.monaco-list-row:has-text("Deploy Bundle") .custom-view-tree-node-item-icon.codicon.codicon-check')).toBeVisible({ timeout: 90000 });
+});
+*/

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -11,7 +11,6 @@ test.use({
 });
 
 test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER] }, () => {
-	test.slow();
 	test.afterAll('Delete file from Posit Connect', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
 	});
@@ -70,8 +69,10 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			// Not needed thanks to PR 7840, but this is an example of implementation
 			// await app.workbench.popups.closeSpecificToast('Import your settings from Visual Studio Code into Positron?');
 			await page.getByRole('button', { name: 'Maximize Panel' }).click();
-			await page.getByRole('button', { name: 'Maximize Panel' }).click();
-			await expect(page.locator('.monaco-list-row:has-text("Run Content") .codicon.codicon-check')).toBeVisible({ timeout: 90000 });
+			// The next twi await expects are a bit redundant on purpose. If "Deploy Bundle isn't visible, test should quickly fail (5secs).
+			await expect(page.locator('span.monaco-highlighted-label:has-text("Deploy Bundle")')).toBeVisible({ timeout: 5000 });
+			// Then, checkmark next to it might take a bit long to appear, which is expected.
+			await expect(page.locator('.monaco-list-row:has-text("Deploy Bundle") .custom-view-tree-node-item-icon.codicon.codicon-check')).toBeVisible({ timeout: 90000 });
 		});
 	});
 });

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -3,6 +3,24 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/*
+Summary:
+- This test verifies the end-to-end functionality of the Posit Publisher feature within Positron by initiating the
+deployment of a Shiny app (Python), BEFORE clicking 'Deploy Your Project' button.
+- Clicking on 'Deploy Your Project' button and aftermath are OUT OF SCOPE for this test.
+- This test, excluding commented code, does the following actions:
+1. Opening the Shiny app.py file
+2. Initiating the deployment process
+3. Providing necessary credentials (Connect server and API key)
+4. Including additional necessary files for deployment ('shared.py', 'styles.css', 'tips.csv')
+5. Verifying the presence of the deploy button
+
+Disclaimer:
+- For this test to run successfully, ensure that there are NO stored Posit Connect credentials in your environment
+before executing this test locally.
+- If credentials are already stored, this test is expected to FAIL.
+*/
+
 import { test, tags, expect } from '../_test.setup';
 
 test.use({
@@ -16,7 +34,6 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 		await app.workbench.positConnect.deleteUserContent();
 	});
 	*/
-
 	test('Verify Publisher functionality in Positron with Shiny app deployment as example', async function ({ app, page, openFile }) {
 		test.slow();
 		await test.step('Open file', async () => {
@@ -28,7 +45,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			await deployPublisherButton.click();
 		});
 
-		await test.step('Quick-input shiny-py-example unique name', async () => {
+		await test.step('Enter title for application through quick-input', async () => {
 			await app.workbench.quickInput.waitForQuickInputOpened();
 			await app.workbench.quickInput.type('shiny-py-example');
 			await page.keyboard.press('Enter');
@@ -41,7 +58,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			await page.keyboard.press('Enter');
 		});
 
-		await test.step('Quick-input shiny-py-example', async () => {
+		await test.step('Unique name for credential (Connect Server and API key)', async () => {
 			await app.workbench.quickInput.type('shiny-py-example');
 			await page.keyboard.press('Enter');
 		});
@@ -55,7 +72,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 		const innerFrame = outerFrame.frameLocator('iframe#active-frame');
 		const deployButton = innerFrame.locator('vscode-button[data-automation="deploy-button"] >>> button');
 
-		await test.step('Expect Deploy button to appear', async () => {
+		await test.step('Expect Deploy Your Project button to appear', async () => {
 			await expect(deployButton).toBeVisible();
 		});
 	});

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -44,7 +44,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			await page.keyboard.press('Enter');
 		});
 
-		await test.step('Add files to deployment-***.toml and save', async () => {
+		await test.step('Add files to deployment file (after app.py) and save', async () => {
 			const files = ['shared.py', 'styles.css', 'tips.csv'];
 			await app.workbench.positConnect.selectFilesForDeploy(files);
 		});
@@ -69,7 +69,7 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER
 			// Not needed thanks to PR 7840, but this is an example of implementation
 			// await app.workbench.popups.closeSpecificToast('Import your settings from Visual Studio Code into Positron?');
 			await page.getByRole('button', { name: 'Maximize Panel' }).click();
-			// The next twi await expects are a bit redundant on purpose. If "Deploy Bundle isn't visible, test should quickly fail (5secs).
+			// The next two await expects are a bit redundant on purpose. If "Deploy Bundle" isn't visible, test should quickly fail (5secs).
 			await expect(page.locator('span.monaco-highlighted-label:has-text("Deploy Bundle")')).toBeVisible({ timeout: 5000 });
 			// Then, checkmark next to it might take a bit long to appear, which is expected.
 			await expect(page.locator('.monaco-list-row:has-text("Deploy Bundle") .custom-view-tree-node-item-icon.codicon.codicon-check')).toBeVisible({ timeout: 90000 });

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER] }, () => {
 	test.slow();
-	test.afterAll('Debug deletion of file', async function ({ app }) {
+	test.afterAll('Delete file from Posit Connect', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
 	});
 

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () => {
+test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.PUBLISHER] }, () => {
 	test.slow();
 	test.afterAll('Debug deletion of file', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
@@ -18,60 +18,81 @@ test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }
 
 	test('Verify Publisher functionality in Positron with Shiny app deployment as example', async function ({ app, logger, page, python }, testInfo) {
 		test.slow();
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
+		await test.step('Open file', async () => {
+			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
+		});
 
-		const deployPublisherButton = page.getByRole('button', { name: 'Deploy with Posit Publisher' });
-		await deployPublisherButton.click();
+		await test.step('Click on Publish button', async () => {
+			const deployPublisherButton = page.getByRole('button', { name: 'Deploy with Posit Publisher' });
+			await deployPublisherButton.click();
+		});
 
-		await app.workbench.quickInput.waitForQuickInputOpened();
-		await app.workbench.quickInput.type('shiny-py-example');
-		await page.keyboard.press('Enter');
+		await test.step('Quick-input shiny-py-example unique name', async () => {
+			await app.workbench.quickInput.waitForQuickInputOpened();
+			await app.workbench.quickInput.type('shiny-py-example');
+			await page.keyboard.press('Enter');
+		});
 
-		await app.workbench.quickInput.type(process.env.E2E_CONNECT_SERVER!);
-		await page.keyboard.press('Enter');
+		await test.step('Enter Connect server and API key', async () => {
+			await app.workbench.quickInput.type(process.env.E2E_CONNECT_SERVER!);
+			await page.keyboard.press('Enter');
+			await app.workbench.quickInput.type(process.env.E2E_CONNECT_APIKEY!);
+			await page.keyboard.press('Enter');
+		});
 
-		await app.workbench.quickInput.type(process.env.E2E_CONNECT_APIKEY!);
-		await page.keyboard.press('Enter');
+		await test.step('Quick-input shiny-py-example', async () => {
+			await app.workbench.quickInput.type('shiny-py-example');
+			await page.keyboard.press('Enter');
+		});
 
-		await app.workbench.quickInput.type('shiny-py-example');
-		await page.keyboard.press('Enter');
+		// This is a long step to insert the other files into the toml file, after last line.
+		await test.step('Add shared.py, styles.css, tips.csv to deployment-***.toml and save', async () => {
+			const editorContainer = page.locator('[id="workbench\\.parts\\.editor"]');
+			const dynamicTomlLineRegex = /deployment-.*?\.toml/;
+			const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
 
-		const editorContainer = page.locator('[id="workbench\\.parts\\.editor"]');
-		const dynamicTomlLineRegex = /deployment-.*?\.toml/;
-		const targetLine = editorContainer.locator('.view-line').filter({ hasText: dynamicTomlLineRegex });
+			await targetLine.scrollIntoViewIfNeeded({ timeout: 20000 });
+			await expect(targetLine).toBeVisible({ timeout: 10000 });
 
-		await targetLine.scrollIntoViewIfNeeded({ timeout: 20000 });
-		await expect(targetLine).toBeVisible({ timeout: 10000 });
+			await targetLine.click();
+			await page.keyboard.press('End');
+			await page.keyboard.type(',');
 
-		await targetLine.click();
-		await page.keyboard.press('End');
-		await page.keyboard.type(',');
+			await page.keyboard.press('Enter');
+			await page.keyboard.type("'/shared.py',");
+			await page.keyboard.press('Enter');
+			await page.keyboard.type("'/styles.css',");
+			await page.keyboard.press('Enter');
+			await page.keyboard.type("'/tips.csv'");
 
-		await page.keyboard.press('Enter');
-		await page.keyboard.type("'/shared.py',");
-		await page.keyboard.press('Enter');
-		await page.keyboard.type("'/styles.css',");
-		await page.keyboard.press('Enter');
-		await page.keyboard.type("'/tips.csv'");
+			const saveButton = page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
+			await saveButton.click();
+		});
 
-		const saveButton = page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
-		await saveButton.click();
-
+		// This step was tricky due to button being inside iframe --> iframe --> shadow DOM (for any left pane interactivity, check this approach)
 		const outerFrame = page.frameLocator('iframe.webview.ready');
 		const innerFrame = outerFrame.frameLocator('iframe#active-frame');
 		const deployButton = innerFrame.locator('vscode-button[data-automation="deploy-button"] >>> button');
-		await deployButton.waitFor({ state: 'visible' });
-		await deployButton.click();
 
-		const viewLogLink = innerFrame.locator('a.webview-link', { hasText: 'View Log' });
-		await viewLogLink.waitFor({ state: 'visible' });
-		await viewLogLink.click();
-
-		const toast = page.locator('.notification-list-item-message span', {
-			hasText: 'Deployment was successful',
+		await test.step('Click on Deploy Your Project button', async () => {
+			await deployButton.waitFor({ state: 'visible' });
+			await deployButton.click();
 		});
-		await toast.waitFor({ state: 'visible', timeout: 120000 });
-		await expect(toast).toBeVisible();
 
+		await test.step('Click on View Log', async () => {
+			const viewLogLink = innerFrame.locator('a.webview-link', { hasText: 'View Log' });
+			await viewLogLink.waitFor({ state: 'visible' });
+			await viewLogLink.click();
+		});
+
+
+		// This step may be flacky due to deployment toast sometimes showing failure despite successful deployment
+		await test.step('Verify deployment was successful', async () => {
+			const toast = page.locator('.notification-list-item-message span', {
+				hasText: 'Deployment was successful',
+			});
+			await toast.waitFor({ state: 'visible', timeout: 120000 });
+			await expect(toast).toBeVisible();
+		});
 	});
 });

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -11,9 +11,9 @@ test.use({
 });
 
 test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () => {
-	test.afterAll(async function ({ app }) {
+	/*test.afterAll(async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
-	});
+	});*/
 
 	test('Debug deletion of file', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -11,11 +11,8 @@ test.use({
 });
 
 test.describe('Publisher - Positron', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () => {
-	/*test.afterAll(async function ({ app }) {
-		await app.workbench.positConnect.deleteUserContent();
-	});*/
-
-	test('Debug deletion of file', async function ({ app }) {
+	test.slow();
+	test.afterAll('Debug deletion of file', async function ({ app }) {
 		await app.workbench.positConnect.deleteUserContent();
 	});
 

--- a/test/e2e/tests/publisher/publisher.test.ts
+++ b/test/e2e/tests/publisher/publisher.test.ts
@@ -56,10 +56,10 @@ test('Verify Publisher functionality in Positron with Shiny app deployment as ex
 	const saveButton = page.locator('.action-bar-button-icon.codicon.codicon-positron-save').first();
 	await saveButton.click(); // up to here it works
 
-	// below doesn't work: I've tried multiple ways to click the button
-	const frame = page.frameLocator('iframe[src*="vscode-webview://"][src*="index.html"]');
-	await frame.locator('vscode-button[data-automation="deploy-button"] >>> button.control').click();
-
-
-
+	// now below works as well (until deploy button)
+	const outerFrame = page.frameLocator('iframe.webview.ready');
+	const innerFrame = outerFrame.frameLocator('iframe#active-frame');
+	const deployButton = innerFrame.locator('vscode-button[data-automation="deploy-button"] >>> button');
+	await deployButton.waitFor({ state: 'visible' });
+	await deployButton.click();
 });


### PR DESCRIPTION
Update (05/28/2025): 
- To avoid flaky tests due to issues external to the team, this test scope has been restricted to up to waiting for the 'Deploy Your Project' button to appear. 
- Subsequent steps are commented out for now, because later we may have a more feature-rich integration with Publisher. Keeping `connect.ts` file intact for future usage if needed. 

Original Plan: (05/22/2025):
- This test verifies the functionality of publishing a `Shiny` app to `Posit Connect` through `Positron`. 
- These changes enhance the testing framework's ability to validate deployment workflows. 
- After test is over, regardless of outcome, created files for user are deleted from `Posit Connect` to ensure clean-up.
- This test can also be useful for future attempts to access and click on elements on the left pane, by exploring the iframe --> iframe --> shadow DOM penetration, which played a crucial role for this E2E test.

### QA Notes

@:web @:win @:publisher
