### PR TITLE
Assistant: Synchronize the current model and provider

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -95,7 +95,7 @@
         "command": "positron-assistant.addModelConfiguration",
         "title": "%commands.addModelConfiguration.title%",
         "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable"
+        "enablement": "config.positron.assistant.enable && !config.positron.assistant.newModelConfiguration"
       },
       {
         "command": "positron-assistant.configureModels",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -1,8 +1,8 @@
 {
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
-	"commands.addModelConfiguration.title": "Add Language Model",
-	"commands.configureModels.title": "Configure Language Models",
+	"commands.addModelConfiguration.title": "Add Language Model Provider",
+	"commands.configureModels.title": "Configure Language Model Providers",
 	"commands.copilot.signin.title": "Copilot Sign In",
 	"commands.copilot.signout.title": "Copilot Sign Out",
 	"commands.category": "Positron Assistant",

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -173,16 +173,22 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 
 function registerAddModelConfigurationCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.addModelConfiguration', () => {
-			showConfigurationDialog(context, storage);
+		vscode.commands.registerCommand('positron-assistant.addModelConfiguration', async () => {
+			await showConfigurationDialog(context, storage);
 		})
 	);
 }
 
 function registerConfigureModelsCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.configureModels', () => {
-			showModelList(context, storage);
+		vscode.commands.registerCommand('positron-assistant.configureModels', async () => {
+			if (vscode.workspace.getConfiguration('positron.assistant').get('newModelConfiguration', true)) {
+				// The new model configuration UI lets users sign out of providers as well,
+				// so there's no need to show the model list.
+				await showConfigurationDialog(context, storage);
+			} else {
+				await showModelList(context, storage);
+			}
 		})
 	);
 }

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -518,15 +518,21 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 			if (e.removed) {
 				// if the current model is removed, try to set a new model
-				if (this._currentLanguageModel && e.removed.some(model => model === this._currentLanguageModel?.identifier)) {
-					const models = this.getModels();
-					if (models.length > 0) {
+				const models = this.getModels();
+				if (models.length > 0) {
+					if (this._currentLanguageModel && e.removed.some(model => model === this._currentLanguageModel?.identifier)) {
 						this.setCurrentLanguageModel(models[0]);
-						// switch to showing models from all providers
-						this.currentProvider = undefined;
 					}
+				} else {
+					// If there are no models left, unset the current provider as well.
+					this.currentProvider = undefined;
 				}
 			}
+		}));
+
+		this._register(this._onDidChangeCurrentLanguageModel.event(e => {
+			// When a new language model is set, update the current provider.
+			this.currentProvider = { id: e.metadata.family, displayName: e.metadata.providerName ?? e.metadata.name };
 		}));
 
 		const storedCurrentProvider = this.storageService.getObject<IPositronChatProvider>(this.getSelectedProviderStorageKey(), StorageScope.APPLICATION, undefined);

--- a/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
+++ b/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
@@ -25,15 +25,13 @@ const addModelProviderTooltip = () => localize('positronChatSelector.addModelPro
 export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 	const positronActionBarContext = usePositronActionBarContext();
 	const positronChatContext = usePositronChatContext();
-
-	const [providers, setProviders] = React.useState<IPositronChatProvider[] | undefined>(positronChatContext.providers)
-	const [selectorLabel, setSelectorLabel] = React.useState<string>();
+	const { providers, currentProvider } = positronChatContext;
 
 	const actions = React.useCallback(() => {
 		const providerActions: IAction[] = [];
 		providers?.forEach((provider) => {
 			// Skip the current provider -- it's already selected.
-			if (positronChatContext.currentProvider && positronChatContext.currentProvider.id === provider.id) {
+			if (currentProvider && currentProvider.id === provider.id) {
 				return;
 			}
 
@@ -61,26 +59,10 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 		}];
 
 		return Separator.join(providerActions, otherActions);
-	}, [providers, props, positronChatContext.currentProvider, positronActionBarContext.commandService]);
+	}, [props, providers, currentProvider, positronActionBarContext.commandService]);
 
-	React.useEffect(() => {
-		if (positronChatContext.currentProvider) {
-			setSelectorLabel(positronChatContext.currentProvider.displayName);
-		} else if (providers?.length && providers.length > 1 && positronChatContext.currentProvider === undefined) {
-			setSelectorLabel((() => localize('positronChatSelector.allModels', 'All Models'))());
-		} else if (providers?.length === 1) {
-			setSelectorLabel(providers[0].displayName);
-		} else {
-			setSelectorLabel(undefined);
-		}
-	}, [positronChatContext.currentProvider, providers]);
-
-	React.useEffect(() => {
-		setProviders(positronChatContext.providers);
-	}, [positronChatContext.providers]);
-
-	const renderSelector = () => {
-		if (!selectorLabel) {
+	const renderCurrentProvider = () => {
+		if (!currentProvider) {
 			return <ActionBarButton
 				label={addModelProviderLabel()}
 				tooltip={addModelProviderTooltip()}
@@ -93,7 +75,7 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 			<LanguageModelIcon provider={positronChatContext.currentProvider?.id ?? ''} />
 			<ActionBarMenuButton
 				actions={actions}
-				label={selectorLabel}
+				label={currentProvider.displayName}
 			/>
 		</>
 	};
@@ -101,7 +83,7 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 	return (
 		<div className='chat-action-bar'>
 			<PositronActionBar>
-				{renderSelector()}
+				{renderCurrentProvider()}
 			</PositronActionBar>
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -287,7 +287,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			height={540}
 			okButtonTitle={(() => localize('positron.languageModelModalDialog.save', "Save"))()}
 			renderer={props.renderer}
-			title={(() => localize('positron.languageModelModalDialog.title', "Add a Language Model Provider"))()}
+			title={(() => localize('positron.languageModelModalDialog.title.old', "Add a Language Model Provider"))()}
 			width={540}
 			onAccept={onAccept}
 			onCancel={onCancel}
@@ -405,7 +405,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			height={400}
 			okButtonTitle={(() => localize('positron.languageModelModalDialog.done', "Done"))()}
 			renderer={props.renderer}
-			title={(() => localize('positron.languageModelModalDialog.title', "Add a Language Model Provider"))()}
+			title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}
 			width={600}
 			onAccept={onAccept}
 		>


### PR DESCRIPTION
This PR improves synchronization of the current selected language model and provider. It also removes the "All Models" option and instead automatically selects a provider when the first one is registered. Addresses #7734, #7938.

### QA Notes

1. When there are no registered models, the provider dropdown should be an "Add Model Provider..." button.
2. When signing in to the first provider, it should get automatically selected.
3. When signing out of the selected provider, an alternative provider should be selected, or if there is none the "Add Model Provider..." button should be displayed.
    1. Only the signed out provider should be unregistered (we were previously unregistering everything and reregistering again).

@:assistant