### PR TITLE
E2E test: allow remaining tests to run if bootstrap check fails

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -241,7 +241,7 @@ jobs:
 
           # Don't run this test in parallel & don't allow skipping it
           echo "Running: DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null"
-          eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null
+          eval DISPLAY=:10 npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null || true
           BOOTSTRAP_EXIT_CODE=$?
 
           # Run the Playwright test command directly using eval
@@ -250,8 +250,8 @@ jobs:
 
           # Fail the step if the bootstrap test failed
           if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then
-            echo "Bootstrap extensions test failed."
-            exit $BOOTSTRAP_EXIT_CODE
+            echo "Bootstrap extensions test failed. Exiting with code $BOOTSTRAP_EXIT_CODE."
+            exit "$BOOTSTRAP_EXIT_CODE"
           fi
 
 


### PR DESCRIPTION
Added || true so bootstrap test can fail and others will still run

### QA Notes


