### PR TITLE
e2e test: updated import vscode settings test to clear contents of user settings json for test

### DIFF
--- a/test/e2e/tests/zzz_import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/zzz_import-vs-code-settings/import-vscode-settings.test.ts
@@ -35,6 +35,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 		workspaceSettings = await app.workbench.settings.backupWorkspaceSettings();
 		await app.workbench.settings.removeWorkspaceSettings(['positron.importSettings.enable']);
 		await vscodeUserSettings.ensureExists();
+		await positronUserSettings.delete();
 		await positronUserSettings.ensureExists();
 		await runCommand('workbench.action.reloadWindow');
 	});


### PR DESCRIPTION
### Summary

There was a recent change (https://github.com/posit-dev/positron/pull/7926) that impacts the expected contents of the user settings JSON for the import vscode settings test. Updated the test to backup, then delete (this part is new), and then it writes our dummy content to the settings json.

I might look into just appending our dummy contents, but for now this was a super simple fix.

### QA Notes

@:vscode-settings @:web @:win
