### PR TITLE
Stub in an idea that gets R dev help to refresh

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -433,10 +433,13 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 * @param helpEntry The help entry to add.
 	 */
 	private addHelpEntry(helpEntry: HelpEntry) {
-		// If the help entry being added matches the current help entry, don't open it again.
-		if (this._helpEntries[this._helpEntryIndex]?.sourceUrl === helpEntry.sourceUrl) {
-			return;
-		}
+		// Note: The frontend can't know whether the content underlying the url is fully static or not,
+		// so the frontend should not be in charge of whether or not we re-request the url content.
+		//
+		// // If the help entry being added matches the current help entry, don't open it again.
+		// if (this._helpEntries[this._helpEntryIndex]?.sourceUrl === helpEntry.sourceUrl) {
+		// 	return;
+		// }
 
 		// Splice the help entry into the help entries at the current help entry index and trim the
 		// remaining help entries to 10.


### PR DESCRIPTION
@softwarenerd I think I'm going to need some help from you on this one. I don't anticipate this being merged as is, but I wanted to get some of your thoughts on it now

When writing development documentation for R packages, you typically are in a hot iterative loop of:
- Write some documentation
- Regenerate with `devtools::document()`
- Look at it with `?function_name`
- Tweak the documentation
- Regenerate with `devtools::document()`
- Look at it with `?function_name` (here's where a problem lies)
- Etc

This doesn't currently work with our help server. It pseudo-caches the help url we were previously on, so if you navigate to the same url twice in a row, no refresh occurs. I'm not sure this is right, because I don't think the frontend can really "know" if the url's content is static (much of the time it is) or dynamic (like with dev help in this example) and has changed out from under it.

You currently have to navigate to a completely different page, and then recall `?function_name`, and _then_ it will refresh.

Here is what it currently looks like:

https://github.com/user-attachments/assets/16cbb665-42dc-4ab5-a1ed-1dc7aba6bcd3

Here is what I am expecting it to look like (with this PR idea):

https://github.com/user-attachments/assets/366c9295-176e-49d8-9521-d9f9503009cb

This patch doesn't fully fix all of the problems. There are some issues with the left arrow "navigate backwards" command (shown in the video below), for example:
- Show development `?function_name`
- Show `?abs`
- Tweak development documentation
- Tweak the documentation
- Regenerate with `devtools::document()`
- Use the left arrow to navigate backwards to the `function_name` page

If you do this, we still don't get a refresh. I don't find any evidence that our proxy is even getting a "request" to render this content, so it is possible this issue is deep in the proxy server rather than at the help service level, but I am not sure.

https://github.com/user-attachments/assets/ab861e5a-eaaf-4b57-92a5-eb2d5bd6774e

