### PR TITLE
E2E test: await bootstrap install on windows; skip during main CI run

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -246,7 +246,7 @@ jobs:
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
-          eval DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+          eval DISPLAY=:10 SKIP_BOOTSTRAP=true npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
           # Fail the step if the bootstrap test failed
           if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -196,7 +196,18 @@ jobs:
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
-        run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+        run: |
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=null || true
+          BOOTSTRAP_EXIT_CODE=$?
+
+          SKIP_BOOTSTRAP=true npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+
+          # Fail the step if the bootstrap test failed
+          if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then
+            echo "Bootstrap extensions test failed. Exiting with code $BOOTSTRAP_EXIT_CODE."
+            exit "$BOOTSTRAP_EXIT_CODE"
+          fi
+
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -13,7 +13,7 @@ test.use({
 
 
 test.describe('Bootstrap Extensions', {
-	tag: [tags.EXTENSIONS, tags.WEB],
+	tag: [tags.EXTENSIONS, tags.WEB, tags.WIN],
 }, () => {
 
 	test.beforeAll('Skip during main run', async function () {

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -16,6 +16,12 @@ test.describe('Bootstrap Extensions', {
 	tag: [tags.EXTENSIONS, tags.WEB],
 }, () => {
 
+	test.beforeAll('Skip during main run', async function () {
+		if (process.env.SKIP_BOOTSTRAP === 'true') {
+			test.skip();
+		}
+	});
+
 	test('Verify All Bootstrap extensions are installed', async function ({ options }) {
 		const extensions = readProductJson();
 		await waitForExtensions(extensions, options.extensionsPath);


### PR DESCRIPTION
Perform waiting for bootstrap extensions for windows.

Don't re-run bootstrap extensions case during main runs.

### QA Notes

@:web @:win @:all
