### PR TITLE
Assistant: Language model configuration notice refinements

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -191,14 +191,18 @@ const ProviderNotice = (props: { provider: IProvider }) => {
 		(key) => {
 			switch (key) {
 				case 'posit-eula':
-					return <a href='https://posit.co/about/eula/'>{positEulaLabel}</a>;
+					return <ExternalLink href='https://posit.co/about/eula/'>{positEulaLabel}</ExternalLink>;
 				case 'provider-tos': {
 					const link = getProviderTermsOfServiceLink(props.provider.id);
-					return link ? <a href={link}>{providerTermsOfServiceLabel}</a> : providerTermsOfServiceLabel;
+					return link ?
+						<ExternalLink href={link}>{providerTermsOfServiceLabel}</ExternalLink> :
+						providerTermsOfServiceLabel;
 				}
 				case 'provider-privacy-policy': {
 					const link = getProviderPrivacyPolicyLink(props.provider.id);
-					return link ? <a href={link}>{providerPrivacyPolicyLabel}</a> : providerPrivacyPolicyLabel;
+					return link ?
+						<ExternalLink href={link}>{providerPrivacyPolicyLabel}</ExternalLink> :
+						providerPrivacyPolicyLabel;
 				}
 				default:
 					return undefined;
@@ -213,4 +217,10 @@ const ProviderNotice = (props: { provider: IProvider }) => {
 		<p>{termsOfService}</p>
 		<p>{disclaimerText}</p>
 	</div>;
+}
+
+const ExternalLink = (props: { href: string, children: React.ReactNode }) => {
+	return <a href={props.href} rel='noreferrer' target='_blank'>
+		{props.children}
+	</a>;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -9,7 +9,6 @@ import { localize } from '../../../../../nls.js'
 import { LabeledTextInput } from '../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js'
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js'
 import { LanguageModelUIConfiguration } from '../languageModelModalDialog.js'
-import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.js'
 import { AuthMethod } from '../types.js'
 
 interface LanguageModelConfigComponentProps {
@@ -22,39 +21,128 @@ interface LanguageModelConfigComponentProps {
 	onCancel: () => void,
 }
 
-export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
-	function getTos(provider: string): string {
-		const providerConfig = new Array<string>();
+const knownProviders = ['anthropic', 'google', 'copilot'] as const;
+type Provider = typeof knownProviders[number];
 
-		switch (provider) {
-			case 'anthropic':
-				providerConfig.push('Anthropic');
-				providerConfig.push('[Terms of Service](https://www.anthropic.com/legal/consumer-terms)');
-				providerConfig.push('[Privacy Policy](https://www.anthropic.com/legal/privacy)');
-				break;
-			case 'google':
-				providerConfig.push('Google Gemini');
-				providerConfig.push('[Terms of Service](https://cloud.google.com/terms/service-terms)');
-				providerConfig.push('[Privacy Policy](https://policies.google.com/privacy)');
-				break;
-			case 'copilot':
-				providerConfig.push('GitHub Copilot');
-				providerConfig.push('[Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)');
-				providerConfig.push('[Privacy Policy](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)');
-				break;
-			default:
-				return '';
-		}
+const positEulaLabel = localize('positron.languageModelConfig.positEula', 'Posit EULA');
+const completionsOnlyEmphasizedText = localize('positron.languageModelConfig.completionsOnly', 'code completions only');
+const providerTermsOfServiceLabel = localize('positron.languageModelConfig.termsOfService', 'Terms of Service');
+const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privacyPolicy', 'Privacy Policy');
 
-		return localize('positron.newConnectionModalDialog.tos',
-			'{0} is considered "Third Party Materials" as defined in the [Posit EULA](https://posit.co/about/eula/) and subject to the {0} terms of service at {1} and privacy policy at {2}.\n\nYour use of {0} is optional and at your sole risk.',
-			...providerConfig
+function isKnownProvider(provider: string): provider is Provider {
+	return knownProviders.includes(provider as Provider);
+}
+
+function getProviderCompletionsOnlyNoticeText(provider: Provider) {
+	return localize(
+		'positron.languageModelConfig.completionsOnlyNotice',
+		'{0} functions for {code-completions-only} in Positron at this time.',
+		getProviderDisplayName(provider),
+	);
+}
+
+function getProviderTermsOfServiceText(provider: Provider) {
+	return localize(
+		'positron.languageModelConfig.tos',
+		'{0} is considered "Third Party Materials" as defined in the {posit-eula} and subject to the {0} {provider-tos} and {provider-privacy-policy}.',
+		getProviderDisplayName(provider),
+	);
+}
+
+function getProviderUsageDisclaimerText(provider: Provider) {
+	return localize(
+		'positron.languageModelConfig.tos2',
+		'Your use of {0} is optional and at your sole risk.',
+		getProviderDisplayName(provider),
+	);
+}
+
+function getProviderDisplayName(provider: Provider) {
+	switch (provider) {
+		case 'anthropic':
+			return 'Anthropic';
+		case 'google':
+			return 'Google Gemini';
+		case 'copilot':
+			return 'GitHub Copilot';
+	}
+}
+
+function getProviderTermsOfServiceLink(provider: Provider) {
+	switch (provider) {
+		case 'anthropic':
+			return 'https://www.anthropic.com/legal/consumer-terms';
+		case 'google':
+			return 'https://cloud.google.com/terms/service-terms';
+		case 'copilot':
+			return 'https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot';
+	}
+}
+
+function getProviderPrivacyPolicyLink(provider: Provider) {
+	switch (provider) {
+		case 'anthropic':
+			return 'https://www.anthropic.com/legal/privacy';
+		case 'google':
+			return 'https://policies.google.com/privacy';
+		case 'copilot':
+			return 'https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect';
+	}
+}
+
+function getProviderCompletionsOnlyNotice(provider: Provider) {
+	if (provider === 'copilot') {
+		const text = getProviderCompletionsOnlyNoticeText(provider);
+		return interpolate(
+			text,
+			(key) => key === 'code-completions-only' ?
+				<strong>{completionsOnlyEmphasizedText}</strong> :
+				undefined
 		);
 	}
+	return undefined;
+}
 
+/**
+ * Interpolates placeholders in a string with React nodes.
+ *
+ * Scans the input `text` for placeholders in the form `{key}` and replaces each with the result of the `value` function.
+ * If `value(key)` returns `undefined`, the original placeholder is left in place.
+ *
+ * @param text The input string containing zero or more `{key}` placeholders.
+ * @param value A function that takes a key and returns a React node to replace the corresponding placeholder, or `undefined` to leave it unchanged.
+ * @returns An array of React nodes and strings representing the interpolated text.
+ */
+function interpolate(text: string, value: (key: string) => React.ReactNode | undefined): React.ReactNode[] {
+	const nodes: React.ReactNode[] = [];
+	let index = 0;
+	for (const match of text.matchAll(/\{([^\}]+)\}/g)) {
+		// Push text before the match, if any.
+		if (index < match.index) {
+			nodes.push(text.slice(index, match.index));
+		}
+
+		// Push the interpolated value, if there is one, or the original text.
+		const key = match[1];
+		const replacement = value(key) ?? match[0];
+		nodes.push(replacement);
+
+		// Bump the index.
+		index = match.index + match[0].length;
+	}
+
+	// Push remaining text.
+	if (index < text.length) {
+		nodes.push(text.slice(index));
+	}
+
+	return nodes;
+}
+
+export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const apiKeySpecified = props.source.supportedOptions.includes(AuthMethod.API_KEY) && !!props.provider.apiKey && props.provider.apiKey.length > 0;
 
-	return (<>
+	return <>
 		<div className='language-model-container input'>
 			{props.source.supportedOptions.includes('apiKey') && !props.source.signedIn && (
 				<ApiKey apiKey={props.provider.apiKey} signedIn={props.source.signedIn} onChange={(newApiKey) => {
@@ -65,14 +153,12 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 			{
 				props.signingIn && props.provider.oauth && !props.source.signedIn &&
 				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
-					{localize('positron.newConnectionModalDialog.cancel', "Cancel")}
+					{localize('positron.languageModelConfig.cancel', "Cancel")}
 				</Button>
 			}
 		</div>
-		<div className='language-model-dialog-tos' id='model-tos'>
-			<EmbeddedLink>{getTos(props.provider.provider)}</EmbeddedLink>
-		</div>
-	</>)
+		{isKnownProvider(props.provider.provider) ? <ProviderNotice provider={props.provider.provider} /> : null}
+	</>;
 }
 
 // Language config parts
@@ -81,7 +167,7 @@ const ApiKey = (props: { apiKey?: string, signedIn?: boolean, onChange: (newApiK
 		<div className='language-model-authentication-container' id='api-key-input'>
 			<LabeledTextInput
 				disabled={props.signedIn}
-				label={(() => localize('positron.newConnectionModalDialog.apiKey', "API Key"))()}
+				label={(() => localize('positron.languageModelConfig.apiKey', "API Key"))()}
 				type='password'
 				value={props.apiKey ?? ''}
 				onChange={e => { props.onChange(e.currentTarget.value) }} />
@@ -100,10 +186,43 @@ const SignInButton = (props: { apiKeySpecified: boolean, authMethod: AuthMethod,
 	>
 		{(() => {
 			if (props.signedIn) {
-				return localize('positron.newConnectionModalDialog.signOut', "Sign out");
+				return localize('positron.languageModelConfig.signOut', "Sign out");
 			} else {
-				return localize('positron.newConnectionModalDialog.signIn', "Sign in");
+				return localize('positron.languageModelConfig.signIn', "Sign in");
 			}
 		})()}
 	</Button>
+}
+
+const ProviderNotice = (props: { provider: Provider }) => {
+	const completionsOnlyNotice = getProviderCompletionsOnlyNotice(props.provider);
+
+	const termsOfServiceText = getProviderTermsOfServiceText(props.provider);
+	const termsOfService = interpolate(
+		termsOfServiceText,
+		(key) => {
+			switch (key) {
+				case 'posit-eula':
+					return <a href='https://posit.co/about/eula/'>{positEulaLabel}</a>;
+				case 'provider-tos': {
+					const link = getProviderTermsOfServiceLink(props.provider);
+					return <a href={link}>{providerTermsOfServiceLabel}</a>;
+				}
+				case 'provider-privacy-policy': {
+					const link = getProviderPrivacyPolicyLink(props.provider);
+					return <a href={link}>{providerPrivacyPolicyLabel}</a>;
+				}
+				default:
+					return undefined;
+			}
+		},
+	)
+
+	const disclaimerText = getProviderUsageDisclaimerText(props.provider);
+
+	return <div className='language-model-dialog-tos' id='model-tos'>
+		{completionsOnlyNotice ? <p>{completionsOnlyNotice}</p> : null}
+		<p>{termsOfService}</p>
+		<p>{disclaimerText}</p>
+	</div>;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -124,6 +124,10 @@
 	font-size: 0.7rem;
 }
 
+#model-tos a {
+	color: var(--vscode-textLink-foreground);
+}
+
 .language-model-modal-dialog .ok-action-bar.top-separator {
 	border-top: none;
 	padding-bottom: 16px;


### PR DESCRIPTION
Addresses #7614. Also refactored to support styling localized text in the notice, and reworded slightly. Details below.

#### GitHub code completions only notice

<img width="598" alt="image" src="https://github.com/user-attachments/assets/8cb8a42d-ff9f-4971-8c9a-dd6a1850cb01" />

#### Slightly reworded the notice

Wording before:

> ... and subject to the {provider} terms of service at [Terms of Service]() and privacy policy at [Privacy Policy]().

Wording after:

> ... and subject to the {provider} [Terms of Service]() and [Privacy Policy]().

<img width="598" alt="image" src="https://github.com/user-attachments/assets/b73971ed-2e80-4a6e-94fe-51e2d1a0f4f6" />

#### Use registered provider display names

We now use the display name that the models are registered with. The only change is that where we used to say "Google Gemini" in the ToS notice we now say "Gemini Code Assist". Is that what we want or no?

#### Handling when ToS links are not known

We now display the notice even when ToS links are not known, just as plain text. Is that what we want?

For example, AWS Bedrock:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/7c244fa6-b024-4c50-96cb-bee906dbd340" />