### PR TITLE
Pad base64 image for plot clients

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
@@ -388,7 +388,7 @@ export class PositronPlotRenderQueue extends Disposable {
 					const renderTimeMs = finishedTime - startedTime;
 
 					// The server returned a rendered plot image; save it and resolve the promise
-					const uri = `data:${response.mime_type};base64,${response.data}`;
+					const uri = `data:${response.mime_type};base64,${this.padBase64(response.data)}`;
 					const renderResult: IRenderedPlot = {
 						size: operationRequest.size,
 						pixel_ratio: operationRequest.pixel_ratio!,
@@ -420,6 +420,15 @@ export class PositronPlotRenderQueue extends Disposable {
 			queuedOperation.operation.error(new Error(`Unknown operation type: ${operationRequest.type}`));
 			this._isProcessing = false;
 			this.processQueue();
+		}
+	}
+
+	private padBase64(base64: string): string {
+		const remainder = base64.length % 4;
+		if (remainder === 0) {
+			return base64; // No padding needed
+		} else {
+			return `${base64}${'='.repeat(4 - remainder)}`;
 		}
 	}
 


### PR DESCRIPTION
Address #7510

Pads the base64 encoding to a multiple of 4. This fixes sending the get plot tool for Anthropic models that expect strict base64 encoding.

@:plots

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix plot image encoding for Anthropic model provider #7510


### QA Notes
This changes the source image for plots so it affects the Plots pane as well but it shouldn't affect how plots are displayed.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts

  Example tags: @:web @:win
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
