### PR TITLE
Fix Publisher test - validate password input field is present and skip test if Dogfood is down

### DIFF
--- a/test/e2e/pages/connect.ts
+++ b/test/e2e/pages/connect.ts
@@ -16,7 +16,7 @@ export class PositConnect {
 		}
 		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`;
 		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
-		const userGuid = (await (await fetch(connectApiUrl + 'user', { headers: headers })).json()).guid;
+		const userGuid = await this.getUser();
 
 		const appInfo = await (await fetch(connectApiUrl + `content?owner_guid=${userGuid}`, { headers: headers })).json();
 
@@ -32,6 +32,16 @@ export class PositConnect {
 				throw new Error(`Failed to delete content with GUID: ${guid}`);
 			}
 		}
+	}
+
+	async getUser(): Promise<string> {
+		if (!process.env.E2E_CONNECT_SERVER || !process.env.E2E_CONNECT_APIKEY) {
+			throw new Error('Missing E2E_CONNECT_SERVER or E2E_CONNECT_APIKEY env vars.');
+		}
+		const connectApiUrl = `${process.env.E2E_CONNECT_SERVER}__api__/v1/`;
+		const headers = { 'Authorization': `Key ${process.env.E2E_CONNECT_APIKEY}` };
+		const userGuid = (await (await fetch(connectApiUrl + 'user', { headers: headers })).json()).guid;
+		return userGuid;
 	}
 
 	// To prevent flakiness, this function always add the file name after app.py, which is guaranteed to be present


### PR DESCRIPTION
#### New Features

- Skip test if Dogfood is down
- Test should fail if password input field is NOT visible in order to prevent automation from pasting credentials to incorrect locations (e.g., if order of input boxes changes in the future)
- Instructions for how to delete stored credentials when running it locally (to prevent failure due to saved credentials. 

### QA Notes

@:web @:win @:publisher
