### PR TITLE
E2E test: don't download large test file from s3 for windows

### DIFF
--- a/test/e2e/tests/data-explorer/very-large-data-frame.test.ts
+++ b/test/e2e/tests/data-explorer/very-large-data-frame.test.ts
@@ -21,7 +21,7 @@ const githubActions = process.env.GITHUB_ACTIONS === "true";
 
 test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
 	test.beforeAll(async function ({ app }) {
-		if (githubActions) {
+		if (githubActions && process.platform !== 'win32') {
 			const localFilePath = join(app.workspacePathOrFolder, "data-files", objectKey);
 			const downloadOptions: S3FileDownloadOptions = {
 				region: region,
@@ -38,7 +38,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 		await app.workbench.variables.togglePane('show');
 	});
 
-	if (githubActions) {
+	if (githubActions && process.platform !== 'win32') {
 
 		test('Python - Verify data loads with very large unique data dataframe', async function ({ app, logger, python }) {
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'performance', 'loadBigParquet.py'));


### PR DESCRIPTION
We have seen test flakes trying to pull a large test resource from s3 with windows so skipping that.

### QA Notes

@:win @:data-explorer
