### PR TITLE
Add pyproject.toml to New Python Projects

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -278,6 +278,11 @@
                 "command": "python.createNewFile"
             },
             {
+                "title": "%python.command.python.createPyprojectToml.title%",
+                "category": "Python",
+                "command": "python.createPyprojectToml"
+            },
+            {
                 "category": "Python",
                 "command": "python.analysis.restartLanguageServer",
                 "title": "%python.command.python.analysis.restartLanguageServer.title%"

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -5,6 +5,7 @@
     "python.command.python.startNativeREPL.title": "Start Native Python REPL",
     "python.command.python.createEnvironment.title": "Create Environment...",
     "python.command.python.createNewFile.title": "New Python File",
+    "python.command.python.createPyprojectToml.title": "Create pyproject.toml If Not Found",
     "python.command.python.createTerminal.title": "Create Terminal",
     "python.command.python.execInTerminal.title": "Run Python File in Terminal",
     "python.command.python.execDashInTerminal.title": "Run Dash App in Terminal",

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -45,7 +45,6 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [Commands.Show_Interpreter_Debug_Info]: [];
     // New command that opens the multisession interpreter picker
     ['workbench.action.language.runtime.selectSession']: [];
-    [Commands.Create_Pyproject_Toml]: [];
     // --- End Positron ---
 }
 
@@ -111,6 +110,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_Streamlit_In_Terminal]: [];
     [Commands.Exec_In_Console]: [];
     [Commands.Focus_Positron_Console]: [];
+    [Commands.Create_Pyproject_Toml]: [string | undefined];
     // --- End Positron ---
     [Commands.Tests_Configure]: [undefined, undefined | CommandSource, undefined | Uri];
     [Commands.Tests_CopilotSetup]: [undefined | Uri];

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -45,6 +45,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [Commands.Show_Interpreter_Debug_Info]: [];
     // New command that opens the multisession interpreter picker
     ['workbench.action.language.runtime.selectSession']: [];
+    [Commands.Create_Pyproject_Toml]: [];
     // --- End Positron ---
 }
 

--- a/extensions/positron-python/src/client/common/application/commands/createPyprojectToml.ts
+++ b/extensions/positron-python/src/client/common/application/commands/createPyprojectToml.ts
@@ -33,7 +33,7 @@ export class CreatePyprojectTomlCommandHandler implements IExtensionSingleActiva
         );
     }
 
-    public async createPyprojectToml(): Promise<CreatePyprojectTomlResult> {
+    public async createPyprojectToml(minPythonVersion?: string): Promise<CreatePyprojectTomlResult> {
         const workspaceFolder = this.workspaceService.workspaceFolders?.[0];
         if (!workspaceFolder) {
             traceError('No workspace folder found to create pyproject.toml');
@@ -42,6 +42,9 @@ export class CreatePyprojectTomlCommandHandler implements IExtensionSingleActiva
 
         const workspaceName = path.basename(workspaceFolder.uri.fsPath);
         const pyprojectPath = Uri.joinPath(workspaceFolder.uri, 'pyproject.toml');
+        if (!minPythonVersion) {
+            minPythonVersion = MINIMUM_PYTHON_VERSION.raw;
+        }
 
         try {
             await workspace.fs.stat(pyprojectPath);
@@ -52,12 +55,10 @@ export class CreatePyprojectTomlCommandHandler implements IExtensionSingleActiva
         }
 
         try {
-            // We use MINIMUM_PYTHON_VERSION as the least-strict option for the minimum Python version.
-            // See https://github.com/posit-dev/positron/issues/7902
             const tomlContent = `[project]
 name = "${workspaceName}"
 version = "0.1.0"
-requires-python = ">= ${MINIMUM_PYTHON_VERSION.raw}"
+requires-python = ">= ${minPythonVersion}"
 dependencies = []
 `;
             const contentBytes = new TextEncoder().encode(tomlContent);

--- a/extensions/positron-python/src/client/common/application/commands/createPyprojectToml.ts
+++ b/extensions/positron-python/src/client/common/application/commands/createPyprojectToml.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Similar to createPythonFile.ts
+
+import { injectable, inject } from 'inversify';
+import { Uri, workspace } from 'vscode';
+import * as path from 'path';
+import { IExtensionSingleActivationService } from '../../../activation/types';
+import { Commands } from '../../constants';
+import { ICommandManager, IWorkspaceService } from '../types';
+import { IDisposableRegistry } from '../../types';
+import { MINIMUM_PYTHON_VERSION } from '../../constants';
+import { traceError, traceInfo } from '../../../logging';
+
+export type CreatePyprojectTomlResult = { success: true; path: string } | { success: false; error: string };
+
+@injectable()
+export class CreatePyprojectTomlCommandHandler implements IExtensionSingleActivationService {
+    public readonly supportedWorkspaceTypes = { untrustedWorkspace: true, virtualWorkspace: true };
+
+    constructor(
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+    ) {}
+
+    public async activate(): Promise<void> {
+        this.disposables.push(
+            this.commandManager.registerCommand(Commands.Create_Pyproject_Toml, this.createPyprojectToml, this),
+        );
+    }
+
+    public async createPyprojectToml(): Promise<CreatePyprojectTomlResult> {
+        const workspaceFolder = this.workspaceService.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            traceError('No workspace folder found to create pyproject.toml');
+            return { success: false, error: 'No workspace folder found' };
+        }
+
+        const workspaceName = path.basename(workspaceFolder.uri.fsPath);
+        const pyprojectPath = Uri.joinPath(workspaceFolder.uri, 'pyproject.toml');
+
+        try {
+            await workspace.fs.stat(pyprojectPath);
+            traceInfo(`pyproject.toml already exists in ${workspaceName}. No action taken.`);
+            return { success: true, path: pyprojectPath.toString() };
+        } catch {
+            traceInfo(`Creating pyproject.toml in ${workspaceName}`);
+        }
+
+        try {
+            // We use MINIMUM_PYTHON_VERSION as the least-strict option for the minimum Python version.
+            // See https://github.com/posit-dev/positron/issues/7902
+            const tomlContent = `[project]
+name = "${workspaceName}"
+version = "0.1.0"
+requires-python = ">= ${MINIMUM_PYTHON_VERSION.raw}"
+dependencies = []
+`;
+            const contentBytes = new TextEncoder().encode(tomlContent);
+            await workspace.fs.writeFile(pyprojectPath, contentBytes);
+            return { success: true, path: pyprojectPath.toString() };
+        } catch (error) {
+            traceError(`Failed to create pyproject.toml in ${workspaceName}`, error);
+            return {
+                success: false,
+                error: `Failed to create pyproject.toml: ${error instanceof Error ? error.message : String(error)}`,
+            };
+        }
+    }
+}

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -85,6 +85,7 @@ export namespace Commands {
     export const Get_Uv_Python_Versions = 'python.getUvPythonVersions';
     export const Is_Global_Python = 'python.isGlobalPython';
     export const Show_Interpreter_Debug_Info = 'python.interpreters.debugInfo';
+    export const Create_Pyproject_Toml = 'python.createPyprojectToml';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
     export const InstallPython = 'python.installPython';

--- a/extensions/positron-python/src/client/positron/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/positron/serviceRegistry.ts
@@ -1,11 +1,17 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IExtensionSingleActivationService } from '../activation/types';
+import { CreatePyprojectTomlCommandHandler } from '../common/application/commands/createPyprojectToml';
 import { IServiceManager } from '../ioc/types';
 import { IPythonRuntimeManager, PythonRuntimeManager } from './manager';
 
 export function registerPositronTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingleton<IPythonRuntimeManager>(IPythonRuntimeManager, PythonRuntimeManager);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        CreatePyprojectTomlCommandHandler,
+    );
 }

--- a/extensions/positron-python/src/test/common/application/commands/createPyprojectToml.unit.test.ts
+++ b/extensions/positron-python/src/test/common/application/commands/createPyprojectToml.unit.test.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { assert } from 'chai';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Uri, workspace, WorkspaceFolder } from 'vscode';
+import * as sinon from 'sinon';
+import { Commands } from '../../../../client/common/constants';
+import { CommandManager } from '../../../../client/common/application/commandManager';
+import { ICommandManager, IWorkspaceService } from '../../../../client/common/application/types';
+import { WorkspaceService } from '../../../../client/common/application/workspace';
+import { CreatePyprojectTomlCommandHandler } from '../../../../client/common/application/commands/createPyprojectToml';
+
+suite('Create pyproject.toml Command', () => {
+    let createPyprojectTomlCommandHandler: CreatePyprojectTomlCommandHandler;
+    let cmdManager: ICommandManager;
+    let workspaceService: IWorkspaceService;
+    let workspaceStatStub: sinon.SinonStub;
+    let workspaceWriteFileStub: sinon.SinonStub;
+
+    setup(async () => {
+        cmdManager = mock(CommandManager);
+        workspaceService = mock(WorkspaceService);
+
+        // Create a mock workspace.fs object with proper methods
+        const mockFs = {
+            stat: sinon.stub(),
+            writeFile: sinon.stub(),
+        };
+
+        // Replace workspace.fs with our mock
+        (workspace as any).fs = mockFs;
+
+        // Store references to the stubs for test use
+        workspaceStatStub = mockFs.stat;
+        workspaceWriteFileStub = mockFs.writeFile;
+
+        createPyprojectTomlCommandHandler = new CreatePyprojectTomlCommandHandler(
+            instance(cmdManager),
+            instance(workspaceService),
+            [],
+        );
+
+        await createPyprojectTomlCommandHandler.activate();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Create pyproject.toml command is registered', async () => {
+        verify(cmdManager.registerCommand(Commands.Create_Pyproject_Toml, anything(), anything())).once();
+    });
+
+    test('Returns error when no workspace folder found', async () => {
+        when(workspaceService.workspaceFolders).thenReturn(undefined);
+
+        const result = await createPyprojectTomlCommandHandler.createPyprojectToml();
+
+        assert.equal(result.success, false);
+        if (!result.success) {
+            assert.equal(result.error, 'No workspace folder found');
+        }
+    });
+
+    test('Successfully creates pyproject.toml file when it does not exist', async () => {
+        const mockWorkspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/test/workspace'),
+            name: 'test-workspace',
+            index: 0,
+        };
+        when(workspaceService.workspaceFolders).thenReturn([mockWorkspaceFolder]);
+
+        // Mock file does not exist (stat throws)
+        workspaceStatStub.rejects(new Error('File not found'));
+        // Mock successful file write
+        workspaceWriteFileStub.resolves();
+
+        const result = await createPyprojectTomlCommandHandler.createPyprojectToml();
+
+        assert.equal(result.success, true);
+        if (result.success) {
+            assert.include(result.path, 'pyproject.toml');
+        }
+        assert.isTrue(workspaceWriteFileStub.calledOnce, 'writeFile should be called once');
+    });
+
+    test('Returns success when pyproject.toml file already exists', async () => {
+        const mockWorkspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/test/workspace'),
+            name: 'test-workspace',
+            index: 0,
+        };
+        when(workspaceService.workspaceFolders).thenReturn([mockWorkspaceFolder]);
+
+        // Mock file exists (stat succeeds)
+        workspaceStatStub.resolves({ type: 1, ctime: 0, mtime: 0, size: 100 });
+
+        const result = await createPyprojectTomlCommandHandler.createPyprojectToml();
+
+        assert.equal(result.success, true);
+        if (result.success) {
+            assert.include(result.path, 'pyproject.toml');
+        }
+        assert.isFalse(workspaceWriteFileStub.called, 'writeFile should not be called when file exists');
+    });
+
+    test('Returns error when file write operation fails', async () => {
+        const mockWorkspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/test/workspace'),
+            name: 'test-workspace',
+            index: 0,
+        };
+        when(workspaceService.workspaceFolders).thenReturn([mockWorkspaceFolder]);
+
+        // Mock file does not exist (stat throws)
+        workspaceStatStub.rejects(new Error('File not found'));
+        // Mock file write failure
+        const writeError = new Error('Permission denied');
+        workspaceWriteFileStub.rejects(writeError);
+
+        const result = await createPyprojectTomlCommandHandler.createPyprojectToml();
+
+        assert.equal(result.success, false);
+        if (!result.success) {
+            assert.include(result.error, 'Failed to create pyproject.toml');
+            assert.include(result.error, 'Permission denied');
+        }
+        assert.isTrue(workspaceWriteFileStub.calledOnce, 'writeFile should be called once');
+    });
+});

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
@@ -316,6 +316,17 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 						))()}
 					onChanged={(checked) => context.initGitRepo = checked}
 				/>
+				{context.folderTemplate === FolderTemplate.PythonProject && (
+					<Checkbox
+						initialChecked={context.createPyprojectToml}
+						label={(() =>
+							localize(
+								'folderNameLocationSubStep.createPyprojectToml.label',
+								"Create pyproject.toml file"
+							))()}
+						onChanged={(checked) => context.createPyprojectToml = checked}
+					/>
+				)}
 			</PositronFlowSubStep>
 		</PositronFlowStep>
 	);

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -122,6 +122,7 @@ export const showNewFolderFlowModalDialog = async (
 						folderPath: folder.path,
 						folderName: result.folderName,
 						initGitRepo: result.initGitRepo,
+						createPyprojectToml: result.createPyprojectToml,
 						pythonEnvProviderId: result.pythonEnvProviderId,
 						pythonEnvProviderName: result.pythonEnvProviderName,
 						installIpykernel: result.installIpykernel,

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -1067,6 +1067,7 @@ export class NewFolderFlowStateManager
 			this._uvPythonVersion = undefined;
 			this._uvPythonVersionInfo = undefined;
 			this._isUvInstalled = undefined;
+			this._createPyprojectToml = true;
 		};
 
 		// Clear R-specific state.

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -68,8 +68,8 @@ export interface NewFolderFlowState {
 	folderName: string;
 	parentFolder: URI;
 	initGitRepo: boolean;
-	createPyprojectToml: boolean;
 	openInNewWindow: boolean;
+	createPyprojectToml: boolean | undefined;
 	pythonEnvSetupType: EnvironmentSetupType | undefined;
 	pythonEnvProviderId: string | undefined;
 	condaPythonVersion: string | undefined;
@@ -109,13 +109,13 @@ export class NewFolderFlowStateManager
 	private _folderNameFeedback: FlowFormattedTextItem | undefined;
 	private _parentFolder: URI;
 	private _initGitRepo: boolean;
-	private _createPyprojectToml: boolean;
 	private _openInNewWindow: boolean;
 
 	// Python-specific state.
 	private _pythonEnvSetupType: EnvironmentSetupType | undefined;
 	private _pythonEnvProviderId: string | undefined;
 	private _installIpykernel: boolean | undefined;
+	private _createPyprojectToml: boolean | undefined;
 	private _minimumPythonVersion: string | undefined;
 	private _condaPythonVersion: string | undefined;
 	private _condaPythonVersionInfo: CondaPythonVersionInfo | undefined;
@@ -158,7 +158,6 @@ export class NewFolderFlowStateManager
 		this._folderNameFeedback = undefined;
 		this._parentFolder = config.parentFolder ?? '';
 		this._initGitRepo = false;
-		this._createPyprojectToml = true;
 		// Default to a new window as the least "destructive" option.
 		this._openInNewWindow = true;
 		this._pythonEnvSetupType = EnvironmentSetupType.NewEnvironment;
@@ -167,6 +166,7 @@ export class NewFolderFlowStateManager
 		this._useRenv = undefined;
 		this._steps = config.steps ?? [config.initialStep];
 		this._currentStep = config.initialStep;
+		this._createPyprojectToml = undefined;
 		this._pythonEnvProviders = undefined;
 		this._interpreters = undefined;
 		this._preferredInterpreter = undefined;
@@ -256,6 +256,10 @@ export class NewFolderFlowStateManager
 		if (this._folderTemplate !== folderTemplate) {
 			this._resetFolderConfig();
 		}
+		if (folderTemplate === FolderTemplate.PythonProject) {
+			// Defaults to true for Python projects only.
+			this.createPyprojectToml = true;
+		}
 		this._folderTemplate = folderTemplate;
 		this._updateInterpreterRelatedState();
 	}
@@ -331,7 +335,7 @@ export class NewFolderFlowStateManager
 	 * Gets the createPyprojectToml flag.
 	 * @returns The createPyprojectToml flag.
 	 */
-	get createPyprojectToml(): boolean {
+	get createPyprojectToml(): boolean | undefined {
 		return this._createPyprojectToml;
 	}
 
@@ -339,7 +343,7 @@ export class NewFolderFlowStateManager
 	 * Sets the createPyprojectToml flag.
 	 * @param value Whether to create a pyproject.toml file.
 	 */
-	set createPyprojectToml(value: boolean) {
+	set createPyprojectToml(value: boolean | undefined) {
 		this._createPyprojectToml = value;
 	}
 
@@ -617,12 +621,12 @@ export class NewFolderFlowStateManager
 			folderName: this._folderName,
 			parentFolder: this._parentFolder,
 			initGitRepo: this._initGitRepo,
-			createPyprojectToml: this._createPyprojectToml,
 			openInNewWindow: this._openInNewWindow,
 			pythonEnvSetupType: this._pythonEnvSetupType,
 			pythonEnvProviderId: this._pythonEnvProviderId,
 			pythonEnvProviderName: this._getEnvProviderName(),
 			installIpykernel: this._installIpykernel,
+			createPyprojectToml: this._createPyprojectToml,
 			condaPythonVersion: this._condaPythonVersion,
 			uvPythonVersion: this._uvPythonVersion,
 			useRenv: this._useRenv,
@@ -1043,7 +1047,7 @@ export class NewFolderFlowStateManager
 	 */
 	private _resetFolderConfig() {
 		this._initGitRepo = false;
-		this._createPyprojectToml = true;
+		this._createPyprojectToml = undefined;
 		this._useRenv = undefined;
 		this.folderNameFeedback = undefined;
 	}
@@ -1067,7 +1071,7 @@ export class NewFolderFlowStateManager
 			this._uvPythonVersion = undefined;
 			this._uvPythonVersionInfo = undefined;
 			this._isUvInstalled = undefined;
-			this._createPyprojectToml = true;
+			this._createPyprojectToml = undefined;
 		};
 
 		// Clear R-specific state.

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -68,6 +68,7 @@ export interface NewFolderFlowState {
 	folderName: string;
 	parentFolder: URI;
 	initGitRepo: boolean;
+	createPyprojectToml: boolean;
 	openInNewWindow: boolean;
 	pythonEnvSetupType: EnvironmentSetupType | undefined;
 	pythonEnvProviderId: string | undefined;
@@ -108,6 +109,7 @@ export class NewFolderFlowStateManager
 	private _folderNameFeedback: FlowFormattedTextItem | undefined;
 	private _parentFolder: URI;
 	private _initGitRepo: boolean;
+	private _createPyprojectToml: boolean;
 	private _openInNewWindow: boolean;
 
 	// Python-specific state.
@@ -156,6 +158,7 @@ export class NewFolderFlowStateManager
 		this._folderNameFeedback = undefined;
 		this._parentFolder = config.parentFolder ?? '';
 		this._initGitRepo = false;
+		this._createPyprojectToml = true;
 		// Default to a new window as the least "destructive" option.
 		this._openInNewWindow = true;
 		this._pythonEnvSetupType = EnvironmentSetupType.NewEnvironment;
@@ -322,6 +325,22 @@ export class NewFolderFlowStateManager
 	 */
 	set initGitRepo(value: boolean) {
 		this._initGitRepo = value;
+	}
+
+	/**
+	 * Gets the createPyprojectToml flag.
+	 * @returns The createPyprojectToml flag.
+	 */
+	get createPyprojectToml(): boolean {
+		return this._createPyprojectToml;
+	}
+
+	/**
+	 * Sets the createPyprojectToml flag.
+	 * @param value Whether to create a pyproject.toml file.
+	 */
+	set createPyprojectToml(value: boolean) {
+		this._createPyprojectToml = value;
 	}
 
 	/**
@@ -598,6 +617,7 @@ export class NewFolderFlowStateManager
 			folderName: this._folderName,
 			parentFolder: this._parentFolder,
 			initGitRepo: this._initGitRepo,
+			createPyprojectToml: this._createPyprojectToml,
 			openInNewWindow: this._openInNewWindow,
 			pythonEnvSetupType: this._pythonEnvSetupType,
 			pythonEnvProviderId: this._pythonEnvProviderId,
@@ -1023,6 +1043,7 @@ export class NewFolderFlowStateManager
 	 */
 	private _resetFolderConfig() {
 		this._initGitRepo = false;
+		this._createPyprojectToml = true;
 		this._useRenv = undefined;
 		this.folderNameFeedback = undefined;
 	}

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -94,7 +94,7 @@ export interface NewFolderConfiguration {
 	readonly folderPath: string;
 	readonly folderName: string;
 	readonly initGitRepo: boolean;
-	readonly createPyprojectToml: boolean;
+	readonly createPyprojectToml: boolean | undefined;
 	readonly pythonEnvProviderId: string | undefined;
 	readonly pythonEnvProviderName: string | undefined;
 	readonly installIpykernel: boolean | undefined;

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -80,6 +80,7 @@ export enum NewFolderTask {
 	PythonEnvironment = 'pythonEnvironment',
 	REnvironment = 'rEnvironment',
 	CreateNewFile = 'createNewFile',
+	CreatePyprojectToml = 'createPyprojectToml',
 }
 
 /**

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -93,6 +93,7 @@ export interface NewFolderConfiguration {
 	readonly folderPath: string;
 	readonly folderName: string;
 	readonly initGitRepo: boolean;
+	readonly createPyprojectToml: boolean;
 	readonly pythonEnvProviderId: string | undefined;
 	readonly pythonEnvProviderName: string | undefined;
 	readonly installIpykernel: boolean | undefined;
@@ -193,6 +194,14 @@ export type CreateEnvironmentResult = {
 	readonly error?: Error;
 	readonly metadata?: ILanguageRuntimeMetadata;
 };
+
+/**
+ * CreatePyprojectTomlResult type.
+ * Used to capture the result of creating a pyproject.toml file in the new folder.
+ * Based on the result from the Create_Pyproject_Toml 'python.createPyprojectToml'
+ * command defined in extensions/positron-python/src/client/common/application/commands/createPyprojectToml.ts.
+ */
+export type CreatePyprojectTomlResult = { success: true; path: string } | { success: false; error: string };
 
 /**
  * LanguageIds enum.

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -408,24 +408,6 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 	}
 
 	/**
-	 * Adds the pyproject.toml file.
-	 * Relies on the positron-python extension.
-	 */
-	private async _createPyprojectToml() {
-		const result = await this._commandService.executeCommand<CreatePyprojectTomlResult>(
-			'python.createPyprojectToml'
-		);
-		if (!result || !result.success) {
-			const errorDesc = result?.error ? result.error : 'unknown error';
-			const message = this._failedPythonEnvMessage(`Failed to create pyproject.toml: ${errorDesc}`);
-			this._logService.error(message);
-			this._notificationService.warn(message);
-		}
-
-		this._removePendingInitTask(NewFolderTask.CreatePyprojectToml);
-	}
-
-	/**
 	 * Creates the Python environment.
 	 * Relies on extension ms-python.python
 	 */
@@ -539,6 +521,30 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			this._removePendingInitTask(NewFolderTask.PythonEnvironment);
 			return;
 		}
+	}
+
+	/**
+	 * Adds the pyproject.toml file.
+	 * Relies on the positron-python extension.
+	 */
+	private async _createPyprojectToml() {
+		// Use the selected Python version for the `requires-python` field if available.
+		let minPythonVersion: string | undefined;
+		if (this._runtimeMetadata?.languageVersion) {
+			minPythonVersion = this._runtimeMetadata.languageVersion;
+		}
+
+		const result = await this._commandService.executeCommand<CreatePyprojectTomlResult>(
+			'python.createPyprojectToml', minPythonVersion
+		);
+		if (!result || !result.success) {
+			const errorDesc = result?.error ? result.error : 'unknown error';
+			const message = this._failedPythonEnvMessage(`Failed to create pyproject.toml: ${errorDesc}`);
+			this._logService.error(message);
+			this._notificationService.warn(message);
+		}
+
+		this._removePendingInitTask(NewFolderTask.CreatePyprojectToml);
 	}
 
 	/**

--- a/test/e2e/pages/newFolderFlow.ts
+++ b/test/e2e/pages/newFolderFlow.ts
@@ -59,11 +59,22 @@ export class NewFolderFlow {
 	 * @param initGitRepo Whether to initialize a Git repository.
 	 **/
 	async setFolderNameLocation(options: CreateFolderOptions) {
-		const { folderName, initGitRepo } = options;
+		const { folderName, initGitRepo, createPyprojectToml, folderTemplate: type } = options;
 
 		await this.folderNameInput.fill(folderName);
 		if (initGitRepo) {
 			await this.code.driver.page.getByText('Initialize Git repository').check();
+		}
+
+		if (type === FolderTemplate.PYTHON_PROJECT) {
+			const checkboxLabel = this.code.driver.page.getByText('Create pyproject.toml file');
+			const shouldBeChecked = createPyprojectToml ?? false;
+			if (!shouldBeChecked) {
+				// It's checked by default, so click to uncheck
+				await checkboxLabel.click();
+			}
+		} else {
+			await expect(this.code.driver.page.getByText('Create pyproject.toml file')).not.toBeVisible();
 		}
 
 		const button = options.folderTemplate === FolderTemplate.EMPTY_PROJECT ? FlowButton.CREATE : FlowButton.NEXT;
@@ -232,6 +243,7 @@ export interface CreateFolderOptions {
 	rEnvCheckbox?: boolean;
 	pythonEnv?: 'conda' | 'venv' | 'uv';
 	initGitRepo?: boolean;
+	createPyprojectToml?: boolean;
 	ipykernelFeedback?: 'show' | 'hide';
 	interpreterPath?: string;
 }

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -87,3 +87,17 @@ export async function verifyUvEnvStarts(app: Application) {
 		await app.workbench.console.waitForConsoleContents('(Uv: .venv) started.');
 	});
 }
+
+export async function verifyPyprojectTomlCreated(app: Application) {
+	await test.step('Verify pyproject.toml file is created', async () => {
+		const files = app.code.driver.page.locator('.monaco-list > .monaco-scrollable-element');
+		await expect(files.getByText('pyproject.toml')).toBeVisible({ timeout: 50000 });
+	});
+}
+
+export async function verifyPyprojectTomlNotCreated(app: Application) {
+	await test.step('Verify pyproject.toml file is not created', async () => {
+		const files = app.code.driver.page.locator('.monaco-list > .monaco-scrollable-element');
+		await expect(files.getByText('pyproject.toml')).toHaveCount(0, { timeout: 50000 });
+	});
+}

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
@@ -5,7 +5,7 @@
 
 import { FolderTemplate } from '../../infra';
 import { test, tags } from '../_test.setup';
-import { addRandomNumSuffix } from './helpers/new-folder-flow.js';
+import { addRandomNumSuffix, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
 	suiteId: __filename
@@ -25,5 +25,6 @@ test.describe('New Folder Flow: Empty Project', { tag: [tags.MODAL, tags.NEW_FOL
 		});
 
 		await newFolderFlow.verifyFolderCreation(folderName);
+		await verifyPyprojectTomlNotCreated(app);
 	});
 });

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -6,7 +6,7 @@
 import { Application } from '../../infra/index.js';
 import { FolderTemplate } from '../../pages/newFolderFlow.js';
 import { test, tags, expect } from '../_test.setup';
-import { addRandomNumSuffix, verifyConsoleReady, verifyFolderCreation } from './helpers/new-folder-flow.js';
+import { addRandomNumSuffix, verifyConsoleReady, verifyFolderCreation, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
 	suiteId: __filename
@@ -32,6 +32,7 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyNotebookEditorVisible(app);
 		await verifyNotebookAndConsolePythonVersion(app);
+		await verifyPyprojectTomlNotCreated(app);
 	});
 });
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -5,7 +5,7 @@
 
 import { FolderTemplate } from '../../infra';
 import { test, tags } from '../_test.setup';
-import { addRandomNumSuffix, createNewFolder, verifyCondaEnvStarts, verifyCondaFilesArePresent, verifyConsoleReady, verifyFolderCreation, verifyGitFilesArePresent, verifyGitStatus, verifyUvEnvStarts, verifyVenvEnvStarts } from './helpers/new-folder-flow.js';
+import { addRandomNumSuffix, createNewFolder, verifyCondaEnvStarts, verifyCondaFilesArePresent, verifyConsoleReady, verifyFolderCreation, verifyGitFilesArePresent, verifyGitStatus, verifyUvEnvStarts, verifyVenvEnvStarts, verifyPyprojectTomlCreated, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
 	suiteId: __filename
@@ -24,11 +24,13 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 			folderName,
 			status: 'existing',
 			ipykernelFeedback: 'hide',
-			interpreterPath: (await sessions.getSelectedSessionInfo()).path
+			interpreterPath: (await sessions.getSelectedSessionInfo()).path,
+			createPyprojectToml: false,
 		});
 
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
+		await verifyPyprojectTomlNotCreated(app);
 	});
 
 	// untagged windows because we cannot find any way to copy text from the terminal now that its a canvas
@@ -41,6 +43,7 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 			initGitRepo: true,
 			status: 'new',
 			pythonEnv: 'venv',
+			createPyprojectToml: true,
 		});
 
 		await verifyFolderCreation(app, folderName);
@@ -48,6 +51,7 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 		await verifyGitFilesArePresent(app);
 		await verifyVenvEnvStarts(app);
 		await verifyGitStatus(app);
+		await verifyPyprojectTomlCreated(app);
 	});
 
 	test('New env: Conda environment', async function ({ app }) {
@@ -57,12 +61,14 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 			folderName,
 			status: 'new',
 			pythonEnv: 'conda', // test relies on conda already installed on machine
+			createPyprojectToml: true,
 		});
 
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyCondaFilesArePresent(app);
 		await verifyCondaEnvStarts(app);
+		await verifyPyprojectTomlCreated(app);
 	});
 
 	test('New env: Venv environment', { tag: [tags.CRITICAL, tags.WIN] }, async function ({ app }) {
@@ -73,11 +79,13 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 			folderName,
 			status: 'new',
 			pythonEnv: 'venv',
+			createPyprojectToml: false,
 		});
 
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyVenvEnvStarts(app);
+		await verifyPyprojectTomlNotCreated(app);
 	});
 
 	test('New env: uv environment', { tag: [tags.CRITICAL] }, async function ({ app }) {
@@ -88,10 +96,12 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 			folderName,
 			status: 'new',
 			pythonEnv: 'uv',  // test relies on uv already installed on machine
+			createPyprojectToml: true,
 		});
 
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyUvEnvStarts(app);
+		await verifyPyprojectTomlCreated(app);
 	});
 });

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
@@ -5,7 +5,7 @@
 
 import { FolderTemplate, } from '../../infra';
 import { test, tags } from '../_test.setup';
-import { addRandomNumSuffix, createNewFolder, handleRenvInstallModal, verifyConsoleReady, verifyFolderCreation, verifyRenvFilesArePresent } from './helpers/new-folder-flow.js';
+import { addRandomNumSuffix, createNewFolder, handleRenvInstallModal, verifyConsoleReady, verifyFolderCreation, verifyRenvFilesArePresent, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
 	suiteId: __filename
@@ -30,6 +30,7 @@ test.describe('New Folder Flow: R Project', { tag: [tags.MODAL, tags.NEW_FOLDER_
 
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
+		await verifyPyprojectTomlNotCreated(app);
 	});
 
 	test('R - Accept Renv install', { tag: [tags.WIN] }, async function ({ app }) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #7902.

Adds a checkbox to the New Python Project workflow that sets up a minimal `pyproject.toml` file.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- New Python Projects can optionally now create a `pyproject.toml` file #7902 

#### Bug Fixes

- N/A


### QA Notes

I added some e2e tests. Note: I could not figure out how to check whether the selected interpreter version is in the created file. We'll have to check this manually.

Make sure the file is created when the box is checked, and not created when it's not checked (including for the other language project types 🙈)
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts

  Example tags: 
-->
@:new-folder-flow @:win

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
