### PR TITLE
Fix console split button bugs

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -414,14 +414,14 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		const activeRuntimes = this.runtimeSessionService.activeSessions
 			// Sort by last used, descending.
 			.sort((a, b) => b.lastUsed - a.lastUsed)
-			// Restrict to the first 5.
-			.slice(0, 5)
 			// Map from session to runtime metadata.
 			.map(session => session.runtimeMetadata)
 			// Remove duplicates, and current runtime.
 			.filter((runtime, index, runtimes) =>
 				runtime.runtimeId !== currentRuntime?.runtimeId && runtimes.findIndex(r => r.runtimeId === runtime.runtimeId) === index
-			);
+			)
+			// Restrict to the first 5.
+			.slice(0, 5);
 
 		// Add current runtime first, if present.
 		// Allows for "plus" + enter behavior to clone session.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -274,6 +274,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		}));
 
 		this._register(this.runtimeSessionService.onDidStartRuntime(() => this.updateActions()));
+		this._register(this.runtimeSessionService.onDidChangeForegroundSession(() => this.updateActions()));
 		this._register(this.runtimeSessionService.onDidDeleteRuntimeSession(() => this.updateActions()));
 
 		// Update the context key used to manage the session dropdown when the console instances change.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -412,7 +412,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 		const currentRuntime = this.runtimeSessionService.foregroundSession?.runtimeMetadata;
 
 		// Grab the active runtimes.
-		const activeRuntimes = this.runtimeSessionService.activeSessions
+		let activeRuntimes = this.runtimeSessionService.activeSessions
 			// Sort by last used, descending.
 			.sort((a, b) => b.lastUsed - a.lastUsed)
 			// Map from session to runtime metadata.
@@ -421,14 +421,15 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 			.filter((runtime, index, runtimes) =>
 				runtime.runtimeId !== currentRuntime?.runtimeId && runtimes.findIndex(r => r.runtimeId === runtime.runtimeId) === index
 			)
-			// Restrict to the first 5.
-			.slice(0, 5);
 
 		// Add current runtime first, if present.
 		// Allows for "plus" + enter behavior to clone session.
 		if (currentRuntime && this.runtimeSessionService.foregroundSession?.getRuntimeState() !== RuntimeState.Exited) {
 			activeRuntimes.unshift(currentRuntime);
 		}
+
+		// Limit to 5 active runtimes to avoid cluttering the dropdown.
+		activeRuntimes = activeRuntimes.slice(0, 5);
 
 		const dropdownMenuActions = activeRuntimes.map(runtime => new Action(
 			`console.startSession.${runtime.runtimeId}`,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -332,6 +332,7 @@ export interface IRuntimeSessionService {
 	// An event that fires when the active runtime changes.
 	readonly onDidChangeForegroundSession: Event<ILanguageRuntimeSession | undefined>;
 
+	// An event that fires when a runtime session is deleted.
 	readonly onDidDeleteRuntimeSession: Event<string>;
 
 	// An event that fires when a notebook session's URI is updated.


### PR DESCRIPTION
Addresses #7854 

Fixes a few bugs with the dropdown list shown in the console split button:
*  The dropdown list did not show the last 5 used runtimes. This was due to the fact that the list was sliced before we de-duplicated the list of active runtimes from all the active sessions. The number of items in the list is now capped at the very end of the filtering process.
* Fixed a bug where deleting the active session caused the runtime for that session to disappear from the dropdown even if there were other active sessions for the same runtime. The issue here was that the dropdown was not re-rendered when the foreground session changed after the delete action. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix bug causing fewer than the last 5 runtimes to show up in the console (+) split button


### QA Notes

@:sessions @:console

### Screenshots

https://github.com/user-attachments/assets/1a194ac3-3bab-4030-98dc-0ec5fe5732f4


