### PR TITLE
Assistant: Refine language model provider configuration commands

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -95,7 +95,7 @@
         "command": "positron-assistant.addModelConfiguration",
         "title": "%commands.addModelConfiguration.title%",
         "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable"
+        "enablement": "config.positron.assistant.enable && !config.positron.assistant.newModelConfiguration"
       },
       {
         "command": "positron-assistant.configureModels",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -1,8 +1,8 @@
 {
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
-	"commands.addModelConfiguration.title": "Add Language Model",
-	"commands.configureModels.title": "Configure Language Models",
+	"commands.addModelConfiguration.title": "Add Language Model Provider",
+	"commands.configureModels.title": "Configure Language Model Providers",
 	"commands.copilot.signin.title": "Copilot Sign In",
 	"commands.copilot.signout.title": "Copilot Sign Out",
 	"commands.category": "Positron Assistant",

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -173,16 +173,22 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 
 function registerAddModelConfigurationCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.addModelConfiguration', () => {
-			showConfigurationDialog(context, storage);
+		vscode.commands.registerCommand('positron-assistant.addModelConfiguration', async () => {
+			await showConfigurationDialog(context, storage);
 		})
 	);
 }
 
 function registerConfigureModelsCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.configureModels', () => {
-			showModelList(context, storage);
+		vscode.commands.registerCommand('positron-assistant.configureModels', async () => {
+			if (vscode.workspace.getConfiguration('positron.assistant').get('newModelConfiguration', true)) {
+				// The new model configuration UI lets users sign out of providers as well,
+				// so there's no need to show the model list.
+				await showConfigurationDialog(context, storage);
+			} else {
+				await showModelList(context, storage);
+			}
 		})
 	);
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -287,7 +287,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			height={540}
 			okButtonTitle={(() => localize('positron.languageModelModalDialog.save', "Save"))()}
 			renderer={props.renderer}
-			title={(() => localize('positron.languageModelModalDialog.title', "Add a Language Model Provider"))()}
+			title={(() => localize('positron.languageModelModalDialog.title.old', "Add a Language Model Provider"))()}
 			width={540}
 			onAccept={onAccept}
 			onCancel={onCancel}
@@ -405,7 +405,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			height={400}
 			okButtonTitle={(() => localize('positron.languageModelModalDialog.done', "Done"))()}
 			renderer={props.renderer}
-			title={(() => localize('positron.languageModelModalDialog.title', "Add a Language Model Provider"))()}
+			title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}
 			width={600}
 			onAccept={onAccept}
 		>


### PR DESCRIPTION
When the new UI is enabled (which is the default, but adjustable via the hidden `positron.assistant.newModelConfiguration` setting), both add and configure commands show the new UI, and only the configure command is included in the command palette.

I decided not to remove any of the old UI yet since it can be useful for testing models that aren't yet available in the new UI.