### PR TITLE
Bump ark to 0.1.188

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -757,7 +757,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.187"
+      "ark": "0.1.188"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Bumps ark version to 0.1.188 to pick up the fix for https://github.com/posit-dev/positron/issues/4843 (see https://github.com/posit-dev/ark/pull/818)

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue opening localhost URLs from `shiny::paneViewer()` and related methods in R (#4843)

