### PR TITLE
add note about e2e test tags in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ main branch by either pulling or rebasing.
 	for instructions on including the tags, and https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
 	for the list of available tags.
 
-	Example tags: @:web @:windows
+	Example tags: @:web @:win
 -->
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,18 @@ main branch by either pulling or rebasing.
 ### QA Notes
 
 <!--
+	Positron team members: please add relevant e2e test tags, so the tests can be
+	run when you open this pull request.
+
+	See https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
+	for instructions on including the tags, and https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
+	for the list of available tags.
+
+	Example tags: @:web @:windows
+-->
+
+
+<!--
   Add additional information for QA on how to validate the change,
   paying special attention to the level of risk, adjacent areas that
   could be affected by the change, and any important contextual


### PR DESCRIPTION
- add a comment in the PR template to include e2e test tags
- e2e tests run right after the PR is created, so if a developer adds a test tag to the PR description after the e2e tests are kicked off, they need to manually run the e2e tests again or push a commit to trigger the e2e test flow
- the comment in the PR template is a note to add the test tags _before_ the PR is opened, hopefully to alleviate cases where one forgets to add them at PR creation and needs to do manual steps to get the e2e tests started again
