### PR TITLE
Fix hvplot chunk-execution display

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
@@ -61,10 +61,10 @@ def set_holoviews_extension(ui_service: UiService) -> None:
             original_load_nb = Renderer.load_nb
 
             @classmethod
-            def patched_load_nb(cls, *args, **kwargs):
+            def patched_load_nb(cls, *args, **kwargs):  # noqa: ARG001
                 # Simply override reloading if present, pass everything else through
-                if 'reloading' in kwargs:
-                    kwargs['reloading'] = False
+                if "reloading" in kwargs:
+                    kwargs["reloading"] = False
                 return original_load_nb(*args, **kwargs)
 
             Renderer.load_nb = patched_load_nb

--- a/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
@@ -39,3 +39,40 @@ def set_holoviews_extension(ui_service: UiService) -> None:
                     super().__call__(*args, **kwargs)
 
             holoviews.extension = PositronNotebookExtension
+
+        # Fix hvplot block execution issue in Positron console
+        #
+        # Issue: When hvplot code is executed as a block (multiple lines at once) in Positron's
+        # console, plots fail to render. This happens because:
+        #
+        # 1. HoloViews tracks execution context using a `_repeat_execution_in_cell` flag
+        # 2. When multiple displays occur in the same execution (like when running a block),
+        #    this flag becomes True
+        # 3. HoloViews passes this flag as `reloading=True` to Panel's load_notebook() function
+        # 4. Panel then generates JavaScript with `force=false`, skipping essential dependencies
+        #    like Bokeh, Panel itself, and plotting libraries
+        # 5. Positron creates fresh webviews for each plot (unlike notebooks which have persistent
+        #    webviews), so these missing dependencies cause plots to fail
+        #
+        # The fix: Force `reloading=False` to ensure Panel always loads all dependencies.
+        # This is required because Positron's fresh webviews always need the full dependency set.
+        try:
+            from holoviews.plotting import Renderer
+            original_load_nb = Renderer.load_nb
+
+            @classmethod
+            def patched_load_nb(cls, *args, **kwargs):
+                # Simply override reloading if present, pass everything else through
+                if 'reloading' in kwargs:
+                    kwargs['reloading'] = False
+                return original_load_nb(*args, **kwargs)
+
+            Renderer.load_nb = patched_load_nb
+        except Exception as e:
+            # If patching fails, hvplot still works, just without our fix
+            import sys
+            print(
+                f"Warning: Could not patch hvplot for block execution due to an error: {e}. "
+                "Run each line separately if plots don't appear.",
+                file=sys.stderr
+            )

--- a/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
@@ -3,7 +3,11 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
+import logging
+
 from ..ui import UiService
+
+logger = logging.getLogger(__name__)
 
 
 def set_holoviews_extension(ui_service: UiService) -> None:
@@ -71,10 +75,8 @@ def set_holoviews_extension(ui_service: UiService) -> None:
             Renderer.load_nb = patched_load_nb
         except Exception as e:
             # If patching fails, hvplot still works, just without our fix
-            import sys
-
-            print(
-                f"Warning: Could not patch hvplot for block execution due to an error: {e}. "
+            logger.warning(
+                "Could not patch hvplot for block execution due to an error: %s. "
                 "Run each line separately if plots don't appear.",
-                file=sys.stderr,
+                e,
             )

--- a/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/holoviews.py
@@ -58,6 +58,7 @@ def set_holoviews_extension(ui_service: UiService) -> None:
         # This is required because Positron's fresh webviews always need the full dependency set.
         try:
             from holoviews.plotting import Renderer
+
             original_load_nb = Renderer.load_nb
 
             @classmethod
@@ -71,8 +72,9 @@ def set_holoviews_extension(ui_service: UiService) -> None:
         except Exception as e:
             # If patching fails, hvplot still works, just without our fix
             import sys
+
             print(
                 f"Warning: Could not patch hvplot for block execution due to an error: {e}. "
                 "Run each line separately if plots don't appear.",
-                file=sys.stderr
+                file=sys.stderr,
             )

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -195,6 +195,14 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await runScriptAndValidatePlot(app, plotly, '.plotly', false, true);
 		});
 
+		test('Python - Verify hvplot with plotly extension works in block execution', {
+			tag: [tags.WEB, tags.WIN],
+			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5991' }],
+		}, async function ({ app }) {
+			// Test that our fix allows hvplot to work when executed as a block
+			await runScriptAndValidatePlot(app, plotly, '.plotly', false, false);
+		});
+
 		test('Python - Verify ipytree Python widget', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, ipytree, '.jstree-container-ul');
 


### PR DESCRIPTION
Addresses #5991.

@:plots
@:notebooks

Fixes hvplot plots failing to render when executed as a block in Positron's console. The issue occurred because HoloViews detected block execution as a "repeat execution" and instructed Panel to skip loading dependencies (https://github.com/holoviz/holoviews/blob/main/holoviews/ipython/__init__.py#L147), but Positron's fresh webviews need all dependencies loaded every time. Added an e2e test to ensure block execution continues to work correctly.

### What's actually happening:

**Relevant hvplot code:** https://github.com/holoviz/pyviz_comms/blob/bb11dce70106663113cebf0c45a0ce88cf350788/pyviz_comms/__init__.py#L58-L62

When `hvplot.extension('plotly')` is called...
1. Extension instantiation - Creates a new instance of the extension class
2. Execution count check - The `__new__` method checks if the current IPython execution count matches the last recorded one
3. Flag setting - If they match (meaning multiple extension calls in the same cell/block), it sets `_repeat_execution_in_cell = True`

**In block execution:**
```python
import hvplot.pandas         # First extension (bokeh) - sets _last_execution_count
import pandas as pd
hvplot.extension('plotly')   # Second extension - same execution count -> _repeat_execution_in_cell = True
df.hvplot()                  # Fails because JavaScript dependencies were skipped
```

**In line-by-line execution:**
```python
import hvplot.pandas        # First extension (execution count = 1)
import pandas as pd         # (execution count = 2) 
hvplot.extension('plotly')  # Second extension (execution count = 3) -> different counts -> _repeat_execution_in_cell = False
df.hvplot()                 # Works because all JavaScript dependencies were loaded
```

This is why the patch is necessary - in Positron's block execution, the automatic bokeh extension loading from the import and the explicit plotly extension loading happen in the same execution context, triggering the optimization that skips JavaScript dependency loading in Positron's fresh webviews.


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed hvplot plots not displaying when code is executed as a block in the console

### QA Notes

Run the following code as a block (select all lines and execute). The scatter plot should display correctly.

```python
import hvplot.pandas
import pandas as pd
hvplot.extension('plotly')
pd.DataFrame(dict(x=[1,2,3], y=[4,5,6])).hvplot.scatter(x="x", y="y")
```

Previously, this would fail with no plot output. Now it should display an interactive scatter plot.