### PR TITLE
Change settings import button to say "Compare settings"

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -47,7 +47,7 @@ export async function promptImport(
 			// Open the import settings command and set the import was prompted flag to true.
 			// This will prevent the prompt from showing up again.
 			{
-				label: localize('positron.settingsImport.import', 'Import'),
+				label: localize('positron.settingsImport.compareSettings', 'Compare settings'),
 				run: () => {
 					commandService.executeCommand(PositronImportSettings.ID);
 					setImportWasPrompted(storageService);

--- a/test/e2e/pages/popups.ts
+++ b/test/e2e/pages/popups.ts
@@ -21,7 +21,7 @@ const NOTIFICATION_TOAST = '.notification-toast';
 export class Popups {
 
 	public toastLocator = this.code.driver.page.locator(NOTIFICATION_TOAST);
-	public importButton = this.toastLocator.getByRole('button', { name: 'Import' });
+	public importButton = this.toastLocator.getByRole('button', { name: 'Compare settings' });
 	public laterButton = this.toastLocator.getByRole('button', { name: 'Later' });
 	public doNotShowAgainButton = this.toastLocator.getByRole('button', { name: 'Don\'t Show Again' });
 	public acceptButton = this.toastLocator.getByRole('button', { name: 'Accept' });


### PR DESCRIPTION
Addresses #7845 by changing the button text:

![Screenshot 2025-06-05 at 9 43 01 AM](https://github.com/user-attachments/assets/1a91d141-c43a-49cb-8827-ca370872eaae)

@:vscode-settings

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

The text on the button to import settings should be updated!
