### PR TITLE
Close the LSP comm during deactivation

### DIFF
--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -84,19 +84,37 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * Convenience method for starting the Positron LSP server, if the
      * language runtime supports it.
      *
+     * @param clientId The ID of the client comm, created with
+     *  `createPositronLspClientId()`.
      * @param ipAddress The address of the client that will connect to the
      *  language server.
      */
-    startPositronLsp(ipAddress: string): Promise<number>;
+    startPositronLsp(clientId: string, ipAddress: string): Promise<number>;
 
     /**
      * Convenience method for starting the Positron DAP server, if the
      * language runtime supports it.
      *
+     * @param clientId The ID of the client comm, created with
+     *  `createPositronDapClientId()`.
      * @param debugType Passed as `vscode.DebugConfiguration.type`.
      * @param debugName Passed as `vscode.DebugConfiguration.name`.
      */
-    startPositronDap(debugType: string, debugName: string): Promise<void>;
+    startPositronDap(clientId: string, debugType: string, debugName: string): Promise<void>;
+
+    /**
+     * Convenience method for creating a client id to pass to
+     * `startPositronLsp()`. The caller can later remove the client using this
+     * id as well.
+     */
+    createPositronLspClientId(): string;
+
+    /**
+     * Convenience method for creating a client id to pass to
+     * `startPositronDap()`. The caller can later remove the client using this
+     * id as well.
+     */
+    createPositronDapClientId(): string;
 
     /**
      * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -53,6 +53,16 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     /** Queue for language server activation/deactivation */
     private _lspQueue: PQueue;
 
+    /**
+     * Promise that resolves after LSP server activation is finished.
+     * Tracked to avoid stopping in the middle of startup.
+     * Resolves to the port number the client should connect on.
+     */
+    private _lspStartingPromise: Promise<number> = Promise.resolve(0);
+
+    /** Client ID for the LSP, used to close the Jupyter comm during deactivation */
+    private _lspClientId?: string;
+
     /** The Jupyter kernel-based implementation of the Language Runtime API */
     private _kernel?: JupyterLanguageRuntimeSession;
 
@@ -489,10 +499,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
     }
 
-    // Keep track of LSP init to avoid stopping in the middle of startup.
-    // Resolves to the port number used to connect on the client side.
-    private _lspStarting: Promise<number> = Promise.resolve(0);
-
     private async createLsp(interpreter: PythonEnvironment): Promise<void> {
         const environmentService = this.serviceContainer.get<IEnvironmentVariablesProvider>(
             IEnvironmentVariablesProvider,
@@ -569,10 +575,11 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             // port since it is in charge of binding to it, which avoids
             // race conditions). We also use this promise to avoid restarting
             // in the middle of initialization.
-            this._lspStarting = this._kernel.startPositronLsp('127.0.0.1');
+            this._lspClientId = this._kernel.createPositronLspClientId();
+            this._lspStartingPromise = this._kernel.startPositronLsp(this._lspClientId, '127.0.0.1');
             let port: number;
             try {
-                port = await this._lspStarting;
+                port = await this._lspStartingPromise;
             } catch (err) {
                 this._kernel.emitJupyterLog(`Error starting Positron LSP: ${err}`, vscode.LogLevel.Error);
                 return;
@@ -619,7 +626,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
             this._kernel?.emitJupyterLog(`Stopping Positron LSP server, reason: ${reason}`);
             await this._lsp.deactivate();
-
+            if (this._lspClientId) {
+                this._kernel?.removeClient(this._lspClientId);
+                this._lspClientId = undefined;
+            }
             this._kernel?.emitJupyterLog(`Positron LSP server stopped`, vscode.LogLevel.Debug);
         });
     }
@@ -637,7 +647,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             // keep track of this state itself.
             const timedOut = await Promise.race([
                 // No need to log LSP start failures here; they're logged on activation.
-                this._lspStarting.ignoreErrors(),
+                this._lspStartingPromise.ignoreErrors(),
                 whenTimeout(400, () => true),
             ]);
             if (timedOut) {

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -83,19 +83,37 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron LSP server, if the
 	 * language runtime supports it.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronLspClientId()`.
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(ipAddress: string): Promise<number>;
+	startPositronLsp(clientId: string, ipAddress: string): Promise<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the
 	 * language runtime supports it.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronDapClientId()`.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(debugType: string, debugName: string): Promise<void>;
+	startPositronDap(clientId: string, debugType: string, debugName: string): Promise<void>;
+
+	/**
+	 * Convenience method for creating a client id to pass to
+	 * `startPositronLsp()`. The caller can later remove the client using this
+	 * id as well.
+	 */
+	createPositronLspClientId(): string;
+
+	/**
+	 * Convenience method for creating a client id to pass to
+	 * `startPositronDap()`. The caller can later remove the client using this
+	 * id as well.
+	 */
+	createPositronDapClientId(): string;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -446,12 +446,12 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	 * Note: This is only useful if the kernel hasn't already started an LSP
 	 * server.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronLspClientId()`.
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	async startPositronLsp(ipAddress: string): Promise<number> {
-		// Create a unique client ID for this instance
-		const clientId = `positron-lsp-${this.runtimeMetadata.languageId}-${createUniqueId()}`;
+	async startPositronLsp(clientId: string, ipAddress: string): Promise<number> {
 		this.log(`Starting LSP server ${clientId} for ${ipAddress}`, vscode.LogLevel.Info);
 
 		// Notify Positron that we're handling messages from this client
@@ -475,10 +475,12 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	 * Requests that the kernel start a Debug Adapter Protocol server, and
 	 * connect it to the client locally on the given TCP address.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronDapClientId()`.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	async startPositronDap(debugType: string, debugName: string) {
+	async startPositronDap(clientId: string, debugType: string, debugName: string) {
 		// NOTE: Ideally we'd connect to any address but the
 		// `debugServer` property passed in the configuration below
 		// needs to be localhost.
@@ -490,8 +492,6 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// The Jupyter kernel spec does not provide a way to query for
 		// supported comms; the only way to know is to try to create one.
 
-		// Create a unique client ID for this instance
-		const clientId = `positron-dap-${this.runtimeMetadata.languageId}-${createUniqueId()}`;
 		this.log(`Starting DAP server ${clientId} for ${ipAddress}`, vscode.LogLevel.Debug);
 
 		// Notify Positron that we're handling messages from this client
@@ -515,6 +515,14 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		// Create the DAP client message handler
 		this._dapClient = new DapClient(clientId, port, debugType, debugName, this);
+	}
+
+	createPositronLspClientId(): string {
+		return `positron-lsp-${this.runtimeMetadata.languageId}-${createUniqueId()}`;
+	}
+
+	createPositronDapClientId(): string {
+		return `positron-dap-${this.runtimeMetadata.languageId}-${createUniqueId()}`;
 	}
 
 	/**

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -84,19 +84,37 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * Convenience method for starting the Positron LSP server, if the
 	 * language runtime supports it.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronLspClientId()`.
 	 * @param ipAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(ipAddress: string): Promise<number>;
+	startPositronLsp(clientId: string, ipAddress: string): Promise<number>;
 
 	/**
 	 * Convenience method for starting the Positron DAP server, if the
 	 * language runtime supports it.
 	 *
+	 * @param clientId The ID of the client comm, created with
+	 *  `createPositronDapClientId()`.
 	 * @param debugType Passed as `vscode.DebugConfiguration.type`.
 	 * @param debugName Passed as `vscode.DebugConfiguration.name`.
 	 */
-	startPositronDap(debugType: string, debugName: string): Promise<void>;
+	startPositronDap(clientId: string, debugType: string, debugName: string): Promise<void>;
+
+	/**
+	 * Convenience method for creating a client id to pass to
+	 * `startPositronLsp()`. The caller can later remove the client using this
+	 * id as well.
+	 */
+	createPositronLspClientId(): string;
+
+	/**
+	 * Convenience method for creating a client id to pass to
+	 * `startPositronDap()`. The caller can later remove the client using this
+	 * id as well.
+	 */
+	createPositronDapClientId(): string;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6848

In https://github.com/posit-dev/positron/issues/6848#issuecomment-2755810421 I thought that maybe `startPositronLsp()` and `startPositronDap()` should return both the port number and client id as _outputs_.

After looking more closely at the fact that we have `createClient()`, which takes `id` as an _input_, and the fact that we have `generateClientId()` to easily create a client id over in `mainThreadLanguageRuntime.ts` (for our "normal" usage of `createClient()`), I've determined that it probably makes sense to follow that pattern here as well.

i.e. the caller uses the new `createPositronLspClientId()` and `createPositronDapClientId()` to create client ids, which allows the caller to:
- Pass the id to `startPositronLsp()` and `startPositronDap()` (same as before)
- Store the id as required, so that it can supply it to `removeClient(id)` during deactivation (new)

There is no longer a proliferation of LSP comms as we switch between multiple consoles, in the images below:

- I start R
    - `positron-lsp-r-3c226c0e` opens, we have 5 open comms
- I start a 2nd R session and switch to it
    - `positron-lsp-r-3c226c0e` closes, we have 4 open comms
    - `positron-lsp-r-505716` opens, we have 5 open comms


<img width="1143" alt="Screenshot 2025-06-11 at 12 48 54 PM" src="https://github.com/user-attachments/assets/20756e58-b67f-4e08-84cb-d5b1bee5f9ce" />

<img width="1117" alt="Screenshot 2025-06-11 at 12 51 06 PM" src="https://github.com/user-attachments/assets/f549097b-2593-40de-98aa-d614139b125a" />

<img width="1137" alt="Screenshot 2025-06-11 at 12 51 12 PM" src="https://github.com/user-attachments/assets/4eb0fb61-70ba-46b6-9748-edf20642bf75" />
