### PR TITLE
Extend timeout to wait for RPC reply

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1131,7 +1131,7 @@ class ExtHostRuntimeClientInstance<Input, Output>
 				// so we need to wait a bit before rejecting the promise.
 				// This currently only happens with Ark/Amalthea. IPykernel always sends the RPC result before
 				// sending the 'Idle' status.
-				const timeout = 2000;
+				const timeout = 5000;
 				setTimeout(() => {
 					if (pending.promise.isSettled) {
 						return;


### PR DESCRIPTION
Currently, when processing comm messages, we wait 2s after receiving an `Idle` before we give up on receiving an RPC reply. Empirically this doesn't seem to be enough to handle all cases, so this change kicks the can down the road a bit by waiting 5s.

Mitigates, but doesn't fix, https://github.com/posit-dev/positron/issues/7755. 