### PR TITLE
Don't bind Cmd+I to Reindent Lines when Assistant is enabled

### DIFF
--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -189,13 +189,18 @@ class PositronKeybindingsContribution extends Disposable {
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
 		}));
 
-		// Reindent selected lines
-		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
-			id: 'editor.action.reindentselectedlines',
-			weight: KeybindingWeight.BuiltinExtension,
-			when: EditorContextKeys.editorTextFocus,
-			primary: KeyMod.CtrlCmd | KeyCode.KeyI
-		}));
+		// Reindent selected lines. We only bind this if Assistant is not enabled,
+		// since this binding is used to invoke inline chat with Assistant.
+		const positronAssistantEnabled =
+			this._configurationService.getValue('positron.assistant.enable');
+		if (!positronAssistantEnabled) {
+			this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
+				id: 'editor.action.reindentselectedlines',
+				weight: KeybindingWeight.BuiltinExtension,
+				when: EditorContextKeys.editorTextFocus,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyI
+			}));
+		}
 
 		// Format selection
 		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({


### PR DESCRIPTION
Skip binding <kbd>Cmd</kbd> <kbd>I</kbd> to _Reindent Lines_ (RStudio keybinding) when Assistant is enabled.

Addresses https://github.com/posit-dev/positron/issues/7889. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue invoking Inline Chat with Cmd/Ctrl + I when RStudio keybindings are enabled (#7889)


### QA Notes

Note that a reload or restart is necessary whenever enabling/disabling Assistant or the RStudio keybindings before you'll see the expected bindings.