### PR TITLE
fix broken extension url from upstream merge

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -47,7 +47,7 @@ export class ExtensionGalleryManifestService extends Disposable implements IExte
 			},
 			{
 				// --- Start PWB: Fix Open VSX URLs
-				id: `${extensionsGallery.serviceUrl}/vscode/{publisher}/{name}/latest`,
+				id: `${extensionsGallery.serviceUrl}/{publisher}/{name}/latest`,
 				// --- End PWB: Fix Open VSX URLs
 				type: ExtensionGalleryResourceType.ExtensionLatestVersionUri
 			},


### PR DESCRIPTION
Addresses #7807 
Pulls in change originally made in https://github.com/posit-dev/positron/pull/7374 that had been overwritten.

Interestingly, I couldn't actually reproduce the issue off of main this time, but I think that must've been due to my environment and this should fix the issue.
