### PR TITLE
Add additional logging to help track down failing tests

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
@@ -227,8 +227,10 @@ export abstract class AbstractExtensionsProfileScannerService extends Disposable
 			let storedProfileExtensions: IStoredProfileExtension[] | undefined;
 			try {
 				const content = await this.fileService.readFile(file);
+				this.logService.info(`Parsing JSON from ${file.toString()} with contents ${content.value.toString()}`);
 				storedProfileExtensions = JSON.parse(content.value.toString().trim() || '[]');
 			} catch (error) {
+				this.logService.error(`Extensions profile: Failed to read extensions from ${file.toString()}`, getErrorMessage(error));
 				if (toFileOperationResult(error) !== FileOperationResult.FILE_NOT_FOUND) {
 					throw error;
 				}

--- a/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -297,7 +297,9 @@ export abstract class AbstractExtensionsScannerService extends Disposable implem
 		try {
 			await this.extensionsProfileScannerService.scanProfileExtensions(this.userDataProfilesService.defaultProfile.extensionsResource, { bailOutWhenFileNotFound: true });
 		} catch (error) {
+			this.logService.warn('Failed to scan default profile extensions in extensions installation folder.', this.userExtensionsLocation.toString(), getErrorMessage(error));
 			if (error instanceof ExtensionsProfileScanningError && error.code === ExtensionsProfileScanningErrorCode.ERROR_PROFILE_NOT_FOUND) {
+				this.logService.info('Default profile extensions not found, initializing default profile extensions in extensions installation folder.', this.userExtensionsLocation.toString());
 				await this.doInitializeDefaultProfileExtensions();
 			} else {
 				throw error;

--- a/src/vs/platform/extensionManagement/node/extensionsWatcher.ts
+++ b/src/vs/platform/extensionManagement/node/extensionsWatcher.ts
@@ -46,9 +46,13 @@ export class ExtensionsWatcher extends Disposable {
 
 	private async initialize(): Promise<void> {
 		await this.extensionsScannerService.initializeDefaultProfileExtensions();
+		this.logService.info('Extensions Watcher initialized with default profile extensions');
 		await this.onDidChangeProfiles(this.userDataProfilesService.profiles);
+		this.logService.info('Extensions Watcher populated with existing profiles:', this.userDataProfilesService.profiles.map(profile => profile.id).join(', '));
 		this.registerListeners();
+		this.logService.info('Extensions Watcher registered listeners for profile changes');
 		await this.deleteExtensionsNotInProfiles();
+		this.logService.info('Extensions Watcher deleted extensions not in any profile');
 	}
 
 	private registerListeners(): void {


### PR DESCRIPTION
We are occasionally seeing tests fail because an expected extension isn't installed. When this happens we see logs like the following: 
```
2025-06-04 16:16:51.871 [info] Subsequent launch, skipping bootstrapped extensions
2025-06-04 16:16:51.873 [debug] Writing language packs {}
2025-06-04 16:16:51.889 [error] Error while initializing Extensions Watcher Unexpected non-whitespace character after JSON at position 807 (line 1 column 808)
2025-06-04 16:16:51.911 [debug] No extensions are marked as removed.
2025-06-04 16:16:51.924 [error] [uncaught exception in sharedProcess]: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808): SyntaxError: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808)
    at JSON.parse (<anonymous>)
    at Object.factory (file:///home/runner/work/positron/positron/out/vs/platform/extensionManagement/common/extensionsProfileScannerService.js:180:48)
2025-06-04 16:16:51.925 [error] [uncaught exception in sharedProcess]: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808): SyntaxError: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808)
    at JSON.parse (<anonymous>)
    at Object.factory (file:///home/runner/work/positron/positron/out/vs/platform/extensionManagement/common/extensionsProfileScannerService.js:180:48)
2025-06-04 16:16:51.946 [error] SyntaxError: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808)
    at JSON.parse (<anonymous>)
    at Object.factory (file:///home/runner/work/positron/positron/out/vs/platform/extensionManagement/common/extensionsProfileScannerService.js:180:48)
2025-06-04 16:16:52.093 [info] ComputeTargetPlatform: linux-x64
2025-06-04 16:16:52.347 [info] ComputeTargetPlatform: linux-x64
2025-06-04 16:16:52.348 [debug] User data changed
2025-06-04 16:16:53.209 [debug] User data changed
2025-06-04 16:16:53.320 [debug] User data changed
2025-06-04 16:16:53.496 [debug] User data changed
2025-06-04 16:16:54.881 [error] [uncaught exception in sharedProcess]: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808): SyntaxError: Unexpected non-whitespace character after JSON at position 807 (line 1 column 808)
    at JSON.parse (<anonymous>)
    at Object.factory (file:///home/runner/work/positron/positron/out/vs/platform/extensionManagement/common/extensionsProfileScannerService.js:180:48)
2025-06-04 16:16:56.676 [debug] User data changed
2025-06-04 16:17:03.497 [debug] User data changed
2025-06-04 16:17:03.498 [debug] User data changed
2025-06-04 16:17:03.597 [debug] User data changed
2025-06-04 16:17:03.599 [debug] User data changed
```

This PR adds some additional logs to hopefully aid in this investigation.