### PR TITLE
Feature/extenson supported positron version

### DIFF
--- a/src/vs/platform/extensions/common/positronExtensionValidator.ts
+++ b/src/vs/platform/extensions/common/positronExtensionValidator.ts
@@ -45,7 +45,10 @@ export function isValidPositronExtensionVersion(positronVersion: string, product
 		return true;
 	}
 
-	return isVersionValid(positronVersion, productDate, requestedVersion, notices);
+	// In Positron, we employ a customized SemVer versioning scheme where
+	// ^2025.1.0 means >= 2025.1.0. Replace the caret (^) with a greater
+	// than or equal to (>=) operator.
+	return isVersionValid(positronVersion, productDate, requestedVersion.replace(/^(\^)/, '>='), notices);
 }
 
 function isVersionValid(currentVersion: string, date: ProductDate, requestedVersion: string, notices: string[] = []): boolean {

--- a/src/vs/platform/extensions/common/positronExtensionValidator.ts
+++ b/src/vs/platform/extensions/common/positronExtensionValidator.ts
@@ -46,7 +46,7 @@ export function isValidPositronExtensionVersion(positronVersion: string, product
 	}
 
 	// In Positron, we employ a customized SemVer versioning scheme where
-	// ^2025.1.0 means >= 2025.1.0. Replace the caret (^) with a greater
+	// ^2025.1.0 means >=2025.1.0. Replace the caret (^) with a greater
 	// than or equal to (>=) operator.
 	return isVersionValid(positronVersion, productDate, requestedVersion.replace(/^(\^)/, '>='), notices);
 }

--- a/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
+++ b/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
@@ -10,9 +10,12 @@ import { validatePositronExtensionManifest } from '../../common/positronExtensio
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 /**
- * Validate Positron Extension Manifest suite.
+ * Positron Extension Validator suite.
  */
 suite('Positron Extension Validator', () => {
+	/**
+	 * Test for validating the Positron extension manifest's Positron version.
+	 */
 	test('Positron Extension Validator - Positron Version', () => {
 		// Setup the tests.
 		const uri = URI.parse('http://test-extension.com');

--- a/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
+++ b/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
@@ -40,7 +40,7 @@ suite('Positron Extension Validator', () => {
 				// Test builds.
 				for (const build of buildsToTest) {
 					// Create the version under test and validate the manifest for it.
-					const versionUnderTest = `${year}.${month}.${build}`;
+					const versionUnderTest = `${year}.${String(month).padStart(2, '0')}.${build}`;
 					const testResult = validatePositronExtensionManifest(versionUnderTest, undefined, uri, manifest, false).length;
 
 					// Check the text result based on the year and month.

--- a/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
+++ b/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { URI } from '../../base/common/uri.js';
-import { IExtensionManifest } from '../extensions/common/extensions.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../base/test/common/utils.js';
-import { validatePositronExtensionManifest } from '../extensions/common/positronExtensionValidator.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IExtensionManifest } from '../../common/extensions.js';
+import { validatePositronExtensionManifest } from '../../common/positronExtensionValidator.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 /**
  * Validate Positron Extension Manifest suite.
  */
-suite('Validate Positron Extension Manifest', () => {
-	test('Validate Positron Extension Manifest Positron Version', () => {
+suite('Positron Extension Validator', () => {
+	test('Positron Extension Validator - Positron Version', () => {
 		// Setup the tests.
 		const uri = URI.parse('http://test-extension.com');
 		const manifest: IExtensionManifest = {

--- a/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
+++ b/src/vs/platform/extensions/test/common/positronExtensionValidator.test.ts
@@ -37,7 +37,7 @@ suite('Positron Extension Validator', () => {
 		for (let year = 2000; year <= 2050; year++) {
 			// Test months, including weird months we'll never use like 13-20, just to ensure robustness.
 			for (let month = 1; month <= 20; month++) {
-				// Test random builds.
+				// Test builds.
 				for (const build of buildsToTest) {
 					// Create the version under test and validate the manifest for it.
 					const versionUnderTest = `${year}.${month}.${build}`;

--- a/src/vs/platform/test/validatePositronExtensionManifest.test.ts
+++ b/src/vs/platform/test/validatePositronExtensionManifest.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from '../../base/common/uri.js';
+import { IExtensionManifest } from '../extensions/common/extensions.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../base/test/common/utils.js';
+import { validatePositronExtensionManifest } from '../extensions/common/positronExtensionValidator.js';
+
+/**
+ * Validate Positron Extension Manifest suite.
+ */
+suite('Validate Positron Extension Manifest', () => {
+	test('Validate Positron Extension Manifest Positron Version', () => {
+		// Setup the tests.
+		const uri = URI.parse('http://test-extension.com');
+		const manifest: IExtensionManifest = {
+			name: "testExtension",
+			publisher: "testPublisher",
+			version: "0.1.0",
+			main: "./main.js",
+			engines: {
+				vscode: "^1.0.0",
+				positron: "^2025.6.0"
+			}
+		};
+
+		// Some builds to test.
+		const buildsToTest = [0, 24, 49, 99];
+
+		// Test years between 2000 and 2050.
+		for (let year = 2000; year <= 2050; year++) {
+			// Test months, including weird months we'll never use like 13-20, just to ensure robustness.
+			for (let month = 1; month <= 20; month++) {
+				// Test random builds.
+				for (const build of buildsToTest) {
+					// Create the version under test and validate the manifest for it.
+					const versionUnderTest = `${year}.${month}.${build}`;
+					const testResult = validatePositronExtensionManifest(versionUnderTest, undefined, uri, manifest, false).length;
+
+					// Check the text result based on the year and month.
+					if (year < 2025 || (year === 2025 && month < 6)) {
+						assert.notEqual(testResult, 0, `Expected errors for version ${versionUnderTest}`);
+					} else {
+						assert.equal(testResult, 0, `Expected no errors for version ${versionUnderTest}`);
+					}
+				}
+			}
+		}
+	});
+
+	// Ensure that no disposables are leaked.
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
### 

This PR addresses #7202 by updating how the Positron version field is specified and validated for Positron extensions. Now, Positron extensions can specify the Positron version they require in the `engines` section of the `package.json` file. For example:

```json
{
    "name": "my-positron-extension",
    "displayName": "My Positron Extension",
    "description": "This is My Positron Extension.",
    "version": "0.1.0",
    "engines": {
        "vscode": "^1.100.0",
        "positron": "^2025.06.0"
    },
}
```

Note that Positron employs a custom SemVer versioning scheme where `^2025.06.0` means `>=2025.06.0`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #7202 Update how the Positron version field is specified and validated for Positron extensions.

### QA Notes

This PR includes a new unit test suite which tests the Positron version.