### PR TITLE
Shut down supervisor gracefully on SIGINT/SIGTERM

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -150,7 +150,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.43"
+      "kallichore": "0.1.45"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
Speculative fix for #7991. I could not reproduce with the steps in that issue, but was able to reproduce a similar situation synthetically as follows:

- start with Positron with supervisor's idle shutdown timeout set to 4 hours
- start R and Python, observer `kcserver` is running as part of the Positron process tree
- close Positron, observe `kcserver` is now owned by `init(1)` and still running (expected)
- `killall kcserver` to terminate the supervisor
- now `ark` is running all by its lonesome, unsupervised (unexpected)

To help prevent this from happening, this change adds signal handlers to the supervisor that cause it to send shutdown requests to the kernels it is running before it exits itself.

QA team, could you review by seeing if this fixes the issue for you?
