### PR TITLE
Add new tools to get date/time and version

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -186,6 +186,24 @@
         }
       },
       {
+        "name": "getCurrentDateTime",
+        "displayName": "Get current date and time",
+        "modelDescription": "Get the current date and time in the user's local timezone, and the timezone itself.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ]
+      },
+      {
+        "name": "getPositronVersion",
+        "displayName": "Get Positron version",
+        "modelDescription": "You are running in an IDE called Positron. Get the version of Positron you are running.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ]
+      },
+      {
         "name": "executeCode",
         "displayName": "Execute Code",
         "modelDescription": "Execute a piece of code in the specified programming language. Only use this tool if you absolutely need to execute code, otherwise reply directly to the user with markdown code snippets.",

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -218,6 +218,60 @@ export function registerAssistantTools(
 
 	context.subscriptions.push(executeCodeTool);
 
+	const dateTimeTool = vscode.lm.registerTool<{}>(PositronAssistantToolName.GetCurrentDateTime, {
+		/**
+		 * Called to get the current date and time.
+		 *
+		 * @param options The options for the tool invocation.
+		 * @param token The cancellation token.
+		 *
+		 * @returns A vscode.LanguageModelToolResult.
+		 */
+		invoke: async (_options, _token) => {
+
+			// Get the current date as an ISO string
+			const now = new Date();
+			const isoString = now.toISOString();
+
+			// Get the current timezone
+			const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+			const result = {
+				utcTime: isoString,
+				localTime: now.toLocaleString(),
+				timezone: timezone,
+				utcOffset: now.getTimezoneOffset() / -60, // Convert to hours
+			};
+
+			// Return the result as a JSON string to the model
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(JSON.stringify(result))
+			]);
+		}
+	});
+
+	context.subscriptions.push(dateTimeTool);
+
+	const positronVersionTool = vscode.lm.registerTool<{}>(PositronAssistantToolName.GetPositronVersion, {
+		/**
+		 * Called to get the current Positron version
+		 *
+		 * @param options The options for the tool invocation.
+		 * @param token The cancellation token.
+		 *
+		 * @returns A vscode.LanguageModelToolResult.
+		 */
+		invoke: async (_options, _token) => {
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`${positron.version}-${positron.buildNumber}`)
+			]);
+		}
+	});
+
+	context.subscriptions.push(positronVersionTool);
+
+
 	const getPlotTool = vscode.lm.registerTool<{}>(PositronAssistantToolName.GetPlot, {
 		prepareInvocation: async (options, token) => {
 			return {

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -9,6 +9,8 @@ export enum PositronAssistantToolName {
 	ExecuteCode = 'executeCode',
 	GetPlot = 'getPlot',
 	InspectVariables = 'inspectVariables',
+	GetCurrentDateTime = 'getCurrentDateTime',
+	GetPositronVersion = 'getPositronVersion',
 	SelectionEdit = 'selectionEdit',
 	ProjectTree = 'getProjectTree',
 }


### PR DESCRIPTION
This change adds a couple of new tools that enable Assistant to look up the current date time and Positron version.

I initially tried including this information in the context, but had a hard time getting the model to acknowledge it.  For instance, even including a context item called `positronVersion` caused the model to shrug when asked for the "Positron version". Tool calls work better.

The model seems pretty good about calling these tools when necessary:

<img width="311" alt="image" src="https://github.com/user-attachments/assets/279deed8-c64b-4347-ac0e-8be090d4d1e9" />

Addresses https://github.com/posit-dev/positron/issues/7821
Addresses https://github.com/posit-dev/positron/issues/8050

Test tags: `@:assistant`
