### PR TITLE
e2e test: refactor python polars data explorer test to be independent

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -115,19 +115,21 @@ export class DataExplorer {
 	 * Add a filter to the data explorer.  Only works for a single filter at the moment.
 	 */
 	async addFilter(columnName: string, functionText: string, filterValue: string) {
-		await this.addFilterButton.click();
+		await test.step(`Add filter: ${columnName} ${functionText} ${filterValue}`, async () => {
+			await this.addFilterButton.click();
 
-		// select column
-		await this.selectColumnButton.click();
-		await this.code.driver.page.getByRole('button', { name: columnName }).click();
+			// select column
+			await this.selectColumnButton.click();
+			await this.code.driver.page.getByRole('button', { name: columnName }).click();
 
-		// select condition
-		await this.selectConditionButton.click();
-		await this.code.driver.page.getByRole('button', { name: functionText, exact: true }).click();
+			// select condition
+			await this.selectConditionButton.click();
+			await this.code.driver.page.getByRole('button', { name: functionText, exact: true }).click();
 
-		// enter value
-		await this.code.driver.page.getByRole('textbox', { name: 'value' }).fill(filterValue);
-		await this.applyFilterButton.click();
+			// enter value
+			await this.code.driver.page.getByRole('textbox', { name: 'value' }).fill(filterValue);
+			await this.applyFilterButton.click();
+		});
 	}
 
 	async getDataExplorerStatusBarText(): Promise<String> {
@@ -136,7 +138,7 @@ export class DataExplorer {
 	}
 
 	async selectColumnMenuItem(columnIndex: number, menuItem: string) {
-		await test.step(`Sort column ${columnIndex} by menu item: ${menuItem}`, async () => {
+		await test.step(`Sort column ${columnIndex} by: ${menuItem}`, async () => {
 			await this.code.driver.page.locator(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`).click();
 			await this.code.driver.page.locator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
 		});
@@ -269,55 +271,22 @@ export class DataExplorer {
 		});
 	}
 
-	/**
- * Universal helper method to verify column data
- * @param dataExplorer The data explorer object
- * @param expectations Array of objects containing column index, property name to verify, and expected value
- */
-	async verifyColumnData(expectations: Array<{ column?: number; property: string; expected: any }>) {
-		for (const { column, property, expected } of expectations) {
-			if (property === 'missingPercent') {
-				if (column === undefined) {
-					throw new Error('Column index must be provided for missingPercent verification');
-				}
-				const missingPercent = await this.getColumnMissingPercent(column);
-				expect(missingPercent).toBe(expected);
-			} else if (property === 'profileData') {
-				if (column === undefined) {
-					throw new Error('Column index must be provided for profileData verification');
-				}
-				const profileInfo = await this.getColumnProfileInfo(column);
-				expect(profileInfo.profileData).toStrictEqual(expected);
-			} else if (property === 'tableData') {
-				await this.verifyTableData(expected);
-			} else {
-				throw new Error(`Unsupported property: ${property}`);
-			}
-		}
-	}
-
-
-	/**
-	 * Helper function to verify table data matches expected values
-	 * @param dataExplorer The dataExplorer object from the workbench
-	 * @param expectedData Array of objects representing expected row data
-	 * @param timeout Optional timeout value in ms
-	 */
 	async verifyTableData(expectedData, timeout = 60000) {
-		await expect(async () => {
-			const tableData = await this.getDataExplorerTableData();
+		await test.step('Verify data explorer data', async () => {
+			await expect(async () => {
+				const tableData = await this.getDataExplorerTableData();
 
-			expect(tableData.length).toBe(expectedData.length);
+				expect(tableData.length).toBe(expectedData.length);
 
-			for (let i = 0; i < expectedData.length; i++) {
-				const row = expectedData[i];
-				for (const [key, value] of Object.entries(row)) {
-					expect(tableData[i][key]).toBe(value);
+				for (let i = 0; i < expectedData.length; i++) {
+					const row = expectedData[i];
+					for (const [key, value] of Object.entries(row)) {
+						expect(tableData[i][key]).toBe(value);
+					}
 				}
-			}
-		}).toPass({ timeout });
+			}).toPass({ timeout });
+		});
 	}
-
 
 	async verifyMissingPercent(expectedValues: Array<{ column: number; expected: string }>) {
 		await test.step('Verify missing percent values', async () => {
@@ -338,7 +307,7 @@ export class DataExplorer {
 	}
 
 	async verifySparklineHoverDialog(verificationText: string[]): Promise<void> {
-		await test.step('Verify bin count hover dialog', async () => {
+		await test.step(`Verify sparkline tooltip: ${verificationText}`, async () => {
 			const firstSparkline = this.code.driver.page.locator('.column-sparkline .tooltip-container').nth(0);
 			await firstSparkline.hover();
 			const hoverTooltip = this.code.driver.page.locator('.hover-contents');

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -18,6 +18,7 @@ const SCROLLBAR_LOWER_RIGHT_CORNER = '.data-grid-scrollbar-corner';
 const DATA_GRID_TOP_LEFT = '.data-grid-corner-top-left';
 const STATUS_BAR = '.positron-data-explorer .status-bar';
 const CLEAR_SORTING_BUTTON = '.codicon-positron-clear-sorting';
+const CLEAR_FILTER_BUTTON = '.codicon-positron-clear-filter';
 const MISSING_PERCENT = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-null-percent .text-percent`;
 const EXPAND_COLLAPSE_PROFILE = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .expand-collapse-button`;
 const EXPAND_COLLASPE_ICON = '.expand-collapse-icon';
@@ -41,16 +42,27 @@ export class DataExplorer {
 
 	clearSortingButton: Locator;
 	addFilterButton: Locator;
+	clearFilterButton: Locator;
 	selectColumnButton: Locator;
 	selectConditionButton: Locator;
 	applyFilterButton: Locator;
 
 	constructor(private code: Code, private workbench: Workbench) {
 		this.clearSortingButton = this.code.driver.page.locator(CLEAR_SORTING_BUTTON);
+		this.clearFilterButton = this.code.driver.page.locator(CLEAR_FILTER_BUTTON);
 		this.addFilterButton = this.code.driver.page.getByRole('button', { name: 'Add Filter' });
 		this.selectColumnButton = this.code.driver.page.getByRole('button', { name: 'Select Column' });
 		this.selectConditionButton = this.code.driver.page.getByRole('button', { name: 'Select Condition' });
 		this.applyFilterButton = this.code.driver.page.getByRole('button', { name: 'Apply Filter' });
+	}
+
+	async clearAllFilters() {
+		if (await this.clearSortingButton.isVisible() && await this.clearSortingButton.isEnabled()) {
+			await this.clearSortingButton.click();
+		}
+		if (await this.clearFilterButton.isVisible()) {
+			await this.clearFilterButton.click();
+		}
 	}
 
 	/*
@@ -124,11 +136,10 @@ export class DataExplorer {
 	}
 
 	async selectColumnMenuItem(columnIndex: number, menuItem: string) {
-
-		await this.code.driver.page.locator(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`).click();
-
-		await this.code.driver.page.locator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
-
+		await test.step(`Sort column ${columnIndex} by menu item: ${menuItem}`, async () => {
+			await this.code.driver.page.locator(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`).click();
+			await this.code.driver.page.locator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
+		});
 	}
 
 	async home(): Promise<void> {
@@ -236,7 +247,9 @@ export class DataExplorer {
 	}
 
 	async expandSummary(): Promise<void> {
-		await this.workbench.quickaccess.runCommand('workbench.action.positronDataExplorer.expandSummary');
+		await test.step('Expand data explorer summary', async () => {
+			await this.workbench.quickaccess.runCommand('workbench.action.positronDataExplorer.expandSummary');
+		});
 	}
 
 	async verifyTab(
@@ -253,6 +266,74 @@ export class DataExplorer {
 			await (isSelected
 				? expect(tabLocator).toHaveClass(/selected/)
 				: expect(tabLocator).not.toHaveClass(/selected/));
+		});
+	}
+
+	/**
+ * Universal helper method to verify column data
+ * @param dataExplorer The data explorer object
+ * @param expectations Array of objects containing column index, property name to verify, and expected value
+ */
+	async verifyColumnData(expectations: Array<{ column?: number; property: string; expected: any }>) {
+		for (const { column, property, expected } of expectations) {
+			if (property === 'missingPercent') {
+				if (column === undefined) {
+					throw new Error('Column index must be provided for missingPercent verification');
+				}
+				const missingPercent = await this.getColumnMissingPercent(column);
+				expect(missingPercent).toBe(expected);
+			} else if (property === 'profileData') {
+				if (column === undefined) {
+					throw new Error('Column index must be provided for profileData verification');
+				}
+				const profileInfo = await this.getColumnProfileInfo(column);
+				expect(profileInfo.profileData).toStrictEqual(expected);
+			} else if (property === 'tableData') {
+				await this.verifyTableData(expected);
+			} else {
+				throw new Error(`Unsupported property: ${property}`);
+			}
+		}
+	}
+
+
+	/**
+	 * Helper function to verify table data matches expected values
+	 * @param dataExplorer The dataExplorer object from the workbench
+	 * @param expectedData Array of objects representing expected row data
+	 * @param timeout Optional timeout value in ms
+	 */
+	async verifyTableData(expectedData, timeout = 60000) {
+		await expect(async () => {
+			const tableData = await this.getDataExplorerTableData();
+
+			expect(tableData.length).toBe(expectedData.length);
+
+			for (let i = 0; i < expectedData.length; i++) {
+				const row = expectedData[i];
+				for (const [key, value] of Object.entries(row)) {
+					expect(tableData[i][key]).toBe(value);
+				}
+			}
+		}).toPass({ timeout });
+	}
+
+
+	async verifyMissingPercent(expectedValues: Array<{ column: number; expected: string }>) {
+		await test.step('Verify missing percent values', async () => {
+			for (const { column, expected } of expectedValues) {
+				const missingPercent = await this.getColumnMissingPercent(column);
+				expect(missingPercent).toBe(expected);
+			}
+		});
+	}
+
+	async verifyProfileData(expectedValues: Array<{ column: number; expected: { [key: string]: string } }>) {
+		await test.step('Verify profile data', async () => {
+			for (const { column, expected } of expectedValues) {
+				const profileInfo = await this.getColumnProfileInfo(column);
+				expect(profileInfo.profileData).toStrictEqual(expected);
+			}
 		});
 	}
 

--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -1,10 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
+import { Application } from '../../infra/index.js';
 
 test.use({
 	suiteId: __filename
@@ -13,129 +14,115 @@ test.use({
 test.describe('Data Explorer - Python Polars', {
 	tag: [tags.WIN, tags.WEB, tags.CRITICAL, tags.DATA_EXPLORER]
 }, () => {
-	test.describe.configure({ mode: 'serial' });
-	test('Python Polars - Verify basic data explorer functionality', async function ({ app, python, logger, hotKeys }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'polars-dataframe-py', 'polars_basic.py'));
-		await app.workbench.quickaccess.runCommand('python.execInConsole');
 
-		logger.log('Opening data grid');
-		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true });
+	test.beforeAll(async function ({ app, openFile, runCommand, python }) {
+		const { variables, dataExplorer } = app.workbench;
 
-		await app.workbench.dataExplorer.maximizeDataExplorer(true);
+		await openFile(join('workspaces', 'polars-dataframe-py', 'polars_basic.py'));
+		await runCommand('python.execInConsole');
 
-		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+		// open the data frame in the data explorer
+		await variables.doubleClickVariableRow('df');
+		await dataExplorer.verifyTab('Data: df', { isVisible: true });
+		await dataExplorer.maximizeDataExplorer(true);
+	});
 
-			expect(tableData[0]['foo']).toBe('1');
-			expect(tableData[1]['foo']).toBe('2');
-			expect(tableData[2]['foo']).toBe('3');
-			expect(tableData[0]['bar']).toBe('6.00');
-			expect(tableData[1]['bar']).toBe('7.00');
-			expect(tableData[2]['bar']).toBe('8.00');
-			expect(tableData[0]['ham']).toBe('2020-01-02');
-			expect(tableData[1]['ham']).toBe('2021-03-04');
-			expect(tableData[2]['ham']).toBe('2022-05-06');
-			expect(tableData.length).toBe(3);
-		}).toPass({ timeout: 60000 });
+	test.afterEach(async function ({ app }) {
+		app.workbench.dataExplorer.clearAllFilters();
+	});
 
-		await test.step('Verify copy to clipboard', async () => {
-			await expect(async () => {
-				await app.code.driver.page.locator('#data-grid-row-cell-content-0-0 .text-container .text-value').click();
-				await hotKeys.copy();
-				const clipboardText = await app.workbench.clipboard.getClipboardText();
-				expect(clipboardText).toBe('1');
-			}).toPass({ timeout: 20000 });
-		});
+	test('Python Polars - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app, hotKeys }) {
+		const { dataExplorer } = app.workbench;
 
-		await app.workbench.dataExplorer.expandSummary();
+		// verify table data
+		await dataExplorer.verifyTableData([
+			{ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' },
+			{ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' },
+			{ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' }
+		]);
 
-		await app.workbench.dataExplorer.verifySparklineHoverDialog(['Range', 'Count']);
+		// verify can copy data to clipboard
+		await verifyCanCopyDataToClipboard(app);
 
-		await app.workbench.dataExplorer.verifyNullPercentHoverDialog();
+		// verify sparkline hover
+		await dataExplorer.expandSummary();
+		await dataExplorer.verifySparklineHoverDialog(['Range', 'Count']);
+
+		// verify null percentage hover
+		await dataExplorer.verifyNullPercentHoverDialog();
+	});
+
+
+	test('Python Polars - Verify column info functionality: missing %s, profile data', async function ({ app }) {
+		const { dataExplorer } = app.workbench;
+		await dataExplorer.expandSummary();
+
+		// Verify all missing percentages
+		await dataExplorer.verifyMissingPercent([
+			{ column: 1, expected: '0%' },
+			{ column: 2, expected: '0%' },
+			{ column: 3, expected: '0%' },
+			{ column: 4, expected: '33%' },
+			{ column: 5, expected: '33%' },
+			{ column: 6, expected: '33%' }
+		]);
+
+		// Verify all column profile data
+		await dataExplorer.verifyProfileData([
+			{ column: 1, expected: { 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' } },
+			{ column: 2, expected: { 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' } },
+			{ column: 3, expected: { 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' } },
+			{ column: 4, expected: { 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' } },
+			{ column: 5, expected: { 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' } },
+			{ column: 6, expected: { 'Missing': '1', 'True': '1', 'False': '1' } }
+		]);
+
+		// await dataExplorer.collapseSummary();
 
 	});
 
-	// Cannot be run by itself, relies on the previous test
-	test('Python Polars - Verify basic data explorer column info functionality', async function ({ app }) {
+	test('Python Polars - Verify can filter column', async function ({ app }) {
+		const { dataExplorer } = app.workbench;
 
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(1)).toBe('0%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(2)).toBe('0%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(3)).toBe('0%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(4)).toBe('33%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(5)).toBe('33%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(6)).toBe('33%');
-
-		const col1ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(1);
-		expect(col1ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' });
-
-		const col2ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(2);
-		expect(col2ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' });
-
-		const col3ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(3);
-		expect(col3ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' });
-
-		const col4ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(4);
-		expect(col4ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' });
-
-		const col5ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(5);
-		expect(col5ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' });
-
-		const col6ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(6);
-		expect(col6ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'True': '1', 'False': '1' });
-
-		await app.workbench.dataExplorer.collapseSummary();
-
-	});
-
-	test('Python Polars - Verify Simple Column filter', async function ({ app }) {
-
+		// filter table by column 1 (foo) not equal to 1
 		const FILTER_PARAMS = ['foo', 'is not equal to', '1'];
-		await app.workbench.dataExplorer.addFilter(...FILTER_PARAMS as [string, string, string]);
-
-		await expect(async () => {
-
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
-
-			expect(tableData[0]['foo']).toBe('2');
-			expect(tableData[1]['foo']).toBe('3');
-			expect(tableData[0]['bar']).toBe('7.00');
-			expect(tableData[1]['bar']).toBe('8.00');
-			expect(tableData[0]['ham']).toBe('2021-03-04');
-			expect(tableData[1]['ham']).toBe('2022-05-06');
-			expect(tableData.length).toBe(2);
-
-		}).toPass({ timeout: 60000 });
+		await dataExplorer.addFilter(...FILTER_PARAMS as [string, string, string]);
+		await dataExplorer.verifyTableData([
+			{ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' },
+			{ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' }
+		]);
 	});
 
-	test('Python Polars - Verify Simple Column Sort', async function ({ app }) {
-		await app.workbench.dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
+	test('Python Polars - Verify can sort column', async function ({ app }) {
+		const { dataExplorer } = app.workbench;
 
-		let tableData;
-		await expect(async () => {
-			tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+		// sort table descending by column 1 (foo)
+		await dataExplorer.expandSummary();
+		await dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
+		await dataExplorer.verifyTableData([
+			{ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' },
+			{ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' },
+			{ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' }
+		]);
 
-			expect(tableData[0]['foo']).toBe('3');
-			expect(tableData[1]['foo']).toBe('2');
-			expect(tableData[0]['bar']).toBe('8.00');
-			expect(tableData[1]['bar']).toBe('7.00');
-			expect(tableData[0]['ham']).toBe('2022-05-06');
-			expect(tableData[1]['ham']).toBe('2021-03-04');
-			expect(tableData.length).toBe(2);
-		}).toPass({ timeout: 60000 });
-
-		await app.workbench.dataExplorer.selectColumnMenuItem(1, 'Clear Sorting');
-
-		await expect(async () => {
-			tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
-
-			expect(tableData[0]['foo']).toBe('2');
-			expect(tableData[1]['foo']).toBe('3');
-			expect(tableData[0]['bar']).toBe('7.00');
-			expect(tableData[1]['bar']).toBe('8.00');
-			expect(tableData[0]['ham']).toBe('2021-03-04');
-			expect(tableData[1]['ham']).toBe('2022-05-06');
-			expect(tableData.length).toBe(2);
-		}).toPass({ timeout: 60000 });
+		// sort table ascending by column 1 (foo)
+		await dataExplorer.selectColumnMenuItem(1, 'Clear Sorting');
+		await dataExplorer.verifyTableData([
+			{ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' },
+			{ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' },
+			{ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' }
+		]);
 	});
 });
+
+
+async function verifyCanCopyDataToClipboard(app: Application) {
+	await test.step('Verify can copy data to clipboard', async () => {
+		await expect(async () => {
+			await app.code.driver.page.locator('#data-grid-row-cell-content-0-0 .text-container .text-value').click();
+			await app.workbench.hotKeys.copy();
+			const clipboardText = await app.workbench.clipboard.getClipboardText();
+			expect(clipboardText).toBe('1');
+		}).toPass({ timeout: 20000 });
+	});
+}

--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -31,7 +31,7 @@ test.describe('Data Explorer - Python Polars', {
 		app.workbench.dataExplorer.clearAllFilters();
 	});
 
-	test('Python Polars - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app, hotKeys }) {
+	test('Python Polars - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
 		// verify table data
@@ -76,15 +76,12 @@ test.describe('Data Explorer - Python Polars', {
 			{ column: 5, expected: { 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' } },
 			{ column: 6, expected: { 'Missing': '1', 'True': '1', 'False': '1' } }
 		]);
-
-		// await dataExplorer.collapseSummary();
-
 	});
 
 	test('Python Polars - Verify can filter column', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
-		// filter table by column 1 (foo) not equal to 1
+		// filter table by: foo is not equal to 1
 		const FILTER_PARAMS = ['foo', 'is not equal to', '1'];
 		await dataExplorer.addFilter(...FILTER_PARAMS as [string, string, string]);
 		await dataExplorer.verifyTableData([
@@ -96,7 +93,7 @@ test.describe('Data Explorer - Python Polars', {
 	test('Python Polars - Verify can sort column', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
-		// sort table descending by column 1 (foo)
+		// sort table by column 1 (foo): descending
 		await dataExplorer.expandSummary();
 		await dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 		await dataExplorer.verifyTableData([
@@ -105,7 +102,7 @@ test.describe('Data Explorer - Python Polars', {
 			{ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' }
 		]);
 
-		// sort table ascending by column 1 (foo)
+		// clear sorting
 		await dataExplorer.selectColumnMenuItem(1, 'Clear Sorting');
 		await dataExplorer.verifyTableData([
 			{ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' },


### PR DESCRIPTION
### Summary

Semi-recently I had to make updates to `data-explorer-python-polars.test.ts` and I became frustrated that I couldn't just fix the single problem because there were dependencies between the tests. We should always strive to have isolated tests. Why you ask? (I'll quote PW directly here)

> * No failure carry-over. If one test fails it doesn't affect the other test.
> * Easy to debug errors or flakiness, because you can run just a single test as many times as you'd like.
> * Don't have to think about the order when running in parallel, sharding, etc.

That being said, this spec has now been updated and each test can run in isolation. 🎉 

### QA Notes

@:web @:win