### PR TITLE
Assistant: Welcome screen style improvements

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -73,6 +73,8 @@ import { ChatViewWelcomePart } from './viewsWelcome/chatViewWelcomeController.js
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ILanguageModelsService } from '../common/languageModels.js';
 import { ChatActionBarControl } from './positron/chatActionBarControl.js';
+// eslint-disable-next-line no-duplicate-imports
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -731,6 +733,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		const numItems = this.viewModel?.getItems().length ?? 0;
 		let welcomeText;
 		let welcomeTitle;
+		let firstLinkToButton = false;
+		let tips: IMarkdownString | undefined;
 
 		// Show an extra configuration link if there are no configured models yet
 		if (!this.configurationService.getValue('positron.assistant.enable')) {
@@ -738,7 +742,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			welcomeText = localize('positronAssistant.comingSoonMessage', "Positron Assistant is under development and will be available in a future version of Positron.\n");
 		} else if (this.languageModelsService.getLanguageModelIds().length === 0) {
 			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
-			const addLanguageModelMessage = localize('positronAssistant.addLanguageModelMessage', "Add Language Model");
+			const addLanguageModelMessage = localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider");
+			firstLinkToButton = true;
 			// create a multi-line message
 			welcomeText = localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n");
 			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.addModelConfiguration)`;
@@ -747,13 +752,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			// eslint-disable-next-line local/code-no-unexternalized-strings
 			welcomeText = localize('positronAssistant.welcomeMessageReady', `Positron Assistant is an AI coding companion designed to accelerate and enhance your data science projects.
 
-Click on or type $(mention) to work with Chat Participants in Positron Assistant.
-
-Click on $(attach) or type \`#\` to add context, such as files to your Positron Assistant chat.
-
-Type \`/\` to use predefined quick commands such as \`/help\` or \`/quarto\`.
-
 Always verify results. AI assistants can sometimes produce incorrect code.`);
+			// eslint-disable-next-line local/code-no-unexternalized-strings
+			tips = new MarkdownString(localize('positronAssistant.welcomeMessageReadyTips', `Type $(mention) to select a Chat Participant.
+
+Click on $(attach) or type \`#\` to add context, such as files to your chat.
+
+Type \`/\` to use predefined commands such as \`/help\` or \`/quarto\`.`,
+			), { supportThemeIcons: true, isTrusted: true });
 		}
 
 		dom.clearNode(this.welcomeMessageContainer);
@@ -763,10 +769,12 @@ Always verify results. AI assistants can sometimes produce incorrect code.`);
 				icon: ThemeIcon.fromId('positron-assistant'),
 				title: welcomeTitle,
 				message: new MarkdownString(welcomeText, { supportThemeIcons: true, isTrusted: true }),
+				tips,
 			},
 			{
 				location: this.location,
-				isWidgetAgentWelcomeViewContent: this.input?.currentMode === ChatMode.Agent
+				isWidgetAgentWelcomeViewContent: this.input?.currentMode === ChatMode.Agent,
+				firstLinkToButton,
 			}
 		);
 		dom.append(this.welcomeMessageContainer, this.welcomePart.value.element);

--- a/src/vs/workbench/contrib/chat/browser/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatViewWelcome.css
@@ -74,11 +74,6 @@ div.chat-welcome-view {
 
 	& > .chat-welcome-view-message {
 		text-align: center;
-		/* Begin Positron */
-		/* Center aligned text is pretty hard to read and Positron’s welcome
-		message is fairly long. */
-		text-align: start;
-		/* End Positron */
 		max-width: 350px;
 		padding: 0 20px;
 		margin-top: 10px;
@@ -106,12 +101,22 @@ div.chat-welcome-view {
 		}
 
 		.rendered-markdown p {
+			/* --- Start Positron ---
+			Disable flexbox since it breaks normal text flow when tips are longer than one line.
+			The intention was probably to format codicons which we handle in a different way below.
 			display: flex;
 			gap: 6px;
+			--- End Positron --- */
 			margin: 6px 0 0 0;
 
 			.codicon {
+				/* --- Start Positron ---
+				Instead of making the parent a flex container, vertically align the codicon
+				with a slight offset to match the text baseline.
 				padding-top: 1px;
+				--- End Positron ---*/
+				vertical-align: middle;
+				margin-bottom: 2px;
 			}
 		}
 	}
@@ -120,5 +125,6 @@ div.chat-welcome-view {
 /* --- Start Positron --- */
 div.chat-welcome-view-container div.chat-welcome-view-message .rendered-markdown .codicon {
 	vertical-align: middle;
+	margin-bottom: 2px;
 }
 /* --- End Positron --- */


### PR DESCRIPTION
Changes the "Add Language Model" link to a button and rewords it:

<img width="326" alt="image" src="https://github.com/user-attachments/assets/57ab6058-6282-43a5-8293-7fafcb7f417d" />

A previous fix for small screens (#7914) also made this left-aligned which didn't look great for the button. I opted to put the tips in the "tips" container, which is already left aligned and with a margin (we can adjust that), and reverted to center alignment for the main message and the button. If we don't like that, we could also customize the upstream code a bit more to center the button and retain our previous tips formatting.

<img width="373" alt="image" src="https://github.com/user-attachments/assets/977883b3-d9be-40c2-975f-415a29cda86f" />

Does not break small screen behavior:

<img width="426" alt="image" src="https://github.com/user-attachments/assets/16ab3c0d-d29b-499f-9529-a5db4569447c" />