### PR TITLE
assistant: fix issues where file in workspace can't be found

### DIFF
--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -10,7 +10,7 @@ import { ParticipantService } from './participants.js';
 
 export enum PositronAssistantToolName {
 	DocumentEdit = 'documentEdit',
-	EditFile = 'vscode_editFile_internal',
+	EditFile = 'positron_editFile_internal',
 	ExecuteCode = 'executeCode',
 	GetPlot = 'getPlot',
 	InspectVariables = 'inspectVariables',

--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -1,0 +1,290 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// --- Start Positron ---
+/**
+ * This is a duplicate of the EditFileTool from src/vs/workbench/contrib/chat/common/tools/editFileTool.ts,
+ * but reverted to the 1.99.0 upstream merge, with some changes applied to make it work with the
+ * 1.100.0 upstream merge changes.
+ *
+ * This file does not exist upstream. Positron markers have been added around the code that has been changed
+ * from the 1.99.0 state to allow for this tool to be used with the 1.100.0 upstream merge:
+ * https://github.com/posit-dev/positron/blob/121d131b19afed5646b3f57d5453fe53b44ca0c1/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+ */
+// --- End Positron ---
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI, UriComponents } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { localize } from '../../../../../nls.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { SaveReason } from '../../../../common/editor.js';
+import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { CellUri } from '../../../notebook/common/notebookCommon.js';
+import { INotebookService } from '../../../notebook/common/notebookService.js';
+import { ICodeMapperService } from '../../common/chatCodeMapperService.js';
+import { ChatModel } from '../../common/chatModel.js';
+import { IChatService } from '../../common/chatService.js';
+import { ILanguageModelIgnoredFilesService } from '../../common/ignoredFiles.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { ToolProgress } from '../../common/languageModelToolsService.js';
+// --- End Positron ---
+
+const codeInstructions = `
+The user is very smart and can understand how to apply your edits to their files, you just need to provide minimal hints.
+Avoid repeating existing code, instead use comments to represent regions of unchanged code. The user prefers that you are as concise as possible. For example:
+// ...existing code...
+{ changed code }
+// ...existing code...
+{ changed code }
+// ...existing code...
+
+Here is an example of how you should use format an edit to an existing Person class:
+class Person {
+	// ...existing code...
+	age: number;
+	// ...existing code...
+	getAge() {
+		return this.age;
+	}
+}
+`;
+
+// --- Start Positron ---
+// To avoid name collisions with the upstream editFileTool, we are using a different name for the extension tool ID.
+// export const ExtensionEditToolId = 'vscode_editFile';
+// export const InternalEditToolId = 'vscode_editFile_internal';
+export const ExtensionEditToolId = 'positron_editFile';
+export const InternalEditToolId = `${ExtensionEditToolId}_internal`;
+// --- End Positron ---
+export const EditToolData: IToolData = {
+	id: InternalEditToolId,
+	displayName: localize('chat.tools.editFile', "Edit File"),
+	modelDescription: `Edit a file in the workspace. Use this tool once per file that needs to be modified, even if there are multiple changes for a file. Generate the "explanation" property first. ${codeInstructions}`,
+	source: { type: 'internal' },
+	inputSchema: {
+		type: 'object',
+		properties: {
+			explanation: {
+				type: 'string',
+				description: 'A short explanation of the edit being made. Can be the same as the explanation you showed to the user.',
+			},
+			filePath: {
+				type: 'string',
+				description: 'An absolute path to the file to edit, or the URI of a untitled, not yet named, file, such as `untitled:Untitled-1.',
+			},
+			code: {
+				type: 'string',
+				description: 'The code change to apply to the file. ' + codeInstructions
+			}
+		},
+		required: ['explanation', 'filePath', 'code']
+	}
+};
+
+export class EditTool implements IToolImpl {
+
+	constructor(
+		@IChatService private readonly chatService: IChatService,
+		@ICodeMapperService private readonly codeMapperService: ICodeMapperService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@ILanguageModelIgnoredFilesService private readonly ignoredFilesService: ILanguageModelIgnoredFilesService,
+		@ITextFileService private readonly textFileService: ITextFileService,
+		@INotebookService private readonly notebookService: INotebookService,
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
+	) { }
+
+	// --- Start Positron ---
+	// Added the progress parameter to the invoke method
+	// async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback,  token: CancellationToken): Promise<IToolResult> {
+	async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
+		// --- End Positron ---
+		if (!invocation.context) {
+			throw new Error('toolInvocationToken is required for this tool');
+		}
+		// --- Start Positron ---
+		// Moved the code that was previously in EditToolInputProcessor processInput() to here.
+		const input = invocation.parameters as EditToolRawParams;
+		if (!input.filePath) {
+			// Tool name collision, or input wasn't properly validated upstream
+			throw new Error('filePath is required for this tool');
+		}
+		const filePath = input.filePath;
+		const updatedParams = {
+			file: filePath.startsWith('untitled:') ? URI.parse(filePath) : URI.file(filePath),
+			explanation: input.explanation,
+			code: input.code,
+		};
+		// const parameters = invocation.parameters as EditToolParams;
+		const parameters = updatedParams as EditToolParams;
+		// --- End Positron ---
+
+		const fileUri = URI.revive(parameters.file); // TODO@roblourens do revive in MainThreadLanguageModelTools
+		const uri = CellUri.parse(fileUri)?.notebook || fileUri;
+
+		if (!this.workspaceContextService.isInsideWorkspace(uri) && !this.notebookService.getNotebookTextModel(uri)) {
+			const groupsByLastActive = this.editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
+			const uriIsOpenInSomeEditor = groupsByLastActive.some((group) => {
+				return group.editors.some((editor) => {
+					return isEqual(editor.resource, uri);
+				});
+			});
+
+			if (!uriIsOpenInSomeEditor) {
+				throw new Error(`File ${uri.fsPath} can't be edited because it's not inside the current workspace`);
+			}
+		}
+
+		if (await this.ignoredFilesService.fileIsIgnored(uri, token)) {
+			throw new Error(`File ${uri.fsPath} can't be edited because it is configured to be ignored by Copilot`);
+		}
+
+		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
+		const request = model.getRequests().at(-1)!;
+
+		// Undo stops mark groups of response data in the output. Operations, such
+		// as text edits, that happen between undo stops are all done or undone together.
+		if (request.response?.response.getMarkdown().length) {
+			// slightly hacky way to avoid an extra 'no-op' undo stop at the start of responses that are just edits
+			model.acceptResponseProgress(request, {
+				kind: 'undoStop',
+				id: generateUuid(),
+			});
+		}
+
+		model.acceptResponseProgress(request, {
+			kind: 'markdownContent',
+			content: new MarkdownString('\n````\n')
+		});
+		model.acceptResponseProgress(request, {
+			kind: 'codeblockUri',
+			uri,
+			isEdit: true
+		});
+		model.acceptResponseProgress(request, {
+			kind: 'markdownContent',
+			content: new MarkdownString(parameters.code + '\n````\n')
+		});
+		// Signal start.
+		if (this.notebookService.hasSupportedNotebooks(uri) && (this.notebookService.getNotebookTextModel(uri))) {
+			model.acceptResponseProgress(request, {
+				kind: 'notebookEdit',
+				edits: [],
+				uri
+			});
+		} else {
+			model.acceptResponseProgress(request, {
+				kind: 'textEdit',
+				edits: [],
+				uri
+			});
+		}
+
+		const editSession = model.editingSession;
+		if (!editSession) {
+			throw new Error('This tool must be called from within an editing session');
+		}
+
+		const result = await this.codeMapperService.mapCode({
+			codeBlocks: [{ code: parameters.code, resource: uri, markdownBeforeBlock: parameters.explanation }],
+			location: 'tool',
+			chatRequestId: invocation.chatRequestId
+		}, {
+			textEdit: (target, edits) => {
+				model.acceptResponseProgress(request, { kind: 'textEdit', uri: target, edits });
+			},
+			notebookEdit(target, edits) {
+				model.acceptResponseProgress(request, { kind: 'notebookEdit', uri: target, edits });
+			},
+		}, token);
+
+		// Signal end.
+		if (this.notebookService.hasSupportedNotebooks(uri) && (this.notebookService.getNotebookTextModel(uri))) {
+			model.acceptResponseProgress(request, { kind: 'notebookEdit', uri, edits: [], done: true });
+		} else {
+			model.acceptResponseProgress(request, { kind: 'textEdit', uri, edits: [], done: true });
+		}
+
+		if (result?.errorMessage) {
+			throw new Error(result.errorMessage);
+		}
+
+		let dispose: IDisposable;
+		await new Promise((resolve) => {
+			// The file will not be modified until the first edits start streaming in,
+			// so wait until we see that it _was_ modified before waiting for it to be done.
+			let wasFileBeingModified = false;
+
+			dispose = autorun((r) => {
+
+				const entries = editSession.entries.read(r);
+				const currentFile = entries?.find((e) => e.modifiedURI.toString() === uri.toString());
+				if (currentFile) {
+					if (currentFile.isCurrentlyBeingModifiedBy.read(r)) {
+						wasFileBeingModified = true;
+					} else if (wasFileBeingModified) {
+						resolve(true);
+					}
+				}
+			});
+		}).finally(() => {
+			dispose.dispose();
+		});
+
+		await this.textFileService.save(uri, {
+			reason: SaveReason.AUTO,
+			skipSaveParticipants: true,
+		});
+
+		return {
+			content: [{ kind: 'text', value: 'The file was edited successfully' }]
+		};
+	}
+
+	async prepareToolInvocation(parameters: any, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+		return {
+			presentation: 'hidden'
+		};
+	}
+}
+
+export interface EditToolParams {
+	file: UriComponents;
+	explanation: string;
+	code: string;
+}
+
+export interface EditToolRawParams {
+	filePath: string;
+	explanation: string;
+	code: string;
+}
+
+// --- Start Positron ---
+// Removed in 1.100.0 upstream merge
+// export class EditToolInputProcessor implements IToolInputProcessor {
+// 	processInput(input: EditToolRawParams): EditToolParams {
+// 		if (!input.filePath) {
+// 			// Tool name collision, or input wasn't properly validated upstream
+// 			return input as any;
+// 		}
+// 		const filePath = input.filePath;
+// 		// Runs in EH, will be mapped
+// 		return {
+// 			file: filePath.startsWith('untitled:') ? URI.parse(filePath) : URI.file(filePath),
+// 			explanation: input.explanation,
+// 			code: input.code,
+// 		};
+// 	}
+// }
+// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -38,6 +38,7 @@ import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, ITo
 // --- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
 import { ToolProgress } from '../../common/languageModelToolsService.js';
+import { getUriForFileOpenOrInsideWorkspace } from './utils.js';
 // --- End Positron ---
 
 const codeInstructions = `
@@ -127,9 +128,17 @@ export class EditTool implements IToolImpl {
 		};
 		// const parameters = invocation.parameters as EditToolParams;
 		const parameters = updatedParams as EditToolParams;
+
+		// const fileUri = URI.revive(parameters.file); // TODO@roblourens do revive in MainThreadLanguageModelTools
+		// Use the same logic as the fileContentsTool to get the URI for the file.
+		let fileUri: URI | undefined = undefined;
+		try {
+			fileUri = getUriForFileOpenOrInsideWorkspace(filePath, this.workspaceContextService, this.editorGroupsService);
+		} catch (error) {
+			throw new Error(`Can't edit file: ${JSON.stringify(error)}`);
+		}
 		// --- End Positron ---
 
-		const fileUri = URI.revive(parameters.file); // TODO@roblourens do revive in MainThreadLanguageModelTools
 		const uri = CellUri.parse(fileUri)?.notebook || fileUri;
 
 		if (!this.workspaceContextService.isInsideWorkspace(uri) && !this.notebookService.getNotebookTextModel(uri)) {

--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -135,7 +135,7 @@ export class EditTool implements IToolImpl {
 		try {
 			fileUri = getUriForFileOpenOrInsideWorkspace(filePath, this.workspaceContextService, this.editorGroupsService);
 		} catch (error) {
-			throw new Error(`Can't edit file: ${JSON.stringify(error)}`);
+			throw new Error(`Can't edit file: ${error.message}`);
 		}
 		// --- End Positron ---
 

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -59,7 +59,7 @@ export class FileContentsTool implements IToolImpl {
 		try {
 			uri = getUriForFileOpenOrInsideWorkspace(filePath, this._workspaceContextService, this._editorGroupsService);
 		} catch (error) {
-			throw new Error(`Can't retrieve file contents: ${JSON.stringify(error)}`);
+			throw new Error(`Can't retrieve file contents: ${error.message}`);
 		}
 
 		// The file is in the workspace, so grab the file contents

--- a/src/vs/workbench/contrib/chat/browser/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/tools.ts
@@ -17,6 +17,7 @@ import { ILanguageModelToolsService } from '../../common/languageModelToolsServi
 import { ProjectTreeTool, ProjectTreeToolData } from '../../browser/tools/projectTreeTool.js';
 import { TextSearchTool, TextSearchToolData } from './textSearchTool.js';
 import { FileContentsTool, FileContentsToolData } from './fileContentsTool.js';
+import { EditTool, EditToolData } from './editFileTool.js';
 
 export class PositronBuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -31,7 +32,8 @@ export class PositronBuiltinToolsContribution extends Disposable implements IWor
 		const toolDescriptors = [
 			{ data: ProjectTreeToolData, ctor: ProjectTreeTool },
 			{ data: TextSearchToolData, ctor: TextSearchTool },
-			{ data: FileContentsToolData, ctor: FileContentsTool }
+			{ data: FileContentsToolData, ctor: FileContentsTool },
+			{ data: EditToolData, ctor: EditTool },
 		];
 
 		for (const { data, ctor } of toolDescriptors) {

--- a/src/vs/workbench/contrib/chat/browser/tools/utils.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/utils.ts
@@ -9,6 +9,14 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 
+/**
+ * Constructs a URI for a file path that is either absolute or relative to the workspace.
+ * The file must either be open in an editor or inside a folder within the workspace.
+ * @param filePath The file path to check. It can be either absolute or relative.
+ * @param workspaceContextService The workspace context service
+ * @param editorGroupsService The editor groups service
+ * @returns The URI of the file or throws an error if the file is not open or inside the workspace.
+ */
 export function getUriForFileOpenOrInsideWorkspace(
 	filePath: string,
 	workspaceContextService: IWorkspaceContextService,
@@ -51,6 +59,13 @@ export function getUriForFileOpenOrInsideWorkspace(
 	return uri;
 }
 
+/**
+ * Checks if a file is open in any editor or inside the workspace.
+ * @param uri The URI of the file to check
+ * @param workspaceContextService The workspace context service
+ * @param editorGroupsService The editor groups service
+ * @returns Whether the file is open in any editor or inside the workspace
+ */
 function fileIsOpenOrInsideWorkspace(
 	uri: URI,
 	workspaceContextService: IWorkspaceContextService,

--- a/src/vs/workbench/contrib/chat/browser/tools/utils.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/utils.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isAbsolute } from '../../../../../base/common/path.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { GroupsOrder, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+
+export function getUriForFileOpenOrInsideWorkspace(
+	filePath: string,
+	workspaceContextService: IWorkspaceContextService,
+	editorGroupsService: IEditorGroupsService,
+): URI {
+	let uri: URI | undefined = undefined;
+	if (isAbsolute(filePath)) {
+		uri = URI.file(filePath);
+		if (!fileIsOpenOrInsideWorkspace(uri, workspaceContextService, editorGroupsService)) {
+			throw new Error(`Absolute file path "${filePath}" is not inside the workspace or open in an editor.`);
+		}
+	} else {
+		// If the file path is relative, try to resolve it against the workspace folders
+		const workspaceFolders = workspaceContextService.getWorkspace().folders;
+		for (const folder of workspaceFolders) {
+			const resolvedUri = folder.toResource(filePath);
+			if (fileIsOpenOrInsideWorkspace(resolvedUri, workspaceContextService, editorGroupsService)) {
+				uri = resolvedUri;
+				break;
+			}
+		}
+		if (!uri) {
+			throw new Error(`Relative file path "${filePath}" is not inside the workspace or open in an editor.`);
+		}
+	}
+	return uri;
+}
+
+function fileIsOpenOrInsideWorkspace(
+	uri: URI,
+	workspaceContextService: IWorkspaceContextService,
+	editorGroupsService: IEditorGroupsService,
+): boolean {
+	// Check if the file is inside the workspace
+	if (workspaceContextService.isInsideWorkspace(uri)) {
+		return true;
+	}
+
+	// Otherwise, check if the file is open in any editor
+	const groupsByLastActive = editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
+	return groupsByLastActive.some((group) => {
+		return group.editors.some((editor) => {
+			return isEqual(editor.resource, uri);
+		});
+	});
+}


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7417

#### Approach

- create our own copy of the editFile tool, which I've reverted to the 1.99.0 merge state and then applied the necessary fixes to make the tool definition compatible with the 1.100.0 changes
- we need to revert back to 1.99.0 so that the tool can be defined and registered in Core, otherwise it is not currently available as a tool
- I've moved the file path handling from the fileContents tool to a separate util which is now shared with the editFile tool
    - the file path handling and multi-root workspace handling may still be fragile, and I'd like to move to a different approach in the future where we pre-construct the URI to pass as a parameter, so we don't ask the tools to individually determine that information

### Release Notes

#### Bug Fixes

- Assistant: fix issues where file in workspace can't be found (#7417)

### QA Notes

@:assistant

Testing Matrix
- Tools: `editFileTool`, `fileContentsTool`
- OS: Windows, Mac
- Workspace setup: single folder, multi-root, file open in editor that is not in a folder within the workspace
    - there are likely still issues with multi-root support. I'm hoping that we can improve the filepath handling by constructing URIs before we pass file paths to the tools. We should open up a separate issue if this comes up.

Expected Outcomes
- the `editFileTool` is now available in Edit mode
- the `editFileTool` should no longer error when attempting to apply edits to a file in a single-folder workspace
- the `editFileTool` should be more adept at handling file edits in multi-folder workspaces, but there are likely still some issues with this