### PR TITLE
Fix intermittent issue applying mapped edits

### DIFF
--- a/extensions/positron-assistant/src/edits.ts
+++ b/extensions/positron-assistant/src/edits.ts
@@ -105,5 +105,23 @@ async function mapEdit(
 		}
 		replacement += delta;
 	}
+
+	// The model is instructed in `mapedit.md` to return the result as plain
+	// JSON. Despite these instructions, it has been known to return the JSON
+	// inside a Markdown code fence. If it does, we need to extract the JSON
+	// content from it so it can be parsed correctly.
+	const jsonStart = replacement.indexOf('```json');
+	if (jsonStart !== -1) {
+		const jsonEnd = replacement.indexOf('```', jsonStart + 6);
+		if (jsonEnd !== -1) {
+			replacement = replacement.substring(jsonStart + 6, jsonEnd).trim();
+		} else {
+			// If the closing code fence is missing, we return the whole content after the opening code fence.
+			replacement = replacement.substring(jsonStart + 6).trim();
+		}
+	} else {
+		// If no code fence is found, we assume the model returned plain JSON.
+		replacement = replacement.trim();
+	}
 	return replacement;
 }

--- a/extensions/positron-assistant/src/md/prompts/chat/mapedit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/mapedit.md
@@ -3,4 +3,5 @@ You will be given a document and a block. Output a JSON array containing objects
 For example, for the input { "document": "a\nb\nc\nd\ne", "block": "b\n123\ne" } output [{ "delete": "b\nc\nd\ne", "replace": "b\n123\ne" }].
 
 If it is not clear where the block should go, output an { "append": string } object in the array to add it to the end of the document.
-Return ONLY the JSON string, nothing else.
+Return ONLY the JSON string, nothing else. Do NOT use a code fence, return the JSON as plain output.
+


### PR DESCRIPTION
This change fixes an intermittent issue applying changes from a block in Positron Assistant to the code editor. 

We ask the model to generate a list of changes to apply and return the list as JSON, which we then parse. However, the model sometimes returns the JSON inside a Markdown code fence. That whole result gets parsed as JSON and fails since code fences aren't JSON. 

It's difficult to keep the model from doing this since most models seem trained to do it. I have tried to work around this behavior as follows:
- Instructing the model more specifically not to use code fences in its output.
- If the model _does_ return output wrapped in a JSON code fence, discard the fence before parsing the JSON. 

Addresses https://github.com/posit-dev/positron/issues/7188.

### QA Notes

This issue is very dependent on stochastic behavior from the model, and does not reproduce reliably for me, so try it in several contexts.