### PR TITLE
remove e2e test tag examples from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,8 +47,6 @@ main branch by either pulling or rebasing.
 
   - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
   - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-
-  Example tags: @:web @:win
 -->
 
 


### PR DESCRIPTION
The example tags added in a comment to the PR template (#7983, #7968) are read by the script that parses for e2e tags in the PR description (the script looks for the tags anywhere in the PR description, regardless of if the tags are in a comment or not).

This results in those corresponding tests run automatically on every PR, but we don't want these tests running by default on _every_ PR, so let's remove them from the template.

The "Available tags" URL in the comment can be used to find the available tags.