### PR TITLE
Fix showing local web servers over Remote SSH

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -15,6 +15,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { PlotRenderSettings } from '../../positronPlots/common/positronPlots.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 
 export const POSITRON_PREVIEW_PLOTS_IN_VIEWER = 'positron.viewer.interactivePlotsInViewer';
 
@@ -107,6 +108,7 @@ export class UiClientInstance extends Disposable {
 		private readonly _logService: ILogService,
 		private readonly _openerService: IOpenerService,
 		private readonly _configurationService: IConfigurationService,
+		private readonly _environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 		this._register(this._client);
@@ -248,8 +250,9 @@ export class UiClientInstance extends Disposable {
 
 		let uri = URI.parse(url);
 		try {
+			const allowTunneling = !!this._environmentService.remoteAuthority;
 			const resolvedUri = await this._openerService.resolveExternalUri(uri, {
-				allowTunneling: true,
+				allowTunneling,
 			});
 			uri = resolvedUri.resolved;
 		} catch {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -149,7 +149,10 @@ export class UiClientInstance extends Disposable {
 
 				// Resolve the URI if it is an external URI
 				try {
-					const resolvedUri = await this._openerService.resolveExternalUri(uri);
+					const allowTunneling = !!this._environmentService.remoteAuthority;
+					const resolvedUri = await this._openerService.resolveExternalUri(uri, {
+						allowTunneling,
+					});
 					uri = resolvedUri.resolved;
 				} catch {
 					// Noop; use the original URI

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -248,7 +248,9 @@ export class UiClientInstance extends Disposable {
 
 		let uri = URI.parse(url);
 		try {
-			const resolvedUri = await this._openerService.resolveExternalUri(uri);
+			const resolvedUri = await this._openerService.resolveExternalUri(uri, {
+				allowTunneling: true,
+			});
 			uri = resolvedUri.resolved;
 		} catch {
 			// Noop; use the original URI
@@ -283,6 +285,6 @@ export class UiClientInstance extends Disposable {
 	 *
 	 */
 	public async didChangePlotsRenderSettings(settings: PlotRenderSettings): Promise<void> {
-			await this._comm.didChangePlotsRenderSettings(settings);
+		await this._comm.didChangePlotsRenderSettings(settings);
 	}
 }

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,6 +10,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { RuntimeClientState } from '../../languageRuntime/common/languageRuntimeClientInstance.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { IUiClientMessageInput, IUiClientMessageOutput, UiClientInstance } from '../../languageRuntime/common/languageRuntimeUiClient.js';
@@ -53,6 +54,7 @@ export class ActiveRuntimeSession extends Disposable {
 		private readonly _logService: ILogService,
 		private readonly _openerService: IOpenerService,
 		private readonly _configurationService: IConfigurationService,
+		private readonly _environmentService: IWorkbenchEnvironmentService
 	) {
 		super();
 
@@ -133,7 +135,9 @@ export class ActiveRuntimeSession extends Disposable {
 			(RuntimeClientType.Ui, {});
 
 		// Create the UI client instance wrapping the client instance.
-		const uiClient = new UiClientInstance(client, this._commandService, this._logService, this._openerService, this._configurationService);
+		const uiClient = new UiClientInstance(client, this._commandService, this._logService, this._openerService, this._configurationService,
+			this._environmentService
+		);
 		this._uiClient = uiClient;
 		this._register(this._uiClient);
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -26,6 +26,7 @@ import { IUpdateService } from '../../../../platform/update/common/update.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { localize } from '../../../../nls.js';
 import { UiClientInstance } from '../../languageRuntime/common/languageRuntimeUiClient.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 
 /**
  * The maximum number of active sessions a user can have running at a time.
@@ -165,6 +166,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IUpdateService private readonly _updateService: IUpdateService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService
 	) {
 
 		super();
@@ -1662,6 +1664,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			this._logService,
 			this._openerService,
 			this._configurationService,
+			this._environmentService,
 		);
 		this._activeSessionsBySessionId.set(session.sessionId, activeSession);
 		this._register(activeSession);


### PR DESCRIPTION
This change fixes an issue that happens in Remote SSH environments when viewing content from web servers on the remote machine.

<img width="1691" alt="image" src="https://github.com/user-attachments/assets/eb23f363-876b-47e3-ba5a-95657c43c99a" />

The issue was somewhat intermittent because it's timing-related. Very briefly, content from web servers on Remote SSH is made available on the client machine by creating an SSH tunnel that forwards the port, e.g. from `localhost:1234` on the remote machine to `localhost:1234` on the client. However, we load the URL immediately in the Viewer, which causes it to attempt to load before the tunnel is created in some cases.

The fix is very straightforward: when running in a remote environment, we add the `allowTunneling` flag when resolving the URL. This causes the port forwarding to happen immediately (before we attempt to load the URL), and also has the advantage of correcting the URL in the case that there is a port conflict.

Addresses https://github.com/posit-dev/positron/issues/7406.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix failure loading local web server (e.g. Shiny) content in the Viewer pane in Remote SSH sessions (#7406)


### QA Notes

