### PR TITLE
Register renv.lock as a file association instead of a language

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -399,15 +399,6 @@
           ".Rd"
         ],
         "configuration": "./language-configuration/r-docs-language-configuration.json"
-      },
-      {
-        "id": "json",
-        "aliases": [
-          "renv lockfile"
-        ],
-        "filenames": [
-          "renv.lock"
-        ]
       }
     ],
     "grammars": [

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -13,6 +13,7 @@ import { setupTestExplorer, refreshTestExplorer } from './testing/testing';
 import { RRuntimeManager } from './runtime-manager';
 import { registerUriHandler } from './uri-handler';
 import { registerRLanguageModelTools } from './llm-tools.js';
+import { registerFileAssociations } from './file-associations.js';
 
 export const LOGGER = vscode.window.createOutputChannel('R Language Pack', { log: true });
 
@@ -37,6 +38,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Provide tasks.
 	providePackageTasks(context);
+
+	// Register file associations.
+	registerFileAssociations();
 
 	// Prepare to handle cli-produced hyperlinks that target the positron-r extension.
 	registerUriHandler();

--- a/extensions/positron-r/src/file-associations.ts
+++ b/extensions/positron-r/src/file-associations.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * Registers the file association for 'renv.lock' to be treated as a JSON file.
+ */
+export function registerFileAssociations(): void {
+	const config = vscode.workspace.getConfiguration();
+	const fileAssociations = config.get('files.associations') as Record<string, string> || {};
+
+	if (!fileAssociations['renv.lock']) {
+		fileAssociations['renv.lock'] = 'json';
+		config.update('files.associations', fileAssociations, vscode.ConfigurationTarget.Global);
+	}
+}


### PR DESCRIPTION
This change fixes an issue that causes all JSON files to show up as "renv lockfiles". Instead of re-using the `json` ID for these files, we register `renv.lock` with the JSON file type.

There is a slightly more complicated way to address this that would allow renv lockfiles to have their own file type with custom schema/grammar that derives from JSON, but probably not worth it given that these are not meant to be hand-edited in the first place. 

Addresses #7777.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing all JSON files to have the filetype "renv lockfile" (#7777)


### QA Notes

Note that after the change, renv lockfiles no longer have a special file type. They should now just show up as JSON files.

