### PR TITLE
E2E test: fix plot flakes

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -388,7 +388,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('R - Two simultaneous plots', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
-			await app.workbench.console.typeToConsole(rTwoPlots, true, 100);
+			await app.workbench.console.pasteCodeToConsole(rTwoPlots, true);
 			await app.workbench.plots.waitForCurrentPlot();
 			await app.workbench.plots.expectPlotThumbnailsCountToBe(2);
 		});
@@ -397,25 +397,25 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 
 			await app.workbench.plots.enlargePlotArea();
 
-			await app.workbench.console.typeToConsole('par(mfrow = c(2, 2))', true, 100);
-			await app.workbench.console.typeToConsole('plot(1:5)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('par(mfrow = c(2, 2))', true);
+			await app.workbench.console.pasteCodeToConsole('plot(1:5)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 
-			await app.workbench.console.typeToConsole('plot(2:6)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('plot(2:6)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 
-			await app.workbench.console.typeToConsole('plot(3:7)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('plot(3:7)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 
-			await app.workbench.console.typeToConsole('plot(4:8)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('plot(4:8)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 
-			await app.workbench.console.typeToConsole('plot(5:9)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('plot(5:9)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 			await app.workbench.plots.expectPlotThumbnailsCountToBe(2);
 
-			await app.workbench.console.typeToConsole('par(mfrow = c(1, 1))', true, 100);
-			await app.workbench.console.typeToConsole('plot(1:10)', true, 100);
+			await app.workbench.console.pasteCodeToConsole('par(mfrow = c(1, 1))', true);
+			await app.workbench.console.pasteCodeToConsole('plot(1:10)', true);
 			await app.workbench.plots.waitForCurrentPlot();
 			await app.workbench.plots.expectPlotThumbnailsCountToBe(3);
 
@@ -426,10 +426,10 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 
 			await app.workbench.plots.enlargePlotArea();
 
-			await app.workbench.console.typeToConsole('par(mfrow = c(2, 1))', true, 100);
-			await app.workbench.console.typeToConsole('plot(1:10)', true, 100);
-			await app.workbench.console.typeToConsole('plot(2:20)', true, 100);
-			await app.workbench.console.typeToConsole('par(mfrow = c(1, 1))', true, 100);
+			await app.workbench.console.pasteCodeToConsole('par(mfrow = c(2, 1))', true);
+			await app.workbench.console.pasteCodeToConsole('plot(1:10)', true);
+			await app.workbench.console.pasteCodeToConsole('plot(2:20)', true);
+			await app.workbench.console.pasteCodeToConsole('par(mfrow = c(1, 1))', true);
 			await app.workbench.plots.waitForCurrentPlot();
 
 			await app.workbench.plots.restorePlotArea();
@@ -442,7 +442,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 
 			await app.workbench.console.waitForConsoleContents('restarted', { expectedCount: 1 });
 
-			await app.workbench.console.typeToConsole(rPlotAndSave, true, 100);
+			await app.workbench.console.pasteCodeToConsole(rPlotAndSave, true);
 			await app.workbench.plots.waitForCurrentPlot();
 
 			await runCommand('workbench.action.fullSizedAuxiliaryBar');


### PR DESCRIPTION
Just replacing some typeToConsole calls with pasteToConsole to reduce flakiness.

### QA Notes

@:web @:win @:plots
