### PR TITLE
Assistant: Basic inline terminal support

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/terminal.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/terminal.md
@@ -3,6 +3,7 @@ You may respond in one of two ways:
 1. Answer the user's question in 1-3 brief sentences.
 2. Return ONLY a single line terminal command that addresses the user's question.
    1. If the command includes arguments, explain them in bulleted form.
+   2. If the command is destructive, include a warning.
 
 <examples>
 <example>
@@ -30,6 +31,20 @@ ls -l
 
 - `-l`: List files in long format, showing details including creation time.
 </response>
+
+<example>
+<user>delete the current directory</user>
+<response>
+**Warning: This command will permanently delete the current directory and all its contents. Use with caution!**
+
+```sh
+rm -rf .
+```
+
+- `-r`: Recursively delete the directory and its contents.
+- `-f`: Force deletion without prompting for confirmation.
+</response>
+</example>
 </example>
 
 </examples>

--- a/extensions/positron-assistant/src/md/prompts/chat/terminal.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/terminal.md
@@ -1,4 +1,16 @@
-Return ONLY a single line terminal command that addresses the user's query.
+You may respond in one of two ways:
+
+1. Answer the user's question in 1-3 brief sentences.
+2. Return ONLY a single line terminal command that addresses the user's question.
+   1. If the command includes arguments, explain them in bulleted form.
+
+<examples>
+<example>
+<user>what is mkdir?</user>
+<response>
+`mkdir` is a command used to create a new directory. It stands for "make directory".
+</response>
+</example>
 
 <example>
 <user>what folder am I in?</user>
@@ -8,3 +20,16 @@ pwd
 ```
 </response>
 </example>
+
+<example>
+<user>what files are in the current folder and when were they created?</user>
+<response>
+```sh
+ls -l
+```
+
+- `-l`: List files in long format, showing details including creation time.
+</response>
+</example>
+
+</examples>

--- a/extensions/positron-assistant/src/md/prompts/chat/terminal.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/terminal.md
@@ -1,4 +1,10 @@
-You are an expert user of the terminal.
-You help users write terminal commands.
+Return ONLY a single line terminal command that addresses the user's query.
 
-The user will ask you to write a command, give a short explanation and then provide the command.
+<example>
+<user>what folder am I in?</user>
+<response>
+```sh
+pwd
+```
+</response>
+</example>

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -194,6 +194,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		// List of tools for use by the language model.
 		const tools: vscode.LanguageModelChatTool[] = vscode.lm.tools.filter(
 			tool => {
+				// Don't allow any tools in the terminal.
+				if (this.id === ParticipantID.Terminal) {
+					return false;
+				}
+
 				// Define more readable variables for filtering.
 				const inChatPane = request.location2 === undefined;
 				const inEditor = request.location2 instanceof vscode.ChatRequestEditorData;
@@ -255,7 +260,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		};
 	}
 
-	private async getDefaultSystemPrompt(): Promise<string> {
+	protected async getDefaultSystemPrompt(): Promise<string> {
 		return await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
 	}
 
@@ -527,7 +532,7 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 class PositronAssistantTerminalParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
 	id = ParticipantID.Terminal;
 
-	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string | undefined> {
+	protected override async getDefaultSystemPrompt(): Promise<string> {
 		return await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'terminal.md'), 'utf8');
 	}
 }


### PR DESCRIPTION
This PR adds very basic terminal support, mostly relying on the language model's existing knowledge and prompting as well as existing Code OSS functionality.

Curious to hear folks' thoughts on whether this change makes it worth keeping the terminal participant enabled versus just disabling it for RC.

### QA Notes

Try Assistant in the terminal. Compare with other IDEs.