### PR TITLE
ci: upload e2e test-logs dir for browser only

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -19,6 +19,7 @@ jobs:
       install_undetectable_interpreters: false
       install_license: false
       skip_tags: "@:nightly-only"
+      upload_logs: false
     secrets: inherit
 
   e2e-windows-electron:
@@ -29,6 +30,7 @@ jobs:
       display_name: "electron (windows)"
       currents_tags: "merge,electron/windows"
       report_testrail: false
+      upload_logs: false
     secrets: inherit
 
   e2e-linux-browser:
@@ -43,6 +45,7 @@ jobs:
       install_undetectable_interpreters: false
       install_license: true
       skip_tags: "@:nightly-only"
+      upload_logs: true
     secrets: inherit
 
   unit-tests:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -42,6 +42,7 @@ jobs:
       install_undetectable_interpreters: false
       install_license: false
       skip_tags: "@:nightly-only"
+      upload_logs: false
     secrets: inherit
 
   e2e-windows-electron:
@@ -55,6 +56,7 @@ jobs:
       currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       report_currents: false
+      upload_logs: false
     secrets: inherit
 
   e2e-ubuntu-browser:
@@ -72,6 +74,7 @@ jobs:
       install_undetectable_interpreters: false
       install_license: true
       skip_tags: "@:nightly-only"
+      upload_logs: true
     secrets: inherit
 
   unit-tests:

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -453,7 +457,7 @@
         "filename": ".github/workflows/test-merge.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -463,7 +467,7 @@
         "filename": ".github/workflows/test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 46,
         "is_secret": false
       }
     ],
@@ -1461,5 +1465,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-29T19:55:11Z"
+  "generated_at": "2025-06-04T16:54:01Z"
 }


### PR DESCRIPTION
### Summary
Uploading the entire `test-logs` dir as an artifact to the workflows for browser runs only.


### QA Notes

n/a