### PR TITLE
App Launcher: handle python app terminal links in `positron-run-app` extension

### DIFF
--- a/extensions/positron-run-app/package.json
+++ b/extensions/positron-run-app/package.json
@@ -25,6 +25,21 @@
           "type": "boolean",
           "default": true,
           "description": "%configuration.appLauncher.showShellIntegrationNotSupportedMessage%"
+        },
+        "positron.appLauncher.terminalAppUrlOpenLocation": {
+          "type": "string",
+          "default": "ask",
+          "enum": [
+            "ask",
+            "viewer",
+            "browser"
+          ],
+          "enumDescriptions": [
+            "%configuration.appLauncher.terminalAppUrlOpenLocation.ask%",
+            "%configuration.appLauncher.terminalAppUrlOpenLocation.viewer%",
+            "%configuration.appLauncher.terminalAppUrlOpenLocation.browser%"
+          ],
+          "description": "%configuration.appLauncher.terminalAppUrlOpenLocation%"
         }
       }
     }

--- a/extensions/positron-run-app/package.nls.json
+++ b/extensions/positron-run-app/package.nls.json
@@ -2,5 +2,9 @@
 	"displayName": "Positron Run App",
 	"description": "Generic 'Run App' Framework for Positron",
 	"configuration.appLauncher.showEnableShellIntegrationMessage": "Show a prompt when shell integration is disabled.",
-	"configuration.appLauncher.showShellIntegrationNotSupportedMessage": "Show a warning when shell integration is not supported by the active terminal."
+	"configuration.appLauncher.showShellIntegrationNotSupportedMessage": "Show a warning when shell integration is not supported by the active terminal.",
+	"configuration.appLauncher.terminalAppUrlOpenLocation": "Where to open app URLs when clicked in the Terminal.",
+	"configuration.appLauncher.terminalAppUrlOpenLocation.ask": "Prompt to choose where to open app URLs when clicked.",
+	"configuration.appLauncher.terminalAppUrlOpenLocation.viewer": "Open app URLs in the Viewer.",
+	"configuration.appLauncher.terminalAppUrlOpenLocation.browser": "Open app URLs in the default browser."
 }

--- a/extensions/positron-run-app/src/api-utils.ts
+++ b/extensions/positron-run-app/src/api-utils.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { log } from './extension.js';
+import { IS_POSITRON_WEB, IS_RUNNING_ON_PWB, APP_URL_PLACEHOLDER, URL_LIKE_REGEX, HTTP_URL_REGEX } from './constants.js';
+import { Config } from './types.js';
+
+export async function showEnableShellIntegrationMessage(rerunApplicationCallback: () => any): Promise<void> {
+	// Don't show if the user disabled this message.
+	if (!vscode.workspace.getConfiguration().get<boolean>(Config.ShowEnableShellIntegrationMessage)) {
+		return;
+	}
+
+	// Prompt the user to enable shell integration.
+	const enableShellIntegration = vscode.l10n.t('Enable Shell Integration');
+	const notNow = vscode.l10n.t('Not Now');
+	const dontAskAgain = vscode.l10n.t('Don\'t Ask Again');
+	const selection = await vscode.window.showInformationMessage(
+		vscode.l10n.t(
+			'Shell integration is disabled. Would you like to enable shell integration for this ' +
+			'workspace to automatically preview your application in the Viewer pane?',
+		),
+		enableShellIntegration,
+		notNow,
+		dontAskAgain,
+	);
+
+	if (selection === enableShellIntegration) {
+		// Enable shell integration.
+		const shellIntegrationConfig = vscode.workspace.getConfiguration('terminal.integrated.shellIntegration');
+		await shellIntegrationConfig.update('enabled', true, vscode.ConfigurationTarget.Workspace);
+
+		// Prompt the user to rerun the application.
+		const rerunApplication = vscode.l10n.t('Rerun Application');
+		const notNow = vscode.l10n.t('Not Now');
+		const selection = await vscode.window.showInformationMessage(
+			vscode.l10n.t('Shell integration is now enabled. Would you like to rerun the application?'),
+			rerunApplication,
+			notNow,
+		);
+
+		if (selection === rerunApplication) {
+			// Rerun the application.
+			rerunApplicationCallback();
+		}
+	} else if (selection === dontAskAgain) {
+		// Disable the prompt for future runs.
+		const runAppConfig = vscode.workspace.getConfiguration('positron.appLauncher');
+		await runAppConfig.update('showShellIntegrationPrompt', false, vscode.ConfigurationTarget.Global);
+	}
+}
+
+export async function showShellIntegrationNotSupportedMessage(): Promise<void> {
+	// Don't show if the user disabled this message.
+	if (!vscode.workspace.getConfiguration().get<boolean>(Config.ShowShellIntegrationNotSupportedMessage)) {
+		return;
+	}
+
+	const learnMore = vscode.l10n.t('Learn More');
+	const dismiss = vscode.l10n.t('Dismiss');
+	const dontShowAgain = vscode.l10n.t('Don\'t Show Again');
+	const selection = await vscode.window.showWarningMessage(
+		vscode.l10n.t(
+			'Shell integration isn\'t supported in this terminal, ' +
+			'so automatic preview in the Viewer pane isn\'t available. ' +
+			'To use this feature, please switch to a terminal that supports shell integration.'
+		),
+		learnMore,
+		dismiss,
+		dontShowAgain,
+	);
+
+	if (selection === learnMore) {
+		await vscode.env.openExternal(vscode.Uri.parse('https://code.visualstudio.com/docs/terminal/shell-integration'));
+	} else if (selection === dontShowAgain) {
+		// Disable the prompt for future runs.
+		const runAppConfig = vscode.workspace.getConfiguration('positron.appLauncher');
+		await runAppConfig.update('showShellIntegrationNotSupportedMessage', false, vscode.ConfigurationTarget.Global);
+	}
+}
+
+/**
+ * Check if the Positron proxy should be used for the given app.
+ * Generally, we should avoid skipping the proxy unless there is a good reason to do so, as the
+ * proxy gives us the ability to intercept requests and responses to the app, which is useful for
+ * things like debugging, applying styling or fixing up urls.
+ * @param appName The name of the app; indicated in extensions/positron-python/src/client/positron/webAppCommands.ts
+ * @returns Whether to use the Positron proxy for the app.
+ */
+export function shouldUsePositronProxy(appName: string) {
+	// If we're running on Positron Desktop, don't use the proxy.
+	if (!IS_POSITRON_WEB) {
+		return false;
+	}
+
+	// Otherwise, check if the app is one of the known apps that don't work with the proxy.
+	switch (appName.trim().toLowerCase()) {
+		// Streamlit apps don't work in Positron on Workbench with SSL enabled when run through the proxy.
+		case 'streamlit':
+		// FastAPI apps don't work in Positron on Workbench when run through the proxy.
+		case 'fastapi':
+			if (IS_RUNNING_ON_PWB) {
+				return false;
+			}
+			return true;
+		default:
+			// By default, proxy the app.
+			return true;
+	}
+}
+
+/**
+ * Extracts a URL from a string using the provided appUrlStrings.
+ * @param str The string to match the URL in.
+ * @param appUrlStrings An array of app url strings to match and extract the URL from.
+ * @returns The matched URL, or undefined if no URL is found.
+ */
+export function extractAppUrlFromString(str: string, appUrlStrings?: string[]) {
+	if (appUrlStrings && appUrlStrings.length > 0) {
+		// Try to match any of the provided appUrlStrings.
+		log.debug('Attempting to match URL with:', appUrlStrings);
+		for (const appUrlString of appUrlStrings) {
+			if (!appUrlString.includes(APP_URL_PLACEHOLDER)) {
+				log.warn(`Skipping '${appUrlString}' since it doesn't contain an ${APP_URL_PLACEHOLDER} placeholder.`);
+				continue;
+			}
+
+			const pattern = appUrlString.replace(APP_URL_PLACEHOLDER, URL_LIKE_REGEX.source);
+			const appUrlRegex = new RegExp(pattern);
+
+			const match = str.match(appUrlRegex);
+			if (match) {
+				const endsWithAppUrl = appUrlString.endsWith(APP_URL_PLACEHOLDER);
+				// Placeholder is at the end of the string. This is the most common case.
+				// Example: 'The app is running at {{APP_URL}}'
+				// [0] = 'The app is running at ', [1] = '{{APP_URL}}'
+				// Also covers the case where the placeholder is the entire string.
+				if (endsWithAppUrl) {
+					return match[1];
+				}
+
+				const startsWithAppUrl = appUrlString.startsWith(APP_URL_PLACEHOLDER);
+				// Placeholder is at the start of the string.
+				// Example: '{{APP_URL}} is where the app is running'
+				// [0] = '{{APP_URL}}', [1] = ' is where the app is running'
+				if (startsWithAppUrl) {
+					return match[0];
+				}
+
+				// Placeholder is in the middle of the string.
+				// Example: 'Open {{APP_URL}} to view the app'
+				// [0] = 'Open ', [1] = '{{APP_URL}}', [2] = ' to view the app'
+				return match[1];
+			}
+		}
+	}
+
+	// Fall back to the default URL regex if no appUrlStrings were provided or matched.
+	log.debug('No appUrlStrings matched. Falling back to default URL regex to match URL.');
+	return str.match(HTTP_URL_REGEX)?.[0];
+}

--- a/extensions/positron-run-app/src/api-utils.ts
+++ b/extensions/positron-run-app/src/api-utils.ts
@@ -162,3 +162,7 @@ export function extractAppUrlFromString(str: string, appUrlStrings?: string[]) {
 	log.debug('No appUrlStrings matched. Falling back to default URL regex to match URL.');
 	return str.match(HTTP_URL_REGEX)?.[0];
 }
+
+export function getTerminalAppUrlOpenLocationConfig() {
+	return vscode.workspace.getConfiguration('positron.appLauncher').get<string>('terminalAppUrlOpenLocation');
+}

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -7,11 +7,12 @@ import { randomUUID } from 'crypto';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { DebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
-import { Config, log } from './extension';
+import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, RunAppOptions } from './positron-run-app';
 import { raceTimeout, removeAnsiEscapeCodes, SequencerByKey } from './utils';
-import { APP_URL_PLACEHOLDER, DID_PREVIEW_URL_TIMEOUT, HTTP_URL_REGEX, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT, URL_LIKE_REGEX } from './constants.js';
-import { AppPreviewOptions, PositronProxyInfo } from './types.js';
+import { DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
+import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
+import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage, extractAppUrlFromString } from './api-utils.js';
 
 
 export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable {
@@ -19,8 +20,6 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _debugApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
-
-	/** A map of launched app urls to their app name and proxy server Uris */
 	private readonly _appServers = new Map<string, { terminalPid: number; proxyUri: vscode.Uri }>();
 
 	constructor(
@@ -60,10 +59,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		const url = appUrl.endsWith('/')
 			? appUrl.slice(0, -1) // Remove trailing slash if present
 			: appUrl; // Otherwise, use the URL as is
+
 		log.trace(`Getting proxy URI for app URL: ${url}`);
 		log.trace(`Known app servers: ${JSON.stringify(Array.from(this._appServers.entries()))}`);
-		const appServer = this._appServers.get(url);
 
+		const appServer = this._appServers.get(url);
 		if (appServer) {
 			log.trace(`Returning known proxy URI for app URL ${url}: ${appServer.proxyUri.toString(true)}`);
 			return appServer.proxyUri;
@@ -529,159 +529,4 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		serversToRemove.forEach(key => this._appServers.delete(key));
 		log.trace(`Known app servers: ${JSON.stringify(Array.from(this._appServers.entries()))}`);
 	}
-}
-
-async function showEnableShellIntegrationMessage(rerunApplicationCallback: () => any): Promise<void> {
-	// Don't show if the user disabled this message.
-	if (!vscode.workspace.getConfiguration().get<boolean>(Config.ShowEnableShellIntegrationMessage)) {
-		return;
-	}
-
-	// Prompt the user to enable shell integration.
-	const enableShellIntegration = vscode.l10n.t('Enable Shell Integration');
-	const notNow = vscode.l10n.t('Not Now');
-	const dontAskAgain = vscode.l10n.t('Don\'t Ask Again');
-	const selection = await vscode.window.showInformationMessage(
-		vscode.l10n.t(
-			'Shell integration is disabled. Would you like to enable shell integration for this ' +
-			'workspace to automatically preview your application in the Viewer pane?',
-		),
-		enableShellIntegration,
-		notNow,
-		dontAskAgain,
-	);
-
-	if (selection === enableShellIntegration) {
-		// Enable shell integration.
-		const shellIntegrationConfig = vscode.workspace.getConfiguration('terminal.integrated.shellIntegration');
-		await shellIntegrationConfig.update('enabled', true, vscode.ConfigurationTarget.Workspace);
-
-		// Prompt the user to rerun the application.
-		const rerunApplication = vscode.l10n.t('Rerun Application');
-		const notNow = vscode.l10n.t('Not Now');
-		const selection = await vscode.window.showInformationMessage(
-			vscode.l10n.t('Shell integration is now enabled. Would you like to rerun the application?'),
-			rerunApplication,
-			notNow,
-		);
-
-		if (selection === rerunApplication) {
-			// Rerun the application.
-			rerunApplicationCallback();
-		}
-	} else if (selection === dontAskAgain) {
-		// Disable the prompt for future runs.
-		const runAppConfig = vscode.workspace.getConfiguration('positron.appLauncher');
-		await runAppConfig.update('showShellIntegrationPrompt', false, vscode.ConfigurationTarget.Global);
-	}
-}
-
-async function showShellIntegrationNotSupportedMessage(): Promise<void> {
-	// Don't show if the user disabled this message.
-	if (!vscode.workspace.getConfiguration().get<boolean>(Config.ShowShellIntegrationNotSupportedMessage)) {
-		return;
-	}
-
-	const learnMore = vscode.l10n.t('Learn More');
-	const dismiss = vscode.l10n.t('Dismiss');
-	const dontShowAgain = vscode.l10n.t('Don\'t Show Again');
-	const selection = await vscode.window.showWarningMessage(
-		vscode.l10n.t(
-			'Shell integration isn\'t supported in this terminal, ' +
-			'so automatic preview in the Viewer pane isn\'t available. ' +
-			'To use this feature, please switch to a terminal that supports shell integration.'
-		),
-		learnMore,
-		dismiss,
-		dontShowAgain,
-	);
-
-	if (selection === learnMore) {
-		await vscode.env.openExternal(vscode.Uri.parse('https://code.visualstudio.com/docs/terminal/shell-integration'));
-	} else if (selection === dontShowAgain) {
-		// Disable the prompt for future runs.
-		const runAppConfig = vscode.workspace.getConfiguration('positron.appLauncher');
-		await runAppConfig.update('showShellIntegrationNotSupportedMessage', false, vscode.ConfigurationTarget.Global);
-	}
-}
-
-/**
- * Check if the Positron proxy should be used for the given app.
- * Generally, we should avoid skipping the proxy unless there is a good reason to do so, as the
- * proxy gives us the ability to intercept requests and responses to the app, which is useful for
- * things like debugging, applying styling or fixing up urls.
- * @param appName The name of the app; indicated in extensions/positron-python/src/client/positron/webAppCommands.ts
- * @returns Whether to use the Positron proxy for the app.
- */
-function shouldUsePositronProxy(appName: string) {
-	// If we're running on Positron Desktop, don't use the proxy.
-	if (!IS_POSITRON_WEB) {
-		return false;
-	}
-
-	// Otherwise, check if the app is one of the known apps that don't work with the proxy.
-	switch (appName.trim().toLowerCase()) {
-		// Streamlit apps don't work in Positron on Workbench with SSL enabled when run through the proxy.
-		case 'streamlit':
-		// FastAPI apps don't work in Positron on Workbench when run through the proxy.
-		case 'fastapi':
-			if (IS_RUNNING_ON_PWB) {
-				return false;
-			}
-			return true;
-		default:
-			// By default, proxy the app.
-			return true;
-	}
-}
-
-/**
- * Extracts a URL from a string using the provided appUrlStrings.
- * @param str The string to match the URL in.
- * @param appUrlStrings An array of app url strings to match and extract the URL from.
- * @returns The matched URL, or undefined if no URL is found.
- */
-function extractAppUrlFromString(str: string, appUrlStrings?: string[]) {
-	if (appUrlStrings && appUrlStrings.length > 0) {
-		// Try to match any of the provided appUrlStrings.
-		log.debug('Attempting to match URL with:', appUrlStrings);
-		for (const appUrlString of appUrlStrings) {
-			if (!appUrlString.includes(APP_URL_PLACEHOLDER)) {
-				log.warn(`Skipping '${appUrlString}' since it doesn't contain an ${APP_URL_PLACEHOLDER} placeholder.`);
-				continue;
-			}
-
-			const pattern = appUrlString.replace(APP_URL_PLACEHOLDER, URL_LIKE_REGEX.source);
-			const appUrlRegex = new RegExp(pattern);
-
-			const match = str.match(appUrlRegex);
-			if (match) {
-				const endsWithAppUrl = appUrlString.endsWith(APP_URL_PLACEHOLDER);
-				// Placeholder is at the end of the string. This is the most common case.
-				// Example: 'The app is running at {{APP_URL}}'
-				// [0] = 'The app is running at ', [1] = '{{APP_URL}}'
-				// Also covers the case where the placeholder is the entire string.
-				if (endsWithAppUrl) {
-					return match[1];
-				}
-
-				const startsWithAppUrl = appUrlString.startsWith(APP_URL_PLACEHOLDER);
-				// Placeholder is at the start of the string.
-				// Example: '{{APP_URL}} is where the app is running'
-				// [0] = '{{APP_URL}}', [1] = ' is where the app is running'
-				if (startsWithAppUrl) {
-					return match[0];
-				}
-
-				// Placeholder is in the middle of the string.
-				// Example: 'Open {{APP_URL}} to view the app'
-				// [0] = 'Open ', [1] = '{{APP_URL}}', [2] = ' to view the app'
-				return match[1];
-			}
-		}
-	}
-
-	// Fall back to the default URL regex if no appUrlStrings were provided or matched.
-	log.debug('No appUrlStrings matched. Falling back to default URL regex to match URL.');
-	return str.match(HTTP_URL_REGEX)?.[0];
 }

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+// Regex to match a string that starts with http:// or https://.
+export const HTTP_URL_REGEX = /((https?:\/\/)([a-zA-Z0-9.-]+)(:\d{1,5})?(\/[^\s]*)?)/g;
+// A more permissive URL regex to be used when a string containing an {{APP_URL}} placeholder is expected.
+export const URL_LIKE_REGEX = /((https?:\/\/)?([a-zA-Z0-9.-]*[.:][a-zA-Z0-9.-]*)(:\d{1,5})?(\/[^\s]*)?)/g;
+
+// App URL Placeholder string.
+export const APP_URL_PLACEHOLDER = '{{APP_URL}}';
+
+// Flags to determine where Positron is running.
+export const IS_POSITRON_WEB = vscode.env.uiKind === vscode.UIKind.Web;
+export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && IS_POSITRON_WEB;
+
+// Timeouts.
+export const TERMINAL_OUTPUT_TIMEOUT = 25_000;
+export const DID_PREVIEW_URL_TIMEOUT = TERMINAL_OUTPUT_TIMEOUT + 5_000;
+/** Time between creating a terminal and receiving its onDidChangeTerminalShellIntegration event. */
+export const SHELL_INTEGRATION_TIMEOUT = 5_000;

--- a/extensions/positron-run-app/src/extension.ts
+++ b/extensions/positron-run-app/src/extension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { PositronRunAppApiImpl } from './api';
 import { registerDebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { PositronRunApp } from './positron-run-app';
+import { AppLauncherTerminalLinkProvider } from './terminalLinkProvider.js';
 
 export const log = vscode.window.createOutputChannel('App Launcher', { log: true });
 
@@ -20,6 +21,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Positr
 	context.subscriptions.push(log);
 
 	const debugSessionTerminalWatcher = registerDebugAdapterTrackerFactory(context.subscriptions);
+	const positronRunApp = new PositronRunAppApiImpl(context.globalState, debugSessionTerminalWatcher);
 
-	return new PositronRunAppApiImpl(context.globalState, debugSessionTerminalWatcher);
+	context.subscriptions.push(
+		vscode.window.registerTerminalLinkProvider(new AppLauncherTerminalLinkProvider(positronRunApp))
+	);
+
+	return positronRunApp;
 }

--- a/extensions/positron-run-app/src/extension.ts
+++ b/extensions/positron-run-app/src/extension.ts
@@ -11,12 +11,6 @@ import { AppLauncherTerminalLinkProvider } from './terminalLinkProvider.js';
 
 export const log = vscode.window.createOutputChannel('App Launcher', { log: true });
 
-export enum Config {
-	ShellIntegrationEnabled = 'terminal.integrated.shellIntegration.enabled',
-	ShowEnableShellIntegrationMessage = 'positron.appLauncher.showEnableShellIntegrationMessage',
-	ShowShellIntegrationNotSupportedMessage = 'positron.appLauncher.showShellIntegrationNotSupportedMessage',
-}
-
 export async function activate(context: vscode.ExtensionContext): Promise<PositronRunApp> {
 	context.subscriptions.push(log);
 

--- a/extensions/positron-run-app/src/terminalLinkProvider.ts
+++ b/extensions/positron-run-app/src/terminalLinkProvider.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { PositronRunAppApiImpl } from './api.js';
+import { AppLauncherTerminalLink } from './types.js';
+import { HTTP_URL_REGEX } from './constants.js';
+
+/**
+ * A provider for terminal links that handles app URLs.
+ *
+ * This is needed because the default openers are not aware of the proxied server URLs
+ * that the App Launcher uses for previewing the application.
+ */
+export class AppLauncherTerminalLinkProvider implements vscode.TerminalLinkProvider {
+	constructor(private readonly positronRunApp: PositronRunAppApiImpl) { }
+
+	/**
+	 * Locates the relevant App Launcher terminal links in the provided terminal context.
+	 * @param context The context of the terminal link, which includes the line of text in the terminal.
+	 * @param _token The cancellation token, which can be used to cancel the operation.
+	 * @returns A promise that resolves to an array of matched terminal links.
+	 */
+	async provideTerminalLinks(context: vscode.TerminalLinkContext, _token: vscode.CancellationToken): Promise<AppLauncherTerminalLink[]> {
+		const links: AppLauncherTerminalLink[] = [];
+		const matches = context.line.matchAll(HTTP_URL_REGEX);
+		for (const match of matches) {
+			if (match.index !== undefined) {
+				const url = match[0];
+				const proxyUri = this.positronRunApp.getProxyServerUri(url);
+				if (!proxyUri) {
+					// If we don't have a proxy URI for this URL, we'll skip it
+					// and let the default link handling take care of it.
+					continue;
+				}
+
+				// Otherwise, we will handle the app link via this extension.
+				links.push({
+					startIndex: match.index,
+					length: url.length,
+					tooltip: vscode.l10n.t('Open App URL'),
+					url,
+					proxyUri,
+				});
+			}
+		}
+		return links;
+
+	}
+
+	/**
+	 * Handles the terminal link by opening the URL in either the Viewer pane or a new browser window.
+	 * @param link The terminal link to handle, which contains the URL and proxy URI.
+	 */
+	async handleTerminalLink(link: AppLauncherTerminalLink): Promise<void> {
+		const uri = await vscode.env.asExternalUri(link.proxyUri);
+
+		// Ask the user if they want to open the URL in the Viewer or in the a new browser tab.
+		const viewerPane = vscode.l10n.t('Open in Viewer pane');
+		const browserWindow = vscode.l10n.t('Open in new browser window');
+		const choice = await vscode.window.showQuickPick(
+			[
+				{ label: viewerPane },
+				{ label: browserWindow }
+			],
+			{
+				placeHolder: vscode.l10n.t('How would you like to open: {0}', uri.toString())
+			}
+		);
+		if (!choice) {
+			return;
+		}
+		if (choice.label === viewerPane) {
+			positron.window.previewUrl(uri);
+		} else {
+			await vscode.env.openExternal(uri);
+		}
+	}
+}

--- a/extensions/positron-run-app/src/types.ts
+++ b/extensions/positron-run-app/src/types.ts
@@ -5,6 +5,12 @@
 
 import * as vscode from 'vscode';
 
+export enum Config {
+	ShellIntegrationEnabled = 'terminal.integrated.shellIntegration.enabled',
+	ShowEnableShellIntegrationMessage = 'positron.appLauncher.showEnableShellIntegrationMessage',
+	ShowShellIntegrationNotSupportedMessage = 'positron.appLauncher.showShellIntegrationNotSupportedMessage',
+}
+
 export type PositronProxyInfo = {
 	proxyPath: string;
 	externalUri: vscode.Uri;

--- a/extensions/positron-run-app/src/types.ts
+++ b/extensions/positron-run-app/src/types.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export type PositronProxyInfo = {
+	proxyPath: string;
+	externalUri: vscode.Uri;
+	finishProxySetup: (targetOrigin: string) => Promise<void>;
+};
+
+export type AppPreviewOptions = {
+	terminalPid: number;
+	proxyInfo?: PositronProxyInfo;
+	urlPath?: string;
+	appReadyMessage?: string;
+	appUrlStrings?: string[];
+};
+
+export type AppLauncherTerminalLink = vscode.TerminalLink & {
+	url: string;
+	proxyUri: vscode.Uri;
+};


### PR DESCRIPTION
### Summary

- addresses #5431

#### Implementation

- we now register a TerminalLinkProvider in the positron-run-app extension which handles the python app urls in the Terminal, instead of going through the usual uri opener flow (which does not have access to the proxied app urls)
- api.ts: we now keep track of the app servers and corresponding terminals so that we can handle the terminal links and resolve them to the correct proxied app url
- reorganized constants, types, api-utils into separate files to reduce the size of the main app launcher api.ts file
- we don't proxy web apps through the positron-proxy when running on Desktop anymore -- this seemed unnecessary 🤷 

#### Demo

https://github.com/user-attachments/assets/7350d6f4-2b9c-442a-b422-8eab797fccc8

#### `positron.appLauncher.terminalAppUrlOpenLocation` setting

This setting allows the user to control where the app url will open when Cmd/Ctrl-clicked in the Terminal. A gear icon shows in the default quickpick that shows when the user Cmd/Ctrl-clicks the terminal link which navigates the user to the setting in the UI.

### Release Notes

#### Bug Fixes

- App Launcher: app urls from Terminal links are now resolved correctly (#5431)

### QA Notes

@:web @:apps @:win

This was most obviously broken for Dash apps on Web, however all supported App Launcher app types should work.

1. Run a supported App Launcher Python app in the Terminal via the play button
2. Note the url that displays in the Viewer when the app is loaded
3. Cmd/Ctrl+click the url of the app in the Terminal
4. A quickpick should open and the url in the quickpick placeholder area should match the URL in the Viewer
5. Selecting either of the options (viewer pane or browser window) should load the app successfully
