### PR TITLE
e2e Test: Fix failure in rmd document test

### DIFF
--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -25,7 +25,7 @@ export class EditorActionBar {
 	async clickButton(
 		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer' | 'Move into new window' | 'Open as Plain Text File'
 	): Promise<void> {
-		const buttonLocator = this.page.getByLabel(button, { exact: true });
+		const buttonLocator = this.page.getByLabel(button, { exact: true }).nth(0);
 
 		if (button === 'Split Editor Down') {
 			// Special case: "Split Editor Down" requires holding Alt key

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -25,7 +25,7 @@ export class EditorActionBar {
 	async clickButton(
 		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer' | 'Move into new window' | 'Open as Plain Text File'
 	): Promise<void> {
-		const buttonLocator = this.page.getByLabel(button, { exact: true }).nth(0);
+		const buttonLocator = this.page.getByLabel(button, { exact: true });
 
 		if (button === 'Split Editor Down') {
 			// Special case: "Split Editor Down" requires holding Alt key
@@ -134,7 +134,7 @@ export class EditorActionBar {
 	 */
 	async verifyPreviewRendersHtml(heading: string) {
 		await test.step('Verify "preview" renders html', async () => {
-			await this.page.getByLabel('Preview', { exact: true }).click();
+			await this.page.getByLabel('Preview', { exact: true }).nth(0).click();
 			const viewerFrame = this.viewer.getViewerFrame().frameLocator('iframe');
 			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout: 60000 });
 		});

--- a/test/e2e/tests/editor-action-bar/document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/document-files.test.ts
@@ -70,7 +70,7 @@ test.describe('Editor Action Bar: Document Files', {
 // Helper functions
 
 async function verifyPreviewRendersHtml(heading: string) {
-	await editorActionBar.clickButton('Preview');
+	// await editorActionBar.clickButton('Preview');
 	await editorActionBar.verifyPreviewRendersHtml(heading);
 }
 


### PR DESCRIPTION
Workaround for #7850

Makes an explicit .nth(0) for the action bar button click.

### QA Notes
@:editor-action-bar @:win @:web
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
