### PR TITLE
Update `RSTUDIO_PANDOC` with the correct location in Linux release builds

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -1,6 +1,6 @@
 "use strict";
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
@@ -99,6 +99,7 @@ function getQuartoMacOS(version) {
 function getQuartoLinux(version) {
     const gunzip = require('gulp-gunzip');
     const untar = require('gulp-untar');
+    const rename = require('gulp-rename');
     const basename = process.env['npm_config_arch'] === 'x64' ?
         `quarto-${version}-linux-amd64` :
         `quarto-${version}-linux-arm64`;
@@ -109,7 +110,13 @@ function getQuartoLinux(version) {
     })
         // Unzip, then untar
         .pipe(gunzip())
-        .pipe(untar());
+        .pipe(untar())
+        // Remove the leading directory from the path
+        .pipe(rename((path) => {
+        if (path.dirname.startsWith(`quarto-${version}`)) {
+            path.dirname = path.dirname.replace(/^quarto-[^/]+\/?/, '');
+        }
+    }));
 }
 /**
  * Gets a stream that downloads and unpacks the quarto executable. Reads

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -66,6 +66,7 @@ function getQuartoMacOS(version: string): Stream {
 function getQuartoLinux(version: string): Stream {
 	const gunzip = require('gulp-gunzip');
 	const untar = require('gulp-untar');
+	const rename = require('gulp-rename');
 
 	const basename = process.env['npm_config_arch'] === 'x64' ?
 		`quarto-${version}-linux-amd64` :
@@ -78,7 +79,13 @@ function getQuartoLinux(version: string): Stream {
 	})
 		// Unzip, then untar
 		.pipe(gunzip())
-		.pipe(untar());
+		.pipe(untar())
+		// Remove the leading directory from the path
+		.pipe(rename((path: any) => {
+			if (path.dirname.startsWith(`quarto-${version}`)) {
+				path.dirname = path.dirname.replace(/^quarto-[^/]+\/?/, '');
+			}
+		}));
 }
 
 /**

--- a/extensions/positron-environment/package-lock.json
+++ b/extensions/positron-environment/package-lock.json
@@ -7,9 +7,19 @@
     "": {
       "name": "positron-environment",
       "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "14.x"
+      },
       "engines": {
         "vscode": "^1.65.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -23,40 +23,35 @@
             "default": true,
             "description": "%environment.configuration.enabled.description%"
           },
-          "positron.environment.variables": {
+          "positron.environment.variables.replace": {
             "scope": "window",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "action": {
-                  "type": "string",
-                  "enum": ["replace", "append", "prepend"],
-                  "description": "%environment.configuration.variables.action%"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "%environment.configuration.variables.name%"
-                },
-                "value": {
-                  "type": "string",
-                  "description": "%environment.configuration.variables.value%"
-                }
-              }
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
             },
-            "default": [
-              {
-                "action": "replace",
-                "name": "SF_PARTNER",
-                "value": "posit_positron"
-              },
-              {
-                "action": "replace",
-                "name": "SPARK_CONNECT_USER_AGENT",
-                "value": "posit-positron"
-              }
-            ],
-            "description": "%environment.configuration.variables.description%"
+            "default": {
+              "SF_PARTNER": "posit_positron",
+              "SPARK_CONNECT_USER_AGENT": "posit-positron"
+            },
+            "description": "%environment.configuration.variables.replace.description%"
+          },
+          "positron.environment.variables.append": {
+            "scope": "window",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "description": "%environment.configuration.variables.append.description%"
+          },
+          "positron.environment.variables.prepend": {
+            "scope": "window",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "description": "%environment.configuration.variables.prepend.description%"
           }
         }
       }

--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -70,6 +70,9 @@
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js"
   },
+  "devDependencies": {
+    "@types/node": "14.x"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/posit-dev/positron"

--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -17,13 +17,14 @@
         "type": "object",
         "title": "%environment.configuration.title%",
         "properties": {
-          "positron.environment.enabled": {
+          "environmentVariables.enabled": {
             "scope": "window",
             "type": "boolean",
             "default": true,
-            "description": "%environment.configuration.enabled.description%"
+            "description": "%environment.configuration.enabled.description%",
+            "order": 1
           },
-          "positron.environment.variables.replace": {
+          "environmentVariables.set": {
             "scope": "window",
             "type": "object",
             "additionalProperties": {
@@ -33,25 +34,28 @@
               "SF_PARTNER": "posit_positron",
               "SPARK_CONNECT_USER_AGENT": "posit-positron"
             },
-            "description": "%environment.configuration.variables.replace.description%"
+            "description": "%environment.configuration.variables.set.description%",
+            "order": 2
           },
-          "positron.environment.variables.append": {
+          "environmentVariables.append": {
             "scope": "window",
             "type": "object",
             "additionalProperties": {
               "type": "string"
             },
             "default": {},
-            "description": "%environment.configuration.variables.append.description%"
+            "description": "%environment.configuration.variables.append.description%",
+            "order": 3
           },
-          "positron.environment.variables.prepend": {
+          "environmentVariables.prepend": {
             "scope": "window",
             "type": "object",
             "additionalProperties": {
               "type": "string"
             },
             "default": {},
-            "description": "%environment.configuration.variables.prepend.description%"
+            "description": "%environment.configuration.variables.prepend.description%",
+            "order": 4
           }
         }
       }

--- a/extensions/positron-environment/package.nls.json
+++ b/extensions/positron-environment/package.nls.json
@@ -1,9 +1,9 @@
 {
 	"displayName": "Environment",
-	"description": "Positron Environment Variables",
+	"description": "Environment Variables",
 	"environment.configuration.title": "Environment Variables",
 	"environment.configuration.enabled.description": "Enable the Positron environment variable collection.",
-	"environment.configuration.variables.replace.description": "Environment variables to set in all Positron terminals and consoles.",
+	"environment.configuration.variables.set.description": "Environment variables to set in all Positron terminals and consoles.",
 	"environment.configuration.variables.append.description": "Values to append to existing environment variables, naming the variable to append to and the value to append.",
 	"environment.configuration.variables.prepend.description": "Values to prepend to existing environment variables, naming the variable to prepend to and the value to prepend."
 }

--- a/extensions/positron-environment/package.nls.json
+++ b/extensions/positron-environment/package.nls.json
@@ -3,8 +3,7 @@
 	"description": "Positron Environment Variables",
 	"environment.configuration.title": "Environment Variables",
 	"environment.configuration.enabled.description": "Enable the Positron environment variable collection.",
-	"environment.configuration.variables.description": "Global environment variables for all Positron consoles and terminals.",
-	"environment.configuration.variables.action": "The action to take when setting the environment variable. 'replace' will replace the existing value, 'append' will append to the existing value, and 'prepend' will prepend to the existing value.",
-	"environment.configuration.variables.name": "The name of the environment variable.",
-	"environment.configuration.variables.value": "The value of the environment variable."
+	"environment.configuration.variables.replace.description": "Environment variables to set in all Positron terminals and consoles.",
+	"environment.configuration.variables.append.description": "Values to append to existing environment variables, naming the variable to append to and the value to append.",
+	"environment.configuration.variables.prepend.description": "Values to prepend to existing environment variables, naming the variable to prepend to and the value to prepend."
 }

--- a/extensions/positron-environment/src/extension.ts
+++ b/extensions/positron-environment/src/extension.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { getPandocPath } from './pandoc.js';
 
 /**
  * Interface for the environment variable action. Mirrors the definition in the
@@ -33,6 +34,10 @@ function applyConfiguration(context: vscode.ExtensionContext) {
 	// Clear the initial collection to remove any old values
 	const collection = context.environmentVariableCollection;
 	collection.clear();
+
+	// Add the built-in variables to the collection. We always add these even if
+	// the configuration-based variables are not enabled.
+	addBuiltinVars(context);
 
 	// Set the vars using the environment variable collection
 	if (!vars.get('enabled')) {
@@ -78,4 +83,20 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	context.subscriptions.push(disposable);
+}
+
+/**
+ * Adds built-in environment variables to the global environment variable
+ * collection.
+ *
+ * @param context
+ */
+export function addBuiltinVars(context: vscode.ExtensionContext) {
+	const collection = context.environmentVariableCollection;
+	const pandocPath = getPandocPath();
+
+	// Advertise the location of the Pandoc executable.
+	if (pandocPath) {
+		collection.replace('RSTUDIO_PANDOC', pandocPath);
+	}
 }

--- a/extensions/positron-environment/src/extension.ts
+++ b/extensions/positron-environment/src/extension.ts
@@ -8,21 +8,6 @@ import * as positron from 'positron';
 import { getPandocPath } from './pandoc.js';
 
 /**
- * Interface for the environment variable action. Mirrors the definition in the
- * configuration schema.
- */
-interface EnvironmentVariableAction {
-	/** The action to take */
-	action: 'replace' | 'append' | 'prepend';
-
-	/** The name of the variable */
-	name: string;
-
-	/** The value to replace, append, or remove */
-	value: string;
-};
-
-/**
  * Apply the configuration for the environment variables.
  *
  * @param context The extension context.
@@ -47,20 +32,22 @@ function applyConfiguration(context: vscode.ExtensionContext) {
 	// Set the collection description
 	collection.description = vscode.l10n.t('Global Positron environment variables');
 
-	// Get the configured environment variables
-	const actions = vars.get<Array<EnvironmentVariableAction>>('variables') ?? [];
-	for (const action of actions) {
-		switch (action.action) {
-			case 'replace':
-				collection.replace(action.name, action.value);
-				break;
-			case 'append':
-				collection.append(action.name, action.value);
-				break;
-			case 'prepend':
-				collection.prepend(action.name, action.value);
-				break;
-		}
+	// Get the configured environment variables for replace action
+	const replaceVars = vars.get<Record<string, string>>('variables.replace') ?? {};
+	for (const [name, value] of Object.entries(replaceVars)) {
+		collection.replace(name, value);
+	}
+
+	// Get the configured environment variables for append action
+	const appendVars = vars.get<Record<string, string>>('variables.append') ?? {};
+	for (const [name, value] of Object.entries(appendVars)) {
+		collection.append(name, value);
+	}
+
+	// Get the configured environment variables for prepend action
+	const prependVars = vars.get<Record<string, string>>('variables.prepend') ?? {};
+	for (const [name, value] of Object.entries(prependVars)) {
+		collection.prepend(name, value);
 	}
 }
 

--- a/extensions/positron-environment/src/extension.ts
+++ b/extensions/positron-environment/src/extension.ts
@@ -14,7 +14,7 @@ import { getPandocPath } from './pandoc.js';
  */
 function applyConfiguration(context: vscode.ExtensionContext) {
 
-	const vars = vscode.workspace.getConfiguration('positron.environment');
+	const vars = vscode.workspace.getConfiguration('environmentVariables');
 
 	// Clear the initial collection to remove any old values
 	const collection = context.environmentVariableCollection;
@@ -30,22 +30,22 @@ function applyConfiguration(context: vscode.ExtensionContext) {
 	}
 
 	// Set the collection description
-	collection.description = vscode.l10n.t('Global Positron environment variables');
+	collection.description = vscode.l10n.t('Custom Positron environment variables');
 
 	// Get the configured environment variables for replace action
-	const replaceVars = vars.get<Record<string, string>>('variables.replace') ?? {};
+	const replaceVars = vars.get<Record<string, string>>('set') ?? {};
 	for (const [name, value] of Object.entries(replaceVars)) {
 		collection.replace(name, value);
 	}
 
 	// Get the configured environment variables for append action
-	const appendVars = vars.get<Record<string, string>>('variables.append') ?? {};
+	const appendVars = vars.get<Record<string, string>>('append') ?? {};
 	for (const [name, value] of Object.entries(appendVars)) {
 		collection.append(name, value);
 	}
 
 	// Get the configured environment variables for prepend action
-	const prependVars = vars.get<Record<string, string>>('variables.prepend') ?? {};
+	const prependVars = vars.get<Record<string, string>>('prepend') ?? {};
 	for (const [name, value] of Object.entries(prependVars)) {
 		collection.prepend(name, value);
 	}
@@ -64,7 +64,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// Register a listener for when the configuration changes and reapply
 	// the configuration.
 	const disposable = vscode.workspace.onDidChangeConfiguration((e) => {
-		if (e.affectsConfiguration('positron.environment')) {
+		if (e.affectsConfiguration('environmentVariables')) {
 			applyConfiguration(context);
 		}
 	});

--- a/extensions/positron-environment/src/pandoc.ts
+++ b/extensions/positron-environment/src/pandoc.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(LOGGER.onDidChangeLogLevel(onDidChangeLogLevel));
 	onDidChangeLogLevel(LOGGER.logLevel);
 
-	const rRuntimeManager = new RRuntimeManager();
+	const rRuntimeManager = new RRuntimeManager(context);
 	positron.runtime.registerLanguageRuntimeManager('r', rRuntimeManager);
 
 	// Set contexts.

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -10,7 +10,6 @@ import * as fs from 'fs';
 
 import { JupyterKernelSpec } from './positron-supervisor';
 import { getArkKernelPath } from './kernel';
-import { getPandocPath } from './pandoc';
 import { EXTENSION_ROOT_DIR } from './constants';
 
 /**
@@ -63,16 +62,6 @@ export function createJupyterKernelSpec(
 		// Workaround for
 		// https://github.com/posit-dev/positron/issues/3732
 		env['DYLD_LIBRARY_PATH'] = rHomePath + '/lib';
-	}
-
-	// Inject the path to the Pandoc executable into the environment; R packages
-	// that use Pandoc for rendering will need this.
-	//
-	// On MacOS, the binary path lives alongside the app bundle; on other
-	// platforms, it's a couple of directories up from the app root.
-	const pandocPath = getPandocPath();
-	if (pandocPath) {
-		env['RSTUDIO_PANDOC'] = pandocPath;
 	}
 
 	// R script to run on session startup

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -1,12 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import * as os from 'os';
 import { RSessionManager } from './session-manager';
-import { getPandocPath } from './pandoc';
 import { getEnvVars } from './session';
 import { prepCliEnvVars } from './uri-handler';
 
@@ -68,16 +67,8 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 		}
 	];
 
-	// if we have a local copy of Pandoc available, forward it to the R session
-	// so that it can be used to render R Markdown documents (etc)
-	const env: any = {};
-	const pandocPath = getPandocPath();
-	if (pandocPath) {
-		env['RSTUDIO_PANDOC'] = pandocPath;
-	}
-
 	return taskData.map(data => {
-		let taskEnv = { ...env };
+		let taskEnv = {};
 
 		if (data.envVars) {
 			Object.assign(taskEnv, data.envVars);


### PR DESCRIPTION
This change fixes an issue that causes `RSTUDIO_PANDOC` to be empty in Linux release builds

The issue is that on Linux, the layout of the Quarto distribution is different than on other platforms; the tarball unpacks a top-level folder `./quarto-1.2.3` containing all the files, so e.g. this is where we are looking for Pandoc:

```
/resources/app/quarto/bin/tools/x86_64/pandoc
```

But it's actually here:

```
/resources/app/quarto/quarto-1.7.31/bin/tools/x86_64/pandoc
```

The fix is to remove the extra path segment after unpacking Pandoc on Linux, so the layout is what we're expecting.

Addresses https://github.com/posit-dev/positron/issues/7929.

While I was in the files I made a few adjacent fixes:

- We now set `RSTUDIO_PANDOC` everywhere, not just in select tasks and R sessions. Addresses https://github.com/posit-dev/positron/issues/7700. 
- We also now set `QUARTO_R` in terminals. Addresses https://github.com/posit-dev/positron/issues/7402 but not the larger issue of setting up terminals for R which I didn't want to try to tangle with this change.
- I've made the Environment Variables easier to configure; you can add your own custom environment variables right in the settings UI, without hand-editing JSON.  Addresses https://github.com/posit-dev/positron/issues/7875.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Custom environment variables for the Terminal and Consoles can now be configured in the Settings UI (#7875)

#### Bug Fixes

- The `RSTUDIO_PANDOC` environment variable is now set correctly on Linux builds (#7929)
- The `RSTUDIO_PANDOC` environment variable is now set in terminals and tasks as well as R sessions (#7700)
- The `QUARTO_R` environment variable now points to your chosen R version in the Terminal (#7402)


### QA Notes

Quarto (which includes Pandoc) gets added to the bundle during the release build step, so local development builds will not have any Quarto or Pandoc available, and it's expected that `RSTUDIO_PANDOC` is empty for them. You'll want to use a release build to verify this change.