### PR TITLE
Assistant: Improve completions when using FIM prompting

### DIFF
--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -388,8 +388,8 @@ abstract class FimPromptCompletion extends CompletionModel {
 		}
 
 		const { related, prefix, suffix } = await this.getDocumentContext(document, position);
-		const relatedText = Object.entries(related).map((filename, text) => {
-			return `<file filename="${filename}">${text}</file>`;
+		const relatedText = Object.entries(related).map(([filename, text]) => {
+			return `<|file_separator|>${filename}\n${text}\n`;
 		}).join('\n');
 
 		const controller = new AbortController();
@@ -400,8 +400,12 @@ abstract class FimPromptCompletion extends CompletionModel {
 		const { textStream } = await ai.streamText({
 			model: this.model,
 			system: system,
-			messages: [{ role: 'user', content: `${relatedText}<prefix>${prefix}</prefix><suffix>${suffix}</suffix>` }],
+			messages: [
+				{ role: 'user', content: `${relatedText}\n<|file_separator|>${document.fileName}\n<|fim_prefix|>${prefix}<|fim_suffix|>${suffix}\n<|fim_middle|>` }
+			],
 			maxTokens: 128,
+			temperature: 0.2,
+			stopSequences: ['\n\n', '<|fim_prefix|>', '<|fim_suffix|>', '<|file_separator|>'],
 			abortSignal: signal,
 		});
 

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -459,8 +459,8 @@ class OpenAICompletion extends FimPromptCompletion {
 		},
 		supportedOptions: ['apiKey', 'baseUrl'],
 		defaults: {
-			name: 'GPT-4o',
-			model: 'gpt-4o',
+			name: 'GPT-4.1 Mini',
+			model: 'gpt-4.1-mini',
 			baseUrl: 'https://api.openai.com/v1',
 		},
 	};

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -245,7 +245,7 @@ class MistralCompletion extends OpenAILegacyCompletion {
 		type: positron.PositronLanguageModelType.Completion,
 		provider: {
 			id: 'mistral',
-			displayName: 'Mistral'
+			displayName: 'Mistral AI'
 		},
 		supportedOptions: ['baseUrl', 'apiKey'],
 		defaults: {

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -561,8 +561,8 @@ class GoogleCompletion extends FimPromptCompletion {
 		},
 		supportedOptions: ['baseUrl', 'apiKey'],
 		defaults: {
-			name: 'Gemini 2.0 Flash-Lite',
-			model: 'gemini-2.0-flash-lite',
+			name: 'Gemini 2.0 Flash',
+			model: 'gemini-2.0-flash-001',
 			baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
 			apiKey: undefined,
 		},

--- a/extensions/positron-assistant/src/md/prompts/completion/fim.md
+++ b/extensions/positron-assistant/src/md/prompts/completion/fim.md
@@ -1,9 +1,45 @@
-The user will provide code before and after their current cursor position in the file.
-Code before the cursor will be given in <prefix> tags. Code after the cursor will be given in <suffix> tags, which might be empty.
-The user might provide additional code in <file> tags.
+You are Positron Assistant, an expert R and Python data scientist, software developer, and coding assistant.
 
-You should respond ONLY with valid code to be inserted at the cursor. Do not
-include formatting symbols or Markdown code blocks. Do not include any
-additional text in your response.
+You are pair programming with a user to help with their coding task.
+Your job is to take a user's code and fill in any missing pieces at the user's current cursor position.
 
-To start on a new line, begin your response with a newline.
+<additional-context>
+Some information about the user's project and the current state will be automatically included:
+The user will provide you with related files in `<file>` tags.
+The user will provide you with the code before their cursor in `<prefix>` tags.
+The user will provide you with the code after their cursor in `<suffix>` tags.
+</additional-context>
+
+<communication>
+You MUST respond only with code to be inserted at the user's cursor. Do not include any additional explanatory text or prose.
+ONLY include valid and correct code in your response. Assume the document is a source file, do not include surrounding tags or markdown codeblock syntax.
+The user's cursor is probably already indented to the correct location, the IDE handles that automatically. Take care to keep this in mind and respond with the correct indentation at the start of your reply.
+If the user's file does not look like code, respond with an empty reply.
+</communication>
+
+<example>
+If the user's messages are:
+
+<user>
+<|file filename="context.txt"|>
+foo
+bar
+baz
+<|languageId="python"|>
+<|fim_prefix|>def hello():
+  foo = 123
+  bar = 456
+  <|fim_suffix|>
+  return qux
+<|fim_middle|>
+</user>
+
+You should reply with:
+
+<assistant>
+baz = 789
+  qux = foo + bar + baz
+</assistant>
+</example>
+
+The next messages you see will be from the user.

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -333,6 +333,7 @@ class OpenAILanguageModel extends AILanguageModel implements positron.ai.Languag
 			model: 'gpt-4o',
 			baseUrl: 'https://api.openai.com/v1',
 			toolCalls: true,
+			completions: true,
 		},
 	};
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -592,6 +592,7 @@ class GoogleLanguageModel extends AILanguageModel implements positron.ai.Languag
 			baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
 			apiKey: undefined,
 			toolCalls: true,
+			completions: true,
 		},
 	};
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -356,14 +356,15 @@ class MistralLanguageModel extends AILanguageModel implements positron.ai.Langua
 		type: positron.PositronLanguageModelType.Chat,
 		provider: {
 			id: 'mistral',
-			displayName: 'Mistral'
+			displayName: 'Mistral AI'
 		},
-		supportedOptions: ['apiKey', 'baseUrl', 'toolCalls'],
+		supportedOptions: ['apiKey', 'baseUrl'],
 		defaults: {
-			name: 'Pixtral Large',
-			model: 'pixtral-large-latest',
+			name: 'Mistral Medium',
+			model: 'mistral-medium-latest',
 			baseUrl: 'https://api.mistral.ai/v1',
 			toolCalls: true,
+			completions: true,
 		},
 	};
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2011,6 +2011,7 @@ declare module 'positron' {
 			location?: string;
 			numCtx?: number;
 			maxOutputTokens?: number;
+			completions?: boolean;
 		}
 
 		/**

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -250,6 +250,26 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			setShowProgress(false);
 			setError(localize('positron.newConnectionModalDialog.incompleteConfig', 'The configuration is incomplete.'));
 		}
+
+		if (providerConfig.completions) {
+			// Assume a completion source exists with the same provider ID and compatible auth details
+			const completionSource = props.sources.find((source) => source.provider.id === providerConfig.provider && source.type === 'completion')!;
+			const completionConfig = {
+				provider: providerConfig.provider,
+				type: PositronLanguageModelType.Completion,
+				...completionSource.defaults,
+				apiKey: providerConfig.apiKey,
+				oauth: providerConfig.oauth,
+			}
+			props.onAction(
+				completionConfig,
+				source.signedIn ? 'delete' : 'save')
+				.catch((e) => {
+					setError(e.message);
+				}).finally(() => {
+					setShowProgress(false);
+				});
+		}
 	}
 
 	// Returns a cancel for the dialog and closes it

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -74,6 +74,7 @@ export interface IPositronLanguageModelConfig {
 	location?: string;
 	numCtx?: number;
 	maxOutputTokens?: number;
+	completions?: boolean;
 }
 
 //#endregion


### PR DESCRIPTION
Improves the experience when using a FIM prompt for ghost text completion.

Note: This method is _not_ used for GitHub Copilot completions, but can enable ghost text when using API providers without built-in completion support.

Changes:

* Rewritten and improved the FIM completion prompt.
* Switched from XML to using the "standard" FIM completion tokens: `<|fim_prefix|>`, `<|fim_suffix|>`, `<|fim_middle|>`. IIUC many modern LLM models now support these tokens natively.
* Fixed including related content from additional files in the workspace in the FIM request.
* Lowered temperature (following OpenAI documentation) and added stop sequences.
* Updated some LLM model selection:
  - OpenAI: GPT-4.1 Mini (for completion only)
  - Google: Gemini 2.0 Flash (for completion only)
  - Mistral: Mistral Medium (chat), Codestral (completion)
 
* Added a parameter `completion` to provider config. When `true`, signs in to both a chat and completion source when logging in with that provider.
* Set the above `completion` parameter to `true` for Mistral, Google, and OpenAI.

### QA Notes

It is intended that the "default available" providers Anthropic and GitHub Copilot are unaffected by this change.

To test:
* Add provider to experimental `positron.assistant.enabledProviders` setting.
* Login with a Mistral, Google or OpenAI API key
* Observe that a completion model is registered alongside the chat model
* Confirm ghost text completions appear from the newly registered model