### PR TITLE
E2E test: break up windows test execution into two GH action steps

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -182,7 +182,20 @@ jobs:
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
 
-      - name: Run Tests on Windows (Electron)
+      - name: Run Bootstrap Extensions Test
+        shell: pwsh
+        env:
+          POSITRON_PY_VER_SEL: 3.10.10
+          POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+        run: |
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=null
+          $BOOTSTRAP_EXIT_CODE = $LASTEXITCODE
+          "BOOTSTRAP_EXIT_CODE=$BOOTSTRAP_EXIT_CODE" | Out-File -FilePath bootstrap-result.env
+
+      - name: Run Main Test Suite (Electron)
         shell: pwsh
         env:
           POSITRON_PY_VER_SEL: 3.10.10
@@ -191,24 +204,29 @@ jobs:
           POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }} # only works on push events
+          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID }}
         run: |
-          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows"
-          $BOOTSTRAP_EXIT_CODE = $LASTEXITCODE
-
           $env:SKIP_BOOTSTRAP = "true"
           $env:SKIP_CLONE = "true"
           npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
-          if ($BOOTSTRAP_EXIT_CODE -ne 0) {
-            Write-Host "Bootstrap extensions test failed. Exiting with code $BOOTSTRAP_EXIT_CODE."
-            exit $BOOTSTRAP_EXIT_CODE
+          $BOOTSTRAP_EXIT_CODE = 0
+          if (Test-Path bootstrap-result.env) {
+            Get-Content bootstrap-result.env | ForEach-Object {
+              if ($_ -match "^BOOTSTRAP_EXIT_CODE=(\d+)$") {
+                $BOOTSTRAP_EXIT_CODE = [int]$matches[1]
+              }
+            }
           }
 
+          if ($BOOTSTRAP_EXIT_CODE -ne 0) {
+            Write-Host "Bootstrap extensions test failed earlier. Exiting with code $BOOTSTRAP_EXIT_CODE."
+            exit $BOOTSTRAP_EXIT_CODE
+          }
 
 
       - name: Upload Playwright Report to S3

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -183,6 +183,7 @@ jobs:
         uses: ./.github/actions/gen-report-dir
 
       - name: Run Bootstrap Extensions Test
+        id: bootstrap
         shell: pwsh
         env:
           POSITRON_PY_VER_SEL: 3.10.10
@@ -193,7 +194,7 @@ jobs:
         run: |
           npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "e2e-windows" --reporter=null
           $BOOTSTRAP_EXIT_CODE = $LASTEXITCODE
-          "BOOTSTRAP_EXIT_CODE=$BOOTSTRAP_EXIT_CODE" | Out-File -FilePath bootstrap-result.env
+          "BOOTSTRAP_EXIT_CODE=$BOOTSTRAP_EXIT_CODE" >> $env:GITHUB_OUTPUT
 
       - name: Run Main Test Suite (Electron)
         shell: pwsh
@@ -214,15 +215,7 @@ jobs:
           $env:SKIP_CLONE = "true"
           npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
-          $BOOTSTRAP_EXIT_CODE = 0
-          if (Test-Path bootstrap-result.env) {
-            Get-Content bootstrap-result.env | ForEach-Object {
-              if ($_ -match "^BOOTSTRAP_EXIT_CODE=(\d+)$") {
-                $BOOTSTRAP_EXIT_CODE = [int]$matches[1]
-              }
-            }
-          }
-
+          $BOOTSTRAP_EXIT_CODE = [int]"${{ steps.bootstrap.outputs.BOOTSTRAP_EXIT_CODE }}"
           if ($BOOTSTRAP_EXIT_CODE -ne 0) {
             Write-Host "Bootstrap extensions test failed earlier. Exiting with code $BOOTSTRAP_EXIT_CODE."
             exit $BOOTSTRAP_EXIT_CODE


### PR DESCRIPTION
Breaking up windows test execution into two steps.

### QA Notes

@:win