### PR TITLE
e2e test: fix flake in `notebook-raises-exception.test.ts`

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -71,6 +71,14 @@ export class HotKeys {
 		await this.pressHotKeys(`Cmd+K Cmd+W`);
 	}
 
+	public async scrollToTop() {
+		await this.pressHotKeys(`Cmd+ArrowUp`);
+	}
+
+	public async scrollToBottom() {
+		await this.pressHotKeys(`Cmd+ArrowDown`);
+	}
+
 	// --- Console & Visuals ---
 	public async visualMode() {
 		await this.pressHotKeys(`Cmd+Shift+F4`);

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -72,11 +72,13 @@ export class HotKeys {
 	}
 
 	public async scrollToTop() {
-		await this.pressHotKeys(`Cmd+ArrowUp`);
-	}
+		const platform = process.platform;
 
-	public async scrollToBottom() {
-		await this.pressHotKeys(`Cmd+ArrowDown`);
+		if (platform === 'win32' || platform === 'linux') {
+			await this.code.driver.page.keyboard.press('Home');
+		} else {
+			await this.pressHotKeys(`Cmd+ArrowUp`);
+		}
 	}
 
 	// --- Console & Visuals ---

--- a/test/e2e/tests/notebook/notebook-raises-exception.test.ts
+++ b/test/e2e/tests/notebook/notebook-raises-exception.test.ts
@@ -23,8 +23,9 @@ test.describe('Notebook Cell Execution with raises-exception tag', {
 			await app.workbench.notebooks.closeNotebookWithoutSaving();
 		});
 
-		test('Python - Execution stops at exception without raises-exception tag', async function ({ app, page }) {
+		test('Python - Execution stops at exception without raises-exception tag', async function ({ app, page, hotKeys }) {
 			// Cell 1: Normal execution
+			await hotKeys.scrollToTop();
 			await app.workbench.notebooks.addCodeToCellAtIndex('print("Cell 1 executed")');
 
 			// Cell 2: Exception without tag (should stop execution)
@@ -47,8 +48,9 @@ test.describe('Notebook Cell Execution with raises-exception tag', {
 			await expect(cell3Output).not.toBeVisible();
 		});
 
-		test('Python - Execution continues after exception with raises-exception tag', async function ({ app, page }) {
+		test('Python - Execution continues after exception with raises-exception tag', async function ({ app, page, hotKeys }) {
 			// Cell 1: Normal execution
+			await hotKeys.scrollToTop();
 			await app.workbench.notebooks.addCodeToCellAtIndex('print("Cell 1 executed")');
 
 			// Cell 2: Exception with raises-exception tag


### PR DESCRIPTION
### Summary

This test was consistently failing because the cell was behind the notebook toolbar and unable to click as needed. Adjusted test to scroll to top before interacting.

How bad this has been flaking:
<img width="1126" alt="Screenshot 2025-06-02 at 10 48 18 AM" src="https://github.com/user-attachments/assets/9675e81e-7a2d-4025-948d-a479bafafe62" />
<img width="295" alt="Screenshot 2025-06-02 at 10 46 55 AM" src="https://github.com/user-attachments/assets/62e4c258-fcc7-49f9-af49-ece4eec776b1" />



### QA Notes

@:notebooks @:win