### PR TITLE
E2E test: skip deletion of test data dir in CI

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -246,7 +246,7 @@ jobs:
 
           # Run the Playwright test command directly using eval
           echo "Running: DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
-          eval DISPLAY=:10 SKIP_BOOTSTRAP=true npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+          eval DISPLAY=:10 SKIP_BOOTSTRAP=true SKIP_CLONE=true npx playwright test --project ${{ inputs.project }} --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
           # Fail the step if the bootstrap test failed
           if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -183,7 +183,7 @@ jobs:
         uses: ./.github/actions/gen-report-dir
 
       - name: Run Tests on Windows (Electron)
-        shell: bash
+        shell: pwsh
         env:
           POSITRON_PY_VER_SEL: 3.10.10
           POSITRON_R_VER_SEL: 4.4.0
@@ -195,18 +195,20 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
-          CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
+          CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID }}
         run: |
-          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=null || true
-          BOOTSTRAP_EXIT_CODE=$?
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=null
+          $BOOTSTRAP_EXIT_CODE = $LASTEXITCODE
 
-          SKIP_BOOTSTRAP=true npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+          $env:SKIP_BOOTSTRAP = "true"
+          $env:SKIP_CLONE = "true"
+          npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
-          # Fail the step if the bootstrap test failed
-          if [ "$BOOTSTRAP_EXIT_CODE" -ne 0 ]; then
-            echo "Bootstrap extensions test failed. Exiting with code $BOOTSTRAP_EXIT_CODE."
-            exit "$BOOTSTRAP_EXIT_CODE"
-          fi
+          if ($BOOTSTRAP_EXIT_CODE -ne 0) {
+            Write-Host "Bootstrap extensions test failed. Exiting with code $BOOTSTRAP_EXIT_CODE."
+            exit $BOOTSTRAP_EXIT_CODE
+          }
+
 
 
       - name: Upload Playwright Report to S3

--- a/product.json
+++ b/product.json
@@ -256,7 +256,7 @@
 		},
 		{
 			"name": "posit.air-vscode",
-			"version": "0.12.0",
+			"version": "0.14.0",
 			"repo": "https://github.com/posit-dev/air",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",

--- a/test/e2e/infra/test-runner/test-setup.ts
+++ b/test/e2e/infra/test-runner/test-setup.ts
@@ -110,7 +110,8 @@ function initializeTestEnvironment(rootPath = process.env.ROOT_PATH || 'ROOT_PAT
  * Cleans and prepares the test data directory.
  */
 function prepareTestDataDirectory() {
-	if (fs.existsSync(TEST_DATA_PATH)) {
+	// skipping deletion if running in CI because extensions setup case needs to be able to leave behind its extensions
+	if (!process.env.CI && fs.existsSync(TEST_DATA_PATH)) {
 		rimraf.sync(TEST_DATA_PATH);
 	}
 	mkdirp.sync(TEST_DATA_PATH);

--- a/test/e2e/tests/_global.setup.ts
+++ b/test/e2e/tests/_global.setup.ts
@@ -16,7 +16,9 @@ const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 async function globalSetup() {
 	fs.rmSync(LOGS_ROOT_PATH, { recursive: true, force: true });
 	prepareTestEnv(ROOT_PATH, LOGS_ROOT_PATH);
-	cloneTestRepo(WORKSPACE_PATH);
+	if (process.env.SKIP_CLONE !== 'true') {
+		cloneTestRepo(WORKSPACE_PATH);
+	}
 }
 
 export default globalSetup;


### PR DESCRIPTION
Don't delete the test data dir in CI.  This will allow a test case running serially to get all the bootstrap extensions in place and leave them behind for the large batch of parallel cases that follow.

Also, conditionally skip clone because qa-example-content will be cloned by the first case and doesn't need a reclone at the start of the parallel cases run.

Also, update the current version of Air in product.json.

### QA Notes

@:web @:win
