### PR TITLE
python: search uv dirs for interpreters

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/posixKnownPathsLocator.ts
@@ -19,6 +19,7 @@ import path from 'path';
 // eslint-disable-next-line import/no-duplicates
 import { ADDITIONAL_POSIX_BIN_PATHS } from '../../../common/posixUtils';
 import { findInterpretersInDir } from '../../../common/commonUtils';
+import { getUvDirs } from '../../../common/environmentManagers/uv';
 // --- End Positron ---
 
 export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {
@@ -97,7 +98,11 @@ export class PosixKnownPathsLocator extends Locator<BasicEnvInfo> {
  */
 async function getAdditionalPosixBinDirs(searchDepth = 2): Promise<string[]> {
     const additionalDirs = [];
-    for (const location of ADDITIONAL_POSIX_BIN_PATHS) {
+    const searchPaths = new Set(ADDITIONAL_POSIX_BIN_PATHS);
+    const uvDirs = await getUvDirs();
+    uvDirs.forEach((dir) => searchPaths.add(dir));
+
+    for (const location of searchPaths) {
         const executables = findInterpretersInDir(location, searchDepth);
         for await (const entry of executables) {
             const { filename } = entry;

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/windowsKnownPathsLocator.ts
@@ -21,6 +21,9 @@ import { inExperiment, pathExists } from '../../../common/externalDependencies';
 import { DiscoveryUsingWorkers } from '../../../../common/experiments/groups';
 import { iterPythonExecutablesInDir, looksLikeBasicGlobalPython } from '../../../common/commonUtils';
 import { StopWatch } from '../../../../common/utils/stopWatch';
+// --- Start Positron ---
+import { getUvDirs } from '../../../common/environmentManagers/uv';
+// --- End Positron ---
 
 /**
  * A locator for Windows locators found under the $PATH env var.
@@ -74,6 +77,16 @@ export class WindowsPathEnvVarLocator implements ILocator<BasicEnvInfo>, IDispos
             for await (const env of it) {
                 yield env;
             }
+            // --- Start Positron ---
+            // Search uv dirs too.
+            const uvDirs = await getUvDirs();
+            for (const uvDir of uvDirs) {
+                const envs = getDirFilesLocator(uvDir, PythonEnvKind.Uv, [PythonEnvSource.PathEnvVar], true);
+                for await (const env of envs.iterEnvs(query)) {
+                    yield env;
+                }
+            }
+            // --- End Positron ---
             traceInfo(`Finished searching windows known paths locator: ${stopWatch.elapsedTime} milliseconds`);
         }
         return iterator(this.locators.iterEnvs(query));

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -153,9 +153,7 @@ export async function getUvDirs(): Promise<Set<string>> {
         // Recurse one level deeper to include any subdirectories that might contain interpreters
         try {
             const entries = await fs.promises.readdir(uvDir, { withFileTypes: true });
-            const subdirs = entries
-                .filter(entry => entry.isDirectory())
-                .map(entry => path.join(uvDir, entry.name));
+            const subdirs = entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(uvDir, entry.name));
             for (const subdir of subdirs) {
                 dirs.add(subdir);
             }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -47,6 +47,17 @@ class UvUtils {
             return undefined;
         }
     }
+
+    @cache(-1)
+    public async getUvBinDir(): Promise<string | undefined> {
+        try {
+            const result = await exec(this.command, ['python', 'dir', '--bin'], { throwOnStdErr: true });
+            return result?.stdout.trim();
+        } catch (ex) {
+            traceVerbose(ex);
+            return undefined;
+        }
+    }
 }
 
 /**
@@ -119,4 +130,25 @@ export async function isUvEnvironment(interpreterPath: string): Promise<boolean>
 export async function isUvInstalled(): Promise<boolean> {
     const uvUtils = await UvUtils.getUvUtils();
     return uvUtils !== undefined;
+}
+
+/**
+ * Find all places uv puts global interpreters. These can differ by OS and env vars.
+ * @returns {Set<string>} Set of directories where uv interpreters are located.
+ */
+export async function getUvDirs(): Promise<Set<string>> {
+    const dirs = new Set<string>();
+    const uvUtils = await UvUtils.getUvUtils();
+    if (!uvUtils) {
+        return dirs;
+    }
+
+    const [uvBinDir, uvDir] = await Promise.all([uvUtils.getUvBinDir(), uvUtils.getUvDir()]);
+    if (uvBinDir) {
+        dirs.add(uvBinDir);
+    }
+    if (uvDir) {
+        dirs.add(uvDir);
+    }
+    return dirs;
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -139,27 +139,6 @@ export async function resolveSymbolicLink(absPath: string, stats?: fsapi.Stats, 
     return absPath;
 }
 
-// --- Start Positron ---
-export function resolveSymbolicLinkSync(absPath: string, stats?: fsapi.Stats, count?: number): string {
-    stats = stats ?? fsapi.statSync(absPath);
-    if (stats.isSymbolicLink()) {
-        if (count && count > 5) {
-            traceError(`Detected a potential symbolic link loop at ${absPath}, terminating resolution.`);
-            return absPath;
-        }
-        const link = fs.readlinkSync(absPath);
-        // Result from readlink is not guaranteed to be an absolute path. For eg. on Mac it resolves
-        // /usr/local/bin/python3.9 -> ../../../Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9
-        //
-        // The resultant path is reported relative to the symlink directory we resolve. Convert that to absolute path.
-        const absLinkPath = path.isAbsolute(link) ? link : path.resolve(path.dirname(absPath), link);
-        count = count ? count + 1 : 1;
-        return resolveSymbolicLinkSync(absLinkPath, undefined, count);
-    }
-    return absPath;
-}
-// --- End Positron ---
-
 export async function getFileInfo(filePath: string): Promise<{ ctime: number; mtime: number }> {
     try {
         const data = await fsapi.lstat(filePath);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #6701. Now we search the directories that `uv` puts its global interpreters in by default, if you have uv installed.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- find uv interpreters more often #6701


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

This takes different code paths for Windows vs non-Windows so probably best to try both. Known issue for future work: https://github.com/posit-dev/positron/issues/8005

You can install different versions with `uv python install 3.11` etc.
You can also have uv add those as `python` executables on your PATH with `uv python install --preview --default 3.11`.

I'd recommend doing both at once, and making sure they all show up under the Uv category, and the one that you made default shows up as its shortest alias.

<img width="606" alt="image" src="https://github.com/user-attachments/assets/ec3ddb37-a088-459b-9870-539fac966fb3" />


@:sessions @:win