### PR TITLE
Bump Ark to 0.1.186

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -766,7 +766,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.185"
+      "ark": "0.1.186"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/807

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Completions are now provided for local objects in a function paused in the debugger (#3001).

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->


When stopped in the debugger, you should be able to complete on local arguments and variables, as well as variables up the environment chain. If this chain doesn't inherit from the global env, you shouldn't be able to complete for global objects or objects from attached packages.

E.g. in this example you should be able to complete `foobar`, `quux`, `argument`, `local_var`, but not `global` (from the global env) or `anova` (from the stats package):

```r
global <- 1

f <- local(envir = new.env(parent = baseenv()), {
    foobar <- 1
    quux <- 2
    f <- function(argument) {
        local_var <- "foo"
        browser()
        NULL
    }
})

f()
```