### PR TITLE
Parse section headers as code cells in R

### DIFF
--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -62,6 +62,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
+const rIsSectionHeaderRegExp = new RegExp(/^#+\s+.+\s*[-=]{4,}\s*$/)
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
@@ -76,7 +77,7 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line),
+	isCellStart: (line) => rIsCellStartRegExp.test(line) || rIsSectionHeaderRegExp.test(line),
 	isCellEnd: (_line) => false,
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -62,7 +62,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
-const rIsSectionHeaderRegExp = new RegExp(/^#+\s+.+\s*[-=]{4,}\s*$/)
+const rIsSectionHeaderRegExp = new RegExp(/^#+.*[-=]{4,}\s*$/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
@@ -77,8 +77,9 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line) || rIsSectionHeaderRegExp.test(line),
-	isCellEnd: (_line) => false,
+	isCellStart: (line) => rIsCellStartRegExp.test(line),
+	// isCellEnd: (_line) => false,
+	isCellEnd: (_line) => rIsSectionHeaderRegExp.test(_line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
 	newCell: () => '\n# %%\n'

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -146,12 +146,11 @@ And a [link](target)`;
 			});
 		});
 
-		test('Parses section headers as cells', async () => {
-			const content = [codeCell3, codeCell2].join('\n\n');
+		test('Section headers end code cells', async () => {
+			const content = [codeCell2, codeCell3].join('\n\n');
 			const document = await vscode.workspace.openTextDocument({ language, content });
 			assert.deepStrictEqual(parseCells(document), [
-				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code },
-				{ range: new vscode.Range(5, 0, 8, 3), type: CellType.Code }
+				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code }
 			]);
 		});
 

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -98,6 +98,7 @@ And a [link](target)`;
 		const codeCellBody = '\n123\n456';
 		const codeCell1 = `#+\n${codeCellBody}`;
 		const codeCell2 = `# %%\n789\n\n012`;
+		const codeCell3 = `# Header ----\n\n123\n456`;
 
 		const parser = getParser(language);
 
@@ -143,6 +144,15 @@ And a [link](target)`;
 				const cell = singleCell(document, expectedType);
 				assert.strictEqual(parser?.getCellText(cell, document), expectedText);
 			});
+		});
+
+		test('Parses section headers as cells', async () => {
+			const content = [codeCell3, codeCell2].join('\n\n');
+			const document = await vscode.workspace.openTextDocument({ language, content });
+			assert.deepStrictEqual(parseCells(document), [
+				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code },
+				{ range: new vscode.Range(5, 0, 8, 3), type: CellType.Code }
+			]);
 		});
 
 		test('New cell', async () => {


### PR DESCRIPTION
Fixes #7974. Small change to the R parser to also parse section headers. I'm not sure if this is desired in python. If so, I will make a similar change there.


### Release Notes

#### New Features

- Section headers now act as cell headers (similar to `# %%`)


### QA Notes

I added a test for parsing of section headers. Additionally, I ran in debug mode and verified on mac.
