### PR TITLE
E2E test: check bootstrap extensions

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -240,7 +240,7 @@ jobs:
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
           # Don't run this test in parallel & don't allow skipping it
-          npx playwright test --project ${{ inputs.project }} tests/e2e/extensions/bootstrap-extensions.test.ts
+          npx playwright test --project "${{ inputs.project }}" tests/e2e/extensions/bootstrap-extensions.test.ts
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -240,7 +240,7 @@ jobs:
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
           # Don't run this test in parallel & don't allow skipping it
-          npx playwright test --project "${{ inputs.project }}" tests/e2e/extensions/bootstrap-extensions.test.ts
+          eval DISPLAY=:10 npx playwright test --project ${{ inputs.project }} tests/e2e/extensions/bootstrap-extensions.test.ts
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -242,10 +242,17 @@ jobs:
           # Don't run this test in parallel & don't allow skipping it
           echo "Running: DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}"
           eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}
+          BOOTSTRAP_EXIT_CODE=$?
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
           eval DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+
+          # Fail the step if the bootstrap test failed
+          if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then
+            echo "Bootstrap extensions test failed."
+            exit $BOOTSTRAP_EXIT_CODE
+          fi
 
 
       - name: Upload Playwright Report to S3

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -240,7 +240,8 @@ jobs:
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
           # Don't run this test in parallel & don't allow skipping it
-          eval DISPLAY=:10 npx playwright test --project ${{ inputs.project }} tests/e2e/extensions/bootstrap-extensions.test.ts
+          echo "Running: DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}"
+          eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -240,8 +240,8 @@ jobs:
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
           # Don't run this test in parallel & don't allow skipping it
-          echo "Running: DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}"
-          eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }}
+          echo "Running: DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null"
+          eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null
           BOOTSTRAP_EXIT_CODE=$?
 
           # Run the Playwright test command directly using eval

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -239,6 +239,9 @@ jobs:
           echo "Final --grep argument: $GREP_ARG"
           echo "Final --grep-invert argument: $GREP_INVERT_ARG"
 
+          # Don't run this test in parallel & don't allow skipping it
+          npx playwright test --project ${{ inputs.project }} tests/e2e/extensions/bootstrap-extensions.test.ts
+
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
           eval DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "build/secrets/.secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -978,7 +974,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "34b526d5a6e9f232e586730a609a06db2777027a",
+        "hashed_secret": "2a54c1d991c979b523465b8f592a87ba581bd44a",
         "is_verified": false,
         "line_number": 244,
         "is_secret": false
@@ -1465,5 +1461,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-27T20:11:21Z"
+  "generated_at": "2025-05-29T19:55:11Z"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig<ExtendedTestOptions>({
 	captureGitInfo: { commit: true, diff: true },
 	globalSetup: './test/e2e/tests/_global.setup.ts',
 	testDir: './test/e2e',
-	testIgnore: '**/example.test.ts',
+	testIgnore: [
+		'example.test.ts',
+		'extensions/bootstrap.extensions.test.ts'
+	],
 	testMatch: '*.test.ts',
 	fullyParallel: false, // Run individual tests w/in a spec in parallel
 	forbidOnly: !!process.env.CI,
@@ -97,7 +100,7 @@ export default defineConfig<ExtendedTestOptions>({
 			grep: /@:win/,
 			grepInvert: /@:web-only/
 		},
-				{
+		{
 			name: 'e2e-macOS-ci',
 			use: {
 				web: false,

--- a/product.json
+++ b/product.json
@@ -228,7 +228,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.16.0",
+			"version": "1.16.1",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",
@@ -240,8 +240,8 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.121.0",
-			"sha256sum": "b83149cb696f22a0f7fae8018f634d2544368c7c73fded9bd67c8512dc786141",
+			"version": "1.122.0",
+			"sha256sum": "7df70318307bddcb9089978f5a6c5fa534db50d57fa46bfe3293028dfa5eb9b8",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -68,7 +68,7 @@ else {
 	// Running out of sources
 	if (Object.keys(product).length === 0) {
 		Object.assign(product, {
-			version: '1.95.0-dev',
+			version: '1.100.0-dev',
 			// --- Start Positron ---
 			// This only applies to dev builds where it is not possible to read the
 			// product configuration. Release builds replace the product configuration

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -19,8 +19,8 @@ test.describe('Bootstrap Extensions', {
 }, () => {
 
 	test('Verify All Bootstrap extensions are installed', {
-		tag: [tags.EXTENSIONS, tags.WEB, tags.WIN]
-	}, async function ({ app }) {
+		tag: [tags.EXTENSIONS, tags.WEB]
+	}, async function () {
 
 		const extensions = readProductJson();
 		await waitForExtensions(extensions);

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -12,7 +12,7 @@ test.use({
 	suiteId: __filename
 });
 
-const EXT_DIR = path.join(os.homedir(), '.positron-dev', 'extensions');
+const EXT_DIR = path.join(os.tmpdir(), 'vscsmoke', 'extensions-dir');
 
 test.describe('Bootstrap Extensions', {
 	tag: [tags.EXTENSIONS, tags.WEB],

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -18,7 +18,7 @@ test.describe('Bootstrap Extensions', {
 	tag: [tags.EXTENSIONS, tags.WEB],
 }, () => {
 
-	test('VerifyAll Bootstrap extensions are installed', {
+	test('Verify All Bootstrap extensions are installed', {
 		tag: [tags.EXTENSIONS, tags.WEB, tags.WIN]
 	}, async function ({ app }) {
 

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -23,9 +23,6 @@ test.describe('Bootstrap Extensions', {
 	}, async function ({ app }) {
 
 		const extensions = readProductJson();
-
-		console.log(extensions);
-
 		await waitForExtensions(extensions);
 
 	});

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+import * as fs from 'fs';
+import * as path from 'path';
+import os from 'os';
+
+test.use({
+	suiteId: __filename
+});
+
+const EXT_DIR = path.join(os.homedir(), '.positron-dev', 'extensions');
+
+test.describe('Bootstrap Extensions', {
+	tag: [tags.EXTENSIONS, tags.WEB],
+}, () => {
+
+	test('VerifyAll Bootstrap extensions are installed', {
+		tag: [tags.EXTENSIONS, tags.WEB, tags.WIN]
+	}, async function ({ app }) {
+
+		const extensions = readProductJson();
+
+		console.log(extensions);
+
+		await waitForExtensions(extensions);
+
+	});
+});
+
+
+function sleep(ms: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function readProductJson(): { fullName: string; shortName: string; version: string }[] {
+	const raw = fs.readFileSync('product.json', 'utf-8');
+	const data = JSON.parse(raw);
+	return data.bootstrapExtensions.map((ext: any) => {
+		const fullName: string = ext.name;
+		const shortName = fullName.split('.').pop()!;
+		return {
+			fullName,
+			shortName,
+			version: ext.version
+		};
+	});
+}
+
+function getInstalledExtensions(): Map<string, string> {
+	const installed = new Map<string, string>();
+	if (!fs.existsSync(EXT_DIR)) { return installed; }
+
+	for (const extDir of fs.readdirSync(EXT_DIR)) {
+		const packageJsonPath = path.join(EXT_DIR, extDir, 'package.json');
+		if (fs.existsSync(packageJsonPath)) {
+			const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+			if (pkg.name && pkg.version) {
+				installed.set(pkg.name, pkg.version);
+			}
+		}
+	}
+
+	return installed;
+}
+
+async function waitForExtensions(extensions: { fullName: string; shortName: string; version: string }[]) {
+	const missing = new Set(extensions.map(ext => ext.fullName));
+
+	while (missing.size > 0) {
+		const installed = getInstalledExtensions();
+
+		for (const ext of extensions) {
+			if (!missing.has(ext.fullName)) { continue; }
+
+			const installedVersion = installed.get(ext.shortName);
+			if (installedVersion === ext.version) {
+				console.log(`✅ ${ext.fullName} (${ext.version}) found and matches`);
+				missing.delete(ext.fullName);
+			}
+		}
+
+		if (missing.size > 0) {
+			console.log(`⏳ Waiting on: ${Array.from(missing).join(', ')}`);
+			await sleep(1000);
+		}
+	}
+
+	console.log('🎉 All extensions installed with correct versions.');
+}
+


### PR DESCRIPTION
New test case that checks for the proper versions of the bootstrap extensions serially before the full parallel suite starts.

Checks the product.json expected version against the installed versions using the extensions directories package.json files.

Will fail if Positron updates past the versions in package.json so should help us catch when package.json falls out of date.

If the version check fails, the other tests will still run, but the overall step will fail.

This is probably not needed for the electron tests, but went ahead and let it run there just for completeness.  I don't think we need to migrate this to nightly tests.  The version check test case is on the ignore list so it won't run nightly.  This was primarily needed to address recurring problems we have had with the web tests on ubuntu.

Note that this test is run serially because we believe that two tests running at the same time trying to update extensions for the web tests has led to issues.

### QA Notes

@:web
