### PR TITLE
Bump Ark to 0.1.190

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -757,7 +757,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.188"
+      "ark": "0.1.189"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -757,7 +757,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.189"
+      "ark": "0.1.190"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/815 and https://github.com/posit-dev/ark/pull/825.

Addresses #18
Progress towards #2924 

### Release Notes

#### New Features

- Foding rules are now supported for R comment sections (#18) and R code cells (#2924). Thanks to our contributor @kv9898!

#### Bug Fixes

- N/A


### QA Notes

Contents inside parentheses and curly braces should be foldable as before.

```r
foo(
  a,
  b
)

{
  a,
  b
}

foo({
  a,
  b
})
```

We can now also fold sections in comments:

```r
# level 1 section ---

# This is nested in the section
foo(
  a,
  b
)

## level 2 subsection ---

# new level 1 section ---
```

And code chunks (see https://github.com/posit-dev/positron/issues/2924) are foldable too. They are nested in sections but note that the code cell will overlap sections until https://github.com/posit-dev/positron/issues/7974 is fixed.

```r
# %% Cell in subsection
1

# Cell folding range ends at section ----
2

#+ New cell
3
```

