### PR TITLE
Fix issue setting working directory on Remote SSH

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1246,8 +1246,9 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 				// When connected to a remote environment, use the path directly.
 				session.setWorkingDirectory(resource.path);
 			} else {
-				// When not connected to a remote environment, use the local file system.
-				session.setWorkingDirectory(resource.fsPath);
+				// When not connected to a remote environment, use the local
+				// filesystem path if it exists.
+				session.setWorkingDirectory(resource.fsPath ?? resource.path);
 			}
 		} catch (e) {
 			notificationService.error(e);


### PR DESCRIPTION
This change addresses an issue that makes _Set as Working Directory_ fail when the client is Windows and the server is Linux. 

This issue is that we are using `fsPath` to convert the directory URI to a string. This is in fact necessary when running natively on Windows since it formats the drive letter/etc correctly, but breaks paths if the intended destination is Linux.

The fix is to use the plain `path` when connected to a remote. 

Addresses https://github.com/posit-dev/positron/issues/7239. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix failure to set working directory from Explorer when connecting Remote SSH from Windows to Linux (#7239)


### QA Notes

I tested Windows (local), Windows -> Linux, MacOS (local), and MacOS -> Linux. You probably don't need to verify ALL of these, but it's worth checking some.