### PR TITLE
Change default for `workbench.welcomePage.walkthroughs.openOnInstall` to false

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -375,7 +375,10 @@ configurationRegistry.registerConfiguration({
 		'workbench.welcomePage.walkthroughs.openOnInstall': {
 			scope: ConfigurationScope.MACHINE,
 			type: 'boolean',
-			default: true,
+			// --- Start Positron ---
+			// default: true,
+			default: false,
+			// --- End Positron ---
 			description: localize('workbench.welcomePage.walkthroughs.openOnInstall', "When enabled, an extension's walkthrough will open upon install of the extension.")
 		},
 		'workbench.startupEditor': {


### PR DESCRIPTION
Addresses #7967

@:welcome

I believe we started seeing this unwanted behavior when we started the bootstrap installations of extensions. 

You don't see the problem unless you have a very, very fresh install of Positron. For a dev build, you can do `rm -rf ~/.vscode-oss-dev/ && rm -rf ~/.positron-dev` to get in the right state. First, delete everything, _then_ start a dev build.

- Before this change, if you did this, you would see a walkthrough from one of our bootstrap installed extensions, like Quarto or the Publisher extension.
- After this change, you will not see such a walkthrough.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- [#7967] Fixed behavior on first boot of Positron to _not_ show extension walkthroughs


### QA Notes

You will need a very fresh state to confirm we have solved this problem. You'll want to do something like close all Positron windows, `rm -rf ~/Library/Application\ Support/Positron && rm -rf ~/.positron`, _then_ install and open a brand new build. You should not see an extension walkthrough, such as the ones contributed by Quarto or the Publisher; you should see our Welcome page instead.
