### PR TITLE
Disable the runapp integration tests as they are flaky

### DIFF
--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -64,11 +64,12 @@ echo
 npm run test-extension -- -l positron-connections
 kill_app
 
-echo
-echo "### Positron Run App tests"
-echo
-npm run test-extension -- -l positron-run-app
-kill_app
+# Disabling Positron Run App tests for now as they are flaky
+# echo
+# echo "### Positron Run App tests"
+# echo
+# npm run test-extension -- -l positron-run-app
+# kill_app
 
 echo
 echo "### Positron DuckDB tests"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -151,11 +151,12 @@ echo
 npm run test-extension -- -l positron-connections
 kill_app
 
-echo
-echo "### Positron Run App tests"
-echo
-npm run test-extension -- -l positron-run-app
-kill_app
+# Disabling Positron Run App tests for now as they are flaky
+# echo
+# echo "### Positron Run App tests"
+# echo
+# npm run test-extension -- -l positron-run-app
+# kill_app
 
 echo
 echo "### Positron DuckDB tests"


### PR DESCRIPTION
These tests are flaky, possibly due to a race condition, therefore disabling for now.


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
