### PR TITLE
e2e test - Interpreter Commands (Force Quit, Interrupt, and Shutdown

### DIFF
--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -20,52 +20,50 @@ Summary:
  */
 
 import { test, tags, expect } from '../_test.setup';
-import type { TestInfo } from '@playwright/test'; // remove test.skip and TestInfo import after bug #4604 is fixed
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag: [tags.WEB, tags.WIN, tags.INTERPRETER] }, () => {
+test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', {
+	tag: [tags.WEB, tags.INTERPRETER]
+}, () => {
+
 	test.afterEach(async ({ app }) => {
 		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 	});
 
-	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', async function ({ app, python }) {
+	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', { tag: [tags.WIN] }, async function ({ app, python }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
 	});
 
-	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', async function ({ app, r }) {
+	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', { tag: [tags.WIN] }, async function ({ app, r }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
 	});
 
-	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }, testInfo: TestInfo) {
-		// This if statement is to skip e2e-windows due to bug #4604. Once it's fixed, remove if statement (and testInfo parameter)
-		if (testInfo.project.name === 'e2e-windows') {
-			test.skip();
-			return;
-		}
+	// Skip this test for tags.WIN (e2e-windows) due to Bug #4604
+	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }) {
 		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt');
 	});
 
-	test('Verify Interrupt Interpreter command works (→ empty error line) - R', async function ({ app, page, r }) {
+	test('Verify Interrupt Interpreter command works (→ empty error line) - R', { tag: [tags.WIN] }, async function ({ app, page, r }) {
 		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await expect(page.locator('div.activity-error-stream')).toBeVisible();
 	});
 
-	test('Verify Shutdown Interpreter command works (→ exited) - Python', async function ({ app, python, page }) {
+	test('Verify Shutdown Interpreter command works (→ exited) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
 		await app.workbench.console.pasteCodeToConsole('exit()');
 		await page.keyboard.press('Enter');
 		await app.workbench.console.waitForConsoleContents('exited');
 	});
 
-	test('Verify Shutdown Interpreter command works (→ exited) - R', async function ({ app, r, page }) {
+	test('Verify Shutdown Interpreter command works (→ exited) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
 		await app.workbench.console.pasteCodeToConsole('q()');
 		await page.keyboard.press('Enter');
 		await app.workbench.console.waitForConsoleContents('exited');

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+Summary:
+- This test suite verifies the functionality of interpreter commands via Force Quit, Interrupt, and Shutdown for both Python and R.
+- Tests confirm that each quick input command triggers the expected behavior, verified through console outputs (see Table below).
+
+ * |Command   |Language|Targeted Console Output    |
+ * |----------|--------|---------------------------|
+ * |Force Quit|Python  |'was forced to quit'       |
+ * |Force Quit|R       |'was forced to quit'       |
+ * |Interrupt |Python  |'KeyboardInterrupt'        |
+ * |Interrupt |R       |Empty error line (visible) |
+ * |Shutdown  |Python  |'shut down successfully'   |
+ * |Shutdown  |R       |'shut down successfully'   |
+ */
+
+import { test, tags, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag: [tags.WEB, tags.WIN, tags.INTERPRETER] }, () => {
+	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', async function ({ app, python }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
+		await app.workbench.console.waitForConsoleContents('was forced to quit');
+		await app.workbench.sessions.deleteAll();
+	});
+
+	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', async function ({ app, r }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
+		await app.workbench.console.waitForConsoleContents('was forced to quit');
+		await app.workbench.sessions.deleteAll();
+	});
+
+	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }) {
+		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
+		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt');
+		await app.workbench.console.clearButton.click();
+	});
+
+	test('Verify Interrupt Interpreter command works (→ empty error line) - R', async function ({ app, page, r }) {
+		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
+		expect(page.locator('div.activity-error-stream')).toBeVisible;
+		await app.workbench.console.clearButton.click();
+	});
+
+	test('Verify Shutdown Interpreter command works (→ shut down successfully) - Python', async function ({ app, python }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.shutdown');
+		await app.workbench.console.waitForConsoleContents('shut down successfully');
+		await app.workbench.sessions.deleteAll();
+
+	});
+
+	test('Verify Shutdown Interpreter command works (→ shut down successfully) - R', async function ({ app, r }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.shutdown');
+		await app.workbench.console.waitForConsoleContents('shut down successfully');
+		await app.workbench.sessions.deleteAll();
+	});
+});

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -7,6 +7,7 @@
 Summary:
 - This test suite verifies the functionality of interpreter commands via Force Quit, Interrupt, and Shutdown for both Python and R.
 - Tests confirm that each quick input command triggers the expected behavior, verified through console outputs (see Table below).
+- After each test, console is cleared and session is fully deleted. Doing both for each test makes the tests more robust indeed.
 
  * |Command   |Language|Targeted Console Output    |
  * |----------|--------|---------------------------|
@@ -14,11 +15,12 @@ Summary:
  * |Force Quit|R       |'was forced to quit'       |
  * |Interrupt |Python  |'KeyboardInterrupt'        |
  * |Interrupt |R       |Empty error line (visible) |
- * |Shutdown  |Python  |'shut down successfully'   |
- * |Shutdown  |R       |'shut down successfully'   |
+ * |Shutdown  |Python  |'exited'                   |
+ * |Shutdown  |R       |'exited'                   |
  */
 
 import { test, tags, expect } from '../_test.setup';
+import type { TestInfo } from '@playwright/test'; // remove test.skip and TestInfo import after bug #4604 is fixed
 
 test.use({
 	suiteId: __filename
@@ -28,20 +30,28 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag
 	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', async function ({ app, python }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
+		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 	});
 
 	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', async function ({ app, r }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
+		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 	});
 
-	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }) {
+	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }, testInfo: TestInfo) {
+		// This if statement is to skip e2e-windows due to bug #4604. Once it's fixed, remove if statement (and testInfo parameter)
+		if (testInfo.project.name === 'e2e-windows') {
+			test.skip();
+			return;
+		}
 		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt');
 		await app.workbench.console.clearButton.click();
+		await app.workbench.sessions.deleteAll();
 	});
 
 	test('Verify Interrupt Interpreter command works (→ empty error line) - R', async function ({ app, page, r }) {
@@ -49,18 +59,23 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await expect(page.locator('div.activity-error-stream')).toBeVisible();
 		await app.workbench.console.clearButton.click();
+		await app.workbench.sessions.deleteAll();
 	});
 
-	test('Verify Shutdown Interpreter command works (→ shut down successfully) - Python', async function ({ app, python }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.shutdown');
-		await app.workbench.console.waitForConsoleContents('shut down successfully');
+	test('Verify Shutdown Interpreter command works (→ sexited) - Python', async function ({ app, python, page }) {
+		await app.workbench.console.pasteCodeToConsole('exit()');
+		await page.keyboard.press('Enter');
+		await app.workbench.console.waitForConsoleContents('exited');
+		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 
 	});
 
-	test('Verify Shutdown Interpreter command works (→ shut down successfully) - R', async function ({ app, r }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.shutdown');
-		await app.workbench.console.waitForConsoleContents('shut down successfully');
+	test('Verify Shutdown Interpreter command works (→ exited) - R', async function ({ app, r, page }) {
+		await app.workbench.console.pasteCodeToConsole('q()');
+		await page.keyboard.press('Enter');
+		await app.workbench.console.waitForConsoleContents('exited');
+		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 	});
 });

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -27,18 +27,19 @@ test.use({
 });
 
 test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag: [tags.WEB, tags.WIN, tags.INTERPRETER] }, () => {
+	test.afterEach(async ({ app }) => {
+		await app.workbench.console.clearButton.click();
+		await app.workbench.sessions.deleteAll();
+	});
+
 	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', async function ({ app, python }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
 	});
 
 	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', async function ({ app, r }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
 		await app.workbench.console.waitForConsoleContents('was forced to quit');
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
 	});
 
 	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }, testInfo: TestInfo) {
@@ -50,32 +51,23 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag
 		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt');
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
 	});
 
 	test('Verify Interrupt Interpreter command works (→ empty error line) - R', async function ({ app, page, r }) {
 		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await expect(page.locator('div.activity-error-stream')).toBeVisible();
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
 	});
 
-	test('Verify Shutdown Interpreter command works (→ sexited) - Python', async function ({ app, python, page }) {
+	test('Verify Shutdown Interpreter command works (→ exited) - Python', async function ({ app, python, page }) {
 		await app.workbench.console.pasteCodeToConsole('exit()');
 		await page.keyboard.press('Enter');
 		await app.workbench.console.waitForConsoleContents('exited');
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
-
 	});
 
 	test('Verify Shutdown Interpreter command works (→ exited) - R', async function ({ app, r, page }) {
 		await app.workbench.console.pasteCodeToConsole('q()');
 		await page.keyboard.press('Enter');
 		await app.workbench.console.waitForConsoleContents('exited');
-		await app.workbench.console.clearButton.click();
-		await app.workbench.sessions.deleteAll();
 	});
 });

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -47,7 +47,7 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', { tag
 	test('Verify Interrupt Interpreter command works (→ empty error line) - R', async function ({ app, page, r }) {
 		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
-		expect(page.locator('div.activity-error-stream')).toBeVisible;
+		await expect(page.locator('div.activity-error-stream')).toBeVisible();
 		await app.workbench.console.clearButton.click();
 	});
 


### PR DESCRIPTION
- This test suite verifies the functionality of interpreter commands via `Force Quit`, `Interrupt`, and `Shutdown`* for both Python and R.
- Tests confirm that each quick input command triggers the expected behavior, verified through console outputs.
- After each test, console is cleared and all sessions are deleted. This clean-up makes test suite more robust and reliable.
- For test 3 (`'Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python'`), we are temporarily skipping it for `e2e-windows` due to bug #4604 . Once bug is fixed and verified, we can remove if statement logic for skipping test.
`*` Observation: `Shutdown` has been deprecated as part of #7803 . Hence, we are relying on `exit()` and `q()` to shutdown/exit the interpreter.

| Command    | Language | Targeted Console Output       |
|------------|----------|-------------------------------|
| Force Quit | Python   | 'was forced to quit'          |
| Force Quit | R        | 'was forced to quit'          |
| Interrupt  | Python   | 'KeyboardInterrupt'           |
| Interrupt  | R        | Empty error line (visible)    |
| Shutdown   | Python   | 'exited'      |
| Shutdown   | R        | 'exited'      |

### QA Notes

@:web @:win @:interpreter