### PR TITLE
Default popups to center when no anchor is provided

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -129,12 +129,19 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			anchorY = props.anchorPoint.clientY;
 			anchorWidth = 0;
 			anchorHeight = 0;
-		} else {
+		} else if (props.anchorElement) {
 			const topLeftAnchorOffset = DOM.getTopLeftOffset(props.anchorElement);
 			anchorX = topLeftAnchorOffset.left;
 			anchorY = topLeftAnchorOffset.top;
 			anchorWidth = props.anchorElement.offsetWidth;
 			anchorHeight = props.anchorElement.offsetHeight;
+		} else {
+			// If no anchor point or element is provided, default to the center
+			// of the document.
+			anchorX = documentWidth / 2;
+			anchorY = documentHeight / 2;
+			anchorWidth = 0;
+			anchorHeight = 0;
 		}
 
 		// Calculate the left and right area widths. This is the space that is available for laying


### PR DESCRIPTION
This change is a speculative fix for #7472. 

```
    at Module.getTopLeftOffset (http://localhost:9000/oss-dev/static/out/vs/base/browser/dom.js:469:32)
    at http://localhost:9000/oss-dev/static/out/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.js:81:45
```

Based on the callstack in that issue, it is clear that the problem is that we're trying to show a popup with no anchor element _or_ point. In particular `getOffsetParent` is called on the element passed into `DOM.getTopLeftOffset`, so we can be reasonably confident that we're passing null into there.

Where does that come from? QA has suggested this happens most often when the tests use the console info button. This button passes an anchor to the popup based on a React ref without first checking to see if the ref has a element in it, which is the probable upstream issue.

https://github.com/posit-dev/positron/blob/8b3e95ab7926c0643351147fdbcc1145ab8f5510/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx#L76-L82

However, changes to that would be even more speculative (and involve more risk), so since the intent here is mostly to address test flakes, I've just changed the modal dialog bits.

