### PR TITLE
Fix issue starting R/Python when `/bin/sh` is user's shell

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -150,7 +150,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.41"
+      "kallichore": "0.1.42"
     }
   },
   "extensionDependencies": [

--- a/extensions/positron-supervisor/resources/supervisor-wrapper.sh
+++ b/extensions/positron-supervisor/resources/supervisor-wrapper.sh
@@ -55,7 +55,7 @@ if [ -z "$DEFAULT_SHELL" ] || [ ! -x "$DEFAULT_SHELL" ]; then
 fi
 
 # Print the command line to the log file
-echo "$DEFAULT_SHELL" --login -c "$@" >> "$output_file"
+echo "$DEFAULT_SHELL" -l -c "$@" >> "$output_file"
 
 # Quote the arguments to handle single quotes and spaces correctly
 QUOTED_ARGS=""
@@ -69,11 +69,11 @@ done
 # Run the program with its arguments, redirecting stdout and stderr to the output file
 if [ "$use_nohup" = true ]; then
 	# Use nohup and explicitly redirect its output to prevent nohup.out from being created
-	nohup $DEFAULT_SHELL --login -c "${QUOTED_ARGS}" >> "$output_file" 2>&1 &
+	nohup $DEFAULT_SHELL -l -c "${QUOTED_ARGS}" >> "$output_file" 2>&1 &
 	# Wait for the background process to complete
 	wait $!
 else
-	$DEFAULT_SHELL --login -c "${QUOTED_ARGS}" >> "$output_file" 2>&1
+	$DEFAULT_SHELL -l -c "${QUOTED_ARGS}" >> "$output_file" 2>&1
 fi
 
 # Save the exit code of the program


### PR DESCRIPTION
This change addresses an issue in which starting R/Python sessions fails when `/bin/sh` is the user's default shell.

Vanilla `sh` does not support the long form `--login` flag, only `-l` to run login scripts. Thankfully bash-alikes support `-l` as an alias to `--login` too, so we can support both with `-l`. 

(realize that there are a long tail of other shells we can probably test with like `fish`, `csh`/`tcsh`, etc; the intent of this fix is to just cover the most common shells for now, which is `bash`, `zsh`, and `sh`)

Addresses https://github.com/posit-dev/positron/issues/7874.

### QA Notes

- See the original issue for instructions on changing your shell to `/bin/sh` to test this. 
- Before verifying the issue, I recommend running `echo $SHELL` in a Terminal to verify that you are really using `sh` as a shell. 
