### PR TITLE
Set default of `debug.saveBeforeStart` to non-untitled

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -651,7 +651,13 @@ configurationRegistry.registerConfiguration({
 				nls.localize('debug.saveBeforeStart.nonUntitledEditorsInActiveGroup', "Save all editors in the active group except untitled ones before starting a debug session."),
 				nls.localize('debug.saveBeforeStart.none', "Don't save any editors before starting a debug session."),
 			],
-			default: 'allEditorsInActiveGroup',
+			// --- Start Positron ---
+			// https://github.com/posit-dev/positron/issues/1728
+			// Saving untitled editors is disruptive and unnecessary since it's
+			// unlikely the user wants to debug a scratch file. Furthermore, merely
+			// saving the file does not necessarily guarantees the file is debuggable.
+			default: 'nonUntitledEditorsInActiveGroup',
+			// --- End Positron ---
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},
 		'debug.confirmOnExit': {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- By default, Positron no longer tries to save untitled editors when a debug session is started. This is to avoid disrupting the user workflow with a save dialog when a debug session starts (#1728). You can change this new default by modifying the `debug.saveBeforeStart` setting.

#### Bug Fixes

- N/A


### QA Notes

Untitled scratch files should no longer prompt a save dialog when a debug session is started (e.g. via `browser()` in R). Titled files should still be saved by default and silently when the session starts.
