### PR TITLE
Updates e2e context menu fixture to support Windows & Linux

### DIFF
--- a/test/e2e/infra/contextMenu.ts
+++ b/test/e2e/infra/contextMenu.ts
@@ -93,7 +93,7 @@ export class ContextMenu {
 	 * @param trigger A function that triggers the context menu (e.g., a click on a button)
 	 * @returns
 	 */
-	private async showContextMenu(trigger: () => void): Promise<{ menuId: number; items: string[] } | undefined> {
+	private async showContextMenu(trigger: () => Promise<void>): Promise<{ menuId: number; items: string[] } | undefined> {
 		try {
 			if (!this.code.electronApp) {
 				throw new Error('Electron app is not available before attempting to trigger context menu.');

--- a/test/e2e/infra/contextMenu.ts
+++ b/test/e2e/infra/contextMenu.ts
@@ -12,6 +12,7 @@ export class ContextMenu {
 	constructor(
 		private code: Code,
 		private projectName: string,
+		private platform: string,
 	) { }
 
 	/**
@@ -23,7 +24,7 @@ export class ContextMenu {
 	 */
 	async triggerAndClick({ menuTrigger, menuItemLabel }: { menuTrigger: Locator; menuItemLabel: string }): Promise<void> {
 		await test.step(`Trigger context menu and click '${menuItemLabel}'`, async () => {
-			if (!this.projectName.includes('browser')) {
+			if (this.platform === 'darwin') {
 				await this._triggerAndClick({ menuTrigger, menuItemLabel });
 			}
 			else {

--- a/test/e2e/infra/contextMenu.ts
+++ b/test/e2e/infra/contextMenu.ts
@@ -9,6 +9,9 @@ import test, { Locator } from '@playwright/test';
 export class ContextMenu {
 	private page = this.code.driver.page;
 	private isNativeMenu: boolean;
+	private contextMenu: Locator = this.page.locator('.monaco-menu');
+	private contextMenuItems: Locator = this.contextMenu.getByRole('menuitem');
+	private getContextMenuItem: (label: string) => Locator = (label: string) => this.contextMenu.getByRole('menuitem', { name: label });
 
 	constructor(
 		private code: Code,
@@ -32,9 +35,9 @@ export class ContextMenu {
 			}
 			else {
 				await menuTrigger.click();
-				await this.page.getByRole('menuitem', { name: menuItemLabel }).hover();
+				await this.getContextMenuItem(menuItemLabel).hover();
 				await this.page.waitForTimeout(500);
-				await this.page.getByRole('menuitem', { name: menuItemLabel }).click();
+				await this.getContextMenuItem(menuItemLabel).click();
 			}
 		});
 	}
@@ -57,7 +60,7 @@ export class ContextMenu {
 				return menuItems.items;
 			} else {
 				await menuTrigger.click();
-				const menuItems = this.page.getByRole('menuitem');
+				const menuItems = this.contextMenuItems;
 				const count = await menuItems.count();
 				const labels: string[] = [];
 

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -166,7 +166,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 
 	// This fixture provides a way interact with context menu items for both Electron and web apps. :tada:
 	contextMenu: [async ({ app }, use, testInfo) => {
-		const contextMenu = new ContextMenu(app.code, testInfo.project.name);
+		const contextMenu = new ContextMenu(app.code, testInfo.project.name, process.platform);
 		await use(contextMenu);
 	},
 	{ scope: 'test' }],

--- a/test/e2e/tests/sessions/session-add.test.ts
+++ b/test/e2e/tests/sessions/session-add.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Sessions: Console Add +', {
-	tag: [tags.WEB_ONLY, tags.SESSIONS, tags.CONSOLE]
+	tag: [tags.SESSIONS, tags.CONSOLE]
 }, () => {
 
 	test('Validate can duplicate runtime via Console + button', async function ({ app, page }) {

--- a/test/e2e/tests/sessions/session-add.test.ts
+++ b/test/e2e/tests/sessions/session-add.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Sessions: Console Add +', {
-	tag: [tags.SESSIONS, tags.CONSOLE]
+	tag: [tags.SESSIONS, tags.CONSOLE, tags.WEB, tags.WIN]
 }, () => {
 
 	test('Validate can duplicate runtime via Console + button', async function ({ app, page }) {


### PR DESCRIPTION
Context menus were not functioning properly in Ubuntu & Windows e2e testing. The context menu infrastructure uses HTML-based menus on web, and on Windows & Linux when native titlebars are disabled. 

This PR reworks e2e infrastructure to support this logic.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Context menus in e2e tests supported on Linux & Windows


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:sessions, @:web, @:win