### PR TITLE
Copilot sign-in cancellation

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -9,6 +9,7 @@ import { getLanguageModels } from './models';
 import { completionModels } from './completion';
 import { registerModel, registerModels } from './extension';
 import { CopilotService } from './copilot.js';
+import { CancelledError } from './utils.js';
 
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
@@ -244,6 +245,10 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 			case 'oauth-signout':
 				await oauthSignout(userConfig, sources, storage, context);
 				break;
+			case 'cancel':
+				// User cancelled the dialog, clean up any pending operations
+				CopilotService.instance().cancelCurrentOperation();
+				break;
 			default:
 				throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', action));
 		}
@@ -339,23 +344,21 @@ async function deleteConfigurationByProvider(context: vscode.ExtensionContext, s
 }
 
 async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], storage: SecretStorage, context: vscode.ExtensionContext) {
-	let oauthCompleted = false;
 	try {
 		switch (userConfig.provider) {
 			case 'copilot':
-				oauthCompleted = await CopilotService.instance().signIn();
+				await CopilotService.instance().signIn();
 				break;
 			default:
 				throw new Error(vscode.l10n.t('OAuth sign-in is not supported for provider {0}', userConfig.provider));
 		}
 
-		if (oauthCompleted) {
-			await saveModel(userConfig, sources, storage, context);
-		} else {
-			throw new Error(vscode.l10n.t('OAuth sign-in was not completed successfully.'));
+		await saveModel(userConfig, sources, storage, context);
+	} catch (error) {
+		if (error instanceof CancelledError) {
+			return;
 		}
 
-	} catch (error) {
 		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
 		throw new Error(vscode.l10n.t(`Failed to sign in to provider {0}: {1}`, userConfig.provider, err.message));
 	}

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -9,7 +9,6 @@ import { getLanguageModels } from './models';
 import { completionModels } from './completion';
 import { registerModel, registerModels } from './extension';
 import { CopilotService } from './copilot.js';
-import { CancelledError } from './utils.js';
 
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
@@ -355,7 +354,7 @@ async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources:
 
 		await saveModel(userConfig, sources, storage, context);
 	} catch (error) {
-		if (error instanceof CancelledError) {
+		if (error instanceof vscode.CancellationError) {
 			return;
 		}
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -185,6 +185,12 @@ export class CopilotService implements vscode.Disposable {
 
 		try {
 			await client.sendRequest(ExecuteCommandRequest.type, response.command, this._cancellationToken.token);
+		} catch (error) {
+			if (cancelled) {
+				throw new CancelledError(vscode.l10n.t('GitHub Copilot sign-in was cancelled.'));
+			}
+
+			throw error;
 		} finally {
 			this._cancellationToken?.dispose();
 			this._cancellationToken = null;

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -179,8 +179,6 @@ export class CopilotService implements vscode.Disposable {
 		this._cancellationToken.token.onCancellationRequested(() => {
 			if (this._cancellationToken) {
 				cancelled = true;
-				this._cancellationToken.dispose();
-				this._cancellationToken = null;
 				vscode.window.showInformationMessage(vscode.l10n.t('GitHub Copilot sign-in cancelled.'));
 			}
 		});

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -185,11 +185,8 @@ export class CopilotService implements vscode.Disposable {
 		try {
 			await client.sendRequest(ExecuteCommandRequest.type, response.command, this._cancellationToken.token);
 		} catch (error) {
-			if (cancelled) {
-				throw new vscode.CancellationError();
-			}
-			if (error instanceof vscode.CancellationError) {
-				vscode.window.showInformationMessage(vscode.l10n.t('GitHub Copilot sign-in cancelled in catch.'));
+			if (cancelled || error instanceof vscode.CancellationError) {
+				vscode.window.showInformationMessage(vscode.l10n.t('GitHub Copilot sign-in cancelled.'));
 				throw new vscode.CancellationError();
 			}
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -187,8 +187,6 @@ export class CopilotService implements vscode.Disposable {
 
 		try {
 			await client.sendRequest(ExecuteCommandRequest.type, response.command, this._cancellationToken.token);
-		} catch (error) {
-			throw error;
 		} finally {
 			this._cancellationToken?.dispose();
 			this._cancellationToken = null;

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -11,7 +11,6 @@ import { ExtensionContext } from 'vscode';
 import { Command, Executable, ExecuteCommandRequest, InlineCompletionItem, InlineCompletionRequest, LanguageClient, LanguageClientOptions, NotificationType, RequestType, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { platform } from 'os';
 import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
-import { CancelledError } from './utils.js';
 
 interface EditorPluginInfo {
 	name: string;
@@ -187,7 +186,11 @@ export class CopilotService implements vscode.Disposable {
 			await client.sendRequest(ExecuteCommandRequest.type, response.command, this._cancellationToken.token);
 		} catch (error) {
 			if (cancelled) {
-				throw new CancelledError(vscode.l10n.t('GitHub Copilot sign-in was cancelled.'));
+				throw new vscode.CancellationError();
+			}
+			if (error instanceof vscode.CancellationError) {
+				vscode.window.showInformationMessage(vscode.l10n.t('GitHub Copilot sign-in cancelled in catch.'));
+				throw new vscode.CancellationError();
 			}
 
 			throw error;
@@ -197,7 +200,7 @@ export class CopilotService implements vscode.Disposable {
 		}
 
 		if (cancelled) {
-			throw new CancelledError(vscode.l10n.t('GitHub Copilot sign-in was cancelled.'));
+			throw new vscode.CancellationError();
 		}
 	}
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -164,9 +164,11 @@ export class CopilotService implements vscode.Disposable {
 
 		if (shouldLogin) {
 			try {
+				const timeoutStr = process.env.POSITRON_COPILOT_TIMEOUT;
+				const timeout = timeoutStr ? parseInt(timeoutStr) : 60_000;
 				await Promise.race([
 					client.sendRequest(ExecuteCommandRequest.type, response.command),
-					setTimeout(60_000).then(() => Promise.reject(new Error('Timeout')))
+					setTimeout(timeout).then(() => Promise.reject(new Error('Timeout')))
 				]);
 				return true;
 			} catch (error) {

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -333,11 +333,3 @@ type ToolResultContent = Array<
 		mimeType?: string;
 	}
 >;
-
-export class CancelledError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = 'CancelledError';
-		Object.setPrototypeOf(this, CancelledError.prototype);
-	}
-}

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -333,3 +333,10 @@ type ToolResultContent = Array<
 		mimeType?: string;
 	}
 >;
+
+export class CancelledError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'TimeoutError';
+	}
+}

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -337,6 +337,6 @@ type ToolResultContent = Array<
 export class CancelledError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = 'TimeoutError';
+		this.name = 'CancelledError';
 	}
 }

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -338,5 +338,6 @@ export class CancelledError extends Error {
 	constructor(message: string) {
 		super(message);
 		this.name = 'CancelledError';
+		Object.setPrototypeOf(this, CancelledError.prototype);
 	}
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -17,6 +17,7 @@ interface LanguageModelConfigComponentProps {
 	signingIn?: boolean,
 	onChange: (config: IPositronLanguageModelConfig) => void,
 	onSignIn: () => void,
+	onCancel: () => void,
 }
 
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
@@ -56,7 +57,13 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 					props.onChange({ ...props.provider, apiKey: newApiKey });
 				}} onSignIn={props.onSignIn} />
 			)}
-			<SignInButton signedIn={props.source.signedIn} onSignIn={props.onSignIn} signingIn={props.signingIn} />
+			<SignInButton signedIn={props.source.signedIn} signingIn={props.signingIn} onSignIn={props.onSignIn} />
+			{
+				props.signingIn && props.provider.oauth && !props.source.signedIn &&
+				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
+					{localize('positron.newConnectionModalDialog.cancel', "Cancel")}
+				</Button>
+			}
 		</div>
 		<div className='language-model-dialog-tos' id='model-tos'>
 			<EmbeddedLink>{getTos(props.provider.provider)}</EmbeddedLink>
@@ -79,7 +86,7 @@ const ApiKey = (props: { apiKey?: string, signedIn?: boolean, onChange: (newApiK
 }
 
 const SignInButton = (props: { signedIn?: boolean, signingIn?: boolean, onSignIn: () => void }) => {
-	return <Button className='language-model button sign-in' onPressed={props.onSignIn} disabled={props.signingIn}>
+	return <Button className='language-model button sign-in' disabled={props.signingIn} onPressed={props.onSignIn}>
 		{(() => {
 			if (props.signedIn) {
 				return localize('positron.newConnectionModalDialog.signOut', "Sign out");

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -133,3 +133,9 @@
 .language-model-modal-dialog .content-area {
 	padding: 16px 16px 0 16px;
 }
+
+.language-model-error.error.error-msg {
+	width: 80%;
+	text-wrap: auto;
+	word-break: break-word;
+}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -86,7 +86,8 @@
 	margin-right: 1rem;
 }
 
-.language-model.button.sign-in {
+.language-model.button.sign-in,
+.language-model.button.cancel {
 	align-self: end;
 	font-weight: 600;
 	text-wrap: nowrap;

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -134,9 +134,3 @@
 .language-model-modal-dialog .content-area {
 	padding: 16px 16px 0 16px;
 }
-
-.language-model-error.error.error-msg {
-	width: 80%;
-	text-wrap: auto;
-	word-break: break-word;
-}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -251,35 +251,33 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			setError(localize('positron.newConnectionModalDialog.incompleteConfig', 'The configuration is incomplete.'));
 		}
 	}
+
+	// Returns a cancel for the dialog and closes it
 	const onCancel = async () => {
 		props.onCancel();
 		props.renderer.dispose();
 	}
 
+	// Cancel pending actions with providers
 	const onCancelPending = async () => {
-		if (useNewConfig) {
-			props.onAction({
-				type: type,
-				provider: source.provider.id,
-				model: model,
-				name: name,
-				apiKey: apiKey,
-				baseUrl: baseUrl,
-				resourceName: resourceName,
-				project: project,
-				location: location,
-				toolCalls: toolCalls,
-				numCtx: numCtx,
-			}, 'cancel')
-				.catch((e) => {
-					setError(e.message);
-				}).finally(() => {
-					setShowProgress(false);
-				});
-		} else {
-			props.onCancel();
-			props.renderer.dispose();
-		}
+		props.onAction({
+			type: type,
+			provider: source.provider.id,
+			model: model,
+			name: name,
+			apiKey: apiKey,
+			baseUrl: baseUrl,
+			resourceName: resourceName,
+			project: project,
+			location: location,
+			toolCalls: toolCalls,
+			numCtx: numCtx,
+		}, 'cancel')
+			.catch((e) => {
+				setError(e.message);
+			}).finally(() => {
+				setShowProgress(false);
+			});
 	}
 
 	function oldDialog() {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -192,19 +192,6 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	const onAccept = () => {
 		if (useNewConfig) {
-			props.onAction({
-				type: type,
-				provider: source.provider.id,
-				model: model,
-				name: name,
-				apiKey: apiKey,
-				baseUrl: baseUrl,
-				resourceName: resourceName,
-				project: project,
-				location: location,
-				toolCalls: toolCalls,
-				numCtx: numCtx,
-			}, 'cancel')
 			props.onClose();
 			props.renderer.dispose();
 		} else {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -192,6 +192,19 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	const onAccept = () => {
 		if (useNewConfig) {
+			props.onAction({
+				type: type,
+				provider: source.provider.id,
+				model: model,
+				name: name,
+				apiKey: apiKey,
+				baseUrl: baseUrl,
+				resourceName: resourceName,
+				project: project,
+				location: location,
+				toolCalls: toolCalls,
+				numCtx: numCtx,
+			}, 'cancel')
 			props.onClose();
 			props.renderer.dispose();
 		} else {
@@ -254,6 +267,32 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const onCancel = async () => {
 		props.onCancel();
 		props.renderer.dispose();
+	}
+
+	const onCancelPending = async () => {
+		if (useNewConfig) {
+			props.onAction({
+				type: type,
+				provider: source.provider.id,
+				model: model,
+				name: name,
+				apiKey: apiKey,
+				baseUrl: baseUrl,
+				resourceName: resourceName,
+				project: project,
+				location: location,
+				toolCalls: toolCalls,
+				numCtx: numCtx,
+			}, 'cancel')
+				.catch((e) => {
+					setError(e.message);
+				}).finally(() => {
+					setShowProgress(false);
+				});
+		} else {
+			props.onCancel();
+			props.renderer.dispose();
+		}
 	}
 
 	function oldDialog() {
@@ -422,12 +461,13 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				</div>
 				<LanguageModelConfigComponent
 					provider={providerConfig}
+					signingIn={showProgress}
 					source={source}
+					onCancel={onCancelPending}
 					onChange={(config) => {
 						setProviderConfig(config);
 					}}
 					onSignIn={onSignIn}
-					signingIn={showProgress}
 				/>
 				{showProgress &&
 					<ProgressBar />


### PR DESCRIPTION
Address #7712 #7617

Adds a cancel button to the Copilot sign-in. The sign-in request does have support for a VSCode cancellation token so that's passed to get the cancellation event. Unfortunately, the best that can be done is setting a cancel was requested and assuming the user doesn't follow through with the authorization. I assume it's from the wait on the external website action and that it doesn't poll for cancellation during this time.

This results in waiting for the timeout on the sign-in request and checking if a cancel was requested. Then the entire operation is ignored. On the dialog side, cancelling immediately updates the UI.

I also changed the dialog that shows the code required for sign-in. I think it's simpler to go straight to opening the authorization. It made more sense than having two opportunities to cancel.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- Add timeout to Copilot sign-in #7712 #7617


### QA Notes

