### PR TITLE
Implements console font size (#4411)

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -39,24 +39,24 @@ export interface ActivityPromptProps {
  */
 const getConsoleFontInfo = (configurationService: IConfigurationService) => {
 	// Get the console and terminal options
-	const terminalConfig = configurationService.getValue<any>('terminal.integrated');
+	const editorConfig = configurationService.getValue<any>('editor');
 	const consoleFontFamily = configurationService.getValue<string>('console.fontFamily');
 	const consoleFontSize = configurationService.getValue<number>('console.fontSize');
+	const consoleFontWeight = configurationService.getValue<number | string>('console.fontWeight');
+	const consoleFontLigatures = configurationService.getValue<boolean | string>('console.fontLigatures');
+	const consoleFontVariations = configurationService.getValue<boolean | string>('console.fontVariations');
 	const consoleLineHeight = configurationService.getValue<number>('console.lineHeight');
 	const consoleLetterSpacing = configurationService.getValue<number>('console.letterSpacing');
-	const consoleFontWeight = configurationService.getValue<number | string>('console.fontWeight');
-	const consoleFontLigaturesEnabled = configurationService.getValue<boolean>('console.fontLigatures.enabled');
 
 	// Create console-specific options, falling back to terminal settings
 	const consoleOptions = {
-		fontFamily: consoleFontFamily || terminalConfig.fontFamily,
+		fontFamily: consoleFontFamily || editorConfig.fontFamily,
 		fontSize: consoleFontSize,
 		lineHeight: consoleLineHeight,
 		letterSpacing: consoleLetterSpacing,
-		fontWeight: consoleFontWeight ? String(consoleFontWeight) : terminalConfig.fontWeight,
-		fontWeightBold: consoleFontWeight ? String(consoleFontWeight) : terminalConfig.fontWeight,
-		fontLigatures: consoleFontLigaturesEnabled,
-		fontVariations: false // Terminal doesn't use fontVariations like editor
+		fontWeight: consoleFontWeight ? String(consoleFontWeight) : editorConfig.fontWeight,
+		fontLigatures: consoleFontLigatures ? consoleFontLigatures : editorConfig.fontLigatures,
+		fontVariations: consoleFontVariations ? consoleFontVariations : editorConfig.fontVariations,
 	};
 
 	// Use the active window

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -59,8 +59,7 @@ const getConsoleFontInfo = (
 	const consoleLineHeight = configurationService.getValue<number>('console.lineHeight');
 	const consoleLetterSpacing = configurationService.getValue<number>('console.letterSpacing');
 	const consoleFontWeight = configurationService.getValue<number | string>('console.fontWeight');
-	const consoleFontWeightBold = configurationService.getValue<number | string>('console.fontWeightBold');
-	const consoleFontLigaturesEnabled = configurationService.getValue<boolean>('console.fontLigatures.enabled');
+	const consoleFontLigaturesEnabled = configurationService.getValue<boolean | string>('console.fontLigatures');
 
 	// Create console-specific options, falling back to terminal settings
 	const consoleOptions = {
@@ -69,7 +68,6 @@ const getConsoleFontInfo = (
 		lineHeight: consoleLineHeight,
 		letterSpacing: consoleLetterSpacing,
 		fontWeight: consoleFontWeight ? String(consoleFontWeight) : terminalConfig.fontWeight,
-		fontWeightBold: consoleFontWeightBold ? String(consoleFontWeightBold) : terminalConfig.fontWeightBold,
 		fontLigatures: consoleFontLigaturesEnabled,
 		fontVariations: false
 	};
@@ -244,13 +242,18 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			configurationChangeEvent => {
 				// When something in the terminal or console changes, determine whether it's font-related
 				// and, if it is, apply the new font info to the container.
-				if (configurationChangeEvent.affectedKeys.has('terminal.integrated.fontFamily') ||
+				if (
+					configurationChangeEvent.affectedKeys.has('editor.fontFamily') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontWeight') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontLigatures') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontVariations') ||
 					configurationChangeEvent.affectedKeys.has('console.fontFamily') ||
 					configurationChangeEvent.affectedKeys.has('console.fontWeight') ||
-					configurationChangeEvent.affectedKeys.has('console.fontWeightBold') ||
 					configurationChangeEvent.affectedKeys.has('console.fontSize') ||
 					configurationChangeEvent.affectedKeys.has('console.lineHeight') ||
-					configurationChangeEvent.affectedKeys.has('console.fontLigatures.enabled')
+					configurationChangeEvent.affectedKeys.has('console.letterSpacing') ||
+					configurationChangeEvent.affectedKeys.has('console.fontLigatures') ||
+					configurationChangeEvent.affectedKeys.has('console.fontVariations')
 				) {
 					// Get the font info.
 					const editorFontInfo = getConsoleFontInfo(

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -14,6 +14,7 @@ import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContaine
 import { PositronConsoleViewPane } from './positronConsoleView.js';
 import { registerPositronConsoleActions } from './positronConsoleActions.js';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+import { registerConsoleConfiguration } from '../../../services/positronConsole/browser/positronConsoleService.js';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from './positronConsoleIdentifiers.js';
@@ -110,3 +111,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 // Register all the Positron console actions.
 registerPositronConsoleActions();
+
+// Register console configuration
+registerConsoleConfiguration();

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -179,18 +179,97 @@ const consoleServiceConfigurationBaseNode = Object.freeze<IConfigurationNode>({
  * The scrollback size setting.
  */
 export const scrollbackSizeSettingId = 'console.scrollbackSize';
-configurationRegistry.registerConfiguration({
+export const consoleFontSizeSettingId = 'console.fontSize';
+export const consoleFontFamilySettingId = 'console.fontFamily';
+export const consoleFontWeightSettingId = 'console.fontWeight';
+export const consoleFontWeightBoldSettingId = 'console.fontWeightBold';
+export const consoleLineHeightSettingId = 'console.lineHeight';
+export const consoleLetterSpacingSettingId = 'console.letterSpacing';
+export const consoleFontLigaturesEnabledSettingId = 'console.fontLigatures.enabled';
+
+const consoleConfiguration = {
 	...consoleServiceConfigurationBaseNode,
 	properties: {
 		'console.scrollbackSize': {
-			type: 'number',
+			type: 'number' as const,
 			'minimum': 500,
 			'maximum': 5000,
 			'default': 1000,
 			markdownDescription: localize('console.scrollbackSize', "The number of console output items to display."),
+		},
+		'console.fontFamily': {
+			type: 'string' as const,
+			markdownDescription: localize('console.fontFamily', "Controls the font family of the console. Defaults to {0}'s value.", '`#terminal.integrated.fontFamily#`'),
+			default: ''
+		},
+		'console.fontSize': {
+			type: 'number' as const,
+			minimum: 6,
+			maximum: 100,
+			markdownDescription: localize('console.fontSize', "Controls the font size in pixels of the console."),
+			default: 12
+		},
+		'console.lineHeight': {
+			type: 'number' as const,
+			minimum: 1,
+			maximum: 8,
+			markdownDescription: localize('console.lineHeight', "Controls the line height of the console. This number is multiplied by the terminal font size to get the actual line-height in pixels."),
+			default: 1
+		},
+		'console.letterSpacing': {
+			type: 'number' as const,
+			markdownDescription: localize('console.letterSpacing', "Controls the letter spacing of the console. This is an integer value which represents the number of additional pixels to add between characters."),
+			default: 0
+		},
+		'console.fontWeight': {
+			anyOf: [
+				{
+					type: 'number' as const,
+					minimum: 1,
+					maximum: 1000,
+					errorMessage: localize('console.fontWeightError', "Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.")
+				},
+				{
+					type: 'string' as const,
+					pattern: '^(normal|bold|1000|[1-9][0-9]{0,2})$'
+				},
+				{
+					enum: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900']
+				}
+			],
+			markdownDescription: localize('console.fontWeight', "Controls the font weight of the console. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000."),
+			default: 'normal'
+		},
+		'console.fontWeightBold': {
+			anyOf: [
+				{
+					type: 'number' as const,
+					minimum: 1,
+					maximum: 1000,
+					errorMessage: localize('console.fontWeightBoldError', "Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.")
+				},
+				{
+					type: 'string' as const,
+					pattern: '^(normal|bold|1000|[1-9][0-9]{0,2})$'
+				},
+				{
+					enum: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900']
+				}
+			],
+			markdownDescription: localize('console.fontWeightBold', "Controls the font weight for bold text in the console. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000."),
+			default: 'bold'
+		},
+		'console.fontLigatures.enabled': {
+			type: 'boolean' as const,
+			markdownDescription: localize('console.fontLigatures.enabled', "Controls whether font ligatures are enabled in the console."),
+			default: false
 		}
 	}
-});
+};
+
+export function registerConsoleConfiguration(): void {
+	configurationRegistry.registerConfiguration(consoleConfiguration);
+}
 
 /**
  * PositronConsoleService class.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -182,10 +182,9 @@ export const scrollbackSizeSettingId = 'console.scrollbackSize';
 export const consoleFontSizeSettingId = 'console.fontSize';
 export const consoleFontFamilySettingId = 'console.fontFamily';
 export const consoleFontWeightSettingId = 'console.fontWeight';
-export const consoleFontWeightBoldSettingId = 'console.fontWeightBold';
 export const consoleLineHeightSettingId = 'console.lineHeight';
 export const consoleLetterSpacingSettingId = 'console.letterSpacing';
-export const consoleFontLigaturesEnabledSettingId = 'console.fontLigatures.enabled';
+export const consoleFontLigaturesEnabledSettingId = 'console.fontLigatures';
 
 const consoleConfiguration = {
 	...consoleServiceConfigurationBaseNode,
@@ -199,7 +198,7 @@ const consoleConfiguration = {
 		},
 		'console.fontFamily': {
 			type: 'string' as const,
-			markdownDescription: localize('console.fontFamily', "Controls the font family of the console. Defaults to {0}'s value.", '`#terminal.integrated.fontFamily#`'),
+			markdownDescription: localize('console.fontFamily', "Controls the font family of the console. Defaults to {0}'s value.", '`#editor.fontFamily#`'),
 			default: ''
 		},
 		'console.fontSize': {
@@ -240,28 +239,32 @@ const consoleConfiguration = {
 			markdownDescription: localize('console.fontWeight', "Controls the font weight of the console. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000."),
 			default: 'normal'
 		},
-		'console.fontWeightBold': {
+		'console.fontLigatures': {
 			anyOf: [
 				{
-					type: 'number' as const,
-					minimum: 1,
-					maximum: 1000,
-					errorMessage: localize('console.fontWeightBoldError', "Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.")
+					type: 'boolean' as const,
+					description: localize('console.fontLigatures.boolean', "Enables/Disables font ligatures ('calt' and 'liga' font features) in the console. Change this to a string for fine-grained control of the 'font-feature-settings' CSS property."),
 				},
 				{
 					type: 'string' as const,
-					pattern: '^(normal|bold|1000|[1-9][0-9]{0,2})$'
-				},
-				{
-					enum: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900']
+					description: localize('console.fontLigatures.string', "Explicit 'font-feature-settings' CSS property for the console. A boolean can be passed instead if one only needs to turn on/off ligatures.")
 				}
 			],
-			markdownDescription: localize('console.fontWeightBold', "Controls the font weight for bold text in the console. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000."),
-			default: 'bold'
+			markdownDescription: localize('console.fontLigatures', "Configures font ligatures or font features in the console. Can be either a boolean to enable/disable ligatures or a string for the value of the CSS 'font-feature-settings' property."),
+			default: false
 		},
-		'console.fontLigatures.enabled': {
-			type: 'boolean' as const,
-			markdownDescription: localize('console.fontLigatures.enabled', "Controls whether font ligatures are enabled in the console."),
+		'console.fontVariations': {
+			anyOf: [
+				{
+					type: 'boolean' as const,
+					description: localize('console.fontVariations.boolean', "Enables/Disables the translation from font-weight to font-variation-settings. Change this to a string for fine-grained control of the 'font-variation-settings' CSS property."),
+				},
+				{
+					type: 'string' as const,
+					description: localize('console.fontVariations.string', "Explicit 'font-variation-settings' CSS property. A boolean can be passed instead if one only needs to translate font-weight to font-variation-settings.")
+				}
+			],
+			markdownDescription: localize('console.fontVariations', "Configures font variations. Can be either a boolean to enable/disable the translation from font-weight to font-variation-settings or a string for the value of the CSS 'font-variation-settings' property."),
 			default: false
 		}
 	}


### PR DESCRIPTION
- **Implement console font settings (#4411)**


### Release Notes

#### New Features

- Add configuration settings to change the font of the Console. Previously, the editor font settings were used. 

#### Bug Fixes

- N/A


### QA Notes

I tested this in a debug build of Positron