### PR TITLE
Exclude files from inline completion

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -137,6 +137,14 @@
             "type": "boolean",
             "default": true,
             "description": "%configuration.streamingEdits.enable%"
+          },
+          "positron.assistant.inlineCompletionExcludes": {
+            "type": "array",
+            "default": ["**/.*"],
+            "markdownDescription": "%configuration.inlineCompletionExcludes.description%",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -14,5 +14,6 @@
 	"configuration.title": "Positron Assistant",
 	"configuration.enable.markdownDescription": "Enable [Positron Assistant](https://positron.posit.co/assistant), an AI assistant for Positron.",
 	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
-	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats."
+	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",
+	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions."
 }

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -189,6 +189,11 @@ class OpenAILegacyCompletion extends CompletionModel {
 		context: vscode.InlineCompletionContext,
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
+		// Check if the file should be excluded from AI features
+		if (await positron.ai.isFileExcluded(document.uri)) {
+			return [];
+		}
+
 		// Delay a little before hitting the network, we might be cancelled by further keystrokes
 		await new Promise(resolve => setTimeout(resolve, 200));
 
@@ -380,6 +385,11 @@ abstract class FimPromptCompletion extends CompletionModel {
 		context: vscode.InlineCompletionContext,
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
+		// Check if the file should be excluded from AI features
+		if (await positron.ai.isFileExcluded(document.uri)) {
+			return [];
+		}
+
 		// Delay a little before hitting the network, we might be cancelled by further keystrokes
 		await new Promise(resolve => setTimeout(resolve, 200));
 
@@ -638,6 +648,10 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 		context: vscode.InlineCompletionContext,
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
+		// Check if the file should be excluded from AI features
+		if (await positron.ai.isFileExcluded(document.uri)) {
+			return undefined;
+		}
 		return await this._copilotService.inlineCompletion(document, position, context, token);
 	}
 

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -650,7 +650,7 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
 		// Check if the file should be excluded from AI features
 		if (await positron.ai.isFileExcluded(document.uri)) {
-			return undefined;
+			return [];
 		}
 		return await this._copilotService.inlineCompletion(document, position, context, token);
 	}

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -190,7 +190,7 @@ class OpenAILegacyCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.isFileExcluded(document.uri)) {
+		if (await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -386,7 +386,7 @@ abstract class FimPromptCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.isFileExcluded(document.uri)) {
+		if (await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -649,7 +649,7 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.isFileExcluded(document.uri)) {
+		if (await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 		return await this._copilotService.inlineCompletion(document, position, context, token);

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2115,10 +2115,10 @@ declare module 'positron' {
 		}
 
 		/**
-		 * Checks the file for exclusion from AI features.
+		 * Checks the file for exclusion from AI completion.
 		 * @param file The file to check for exclusion.
-		 * @returns A Thenable that resolves to true if the file is excluded, false otherwise.
+		 * @returns A Thenable that resolves to true if the file should be excluded, false otherwise.
 		 */
-		export function isFileExcluded(file: vscode.Uri): Thenable<boolean>;
+		export function areCompletionsEnabled(file: vscode.Uri): Thenable<boolean>;
 	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2113,5 +2113,12 @@ declare module 'positron' {
 			variables?: RuntimeVariable[];
 			shell?: string;
 		}
+
+		/**
+		 * Checks the file for exclusion from AI features.
+		 * @param file The file to check for exclusion.
+		 * @returns A Thenable that resolves to true if the file is excluded, false otherwise.
+		 */
+		export function isFileExcluded(file: vscode.Uri): Thenable<boolean>;
 	}
 }

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -5,6 +5,7 @@
 
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { revive } from '../../../../base/common/marshalling.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IChatAgentData, IChatAgentService } from '../../../contrib/chat/common/chatAgents.js';
 import { ChatModel } from '../../../contrib/chat/common/chatModel.js';
 import { IChatProgress, IChatService } from '../../../contrib/chat/common/chatService.js';
@@ -106,5 +107,18 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
 		source.signedIn = false;
 		this._positronAssistantService.removeLanguageModelConfig(source);
+	}
+
+	/**
+	 * Check if a file is excluded from AI processing based on configuration settings.
+	 */
+	async $isFileExcluded(file: UriComponents): Promise<boolean> {
+		const uri = URI.revive(file);
+		if (!uri) {
+			return true; // If URI is invalid, consider it excluded
+		}
+
+		// Use the language model ignored files service to check if the file should be excluded
+		return this._positronAssistantService.isFileExcluded(uri);
 	}
 }

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -110,15 +110,15 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	}
 
 	/**
-	 * Check if a file is excluded from AI processing based on configuration settings.
+	 * Check if a file should be excluded from AI completions based on configuration settings.
 	 */
-	async $isFileExcluded(file: UriComponents): Promise<boolean> {
+	async $areCompletionsEnabled(file: UriComponents): Promise<boolean> {
 		const uri = URI.revive(file);
 		if (!uri) {
 			return true; // If URI is invalid, consider it excluded
 		}
 
 		// Use the language model ignored files service to check if the file should be excluded
-		return this._positronAssistantService.isFileExcluded(uri);
+		return this._positronAssistantService.areCompletionsEnabled(uri);
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -287,8 +287,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
 				return extHostAiFeatures.removeLanguageModelConfig(source);
 			},
-			isFileExcluded(file: vscode.Uri): Promise<boolean> {
-				return extHostAiFeatures.isFileExcluded(file);
+			areCompletionsEnabled(file: vscode.Uri): Promise<boolean> {
+				return extHostAiFeatures.areCompletionsEnabled(file);
 			},
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -287,6 +287,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
 				return extHostAiFeatures.removeLanguageModelConfig(source);
 			},
+			isFileExcluded(file: vscode.Uri): Promise<boolean> {
+				return extHostAiFeatures.isFileExcluded(file);
+			},
 		};
 
 		// --- End Positron ---

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -155,7 +155,7 @@ export interface MainThreadAiFeaturesShape {
 	$getSupportedProviders(): Thenable<string[]>;
 	$addLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
-	$isFileExcluded(file: UriComponents): Thenable<boolean>;
+	$areCompletionsEnabled(file: UriComponents): Thenable<boolean>;
 }
 
 export interface ExtHostAiFeaturesShape {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -155,6 +155,7 @@ export interface MainThreadAiFeaturesShape {
 	$getSupportedProviders(): Thenable<string[]>;
 	$addLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
+	$isFileExcluded(file: UriComponents): Thenable<boolean>;
 }
 
 export interface ExtHostAiFeaturesShape {

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -100,4 +100,8 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 	removeLanguageModelConfig(source: IPositronLanguageModelSource): void {
 		this._proxy.$removeLanguageModelConfig(source);
 	}
+
+	async isFileExcluded(file: vscode.Uri): Promise<boolean> {
+		return this._proxy.$isFileExcluded(file);
+	}
 }

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -101,7 +101,7 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 		this._proxy.$removeLanguageModelConfig(source);
 	}
 
-	async isFileExcluded(file: vscode.Uri): Promise<boolean> {
-		return this._proxy.$isFileExcluded(file);
+	async areCompletionsEnabled(file: vscode.Uri): Promise<boolean> {
+		return this._proxy.$areCompletionsEnabled(file);
 	}
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -209,7 +209,7 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		this._onLanguageModelConfigEmitter.fire(source);
 	}
 
-	isFileExcluded(uri: URI): boolean {
+	areCompletionsEnabled(uri: URI): boolean {
 		const globPattern = this._configurationService.getValue<string[]>('positron.assistant.inlineCompletionExcludes');
 
 		if (!globPattern || globPattern.length === 0) {

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -20,6 +20,8 @@ import { ExecutionEntryType, IExecutionHistoryService } from '../../../services/
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { URI } from '../../../../base/common/uri.js';
+import * as glob from '../../../../base/common/glob.js';
 
 /**
  * PositronAssistantService class.
@@ -205,6 +207,12 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		this._languageModelRegistry.delete(source.provider.id);
 
 		this._onLanguageModelConfigEmitter.fire(source);
+	}
+
+	isFileExcluded(uri: URI): boolean {
+		const globPattern = '{**/.*}';
+
+		return glob.match(globPattern, uri.path);
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -210,9 +210,20 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 	}
 
 	isFileExcluded(uri: URI): boolean {
-		const globPattern = '{**/.*}';
+		const globPattern = this._configurationService.getValue<string[]>('positron.assistant.inlineCompletionExcludes');
 
-		return glob.match(globPattern, uri.path);
+		if (!globPattern || globPattern.length === 0) {
+			return false; // No glob patterns configured, so no files are excluded
+		}
+
+		// Check all of the glob patterns and return true if any match
+		for (const pattern of globPattern) {
+			if (glob.match(pattern, uri.path)) {
+				return true; // File matches an exclusion pattern
+			}
+		}
+
+		return false; // No patterns matched, so the file is not excluded
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -7,7 +7,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { Event } from '../../../../../base/common/event.js';
 import { ChatAgentLocation } from '../../../chat/common/constants.js';
 import { Variable } from '../../../../services/languageRuntime/common/positronVariablesComm.js';
-import { UriComponents } from '../../../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 
 // Create the decorator for the Positron assistant service (used in dependency injection).
@@ -130,6 +130,13 @@ export interface IPositronAssistantService {
 	 * Remove a language model configuration.
 	 */
 	removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
+
+	/**
+	 * Check if a file should be excluded from AI processing.
+	 * @param uri The URI of the file to check.
+	 * @returns True if the file is excluded from the Positron Assistant, false otherwise.
+	 */
+	isFileExcluded(uri: URI): boolean;
 
 	/**
 	 * Placeholder that gets called to "initialize" the PositronAssistantService.

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -132,11 +132,11 @@ export interface IPositronAssistantService {
 	removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 
 	/**
-	 * Check if a file should be excluded from AI processing.
+	 * Check if a file should be excluded from AI completions.
 	 * @param uri The URI of the file to check.
-	 * @returns True if the file is excluded from the Positron Assistant, false otherwise.
+	 * @returns True if the file should be excluded from the Positron Assistant, false otherwise.
 	 */
-	isFileExcluded(uri: URI): boolean;
+	areCompletionsEnabled(uri: URI): boolean;
 
 	/**
 	 * Placeholder that gets called to "initialize" the PositronAssistantService.


### PR DESCRIPTION
Address #7724 

Defaults to all dot files are excluded. This list can be altered or appended by changing and adding glob patterns. If any of the glob patterns match the file, it will be excluded from inline completions.

### Release Notes


#### New Features

- Add configuration to exclude files from AI inline completions #7724

#### Bug Fixes

- N/A


### QA Notes
