### PR TITLE
assistant: improve model provider modal close experience

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1376,6 +1376,16 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/contrib/positronAssistant/browser/types.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/workbench/contrib/positronAssistant/browser/types.ts",
+        "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
     "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts": [
       {
         "type": "Basic Auth Credentials",
@@ -1465,5 +1475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-04T16:54:01Z"
+  "generated_at": "2025-06-09T14:21:03Z"
 }

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
@@ -20,6 +20,12 @@ import { PositronModalDialog, PositronModalDialogProps } from './positronModalDi
 export interface OKModalDialogProps extends PositronModalDialogProps {
 	okButtonTitle?: string;
 	onAccept: () => void;
+	/**
+	 * Not all OK modals should be closeable via the Escape key, as they may require the user to click
+	 * the OK button to acknowledge something.
+	 * However, this can be optionally specified to allow the modal to be closed via the Escape key.
+	 */
+	onCancel?: () => void;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -404,7 +404,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	function newDialog() {
 		return <OKModalDialog
 			height={400}
-			okButtonTitle={(() => localize('positron.languageModelModalDialog.done', "Done"))()}
+			okButtonTitle={(() => localize('positron.languageModelModalDialog.close', "Close"))()}
 			renderer={props.renderer}
 			title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}
 			width={600}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -28,6 +28,7 @@ import { LanguageModelConfigComponent } from './components/languageModelConfigCo
 import { RadioButtonItem } from '../../../browser/positronComponents/positronModalDialog/components/radioButton.js';
 import { RadioGroup } from '../../../browser/positronComponents/positronModalDialog/components/radioGroup.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { AuthMethod } from './types.js';
 
 export const showLanguageModelModalDialog = (
 	keybindingService: IKeybindingService,
@@ -114,13 +115,13 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const [numCtx, setNumCtx] = React.useState<number | undefined>(defaultSource.defaults.numCtx);
 	const [model, setModel] = React.useState<string>(defaultSource.defaults.model);
 	const [name, setName] = React.useState<string>(defaultSource.defaults.name);
-	const [authMethod, setAuthMethod] = React.useState<string>('apiKey');
+	const [authMethod, setAuthMethod] = React.useState<AuthMethod>(AuthMethod.API_KEY);
 	const [showProgress, setShowProgress] = React.useState(false);
 	const [errorMessage, setError] = React.useState<string>();
 
 	useEffect(() => {
 		setSource(defaultSource);
-		setAuthMethod(defaultSource.defaults.oauth ? 'oauth' : 'apiKey')
+		setAuthMethod(defaultSource.defaults.oauth ? AuthMethod.OAUTH : AuthMethod.API_KEY)
 	}, [defaultSource]);
 
 	useEffect(() => {
@@ -156,20 +157,20 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	}, [source]);
 
 	useEffect(() => {
-		const authMethod = source.defaults.oauth ? 'oauth' : 'apiKey';
-		setAuthMethod(authMethod);
+		const newAuthMethod = source.defaults.oauth ? AuthMethod.OAUTH : AuthMethod.API_KEY;
+		setAuthMethod(newAuthMethod);
 	}, [source.defaults.oauth]);
 
 	const authMethodRadioButtons: RadioButtonItem[] = [
 		new RadioButtonItem({
-			identifier: 'oauth',
+			identifier: AuthMethod.OAUTH,
 			title: localize('positron.newConnectionModalDialog.oauth', "OAuth"),
-			disabled: !source.supportedOptions.includes('oauth'),
+			disabled: !source.supportedOptions.includes(AuthMethod.OAUTH),
 		}),
 		new RadioButtonItem({
-			identifier: 'apiKey',
+			identifier: AuthMethod.API_KEY,
 			title: localize('positron.newConnectionModalDialog.apiKey', "API Key"),
-			disabled: !source.supportedOptions.includes('apiKey'),
+			disabled: !source.supportedOptions.includes(AuthMethod.API_KEY),
 		}),
 	];
 
@@ -227,7 +228,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		setShowProgress(true);
 		setError(undefined);
 		if (providerConfig) {
-			if (authMethod === 'apiKey') {
+			if (authMethod === AuthMethod.API_KEY) {
 				props.onAction(
 					providerConfig,
 					source.signedIn ? 'delete' : 'save')
@@ -443,11 +444,12 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 						initialSelectionId={authMethod}
 						name='authMethod'
 						onSelectionChanged={(authMethod) => {
-							setAuthMethod(authMethod);
+							setAuthMethod(authMethod as AuthMethod);
 						}}
 					/>
 				</div>
 				<LanguageModelConfigComponent
+					authMethod={authMethod}
 					provider={providerConfig}
 					signingIn={showProgress}
 					source={source}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -168,12 +168,12 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const authMethodRadioButtons: RadioButtonItem[] = [
 		new RadioButtonItem({
 			identifier: AuthMethod.OAUTH,
-			title: localize('positron.newConnectionModalDialog.oauth', "OAuth"),
+			title: localize('positron.languageModelProviderModalDialog.oauth', "OAuth"),
 			disabled: !source.supportedOptions.includes(AuthMethod.OAUTH),
 		}),
 		new RadioButtonItem({
 			identifier: AuthMethod.API_KEY,
-			title: localize('positron.newConnectionModalDialog.apiKey', "API Key"),
+			title: localize('positron.languageModelProviderModalDialog.apiKey', "API Key"),
 			disabled: !source.supportedOptions.includes(AuthMethod.API_KEY),
 		}),
 	];
@@ -256,7 +256,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			}
 		} else {
 			setShowProgress(false);
-			setError(localize('positron.newConnectionModalDialog.incompleteConfig', 'The configuration is incomplete.'));
+			setError(localize('positron.languageModelProviderModalDialog.incompleteConfig', 'The configuration is incomplete.'));
 		}
 	}
 
@@ -291,18 +291,18 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const shouldCloseModal = async () => {
 		if (authMethod === AuthMethod.OAUTH && !source.signedIn && showProgress) {
 			return await props.positronModalDialogsService.showSimpleModalDialogPrompt(
-				localize('positron.newConnectionModalDialog.oauthInProgressTitle', "{0} Authentication in Progress", source.provider.displayName),
-				localize('positron.newConnectionModalDialog.oauthInProgressMessage', "The sign in flow is in progress. If you close this dialog, your sign in may not complete. Are you sure you want to close and abandon signing in?"),
-				localize('positron.newConnectionModalDialog.ok', "Yes"),
-				localize('positron.newConnectionModalDialog.cancel', "No"),
+				localize('positron.languageModelProviderModalDialog.oauthInProgressTitle', "{0} Authentication in Progress", source.provider.displayName),
+				localize('positron.languageModelProviderModalDialog.oauthInProgressMessage', "The sign in flow is in progress. If you close this dialog, your sign in may not complete. Are you sure you want to close and abandon signing in?"),
+				localize('positron.languageModelProviderModalDialog.ok', "Yes"),
+				localize('positron.languageModelProviderModalDialog.cancel', "No"),
 			)
 		}
 		if (authMethod === AuthMethod.API_KEY && !!providerConfig.apiKey && providerConfig.apiKey.length > 0) {
 			return await props.positronModalDialogsService.showSimpleModalDialogPrompt(
-				localize('positron.newConnectionModalDialog.apiKeySignInIncompleteTitle', "{0} Authentication Incomplete", source.provider.displayName),
-				localize('positron.newConnectionModalDialog.apiKeySignInIncompleteMessage', "You have entered an API key, but have not signed in. If you close this dialog, your API key will not be saved. Are you sure you want to close and abandon signing in?"),
-				localize('positron.newConnectionModalDialog.ok', "Yes"),
-				localize('positron.newConnectionModalDialog.cancel', "No"),
+				localize('positron.languageModelProviderModalDialog.apiKeySignInIncompleteTitle', "{0} Authentication Incomplete", source.provider.displayName),
+				localize('positron.languageModelProviderModalDialog.apiKeySignInIncompleteMessage', "You have entered an API key, but have not signed in. If you close this dialog, your API key will not be saved. Are you sure you want to close and abandon signing in?"),
+				localize('positron.languageModelProviderModalDialog.ok', "Yes"),
+				localize('positron.languageModelProviderModalDialog.cancel', "No"),
 			)
 		}
 		return true;
@@ -322,87 +322,87 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		>
 			<VerticalStack>
 				<label>
-					{(() => localize('positron.newConnectionModalDialog.type', "Type"))()}
+					{(() => localize('positron.languageModelProviderModalDialog.type', "Type"))()}
 					<DropDownListBox<string, PositronLanguageModelType>
 						entries={[
 							new DropDownListBoxItem({
 								identifier: 'chat',
-								title: (() => localize('positron.newConnectionModalDialog.chat', "Chat"))(),
+								title: (() => localize('positron.languageModelProviderModalDialog.chat', "Chat"))(),
 								value: 'chat',
 							}),
 							new DropDownListBoxItem({
 								identifier: 'completion',
-								title: (() => localize('positron.newConnectionModalDialog.completion', "Completion"))(),
+								title: (() => localize('positron.languageModelProviderModalDialog.completion', "Completion"))(),
 								value: 'completion',
 							})
 						]}
 						keybindingService={props.keybindingService}
 						layoutService={props.layoutService}
 						selectedIdentifier={type}
-						title={(() => localize('positron.newConnectionModalDialog.selectType', "SelectType"))()}
+						title={(() => localize('positron.languageModelProviderModalDialog.selectType', "SelectType"))()}
 						onSelectionChanged={(item) => setType(item.options.value)}
 					/>
 				</label>
 				<label>
-					{(() => localize('positron.newConnectionModalDialog.provider', "Provider"))()}
+					{(() => localize('positron.languageModelProviderModalDialog.provider', "Provider"))()}
 					<DropDownListBox
 						entries={providers}
 						keybindingService={props.keybindingService}
 						layoutService={props.layoutService}
 						selectedIdentifier={source?.provider.id}
-						title={(() => localize('positron.newConnectionModalDialog.selectProvider', "Select Provider"))()}
+						title={(() => localize('positron.languageModelProviderModalDialog.selectProvider', "Select Provider"))()}
 						onSelectionChanged={(item) => setSource(item.options.value)}
 					/>
 				</label>
 
 				<LabeledTextInput
-					label={(() => localize('positron.newConnectionModalDialog.name', "Name"))()}
-					validator={(value) => value ? undefined : localize('positron.newConnectionModalDialog.missingName', 'A model name is required')}
+					label={(() => localize('positron.languageModelProviderModalDialog.name', "Name"))()}
+					validator={(value) => value ? undefined : localize('positron.languageModelProviderModalDialog.missingName', 'A model name is required')}
 					value={name}
 					onChange={e => { setName(e.currentTarget.value) }}
 				/>
 				<LabeledTextInput
-					label={(() => localize('positron.newConnectionModalDialog.model', "Model"))()}
-					validator={(value) => value ? undefined : localize('positron.newConnectionModalDialog.missingModel', 'A model is required')}
+					label={(() => localize('positron.languageModelProviderModalDialog.model', "Model"))()}
+					validator={(value) => value ? undefined : localize('positron.languageModelProviderModalDialog.missingModel', 'A model is required')}
 					value={model}
 					onChange={e => { setModel(e.currentTarget.value) }}
 				/>
 				{source?.supportedOptions.includes('baseUrl') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.baseURL', "Base URL"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.baseURL', "Base URL"))()}
 						value={baseUrl ?? ''}
 						onChange={e => { setBaseUrl(e.currentTarget.value) }}
 					/>}
 				{source?.supportedOptions.includes('project') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.project', "Google Cloud Project ID"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.project', "Google Cloud Project ID"))()}
 						value={project ?? ''}
 						onChange={e => { setProject(e.currentTarget.value) }}
 					/>}
 				{source?.supportedOptions.includes('location') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.location', "Google Cloud Location"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.location', "Google Cloud Location"))()}
 						value={location ?? ''}
 						onChange={e => { setLocation(e.currentTarget.value) }}
 					/>}
 				{source?.supportedOptions.includes('resourceName') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.resourceName', "Azure resource name"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.resourceName', "Azure resource name"))()}
 						value={resourceName ?? ''}
 						onChange={e => { setResourceName(e.currentTarget.value) }}
 					/>}
 				{source?.supportedOptions.includes('apiKey') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.apiKey', "API Key"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.apiKey', "API Key"))()}
 						type='password'
-						validator={(value) => value ? undefined : localize('positron.newConnectionModalDialog.missingApiKey', 'An API key is required')}
+						validator={(value) => value ? undefined : localize('positron.languageModelProviderModalDialog.missingApiKey', 'An API key is required')}
 						value={apiKey ?? ''}
 						onChange={e => { setApiKey(e.currentTarget.value) }}
 					/>
 				}
 				{source?.supportedOptions.includes('numCtx') &&
 					<LabeledTextInput
-						label={(() => localize('positron.newConnectionModalDialog.numCtx', "Context Window size"))()}
+						label={(() => localize('positron.languageModelProviderModalDialog.numCtx', "Context Window size"))()}
 						type='number'
 						value={numCtx ?? 2048}
 						onChange={e => { setNumCtx(parseInt(e.currentTarget.value)) }}
@@ -417,7 +417,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 							onChange={e => { setToolCalls(e.target.checked) }}
 						/>
 						<label htmlFor='toolCallsCheckbox'>
-							{(() => localize('positron.newConnectionModalDialog.toolCalls', "Enable tool calling"))()}
+							{(() => localize('positron.languageModelProviderModalDialog.toolCalls', "Enable tool calling"))()}
 						</label>
 					</div>
 				}
@@ -442,7 +442,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		>
 			<VerticalStack>
 				<label className='language-model-section'>
-					{(() => localize('positron.newConnectionModalDialog.provider', "Provider"))()}
+					{(() => localize('positron.languageModelProviderModalDialog.provider', "Provider"))()}
 				</label>
 				<div className='language-model button-container'>
 					{
@@ -463,7 +463,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 					}
 				</div>
 				<label className='language-model-section'>
-					{(() => localize('positron.newConnectionModalDialog.authentication', "Authentication"))()}
+					{(() => localize('positron.languageModelProviderModalDialog.authentication', "Authentication"))()}
 				</label>
 				<div className='language-model-authentication-method-container'>
 					<RadioGroup

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -408,6 +408,9 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}
 			width={600}
 			onAccept={onAccept}
+			// onCancel is called when the Escape key is pressed, which in this dialog has the same effect as clicking the OK button
+			// so we just call onAccept to close the dialog
+			onCancel={onAccept}
 		>
 			<VerticalStack>
 				<label className='language-model-section'>

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -198,6 +198,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const onAccept = async () => {
 		if (useNewConfig) {
 			if (await shouldCloseModal()) {
+				await onCancelPending();
 				props.onClose();
 				props.renderer.dispose();
 			}

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -18,6 +18,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { Emitter } from '../../../../base/common/event.js';
 import { ExecutionEntryType, IExecutionHistoryService } from '../../../services/positronHistory/common/executionHistoryService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 
 /**
  * PositronAssistantService class.
@@ -42,6 +43,7 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		@ILayoutService private readonly _layoutService: ILayoutService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExecutionHistoryService private readonly _historyService: IExecutionHistoryService,
+		@IPositronModalDialogsService private readonly _positronModalDialogsService: IPositronModalDialogsService,
 	) {
 		super();
 	}
@@ -193,7 +195,7 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		onCancel: () => void,
 		onClose: () => void,
 	): void {
-		showLanguageModelModalDialog(this._keybindingService, this._layoutService, this._configurationService, this, sources, onAction, onCancel, onClose);
+		showLanguageModelModalDialog(this._keybindingService, this._layoutService, this._configurationService, this, this._positronModalDialogsService, sources, onAction, onCancel, onClose);
 	}
 
 	getSupportedProviders(): string[] {

--- a/src/vs/workbench/contrib/positronAssistant/browser/types.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/types.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum AuthMethod {
+	API_KEY = 'apiKey',
+	OAUTH = 'oauth',
+}


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7404
- escape `esc` key can now be used to close the modal
- when text input is in the API key input box, the enter key triggers sign in instead of closing the modal
- renamed the modal <kbd>Done</kbd> button to <kbd>Close</kbd> to avoid confusion with the Sign In button
    <img width="610" alt="button_rename" src="https://github.com/user-attachments/assets/ec6a4c5d-d623-4c3e-a983-cd0927734337" />

#### Demo

https://github.com/user-attachments/assets/d5dc362e-9845-44e3-98ad-8c10cca9b09b

### Release Notes

#### New Features

- Assistant: improvements to Language Model Provider Configuration Modal close experience (#7404)

### QA Notes

@:assistant

#### Keyboard navigation

- When the Esc escape key is used and auth is not in progress, the modal is closed
- When the Esc escape key is used and auth is in progress, a confirmation modal is shown
- When the Enter key is pressed and no api text has been entered, the modal is closed
- When the Enter key is pressed and some text has been entered in the API Key input box, it triggers the Sign In flow

#### Closing the modal while auth is in progress

First, open the Language Model Provider dialog via the _Positron Assistant: Configure Language Model Providers_ command.

- Copilot (OAuth flow)
    1. Select the Copilot provider
    2. Click <kbd>Sign In</kbd> to kick off the OAuth flow, but leave the browser open and don't complete the flow
    3. Click the <kbd>Close</kbd> button
    4. See a confirmation modal
        <img width="800" alt="copilot_auth_in_progress" src="https://github.com/user-attachments/assets/43757698-b221-4763-9e55-97b560f6fbe9" />
    5. Choosing "Yes" dismisses both modals and choosing "No" returns the user to the Language Model Provider Configuration Modal
 

- Anthropic (API key flow, other experimental providers included)
    1. Select the Anthropic provider
    2. Click <kbd>Sign In</kbd> to kick off the OAuth flow
    3. Click the <kbd>Close</kbd> button
    4. See a confirmation modal
        <img width="1260" alt="api_key_auth_in_progress" src="https://github.com/user-attachments/assets/fe57adad-c992-41a2-b8c2-d06b984647ba" />
    5. Choosing "Yes" dismisses both modals and choosing "No" returns the user to the Language Model Provider Configuration Modal