### PR TITLE
Show exited runtimes in console dropdown

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -35,7 +35,7 @@ import { PositronConsole } from './positronConsole.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { IRuntimeSessionService, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
-import { ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeService, LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IReactComponentContainer, ISize, PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { IExecutionHistoryService } from '../../../services/positronHistory/common/executionHistoryService.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
@@ -424,7 +424,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 
 		// Add current runtime first, if present.
 		// Allows for "plus" + enter behavior to clone session.
-		if (currentRuntime && this.runtimeSessionService.foregroundSession?.getRuntimeState() !== RuntimeState.Exited) {
+		if (currentRuntime) {
 			activeRuntimes.unshift(currentRuntime);
 		}
 


### PR DESCRIPTION
Addresses #7884 

If the active session has a state of exited, it is not include in the runtime in the console dropdown. This behavior isn't helpful for the user given that they shouldn't normally have console instances of exited sessions - to provide an easy path for a new session we want to allow them to start another console session for that runtime so this PR now allows runtimes for exited sessions to show up in the dropdown.

Normally, a session and its console instance are both disposed of together. It is not common for a session and its console instance to hang around when the session has a state of exited. This happens when something goes awry with the session startup/restart/exit. In this situation, providing the runtime for the user is helpful so they can start up another console session of the same runtime.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Show exited runtimes in the dropdown of the console "plus" button


### QA Notes

@:sessions @:console


https://github.com/user-attachments/assets/f64af46b-b6c4-4a64-a535-4548ebdfad3e

