### PR TITLE
Add copilot login to trusted list

### DIFF
--- a/product.json
+++ b/product.json
@@ -293,7 +293,8 @@
 	"linkProtectionTrustedDomains": [
 		"https://open-vsx.org",
 		"https://github.com/posit-dev/positron",
-		"https://positron.posit.co"
+		"https://positron.posit.co",
+		"https://github.com/login/device"
 	],
 	"extensionsEnabledWithApiProposalVersion": [
 		"GitHub.copilot-chat"

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -83,7 +83,13 @@ else {
 			reportIssueUrl: 'https://github.com/posit-dev/positron/issues/new',
 			licenseName: 'Software Evaluation License',
 			licenseUrl: 'https://github.com/posit-dev/positron/tree/main?tab=License-1-ov-file',
-			serverLicenseUrl: 'https://github.com/posit-dev/positron/tree/main?tab=License-1-ov-file'
+			serverLicenseUrl: 'https://github.com/posit-dev/positron/tree/main?tab=License-1-ov-file',
+			linkProtectionTrustedDomains: [
+				'https://open-vsx.org',
+				'https://github.com/posit-dev/positron',
+				'https://positron.posit.co',
+				'https://github.com/login/device',
+			]
 			// --- End Positron ---
 		});
 	}


### PR DESCRIPTION
Address #7818 

Add the Copilot login to the list of trusted domains. I've also added it to `product.ts` to be able to test locally.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- Fix trust dialog when signing in to Copilot provider #7818 


### QA Notes

