### PR TITLE
E2E test: allow bootstrap-extensions.test.ts to run in parallel with other tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,8 +21,7 @@ export default defineConfig<ExtendedTestOptions>({
 	globalSetup: './test/e2e/tests/_global.setup.ts',
 	testDir: './test/e2e',
 	testIgnore: [
-		'example.test.ts',
-		'extensions/bootstrap-extensions.test.ts'
+		'example.test.ts'
 	],
 	testMatch: '*.test.ts',
 	fullyParallel: false, // Run individual tests w/in a spec in parallel


### PR DESCRIPTION
Need to allow this to run with other tests because it cannot run first if ignored

### QA Notes

