### PR TITLE
Expose Positron Assistant settings

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -118,6 +118,53 @@
         "enablement": "config.positron.assistant.enable"
       }
     ],
+    "configuration": [
+      {
+        "type": "object",
+        "title": "%configuration.title%",
+        "properties": {
+          "positron.assistant.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.enable.description%",
+            "tags": ["experimental"]
+          },
+          "positron.assistant.useAnthropicSdk": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.useAnthropicSdk.description%"
+          },
+          "positron.assistant.enabledProviders": {
+            "type": "array",
+            "default": [],
+            "description": "%configuration.enabledProviders.description%",
+            "items": {
+              "type": "string",
+              "enum": [
+                "anthropic",
+                "azure",
+                "bedrock",
+                "google",
+                "mistral",
+                "ollama",
+                "openai",
+                "openrouter"
+              ],
+              "enumDescriptions": [
+                "%configuration.enabledProviders.anthropic%",
+                "%configuration.enabledProviders.azure%",
+                "%configuration.enabledProviders.bedrock%",
+                "%configuration.enabledProviders.google%",
+                "%configuration.enabledProviders.mistral%",
+                "%configuration.enabledProviders.ollama%",
+                "%configuration.enabledProviders.openai%",
+                "%configuration.enabledProviders.openrouter%"
+              ]
+            }
+          }
+        }
+      }
+    ],
     "languageModels": [
       {
         "vendor": "positron"

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -9,5 +9,17 @@
 	"chatParticipants.fullName": "Positron Assistant",
 	"chatParticipants.ask.description": "Ask Assistant",
 	"chatParticipants.edit.description": "Edit files in your workspace",
-	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document."
+	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document.",
+	"configuration.title": "Positron Assistant",
+	"configuration.enable.description": "Enable Positron Assistant, an experimental AI assistant for Positron.",
+	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
+	"configuration.enabledProviders.description": "List of enabled language model providers; leave empty for defaults.",
+	"configuration.enabledProviders.anthropic": "Anthropic Claude",
+	"configuration.enabledProviders.azure": "Microsoft Azure",
+	"configuration.enabledProviders.bedrock": "Amazon Bedrock",
+	"configuration.enabledProviders.google": "Google Gemini",
+	"configuration.enabledProviders.mistral": "Mistral AI",
+	"configuration.enabledProviders.ollama": "Ollama (local)",
+	"configuration.enabledProviders.openai": "OpenAI",
+	"configuration.enabledProviders.openrouter": "OpenRouter"
 }


### PR DESCRIPTION
Exposes Positron Assistant settings in its package.json so that they are available in VS Code's Settings UI. 

Addresses https://github.com/posit-dev/positron/issues/7852.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron Assistant, an experimental AI assistant for Positron, can now be enabled in Settings. https://github.com/posit-dev/positron/issues/7852

#### Bug Fixes

- N/A


### QA Notes

No logic has changed here.
