### PR TITLE
E2E test: synchronize reporters between test steps for windows

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -197,7 +197,7 @@ jobs:
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID }}
         run: |
-          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=list
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows"
           $BOOTSTRAP_EXIT_CODE = $LASTEXITCODE
 
           $env:SKIP_BOOTSTRAP = "true"


### PR DESCRIPTION
Minor change to ensure reporters are synchronized between test steps in github action step to avoid pipe errors.

### QA Notes