### PR TITLE
Set `skipEncoding` to `true` for display URIs

### DIFF
--- a/extensions/positron-run-app/src/terminalLinkProvider.ts
+++ b/extensions/positron-run-app/src/terminalLinkProvider.ts
@@ -86,7 +86,7 @@ export class AppLauncherTerminalLinkProvider implements vscode.TerminalLinkProvi
 
 		const quickPick = vscode.window.createQuickPick();
 		quickPick.title = vscode.l10n.t('Open App Link');
-		quickPick.placeholder = vscode.l10n.t('How would you like to open: {0}', uri.toString());
+		quickPick.placeholder = vscode.l10n.t('How would you like to open: {0}', uri.toString(true));
 		quickPick.items = [
 			{ label: viewerPane, },
 			{ label: browserWindow, },

--- a/src/vs/workbench/api/common/positron/extHostPreviewPanels.ts
+++ b/src/vs/workbench/api/common/positron/extHostPreviewPanels.ts
@@ -221,7 +221,7 @@ export class ExtHostPreviewPanels implements extHostProtocol.ExtHostPreviewPanel
 			enableScripts: true,
 			localResourceRoots: [],
 		};
-		const title = uri.toString();
+		const title = uri.toString(true);
 		this._proxy.$previewUrl(toExtensionData(extension), handle, uri);
 		const webview = this.webviews.$createNewWebview(handle, options, extension);
 		const panel = this.createNewPreviewPanel(handle, viewType, title, webview as ExtHostWebview, true);

--- a/src/vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService.ts
+++ b/src/vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService.ts
@@ -216,7 +216,10 @@ export class ExternalUriOpenerService extends Disposable implements IExternalUri
 			});
 
 		const picked = await this.quickInputService.pick(items, {
-			placeHolder: nls.localize('selectOpenerPlaceHolder', "How would you like to open: {0}", targetUri.toString())
+			// --- Start Positron ---
+			// Skip encodindg the URI here so that it is displayed without escape sequences in the picker.
+			placeHolder: nls.localize('selectOpenerPlaceHolder', "How would you like to open: {0}", targetUri.toString(true))
+			// --- End Positron ---
 		});
 
 		if (!picked) {

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -110,7 +110,7 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 
 			// Restore the old input value.
 			if (urlInputRef.current) {
-				urlInputRef.current.value = currentUri.toString();
+				urlInputRef.current.value = currentUri.toString(true);
 			}
 
 			return;
@@ -154,7 +154,7 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 						}
 					}
 				}
-				urlInputRef.current.value = e.toString();
+				urlInputRef.current.value = e.toString(true);
 			}
 		}));
 		return () => disposables.dispose();
@@ -182,7 +182,7 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 								ref={urlInputRef}
 								aria-label={currentUrl}
 								className='text-input url-bar'
-								defaultValue={props.preview.currentUri.toString()}
+								defaultValue={props.preview.currentUri.toString(true)}
 								name={kUrlBarInputName}
 								type='text'>
 							</input>


### PR DESCRIPTION
## Description

### Release Notes

This PR addresses #6422 by setting `skipEncoding` to `true` for display URIs. Prior to this PR, several display URIs would show encoded URIs.

For example:

![image](https://github.com/user-attachments/assets/d7825d67-da90-4ca2-8601-e2445ad921e0)

![image](https://github.com/user-attachments/assets/f566f310-f813-48da-9601-3b49100ec901)

After this PR, these URIs are now readable:

![image](https://github.com/user-attachments/assets/a371be77-d498-4ed0-86ff-b51c75c792b5)

![image](https://github.com/user-attachments/assets/d24ffe45-72c8-4a20-9fbb-2a3843c04df1)

Tests:
@:viewer

#### New Features

- N/A

#### Bug Fixes

- #6422 Set `skipEncoding` to `true` for display URIs

### QA Notes

- None