### PR TITLE
e2e-test: notebook-create handle possibility of 2 spinners!

### DIFF
--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -116,7 +116,7 @@ export class Notebooks {
 	async executeCodeInCell() {
 		await test.step('Execute code in cell', async () => {
 			await this.quickaccess.runCommand(EXECUTE_CELL_COMMAND);
-			await expect(this.code.driver.page.locator(EXECUTE_CELL_SPINNER), 'execute cell spinner to not be visible').not.toBeVisible({ timeout: 30000 });
+			await expect(this.code.driver.page.locator(EXECUTE_CELL_SPINNER), 'execute cell spinner to not be visible').toHaveCount(0, { timeout: 30000 });
 		});
 	}
 


### PR DESCRIPTION
### Summary
In some (not all) instances we have 2 code execution spinners. Modified code to make sure none are present in UI (previously test failed if it matched more than 1).

<img width="255" alt="Screenshot 2025-06-03 at 4 13 09 PM" src="https://github.com/user-attachments/assets/36d46d77-8025-4572-8e81-98585a785823" />


### QA Notes
n/a
