### PR TITLE
Add playwright project for macOS in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -97,5 +97,14 @@ export default defineConfig<ExtendedTestOptions>({
 			grep: /@:win/,
 			grepInvert: /@:web-only/
 		},
+				{
+			name: 'e2e-macOS-ci',
+			use: {
+				web: false,
+				artifactDir: 'e2e-macOS-ci',
+			},
+			grep: /@:win/,
+			grepInvert: /@:web-only|@:interpreter/
+		},
 	],
 });


### PR DESCRIPTION
Adds a new playwright project for MacOS in CI.  This is needed in release testing for correct currents reporting.

For now it mimics the windows flow. Subsequent work will work to enable the rest of the tests.


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
