### PR TITLE
Positron API package and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "monaco-compile-check": "tsc -p src/tsconfig.monaco.json --noEmit",
     "tsec-compile-check": "node node_modules/tsec/bin/tsec -p src/tsconfig.tsec.json",
     "vscode-dts-compile-check": "tsc -p src/tsconfig.vscode-dts.json && tsc -p src/tsconfig.vscode-proposed-dts.json",
+    "build-types-package": "cd positron-api-pkg && npm run build",
     "valid-layers-check": "node build/lib/layersChecker.js",
     "property-init-order-check": "node build/lib/propertyInitOrderChecker.js",
     "update-distro": "node build/npm/update-distro.mjs",

--- a/positron-api-pkg/.gitignore
+++ b/positron-api-pkg/.gitignore
@@ -1,5 +1,5 @@
 # Generated types file
-index.d.ts
+dist/index.d.ts
 
 # NPM
 node_modules/

--- a/positron-api-pkg/.gitignore
+++ b/positron-api-pkg/.gitignore
@@ -1,0 +1,12 @@
+# Generated types file
+index.d.ts
+
+# NPM
+node_modules/
+npm-debug.log*
+*.tgz
+.npm
+
+# Temporary files
+*.tmp
+*.temp

--- a/positron-api-pkg/LICENSE
+++ b/positron-api-pkg/LICENSE
@@ -1,0 +1,89 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms immediately terminates.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of the software.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/positron-api-pkg/PUBLISHING.md
+++ b/positron-api-pkg/PUBLISHING.md
@@ -1,0 +1,101 @@
+# Publishing @posit-dev/positron
+
+This guide explains how to publish the `@posit-dev/positron` package to npm. This should be done after any changes to the Positron API. (Eventually this will be automated using CI.)
+
+_This guide is not included in the readme because the readme is displayed on the NPM package page and it would be confusing to have two different guides._
+
+## Prerequisites
+
+1. **NPM Account**: You need an npm account with access to publish under the `@posit-dev` scope
+2. **Authentication**: Login to npm with `npm login`
+3. **Permissions**: Ensure you have publish permissions for the `@posit-dev` organization
+
+## Publishing Process
+
+### 1. Build the Package
+
+From the root of the Positron repository:
+
+```bash
+npm run build-api-pkg
+```
+
+Or from the package directory:
+
+```bash
+cd positron-api-pkg
+npm run build
+```
+
+This will run a comprehensive build script that:
+1. Gathers the latest type definitions from Positron source
+2. Compiles TypeScript source code
+3. Copies ambient module declarations to distribution
+4. Adds reference directives for proper module resolution
+
+The build process creates:
+- `dist/index.js` - Compiled JavaScript with runtime detection
+- `dist/index.d.ts` - Main TypeScript definitions with reference directives
+- `dist/positron.d.ts` - Ambient module declarations for 'positron' namespace
+- `dist/ui-comm.d.ts` - Ambient module declarations for 'ui-comm' namespace
+
+### 2. Update Version
+
+Navigate to the package directory and update the version:
+
+```bash
+cd positron-api-pkg
+npm version patch  # or minor/major as appropriate
+```
+
+### 3. Publish
+
+```bash
+npm publish
+```
+
+The `prepublishOnly` script will automatically rebuild the package before publishing.
+
+## Version Guidelines
+
+Follow semantic versioning:
+
+- **Major**: Breaking changes to the API
+- **Minor**: New API features (backward compatible)
+- **Patch**: Bug fixes, documentation updates
+
+## Automated Publishing (Future)
+
+Consider setting up automated publishing via GitHub Actions:
+
+1. On Positron releases
+2. When type definitions change
+3. With proper version bumping based on changes
+
+## Troubleshooting
+
+### Permission Denied
+```bash
+npm login
+# Ensure you're logged in with correct credentials
+```
+
+### Package Already Exists
+Check if version was already published:
+```bash
+npm view @posit-dev/positron versions --json
+```
+
+### Build Failures
+Ensure the main Positron build works:
+```bash
+cd ../..
+npm run compile
+npm run build-js-sdk
+```
+
+Or from the package directory:
+```bash
+npm run clean
+npm run build
+```

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -39,10 +39,30 @@ export function activate(context: vscode.ExtensionContext) {
 }
 ```
 
-You can also directly use the `aquirePositronApi` function that is available in Positron, but you will need to wrap it in a try/catch block to handle the case where it is not available. This is useful if you want to use the Positron API in a way that is not supported by the `tryAcquirePositronApi` function.
-
-
 ### Advanced Usage
+
+#### Global acquirePositronApi Function
+
+When running in Positron, a global `acquirePositronApi` function is injected that you can call directly. This package provides TypeScript definitions for this function. **Important**: This function is `undefined` when running in VS Code.
+
+```typescript
+// The global function is typed as optional - always check before calling
+if (typeof acquirePositronApi !== 'undefined') {
+  const positronApi = acquirePositronApi();
+  if (positronApi) {
+    // Use the API directly
+    positronApi.runtime.executeCode('python', 'print("Direct access!")', true);
+  }
+}
+
+// Alternative using optional chaining
+const positronApi = globalThis.acquirePositronApi?.();
+if (positronApi) {
+  // Safe to use here
+}
+```
+
+> **Recommendation**: For most use cases, prefer `tryAcquirePositronApi()` which handles the detection logic for you and provides cleaner code.
 
 #### Runtime Detection
 ```typescript

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -6,21 +6,21 @@
 
 ---
 
-TypeScript definitions and runtime utilities for the [Positron](https://github.com/posit-dev/positron) API.
+TypeScript definitions and runtime utilities for the [Positron](https://github.com/posit-dev/positron) API. This package is for extensions that want to utilize the Positron API to add custom functionality for Positron.
 
-Positron is a next-generation data science IDE powered by VS Code, designed specifically for data science workflows in Python and R.
 
 ## Installation
 
 ```bash
-npm install --save-dev @posit-dev/positron @types/vscode
+npm install --save-dev @posit-dev/positron
 ```
 
 ## Usage
 
 ### Basic Usage
 
-The `tryAcquirePositronApi` function is the main entry point for the Positron API. It returns the Positron API object if it is available, or `undefined` if it is not. This function is safe to call in both Positron and VS Code.
+The `tryAcquirePositronApi` function is the main entry point for the Positron API. It returns the Positron API object if it is available (aka code is running in Positron), or `undefined` if it is not. This function is safe to call in both Positron and VS Code.
+
 ```typescript
 import { tryAcquirePositronApi } from '@posit-dev/positron';
 import * as vscode from 'vscode';

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -56,6 +56,18 @@ function executeInPositron(code: string) {
 }
 ```
 
+#### Cross-Platform URL Preview
+```typescript
+import { previewUrl } from '@posit-dev/positron';
+
+// Works in both Positron and VS Code
+async function showLocalServer() {
+  // In Positron: Opens in preview pane
+  // In VS Code: Opens in external browser
+  await previewUrl('http://localhost:3000');
+}
+```
+
 #### Type-only Imports
 ```typescript
 import type {
@@ -70,19 +82,19 @@ function processRuntime(runtime: LanguageRuntimeMetadata) {
 ```
 
 #### Feature Flagging
+There are many ways you could "feature flag" Positron-specific functionality. Here is one example:
+
 ```typescript
-import { getPositronApi } from '@posit-dev/positron';
+import { getPositronApi, previewUrl } from '@posit-dev/positron';
 
 export class MyExtension {
   private positronApi = getPositronApi();
 
-  async showData(data: any[]) {
+  async doFoo() {
     if (this.positronApi) {
-      // Use Positron's data viewer
-      await this.positronApi.window.previewUrl(/* data url */);
+      ... // Positron-specific functionality
     } else {
-      // Fallback to VS Code's generic viewer
-      await vscode.commands.executeCommand('vscode.open', /* data file */);
+      ... // VS Code-only functionality
     }
   }
 }

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -66,11 +66,7 @@ if (positronApi) {
 
 #### Runtime Detection
 ```typescript
-import { tryAcquirePositronApi } from '@posit-dev/positron';
-
-function isPositronAvailable(): boolean {
-  return tryAcquirePositronApi() !== undefined;
-}
+import { tryAcquirePositronApi, inPositron } from '@posit-dev/positron';
 
 function executeInPositron(code: string) {
   const api = tryAcquirePositronApi();
@@ -78,6 +74,13 @@ function executeInPositron(code: string) {
     return api.runtime.executeCode('python', code, false);
   }
   throw new Error('Positron not available');
+}
+
+// Clean conditional logic with inPositron()
+if (inPositron()) {
+  // Positron-specific code
+  const api = acquirePositronApi!(); // Safe to assert since inPositron() is true
+  api.runtime.executeCode('python', 'print("Hello!")', true);
 }
 ```
 

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -1,0 +1,214 @@
+# @posit-dev/positron
+
+> ⚠️ **EXPERIMENTAL - USE WITH EXTREME CAUTION**
+>
+> This package is currently experimental and should be used with extreme caution. The API definitions may change without notice, break compatibility, or be removed entirely. This package is not yet recommended for production use. Use at your own risk.
+
+---
+
+TypeScript definitions and runtime utilities for the [Positron](https://github.com/posit-dev/positron) API.
+
+Positron is a next-generation data science IDE powered by VS Code, designed specifically for data science workflows in Python and R.
+
+## Installation
+
+```bash
+npm install --save-dev @posit-dev/positron @types/vscode
+```
+
+## Usage
+
+### Basic Usage
+```typescript
+import { getPositronApi } from '@posit-dev/positron';
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const positronApi = getPositronApi();
+
+  if (positronApi) {
+    // Running in Positron - enhanced features available
+    vscode.window.showInformationMessage('Enhanced by Positron!');
+    positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
+  } else {
+    // Running in VS Code - standard functionality only
+    vscode.window.showInformationMessage('Running in VS Code mode');
+  }
+}
+```
+
+### Advanced Usage
+
+#### Runtime Detection
+```typescript
+import { getPositronApi } from '@posit-dev/positron';
+
+function isPositronAvailable(): boolean {
+  return getPositronApi() !== undefined;
+}
+
+function executeInPositron(code: string) {
+  const api = getPositronApi();
+  if (api) {
+    return api.runtime.executeCode('python', code, false);
+  }
+  throw new Error('Positron not available');
+}
+```
+
+#### Type-only Imports
+```typescript
+import type {
+  LanguageRuntimeMetadata,
+  RuntimeState,
+  LanguageRuntimeSession
+} from '@posit-dev/positron';
+
+function processRuntime(runtime: LanguageRuntimeMetadata) {
+  // Use types for development, getPositronApi() for runtime access
+}
+```
+
+#### Feature Flagging
+```typescript
+import { getPositronApi } from '@posit-dev/positron';
+
+export class MyExtension {
+  private positronApi = getPositronApi();
+
+  async showData(data: any[]) {
+    if (this.positronApi) {
+      // Use Positron's data viewer
+      await this.positronApi.window.previewUrl(/* data url */);
+    } else {
+      // Fallback to VS Code's generic viewer
+      await vscode.commands.executeCommand('vscode.open', /* data file */);
+    }
+  }
+}
+```
+
+## API Coverage
+
+This package includes TypeScript definitions for:
+
+### Core APIs
+- **Runtime Management**: `LanguageRuntimeManager`, `LanguageRuntimeSession`
+- **Language Runtime Messages**: All message types and interfaces
+- **Runtime States**: State enums and metadata interfaces
+- **Client Management**: Runtime client types and handlers
+
+### UI APIs
+- **Window Extensions**: Preview panels, output channels, modal dialogs
+- **Language Features**: Statement range providers, help topic providers
+- **Console Integration**: Console API for language-specific interactions
+
+### Specialized APIs
+- **Connections**: Database connection driver interfaces
+- **Environment**: Environment variable management
+- **AI Features**: Language model and chat agent interfaces
+- **Plotting**: Plot rendering settings and formats
+
+## Version Compatibility
+
+| @posit-dev/positron | Positron Version | VS Code API |
+|----------------|------------------|-------------|
+| 0.1.x          | 2025.07.0+      | 1.74.0+     |
+
+## Development
+
+This package is automatically generated from the Positron source code. The types are extracted and processed to be standalone, with all internal dependencies inlined.
+
+### Building from Source
+
+```bash
+# Clone the Positron repository
+git clone https://github.com/posit-dev/positron.git
+cd positron/positron-api-pkg
+
+# Build the package
+npm run build
+```
+
+This will run a single build script that:
+1. **Gathers types** - Copy `.d.ts` files from main Positron source
+2. **Compiles TypeScript** - Transform source to JavaScript and declarations
+3. **Copies ambient declarations** - Include module declarations in distribution
+4. **Adds reference directives** - Link declarations for proper module resolution
+
+### Development Workflow
+
+From the package directory:
+
+```bash
+# Clean all generated files
+npm run clean
+
+# Run complete build process (all steps above)
+npm run build
+```
+
+### From Positron Repository Root
+
+```bash
+# Build the package from the main repo
+npm run build-js-sdk
+```
+
+## Examples
+
+### Working with Language Runtimes
+
+```typescript
+import { getPositronApi } from '@posit-dev/positron';
+import type { RuntimeCodeExecutionMode } from '@posit-dev/positron';
+
+// Execute code in a runtime (Positron only)
+const positronApi = getPositronApi();
+if (positronApi) {
+  await positronApi.runtime.executeCode(
+    'python',
+    'print("Hello from Positron!")',
+    true, // focus console
+    false, // require complete code
+    RuntimeCodeExecutionMode.Interactive
+  );
+
+  // Get active sessions
+  const sessions = await positronApi.runtime.getActiveSessions();
+  for (const session of sessions) {
+    console.log(`Session: ${session.runtimeMetadata.runtimeName}`);
+  }
+}
+```
+
+### Creating Preview Panels
+
+```typescript
+import { getPositronApi } from '@posit-dev/positron';
+import * as vscode from 'vscode';
+
+// Create a preview panel for web content (Positron only)
+const positronApi = getPositronApi();
+if (positronApi) {
+  const panel = positronApi.window.createPreviewPanel(
+    'myExtension.preview',
+    'My Preview',
+    true, // preserve focus
+    {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.file('/path/to/resources')]
+    }
+  );
+
+  panel.webview.html = '<html><body><h1>Hello Positron!</h1></body></html>';
+}
+```
+
+## Contributing
+
+This package is maintained as part of the Positron project. Please report issues and contribute improvements through the main [Positron repository](https://github.com/posit-dev/positron).
+
+## License
+
+Licensed under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license).

--- a/positron-api-pkg/README.md
+++ b/positron-api-pkg/README.md
@@ -19,12 +19,14 @@ npm install --save-dev @posit-dev/positron @types/vscode
 ## Usage
 
 ### Basic Usage
+
+The `tryAcquirePositronApi` function is the main entry point for the Positron API. It returns the Positron API object if it is available, or `undefined` if it is not. This function is safe to call in both Positron and VS Code.
 ```typescript
-import { getPositronApi } from '@posit-dev/positron';
+import { tryAcquirePositronApi } from '@posit-dev/positron';
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-  const positronApi = getPositronApi();
+  const positronApi = tryAcquirePositronApi();
 
   if (positronApi) {
     // Running in Positron - enhanced features available
@@ -37,18 +39,21 @@ export function activate(context: vscode.ExtensionContext) {
 }
 ```
 
+You can also directly use the `aquirePositronApi` function that is available in Positron, but you will need to wrap it in a try/catch block to handle the case where it is not available. This is useful if you want to use the Positron API in a way that is not supported by the `tryAcquirePositronApi` function.
+
+
 ### Advanced Usage
 
 #### Runtime Detection
 ```typescript
-import { getPositronApi } from '@posit-dev/positron';
+import { tryAcquirePositronApi } from '@posit-dev/positron';
 
 function isPositronAvailable(): boolean {
-  return getPositronApi() !== undefined;
+  return tryAcquirePositronApi() !== undefined;
 }
 
 function executeInPositron(code: string) {
-  const api = getPositronApi();
+  const api = tryAcquirePositronApi();
   if (api) {
     return api.runtime.executeCode('python', code, false);
   }
@@ -77,7 +82,7 @@ import type {
 } from '@posit-dev/positron';
 
 function processRuntime(runtime: LanguageRuntimeMetadata) {
-  // Use types for development, getPositronApi() for runtime access
+  // Use types for development, tryAcquirePositronApi() for runtime access
 }
 ```
 
@@ -85,10 +90,10 @@ function processRuntime(runtime: LanguageRuntimeMetadata) {
 There are many ways you could "feature flag" Positron-specific functionality. Here is one example:
 
 ```typescript
-import { getPositronApi, previewUrl } from '@posit-dev/positron';
+import { tryAcquirePositronApi, previewUrl } from '@posit-dev/positron';
 
 export class MyExtension {
-  private positronApi = getPositronApi();
+  private positronApi = tryAcquirePositronApi();
 
   async doFoo() {
     if (this.positronApi) {
@@ -172,11 +177,11 @@ npm run build-js-sdk
 ### Working with Language Runtimes
 
 ```typescript
-import { getPositronApi } from '@posit-dev/positron';
+import { tryAcquirePositronApi } from '@posit-dev/positron';
 import type { RuntimeCodeExecutionMode } from '@posit-dev/positron';
 
 // Execute code in a runtime (Positron only)
-const positronApi = getPositronApi();
+const positronApi = tryAcquirePositronApi();
 if (positronApi) {
   await positronApi.runtime.executeCode(
     'python',
@@ -197,11 +202,11 @@ if (positronApi) {
 ### Creating Preview Panels
 
 ```typescript
-import { getPositronApi } from '@posit-dev/positron';
+import { tryAcquirePositronApi } from '@posit-dev/positron';
 import * as vscode from 'vscode';
 
 // Create a preview panel for web content (Positron only)
-const positronApi = getPositronApi();
+const positronApi = tryAcquirePositronApi();
 if (positronApi) {
   const panel = positronApi.window.createPreviewPanel(
     'myExtension.preview',

--- a/positron-api-pkg/build.js
+++ b/positron-api-pkg/build.js
@@ -175,20 +175,20 @@ console.log('\n🔍 Step 5: Validating built package...');
 try {
 	// Test that the built package can be required (CommonJS output)
 	const builtPackage = require(path.join(PATHS.DIST_DIR, 'index.js'));
-	
+
 	// Verify the main export exists
-	if (typeof builtPackage.getPositronApi !== 'function') {
-		throw new Error('getPositronApi function not exported');
+	if (typeof builtPackage.tryAcquirePositronApi !== 'function') {
+		throw new Error('tryAcquirePositronApi function not exported');
 	}
-	
+
 	// Test that the function returns undefined in this environment (expected behavior)
-	const api = builtPackage.getPositronApi();
+	const api = builtPackage.tryAcquirePositronApi();
 	if (api !== undefined) {
-		throw new Error('getPositronApi should return undefined in build environment');
+		throw new Error('tryAcquirePositronApi should return undefined in build environment');
 	}
-	
+
 	console.log('   ✅ Package validation passed');
-	console.log('   ✅ getPositronApi function is properly exported');
+	console.log('   ✅ tryAcquirePositronApi function is properly exported');
 	console.log('   ✅ Function correctly returns undefined in non-Positron environment');
 } catch (error) {
 	console.error(`   ❌ Package validation failed: ${error.message}`);

--- a/positron-api-pkg/build.js
+++ b/positron-api-pkg/build.js
@@ -1,0 +1,208 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Complete build script for @posit-dev/positron package
+ *
+ * This script handles the entire build process from source gathering to final package generation.
+ * It combines what were previously separate "gather" and "compile" steps into a single workflow.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Centralize paths to prevent duplication and make maintenance easier
+const PATHS = {
+	SOURCE_DIR: path.join(__dirname, '../src/positron-dts'),
+	PACKAGE_SRC: path.join(__dirname, 'src'),
+	DIST_DIR: path.join(__dirname, 'dist')
+};
+
+// Centralize filenames to avoid typos and enable easy renaming
+const FILES = {
+	POSITRON_DTS: 'positron.d.ts',
+	UI_COMM_DTS: 'ui-comm.d.ts',
+	INDEX_DTS: 'index.d.ts'
+};
+
+console.log('🔨 Building @posit-dev/positron package...\n');
+
+// =============================================================================
+// PREREQUISITE VALIDATION
+// =============================================================================
+// Early validation prevents confusing error messages later in the build process
+
+console.log('🔍 Validating prerequisites...');
+
+const sourceFile = path.join(PATHS.SOURCE_DIR, FILES.POSITRON_DTS);
+const uiCommFile = path.join(PATHS.SOURCE_DIR, FILES.UI_COMM_DTS);
+
+if (!fs.existsSync(sourceFile)) {
+	console.error(`   ❌ Source file not found: ${sourceFile}`);
+	process.exit(1);
+}
+
+if (!fs.existsSync(uiCommFile)) {
+	console.error(`   ❌ Source file not found: ${uiCommFile}`);
+	process.exit(1);
+}
+
+// Fail fast if TypeScript isn't available rather than during compilation
+try {
+	execSync('tsc --version', { stdio: 'pipe' });
+} catch (error) {
+	console.error('   ❌ TypeScript compiler not found. Please install TypeScript globally or in this project.');
+	process.exit(1);
+}
+
+// Verify we're in the correct working directory
+const packageJsonPath = path.join(__dirname, 'package.json');
+if (!fs.existsSync(packageJsonPath)) {
+	console.error('   ❌ package.json not found. Are you running this script from the correct directory?');
+	process.exit(1);
+}
+
+console.log('   ✅ All prerequisites validated');
+
+// =============================================================================
+// STEP 1: GATHER TYPE DEFINITIONS FROM MAIN POSITRON SOURCE
+// =============================================================================
+// Copy ambient module declarations from the main Positron repository.
+// These .d.ts files contain 'declare module' statements that register the
+// 'positron' and 'ui-comm' modules in TypeScript's module system, making
+// them available for import in consumer code.
+
+console.log('📥 Step 1: Gathering type definitions from Positron source...');
+
+// Create src directory if missing to avoid copy failures
+if (!fs.existsSync(PATHS.PACKAGE_SRC)) {
+	try {
+		fs.mkdirSync(PATHS.PACKAGE_SRC, { recursive: true });
+	} catch (error) {
+		console.error(`   ❌ Failed to create package source directory: ${error.message}`);
+		process.exit(1);
+	}
+}
+
+// Copy source files with error handling to catch permission or disk space issues
+try {
+	fs.copyFileSync(sourceFile, path.join(PATHS.PACKAGE_SRC, FILES.POSITRON_DTS));
+	fs.copyFileSync(uiCommFile, path.join(PATHS.PACKAGE_SRC, FILES.UI_COMM_DTS));
+	console.log('   ✅ Type definitions copied to package source directory');
+} catch (error) {
+	console.error(`   ❌ Failed to copy type definitions: ${error.message}`);
+	process.exit(1);
+}
+
+// =============================================================================
+// STEP 2: COMPILE TYPESCRIPT SOURCE CODE
+// =============================================================================
+// Run the TypeScript compiler to transform our TypeScript source files into
+// JavaScript (.js) and declaration files (.d.ts). This generates the main
+// package entry point that consumers will actually use.
+
+console.log('\n🔧 Step 2: Compiling TypeScript source code...');
+
+try {
+	execSync('tsc --project tsconfig.json', { stdio: 'inherit', cwd: __dirname });
+	console.log('   ✅ TypeScript compilation completed');
+} catch (error) {
+	console.error('   ❌ TypeScript compilation failed');
+	process.exit(1);
+}
+
+// =============================================================================
+// STEP 3: COPY AMBIENT DECLARATIONS TO DISTRIBUTION
+// =============================================================================
+// Copy the ambient module declarations from src/ to dist/ so they're included
+// in the published package. These files must be distributed alongside the
+// compiled code to make the 'positron' and 'ui-comm' namespaces available
+// to package consumers.
+
+console.log('\n📦 Step 3: Copying ambient module declarations to distribution...');
+
+// Copy files with error handling since dist operations can fail due to permissions
+try {
+	fs.copyFileSync(path.join(PATHS.PACKAGE_SRC, FILES.POSITRON_DTS), path.join(PATHS.DIST_DIR, FILES.POSITRON_DTS));
+	fs.copyFileSync(path.join(PATHS.PACKAGE_SRC, FILES.UI_COMM_DTS), path.join(PATHS.DIST_DIR, FILES.UI_COMM_DTS));
+	console.log('   ✅ Ambient declarations copied to dist/');
+} catch (error) {
+	console.error(`   ❌ Failed to copy ambient declarations: ${error.message}`);
+	process.exit(1);
+}
+
+// =============================================================================
+// STEP 4: ADD REFERENCE DIRECTIVES TO MAIN DECLARATION FILE
+// =============================================================================
+// Modify the compiled index.d.ts file to include reference directives that
+// point to our ambient module declarations. This ensures TypeScript can
+// properly resolve the 'positron' and 'ui-comm' modules when consumers
+// import this package.
+
+console.log('\n🔗 Step 4: Adding reference directives to main declaration file...');
+
+const indexFile = path.join(PATHS.DIST_DIR, FILES.INDEX_DTS);
+
+// Handle file operations with error checking since file corruption here breaks the entire package
+try {
+	const content = fs.readFileSync(indexFile, 'utf8');
+	const references = [
+		`/// <reference path="./${FILES.POSITRON_DTS}" />`,
+		`/// <reference path="./${FILES.UI_COMM_DTS}" />`,
+		'',
+		content
+	].join('\n');
+
+	fs.writeFileSync(indexFile, references);
+	console.log('   ✅ Reference directives added to index.d.ts');
+} catch (error) {
+	console.error(`   ❌ Failed to add reference directives: ${error.message}`);
+	process.exit(1);
+}
+
+// =============================================================================
+// STEP 5: VALIDATE BUILT PACKAGE
+// =============================================================================
+// Test that the built package can actually be imported and used. This ensures
+// that all the compilation and file operations resulted in a working package
+// that exports the expected functionality.
+
+console.log('\n🔍 Step 5: Validating built package...');
+
+try {
+	// Test that the built package can be required (CommonJS output)
+	const builtPackage = require(path.join(PATHS.DIST_DIR, 'index.js'));
+	
+	// Verify the main export exists
+	if (typeof builtPackage.getPositronApi !== 'function') {
+		throw new Error('getPositronApi function not exported');
+	}
+	
+	// Test that the function returns undefined in this environment (expected behavior)
+	const api = builtPackage.getPositronApi();
+	if (api !== undefined) {
+		throw new Error('getPositronApi should return undefined in build environment');
+	}
+	
+	console.log('   ✅ Package validation passed');
+	console.log('   ✅ getPositronApi function is properly exported');
+	console.log('   ✅ Function correctly returns undefined in non-Positron environment');
+} catch (error) {
+	console.error(`   ❌ Package validation failed: ${error.message}`);
+	process.exit(1);
+}
+
+// =============================================================================
+// BUILD COMPLETE
+// =============================================================================
+
+console.log('\n🎉 Build completed successfully!');
+console.log('\n📋 Generated files:');
+console.log('   • dist/index.js     - Runtime API detection function');
+console.log('   • dist/index.d.ts   - Main TypeScript definitions');
+console.log('   • dist/positron.d.ts - Ambient \'positron\' module declarations');
+console.log('   • dist/ui-comm.d.ts  - Ambient \'ui-comm\' module declarations');
+console.log('\n🚀 Package is ready for publishing or consumption!');

--- a/positron-api-pkg/dist/index.js
+++ b/positron-api-pkg/dist/index.js
@@ -1,0 +1,44 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getPositronApi = getPositronApi;
+/**
+ * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
+ *
+ * This function handles the detection of whether the extension is running in Positron or VS Code,
+ * and provides access to Positron-specific functionality when available.
+ *
+ * @returns The Positron API object if available, or undefined if running in VS Code
+ *
+ * @example
+ * ```typescript
+ * import { getPositronApi } from '@posit-dev/positron';
+ *
+ * const positronApi = getPositronApi();
+ * if (positronApi) {
+ *   // We're in Positron - use enhanced features
+ *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+function getPositronApi() {
+    try {
+        // Check if we're running in Positron by looking for the global acquirePositronApi function
+        if (typeof globalThis !== 'undefined' &&
+            typeof globalThis.acquirePositronApi === 'function') {
+            return globalThis.acquirePositronApi();
+        }
+        return undefined;
+    }
+    catch (error) {
+        // If any error occurs (e.g., acquirePositronApi throws), return undefined
+        // This ensures extensions gracefully degrade to VS Code mode
+        return undefined;
+    }
+}

--- a/positron-api-pkg/dist/index.js
+++ b/positron-api-pkg/dist/index.js
@@ -4,10 +4,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.previewUrl = exports.tryAcquirePositronApi = void 0;
+exports.previewUrl = exports.inPositron = exports.tryAcquirePositronApi = void 0;
 // Re-export the runtime function and types from the runtime module
 var runtime_1 = require("./runtime");
 Object.defineProperty(exports, "tryAcquirePositronApi", { enumerable: true, get: function () { return runtime_1.tryAcquirePositronApi; } });
+Object.defineProperty(exports, "inPositron", { enumerable: true, get: function () { return runtime_1.inPositron; } });
 // Re-export preview functions
 var preview_1 = require("./preview");
 Object.defineProperty(exports, "previewUrl", { enumerable: true, get: function () { return preview_1.previewUrl; } });

--- a/positron-api-pkg/dist/index.js
+++ b/positron-api-pkg/dist/index.js
@@ -4,41 +4,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getPositronApi = getPositronApi;
-/**
- * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
- *
- * This function handles the detection of whether the extension is running in Positron or VS Code,
- * and provides access to Positron-specific functionality when available.
- *
- * @returns The Positron API object if available, or undefined if running in VS Code
- *
- * @example
- * ```typescript
- * import { getPositronApi } from '@posit-dev/positron';
- *
- * const positronApi = getPositronApi();
- * if (positronApi) {
- *   // We're in Positron - use enhanced features
- *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
- * } else {
- *   // We're in VS Code - use standard functionality
- *   console.log('Running in VS Code mode');
- * }
- * ```
- */
-function getPositronApi() {
-    try {
-        // Check if we're running in Positron by looking for the global acquirePositronApi function
-        if (typeof globalThis !== 'undefined' &&
-            typeof globalThis.acquirePositronApi === 'function') {
-            return globalThis.acquirePositronApi();
-        }
-        return undefined;
-    }
-    catch (error) {
-        // If any error occurs (e.g., acquirePositronApi throws), return undefined
-        // This ensures extensions gracefully degrade to VS Code mode
-        return undefined;
-    }
-}
+exports.previewUrl = exports.tryAcquirePositronApi = void 0;
+// Re-export the runtime function and types from the runtime module
+var runtime_1 = require("./runtime");
+Object.defineProperty(exports, "tryAcquirePositronApi", { enumerable: true, get: function () { return runtime_1.tryAcquirePositronApi; } });
+// Re-export preview functions
+var preview_1 = require("./preview");
+Object.defineProperty(exports, "previewUrl", { enumerable: true, get: function () { return preview_1.previewUrl; } });

--- a/positron-api-pkg/dist/positron.d.ts
+++ b/positron-api-pkg/dist/positron.d.ts
@@ -1,0 +1,2091 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'positron' {
+
+	import * as vscode from 'vscode';
+
+	/**
+	 * The current Positron version. This is the Positron calendar version, e.g. "2028.10.2"
+	 */
+	export const version: string;
+
+	/**
+	 * The Positron build number. This is a monotonically increasing number that uniquely
+	 * identifies a build of Positron within a release.
+	 */
+	export const buildNumber: number;
+
+	/** The set of possible language runtime messages */
+	export enum LanguageRuntimeMessageType {
+		/** A message instructing the frontend to clear the output of a runtime execution. */
+		ClearOutput = 'clear_output',
+
+		/** A message representing output (text, plots, etc.) */
+		Output = 'output',
+
+		/** A message representing the computational result of a runtime execution */
+		Result = 'result',
+
+		/** A message representing output from one of the standard streams (stdout or stderr) */
+		Stream = 'stream',
+
+		/** A message representing echoed user input */
+		Input = 'input',
+
+		/** A message representing an error that occurred while executing user code */
+		Error = 'error',
+
+		/** A message representing a prompt for user input */
+		Prompt = 'prompt',
+
+		/** A message representing a change in the runtime's online state */
+		State = 'state',
+
+		/** A message representing a runtime event */
+		Event = 'event',
+
+		/** A message representing a new comm (client instance) being opened from the runtime side */
+		CommOpen = 'comm_open',
+
+		/** A message representing data received via a comm (to a client instance) */
+		CommData = 'comm_data',
+
+		/** A message indicating that a comm (client instance) was closed from the server side */
+		CommClosed = 'comm_closed',
+
+		/** A message that should be handled by an IPyWidget */
+		IPyWidget = 'ipywidget',
+
+		/** A message representing a request to update an output */
+		UpdateOutput = 'update_output',
+	}
+
+	/**
+	 * The set of possible statuses for a language runtime while online
+	 */
+	export enum RuntimeOnlineState {
+		/** The runtime is starting up */
+		Starting = 'starting',
+
+		/** The runtime is ready to execute code. */
+		Idle = 'idle',
+
+		/** The runtime is busy executing code. */
+		Busy = 'busy',
+	}
+
+	/**
+	 * The set of possible statuses for a language runtime
+	 */
+	export enum RuntimeState {
+		/** The runtime has not been started or initialized yet. */
+		Uninitialized = 'uninitialized',
+
+		/** The runtime is initializing (preparing to start). */
+		Initializing = 'initializing',
+
+		/** The runtime is in the process of starting up. It isn't ready for messages. */
+		Starting = 'starting',
+
+		/** The runtime has a heartbeat and is ready for messages. */
+		Ready = 'ready',
+
+		/** The runtime is ready to execute code. */
+		Idle = 'idle',
+
+		/** The runtime is busy executing code. */
+		Busy = 'busy',
+
+		/** The runtime is in the process of restarting. */
+		Restarting = 'restarting',
+
+		/** The runtime is in the process of shutting down. */
+		Exiting = 'exiting',
+
+		/** The runtime's host process has ended. */
+		Exited = 'exited',
+
+		/** The runtime is not responding to heartbeats and is presumed offline. */
+		Offline = 'offline',
+
+		/** The user has interrupted a busy runtime, but the runtime is not idle yet. */
+		Interrupting = 'interrupting',
+	}
+
+	/**
+	 * Results of analyzing code fragment for completeness
+	 */
+	export enum RuntimeCodeFragmentStatus {
+		/** The code fragment is complete: it is a valid, self-contained expression */
+		Complete = 'complete',
+
+		/** The code is incomplete: it is an expression that is missing elements or operands, such as "1 +" or "foo(" */
+		Incomplete = 'incomplete',
+
+		/** The code is invalid: an expression that cannot be parsed because of a syntax error */
+		Invalid = 'invalid',
+
+		/** It was not possible to ascertain the code fragment's status */
+		Unknown = 'unknown'
+	}
+
+	/**
+	 * Possible code execution modes for a language runtime
+	 */
+	export enum RuntimeCodeExecutionMode {
+		/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+		Interactive = 'interactive',
+
+		/** The code should be executed but not stored in history. */
+		Transient = 'transient',
+
+		/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+		Silent = 'silent'
+	}
+
+	/**
+	 * Possible error dispositions for a language runtime
+	 */
+	export enum RuntimeErrorBehavior {
+		/** The runtime should stop when an error is encountered. */
+		Stop = 'stop',
+
+		/** The runtime should continue execution when an error is encountered */
+		Continue = 'continue',
+	}
+
+	/**
+	 * Possible reasons a language runtime could exit.
+	 */
+	export enum RuntimeExitReason {
+		/** The runtime exited because it could not start correctly. */
+		StartupFailed = 'startupFailed',
+
+		/** The runtime is shutting down at the request of the user. */
+		Shutdown = 'shutdown',
+
+		/** The runtime exited because it was forced to quit. */
+		ForcedQuit = 'forcedQuit',
+
+		/** The runtime is exiting in order to restart. */
+		Restart = 'restart',
+
+		/** The runtime is exiting in order to switch to a new runtime. */
+		SwitchRuntime = 'switchRuntime',
+
+		/** The runtime exited because of an error, most often a crash. */
+		Error = 'error',
+
+		/**
+		 * The runtime session was transferred somewhere else. This happens when
+		 * it is loaded into a different Positron window; it 'exits' from the
+		 * old window and is reconnected in the new window.
+		 */
+		Transferred = 'transferred',
+
+		/** The runtime exited because the extension hosting it was stopped. */
+		ExtensionHost = 'extensionHost',
+
+		/**
+		 * The runtime exited for an unknown reason. This typically means that
+		 * it exited unexpectedly but with a normal exit code (0).
+		 */
+		Unknown = 'unknown',
+	}
+
+	/**
+	 * LanguageRuntimeExit is an interface that defines an event occurring when a
+	 * language runtime exits.
+	 */
+	export interface LanguageRuntimeExit {
+		/** Runtime name */
+		runtime_name: string;
+
+		/** Session name */
+		session_name: string;
+
+		/**
+		 * The process exit code, if the runtime is backed by a process. If the
+		 * runtime is not backed by a process, this should just be 0 for a
+		 * succcessful exit and 1 for an error.
+		 */
+		exit_code: number;
+
+		/**
+		 * The reason the runtime exited.
+		 */
+		reason: RuntimeExitReason;
+
+		/** The exit message, if any. */
+		message: string;
+	}
+
+	/**
+	 * LanguageRuntimeMessage is an interface that defines an event occurring in a
+	 * language runtime, such as outputting text or plots.
+	 */
+	export interface LanguageRuntimeMessage {
+		/** The event ID */
+		id: string;
+
+		/** The ID of this event's parent (the event that caused it), if applicable */
+		parent_id: string;
+
+		/** The message's date and time, in ISO 8601 format */
+		when: string;
+
+		/** The type of event */
+		type: LanguageRuntimeMessageType;
+
+		/** Additional metadata, if any */
+		metadata?: Record<string, unknown>;
+
+		/** Additional binary data, if any */
+		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * LanguageRuntimeClearOutput is a LanguageRuntimeMessage instructing the frontend to clear the
+	 * output of a runtime execution. */
+	export interface LanguageRuntimeClearOutput extends LanguageRuntimeMessage {
+		/** Wait to clear the output until new output is available. */
+		wait: boolean;
+	}
+
+	/** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */
+	export interface LanguageRuntimeOutput extends LanguageRuntimeMessage {
+		/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
+		data: Record<string, unknown>;
+
+		/**
+		 * The optional identifier of the output. If specified, this output can be referenced
+		 * in future messages e.g. when {@link LanguageRuntimeUpdateOutput updating an output}.
+		 */
+		output_id?: string;
+	}
+
+	/**
+	 * LanguageRuntimeUpdateOutput is a LanguageRuntimeMessage instructing the frontend
+	 * to update an existing output.
+	 */
+	export interface LanguageRuntimeUpdateOutput extends LanguageRuntimeMessage {
+		/** The updated output data */
+		data: Record<string, unknown>;
+
+		/** The identifier of the output to update */
+		output_id: string;
+	}
+
+	/**
+	 * LanguageRuntimeResult is a LanguageRuntimeOutput representing the computational result of a
+	 * runtime execution.
+	 */
+	export interface LanguageRuntimeResult extends LanguageRuntimeOutput {
+	}
+
+	/**
+	 * The set of possible output locations for a LanguageRuntimeOutput.
+	 */
+	export enum PositronOutputLocation {
+		/** The output should be displayed inline in Positron's Console */
+		Console = 'console',
+
+		/** The output should be displayed in Positron's Viewer pane */
+		Viewer = 'viewer',
+
+		/** The output should be displayed in Positron's Plots pane */
+		Plot = 'plot',
+	}
+
+	/**
+	 * LanguageRuntimeWebOutput amends LanguageRuntimeOutput with additional information needed
+	 * to render web content in Positron.
+	 */
+	export interface LanguageRuntimeWebOutput extends LanguageRuntimeOutput {
+		/** Where the web output should be displayed */
+		output_location: PositronOutputLocation;
+
+		/** The set of resource roots needed to display the output */
+		resource_roots: vscode.Uri[];
+	}
+
+	/**
+	 * The set of standard stream names supported for streaming textual output.
+	 */
+	export enum LanguageRuntimeStreamName {
+		Stdout = 'stdout',
+		Stderr = 'stderr'
+	}
+
+	/**
+	 * LanguageRuntimeStream is a LanguageRuntimeMessage representing output from a standard stream
+	 * (stdout or stderr).
+	 */
+	export interface LanguageRuntimeStream extends LanguageRuntimeMessage {
+		/** The stream name */
+		name: LanguageRuntimeStreamName;
+
+		/** The stream's text */
+		text: string;
+	}
+
+	/** LanguageRuntimeInput is a LanguageRuntimeMessage representing echoed user input */
+	export interface LanguageRuntimeInput extends LanguageRuntimeMessage {
+		/** The code that was input */
+		code: string;
+
+		/** The execution count */
+		execution_count: number;
+	}
+
+	/** LanguageRuntimePrompt is a LanguageRuntimeMessage representing a prompt for input */
+	export interface LanguageRuntimePrompt extends LanguageRuntimeMessage {
+		/** The prompt text */
+		prompt: string;
+
+		/** Whether this is a password prompt (and typing should be hidden)  */
+		password: boolean;
+	}
+
+	/** LanguageRuntimeInfo contains metadata about the runtime after it has started. */
+	export interface LanguageRuntimeInfo {
+		/** A startup banner */
+		banner: string;
+
+		/** The implementation version number */
+		implementation_version: string;
+
+		/** The language version number */
+		language_version: string;
+
+		/** Initial prompt string in case user customized it */
+		input_prompt?: string;
+
+		/** Continuation prompt string in case user customized it */
+		continuation_prompt?: string;
+	}
+
+	/** LanguageRuntimeState is a LanguageRuntimeMessage representing a new runtime state */
+	export interface LanguageRuntimeState extends LanguageRuntimeMessage {
+		/** The new state */
+		state: RuntimeOnlineState;
+	}
+
+	/** LanguageRuntimeError is a LanguageRuntimeMessage that represents a run-time error */
+	export interface LanguageRuntimeError extends LanguageRuntimeMessage {
+		/** The error name */
+		name: string;
+
+		/** The error message */
+		message: string;
+
+		/** The error stack trace */
+		traceback: Array<string>;
+	}
+
+	/**
+	 * LanguageRuntimeMessageIPyWidget is a wrapped LanguageRuntimeMessage that should be handled
+	 * by an IPyWidget.
+	 *
+	 * Output widgets may intercept replies to an execution and instead render them inside the
+	 * output widget. See https://ipywidgets.readthedocs.io/en/latest/examples/Output%20Widget.html
+	 * for more.
+	 */
+	export interface LanguageRuntimeMessageIPyWidget extends LanguageRuntimeMessage {
+		/** The original runtime message that was intercepted by an IPyWidget */
+		original_message: LanguageRuntimeMessage;
+	}
+
+	/**
+	 * LanguageRuntimeCommOpen is a LanguageRuntimeMessage that indicates a
+	 * comm (client instance) was opened from the server side
+	 */
+	export interface LanguageRuntimeCommOpen extends LanguageRuntimeMessage {
+		/** The unique ID of the comm being opened */
+		comm_id: string;
+
+		/** The name (type) of the comm being opened, e.g. 'jupyter.widget' */
+		target_name: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/** LanguageRuntimeCommMessage is a LanguageRuntimeMessage that represents data for a comm (client instance) */
+	export interface LanguageRuntimeCommMessage extends LanguageRuntimeMessage {
+		/** The unique ID of the client comm ID for which the message is intended */
+		comm_id: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/**
+	 * LanguageRuntimeCommClosed is a LanguageRuntimeMessage that indicates a
+	 * comm (client instance) was closed from the server side
+	 */
+	export interface LanguageRuntimeCommClosed extends LanguageRuntimeMessage {
+		/** The unique ID of the client comm ID for which the message is intended */
+		comm_id: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/**
+	 * LanguageRuntimeMetadata contains information about a language runtime that is known
+	 * before the runtime is started.
+	 */
+	export interface LanguageRuntimeMetadata {
+		/** The path to the runtime. */
+		runtimePath: string;
+
+		/** A unique identifier for this runtime; takes the form of a GUID */
+		runtimeId: string;
+
+		/**
+		 * The fully qualified name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)".
+		 * Should be unique across languages.
+		 */
+		runtimeName: string;
+
+		/**
+		 * A language specific runtime name displayed to the user; e.g. "4.2 (64-bit)".
+		 * Should be unique within a single language.
+		 */
+		runtimeShortName: string;
+
+		/** The version of the runtime itself (e.g. kernel or extension version) as a string; e.g. "0.1" */
+		runtimeVersion: string;
+
+		/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
+		runtimeSource: string;
+
+		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
+		languageName: string;
+
+		/**
+		 * The Visual Studio Code Language ID of the language this runtime can execute; e.g. "r"
+		 *
+		 * See here for a list of known language IDs:
+		 * https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
+		 */
+		languageId: string;
+
+		/** The version of the language; e.g. "4.2" */
+		languageVersion: string;
+
+		/** The Base64-encoded icon SVG for the language. */
+		base64EncodedIconSvg: string | undefined;
+
+		/** Whether the runtime should start up automatically or wait until explicitly requested */
+		startupBehavior: LanguageRuntimeStartupBehavior;
+
+		/** Where sessions will be located; used as a hint to control session restoration */
+		sessionLocation: LanguageRuntimeSessionLocation;
+
+		/**
+		 * Extra data supplied by the runtime provider; not read by Positron but supplied
+		 * when creating a new session from the metadata.
+		 */
+		extraRuntimeData: any;
+
+		/**
+		 * Subscriptions to notifications from the UI. When subscribed, the frontend sends
+		 * notifications to the backend via the UI client.
+		 */
+		uiSubscriptions?: UiRuntimeNotifications[];
+	}
+
+	/**
+	 * UI notifications from frontend to backends.
+	 */
+	export enum UiRuntimeNotifications {
+		/** Notification that the settings for rendering a plot have changed, typically because the plot area did */
+		DidChangePlotsRenderSettings = 'did_change_plots_render_settings',
+	}
+
+	export interface RuntimeSessionMetadata {
+		/** The ID of this session */
+		readonly sessionId: string;
+
+		/** The session's mode */
+		readonly sessionMode: LanguageRuntimeSessionMode;
+
+		/** The URI of the notebook document associated with the session, if any */
+		readonly notebookUri?: vscode.Uri;
+	}
+
+	/**
+	 * LanguageRuntimeSessionMode is an enum representing the set of possible
+	 * modes for a language runtime session.
+	 */
+	export enum LanguageRuntimeSessionMode {
+		/**
+		 * The runtime session is bound to a Positron console. Typically,
+		 * there's only one console session per language.
+		 */
+		Console = 'console',
+
+		/** The runtime session backs a notebook. */
+		Notebook = 'notebook',
+
+		/** The runtime session is a background session (not attached to any UI). */
+		Background = 'background',
+	}
+
+
+	/**
+	 * LanguageRuntimeDynState contains information about a language runtime that may
+	 * change after a runtime has started.
+	 */
+	export interface LanguageRuntimeDynState {
+		/** The text the language's interpreter uses to prompt the user for input, e.g. ">" or ">>>" */
+		inputPrompt: string;
+
+		/** The text the language's interpreter uses to prompt the user for continued input, e.g. "+" or "..." */
+		continuationPrompt: string;
+
+		/** The user-facing name of this session */
+		sessionName: string;
+	}
+
+	export enum LanguageRuntimeStartupBehavior {
+		/**
+		 * The runtime should be started immediately after registration; usually used for runtimes
+		 * that are affiliated with the current workspace.
+		 */
+		Immediate = 'immediate',
+
+		/**
+		 * The runtime should start automatically; usually used for runtimes that provide LSPs
+		 */
+		Implicit = 'implicit',
+
+		/**
+		 * The runtime should start when the user explicitly requests it;
+		 * usually used for runtimes that only provide REPLs
+		 */
+		Explicit = 'explicit',
+
+		/**
+		 * The runtime only starts up if manually requested by the user.
+		 * The difference from Explicit, is that Manual startup never
+		 * starts automatically, even if the run time is affiliated to the
+		 * workspace.
+		 */
+		Manual = 'manual'
+	}
+
+	/**
+	 * An enumeration of possible locations for runtime sessions.
+	 */
+	export enum LanguageRuntimeSessionLocation {
+		/**
+		 * The runtime session is persistent on the machine; it should be
+		 * restored when the workspace is re-opened, and may persist across
+		 * Positron sessions.
+		 */
+		Machine = 'machine',
+
+		/**
+		 * The runtime session is located in the current workspace (usually a
+		 * terminal); it should be restored when the workspace is re-opened in
+		 * the same Positron session (e.g. during a browser reload or
+		 * reconnect)
+		 */
+		Workspace = 'workspace',
+
+		/**
+		 * The runtime session is browser-only; it should not be restored when the
+		 * workspace is re-opened.
+		 */
+		Browser = 'browser',
+	}
+
+	/**
+	 * The set of client types that can be generated by a language runtime. Note
+	 * that, because client types can share a namespace with other kinds of
+	 * widgets, each client type in Positron's API is prefixed with the string
+	 * "positron".
+	 */
+	export enum RuntimeClientType {
+		Variables = 'positron.variables',
+		Lsp = 'positron.lsp',
+		Dap = 'positron.dap',
+		Plot = 'positron.plot',
+		DataExplorer = 'positron.dataExplorer',
+		Ui = 'positron.ui',
+		Help = 'positron.help',
+		Connection = 'positron.connection',
+		Reticulate = 'positron.reticulate',
+		IPyWidget = 'jupyter.widget',
+		IPyWidgetControl = 'jupyter.widget.control',
+
+		// Future client types may include:
+		// - Watch window/variable explorer
+		// - Code inspector
+		// - etc.
+	}
+
+	/**
+	 * The possible states for a language runtime client instance. These
+	 * represent the state of the communications channel between the client and
+	 * the runtime.
+	 */
+	export enum RuntimeClientState {
+		/** The client has not yet been initialized */
+		Uninitialized = 'uninitialized',
+
+		/** The connection between the server and the client is being opened */
+		Opening = 'opening',
+
+		/** The connection between the server and the client has been established */
+		Connected = 'connected',
+
+		/** The connection between the server and the client is being closed */
+		Closing = 'closing',
+
+		/** The connection between the server and the client is closed */
+		Closed = 'closed',
+	}
+
+	/**
+	 * A variable in the runtime's memory or environment.
+	 */
+	export interface RuntimeVariable {
+		/** An internal access key for the variable */
+		access_key: string;
+
+		/** A human-readable display name for the variable */
+		display_name: string;
+
+		/** The type of the variable (string, number, etc.) */
+		display_type: string;
+
+		/** A string representation of the value of the variable */
+		display_value: string;
+
+		/**
+		 * Extended type information naming e.g. the exact class name of the
+		 * variable
+		 */
+		type_info?: string;
+
+		/** The length of the variable, e.g. number of elements in an array */
+		length: number;
+
+		/** The size of a variable, e.g. in bytes */
+		size: number;
+
+		/** Whether the variable has child variables, e.g columns in a data frame */
+		has_children: boolean;
+	}
+
+	/**
+	 * The possible types of language model that can be used with the Positron Assistant.
+	 */
+	export enum PositronLanguageModelType {
+		Chat = 'chat',
+		Completion = 'completion',
+	}
+
+	/**
+	 * The possible locations a Positron Assistant chat request can be invoked from.
+	 */
+	export enum PositronChatAgentLocation {
+		Panel = 'panel',
+		Terminal = 'terminal',
+		Notebook = 'notebook',
+		Editor = 'editor',
+	}
+
+	/**
+	 * The possible modes for a Positron Assistant chat request.
+	 */
+	export enum PositronChatMode {
+		Ask = 'ask',
+		Edit = 'edit',
+		Agent = 'agent',
+	}
+
+	/**
+	 * A message received from a runtime client instance.
+	 */
+	export interface RuntimeClientOutput<T> {
+		/** The message data */
+		data: T;
+
+		/** Raw binary data associated with the message, if any */
+		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * An instance of a client widget generated by a language runtime. See
+	 * RuntimeClientType for the set of possible client types.
+	 *
+	 * The client is responsible for disposing itself when it is no longer
+	 * needed; this will trigger the closure of the communications channel
+	 * between the client and the runtime.
+	 */
+	export interface RuntimeClientInstance extends vscode.Disposable {
+		onDidChangeClientState: vscode.Event<RuntimeClientState>;
+		onDidSendEvent: vscode.Event<RuntimeClientOutput<object>>;
+		performRpcWithBuffers<T>(data: object): Thenable<RuntimeClientOutput<T>>;
+		performRpc<T>(data: object): Thenable<T>;
+		getClientState(): RuntimeClientState;
+		getClientId(): string;
+		getClientType(): RuntimeClientType;
+	}
+
+	/**
+	 * Code attribution sources for code executed by Positron.
+	 */
+	export enum CodeAttributionSource {
+		/** The code was executed by an AI assistant. */
+		Assistant = 'assistant',
+
+		/** The code was executed by a Positron extension. */
+		Extension = 'extension',
+
+		/** The code was executed interactively (the user typed it in). */
+		Interactive = 'interactive',
+
+		/** The code was executed from a notebook cell. */
+		Notebook = 'notebook',
+
+		/** The code was pasted into the Console. */
+		Paste = 'paste',
+
+		/** The code was run as a fragment or whole of a script. */
+		Script = 'script',
+	}
+
+	/**
+	 * Code attribution metadata for code executed by Positron.
+	 */
+	export interface CodeAttribution {
+		/** The code's origin */
+		source: CodeAttributionSource;
+
+		/**
+		 * Additional metadata specific to the attribution source, if any. For
+		 * example, when code is executed from an extension, it names the
+		 * extension, and when code is executed from a script, it names the
+		 * script.
+		 */
+		metadata?: Record<string, any>;
+	}
+
+	/**
+	 * An event that is emitted when code is executed in Positron.
+	 */
+	export interface CodeExecutionEvent {
+		/** The ID of the language in which the code was executed (e.g. 'python') */
+		languageId: string;
+
+		/** The name of the runtime that executed the code (e.g. 'Python 3.12') */
+		runtimeName: string;
+
+		/** The actual code that was executed. */
+		code: string;
+
+		/** An object describing the origin of the code. */
+		attribution: CodeAttribution;
+	}
+
+	export interface LanguageRuntimeManager {
+		/**
+		 * Returns a generator that yields metadata about all the language
+		 * runtimes that are available to the user.
+		 *
+		 * This metadata will be passed to `createSession` to create new runtime
+		 * sessions.
+		 */
+		discoverAllRuntimes(): AsyncGenerator<LanguageRuntimeMetadata>;
+
+		/**
+		 * Returns a single runtime metadata object representing the runtime
+		 * that should be used in the current workspace, if any.
+		 *
+		 * Note that this is called before `discoverAllRuntimes` during
+		 * startup, and should return `undefined` if no runtime is recommended.
+		 *
+		 * If a runtime is returned, `startupBehavior` property of the runtime
+		 * metadata is respected here; use `Immediately` to start the runtime
+		 * right away, or any other value to save the runtime as the project
+		 * default without starting it.
+		 */
+		recommendedWorkspaceRuntime(): Thenable<LanguageRuntimeMetadata | undefined>;
+
+		/**
+		 * An optional event that fires when a new runtime is discovered.
+		 *
+		 * Not fired during `discoverRuntimes()`; used to notify Positron of a
+		 * new runtime or environment after the initial discovery has completed.
+		 */
+		onDidDiscoverRuntime?: vscode.Event<LanguageRuntimeMetadata>;
+
+		/**
+		 * An optional metadata validation function. If provided, Positron will
+		 * validate any stored metadata before attempting to use it to create a
+		 * new session. This happens when a workspace is re-opened, for example.
+		 *
+		 * If the metadata is invalid, the function should return a new version
+		 * of the metadata with the necessary corrections.
+		 *
+		 * If it is not possible to correct the metadata, the function should
+		 * reject with an error.
+		 *
+		 * @param metadata The metadata to validate
+		 * @returns A Thenable that resolves with an updated version of the
+		 *   metadata.
+		 */
+		validateMetadata?(metadata: LanguageRuntimeMetadata):
+			Thenable<LanguageRuntimeMetadata>;
+
+		/**
+		 * An optional session validation function. If provided, Positron will
+		 * validate any stored session metadata before reconnecting to the
+		 * session.
+		 *
+		 * @param metadata The metadata to validate
+		 * @returns A Thenable that resolves with true (the session is valid) or
+		 *  false (the session is invalid).
+		 */
+		validateSession?(sessionId: string): Thenable<boolean>;
+
+		/**
+		 * Creates a new runtime session.
+		 *
+		 * @param runtimeMetadata One of the runtime metadata items returned by
+		 * `discoverRuntimes`.
+		 * @param sessionMetadata The metadata for the new session.
+		 *
+		 * @returns A Thenable that resolves with the new session, or rejects with an error.
+		 */
+		createSession(runtimeMetadata: LanguageRuntimeMetadata,
+			sessionMetadata: RuntimeSessionMetadata):
+			Thenable<LanguageRuntimeSession>;
+
+		/**
+		 * Reconnects to a runtime session using the given metadata.
+		 *
+		 * Implementing this method is optional, since not all sessions can be
+		 * reconnected; for example, sessions that run in the browser cannot be
+		 * reconnected.
+		 *
+		 * @param runtimeMetadata The metadata for the runtime that owns the
+		 * session.
+		 * @param sessionMetadata The metadata for the session to reconnect.
+		 * @param sessionName The name of the session to reconnect.
+		 * @returns A Thenable that resolves with the reconnected session, or
+		 * rejects with an error.
+		 */
+		restoreSession?(runtimeMetadata: LanguageRuntimeMetadata,
+			sessionMetadata: RuntimeSessionMetadata,
+			sessionName: string):
+			Thenable<LanguageRuntimeSession>;
+	}
+
+	/**
+	 * An enum representing the set of runtime method error codes; these map to
+	 * JSON-RPC error codes.
+	 */
+	export enum RuntimeMethodErrorCode {
+		ParseError = -32700,
+		InvalidRequest = -32600,
+		MethodNotFound = -32601,
+		InvalidParams = -32602,
+		InternalError = -32603,
+		ServerErrorStart = -32000,
+		ServerErrorEnd = -32099
+	}
+
+	/**
+	 * An error returned by a runtime method call.
+	 */
+	export interface RuntimeMethodError {
+		/** An error code */
+		code: RuntimeMethodErrorCode;
+
+		/** A human-readable error message */
+		message: string;
+
+		/**
+		 * A name for the error, for compatibility with the Error object.
+		 * Usually `RPC Error ${code}`.
+		 */
+		name: string;
+
+		/** Additional error information (optional) */
+		data: any | undefined;
+	}
+
+	/**
+	 * Enum of available channels for a language runtime session.
+	 * Used to enumerate available channels for users.
+	 */
+	export enum LanguageRuntimeSessionChannel {
+		Console = 'console',
+		Kernel = 'kernel',
+		LSP = 'lsp',
+	}
+
+	/**
+	 * LanguageRuntimeSession is an interface implemented by extensions that provide a
+	 * set of common tools for interacting with a language runtime, such as code
+	 * execution, LSP implementation, and plotting.
+	 */
+	export interface LanguageRuntimeSession extends vscode.Disposable {
+
+		/** An object supplying immutable metadata about this specific session */
+		readonly metadata: RuntimeSessionMetadata;
+
+		/**
+		 * An object supplying metadata about the runtime with which this
+		 * session is associated.
+		 */
+		readonly runtimeMetadata: LanguageRuntimeMetadata;
+
+		/** The state of the runtime that changes during a user session */
+		dynState: LanguageRuntimeDynState;
+
+		/** An object that emits language runtime events */
+		onDidReceiveRuntimeMessage: vscode.Event<LanguageRuntimeMessage>;
+
+		/** An object that emits the current state of the runtime */
+		onDidChangeRuntimeState: vscode.Event<RuntimeState>;
+
+		/** An object that emits an event when the user's session ends and the runtime exits */
+		onDidEndSession: vscode.Event<LanguageRuntimeExit>;
+
+		/**
+		 * Opens a resource in the runtime.
+		 * @param resource The resource to open.
+		 * @returns true if the resource was opened; otherwise, false.
+		 */
+		openResource?(resource: vscode.Uri | string): Thenable<boolean>;
+
+		/**
+		 * Execute code in the runtime
+		 *
+		 * @param code The code to execute
+		 * @param id The language ID of the code
+		 * @param mode The code execution mode
+		 * @param errorBehavior The code execution error behavior
+		 * Note: The errorBehavior parameter is currently ignored by kernels
+		 */
+		execute(code: string,
+			id: string,
+			mode: RuntimeCodeExecutionMode,
+			errorBehavior: RuntimeErrorBehavior): void;
+
+		/**
+		 * Calls a method in the runtime and returns the result.
+		 *
+		 * Throws a RuntimeMethodError if the method call fails.
+		 *
+		 * @param method The name of the method to call
+		 * @param args Arguments to pass to the method
+		 */
+		callMethod?(method: string, ...args: any[]): Thenable<any>;
+
+		/** Test a code fragment for completeness */
+		isCodeFragmentComplete(code: string): Thenable<RuntimeCodeFragmentStatus>;
+
+		/**
+		 * Create a new instance of a client; return null if the client type
+		 * is not supported by this runtime, or a string containing the ID of
+		 * the client if it is supported.
+		 *
+		 * @param id The unique, client-supplied ID of the client instance. Can be any
+		 *   unique string.
+		 * @param type The type of client to create
+		 * @param params A set of parameters to pass to the client; specific to the client type
+		 * @param metadata A set of metadata to pass to the client; specific to the client type
+		 */
+		createClient(id: string, type: RuntimeClientType, params: Record<string, unknown>, metadata?: Record<string, unknown>): Thenable<void>;
+
+		/**
+		 * List all clients, optionally filtered by type.
+		 *
+		 * @param type If specified, only clients of this type will be returned.
+		 * @returns A Thenable that resolves with a map of client IDs to client types.
+		 */
+		listClients(type?: RuntimeClientType): Thenable<Record<string, string>>;
+
+		/** Remove an instance of a client (created with `createClient`) */
+		removeClient(id: string): void;
+
+		/**
+		 * Send a message to the server end of a client instance. Any replies to the message
+		 * will be sent back to the client via the `onDidReceiveRuntimeMessage` event, with
+		 * the `parent_id` field set to the `message_id` given here.
+		 */
+		sendClientMessage(client_id: string, message_id: string, message: Record<string, unknown>): void;
+
+		/** Reply to a prompt issued by the runtime */
+		replyToPrompt(id: string, reply: string): void;
+
+		/**
+		 * Set the current working directory of the session.
+		 */
+		setWorkingDirectory(dir: string): Thenable<void>;
+
+		/**
+		 * Start the session; returns a Thenable that resolves with information about the runtime.
+		 * If the runtime fails to start for any reason, the Thenable should reject with an error
+		 * object containing a `message` field with a human-readable error message and an optional
+		 * `details` field with additional information.
+		 */
+		start(): Thenable<LanguageRuntimeInfo>;
+
+		/**
+		 * Interrupt the runtime; returns a Thenable that resolves when the interrupt has been
+		 * successfully sent to the runtime (not necessarily when it has been processed)
+		 */
+		interrupt(): Thenable<void>;
+
+		/**
+		 * Restart the runtime; returns a Thenable that resolves when the runtime restart sequence
+		 * has been successfully started (not necessarily when it has completed). A restart will
+		 * cause the runtime to be shut down and then started again; its status will change from
+		 * `Restarting` => `Exited` => `Initializing` => `Starting` => `Ready`.
+		 *
+		 * @param workingDirectory The new working directory to use for the
+		 * restarted runtime, if any. Use `undefined` to keep the current
+		 * working directory.
+		 */
+		restart(workingDirectory?: string): Thenable<void>;
+
+		/**
+		 * Shut down the runtime; returns a Thenable that resolves when the
+		 * runtime shutdown sequence has been successfully started (not
+		 * necessarily when it has completed).
+		 */
+		shutdown(exitReason: RuntimeExitReason): Thenable<void>;
+
+		/**
+		 * Forcibly quits the runtime; returns a Thenable that resolves when the
+		 * runtime has been terminated. This may be called by Positron if the
+		 * runtime fails to respond to an interrupt and/or shutdown call, and
+		 * should forcibly terminate any underlying processes.
+		 */
+		forceQuit(): Thenable<void>;
+
+		/**
+		 * Update the session name.
+		 *
+		 * @param sessionName The new session name
+		 */
+		updateSessionName(sessionName: string): void;
+
+		/**
+		 * Show runtime log in output panel.
+		 *
+		 * @param channel The channel to show the output in
+		 */
+		showOutput?(channel?: LanguageRuntimeSessionChannel): void;
+
+		/**
+		 * Return a list of output channels
+		 *
+		 * @returns A list of output channels available on this runtime
+		 */
+		listOutputChannels?(): LanguageRuntimeSessionChannel[];
+
+		/**
+		 * Show profiler log if supported.
+		 */
+		showProfile?(): Thenable<void>;
+	}
+
+
+	/**
+	 * A data structure that describes a handler for a runtime client instance,
+	 * and is called when an instance is created.
+	 *
+	 * @param client The client instance that was created
+	 * @param params A set of parameters passed to the client
+	 * @returns true if the handler took ownership of the client, false otherwise
+	 */
+	export type RuntimeClientHandlerCallback = (
+		client: RuntimeClientInstance,
+		params: Object,) => boolean;
+
+	/**
+	 * A data structure that describes a handler for a runtime client instance.
+	 */
+	export interface RuntimeClientHandler {
+		/**
+		 * The type of client that this handler handles.
+		 */
+		clientType: string;
+
+		/**
+		 * A callback that is called when a client of the given type is created;
+		 * returns whether the handler took ownership of the client.
+		 */
+		callback: RuntimeClientHandlerCallback;
+	}
+
+	/**
+	 * Content settings for webviews hosted in the Preview panel.
+	 *
+	 * This interface mirrors the `WebviewOptions` & `WebviewPanelOptions` interfaces, with
+	 * the following exceptions:
+	 *
+	 * - `enableFindWidget` is not supported (we never show it in previews)
+	 * - `retainContextWhenHidden` is not supported (we always retain context)
+	 * - `enableCommandUris` is not supported (we never allow commands in previews)
+	 */
+	export interface PreviewOptions {
+		/**
+		 * Controls whether scripts are enabled in the webview content or not.
+		 *
+		 * Defaults to false (scripts-disabled).
+		 */
+		readonly enableScripts?: boolean;
+
+		/**
+		 * Controls whether forms are enabled in the webview content or not.
+		 *
+		 * Defaults to true if {@link PreviewOptions.enableScripts scripts are enabled}. Otherwise defaults to false.
+		 * Explicitly setting this property to either true or false overrides the default.
+		 */
+		readonly enableForms?: boolean;
+
+		/**
+		 * Root paths from which the webview can load local (filesystem) resources using uris from `asWebviewUri`
+		 *
+		 * Default to the root folders of the current workspace plus the extension's install directory.
+		 *
+		 * Pass in an empty array to disallow access to any local resources.
+		 */
+		readonly localResourceRoots?: readonly vscode.Uri[];
+
+		/**
+		 * Mappings of localhost ports used inside the webview.
+		 *
+		 * Port mapping allow webviews to transparently define how localhost ports are resolved. This can be used
+		 * to allow using a static localhost port inside the webview that is resolved to random port that a service is
+		 * running on.
+		 *
+		 * If a webview accesses localhost content, we recommend that you specify port mappings even if
+		 * the `webviewPort` and `extensionHostPort` ports are the same.
+		 *
+		 * *Note* that port mappings only work for `http` or `https` urls. Websocket urls (e.g. `ws://localhost:3000`)
+		 * cannot be mapped to another port.
+		 */
+		readonly portMapping?: readonly vscode.WebviewPortMapping[];
+	}
+
+	/**
+	 * A preview panel that contains a webview. This interface mirrors the
+	 * `WebviewPanel` interface, but omits elements that don't apply to
+	 * preview panels, such as `viewColumn`.
+	 */
+	export interface PreviewPanel {
+		/**
+		 * Identifies the type of the preview panel, such as `'markdown.preview'`.
+		 */
+		readonly viewType: string;
+
+		/**
+		 * Title of the panel shown in UI.
+		 */
+		title: string;
+
+		/**
+		 * {@linkcode Webview} belonging to the panel.
+		 */
+		readonly webview: vscode.Webview;
+
+		/**
+		 * Whether the panel is active (focused by the user).
+		 */
+		readonly active: boolean;
+
+		/**
+		 * Whether the panel is visible.
+		 */
+		readonly visible: boolean;
+
+		/**
+		 * Fired when the panel's view state changes.
+		 */
+		readonly onDidChangeViewState: vscode.Event<PreviewPanelOnDidChangeViewStateEvent>;
+
+		/**
+		 * Fired when the panel is disposed.
+		 *
+		 * This may be because the user closed the panel or because `.dispose()` was
+		 * called on it.
+		 *
+		 * Trying to use the panel after it has been disposed throws an exception.
+		 */
+		readonly onDidDispose: vscode.Event<void>;
+
+		/**
+		 * Show the preview panel
+		 *
+		 * Only one preview panel can be shown at a time. If a different preview
+		 * is already showing, it will be hidden.
+		 *
+		 * @param preserveFocus When `true`, the webview will not take focus.
+		 */
+		reveal(preserveFocus?: boolean): void;
+
+		/**
+		 * Dispose of the preview panel.
+		 *
+		 * This closes the panel if it showing and disposes of the resources
+		 * owned by the underlying webview.  Preview panels are also disposed
+		 * when the user closes the preview panel. Both cases fire the
+		 * `onDispose` event.
+		 */
+		dispose(): any;
+	}
+
+	/**
+	 * Event fired when a preview panel's view state changes.
+	 */
+	export interface PreviewPanelOnDidChangeViewStateEvent {
+		/**
+		 * Preview panel whose view state changed.
+		 */
+		readonly previewPanel: PreviewPanel;
+	}
+
+	export interface StatementRangeProvider {
+		/**
+		 * Given a cursor position, return the range of the statement that the
+		 * cursor is within. If the cursor is not within a statement, return the
+		 * range of the next statement, if one exists.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return The range of the statement at the given position.
+		 */
+		provideStatementRange(document: vscode.TextDocument,
+			position: vscode.Position,
+			token: vscode.CancellationToken): vscode.ProviderResult<StatementRange>;
+	}
+
+	/**
+	 * The range of a statement, plus optionally the code for the range.
+	 */
+	export interface StatementRange {
+		/**
+		 * The range of the statement at the given position.
+		 */
+		readonly range: vscode.Range;
+
+		/**
+		 * The code for this statement range, if different from the document contents at this range.
+		 */
+		readonly code?: string;
+
+	}
+
+	export interface HelpTopicProvider {
+		/**
+		 * Given a cursor position, return the help topic relevant to the cursor
+		 * position, or an empty string if no help topic is recommended or
+		 * relevant.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return A string containing the help topic relevant to the cursor
+		 *   position
+		 */
+		provideHelpTopic(document: vscode.TextDocument,
+			position: vscode.Position,
+			token: vscode.CancellationToken): vscode.ProviderResult<string>;
+	}
+
+	export interface Console {
+		/**
+		 * Pastes text into the console.
+		 */
+		pasteText(text: string): void;
+	}
+
+	/**
+	 * ConnectionsInput interface defines the structure for connection inputs.
+	 */
+	export interface ConnectionsInput {
+		/**
+		 * The unique identifier for the input.
+		 */
+		id: string;
+		/**
+		 * A human-readable label for the input.
+		 */
+		label: string;
+		/**
+		 * The type of the input.
+		 */
+		// eslint-disable-next-line local/vscode-dts-literal-or-types, local/vscode-dts-string-type-literals
+		type: 'string' | 'number' | 'option';
+		/**
+		 * Options, if the input type is an option.
+		 */
+		options?: { 'identifier': string; 'title': string }[];
+		/**
+		 * The default value for the input.
+		 */
+		value?: string;
+	}
+
+	/**
+	 * ConnectionsDriverMetadata interface defines the structure for connection driver metadata.
+	 */
+	export interface ConnectionsDriverMetadata {
+		/**
+		 * The language identifier for the driver.
+		 * Drivers are grouped by language, not by runtime.
+		 */
+		languageId: string;
+		/**
+		 * A human-readable name for the driver.
+		 */
+		name: string;
+		/**
+		 * The base64-encoded SVG icon for the driver.
+		 */
+		base64EncodedIconSvg?: string;
+		/**
+		 * The inputs required to create a connection.
+		 * For instance, a connection might require a username
+		 * and password.
+		 */
+		inputs: Array<ConnectionsInput>;
+	}
+
+	export interface ConnectionsDriver {
+		/**
+		 * The unique identifier for the driver.
+		 */
+		driverId: string;
+
+		/**
+		 * The metadata for the driver.
+		 */
+		metadata: ConnectionsDriverMetadata;
+
+		/**
+		 * Generates the connection code based on the inputs.
+		 */
+		generateCode?: (inputs: Array<ConnectionsInput>) => string;
+
+		/**
+		 * Connect session.
+		 */
+		connect?: (code: string) => Thenable<void>;
+
+		/**
+		 * Checks if the dependencies for the driver are installed
+		 * and functioning.
+		 */
+		checkDependencies?: () => Thenable<boolean>;
+
+		/**
+		 * Installs the dependencies for the driver.
+		 * For instance, R packages would install the required
+		 * R packages, and or other dependencies.
+		 */
+		installDependencies?: () => Thenable<boolean>;
+	}
+
+	/**
+	 * Settings necessary to render a plot in the format expected by the plot widget.
+	 */
+	export interface PlotRenderSettings {
+		size: {
+			width: number;
+			height: number;
+		};
+		pixel_ratio: number;
+		format: PlotRenderFormat;
+	}
+
+	/**
+	 * Possible formats for rendering a plot.
+	 */
+	export enum PlotRenderFormat {
+		Png = 'png',
+		Jpeg = 'jpeg',
+		Svg = 'svg',
+		Pdf = 'pdf',
+		Tiff = 'tiff'
+	}
+
+	namespace languages {
+		/**
+		 * Register a statement range provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A statement range provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerStatementRangeProvider(
+			selector: vscode.DocumentSelector,
+			provider: StatementRangeProvider): vscode.Disposable;
+
+		/**
+		 * Register a help topic provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A help topic provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerHelpTopicProvider(
+			selector: vscode.DocumentSelector,
+			provider: HelpTopicProvider): vscode.Disposable;
+	}
+
+	namespace window {
+		/**
+		 * Create and show a new preview panel.
+		 *
+		 * @param viewType Identifies the type of the preview panel.
+		 * @param title Title of the panel.
+		 * @param options Settings for the new panel.
+		 *
+		 * @return New preview panel.
+		 */
+		export function createPreviewPanel(viewType: string, title: string, preserveFocus?: boolean, options?: PreviewOptions): PreviewPanel;
+
+		/**
+		 * Create and show a new preview panel for a URL. This is a convenience
+		 * method that creates a new webview panel and sets its content to the
+		 * given URL.
+		 *
+		 * @param url The URL to preview
+		 *
+		 * @return New preview panel.
+		 */
+		export function previewUrl(url: vscode.Uri): PreviewPanel;
+
+		/**
+		 * Create and show a new preview panel for an HTML file. This is a
+		 * convenience method that creates a new webview panel and sets its
+		 * content to that of the given file.
+		 *
+		 * @param path The fully qualified path to the HTML file to preview
+		 *
+		 * @return New preview panel.
+		 */
+		export function previewHtml(path: string): PreviewPanel;
+
+		/**
+		 * Create a log output channel from raw data.
+		 *
+		 * Variant of `createOutputChannel()` that creates a "raw log" output channel.
+		 * Compared to a normal `LogOutputChannel`, this doesn't add timestamps or info
+		 * level. It's meant for extensions that create fully formed log lines but still
+		 * want to benefit from the colourised rendering of log output channels.
+		 *
+		 * @param name Human-readable string which will be used to represent the channel in the UI.
+		 *
+		 * @return New log output channel.
+		 */
+		export function createRawLogOutputChannel(name: string): vscode.OutputChannel;
+
+		/**
+		 * Create and show a simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+		 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+		 *
+		 * @returns A Thenable that resolves to true if the user clicked OK, or false
+		 *   if the user clicked Cancel.
+		 */
+		export function showSimpleModalDialogPrompt(title: string,
+			message: string,
+			okButtonTitle?: string,
+			cancelButtonTitle?: string): Thenable<boolean>;
+
+		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+		 *
+		 * @returns A Thenable that resolves when the user clicks OK.
+		 */
+		export function showSimpleModalDialogMessage(title: string,
+			message: string,
+			okButtonTitle?: string): Thenable<null>;
+
+		/**
+		 * Get the `Console` for a runtime `languageId`
+		 *
+		 * @param languageId The runtime language id to retrieve a `Console` for, i.e. 'r' or 'python'.
+		 *
+		 * @returns A Thenable that resolves to a `Console` or `undefined` if no `Console` for
+		 *   that `languageId` exists.
+		 */
+		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
+
+		/**
+		 * Fires when the width of the console input changes. The new width is passed as
+		 * a number, which represents the number of characters that can fit in the
+		 * console horizontally.
+		 */
+		export const onDidChangeConsoleWidth: vscode.Event<number>;
+
+		/**
+		 * Returns the current width of the console input, in characters.
+		 */
+		export function getConsoleWidth(): Thenable<number>;
+
+		/**
+		 * Fires when the settings necessary to render a plot in the format expected by
+		 * plot widget have changed.
+		 */
+		export const onDidChangePlotsRenderSettings: vscode.Event<PlotRenderSettings>;
+
+		/**
+		 * Returns the settings necessary to render a plot in the format expected by
+		 * plot widget.
+		 */
+		export function getPlotsRenderSettings(): Thenable<PlotRenderSettings>;
+	}
+
+	namespace runtime {
+		/**
+		 * An object that observes an ongoing code execution invoked from the
+		 * `executeCode` API.
+		 */
+		export interface ExecutionObserver {
+			/**
+			 * An optional cancellation token that can be used to cancel the
+			 * execution.
+			 */
+			token?: vscode.CancellationToken;
+
+			/**
+			 * An optional callback to invoke when execution has started. This
+			 * may be different than the time `executeCode` was called, since
+			 * there may have been preceding statements in the queue, or we may
+			 * need to wait for the runtime to start or become ready.
+			 */
+			onStarted?: () => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits text
+			 * output. This can be called zero or more times during execution of
+			 * the code.
+			 *
+			 * @param message The message emitted.
+			 */
+			onOutput?: (message: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits error
+			 * output. This just means "output sent to standard error", and does
+			 * not mean that the execution failed. This can be called zero or more
+			 * times during execution of the code.
+			 *
+			 * @param message The message emitted.
+			 */
+			onError?: (message: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits a plot.
+			 *
+			 * NOTE: Currently only fired for static plots, not dynamic plots.
+			 *
+			 * @param plotData The plot data emitted, as a string.
+			 */
+			onPlot?: (plotData: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits a data
+			 * frame or other rectangular data object.
+			 *
+			 * NOTE: Not currently fired.
+			 *
+			 * @param data The data returned.
+			 */
+			onData?: (data: any) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has completed
+			 * sucessfully.
+			 *
+			 * One of `onCompleted` or `onFailed` will be called, but not both.
+			 *
+			 * @param result The result of the successful execution, as a map of MIME types to values.
+			 */
+			onCompleted?: (result: Record<string, any>) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has failed.
+			 *
+			 * One of `onCompleted` or `onFailed` will be called, but not both.
+			 *
+			 * @param error The error that caused the execution to fail.
+			 */
+			onFailed?: (error: Error) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has finished,
+			 * regardless of success or failure.
+			 *
+			 * It is invoked when the runtime returns to an idle state after
+			 * fully completing the execution.
+			 */
+			onFinished?: () => void;
+		}
+
+		/**
+		 * Executes code in a language runtime's console, as though it were typed
+		 * interactively by the user.
+		 *
+		 * @param languageId The language ID of the code snippet
+		 * @param code The code snippet to execute
+		 * @param focus Whether to focus the runtime's console
+		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
+		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
+		 * @param mode Possible code execution mode for a language runtime
+		 * @param errorBehavior Possible error behavior for a language runtime, currently ignored by kernels
+		 * @param observer An optional observer for the execution. This object will be notified of
+		 *  execution events, such as output, error, and completion.
+		 * @returns A Thenable that resolves with the result of the code execution,
+		 *  as a map of MIME types to values.
+		 */
+		export function executeCode(languageId: string,
+			code: string,
+			focus: boolean,
+			allowIncomplete?: boolean,
+			mode?: RuntimeCodeExecutionMode,
+			errorBehavior?: RuntimeErrorBehavior,
+			observer?: ExecutionObserver): Thenable<Record<string, any>>;
+
+		/**
+		 * Register a language runtime manager with Positron.
+		 *
+		 * @param languageId The language ID for which the manager can provide
+		 * runtimes
+		 * @returns A disposable that unregisters the manager when disposed.
+		 *
+		 */
+		export function registerLanguageRuntimeManager(languageId: string, manager: LanguageRuntimeManager): vscode.Disposable;
+
+		/**
+		 * List all registered runtimes.
+		 */
+		export function getRegisteredRuntimes(): Thenable<LanguageRuntimeMetadata[]>;
+
+		/**
+		 * Get the preferred language runtime for a given language.
+		 *
+		 * @param languageId The language ID of the preferred runtime
+		 * @returns The preferred runtime metadata, or undefined if no eligible runtimes
+		 *  are registered.
+		 */
+		export function getPreferredRuntime(languageId: string): Thenable<LanguageRuntimeMetadata | undefined>;
+
+		/**
+		 * List all active sessions.
+		 */
+		export function getActiveSessions(): Thenable<LanguageRuntimeSession[]>;
+
+		/**
+		 * Get the active foreground session, if any.
+		 */
+		export function getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;
+
+		/**
+		 * Get the session corresponding to a notebook, if any.
+		 *
+		 * @param notebookUri The URI of the notebook.
+		 */
+		export function getNotebookSession(notebookUri: vscode.Uri): Thenable<LanguageRuntimeSession | undefined>;
+
+		/**
+		 * Select and start a runtime previously registered with Positron. Any
+		 * previously active runtimes for the language will be shut down.
+		 *
+		 * @param runtimeId The ID of the runtime to select and start.
+		 */
+		export function selectLanguageRuntime(runtimeId: string): Thenable<void>;
+
+		/**
+		 * Start a new session for a runtime previously registered with Positron.
+		 *
+		 * @param runtimeId The ID of the runtime to select and start.
+		 * @param sessionName A human-readable name for the new session.
+		 * @param notebookUri If the session is associated with a notebook,
+		 *   the notebook URI.
+		 *
+		 * Returns a Thenable that resolves with the newly created session.
+		 */
+		export function startLanguageRuntime(runtimeId: string,
+			sessionName: string,
+			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
+
+		/**
+		 * Restart a running session.
+		 *
+		 * @param sessionId The ID of the session to restart.
+		 */
+		export function restartSession(sessionId: string): Thenable<void>;
+
+		/**
+		 * Focus a running session
+		 */
+		export function focusSession(sessionId: string): void;
+
+		/**
+		 * Get the runtime variables for a session.
+		 *
+		 * @param sessionId The session ID of the session to get the variables for.
+		 * @param accessKeys An optional array of access keys. Each access key
+		 * is an array listing the path to a variable. If no access keys are
+		 * provided, all variables will be returned.
+		 *
+		 * @returns A Thenable that resolves with an array of runtime
+		 * variables.
+		 */
+		export function getSessionVariables(
+			sessionId: string,
+			accessKeys?: Array<Array<string>>):
+			Thenable<Array<Array<RuntimeVariable>>>;
+
+		/**
+		 * Register a handler for runtime client instances. This handler will be called
+		 * whenever a new client instance is created by a language runtime of the given
+		 * type.
+		 *
+		 * @param handler A handler for runtime client instances
+		 */
+		export function registerClientHandler(handler: RuntimeClientHandler): vscode.Disposable;
+
+		/**
+		 * Register a runtime client instance. Registering the instance
+		 * indicates that the caller has ownership of the instance, and that
+		 * messages the instance receives do not need to be forwarded to the
+		 * Positron core.
+		 */
+		export function registerClientInstance(clientInstanceId: string): vscode.Disposable;
+
+		/**
+		 * An event that fires when a new runtime is registered.
+		 */
+		export const onDidRegisterRuntime: vscode.Event<LanguageRuntimeMetadata>;
+
+		/**
+		 * An event that fires when the foreground session changes
+		 */
+		export const onDidChangeForegroundSession: vscode.Event<string | undefined>;
+
+		/**
+		 * An event that fires when code is executed.
+		 */
+		export const onDidExecuteCode: vscode.Event<CodeExecutionEvent>;
+	}
+
+	// FIXME: The current (and clearly not final) state of an experiment to bring in interface(s)
+	// here by referring to an external file. Such an external file will presumably be generated by
+	// the generate-comms.ts script. Two goals of the experiment:
+	// * Reduce the manual proliferation of these generated types.
+	// * Ideally a file is meant to edited by humans or by robots, but not both.
+	// Related to https://github.com/posit-dev/positron/issues/12
+	export type EditorContext = import('./ui-comm.js').EditorContext;
+
+	/**
+	 * This namespace contains all frontend RPC methods available to a runtime.
+	 */
+	namespace methods {
+		/**
+		 * Call a frontend method.
+		 *
+		 * `call()` is designed to be hooked up directly to an RPC mechanism. It takes
+		 * `method` and `params` arguments as defined by the UI frontend OpenRPC contract
+		 * and returns a JSON-RPC response. It never throws, all errors are returned as
+		 * JSON-RPC error responses.
+		 *
+		 * @param method The method name.
+		 * @param params An object of named parameters for `method`.
+		 */
+		export function call(method: string, params: Record<string, any>): Thenable<any>;
+
+		/**
+		 * Retrieve last active editor context.
+		 *
+		 * Returns a `EditorContext` for the last active editor.
+		 */
+		export function lastActiveEditorContext(): Thenable<EditorContext | null>;
+
+		/**
+		 * Create and show a simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button
+		 * @param cancelButtonTitle The title of the Cancel button
+		 *
+		 * @returns A Thenable that resolves to true if the user clicked OK, or false
+		 *   if the user clicked Cancel.
+		 */
+		export function showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Thenable<boolean>;
+
+		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 *
+		 * @returns A Thenable that resolves when the user dismisses the dialog.
+		 */
+		export function showDialog(title: string, message: string): Thenable<null>;
+
+
+	}
+
+	/**
+	 * An object that describes an environment variable action.
+	 */
+	export interface EnvironmentVariableAction {
+		/** The action to take - replace, append, or prepend */
+		action: vscode.EnvironmentVariableMutatorType;
+
+		/** The name of the variable on which to take the action */
+		name: string;
+
+		/** The value to replace, append, or prepend */
+		value: string;
+	}
+
+	namespace environment {
+		/**
+		 * Get the environment variable contributions for the current session.
+		 *
+		 * @returns A map of extension IDs to arrays of environment variable actions.
+		 */
+		export function getEnvironmentContributions(): Thenable<Record<string, EnvironmentVariableAction[]>>;
+	}
+
+	/**
+	 * Refers to methods related to the connections pane
+	 */
+	namespace connections {
+		/**
+		 * Registers a new connection driver with Positron allowing extensions to contribute
+		 * to the 'New Connection' dialog.
+		 *
+		 * @param driver The connection driver to register
+		 * @returns A disposable that unregisters the driver when disposed
+		 */
+		export function registerConnectionDriver(driver: ConnectionsDriver): vscode.Disposable;
+	}
+
+	/**
+	 * Experimental AI features.
+	 */
+	namespace ai {
+		/**
+		 * A language model provider, extends vscode.LanguageModelChatProvider.
+		 */
+		export interface LanguageModelChatProvider {
+			name: string;
+			provider: string;
+			identifier: string;
+
+			providerName: string;
+			maxOutputTokens: number;
+
+			readonly capabilities?: {
+				readonly vision?: boolean;
+				readonly toolCalling?: boolean;
+				readonly agentMode?: boolean;
+			};
+
+			/**
+			 * Handle a language model request with tool calls and streaming chat responses.
+			 */
+			provideLanguageModelResponse(
+				messages: Array<vscode.LanguageModelChatMessage>,
+				options: vscode.LanguageModelChatRequestOptions,
+				extensionId: string,
+				progress: vscode.Progress<{
+					index: number;
+					part: vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart;
+				}>,
+				token: vscode.CancellationToken,
+			): Thenable<any>;
+
+			/**
+			 * Calculate the token count for a given string.
+			 */
+			provideTokenCount(text: string | vscode.LanguageModelChatMessage, token: vscode.CancellationToken): Thenable<number>;
+
+			/**
+			 * Tests the connection to the language model provider.
+			 *
+			 * Returns an error if the connection fails.
+			 */
+			resolveConnection(token: vscode.CancellationToken): Thenable<Error | undefined>;
+		}
+
+		/**
+		 * Dynamically defined chat agent properties and metadata.
+		 */
+		export interface ChatAgentData {
+			id: string;
+			name: string;
+			fullName?: string;
+			description?: string;
+			isDefault?: boolean;
+			metadata: { isSticky?: boolean };
+			slashCommands: {
+				name: string;
+				description: string;
+				isSticky?: boolean;
+			}[];
+			modes: PositronChatMode[];
+			locations: PositronChatAgentLocation[];
+			disambiguation: { category: string; description: string; examples: string[] }[];
+		}
+
+		/**
+		 * A chat participant, extends vscode.ChatParticipant with additional dynamic metadata.
+		 */
+		export interface ChatParticipant extends vscode.ChatParticipant {
+			agentData: ChatAgentData;
+		}
+
+		/**
+		 * Register a chat agent dynamically, without requiring registration in `package.json`.
+		 * This allows for dynamic chat agent commands in Positron.
+		 */
+		export function registerChatAgent(agentData: ChatAgentData): Thenable<vscode.Disposable>;
+
+		/**
+		 * Positron Language Model source, used for user configuration of language models.
+		 */
+		export interface LanguageModelSource {
+			type: PositronLanguageModelType;
+			provider: { id: string; displayName: string };
+			supportedOptions: Exclude<{
+				[K in keyof LanguageModelConfig]: undefined extends LanguageModelConfig[K] ? K : never
+			}[keyof LanguageModelConfig], undefined>[];
+			defaults: LanguageModelConfigOptions;
+			signedIn?: boolean;
+			authMethods?: string[];
+		}
+
+		/**
+		 * Positron Language Model configuration.
+		 */
+		export interface LanguageModelConfig extends LanguageModelConfigOptions {
+			type: PositronLanguageModelType;
+			provider: string;
+		}
+
+		/**
+		 * Positron Language Model configuration options.
+		 */
+		export interface LanguageModelConfigOptions {
+			name: string;
+			model: string;
+			baseUrl?: string;
+			apiKey?: string;
+			oauth?: boolean;
+			toolCalls?: boolean;
+			resourceName?: string;
+			project?: string;
+			location?: string;
+			numCtx?: number;
+			maxOutputTokens?: number;
+		}
+
+		/**
+		 * Request the current plot data.
+		 */
+		export function getCurrentPlotUri(): Thenable<string | undefined>;
+
+		/**
+		 * Get Positron global context information to be included with every request.
+		 */
+		export function getPositronChatContext(request: vscode.ChatRequest): Thenable<ChatContext>;
+
+		/**
+		 * Send a progress response to the chat response stream.
+		 */
+		export function responseProgress(token: unknown, part: vscode.ChatResponsePart | {
+			// vscode.ChatResponseConfirmationPart
+			title: string;
+			message: string;
+			data: any;
+			buttons?: string[];
+		} | {
+			// vscode.ChatResponseTextEditPart
+			uri: vscode.Uri;
+			edits: vscode.TextEdit[];
+		}): void;
+
+		export function getSupportedProviders(): Thenable<string[]>;
+
+		/**
+		 * Show a modal dialog for language model configuration.
+		 */
+		export function showLanguageModelConfig(
+			sources: LanguageModelSource[],
+			onAction: (config: LanguageModelConfig, action: string) => Thenable<void>,
+		): Thenable<void>;
+
+		/**
+		 * Adds the model to the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 * @param config the model config
+		 */
+		export function addLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
+		 * Removes the model from the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 */
+		export function removeLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
+		 * The context in which a chat request is made.
+		 */
+		export interface ChatContext {
+			activeSession?: {
+				identifier: string;
+				language: string;
+				version: string;
+				mode: LanguageRuntimeSessionMode;
+				notebookUri?: vscode.Uri;
+				executions: {
+					input: string;
+					output: string;
+					error?: any;
+				}[];
+			};
+			plots?: {
+				hasPlots: boolean;
+			};
+			variables?: RuntimeVariable[];
+			shell?: string;
+		}
+	}
+}

--- a/positron-api-pkg/dist/preview.d.ts
+++ b/positron-api-pkg/dist/preview.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
+ *
+ * This function automatically detects the runtime environment and uses the appropriate
+ * method to display URLs:
+ * - In Positron: Uses the built-in preview pane via `positron.window.previewUrl`
+ * - In VS Code: Opens the URL in the default external browser via `vscode.env.openExternal`
+ *
+ * @param url - The URL to open/preview
+ * @returns Promise that resolves when the URL has been opened
+ *
+ * @example
+ * ```typescript
+ * import { previewUrl } from '@posit-dev/positron/preview';
+ *
+ * // This will work in both Positron and VS Code
+ * await previewUrl('https://example.com');
+ * await previewUrl('http://localhost:3000');
+ * ```
+ */
+export declare function previewUrl(url: string): Promise<void>;

--- a/positron-api-pkg/dist/preview.js
+++ b/positron-api-pkg/dist/preview.js
@@ -1,0 +1,80 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.previewUrl = previewUrl;
+/*---------------------------------------------------------------------------------------------
+ *  Positron URL Preview Functions
+ *
+ *  This file provides cross-platform URL preview functionality that works in both
+ *  Positron and VS Code environments.
+ *--------------------------------------------------------------------------------------------*/
+const runtime_1 = require("./runtime");
+/**
+ * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
+ *
+ * This function automatically detects the runtime environment and uses the appropriate
+ * method to display URLs:
+ * - In Positron: Uses the built-in preview pane via `positron.window.previewUrl`
+ * - In VS Code: Opens the URL in the default external browser via `vscode.env.openExternal`
+ *
+ * @param url - The URL to open/preview
+ * @returns Promise that resolves when the URL has been opened
+ *
+ * @example
+ * ```typescript
+ * import { previewUrl } from '@posit-dev/positron/preview';
+ *
+ * // This will work in both Positron and VS Code
+ * await previewUrl('https://example.com');
+ * await previewUrl('http://localhost:3000');
+ * ```
+ */
+async function previewUrl(url) {
+    const positronApi = (0, runtime_1.tryAcquirePositronApi)();
+    const vscode = await Promise.resolve().then(() => __importStar(require('vscode')));
+    const uri = vscode.Uri.parse(url);
+    if (positronApi) {
+        // We're in Positron - use the preview pane
+        await positronApi.window.previewUrl(uri);
+    }
+    else {
+        // We're in VS Code - open in external browser
+        await vscode.env.openExternal(uri);
+    }
+}

--- a/positron-api-pkg/dist/preview.js
+++ b/positron-api-pkg/dist/preview.js
@@ -71,7 +71,7 @@ async function previewUrl(url) {
     const uri = vscode.Uri.parse(url);
     if (positronApi) {
         // We're in Positron - use the preview pane
-        await positronApi.window.previewUrl(uri);
+        positronApi.window.previewUrl(uri);
     }
     else {
         // We're in VS Code - open in external browser

--- a/positron-api-pkg/dist/runtime.d.ts
+++ b/positron-api-pkg/dist/runtime.d.ts
@@ -1,6 +1,28 @@
 import type * as positron from 'positron';
 export type PositronApi = typeof positron;
 /**
+ * Check if the current environment is Positron.
+ *
+ * This is a simple helper function that returns true if running in Positron,
+ * false if running in VS Code.
+ *
+ * @returns true if running in Positron, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { inPositron } from '@posit-dev/positron';
+ *
+ * if (inPositron()) {
+ *   // We're in Positron - use enhanced features
+ *   console.log('Running in Positron!');
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+export declare function inPositron(): boolean;
+/**
  * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
  *
  * This function handles the detection of whether the extension is running in Positron or VS Code,

--- a/positron-api-pkg/dist/runtime.d.ts
+++ b/positron-api-pkg/dist/runtime.d.ts
@@ -1,0 +1,25 @@
+import type * as positron from 'positron';
+export type PositronApi = typeof positron;
+/**
+ * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
+ *
+ * This function handles the detection of whether the extension is running in Positron or VS Code,
+ * and provides access to Positron-specific functionality when available.
+ *
+ * @returns The Positron API object if available, or undefined if running in VS Code
+ *
+ * @example
+ * ```typescript
+ * import { tryAcquirePositronApi } from '@posit-dev/positron/runtime';
+ *
+ * const positronApi = tryAcquirePositronApi();
+ * if (positronApi) {
+ *   // We're in Positron - use enhanced features
+ *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+export declare function tryAcquirePositronApi(): PositronApi | undefined;

--- a/positron-api-pkg/dist/runtime.js
+++ b/positron-api-pkg/dist/runtime.js
@@ -1,22 +1,10 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-
-/*---------------------------------------------------------------------------------------------
- *  Positron API Runtime Function
- *  Generated from source TypeScript definitions
- *
- *  This file provides a safe runtime function to access the Positron API.
- *--------------------------------------------------------------------------------------------*/
-
-// Import types from the ambient module declaration
-import type * as positron from 'positron';
-
-// The key insight - this captures the complete API shape
-export type PositronApi = typeof positron;
-
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tryAcquirePositronApi = tryAcquirePositronApi;
 /**
  * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
  *
@@ -39,17 +27,18 @@ export type PositronApi = typeof positron;
  * }
  * ```
  */
-export function tryAcquirePositronApi(): PositronApi | undefined {
-	try {
-		// Check if we're running in Positron by looking for the global acquirePositronApi function
-		if (typeof globalThis !== 'undefined' &&
-			typeof (globalThis as any).acquirePositronApi === 'function') {
-			return (globalThis as any).acquirePositronApi();
-		}
-		return undefined;
-	} catch (error) {
-		// If any error occurs (e.g., acquirePositronApi throws), return undefined
-		// This ensures extensions gracefully degrade to VS Code mode
-		return undefined;
-	}
+function tryAcquirePositronApi() {
+    try {
+        // Check if we're running in Positron by looking for the global acquirePositronApi function
+        if (typeof globalThis !== 'undefined' &&
+            typeof globalThis.acquirePositronApi === 'function') {
+            return globalThis.acquirePositronApi();
+        }
+        return undefined;
+    }
+    catch (error) {
+        // If any error occurs (e.g., acquirePositronApi throws), return undefined
+        // This ensures extensions gracefully degrade to VS Code mode
+        return undefined;
+    }
 }

--- a/positron-api-pkg/dist/runtime.js
+++ b/positron-api-pkg/dist/runtime.js
@@ -4,7 +4,33 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.inPositron = inPositron;
 exports.tryAcquirePositronApi = tryAcquirePositronApi;
+/**
+ * Check if the current environment is Positron.
+ *
+ * This is a simple helper function that returns true if running in Positron,
+ * false if running in VS Code.
+ *
+ * @returns true if running in Positron, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { inPositron } from '@posit-dev/positron';
+ *
+ * if (inPositron()) {
+ *   // We're in Positron - use enhanced features
+ *   console.log('Running in Positron!');
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+function inPositron() {
+    return typeof globalThis !== 'undefined' &&
+        typeof globalThis.acquirePositronApi === 'function';
+}
 /**
  * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
  *
@@ -30,8 +56,7 @@ exports.tryAcquirePositronApi = tryAcquirePositronApi;
 function tryAcquirePositronApi() {
     try {
         // Check if we're running in Positron by looking for the global acquirePositronApi function
-        if (typeof globalThis !== 'undefined' &&
-            typeof globalThis.acquirePositronApi === 'function') {
+        if (inPositron()) {
             return globalThis.acquirePositronApi();
         }
         return undefined;

--- a/positron-api-pkg/dist/ui-comm.d.ts
+++ b/positron-api-pkg/dist/ui-comm.d.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//
+// Copied from src/vs/workbench/services/languageRuntime/common/positronUiComm.ts; do not edit.
+//
+
+/**
+ * Editor metadata
+ */
+export interface EditorContext {
+	/**
+	 * Document metadata
+	 */
+	document: TextDocument;
+
+	/**
+	 * Document contents
+	 */
+	contents: Array<string>;
+
+	/**
+	 * The primary selection, i.e. selections[0]
+	 */
+	selection: Selection;
+
+	/**
+	 * The selections in this text editor.
+	 */
+	selections: Array<Selection>;
+
+}
+
+/**
+ * Document metadata
+ */
+export interface TextDocument {
+	/**
+	 * URI of the resource viewed in the editor
+	 */
+	path: string;
+
+	/**
+	 * End of line sequence
+	 */
+	eol: string;
+
+	/**
+	 * Whether the document has been closed
+	 */
+	is_closed: boolean;
+
+	/**
+	 * Whether the document has been modified
+	 */
+	is_dirty: boolean;
+
+	/**
+	 * Whether the document is untitled
+	 */
+	is_untitled: boolean;
+
+	/**
+	 * Language identifier
+	 */
+	language_id: string;
+
+	/**
+	 * Number of lines in the document
+	 */
+	line_count: number;
+
+	/**
+	 * Version number of the document
+	 */
+	version: number;
+
+}
+
+/**
+ * A line and character position, such as the position of the cursor.
+ */
+export interface Position {
+	/**
+	 * The zero-based character value, as a Unicode code point offset.
+	 */
+	character: number;
+
+	/**
+	 * The zero-based line value.
+	 */
+	line: number;
+
+}
+
+/**
+ * Selection metadata
+ */
+export interface Selection {
+	/**
+	 * Position of the cursor.
+	 */
+	active: Position;
+
+	/**
+	 * Start position of the selection
+	 */
+	start: Position;
+
+	/**
+	 * End position of the selection
+	 */
+	end: Position;
+
+	/**
+	 * Text of the selection
+	 */
+	text: string;
+
+}

--- a/positron-api-pkg/package-lock.json
+++ b/positron-api-pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@posit-dev/positron-types",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@posit-dev/positron-types",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Elastic-2.0",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.52.8",

--- a/positron-api-pkg/package-lock.json
+++ b/positron-api-pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@posit-dev/positron-types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@posit-dev/positron-types",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Elastic-2.0",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.52.8",

--- a/positron-api-pkg/package-lock.json
+++ b/positron-api-pkg/package-lock.json
@@ -1,0 +1,601 @@
+{
+  "name": "@posit-dev/positron-types",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@posit-dev/positron-types",
+      "version": "0.1.1",
+      "license": "Elastic-2.0",
+      "devDependencies": {
+        "@microsoft/api-extractor": "^7.52.8",
+        "@types/vscode": "^1.100.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@types/vscode": "^1.74.0"
+      }
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.52.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.8.tgz",
+      "integrity": "sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.30.6",
+        "@microsoft/tsdoc": "~0.15.1",
+        "@microsoft/tsdoc-config": "~0.17.1",
+        "@rushstack/node-core-library": "5.13.1",
+        "@rushstack/rig-package": "0.5.3",
+        "@rushstack/terminal": "0.15.3",
+        "@rushstack/ts-command-line": "5.0.1",
+        "lodash": "~4.17.15",
+        "minimatch": "~3.0.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.8.2"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.30.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.6.tgz",
+      "integrity": "sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "~0.15.1",
+        "@microsoft/tsdoc-config": "~0.17.1",
+        "@rushstack/node-core-library": "5.13.1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
+      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "ajv": "~8.12.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz",
+      "integrity": "sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "~8.13.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~11.3.0",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/ajv": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
+      "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "~1.22.1",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.3.tgz",
+      "integrity": "sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.13.1",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.1.tgz",
+      "integrity": "sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.15.3",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
+      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/positron-api-pkg/package.json
+++ b/positron-api-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posit-dev/positron",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript definitions and runtime utilities for the Positron API",
   "keywords": [
     "positron",

--- a/positron-api-pkg/package.json
+++ b/positron-api-pkg/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@posit-dev/positron",
+  "version": "0.1.1",
+  "description": "TypeScript definitions and runtime utilities for the Positron API",
+  "keywords": [
+    "positron",
+    "typescript",
+    "types",
+    "api",
+    "runtime",
+    "sdk",
+    "vscode",
+    "data-science",
+    "ide"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "node build.js",
+    "clean": "rm -rf dist temp && rm -f src/positron.d.ts src/ui-comm.d.ts",
+    "validate": "npm run build",
+    "prepublishOnly": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/posit-dev/positron.git",
+    "directory": "positron-api-pkg"
+  },
+  "bugs": {
+    "url": "https://github.com/posit-dev/positron/issues"
+  },
+  "homepage": "https://github.com/posit-dev/positron#readme",
+  "license": "Elastic-2.0",
+  "author": {
+    "name": "Posit Software, PBC",
+    "url": "https://posit.co"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@types/vscode": "^1.74.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.100.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/positron-api-pkg/package.json
+++ b/positron-api-pkg/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "node build.js",
     "clean": "rm -rf dist temp && rm -f src/positron.d.ts src/ui-comm.d.ts",
-    "validate": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/positron-api-pkg/package.json
+++ b/positron-api-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posit-dev/positron",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript definitions and runtime utilities for the Positron API",
   "keywords": [
     "positron",

--- a/positron-api-pkg/publish.sh
+++ b/positron-api-pkg/publish.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Publish script for @posit-dev/positron-types
+# This script handles versioning, building, and publishing the package
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$SCRIPT_DIR"
+
+echo -e "${BLUE}🚀 Publishing @posit-dev/positron${NC}"
+echo "========================================"
+
+# Check if we're in a git repository and on the right branch
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo -e "${RED}❌ Error: Not in a git repository${NC}"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if [[ -n $(git status --porcelain) ]]; then
+    echo -e "${YELLOW}⚠️  Warning: You have uncommitted changes${NC}"
+    if [[ "$NON_INTERACTIVE" == "false" ]]; then
+        read -p "Do you want to continue? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo -e "${RED}❌ Aborted${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${BLUE}🤖 Non-interactive mode: continuing with uncommitted changes${NC}"
+    fi
+fi
+
+# Change to package directory
+cd "$PACKAGE_DIR"
+
+# Parse command line arguments
+VERSION_TYPE=""
+NON_INTERACTIVE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --non-interactive|-y)
+            NON_INTERACTIVE=true
+            shift
+            ;;
+        patch|minor|major|prerelease)
+            if [[ -z "$VERSION_TYPE" ]]; then
+                VERSION_TYPE="$1"
+            else
+                echo -e "${RED}❌ Error: Multiple version types specified${NC}"
+                exit 1
+            fi
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [patch|minor|major|prerelease] [--non-interactive|-y]"
+            echo ""
+            echo "Arguments:"
+            echo "  patch|minor|major|prerelease  Version bump type (default: patch)"
+            echo ""
+            echo "Options:"
+            echo "  --non-interactive, -y         Skip confirmation prompts"
+            echo "  --help, -h                   Show this help message"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}❌ Error: Unknown argument '$1'${NC}"
+            echo "Usage: $0 [patch|minor|major|prerelease] [--non-interactive|-y]"
+            exit 1
+            ;;
+    esac
+done
+
+# Set default version type if not specified
+VERSION_TYPE="${VERSION_TYPE:-patch}"
+
+if [[ ! "$VERSION_TYPE" =~ ^(patch|minor|major|prerelease)$ ]]; then
+    echo -e "${RED}❌ Error: Invalid version type '$VERSION_TYPE'${NC}"
+    echo "Usage: $0 [patch|minor|major|prerelease] [--non-interactive|-y]"
+    exit 1
+fi
+
+echo -e "${BLUE}📋 Pre-publish checklist:${NC}"
+
+# Step 1: Build the package (includes type generation)
+echo -e "${BLUE}1. Building package...${NC}"
+cd "$PACKAGE_DIR"
+npm run build
+if [[ $? -ne 0 ]]; then
+    echo -e "${RED}❌ Failed to build package${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ Package built successfully${NC}"
+
+# Step 2: Run package validation
+echo -e "${BLUE}2. Running package validation...${NC}"
+if [[ -f "package.json" ]]; then
+    # Use the package's built-in validation
+    npm run validate
+    if [[ $? -ne 0 ]]; then
+        echo -e "${RED}❌ Package validation failed${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Package validation completed${NC}"
+else
+    echo -e "${RED}❌ package.json not found${NC}"
+    exit 1
+fi
+
+# Step 3: Show current version and ask for confirmation
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+echo -e "${BLUE}3. Current version: ${YELLOW}v$CURRENT_VERSION${NC}"
+
+# Calculate what the new version will be
+echo -e "${BLUE}   Bumping $VERSION_TYPE version...${NC}"
+
+# Step 4: Version bump
+echo -e "${BLUE}4. Updating version...${NC}"
+npm version "$VERSION_TYPE" --no-git-tag-version
+NEW_VERSION=$(node -p "require('./package.json').version")
+echo -e "${GREEN}✅ Version updated to v$NEW_VERSION${NC}"
+
+# Step 5: Final confirmation
+echo -e "${YELLOW}📦 Ready to publish v$NEW_VERSION${NC}"
+if [[ "$NON_INTERACTIVE" == "false" ]]; then
+    read -p "Do you want to publish to npm? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${YELLOW}⚠️  Version was updated but not published${NC}"
+        echo -e "${BLUE}💡 To publish later, run: npm publish${NC}"
+        exit 0
+    fi
+else
+    echo -e "${BLUE}🤖 Non-interactive mode: proceeding with publish${NC}"
+fi
+
+# Step 6: Publish to npm
+echo -e "${BLUE}5. Publishing to npm...${NC}"
+npm publish
+
+if [[ $? -eq 0 ]]; then
+    echo -e "${GREEN}🎉 Successfully published @posit-dev/positron@$NEW_VERSION${NC}"
+    echo -e "${BLUE}💡 Remember to commit and push!${NC}"
+else
+    echo -e "${RED}❌ Failed to publish to npm${NC}"
+    exit 1
+fi
+
+echo
+echo -e "${GREEN}🎊 All done! Package published successfully.${NC}"
+echo -e "${BLUE}📦 Install with: npm install --save-dev @posit-dev/positron${NC}"

--- a/positron-api-pkg/publish.sh
+++ b/positron-api-pkg/publish.sh
@@ -102,35 +102,20 @@ if [[ $? -ne 0 ]]; then
 fi
 echo -e "${GREEN}✅ Package built successfully${NC}"
 
-# Step 2: Run package validation
-echo -e "${BLUE}2. Running package validation...${NC}"
-if [[ -f "package.json" ]]; then
-    # Use the package's built-in validation
-    npm run validate
-    if [[ $? -ne 0 ]]; then
-        echo -e "${RED}❌ Package validation failed${NC}"
-        exit 1
-    fi
-    echo -e "${GREEN}✅ Package validation completed${NC}"
-else
-    echo -e "${RED}❌ package.json not found${NC}"
-    exit 1
-fi
-
-# Step 3: Show current version and ask for confirmation
+# Step 2: Show current version and ask for confirmation
 CURRENT_VERSION=$(node -p "require('./package.json').version")
-echo -e "${BLUE}3. Current version: ${YELLOW}v$CURRENT_VERSION${NC}"
+echo -e "${BLUE}2. Current version: ${YELLOW}v$CURRENT_VERSION${NC}"
 
 # Calculate what the new version will be
 echo -e "${BLUE}   Bumping $VERSION_TYPE version...${NC}"
 
-# Step 4: Version bump
-echo -e "${BLUE}4. Updating version...${NC}"
+# Step 3: Version bump
+echo -e "${BLUE}3. Updating version...${NC}"
 npm version "$VERSION_TYPE" --no-git-tag-version
 NEW_VERSION=$(node -p "require('./package.json').version")
 echo -e "${GREEN}✅ Version updated to v$NEW_VERSION${NC}"
 
-# Step 5: Final confirmation
+# Step 4: Final confirmation
 echo -e "${YELLOW}📦 Ready to publish v$NEW_VERSION${NC}"
 if [[ "$NON_INTERACTIVE" == "false" ]]; then
     read -p "Do you want to publish to npm? (y/N): " -n 1 -r
@@ -144,7 +129,7 @@ else
     echo -e "${BLUE}🤖 Non-interactive mode: proceeding with publish${NC}"
 fi
 
-# Step 6: Publish to npm
+# Step 5: Publish to npm
 echo -e "${BLUE}5. Publishing to npm...${NC}"
 npm publish
 

--- a/positron-api-pkg/src/index.ts
+++ b/positron-api-pkg/src/index.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------------------------
+ *  Positron API Runtime Function
+ *  Generated from source TypeScript definitions
+ *
+ *  This file provides a safe runtime function to access the Positron API.
+ *--------------------------------------------------------------------------------------------*/
+
+// Import types from the ambient module declaration
+import type * as positron from 'positron';
+
+// The key insight - this captures the complete API shape
+export type PositronApi = typeof positron;
+
+
+/**
+ * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
+ *
+ * This function handles the detection of whether the extension is running in Positron or VS Code,
+ * and provides access to Positron-specific functionality when available.
+ *
+ * @returns The Positron API object if available, or undefined if running in VS Code
+ *
+ * @example
+ * ```typescript
+ * import { getPositronApi } from '@posit-dev/positron';
+ *
+ * const positronApi = getPositronApi();
+ * if (positronApi) {
+ *   // We're in Positron - use enhanced features
+ *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+export function getPositronApi(): PositronApi | undefined {
+	try {
+		// Check if we're running in Positron by looking for the global acquirePositronApi function
+		if (typeof globalThis !== 'undefined' &&
+			typeof (globalThis as any).acquirePositronApi === 'function') {
+			return (globalThis as any).acquirePositronApi();
+		}
+		return undefined;
+	} catch (error) {
+		// If any error occurs (e.g., acquirePositronApi throws), return undefined
+		// This ensures extensions gracefully degrade to VS Code mode
+		return undefined;
+	}
+}

--- a/positron-api-pkg/src/index.ts
+++ b/positron-api-pkg/src/index.ts
@@ -3,53 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------------------------
- *  Positron API Runtime Function
- *  Generated from source TypeScript definitions
- *
- *  This file provides a safe runtime function to access the Positron API.
- *--------------------------------------------------------------------------------------------*/
+// Re-export the runtime function and types from the runtime module
+export { getPositronApi, type PositronApi } from './runtime';
 
-// Import types from the ambient module declaration
-import type * as positron from 'positron';
-
-// The key insight - this captures the complete API shape
-export type PositronApi = typeof positron;
-
-
-/**
- * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
- *
- * This function handles the detection of whether the extension is running in Positron or VS Code,
- * and provides access to Positron-specific functionality when available.
- *
- * @returns The Positron API object if available, or undefined if running in VS Code
- *
- * @example
- * ```typescript
- * import { getPositronApi } from '@posit-dev/positron';
- *
- * const positronApi = getPositronApi();
- * if (positronApi) {
- *   // We're in Positron - use enhanced features
- *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
- * } else {
- *   // We're in VS Code - use standard functionality
- *   console.log('Running in VS Code mode');
- * }
- * ```
- */
-export function getPositronApi(): PositronApi | undefined {
-	try {
-		// Check if we're running in Positron by looking for the global acquirePositronApi function
-		if (typeof globalThis !== 'undefined' &&
-			typeof (globalThis as any).acquirePositronApi === 'function') {
-			return (globalThis as any).acquirePositronApi();
-		}
-		return undefined;
-	} catch (error) {
-		// If any error occurs (e.g., acquirePositronApi throws), return undefined
-		// This ensures extensions gracefully degrade to VS Code mode
-		return undefined;
-	}
-}
+// Re-export preview functions
+export { previewUrl } from './preview';

--- a/positron-api-pkg/src/index.ts
+++ b/positron-api-pkg/src/index.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Re-export the runtime function and types from the runtime module
-export { tryAcquirePositronApi, type PositronApi } from './runtime';
+export { tryAcquirePositronApi, inPositron, type PositronApi } from './runtime';
 
 // Re-export preview functions
 export { previewUrl } from './preview';

--- a/positron-api-pkg/src/index.ts
+++ b/positron-api-pkg/src/index.ts
@@ -8,3 +8,44 @@ export { tryAcquirePositronApi, type PositronApi } from './runtime';
 
 // Re-export preview functions
 export { previewUrl } from './preview';
+
+// Re-export all types from the positron namespace for type-only imports
+export type * from 'positron';
+
+// Global type declarations for Positron-injected functions
+declare global {
+	/**
+	 * Global function that may be injected by Positron to acquire the Positron API.
+	 * 
+	 * **Important**: This function is `undefined` when running in VS Code and only exists
+	 * when running in Positron. Always check for its existence before calling it.
+	 * 
+	 * For safer access to the Positron API, consider using `tryAcquirePositronApi()` instead,
+	 * which handles the runtime detection automatically.
+	 * 
+	 * @returns The Positron API object, or undefined if not available
+	 *
+	 * @example
+	 * ```typescript
+	 * // Safe usage with type checking (recommended)
+	 * if (typeof acquirePositronApi !== 'undefined') {
+	 *   const positronApi = acquirePositronApi();
+	 *   if (positronApi) {
+	 *     // Use positronApi...
+	 *     positronApi.runtime.executeCode('python', 'print("Hello!")', true);
+	 *   }
+	 * }
+	 *
+	 * // Alternative safe usage with optional chaining
+	 * const positronApi = globalThis.acquirePositronApi?.();
+	 * if (positronApi) {
+	 *   // Use positronApi...
+	 * }
+	 * 
+	 * // For simpler code, consider using the wrapper function:
+	 * import { tryAcquirePositronApi } from '@posit-dev/positron';
+	 * const positronApi = tryAcquirePositronApi();
+	 * ```
+	 */
+	const acquirePositronApi: (() => typeof import('positron') | undefined) | undefined;
+}

--- a/positron-api-pkg/src/index.ts
+++ b/positron-api-pkg/src/index.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Re-export the runtime function and types from the runtime module
-export { getPositronApi, type PositronApi } from './runtime';
+export { tryAcquirePositronApi, type PositronApi } from './runtime';
 
 // Re-export preview functions
 export { previewUrl } from './preview';

--- a/positron-api-pkg/src/positron.d.ts
+++ b/positron-api-pkg/src/positron.d.ts
@@ -1,0 +1,2091 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'positron' {
+
+	import * as vscode from 'vscode';
+
+	/**
+	 * The current Positron version. This is the Positron calendar version, e.g. "2028.10.2"
+	 */
+	export const version: string;
+
+	/**
+	 * The Positron build number. This is a monotonically increasing number that uniquely
+	 * identifies a build of Positron within a release.
+	 */
+	export const buildNumber: number;
+
+	/** The set of possible language runtime messages */
+	export enum LanguageRuntimeMessageType {
+		/** A message instructing the frontend to clear the output of a runtime execution. */
+		ClearOutput = 'clear_output',
+
+		/** A message representing output (text, plots, etc.) */
+		Output = 'output',
+
+		/** A message representing the computational result of a runtime execution */
+		Result = 'result',
+
+		/** A message representing output from one of the standard streams (stdout or stderr) */
+		Stream = 'stream',
+
+		/** A message representing echoed user input */
+		Input = 'input',
+
+		/** A message representing an error that occurred while executing user code */
+		Error = 'error',
+
+		/** A message representing a prompt for user input */
+		Prompt = 'prompt',
+
+		/** A message representing a change in the runtime's online state */
+		State = 'state',
+
+		/** A message representing a runtime event */
+		Event = 'event',
+
+		/** A message representing a new comm (client instance) being opened from the runtime side */
+		CommOpen = 'comm_open',
+
+		/** A message representing data received via a comm (to a client instance) */
+		CommData = 'comm_data',
+
+		/** A message indicating that a comm (client instance) was closed from the server side */
+		CommClosed = 'comm_closed',
+
+		/** A message that should be handled by an IPyWidget */
+		IPyWidget = 'ipywidget',
+
+		/** A message representing a request to update an output */
+		UpdateOutput = 'update_output',
+	}
+
+	/**
+	 * The set of possible statuses for a language runtime while online
+	 */
+	export enum RuntimeOnlineState {
+		/** The runtime is starting up */
+		Starting = 'starting',
+
+		/** The runtime is ready to execute code. */
+		Idle = 'idle',
+
+		/** The runtime is busy executing code. */
+		Busy = 'busy',
+	}
+
+	/**
+	 * The set of possible statuses for a language runtime
+	 */
+	export enum RuntimeState {
+		/** The runtime has not been started or initialized yet. */
+		Uninitialized = 'uninitialized',
+
+		/** The runtime is initializing (preparing to start). */
+		Initializing = 'initializing',
+
+		/** The runtime is in the process of starting up. It isn't ready for messages. */
+		Starting = 'starting',
+
+		/** The runtime has a heartbeat and is ready for messages. */
+		Ready = 'ready',
+
+		/** The runtime is ready to execute code. */
+		Idle = 'idle',
+
+		/** The runtime is busy executing code. */
+		Busy = 'busy',
+
+		/** The runtime is in the process of restarting. */
+		Restarting = 'restarting',
+
+		/** The runtime is in the process of shutting down. */
+		Exiting = 'exiting',
+
+		/** The runtime's host process has ended. */
+		Exited = 'exited',
+
+		/** The runtime is not responding to heartbeats and is presumed offline. */
+		Offline = 'offline',
+
+		/** The user has interrupted a busy runtime, but the runtime is not idle yet. */
+		Interrupting = 'interrupting',
+	}
+
+	/**
+	 * Results of analyzing code fragment for completeness
+	 */
+	export enum RuntimeCodeFragmentStatus {
+		/** The code fragment is complete: it is a valid, self-contained expression */
+		Complete = 'complete',
+
+		/** The code is incomplete: it is an expression that is missing elements or operands, such as "1 +" or "foo(" */
+		Incomplete = 'incomplete',
+
+		/** The code is invalid: an expression that cannot be parsed because of a syntax error */
+		Invalid = 'invalid',
+
+		/** It was not possible to ascertain the code fragment's status */
+		Unknown = 'unknown'
+	}
+
+	/**
+	 * Possible code execution modes for a language runtime
+	 */
+	export enum RuntimeCodeExecutionMode {
+		/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+		Interactive = 'interactive',
+
+		/** The code should be executed but not stored in history. */
+		Transient = 'transient',
+
+		/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+		Silent = 'silent'
+	}
+
+	/**
+	 * Possible error dispositions for a language runtime
+	 */
+	export enum RuntimeErrorBehavior {
+		/** The runtime should stop when an error is encountered. */
+		Stop = 'stop',
+
+		/** The runtime should continue execution when an error is encountered */
+		Continue = 'continue',
+	}
+
+	/**
+	 * Possible reasons a language runtime could exit.
+	 */
+	export enum RuntimeExitReason {
+		/** The runtime exited because it could not start correctly. */
+		StartupFailed = 'startupFailed',
+
+		/** The runtime is shutting down at the request of the user. */
+		Shutdown = 'shutdown',
+
+		/** The runtime exited because it was forced to quit. */
+		ForcedQuit = 'forcedQuit',
+
+		/** The runtime is exiting in order to restart. */
+		Restart = 'restart',
+
+		/** The runtime is exiting in order to switch to a new runtime. */
+		SwitchRuntime = 'switchRuntime',
+
+		/** The runtime exited because of an error, most often a crash. */
+		Error = 'error',
+
+		/**
+		 * The runtime session was transferred somewhere else. This happens when
+		 * it is loaded into a different Positron window; it 'exits' from the
+		 * old window and is reconnected in the new window.
+		 */
+		Transferred = 'transferred',
+
+		/** The runtime exited because the extension hosting it was stopped. */
+		ExtensionHost = 'extensionHost',
+
+		/**
+		 * The runtime exited for an unknown reason. This typically means that
+		 * it exited unexpectedly but with a normal exit code (0).
+		 */
+		Unknown = 'unknown',
+	}
+
+	/**
+	 * LanguageRuntimeExit is an interface that defines an event occurring when a
+	 * language runtime exits.
+	 */
+	export interface LanguageRuntimeExit {
+		/** Runtime name */
+		runtime_name: string;
+
+		/** Session name */
+		session_name: string;
+
+		/**
+		 * The process exit code, if the runtime is backed by a process. If the
+		 * runtime is not backed by a process, this should just be 0 for a
+		 * succcessful exit and 1 for an error.
+		 */
+		exit_code: number;
+
+		/**
+		 * The reason the runtime exited.
+		 */
+		reason: RuntimeExitReason;
+
+		/** The exit message, if any. */
+		message: string;
+	}
+
+	/**
+	 * LanguageRuntimeMessage is an interface that defines an event occurring in a
+	 * language runtime, such as outputting text or plots.
+	 */
+	export interface LanguageRuntimeMessage {
+		/** The event ID */
+		id: string;
+
+		/** The ID of this event's parent (the event that caused it), if applicable */
+		parent_id: string;
+
+		/** The message's date and time, in ISO 8601 format */
+		when: string;
+
+		/** The type of event */
+		type: LanguageRuntimeMessageType;
+
+		/** Additional metadata, if any */
+		metadata?: Record<string, unknown>;
+
+		/** Additional binary data, if any */
+		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * LanguageRuntimeClearOutput is a LanguageRuntimeMessage instructing the frontend to clear the
+	 * output of a runtime execution. */
+	export interface LanguageRuntimeClearOutput extends LanguageRuntimeMessage {
+		/** Wait to clear the output until new output is available. */
+		wait: boolean;
+	}
+
+	/** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */
+	export interface LanguageRuntimeOutput extends LanguageRuntimeMessage {
+		/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
+		data: Record<string, unknown>;
+
+		/**
+		 * The optional identifier of the output. If specified, this output can be referenced
+		 * in future messages e.g. when {@link LanguageRuntimeUpdateOutput updating an output}.
+		 */
+		output_id?: string;
+	}
+
+	/**
+	 * LanguageRuntimeUpdateOutput is a LanguageRuntimeMessage instructing the frontend
+	 * to update an existing output.
+	 */
+	export interface LanguageRuntimeUpdateOutput extends LanguageRuntimeMessage {
+		/** The updated output data */
+		data: Record<string, unknown>;
+
+		/** The identifier of the output to update */
+		output_id: string;
+	}
+
+	/**
+	 * LanguageRuntimeResult is a LanguageRuntimeOutput representing the computational result of a
+	 * runtime execution.
+	 */
+	export interface LanguageRuntimeResult extends LanguageRuntimeOutput {
+	}
+
+	/**
+	 * The set of possible output locations for a LanguageRuntimeOutput.
+	 */
+	export enum PositronOutputLocation {
+		/** The output should be displayed inline in Positron's Console */
+		Console = 'console',
+
+		/** The output should be displayed in Positron's Viewer pane */
+		Viewer = 'viewer',
+
+		/** The output should be displayed in Positron's Plots pane */
+		Plot = 'plot',
+	}
+
+	/**
+	 * LanguageRuntimeWebOutput amends LanguageRuntimeOutput with additional information needed
+	 * to render web content in Positron.
+	 */
+	export interface LanguageRuntimeWebOutput extends LanguageRuntimeOutput {
+		/** Where the web output should be displayed */
+		output_location: PositronOutputLocation;
+
+		/** The set of resource roots needed to display the output */
+		resource_roots: vscode.Uri[];
+	}
+
+	/**
+	 * The set of standard stream names supported for streaming textual output.
+	 */
+	export enum LanguageRuntimeStreamName {
+		Stdout = 'stdout',
+		Stderr = 'stderr'
+	}
+
+	/**
+	 * LanguageRuntimeStream is a LanguageRuntimeMessage representing output from a standard stream
+	 * (stdout or stderr).
+	 */
+	export interface LanguageRuntimeStream extends LanguageRuntimeMessage {
+		/** The stream name */
+		name: LanguageRuntimeStreamName;
+
+		/** The stream's text */
+		text: string;
+	}
+
+	/** LanguageRuntimeInput is a LanguageRuntimeMessage representing echoed user input */
+	export interface LanguageRuntimeInput extends LanguageRuntimeMessage {
+		/** The code that was input */
+		code: string;
+
+		/** The execution count */
+		execution_count: number;
+	}
+
+	/** LanguageRuntimePrompt is a LanguageRuntimeMessage representing a prompt for input */
+	export interface LanguageRuntimePrompt extends LanguageRuntimeMessage {
+		/** The prompt text */
+		prompt: string;
+
+		/** Whether this is a password prompt (and typing should be hidden)  */
+		password: boolean;
+	}
+
+	/** LanguageRuntimeInfo contains metadata about the runtime after it has started. */
+	export interface LanguageRuntimeInfo {
+		/** A startup banner */
+		banner: string;
+
+		/** The implementation version number */
+		implementation_version: string;
+
+		/** The language version number */
+		language_version: string;
+
+		/** Initial prompt string in case user customized it */
+		input_prompt?: string;
+
+		/** Continuation prompt string in case user customized it */
+		continuation_prompt?: string;
+	}
+
+	/** LanguageRuntimeState is a LanguageRuntimeMessage representing a new runtime state */
+	export interface LanguageRuntimeState extends LanguageRuntimeMessage {
+		/** The new state */
+		state: RuntimeOnlineState;
+	}
+
+	/** LanguageRuntimeError is a LanguageRuntimeMessage that represents a run-time error */
+	export interface LanguageRuntimeError extends LanguageRuntimeMessage {
+		/** The error name */
+		name: string;
+
+		/** The error message */
+		message: string;
+
+		/** The error stack trace */
+		traceback: Array<string>;
+	}
+
+	/**
+	 * LanguageRuntimeMessageIPyWidget is a wrapped LanguageRuntimeMessage that should be handled
+	 * by an IPyWidget.
+	 *
+	 * Output widgets may intercept replies to an execution and instead render them inside the
+	 * output widget. See https://ipywidgets.readthedocs.io/en/latest/examples/Output%20Widget.html
+	 * for more.
+	 */
+	export interface LanguageRuntimeMessageIPyWidget extends LanguageRuntimeMessage {
+		/** The original runtime message that was intercepted by an IPyWidget */
+		original_message: LanguageRuntimeMessage;
+	}
+
+	/**
+	 * LanguageRuntimeCommOpen is a LanguageRuntimeMessage that indicates a
+	 * comm (client instance) was opened from the server side
+	 */
+	export interface LanguageRuntimeCommOpen extends LanguageRuntimeMessage {
+		/** The unique ID of the comm being opened */
+		comm_id: string;
+
+		/** The name (type) of the comm being opened, e.g. 'jupyter.widget' */
+		target_name: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/** LanguageRuntimeCommMessage is a LanguageRuntimeMessage that represents data for a comm (client instance) */
+	export interface LanguageRuntimeCommMessage extends LanguageRuntimeMessage {
+		/** The unique ID of the client comm ID for which the message is intended */
+		comm_id: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/**
+	 * LanguageRuntimeCommClosed is a LanguageRuntimeMessage that indicates a
+	 * comm (client instance) was closed from the server side
+	 */
+	export interface LanguageRuntimeCommClosed extends LanguageRuntimeMessage {
+		/** The unique ID of the client comm ID for which the message is intended */
+		comm_id: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
+	/**
+	 * LanguageRuntimeMetadata contains information about a language runtime that is known
+	 * before the runtime is started.
+	 */
+	export interface LanguageRuntimeMetadata {
+		/** The path to the runtime. */
+		runtimePath: string;
+
+		/** A unique identifier for this runtime; takes the form of a GUID */
+		runtimeId: string;
+
+		/**
+		 * The fully qualified name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)".
+		 * Should be unique across languages.
+		 */
+		runtimeName: string;
+
+		/**
+		 * A language specific runtime name displayed to the user; e.g. "4.2 (64-bit)".
+		 * Should be unique within a single language.
+		 */
+		runtimeShortName: string;
+
+		/** The version of the runtime itself (e.g. kernel or extension version) as a string; e.g. "0.1" */
+		runtimeVersion: string;
+
+		/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
+		runtimeSource: string;
+
+		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
+		languageName: string;
+
+		/**
+		 * The Visual Studio Code Language ID of the language this runtime can execute; e.g. "r"
+		 *
+		 * See here for a list of known language IDs:
+		 * https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
+		 */
+		languageId: string;
+
+		/** The version of the language; e.g. "4.2" */
+		languageVersion: string;
+
+		/** The Base64-encoded icon SVG for the language. */
+		base64EncodedIconSvg: string | undefined;
+
+		/** Whether the runtime should start up automatically or wait until explicitly requested */
+		startupBehavior: LanguageRuntimeStartupBehavior;
+
+		/** Where sessions will be located; used as a hint to control session restoration */
+		sessionLocation: LanguageRuntimeSessionLocation;
+
+		/**
+		 * Extra data supplied by the runtime provider; not read by Positron but supplied
+		 * when creating a new session from the metadata.
+		 */
+		extraRuntimeData: any;
+
+		/**
+		 * Subscriptions to notifications from the UI. When subscribed, the frontend sends
+		 * notifications to the backend via the UI client.
+		 */
+		uiSubscriptions?: UiRuntimeNotifications[];
+	}
+
+	/**
+	 * UI notifications from frontend to backends.
+	 */
+	export enum UiRuntimeNotifications {
+		/** Notification that the settings for rendering a plot have changed, typically because the plot area did */
+		DidChangePlotsRenderSettings = 'did_change_plots_render_settings',
+	}
+
+	export interface RuntimeSessionMetadata {
+		/** The ID of this session */
+		readonly sessionId: string;
+
+		/** The session's mode */
+		readonly sessionMode: LanguageRuntimeSessionMode;
+
+		/** The URI of the notebook document associated with the session, if any */
+		readonly notebookUri?: vscode.Uri;
+	}
+
+	/**
+	 * LanguageRuntimeSessionMode is an enum representing the set of possible
+	 * modes for a language runtime session.
+	 */
+	export enum LanguageRuntimeSessionMode {
+		/**
+		 * The runtime session is bound to a Positron console. Typically,
+		 * there's only one console session per language.
+		 */
+		Console = 'console',
+
+		/** The runtime session backs a notebook. */
+		Notebook = 'notebook',
+
+		/** The runtime session is a background session (not attached to any UI). */
+		Background = 'background',
+	}
+
+
+	/**
+	 * LanguageRuntimeDynState contains information about a language runtime that may
+	 * change after a runtime has started.
+	 */
+	export interface LanguageRuntimeDynState {
+		/** The text the language's interpreter uses to prompt the user for input, e.g. ">" or ">>>" */
+		inputPrompt: string;
+
+		/** The text the language's interpreter uses to prompt the user for continued input, e.g. "+" or "..." */
+		continuationPrompt: string;
+
+		/** The user-facing name of this session */
+		sessionName: string;
+	}
+
+	export enum LanguageRuntimeStartupBehavior {
+		/**
+		 * The runtime should be started immediately after registration; usually used for runtimes
+		 * that are affiliated with the current workspace.
+		 */
+		Immediate = 'immediate',
+
+		/**
+		 * The runtime should start automatically; usually used for runtimes that provide LSPs
+		 */
+		Implicit = 'implicit',
+
+		/**
+		 * The runtime should start when the user explicitly requests it;
+		 * usually used for runtimes that only provide REPLs
+		 */
+		Explicit = 'explicit',
+
+		/**
+		 * The runtime only starts up if manually requested by the user.
+		 * The difference from Explicit, is that Manual startup never
+		 * starts automatically, even if the run time is affiliated to the
+		 * workspace.
+		 */
+		Manual = 'manual'
+	}
+
+	/**
+	 * An enumeration of possible locations for runtime sessions.
+	 */
+	export enum LanguageRuntimeSessionLocation {
+		/**
+		 * The runtime session is persistent on the machine; it should be
+		 * restored when the workspace is re-opened, and may persist across
+		 * Positron sessions.
+		 */
+		Machine = 'machine',
+
+		/**
+		 * The runtime session is located in the current workspace (usually a
+		 * terminal); it should be restored when the workspace is re-opened in
+		 * the same Positron session (e.g. during a browser reload or
+		 * reconnect)
+		 */
+		Workspace = 'workspace',
+
+		/**
+		 * The runtime session is browser-only; it should not be restored when the
+		 * workspace is re-opened.
+		 */
+		Browser = 'browser',
+	}
+
+	/**
+	 * The set of client types that can be generated by a language runtime. Note
+	 * that, because client types can share a namespace with other kinds of
+	 * widgets, each client type in Positron's API is prefixed with the string
+	 * "positron".
+	 */
+	export enum RuntimeClientType {
+		Variables = 'positron.variables',
+		Lsp = 'positron.lsp',
+		Dap = 'positron.dap',
+		Plot = 'positron.plot',
+		DataExplorer = 'positron.dataExplorer',
+		Ui = 'positron.ui',
+		Help = 'positron.help',
+		Connection = 'positron.connection',
+		Reticulate = 'positron.reticulate',
+		IPyWidget = 'jupyter.widget',
+		IPyWidgetControl = 'jupyter.widget.control',
+
+		// Future client types may include:
+		// - Watch window/variable explorer
+		// - Code inspector
+		// - etc.
+	}
+
+	/**
+	 * The possible states for a language runtime client instance. These
+	 * represent the state of the communications channel between the client and
+	 * the runtime.
+	 */
+	export enum RuntimeClientState {
+		/** The client has not yet been initialized */
+		Uninitialized = 'uninitialized',
+
+		/** The connection between the server and the client is being opened */
+		Opening = 'opening',
+
+		/** The connection between the server and the client has been established */
+		Connected = 'connected',
+
+		/** The connection between the server and the client is being closed */
+		Closing = 'closing',
+
+		/** The connection between the server and the client is closed */
+		Closed = 'closed',
+	}
+
+	/**
+	 * A variable in the runtime's memory or environment.
+	 */
+	export interface RuntimeVariable {
+		/** An internal access key for the variable */
+		access_key: string;
+
+		/** A human-readable display name for the variable */
+		display_name: string;
+
+		/** The type of the variable (string, number, etc.) */
+		display_type: string;
+
+		/** A string representation of the value of the variable */
+		display_value: string;
+
+		/**
+		 * Extended type information naming e.g. the exact class name of the
+		 * variable
+		 */
+		type_info?: string;
+
+		/** The length of the variable, e.g. number of elements in an array */
+		length: number;
+
+		/** The size of a variable, e.g. in bytes */
+		size: number;
+
+		/** Whether the variable has child variables, e.g columns in a data frame */
+		has_children: boolean;
+	}
+
+	/**
+	 * The possible types of language model that can be used with the Positron Assistant.
+	 */
+	export enum PositronLanguageModelType {
+		Chat = 'chat',
+		Completion = 'completion',
+	}
+
+	/**
+	 * The possible locations a Positron Assistant chat request can be invoked from.
+	 */
+	export enum PositronChatAgentLocation {
+		Panel = 'panel',
+		Terminal = 'terminal',
+		Notebook = 'notebook',
+		Editor = 'editor',
+	}
+
+	/**
+	 * The possible modes for a Positron Assistant chat request.
+	 */
+	export enum PositronChatMode {
+		Ask = 'ask',
+		Edit = 'edit',
+		Agent = 'agent',
+	}
+
+	/**
+	 * A message received from a runtime client instance.
+	 */
+	export interface RuntimeClientOutput<T> {
+		/** The message data */
+		data: T;
+
+		/** Raw binary data associated with the message, if any */
+		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * An instance of a client widget generated by a language runtime. See
+	 * RuntimeClientType for the set of possible client types.
+	 *
+	 * The client is responsible for disposing itself when it is no longer
+	 * needed; this will trigger the closure of the communications channel
+	 * between the client and the runtime.
+	 */
+	export interface RuntimeClientInstance extends vscode.Disposable {
+		onDidChangeClientState: vscode.Event<RuntimeClientState>;
+		onDidSendEvent: vscode.Event<RuntimeClientOutput<object>>;
+		performRpcWithBuffers<T>(data: object): Thenable<RuntimeClientOutput<T>>;
+		performRpc<T>(data: object): Thenable<T>;
+		getClientState(): RuntimeClientState;
+		getClientId(): string;
+		getClientType(): RuntimeClientType;
+	}
+
+	/**
+	 * Code attribution sources for code executed by Positron.
+	 */
+	export enum CodeAttributionSource {
+		/** The code was executed by an AI assistant. */
+		Assistant = 'assistant',
+
+		/** The code was executed by a Positron extension. */
+		Extension = 'extension',
+
+		/** The code was executed interactively (the user typed it in). */
+		Interactive = 'interactive',
+
+		/** The code was executed from a notebook cell. */
+		Notebook = 'notebook',
+
+		/** The code was pasted into the Console. */
+		Paste = 'paste',
+
+		/** The code was run as a fragment or whole of a script. */
+		Script = 'script',
+	}
+
+	/**
+	 * Code attribution metadata for code executed by Positron.
+	 */
+	export interface CodeAttribution {
+		/** The code's origin */
+		source: CodeAttributionSource;
+
+		/**
+		 * Additional metadata specific to the attribution source, if any. For
+		 * example, when code is executed from an extension, it names the
+		 * extension, and when code is executed from a script, it names the
+		 * script.
+		 */
+		metadata?: Record<string, any>;
+	}
+
+	/**
+	 * An event that is emitted when code is executed in Positron.
+	 */
+	export interface CodeExecutionEvent {
+		/** The ID of the language in which the code was executed (e.g. 'python') */
+		languageId: string;
+
+		/** The name of the runtime that executed the code (e.g. 'Python 3.12') */
+		runtimeName: string;
+
+		/** The actual code that was executed. */
+		code: string;
+
+		/** An object describing the origin of the code. */
+		attribution: CodeAttribution;
+	}
+
+	export interface LanguageRuntimeManager {
+		/**
+		 * Returns a generator that yields metadata about all the language
+		 * runtimes that are available to the user.
+		 *
+		 * This metadata will be passed to `createSession` to create new runtime
+		 * sessions.
+		 */
+		discoverAllRuntimes(): AsyncGenerator<LanguageRuntimeMetadata>;
+
+		/**
+		 * Returns a single runtime metadata object representing the runtime
+		 * that should be used in the current workspace, if any.
+		 *
+		 * Note that this is called before `discoverAllRuntimes` during
+		 * startup, and should return `undefined` if no runtime is recommended.
+		 *
+		 * If a runtime is returned, `startupBehavior` property of the runtime
+		 * metadata is respected here; use `Immediately` to start the runtime
+		 * right away, or any other value to save the runtime as the project
+		 * default without starting it.
+		 */
+		recommendedWorkspaceRuntime(): Thenable<LanguageRuntimeMetadata | undefined>;
+
+		/**
+		 * An optional event that fires when a new runtime is discovered.
+		 *
+		 * Not fired during `discoverRuntimes()`; used to notify Positron of a
+		 * new runtime or environment after the initial discovery has completed.
+		 */
+		onDidDiscoverRuntime?: vscode.Event<LanguageRuntimeMetadata>;
+
+		/**
+		 * An optional metadata validation function. If provided, Positron will
+		 * validate any stored metadata before attempting to use it to create a
+		 * new session. This happens when a workspace is re-opened, for example.
+		 *
+		 * If the metadata is invalid, the function should return a new version
+		 * of the metadata with the necessary corrections.
+		 *
+		 * If it is not possible to correct the metadata, the function should
+		 * reject with an error.
+		 *
+		 * @param metadata The metadata to validate
+		 * @returns A Thenable that resolves with an updated version of the
+		 *   metadata.
+		 */
+		validateMetadata?(metadata: LanguageRuntimeMetadata):
+			Thenable<LanguageRuntimeMetadata>;
+
+		/**
+		 * An optional session validation function. If provided, Positron will
+		 * validate any stored session metadata before reconnecting to the
+		 * session.
+		 *
+		 * @param metadata The metadata to validate
+		 * @returns A Thenable that resolves with true (the session is valid) or
+		 *  false (the session is invalid).
+		 */
+		validateSession?(sessionId: string): Thenable<boolean>;
+
+		/**
+		 * Creates a new runtime session.
+		 *
+		 * @param runtimeMetadata One of the runtime metadata items returned by
+		 * `discoverRuntimes`.
+		 * @param sessionMetadata The metadata for the new session.
+		 *
+		 * @returns A Thenable that resolves with the new session, or rejects with an error.
+		 */
+		createSession(runtimeMetadata: LanguageRuntimeMetadata,
+			sessionMetadata: RuntimeSessionMetadata):
+			Thenable<LanguageRuntimeSession>;
+
+		/**
+		 * Reconnects to a runtime session using the given metadata.
+		 *
+		 * Implementing this method is optional, since not all sessions can be
+		 * reconnected; for example, sessions that run in the browser cannot be
+		 * reconnected.
+		 *
+		 * @param runtimeMetadata The metadata for the runtime that owns the
+		 * session.
+		 * @param sessionMetadata The metadata for the session to reconnect.
+		 * @param sessionName The name of the session to reconnect.
+		 * @returns A Thenable that resolves with the reconnected session, or
+		 * rejects with an error.
+		 */
+		restoreSession?(runtimeMetadata: LanguageRuntimeMetadata,
+			sessionMetadata: RuntimeSessionMetadata,
+			sessionName: string):
+			Thenable<LanguageRuntimeSession>;
+	}
+
+	/**
+	 * An enum representing the set of runtime method error codes; these map to
+	 * JSON-RPC error codes.
+	 */
+	export enum RuntimeMethodErrorCode {
+		ParseError = -32700,
+		InvalidRequest = -32600,
+		MethodNotFound = -32601,
+		InvalidParams = -32602,
+		InternalError = -32603,
+		ServerErrorStart = -32000,
+		ServerErrorEnd = -32099
+	}
+
+	/**
+	 * An error returned by a runtime method call.
+	 */
+	export interface RuntimeMethodError {
+		/** An error code */
+		code: RuntimeMethodErrorCode;
+
+		/** A human-readable error message */
+		message: string;
+
+		/**
+		 * A name for the error, for compatibility with the Error object.
+		 * Usually `RPC Error ${code}`.
+		 */
+		name: string;
+
+		/** Additional error information (optional) */
+		data: any | undefined;
+	}
+
+	/**
+	 * Enum of available channels for a language runtime session.
+	 * Used to enumerate available channels for users.
+	 */
+	export enum LanguageRuntimeSessionChannel {
+		Console = 'console',
+		Kernel = 'kernel',
+		LSP = 'lsp',
+	}
+
+	/**
+	 * LanguageRuntimeSession is an interface implemented by extensions that provide a
+	 * set of common tools for interacting with a language runtime, such as code
+	 * execution, LSP implementation, and plotting.
+	 */
+	export interface LanguageRuntimeSession extends vscode.Disposable {
+
+		/** An object supplying immutable metadata about this specific session */
+		readonly metadata: RuntimeSessionMetadata;
+
+		/**
+		 * An object supplying metadata about the runtime with which this
+		 * session is associated.
+		 */
+		readonly runtimeMetadata: LanguageRuntimeMetadata;
+
+		/** The state of the runtime that changes during a user session */
+		dynState: LanguageRuntimeDynState;
+
+		/** An object that emits language runtime events */
+		onDidReceiveRuntimeMessage: vscode.Event<LanguageRuntimeMessage>;
+
+		/** An object that emits the current state of the runtime */
+		onDidChangeRuntimeState: vscode.Event<RuntimeState>;
+
+		/** An object that emits an event when the user's session ends and the runtime exits */
+		onDidEndSession: vscode.Event<LanguageRuntimeExit>;
+
+		/**
+		 * Opens a resource in the runtime.
+		 * @param resource The resource to open.
+		 * @returns true if the resource was opened; otherwise, false.
+		 */
+		openResource?(resource: vscode.Uri | string): Thenable<boolean>;
+
+		/**
+		 * Execute code in the runtime
+		 *
+		 * @param code The code to execute
+		 * @param id The language ID of the code
+		 * @param mode The code execution mode
+		 * @param errorBehavior The code execution error behavior
+		 * Note: The errorBehavior parameter is currently ignored by kernels
+		 */
+		execute(code: string,
+			id: string,
+			mode: RuntimeCodeExecutionMode,
+			errorBehavior: RuntimeErrorBehavior): void;
+
+		/**
+		 * Calls a method in the runtime and returns the result.
+		 *
+		 * Throws a RuntimeMethodError if the method call fails.
+		 *
+		 * @param method The name of the method to call
+		 * @param args Arguments to pass to the method
+		 */
+		callMethod?(method: string, ...args: any[]): Thenable<any>;
+
+		/** Test a code fragment for completeness */
+		isCodeFragmentComplete(code: string): Thenable<RuntimeCodeFragmentStatus>;
+
+		/**
+		 * Create a new instance of a client; return null if the client type
+		 * is not supported by this runtime, or a string containing the ID of
+		 * the client if it is supported.
+		 *
+		 * @param id The unique, client-supplied ID of the client instance. Can be any
+		 *   unique string.
+		 * @param type The type of client to create
+		 * @param params A set of parameters to pass to the client; specific to the client type
+		 * @param metadata A set of metadata to pass to the client; specific to the client type
+		 */
+		createClient(id: string, type: RuntimeClientType, params: Record<string, unknown>, metadata?: Record<string, unknown>): Thenable<void>;
+
+		/**
+		 * List all clients, optionally filtered by type.
+		 *
+		 * @param type If specified, only clients of this type will be returned.
+		 * @returns A Thenable that resolves with a map of client IDs to client types.
+		 */
+		listClients(type?: RuntimeClientType): Thenable<Record<string, string>>;
+
+		/** Remove an instance of a client (created with `createClient`) */
+		removeClient(id: string): void;
+
+		/**
+		 * Send a message to the server end of a client instance. Any replies to the message
+		 * will be sent back to the client via the `onDidReceiveRuntimeMessage` event, with
+		 * the `parent_id` field set to the `message_id` given here.
+		 */
+		sendClientMessage(client_id: string, message_id: string, message: Record<string, unknown>): void;
+
+		/** Reply to a prompt issued by the runtime */
+		replyToPrompt(id: string, reply: string): void;
+
+		/**
+		 * Set the current working directory of the session.
+		 */
+		setWorkingDirectory(dir: string): Thenable<void>;
+
+		/**
+		 * Start the session; returns a Thenable that resolves with information about the runtime.
+		 * If the runtime fails to start for any reason, the Thenable should reject with an error
+		 * object containing a `message` field with a human-readable error message and an optional
+		 * `details` field with additional information.
+		 */
+		start(): Thenable<LanguageRuntimeInfo>;
+
+		/**
+		 * Interrupt the runtime; returns a Thenable that resolves when the interrupt has been
+		 * successfully sent to the runtime (not necessarily when it has been processed)
+		 */
+		interrupt(): Thenable<void>;
+
+		/**
+		 * Restart the runtime; returns a Thenable that resolves when the runtime restart sequence
+		 * has been successfully started (not necessarily when it has completed). A restart will
+		 * cause the runtime to be shut down and then started again; its status will change from
+		 * `Restarting` => `Exited` => `Initializing` => `Starting` => `Ready`.
+		 *
+		 * @param workingDirectory The new working directory to use for the
+		 * restarted runtime, if any. Use `undefined` to keep the current
+		 * working directory.
+		 */
+		restart(workingDirectory?: string): Thenable<void>;
+
+		/**
+		 * Shut down the runtime; returns a Thenable that resolves when the
+		 * runtime shutdown sequence has been successfully started (not
+		 * necessarily when it has completed).
+		 */
+		shutdown(exitReason: RuntimeExitReason): Thenable<void>;
+
+		/**
+		 * Forcibly quits the runtime; returns a Thenable that resolves when the
+		 * runtime has been terminated. This may be called by Positron if the
+		 * runtime fails to respond to an interrupt and/or shutdown call, and
+		 * should forcibly terminate any underlying processes.
+		 */
+		forceQuit(): Thenable<void>;
+
+		/**
+		 * Update the session name.
+		 *
+		 * @param sessionName The new session name
+		 */
+		updateSessionName(sessionName: string): void;
+
+		/**
+		 * Show runtime log in output panel.
+		 *
+		 * @param channel The channel to show the output in
+		 */
+		showOutput?(channel?: LanguageRuntimeSessionChannel): void;
+
+		/**
+		 * Return a list of output channels
+		 *
+		 * @returns A list of output channels available on this runtime
+		 */
+		listOutputChannels?(): LanguageRuntimeSessionChannel[];
+
+		/**
+		 * Show profiler log if supported.
+		 */
+		showProfile?(): Thenable<void>;
+	}
+
+
+	/**
+	 * A data structure that describes a handler for a runtime client instance,
+	 * and is called when an instance is created.
+	 *
+	 * @param client The client instance that was created
+	 * @param params A set of parameters passed to the client
+	 * @returns true if the handler took ownership of the client, false otherwise
+	 */
+	export type RuntimeClientHandlerCallback = (
+		client: RuntimeClientInstance,
+		params: Object,) => boolean;
+
+	/**
+	 * A data structure that describes a handler for a runtime client instance.
+	 */
+	export interface RuntimeClientHandler {
+		/**
+		 * The type of client that this handler handles.
+		 */
+		clientType: string;
+
+		/**
+		 * A callback that is called when a client of the given type is created;
+		 * returns whether the handler took ownership of the client.
+		 */
+		callback: RuntimeClientHandlerCallback;
+	}
+
+	/**
+	 * Content settings for webviews hosted in the Preview panel.
+	 *
+	 * This interface mirrors the `WebviewOptions` & `WebviewPanelOptions` interfaces, with
+	 * the following exceptions:
+	 *
+	 * - `enableFindWidget` is not supported (we never show it in previews)
+	 * - `retainContextWhenHidden` is not supported (we always retain context)
+	 * - `enableCommandUris` is not supported (we never allow commands in previews)
+	 */
+	export interface PreviewOptions {
+		/**
+		 * Controls whether scripts are enabled in the webview content or not.
+		 *
+		 * Defaults to false (scripts-disabled).
+		 */
+		readonly enableScripts?: boolean;
+
+		/**
+		 * Controls whether forms are enabled in the webview content or not.
+		 *
+		 * Defaults to true if {@link PreviewOptions.enableScripts scripts are enabled}. Otherwise defaults to false.
+		 * Explicitly setting this property to either true or false overrides the default.
+		 */
+		readonly enableForms?: boolean;
+
+		/**
+		 * Root paths from which the webview can load local (filesystem) resources using uris from `asWebviewUri`
+		 *
+		 * Default to the root folders of the current workspace plus the extension's install directory.
+		 *
+		 * Pass in an empty array to disallow access to any local resources.
+		 */
+		readonly localResourceRoots?: readonly vscode.Uri[];
+
+		/**
+		 * Mappings of localhost ports used inside the webview.
+		 *
+		 * Port mapping allow webviews to transparently define how localhost ports are resolved. This can be used
+		 * to allow using a static localhost port inside the webview that is resolved to random port that a service is
+		 * running on.
+		 *
+		 * If a webview accesses localhost content, we recommend that you specify port mappings even if
+		 * the `webviewPort` and `extensionHostPort` ports are the same.
+		 *
+		 * *Note* that port mappings only work for `http` or `https` urls. Websocket urls (e.g. `ws://localhost:3000`)
+		 * cannot be mapped to another port.
+		 */
+		readonly portMapping?: readonly vscode.WebviewPortMapping[];
+	}
+
+	/**
+	 * A preview panel that contains a webview. This interface mirrors the
+	 * `WebviewPanel` interface, but omits elements that don't apply to
+	 * preview panels, such as `viewColumn`.
+	 */
+	export interface PreviewPanel {
+		/**
+		 * Identifies the type of the preview panel, such as `'markdown.preview'`.
+		 */
+		readonly viewType: string;
+
+		/**
+		 * Title of the panel shown in UI.
+		 */
+		title: string;
+
+		/**
+		 * {@linkcode Webview} belonging to the panel.
+		 */
+		readonly webview: vscode.Webview;
+
+		/**
+		 * Whether the panel is active (focused by the user).
+		 */
+		readonly active: boolean;
+
+		/**
+		 * Whether the panel is visible.
+		 */
+		readonly visible: boolean;
+
+		/**
+		 * Fired when the panel's view state changes.
+		 */
+		readonly onDidChangeViewState: vscode.Event<PreviewPanelOnDidChangeViewStateEvent>;
+
+		/**
+		 * Fired when the panel is disposed.
+		 *
+		 * This may be because the user closed the panel or because `.dispose()` was
+		 * called on it.
+		 *
+		 * Trying to use the panel after it has been disposed throws an exception.
+		 */
+		readonly onDidDispose: vscode.Event<void>;
+
+		/**
+		 * Show the preview panel
+		 *
+		 * Only one preview panel can be shown at a time. If a different preview
+		 * is already showing, it will be hidden.
+		 *
+		 * @param preserveFocus When `true`, the webview will not take focus.
+		 */
+		reveal(preserveFocus?: boolean): void;
+
+		/**
+		 * Dispose of the preview panel.
+		 *
+		 * This closes the panel if it showing and disposes of the resources
+		 * owned by the underlying webview.  Preview panels are also disposed
+		 * when the user closes the preview panel. Both cases fire the
+		 * `onDispose` event.
+		 */
+		dispose(): any;
+	}
+
+	/**
+	 * Event fired when a preview panel's view state changes.
+	 */
+	export interface PreviewPanelOnDidChangeViewStateEvent {
+		/**
+		 * Preview panel whose view state changed.
+		 */
+		readonly previewPanel: PreviewPanel;
+	}
+
+	export interface StatementRangeProvider {
+		/**
+		 * Given a cursor position, return the range of the statement that the
+		 * cursor is within. If the cursor is not within a statement, return the
+		 * range of the next statement, if one exists.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return The range of the statement at the given position.
+		 */
+		provideStatementRange(document: vscode.TextDocument,
+			position: vscode.Position,
+			token: vscode.CancellationToken): vscode.ProviderResult<StatementRange>;
+	}
+
+	/**
+	 * The range of a statement, plus optionally the code for the range.
+	 */
+	export interface StatementRange {
+		/**
+		 * The range of the statement at the given position.
+		 */
+		readonly range: vscode.Range;
+
+		/**
+		 * The code for this statement range, if different from the document contents at this range.
+		 */
+		readonly code?: string;
+
+	}
+
+	export interface HelpTopicProvider {
+		/**
+		 * Given a cursor position, return the help topic relevant to the cursor
+		 * position, or an empty string if no help topic is recommended or
+		 * relevant.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return A string containing the help topic relevant to the cursor
+		 *   position
+		 */
+		provideHelpTopic(document: vscode.TextDocument,
+			position: vscode.Position,
+			token: vscode.CancellationToken): vscode.ProviderResult<string>;
+	}
+
+	export interface Console {
+		/**
+		 * Pastes text into the console.
+		 */
+		pasteText(text: string): void;
+	}
+
+	/**
+	 * ConnectionsInput interface defines the structure for connection inputs.
+	 */
+	export interface ConnectionsInput {
+		/**
+		 * The unique identifier for the input.
+		 */
+		id: string;
+		/**
+		 * A human-readable label for the input.
+		 */
+		label: string;
+		/**
+		 * The type of the input.
+		 */
+		// eslint-disable-next-line local/vscode-dts-literal-or-types, local/vscode-dts-string-type-literals
+		type: 'string' | 'number' | 'option';
+		/**
+		 * Options, if the input type is an option.
+		 */
+		options?: { 'identifier': string; 'title': string }[];
+		/**
+		 * The default value for the input.
+		 */
+		value?: string;
+	}
+
+	/**
+	 * ConnectionsDriverMetadata interface defines the structure for connection driver metadata.
+	 */
+	export interface ConnectionsDriverMetadata {
+		/**
+		 * The language identifier for the driver.
+		 * Drivers are grouped by language, not by runtime.
+		 */
+		languageId: string;
+		/**
+		 * A human-readable name for the driver.
+		 */
+		name: string;
+		/**
+		 * The base64-encoded SVG icon for the driver.
+		 */
+		base64EncodedIconSvg?: string;
+		/**
+		 * The inputs required to create a connection.
+		 * For instance, a connection might require a username
+		 * and password.
+		 */
+		inputs: Array<ConnectionsInput>;
+	}
+
+	export interface ConnectionsDriver {
+		/**
+		 * The unique identifier for the driver.
+		 */
+		driverId: string;
+
+		/**
+		 * The metadata for the driver.
+		 */
+		metadata: ConnectionsDriverMetadata;
+
+		/**
+		 * Generates the connection code based on the inputs.
+		 */
+		generateCode?: (inputs: Array<ConnectionsInput>) => string;
+
+		/**
+		 * Connect session.
+		 */
+		connect?: (code: string) => Thenable<void>;
+
+		/**
+		 * Checks if the dependencies for the driver are installed
+		 * and functioning.
+		 */
+		checkDependencies?: () => Thenable<boolean>;
+
+		/**
+		 * Installs the dependencies for the driver.
+		 * For instance, R packages would install the required
+		 * R packages, and or other dependencies.
+		 */
+		installDependencies?: () => Thenable<boolean>;
+	}
+
+	/**
+	 * Settings necessary to render a plot in the format expected by the plot widget.
+	 */
+	export interface PlotRenderSettings {
+		size: {
+			width: number;
+			height: number;
+		};
+		pixel_ratio: number;
+		format: PlotRenderFormat;
+	}
+
+	/**
+	 * Possible formats for rendering a plot.
+	 */
+	export enum PlotRenderFormat {
+		Png = 'png',
+		Jpeg = 'jpeg',
+		Svg = 'svg',
+		Pdf = 'pdf',
+		Tiff = 'tiff'
+	}
+
+	namespace languages {
+		/**
+		 * Register a statement range provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A statement range provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerStatementRangeProvider(
+			selector: vscode.DocumentSelector,
+			provider: StatementRangeProvider): vscode.Disposable;
+
+		/**
+		 * Register a help topic provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A help topic provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerHelpTopicProvider(
+			selector: vscode.DocumentSelector,
+			provider: HelpTopicProvider): vscode.Disposable;
+	}
+
+	namespace window {
+		/**
+		 * Create and show a new preview panel.
+		 *
+		 * @param viewType Identifies the type of the preview panel.
+		 * @param title Title of the panel.
+		 * @param options Settings for the new panel.
+		 *
+		 * @return New preview panel.
+		 */
+		export function createPreviewPanel(viewType: string, title: string, preserveFocus?: boolean, options?: PreviewOptions): PreviewPanel;
+
+		/**
+		 * Create and show a new preview panel for a URL. This is a convenience
+		 * method that creates a new webview panel and sets its content to the
+		 * given URL.
+		 *
+		 * @param url The URL to preview
+		 *
+		 * @return New preview panel.
+		 */
+		export function previewUrl(url: vscode.Uri): PreviewPanel;
+
+		/**
+		 * Create and show a new preview panel for an HTML file. This is a
+		 * convenience method that creates a new webview panel and sets its
+		 * content to that of the given file.
+		 *
+		 * @param path The fully qualified path to the HTML file to preview
+		 *
+		 * @return New preview panel.
+		 */
+		export function previewHtml(path: string): PreviewPanel;
+
+		/**
+		 * Create a log output channel from raw data.
+		 *
+		 * Variant of `createOutputChannel()` that creates a "raw log" output channel.
+		 * Compared to a normal `LogOutputChannel`, this doesn't add timestamps or info
+		 * level. It's meant for extensions that create fully formed log lines but still
+		 * want to benefit from the colourised rendering of log output channels.
+		 *
+		 * @param name Human-readable string which will be used to represent the channel in the UI.
+		 *
+		 * @return New log output channel.
+		 */
+		export function createRawLogOutputChannel(name: string): vscode.OutputChannel;
+
+		/**
+		 * Create and show a simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+		 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+		 *
+		 * @returns A Thenable that resolves to true if the user clicked OK, or false
+		 *   if the user clicked Cancel.
+		 */
+		export function showSimpleModalDialogPrompt(title: string,
+			message: string,
+			okButtonTitle?: string,
+			cancelButtonTitle?: string): Thenable<boolean>;
+
+		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+		 *
+		 * @returns A Thenable that resolves when the user clicks OK.
+		 */
+		export function showSimpleModalDialogMessage(title: string,
+			message: string,
+			okButtonTitle?: string): Thenable<null>;
+
+		/**
+		 * Get the `Console` for a runtime `languageId`
+		 *
+		 * @param languageId The runtime language id to retrieve a `Console` for, i.e. 'r' or 'python'.
+		 *
+		 * @returns A Thenable that resolves to a `Console` or `undefined` if no `Console` for
+		 *   that `languageId` exists.
+		 */
+		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
+
+		/**
+		 * Fires when the width of the console input changes. The new width is passed as
+		 * a number, which represents the number of characters that can fit in the
+		 * console horizontally.
+		 */
+		export const onDidChangeConsoleWidth: vscode.Event<number>;
+
+		/**
+		 * Returns the current width of the console input, in characters.
+		 */
+		export function getConsoleWidth(): Thenable<number>;
+
+		/**
+		 * Fires when the settings necessary to render a plot in the format expected by
+		 * plot widget have changed.
+		 */
+		export const onDidChangePlotsRenderSettings: vscode.Event<PlotRenderSettings>;
+
+		/**
+		 * Returns the settings necessary to render a plot in the format expected by
+		 * plot widget.
+		 */
+		export function getPlotsRenderSettings(): Thenable<PlotRenderSettings>;
+	}
+
+	namespace runtime {
+		/**
+		 * An object that observes an ongoing code execution invoked from the
+		 * `executeCode` API.
+		 */
+		export interface ExecutionObserver {
+			/**
+			 * An optional cancellation token that can be used to cancel the
+			 * execution.
+			 */
+			token?: vscode.CancellationToken;
+
+			/**
+			 * An optional callback to invoke when execution has started. This
+			 * may be different than the time `executeCode` was called, since
+			 * there may have been preceding statements in the queue, or we may
+			 * need to wait for the runtime to start or become ready.
+			 */
+			onStarted?: () => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits text
+			 * output. This can be called zero or more times during execution of
+			 * the code.
+			 *
+			 * @param message The message emitted.
+			 */
+			onOutput?: (message: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits error
+			 * output. This just means "output sent to standard error", and does
+			 * not mean that the execution failed. This can be called zero or more
+			 * times during execution of the code.
+			 *
+			 * @param message The message emitted.
+			 */
+			onError?: (message: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits a plot.
+			 *
+			 * NOTE: Currently only fired for static plots, not dynamic plots.
+			 *
+			 * @param plotData The plot data emitted, as a string.
+			 */
+			onPlot?: (plotData: string) => void;
+
+			/**
+			 * An optional callback to invoke when the execution emits a data
+			 * frame or other rectangular data object.
+			 *
+			 * NOTE: Not currently fired.
+			 *
+			 * @param data The data returned.
+			 */
+			onData?: (data: any) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has completed
+			 * sucessfully.
+			 *
+			 * One of `onCompleted` or `onFailed` will be called, but not both.
+			 *
+			 * @param result The result of the successful execution, as a map of MIME types to values.
+			 */
+			onCompleted?: (result: Record<string, any>) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has failed.
+			 *
+			 * One of `onCompleted` or `onFailed` will be called, but not both.
+			 *
+			 * @param error The error that caused the execution to fail.
+			 */
+			onFailed?: (error: Error) => void;
+
+			/**
+			 * An optional callback to invoke when the execution has finished,
+			 * regardless of success or failure.
+			 *
+			 * It is invoked when the runtime returns to an idle state after
+			 * fully completing the execution.
+			 */
+			onFinished?: () => void;
+		}
+
+		/**
+		 * Executes code in a language runtime's console, as though it were typed
+		 * interactively by the user.
+		 *
+		 * @param languageId The language ID of the code snippet
+		 * @param code The code snippet to execute
+		 * @param focus Whether to focus the runtime's console
+		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
+		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
+		 * @param mode Possible code execution mode for a language runtime
+		 * @param errorBehavior Possible error behavior for a language runtime, currently ignored by kernels
+		 * @param observer An optional observer for the execution. This object will be notified of
+		 *  execution events, such as output, error, and completion.
+		 * @returns A Thenable that resolves with the result of the code execution,
+		 *  as a map of MIME types to values.
+		 */
+		export function executeCode(languageId: string,
+			code: string,
+			focus: boolean,
+			allowIncomplete?: boolean,
+			mode?: RuntimeCodeExecutionMode,
+			errorBehavior?: RuntimeErrorBehavior,
+			observer?: ExecutionObserver): Thenable<Record<string, any>>;
+
+		/**
+		 * Register a language runtime manager with Positron.
+		 *
+		 * @param languageId The language ID for which the manager can provide
+		 * runtimes
+		 * @returns A disposable that unregisters the manager when disposed.
+		 *
+		 */
+		export function registerLanguageRuntimeManager(languageId: string, manager: LanguageRuntimeManager): vscode.Disposable;
+
+		/**
+		 * List all registered runtimes.
+		 */
+		export function getRegisteredRuntimes(): Thenable<LanguageRuntimeMetadata[]>;
+
+		/**
+		 * Get the preferred language runtime for a given language.
+		 *
+		 * @param languageId The language ID of the preferred runtime
+		 * @returns The preferred runtime metadata, or undefined if no eligible runtimes
+		 *  are registered.
+		 */
+		export function getPreferredRuntime(languageId: string): Thenable<LanguageRuntimeMetadata | undefined>;
+
+		/**
+		 * List all active sessions.
+		 */
+		export function getActiveSessions(): Thenable<LanguageRuntimeSession[]>;
+
+		/**
+		 * Get the active foreground session, if any.
+		 */
+		export function getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;
+
+		/**
+		 * Get the session corresponding to a notebook, if any.
+		 *
+		 * @param notebookUri The URI of the notebook.
+		 */
+		export function getNotebookSession(notebookUri: vscode.Uri): Thenable<LanguageRuntimeSession | undefined>;
+
+		/**
+		 * Select and start a runtime previously registered with Positron. Any
+		 * previously active runtimes for the language will be shut down.
+		 *
+		 * @param runtimeId The ID of the runtime to select and start.
+		 */
+		export function selectLanguageRuntime(runtimeId: string): Thenable<void>;
+
+		/**
+		 * Start a new session for a runtime previously registered with Positron.
+		 *
+		 * @param runtimeId The ID of the runtime to select and start.
+		 * @param sessionName A human-readable name for the new session.
+		 * @param notebookUri If the session is associated with a notebook,
+		 *   the notebook URI.
+		 *
+		 * Returns a Thenable that resolves with the newly created session.
+		 */
+		export function startLanguageRuntime(runtimeId: string,
+			sessionName: string,
+			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
+
+		/**
+		 * Restart a running session.
+		 *
+		 * @param sessionId The ID of the session to restart.
+		 */
+		export function restartSession(sessionId: string): Thenable<void>;
+
+		/**
+		 * Focus a running session
+		 */
+		export function focusSession(sessionId: string): void;
+
+		/**
+		 * Get the runtime variables for a session.
+		 *
+		 * @param sessionId The session ID of the session to get the variables for.
+		 * @param accessKeys An optional array of access keys. Each access key
+		 * is an array listing the path to a variable. If no access keys are
+		 * provided, all variables will be returned.
+		 *
+		 * @returns A Thenable that resolves with an array of runtime
+		 * variables.
+		 */
+		export function getSessionVariables(
+			sessionId: string,
+			accessKeys?: Array<Array<string>>):
+			Thenable<Array<Array<RuntimeVariable>>>;
+
+		/**
+		 * Register a handler for runtime client instances. This handler will be called
+		 * whenever a new client instance is created by a language runtime of the given
+		 * type.
+		 *
+		 * @param handler A handler for runtime client instances
+		 */
+		export function registerClientHandler(handler: RuntimeClientHandler): vscode.Disposable;
+
+		/**
+		 * Register a runtime client instance. Registering the instance
+		 * indicates that the caller has ownership of the instance, and that
+		 * messages the instance receives do not need to be forwarded to the
+		 * Positron core.
+		 */
+		export function registerClientInstance(clientInstanceId: string): vscode.Disposable;
+
+		/**
+		 * An event that fires when a new runtime is registered.
+		 */
+		export const onDidRegisterRuntime: vscode.Event<LanguageRuntimeMetadata>;
+
+		/**
+		 * An event that fires when the foreground session changes
+		 */
+		export const onDidChangeForegroundSession: vscode.Event<string | undefined>;
+
+		/**
+		 * An event that fires when code is executed.
+		 */
+		export const onDidExecuteCode: vscode.Event<CodeExecutionEvent>;
+	}
+
+	// FIXME: The current (and clearly not final) state of an experiment to bring in interface(s)
+	// here by referring to an external file. Such an external file will presumably be generated by
+	// the generate-comms.ts script. Two goals of the experiment:
+	// * Reduce the manual proliferation of these generated types.
+	// * Ideally a file is meant to edited by humans or by robots, but not both.
+	// Related to https://github.com/posit-dev/positron/issues/12
+	export type EditorContext = import('./ui-comm.js').EditorContext;
+
+	/**
+	 * This namespace contains all frontend RPC methods available to a runtime.
+	 */
+	namespace methods {
+		/**
+		 * Call a frontend method.
+		 *
+		 * `call()` is designed to be hooked up directly to an RPC mechanism. It takes
+		 * `method` and `params` arguments as defined by the UI frontend OpenRPC contract
+		 * and returns a JSON-RPC response. It never throws, all errors are returned as
+		 * JSON-RPC error responses.
+		 *
+		 * @param method The method name.
+		 * @param params An object of named parameters for `method`.
+		 */
+		export function call(method: string, params: Record<string, any>): Thenable<any>;
+
+		/**
+		 * Retrieve last active editor context.
+		 *
+		 * Returns a `EditorContext` for the last active editor.
+		 */
+		export function lastActiveEditorContext(): Thenable<EditorContext | null>;
+
+		/**
+		 * Create and show a simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button
+		 * @param cancelButtonTitle The title of the Cancel button
+		 *
+		 * @returns A Thenable that resolves to true if the user clicked OK, or false
+		 *   if the user clicked Cancel.
+		 */
+		export function showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Thenable<boolean>;
+
+		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 *
+		 * @returns A Thenable that resolves when the user dismisses the dialog.
+		 */
+		export function showDialog(title: string, message: string): Thenable<null>;
+
+
+	}
+
+	/**
+	 * An object that describes an environment variable action.
+	 */
+	export interface EnvironmentVariableAction {
+		/** The action to take - replace, append, or prepend */
+		action: vscode.EnvironmentVariableMutatorType;
+
+		/** The name of the variable on which to take the action */
+		name: string;
+
+		/** The value to replace, append, or prepend */
+		value: string;
+	}
+
+	namespace environment {
+		/**
+		 * Get the environment variable contributions for the current session.
+		 *
+		 * @returns A map of extension IDs to arrays of environment variable actions.
+		 */
+		export function getEnvironmentContributions(): Thenable<Record<string, EnvironmentVariableAction[]>>;
+	}
+
+	/**
+	 * Refers to methods related to the connections pane
+	 */
+	namespace connections {
+		/**
+		 * Registers a new connection driver with Positron allowing extensions to contribute
+		 * to the 'New Connection' dialog.
+		 *
+		 * @param driver The connection driver to register
+		 * @returns A disposable that unregisters the driver when disposed
+		 */
+		export function registerConnectionDriver(driver: ConnectionsDriver): vscode.Disposable;
+	}
+
+	/**
+	 * Experimental AI features.
+	 */
+	namespace ai {
+		/**
+		 * A language model provider, extends vscode.LanguageModelChatProvider.
+		 */
+		export interface LanguageModelChatProvider {
+			name: string;
+			provider: string;
+			identifier: string;
+
+			providerName: string;
+			maxOutputTokens: number;
+
+			readonly capabilities?: {
+				readonly vision?: boolean;
+				readonly toolCalling?: boolean;
+				readonly agentMode?: boolean;
+			};
+
+			/**
+			 * Handle a language model request with tool calls and streaming chat responses.
+			 */
+			provideLanguageModelResponse(
+				messages: Array<vscode.LanguageModelChatMessage>,
+				options: vscode.LanguageModelChatRequestOptions,
+				extensionId: string,
+				progress: vscode.Progress<{
+					index: number;
+					part: vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart;
+				}>,
+				token: vscode.CancellationToken,
+			): Thenable<any>;
+
+			/**
+			 * Calculate the token count for a given string.
+			 */
+			provideTokenCount(text: string | vscode.LanguageModelChatMessage, token: vscode.CancellationToken): Thenable<number>;
+
+			/**
+			 * Tests the connection to the language model provider.
+			 *
+			 * Returns an error if the connection fails.
+			 */
+			resolveConnection(token: vscode.CancellationToken): Thenable<Error | undefined>;
+		}
+
+		/**
+		 * Dynamically defined chat agent properties and metadata.
+		 */
+		export interface ChatAgentData {
+			id: string;
+			name: string;
+			fullName?: string;
+			description?: string;
+			isDefault?: boolean;
+			metadata: { isSticky?: boolean };
+			slashCommands: {
+				name: string;
+				description: string;
+				isSticky?: boolean;
+			}[];
+			modes: PositronChatMode[];
+			locations: PositronChatAgentLocation[];
+			disambiguation: { category: string; description: string; examples: string[] }[];
+		}
+
+		/**
+		 * A chat participant, extends vscode.ChatParticipant with additional dynamic metadata.
+		 */
+		export interface ChatParticipant extends vscode.ChatParticipant {
+			agentData: ChatAgentData;
+		}
+
+		/**
+		 * Register a chat agent dynamically, without requiring registration in `package.json`.
+		 * This allows for dynamic chat agent commands in Positron.
+		 */
+		export function registerChatAgent(agentData: ChatAgentData): Thenable<vscode.Disposable>;
+
+		/**
+		 * Positron Language Model source, used for user configuration of language models.
+		 */
+		export interface LanguageModelSource {
+			type: PositronLanguageModelType;
+			provider: { id: string; displayName: string };
+			supportedOptions: Exclude<{
+				[K in keyof LanguageModelConfig]: undefined extends LanguageModelConfig[K] ? K : never
+			}[keyof LanguageModelConfig], undefined>[];
+			defaults: LanguageModelConfigOptions;
+			signedIn?: boolean;
+			authMethods?: string[];
+		}
+
+		/**
+		 * Positron Language Model configuration.
+		 */
+		export interface LanguageModelConfig extends LanguageModelConfigOptions {
+			type: PositronLanguageModelType;
+			provider: string;
+		}
+
+		/**
+		 * Positron Language Model configuration options.
+		 */
+		export interface LanguageModelConfigOptions {
+			name: string;
+			model: string;
+			baseUrl?: string;
+			apiKey?: string;
+			oauth?: boolean;
+			toolCalls?: boolean;
+			resourceName?: string;
+			project?: string;
+			location?: string;
+			numCtx?: number;
+			maxOutputTokens?: number;
+		}
+
+		/**
+		 * Request the current plot data.
+		 */
+		export function getCurrentPlotUri(): Thenable<string | undefined>;
+
+		/**
+		 * Get Positron global context information to be included with every request.
+		 */
+		export function getPositronChatContext(request: vscode.ChatRequest): Thenable<ChatContext>;
+
+		/**
+		 * Send a progress response to the chat response stream.
+		 */
+		export function responseProgress(token: unknown, part: vscode.ChatResponsePart | {
+			// vscode.ChatResponseConfirmationPart
+			title: string;
+			message: string;
+			data: any;
+			buttons?: string[];
+		} | {
+			// vscode.ChatResponseTextEditPart
+			uri: vscode.Uri;
+			edits: vscode.TextEdit[];
+		}): void;
+
+		export function getSupportedProviders(): Thenable<string[]>;
+
+		/**
+		 * Show a modal dialog for language model configuration.
+		 */
+		export function showLanguageModelConfig(
+			sources: LanguageModelSource[],
+			onAction: (config: LanguageModelConfig, action: string) => Thenable<void>,
+		): Thenable<void>;
+
+		/**
+		 * Adds the model to the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 * @param config the model config
+		 */
+		export function addLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
+		 * Removes the model from the service's known configurations and notifies its listeners.
+		 * @param id the model id
+		 */
+		export function removeLanguageModelConfig(
+			source: LanguageModelSource,
+		): void;
+
+		/**
+		 * The context in which a chat request is made.
+		 */
+		export interface ChatContext {
+			activeSession?: {
+				identifier: string;
+				language: string;
+				version: string;
+				mode: LanguageRuntimeSessionMode;
+				notebookUri?: vscode.Uri;
+				executions: {
+					input: string;
+					output: string;
+					error?: any;
+				}[];
+			};
+			plots?: {
+				hasPlots: boolean;
+			};
+			variables?: RuntimeVariable[];
+			shell?: string;
+		}
+	}
+}

--- a/positron-api-pkg/src/preview.ts
+++ b/positron-api-pkg/src/preview.ts
@@ -39,7 +39,7 @@ export async function previewUrl(url: string): Promise<void> {
 
 	if (positronApi) {
 		// We're in Positron - use the preview pane
-		await positronApi.window.previewUrl(uri);
+		positronApi.window.previewUrl(uri);
 	} else {
 		// We're in VS Code - open in external browser
 		await vscode.env.openExternal(uri);

--- a/positron-api-pkg/src/preview.ts
+++ b/positron-api-pkg/src/preview.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------------------------
+ *  Positron URL Preview Functions
+ *
+ *  This file provides cross-platform URL preview functionality that works in both
+ *  Positron and VS Code environments.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getPositronApi } from './runtime';
+
+/**
+ * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
+ *
+ * This function automatically detects the runtime environment and uses the appropriate
+ * method to display URLs:
+ * - In Positron: Uses the built-in preview pane via `positron.window.previewUrl`
+ * - In VS Code: Opens the URL in the default external browser via `vscode.env.openExternal`
+ *
+ * @param url - The URL to open/preview
+ * @returns Promise that resolves when the URL has been opened
+ *
+ * @example
+ * ```typescript
+ * import { previewUrl } from '@posit-dev/positron/preview';
+ *
+ * // This will work in both Positron and VS Code
+ * await previewUrl('https://example.com');
+ * await previewUrl('http://localhost:3000');
+ * ```
+ */
+export async function previewUrl(url: string): Promise<void> {
+	const positronApi = getPositronApi();
+	
+	if (positronApi) {
+		// We're in Positron - use the preview pane
+		await positronApi.window.previewUrl(url);
+	} else {
+		// We're in VS Code - open in external browser
+		const vscode = await import('vscode');
+		await vscode.env.openExternal(vscode.Uri.parse(url));
+	}
+}

--- a/positron-api-pkg/src/preview.ts
+++ b/positron-api-pkg/src/preview.ts
@@ -11,7 +11,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { tryAcquirePositronApi } from './runtime';
-import * as vscode from 'vscode';
 
 /**
  * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
@@ -35,12 +34,14 @@ import * as vscode from 'vscode';
  */
 export async function previewUrl(url: string): Promise<void> {
 	const positronApi = tryAcquirePositronApi();
+	const vscode = await import('vscode');
 	const uri = vscode.Uri.parse(url);
 
 	if (positronApi) {
 		// We're in Positron - use the preview pane
 		positronApi.window.previewUrl(uri);
 	} else {
+
 		// We're in VS Code - open in external browser
 		await vscode.env.openExternal(uri);
 	}

--- a/positron-api-pkg/src/preview.ts
+++ b/positron-api-pkg/src/preview.ts
@@ -10,7 +10,7 @@
  *  Positron and VS Code environments.
  *--------------------------------------------------------------------------------------------*/
 
-import { getPositronApi } from './runtime';
+import { tryAcquirePositronApi } from './runtime';
 
 /**
  * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
@@ -33,14 +33,15 @@ import { getPositronApi } from './runtime';
  * ```
  */
 export async function previewUrl(url: string): Promise<void> {
-	const positronApi = getPositronApi();
-	
+	const positronApi = tryAcquirePositronApi();
+	const vscode = await import('vscode');
+	const uri = vscode.Uri.parse(url);
+
 	if (positronApi) {
 		// We're in Positron - use the preview pane
-		await positronApi.window.previewUrl(url);
+		await positronApi.window.previewUrl(uri);
 	} else {
 		// We're in VS Code - open in external browser
-		const vscode = await import('vscode');
-		await vscode.env.openExternal(vscode.Uri.parse(url));
+		await vscode.env.openExternal(uri);
 	}
 }

--- a/positron-api-pkg/src/preview.ts
+++ b/positron-api-pkg/src/preview.ts
@@ -11,6 +11,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { tryAcquirePositronApi } from './runtime';
+import * as vscode from 'vscode';
 
 /**
  * Opens a URL for preview in either Positron's preview pane or VS Code's external browser.
@@ -34,7 +35,6 @@ import { tryAcquirePositronApi } from './runtime';
  */
 export async function previewUrl(url: string): Promise<void> {
 	const positronApi = tryAcquirePositronApi();
-	const vscode = await import('vscode');
 	const uri = vscode.Uri.parse(url);
 
 	if (positronApi) {

--- a/positron-api-pkg/src/runtime.ts
+++ b/positron-api-pkg/src/runtime.ts
@@ -18,6 +18,32 @@ export type PositronApi = typeof positron;
 
 
 /**
+ * Check if the current environment is Positron.
+ *
+ * This is a simple helper function that returns true if running in Positron,
+ * false if running in VS Code.
+ *
+ * @returns true if running in Positron, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { inPositron } from '@posit-dev/positron';
+ *
+ * if (inPositron()) {
+ *   // We're in Positron - use enhanced features
+ *   console.log('Running in Positron!');
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+export function inPositron(): boolean {
+	return typeof globalThis !== 'undefined' &&
+		typeof (globalThis as any).acquirePositronApi === 'function';
+}
+
+/**
  * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
  *
  * This function handles the detection of whether the extension is running in Positron or VS Code,
@@ -42,8 +68,7 @@ export type PositronApi = typeof positron;
 export function tryAcquirePositronApi(): PositronApi | undefined {
 	try {
 		// Check if we're running in Positron by looking for the global acquirePositronApi function
-		if (typeof globalThis !== 'undefined' &&
-			typeof (globalThis as any).acquirePositronApi === 'function') {
+		if (inPositron()) {
 			return (globalThis as any).acquirePositronApi();
 		}
 		return undefined;

--- a/positron-api-pkg/src/runtime.ts
+++ b/positron-api-pkg/src/runtime.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------------------------
+ *  Positron API Runtime Function
+ *  Generated from source TypeScript definitions
+ *
+ *  This file provides a safe runtime function to access the Positron API.
+ *--------------------------------------------------------------------------------------------*/
+
+// Import types from the ambient module declaration
+import type * as positron from 'positron';
+
+// The key insight - this captures the complete API shape
+export type PositronApi = typeof positron;
+
+
+/**
+ * Safely acquire the Positron API if running in Positron, or return undefined if running in VS Code.
+ *
+ * This function handles the detection of whether the extension is running in Positron or VS Code,
+ * and provides access to Positron-specific functionality when available.
+ *
+ * @returns The Positron API object if available, or undefined if running in VS Code
+ *
+ * @example
+ * ```typescript
+ * import { getPositronApi } from '@posit-dev/positron/runtime';
+ *
+ * const positronApi = getPositronApi();
+ * if (positronApi) {
+ *   // We're in Positron - use enhanced features
+ *   positronApi.runtime.executeCode('python', 'print("Hello Positron!")', true);
+ * } else {
+ *   // We're in VS Code - use standard functionality
+ *   console.log('Running in VS Code mode');
+ * }
+ * ```
+ */
+export function getPositronApi(): PositronApi | undefined {
+	try {
+		// Check if we're running in Positron by looking for the global acquirePositronApi function
+		if (typeof globalThis !== 'undefined' &&
+			typeof (globalThis as any).acquirePositronApi === 'function') {
+			return (globalThis as any).acquirePositronApi();
+		}
+		return undefined;
+	} catch (error) {
+		// If any error occurs (e.g., acquirePositronApi throws), return undefined
+		// This ensures extensions gracefully degrade to VS Code mode
+		return undefined;
+	}
+}

--- a/positron-api-pkg/src/ui-comm.d.ts
+++ b/positron-api-pkg/src/ui-comm.d.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//
+// Copied from src/vs/workbench/services/languageRuntime/common/positronUiComm.ts; do not edit.
+//
+
+/**
+ * Editor metadata
+ */
+export interface EditorContext {
+	/**
+	 * Document metadata
+	 */
+	document: TextDocument;
+
+	/**
+	 * Document contents
+	 */
+	contents: Array<string>;
+
+	/**
+	 * The primary selection, i.e. selections[0]
+	 */
+	selection: Selection;
+
+	/**
+	 * The selections in this text editor.
+	 */
+	selections: Array<Selection>;
+
+}
+
+/**
+ * Document metadata
+ */
+export interface TextDocument {
+	/**
+	 * URI of the resource viewed in the editor
+	 */
+	path: string;
+
+	/**
+	 * End of line sequence
+	 */
+	eol: string;
+
+	/**
+	 * Whether the document has been closed
+	 */
+	is_closed: boolean;
+
+	/**
+	 * Whether the document has been modified
+	 */
+	is_dirty: boolean;
+
+	/**
+	 * Whether the document is untitled
+	 */
+	is_untitled: boolean;
+
+	/**
+	 * Language identifier
+	 */
+	language_id: string;
+
+	/**
+	 * Number of lines in the document
+	 */
+	line_count: number;
+
+	/**
+	 * Version number of the document
+	 */
+	version: number;
+
+}
+
+/**
+ * A line and character position, such as the position of the cursor.
+ */
+export interface Position {
+	/**
+	 * The zero-based character value, as a Unicode code point offset.
+	 */
+	character: number;
+
+	/**
+	 * The zero-based line value.
+	 */
+	line: number;
+
+}
+
+/**
+ * Selection metadata
+ */
+export interface Selection {
+	/**
+	 * Position of the cursor.
+	 */
+	active: Position;
+
+	/**
+	 * Start position of the selection
+	 */
+	start: Position;
+
+	/**
+	 * End position of the selection
+	 */
+	end: Position;
+
+	/**
+	 * Text of the selection
+	 */
+	text: string;
+
+}

--- a/positron-api-pkg/tsconfig.json
+++ b/positron-api-pkg/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../src/tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vscode"]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "temp",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Addresses #809 and #458.

This PR setsup an independent npm package that provides safe access to the Positron API for multi-IDE
extensions. Extensions can now use `tryAcquirePositronApi()` to safely detect if they're running in
Positron and access the API without runtime failures in VS Code. The package also includes graceful
degradation functions like `showPreviewUrl()` that automatically fall back to VS Code WebViewPanels
when not in Positron.

Example of usage in extension:
```ts
import * as vscode from "vscode";
// Use helper function to safely get positron api if it exists
import { tryAcquirePositronApi } from "@posit-dev/positron";

export function activate(context: vscode.ExtensionContext) {
  const disposable = vscode.commands.registerCommand(
    "myExtension.helloWorld",
    () => {
      const positron = tryAcquirePositronApi();

      if (positron === undefined) {
        vscode.window.showInformationMessage("Failed to find positron api");
        return;
      }

      // Preview a URL in Positron's viewer
      positron.window.previewUrl(
        vscode.Uri.parse("https://positron.posit.co/")
      );

      // Execute code in the active runtime
      positron.runtime.executeCode(
        "python",
        'print("Hello Positron from the extension")',
        true
      );
    }
  );

  context.subscriptions.push(disposable);
}
```

### Release Notes

#### New Features
- Added [`@posit-dev/positron` npm package](https://www.npmjs.com/package/@posit-dev/positron) for safe cross-IDE extension development
- Extensions can now detect Positron runtime and access APIs with automatic graceful degradation with a simple import. 

#### Bug Fixes
- N/A

### QA Notes

Clone [the demo extension](https://github.com/nstrayer/positron-extension-demo) and test the new API package functionality.

```bash
git clone https://github.com/nstrayer/positron-extension-demo
cd positron-extension-demo
npm install

Open the demo extension folder in Positron, then run the "Run Extension" target in the Debug View. The
extension should successfully detect Positron and use the API without errors.