### PR TITLE
Fix Claude 4 model id

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -653,12 +653,12 @@ export const availableModels = new Map<string, { name: string; identifier: strin
 		['bedrock', [
 			{
 				name: 'Claude 4 Sonnet Bedrock',
-				identifier: 'anthropic.claude-sonnet-4-20250514-v1:0',
+				identifier: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
 				maxOutputTokens: 64_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 			{
 				name: 'Claude 4 Opus Bedrock',
-				identifier: 'anthropic.claude-opus-4-20250514-v1:0',
+				identifier: 'us.anthropic.claude-opus-4-20250514-v1:0',
 				maxOutputTokens: 32_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			},
 			{


### PR DESCRIPTION
I tried Claude 4 on Bedrock and it was getting invalid request errors. The model id requires a `us.` prefix and I'm not sure why. The `ai-sdk` documentation doesn't really specify this in their [examples](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock#language-models) except for one instance in the Reasoning section. Our initial implementation with `ai-sdk` does use `us.` and updating the Claude 4 id's seems to fix it.

Note: I could get a response with Claude 4 Opus but Claude 4 Sonnet returns a throttling error.