### PR TITLE
E2E test: only show import vscode settings popup when needed for related test

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts
@@ -83,7 +83,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				default: true,
 				description: localize('positron.importSettings.enable', "Should Positron allow users to import settings from Visual Studio Code. Requires a restart to take effect."),
 				doNotSuggest: true,
-				scope: ConfigurationScope.APPLICATION_MACHINE
+				scope: ConfigurationScope.MACHINE_OVERRIDABLE
 			}
 		}
 	});

--- a/test/e2e/tests/import-vscode-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vscode-settings/import-vscode-settings.test.ts
@@ -28,11 +28,19 @@ test.use({
 	suiteId: __filename
 });
 
+let workspaceSettings: string;
+
 test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] }, () => {
-	test.beforeAll(async ({ vscodeUserSettings, positronUserSettings, runCommand }) => {
+	test.beforeAll(async ({ vscodeUserSettings, positronUserSettings, runCommand, app }) => {
+		workspaceSettings = await app.workbench.settings.backupWorkspaceSettings();
+		await app.workbench.settings.removeWorkspaceSettings(['positron.importSettings.enable']);
 		await vscodeUserSettings.ensureExists();
 		await positronUserSettings.ensureExists();
 		await runCommand('workbench.action.reloadWindow');
+	});
+
+	test.afterAll(async ({ app }) => {
+		await app.workbench.settings.restoreWorkspaceSettings(workspaceSettings);
 	});
 
 	test.beforeEach(async ({ sessions, hotKeys }) => {


### PR DESCRIPTION
Added:

"positron.importSettings.enable": false

to .vscode/settings.json in qa-example-content to prevent the "Import VSCode Settings" dialog from appearing in all tests.  Also need to turn in back on for the "Import VSCode Settings" tests.  This PR does that and changes the scope of the setting to allow for the qa-example-content setting to work in the first place.

### QA Notes

@:vscode-settings @:win
