### PR TITLE
Updates to disable Editor Actions and replace it with the Editor Action Bar

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -7,7 +7,10 @@ import { ILocalizedString, localize, localize2 } from '../../../nls.js';
 import { MenuId, MenuRegistry, registerAction2, Action2 } from '../../../platform/actions/common/actions.js';
 import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
-import { EditorActionsLocation, EditorTabsMode, IWorkbenchLayoutService, LayoutSettings, Parts, Position, ZenModeSettings, positionToString } from '../../services/layout/browser/layoutService.js';
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+import { /*EditorActionsLocation,*/ EditorTabsMode, IWorkbenchLayoutService, LayoutSettings, Parts, Position, ZenModeSettings, positionToString } from '../../services/layout/browser/layoutService.js';
+// --- End Positron ---
 import { ServicesAccessor, IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { KeyMod, KeyCode, KeyChord } from '../../../base/common/keyCodes.js';
 import { isWindows, isLinux, isWeb, isMacintosh, isNative } from '../../../base/common/platform.js';
@@ -549,6 +552,10 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	when: InEditorZenModeContext
 });
 
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+/*
+
 // --- Show Editor Actions in Title Bar
 
 export class EditorActionsTitleBarAction extends Action2 {
@@ -656,6 +663,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	group: '3_workbench_layout_move',
 	order: 11
 });
+*/
+// --- End Positron ---
 
 // --- Configure Tabs Layout
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -12,7 +12,10 @@ import { isWindows, isLinux, isMacintosh, isWeb, isIOS } from '../../base/common
 import { EditorInputCapabilities, GroupIdentifier, isResourceEditorInput, IUntypedEditorInput, pathsToEditors } from '../common/editor.js';
 import { SidebarPart } from './parts/sidebar/sidebarPart.js';
 import { PanelPart } from './parts/panel/panelPart.js';
-import { Position, Parts, PanelOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, panelOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, EditorActionsLocation, shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart } from '../services/layout/browser/layoutService.js';
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+import { Position, Parts, PanelOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, panelOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, /*EditorActionsLocation,*/ shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart } from '../services/layout/browser/layoutService.js';
+// --- End Positron ---
 import { isTemporaryWorkspace, IWorkspaceContextService, WorkbenchState } from '../../platform/workspace/common/workspace.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../platform/storage/common/storage.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../platform/configuration/common/configuration.js';
@@ -454,8 +457,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 					}
 				}
 
+				// --- Start Positron ---
+				// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+				const editorActionsMovedToTitlebar = false;
+				/*
 				// Show Custom TitleBar if actions enabled in (or moved to) the titlebar
 				const editorActionsMovedToTitlebar = e.affectsConfiguration(LayoutSettings.EDITOR_ACTIONS_LOCATION) && this.configurationService.getValue<EditorActionsLocation>(LayoutSettings.EDITOR_ACTIONS_LOCATION) === EditorActionsLocation.TITLEBAR;
+				*/
+				// --- End Positron ---
 				const commandCenterEnabled = e.affectsConfiguration(LayoutSettings.COMMAND_CENTER) && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER);
 				const layoutControlsEnabled = e.affectsConfiguration(LayoutSettings.LAYOUT_ACTIONS) && this.configurationService.getValue<boolean>(LayoutSettings.LAYOUT_ACTIONS);
 				const activityBarMovedToTopOrBottom = e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION) && [ActivityBarPosition.TOP, ActivityBarPosition.BOTTOM].includes(this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION));

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -69,7 +69,10 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { UntitledTextEditorInputSerializer, UntitledTextEditorWorkingCopyEditorHandler } from '../../../services/untitled/common/untitledTextEditorHandler.js';
 import { DynamicEditorConfigurations } from './editorConfiguration.js';
-import { ConfigureEditorAction, ConfigureEditorTabsAction, EditorActionsDefaultAction, EditorActionsTitleBarAction, HideEditorActionsAction, HideEditorTabsAction, ShowMultipleEditorTabsAction, ShowSingleEditorTabAction, ZenHideEditorTabsAction, ZenShowMultipleEditorTabsAction, ZenShowSingleEditorTabAction } from '../../actions/layoutActions.js';
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+import { ConfigureEditorAction, ConfigureEditorTabsAction, /* EditorActionsDefaultAction, EditorActionsTitleBarAction, HideEditorActionsAction, */ HideEditorTabsAction, ShowMultipleEditorTabsAction, ShowSingleEditorTabAction, ZenHideEditorTabsAction, ZenShowMultipleEditorTabsAction, ZenShowSingleEditorTabAction } from '../../actions/layoutActions.js';
+// --- End Positron ---
 import { ICommandAction } from '../../../../platform/action/common/action.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { getFontSnippets } from '../../../../base/browser/fonts.js';
@@ -382,10 +385,15 @@ MenuRegistry.appendMenuItem(MenuId.EditorTabsBarShowTabsZenModeSubmenu, { comman
 MenuRegistry.appendMenuItem(MenuId.EditorTabsBarShowTabsZenModeSubmenu, { command: { id: ZenShowSingleEditorTabAction.ID, title: localize('singleTab', "Single Tab"), toggled: ContextKeyExpr.equals('config.zenMode.showTabs', 'single') }, group: '1_config', order: 20 });
 MenuRegistry.appendMenuItem(MenuId.EditorTabsBarShowTabsZenModeSubmenu, { command: { id: ZenHideEditorTabsAction.ID, title: localize('hideTabs', "Hidden"), toggled: ContextKeyExpr.equals('config.zenMode.showTabs', 'none') }, group: '1_config', order: 30 });
 
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+/*
 MenuRegistry.appendMenuItem(MenuId.EditorTabsBarContext, { submenu: MenuId.EditorActionsPositionSubmenu, title: localize('editorActionsPosition', "Editor Actions Position"), group: '4_config', order: 20 });
 MenuRegistry.appendMenuItem(MenuId.EditorActionsPositionSubmenu, { command: { id: EditorActionsDefaultAction.ID, title: localize('tabBar', "Tab Bar"), toggled: ContextKeyExpr.equals('config.workbench.editor.editorActionsLocation', 'default') }, group: '1_config', order: 10, when: ContextKeyExpr.equals('config.workbench.editor.showTabs', 'none').negate() });
 MenuRegistry.appendMenuItem(MenuId.EditorActionsPositionSubmenu, { command: { id: EditorActionsTitleBarAction.ID, title: localize('titleBar', "Title Bar"), toggled: ContextKeyExpr.or(ContextKeyExpr.equals('config.workbench.editor.editorActionsLocation', 'titleBar'), ContextKeyExpr.and(ContextKeyExpr.equals('config.workbench.editor.showTabs', 'none'), ContextKeyExpr.equals('config.workbench.editor.editorActionsLocation', 'default'))) }, group: '1_config', order: 20 });
 MenuRegistry.appendMenuItem(MenuId.EditorActionsPositionSubmenu, { command: { id: HideEditorActionsAction.ID, title: localize('hidden', "Hidden"), toggled: ContextKeyExpr.equals('config.workbench.editor.editorActionsLocation', 'hidden') }, group: '1_config', order: 30 });
+*/
+// --- End Positron ---
 
 MenuRegistry.appendMenuItem(MenuId.EditorTabsBarContext, { command: { id: ConfigureEditorTabsAction.ID, title: localize('configureTabs', "Configure Tabs") }, group: '9_configure', order: 10 });
 

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -264,11 +264,11 @@ export class EditorActionBarControlFactory {
 			return;
 		}
 
-		// Notebooks always disable the editor action bar.
-		if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
-			this.updateEnablement(false);
-			return;
-		}
+		// // Notebooks always disable the editor action bar.
+		// if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
+		// 	this.updateEnablement(false);
+		// 	return;
+		// }
 
 		// Settings always enables editor action bar.
 		if (editorInput.typeId === SettingsEditor2Input.ID) {

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -26,12 +26,10 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-// import { NotebookEditorInput } from '../../../contrib/notebook/common/notebookEditorInput.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
-// import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
 
 /**
  * Constants.

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -26,10 +26,12 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { NotebookEditorInput } from '../../../contrib/notebook/common/notebookEditorInput.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
+import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
 
 /**
  * Constants.
@@ -262,11 +264,11 @@ export class EditorActionBarControlFactory {
 			return;
 		}
 
-		// // Notebooks always disable the editor action bar.
-		// if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
-		// 	this.updateEnablement(false);
-		// 	return;
-		// }
+		// Notebooks always disable the editor action bar.
+		if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
+			this.updateEnablement(false);
+			return;
+		}
 
 		// Settings always enables editor action bar.
 		if (editorInput.typeId === SettingsEditor2Input.ID) {

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -26,12 +26,12 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-import { NotebookEditorInput } from '../../../contrib/notebook/common/notebookEditorInput.js';
+// import { NotebookEditorInput } from '../../../contrib/notebook/common/notebookEditorInput.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
-import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
+// import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
 
 /**
  * Constants.

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -173,7 +173,13 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	}
 
 	private get editorActionsEnabled(): boolean {
+		// --- Start Positron ---
+		// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+		return false;
+		/*
 		return this.groupsView.partOptions.editorActionsLocation === 'default' && this.groupsView.partOptions.showTabs !== 'none';
+		*/
+		// --- End Positron ---
 	}
 
 	protected createEditorActionsToolBar(parent: HTMLElement, classes: string[]): void {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -23,7 +23,10 @@ import { CustomMenubarControl } from './menubarControl.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
-import { Parts, IWorkbenchLayoutService, ActivityBarPosition, LayoutSettings, EditorActionsLocation, EditorTabsMode } from '../../../services/layout/browser/layoutService.js';
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+import { Parts, IWorkbenchLayoutService, ActivityBarPosition, LayoutSettings, /*EditorActionsLocation, EditorTabsMode*/ } from '../../../services/layout/browser/layoutService.js';
+// --- End Positron ---
 import { createActionViewItem, fillInActionBarActions as fillInActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { Action2, IMenu, IMenuService, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -817,17 +820,26 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 	protected get isCommandCenterVisible() {
 		// --- Start Positron ---
-		// return !this.isCompact && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== false;
+		// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
 		return false;
+		/*
+		return !this.isCompact && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== false;
+		*/
 		// --- End Positron ---
 	}
 
 	private get editorActionsEnabled(): boolean {
+		// --- Start Positron ---
+		// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+		return false;
+		/*
 		return !this.isCompact && this.editorGroupService.partOptions.editorActionsLocation === EditorActionsLocation.TITLEBAR ||
 			(
 				this.editorGroupService.partOptions.editorActionsLocation === EditorActionsLocation.DEFAULT &&
 				this.editorGroupService.partOptions.showTabs === EditorTabsMode.NONE
 			);
+		*/
+		// --- End Positron ---
 	}
 
 	private get activityActionsEnabled(): boolean {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -10,7 +10,10 @@ import { isMacintosh, isWindows, isLinux, isWeb, isNative } from '../../base/com
 import { ConfigurationMigrationWorkbenchContribution, DynamicWorkbenchSecurityConfiguration, IConfigurationMigrationRegistry, workbenchConfigurationNodeBase, Extensions, ConfigurationKeyValuePairs, problemsConfigurationNodeBase, windowConfigurationNodeBase, DynamicWindowConfiguration } from '../common/configuration.js';
 import { isStandalone } from '../../base/browser/browser.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../common/contributions.js';
-import { ActivityBarPosition, EditorActionsLocation, EditorTabsMode, LayoutSettings } from '../services/layout/browser/layoutService.js';
+// --- Start Positron ---
+// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+import { ActivityBarPosition, /*EditorActionsLocation,*/ EditorTabsMode, LayoutSettings } from '../services/layout/browser/layoutService.js';
+// --- End Positron ---
 import { defaultWindowTitle, defaultWindowTitleSeparator } from './parts/titlebar/windowTitle.js';
 import { CustomEditorLabelService } from '../services/editor/common/customEditorLabelService.js';
 
@@ -56,6 +59,9 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('showEditorTabs', "Controls whether opened editors should show as individual tabs, one single large tab or if the title area should not be shown."),
 				'default': 'multiple'
 			},
+			// --- Start Positron ---
+			// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+			/*
 			[LayoutSettings.EDITOR_ACTIONS_LOCATION]: {
 				'type': 'string',
 				'enum': [EditorActionsLocation.DEFAULT, EditorActionsLocation.TITLEBAR, EditorActionsLocation.HIDDEN],
@@ -65,16 +71,15 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.editor.editorActionsLocation.hidden', "Editor actions are not shown."),
 				],
 				'markdownDescription': localize('editorActionsLocation', "Controls where the editor actions are shown."),
-				// --- Start Positron ---
-				'default': 'hidden'
-				// 'default': 'default'
-				// --- End Positron ---
+				'default': 'default'
 			},
 			'workbench.editor.alwaysShowEditorActions': {
 				'type': 'boolean',
 				'markdownDescription': localize('alwaysShowEditorActions', "Controls whether to always show the editor actions, even when the editor group is not active."),
 				'default': false
 			},
+			*/
+			// --- End Positron ---
 			'workbench.editor.wrapTabs': {
 				'type': 'boolean',
 				'markdownDescription': localize({ comment: ['{0}, {1} will be a setting name rendered as a link'], key: 'wrapTabs' }, "Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead. This value is ignored when {0} is not set to '{1}'.", '`#workbench.editor.showTabs#`', '`multiple`'),

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -48,11 +48,6 @@ import { AccessibilityProgressSignalScheduler } from '../../platform/accessibili
 import { setProgressAcccessibilitySignalScheduler } from '../../base/browser/ui/progressbar/progressAccessibilitySignal.js';
 import { AccessibleViewRegistry } from '../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { NotificationAccessibleView } from './parts/notifications/notificationAccessibleView.js';
-// --- Start Positron ---
-// eslint-disable-next-line no-duplicate-imports
-import { LayoutSettings, EditorActionsLocation } from '../services/layout/browser/layoutService.js';
-import { EDITOR_ACTION_BAR_CONFIGURATION_SETTING } from './parts/editor/editorActionBarControl.js';
-// --- End Positron ---
 
 export interface IWorkbenchOptions {
 
@@ -221,27 +216,6 @@ export class Workbench extends Layout {
 
 		// Configuration changes
 		this._register(configurationService.onDidChangeConfiguration(e => this.updateFontAliasing(e, configurationService)));
-
-		// --- Start Positron ---
-		// Add a onDidChangeConfiguration event listener to listen for changes to the editor action
-		// bar configuration setting. This is a temporary workaround that hides editor actions when
-		// the user has configured the editor action bar to be enabled. Eventually, editor actions
-		// will be replaced by the editor action bar. This approach allows testers to use both the
-		// editor actions and the editor action bar by adjusting the editor actions location after
-		// enabling the editor action bar.
-		this._register(configurationService.onDidChangeConfiguration(async e => {
-			// Check whether the editor action bar configuration setting has changed.
-			if (e.affectsConfiguration(EDITOR_ACTION_BAR_CONFIGURATION_SETTING)) {
-				// Process the editor action bar configuration setting.
-				await configurationService.updateValue(
-					LayoutSettings.EDITOR_ACTIONS_LOCATION,
-					configurationService.getValue(EDITOR_ACTION_BAR_CONFIGURATION_SETTING) ?
-						EditorActionsLocation.HIDDEN :
-						EditorActionsLocation.DEFAULT
-				);
-			}
-		}));
-		// --- End Positron ---
 
 		// Font Info
 		if (isNative) {

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleActionBar.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleActionBar.ts
@@ -27,8 +27,8 @@ export class ToggleActionBarAction extends Action2 {
 		super({
 			id: ToggleActionBarAction.ID,
 			title: {
-				...localize2('toggleActionBar', "Toggle Action Bar"),
-				mnemonicTitle: localize({ key: 'miActionBar', comment: ['&& denotes a mnemonic'] }, "&&Action Bar"),
+				...localize2('toggleEditorActionBar', "Toggle Editor Action Bar"),
+				mnemonicTitle: localize({ key: 'miActionBar', comment: ['&& denotes a mnemonic'] }, "Editor &&Action Bar"),
 			},
 			category: Categories.View,
 			f1: true,

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
@@ -117,6 +117,11 @@ export class PositronPreviewEditor
 		if (!this._positronReactRenderer) {
 			this._positronReactRenderer = new PositronReactRenderer(this._container);
 		}
+
+		if (this._preview) {
+			this._preview.dispose();
+		}
+
 		this._preview = this._positronPreviewService.editorWebview(previewId);
 
 		this._positronReactRenderer.render(

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -48,13 +48,6 @@ export const tocData: ITOCEntry<string> = {
 			label: localize('textEditor', "Text Editor"),
 			settings: ['editor.*'],
 			children: [
-				// --- Start Positron ---
-				{
-					id: 'editor/actionBar',
-					label: localize('actionBar', "Action Bar"),
-					settings: ['editor.actionBar.*']
-				},
-				// --- End Positron ---
 				{
 					id: 'editor/cursor',
 					label: localize('cursor', "Cursor"),

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -450,12 +450,17 @@ function isTitleBarEmpty(configurationService: IConfigurationService): boolean {
 		return false;
 	}
 
+	// --- Start Positron ---
+	// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
+	/*
 	// with the editor actions on top, we should always show
 	const editorActionsLocation = configurationService.getValue<EditorActionsLocation>(LayoutSettings.EDITOR_ACTIONS_LOCATION);
 	const editorTabsMode = configurationService.getValue<EditorTabsMode>(LayoutSettings.EDITOR_TABS_MODE);
 	if (editorActionsLocation === EditorActionsLocation.TITLEBAR || editorActionsLocation === EditorActionsLocation.DEFAULT && editorTabsMode === EditorTabsMode.NONE) {
 		return false;
 	}
+	*/
+	// --- End Positron ---
 
 	// with the layout actions on top, we should always show
 	if (configurationService.getValue<boolean>(LayoutSettings.LAYOUT_ACTIONS)) {

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -3,15 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import test, { expect, Page } from '@playwright/test';
+import test, { expect, Locator, Page } from '@playwright/test';
 import { Viewer } from './viewer';
 import { QuickAccess } from './quickaccess';
 
 
 export class EditorActionBar {
+	actionBar: Locator = this.page.locator('.editor-action-bar > .positron-action-bar > .action-bar-region');
 
-	constructor(private page: Page, private viewer: Viewer, private quickaccess: QuickAccess) {
-	}
+	constructor(private page: Page, private viewer: Viewer, private quickaccess: QuickAccess) { }
 
 	// --- Actions ---
 
@@ -183,6 +183,19 @@ export class EditorActionBar {
 			position === 'Left'
 				? expect(summaryBox.x).toBeLessThan(tableBox.x)
 				: expect(summaryBox.x).toBeGreaterThan(tableBox.x);
+		});
+	}
+
+	/**
+	 * Verify: the visibility of the editor action bar
+	 *
+	 * @param isVisible whether the editor action bar is expected to be visible
+	 */
+	async verifyIsVisible(isVisible: boolean) {
+		await test.step(`Verify editor action bar is ${isVisible ? 'visible' : 'not visible'}`, async () => {
+			isVisible
+				? await expect(this.actionBar).toBeVisible()
+				: await expect(this.actionBar).not.toBeVisible();
 		});
 	}
 }

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
@@ -3,6 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * Editor Action Bar: Data Files
+ *
+ * Summary:
+ * This test suite validates the functionality of the Editor Action Bar when interacting with
+ * various types of data based files (e.g., data frames in R/Python, Parquet, CSV).
+ *
+ * Flow:
+ *  - Open a file containing data frames or a standalone data file directly (e.g., Parquet, CSV via DuckDB)
+ *  - Use the Variables pane to open a data frame in the Data Explorer (when applicable)
+ *  - Verify the Editor Action Bar functionality:
+ */
+
 import { Application } from '../../infra';
 import { EditorActionBar } from '../../pages/editorActionBar';
 import { test, expect, tags } from '../_test.setup';

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -3,6 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * Editor Action Bar: Document Files
+ *
+ * This test suite validates the functionality of the Editor Action Bar when interacting with
+ * various types of files (R Markdown, Quarto, HTML, and Jupyter Notebooks, etc.)
+ *
+ * Flow:
+ * - Open a supported file type
+ * - Interact with action bar controls to preview or split the editor
+ * - Verify content is rendered or shown in a new editor/tab/window as expected
+ * - Confirm expected visibility/invisibility of the action bar based on file type
+ */
+
 import { expect, Page } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 import { EditorActionBar } from '../../pages/editorActionBar';
@@ -45,24 +58,17 @@ test.describe('Editor Action Bar: Document Files', {
 		await verifyOpenInNewWindow(app, 'Diamond sizes');
 	});
 
-	test('HTML Document - Verify `open viewer`, `split editor`, `open in new window` behavior', { tag: [tags.HTML] }, async function ({ app, page, openFile }) {
+	test('HTML Document - Verify `open viewer`, `split editor`, `open in new window` behavior', { tag: [tags.HTML] }, async function ({ app, openFile }) {
 		await openFile('workspaces/dash-py-example/data/OilandGasMetadata.html');
 		await verifyOpenViewerRendersHtml(app, 'Oil, Gas, and Other Regulated');
 		await verifySplitEditor('OilandGasMetadata.html');
 		await verifyOpenInNewWindow(app, '<title> Oil &amp; Gas Wells - Metadata</title>');
 	});
 
-	test('Jupyter Notebook - Verify toggle `line numbers`, `toggle breadcrumbs`, `split editor` behavior', {
+	test('Jupyter Notebook - Verify editor action bar is not visible', {
 		tag: [tags.NOTEBOOKS],
-	}, async function ({ app, page, openDataFile }) {
-		await openDataFile('workspaces/large_r_notebook/spotify.ipynb');
-
-		if (app.web) {
-			await verifyToggleLineNumbers(page);
-			await verifyToggleBreadcrumb(page);
-		}
-
-		await verifySplitEditor('spotify.ipynb');
+	}, async function ({ app }) {
+		await app.workbench.editorActionBar.verifyIsVisible(false);
 	});
 });
 
@@ -116,27 +122,3 @@ async function verifyOpenChanges(page: Page) {
 	});
 }
 
-async function verifyToggleLineNumbers(page: Page) {
-	async function verifyLineNumbersVisibility(page: Page, isVisible: boolean) {
-		for (const lineNum of [1, 2, 3, 4, 5]) {
-			const lineNumbers = expect(page.locator('.line-numbers').getByText(lineNum.toString(), { exact: true }));
-			isVisible ? await lineNumbers.toBeVisible() : await lineNumbers.not.toBeVisible();
-		}
-	}
-
-	await test.step('verify "customize notebook > toggle line numbers" (web only)', async () => {
-		await verifyLineNumbersVisibility(page, false);
-		await editorActionBar.clickCustomizeNotebookMenuItem('Toggle Notebook Line Numbers');
-		await verifyLineNumbersVisibility(page, true);
-	});
-}
-
-async function verifyToggleBreadcrumb(page: Page) {
-	await test.step('verify "customize notebook > toggle breadcrumbs" (web only)', async () => {
-		const breadcrumbs = page.locator('.monaco-breadcrumbs');
-
-		await expect(breadcrumbs).toBeVisible();
-		await editorActionBar.clickCustomizeNotebookMenuItem('Toggle Breadcrumbs');
-		await expect(breadcrumbs).not.toBeVisible();
-	});
-}


### PR DESCRIPTION
## Description

This PR disables the **Editor Actions** feature and replaces it with the **Editor Action Bar** feature. With these changes, there are no remnants of the **Editor Actions** feature left in the app.

This PR is a replacement for https://github.com/posit-dev/positron/pull/7827, which has been withdrawn.

### Release Notes

#### New Features

- #7270 Replaced the **Editor Actions** feature with the **Editor Action Bar** feature.

#### Bug Fixes

- N/A

### QA Notes

Tests:
@:editor-action-bar