### PR TITLE
update secrets baseline and ensure hooks fail precommit

### DIFF
--- a/build/detect-dot-only-hook.js
+++ b/build/detect-dot-only-hook.js
@@ -32,6 +32,9 @@ const detectDotOnlyHook = (reporter) => {
 				break;
 		}
 		reporter(message + '\n', true);
+
+		// Exit the process with an error so that the pre-commit hook fails
+		process.exit(error.status);
 	}
 	return es.through(function () {
 		/* noop, important for the stream to end */

--- a/build/detect-secrets-hook.js
+++ b/build/detect-secrets-hook.js
@@ -26,6 +26,9 @@ function detectSecretsHook(reporter) {
 				break;
 		}
 		reporter(message, true);
+
+		// Exit the process with an error so that the pre-commit hook fails
+		process.exit(error.status);
 	}
 	return es.through(function () { /* noop, important for the stream to end */ });
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1412,7 +1412,8 @@
         "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
         "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 96,
+        "is_secret": false
       }
     ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
@@ -1464,5 +1465,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-23T14:42:52Z"
+  "generated_at": "2025-05-27T20:11:21Z"
 }


### PR DESCRIPTION
For some reason, the detect-secrets and detect-dot-only hooks have stopped failing the precommit hook.

The changes in this PR ensure that the hooks exit the process with an error, which prevents a commit from succeeding.

The secrets baseline file was also missing a false positive mark on an item -- that has now been updated.
