### PR TITLE
fix PR template e2e tag note spacing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,14 +42,13 @@ main branch by either pulling or rebasing.
 ### QA Notes
 
 <!--
-	Positron team members: please add relevant e2e test tags, so the tests can be
-	run when you open this pull request.
+  Positron team members: please add relevant e2e test tags, so the tests can be
+  run when you open this pull request.
 
-	See https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
-	for instructions on including the tags, and https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-	for the list of available tags.
+  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
+  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
 
-	Example tags: @:web @:win
+  Example tags: @:web @:win
 -->
 
 


### PR DESCRIPTION
- follow-up to https://github.com/posit-dev/positron/pull/7968 to fix up the spacing. The indentation was 2-space-sized tabs instead of 2 spaces, which looks the same in an editor, but on Github causes the spacing to look like this:

```
### QA Notes

<!--
	Positron team members: please add relevant e2e test tags, so the tests can be
	run when you open this pull request.

	See https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
	for instructions on including the tags, and https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
	for the list of available tags.

	Example tags: @:web @:win
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
```

instead of this:

```
### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts

  Example tags: @:web @:win
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
```