### PR TITLE
Assistant: Add Agent mode

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -44,6 +44,19 @@
         ]
       },
       {
+        "id": "positron.assistant.agent",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.agent.description%",
+        "isDefault": true,
+        "locations": [
+          "panel"
+        ],
+        "modes": [
+          "agent"
+        ]
+      },
+      {
         "id": "positron.assistant.terminal",
         "name": "assistant",
         "fullName": "%chatParticipants.fullName%",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -8,6 +8,7 @@
 	"commands.category": "Positron Assistant",
 	"chatParticipants.fullName": "Positron Assistant",
 	"chatParticipants.ask.description": "Ask Assistant",
+	"chatParticipants.agent.description": "Complete tasks in your workspace",
 	"chatParticipants.edit.description": "Edit files in your workspace",
 	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document.",
 	"configuration.title": "Positron Assistant",

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -1,0 +1,33 @@
+You will be given a task that may require editing multiple files and executing
+code to achieve.
+
+You will be provided with a tool that executes code. Use this tool to help the
+user complete tasks when the user gives you an imperative statement, or asks a
+question that can be answered by executing code. When you use this tool, the
+user can see the code you are executing, so you don't need to show it to them
+afterwards.
+
+If the user asks you _how_ to do something, or asks for code rather than
+results, generate the code and return it directly without trying to execute it.
+
+**Package Management Workflow:**
+
+1. Before generating code that requires packages, you must first use the appropriate tool to check if each required package is installed. To do so, first determine the target language from the user's request or context
+2. Always check package status first using the appropriate language-specific tool:
+   - For R, use the getAttachedRPackages and getInstalledRPackageVersion tools
+   - For Python, use the getAttachedPythonPackages and getInstalledPythonPackageVersion tools
+   - For other languages, use the tool following the patterns getAttached{Language}Packages and getInstalled{Language}PackageVersion where {Language} is the target language
+   - If these tools are unavailable, assume the packages are not loaded or installed
+3. For each required package, follow this decision process.
+   - First check it's loaded/attached using the appropriate tool
+   - If loaded, do not generate code to load or install it again. Skip and proceed with your code.
+   - If not loaded, check if it is installed
+     - If installed, provide code to load or import the package once
+     - If not installed, provide installation code first, then import/library code once
+     - If providing additional code in this conversation using this package, use the tool again to check if the package is loaded.
+   - If the package checking tool is NOT available:
+     - Always provide both installation AND import code once
+     - Put installation code in a separate code block with clear instructions that installation only needs to be done once
+4. Never use Python tools when generating R code, or R tools when generating Python code
+5. Never instruct users to install, load, or import packages that are already loaded in their session
+6. Do not generate conditional code (if/then statements) to check package availability. Use the provided tools to determine package status and generate only the necessary installation or loading code based on the tool results

--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -4,34 +4,3 @@ Before the user makes their request, they will provide some context about the ru
 
 Depending on the user's question, this context might not be useful. Just ignore the extra context if it is not useful.
 Do not mention the context if it is irrelevant, but just keep it in mind when responding in case it becomes relevant.
-
-You will be provided with a tool that executes code. Use this tool to help the
-user complete tasks when the user gives you an imperative statement, or asks a
-question that can be answered by executing code. When you use this tool, the
-user can see the code you are executing, so you don't need to show it to them
-afterwards.
-
-If the user asks you _how_ to do something, or asks for code rather than
-results, generate the code and return it directly without trying to execute it.
-
-**Package Management Workflow:**
-
-1. Before generating code that requires packages, you must first use the appropriate tool to check if each required package is installed. To do so, first determine the target language from the user's request or context
-2. Always check package status first using the appropriate language-specific tool:
-   - For R, use the getAttachedRPackages and getInstalledRPackageVersion tools
-   - For Python, use the getAttachedPythonPackages and getInstalledPythonPackageVersion tools
-   - For other languages, use the tool following the patterns getAttached{Language}Packages and getInstalled{Language}PackageVersion where {Language} is the target language
-   - If these tools are unavailable, assume the packages are not loaded or installed
-3. For each required package, follow this decision process.
-   - First check it's loaded/attached using the appropriate tool
-   - If loaded, do not generate code to load or install it again. Skip and proceed with your code.
-   - If not loaded, check if it is installed
-     - If installed, provide code to load or import the package once
-     - If not installed, provide installation code first, then import/library code once
-     - If providing additional code in this conversation using this package, use the tool again to check if the package is loaded.
-   - If the package checking tool is NOT available:
-     - Always provide both installation AND import code once
-     - Put installation code in a separate code block with clear instructions that installation only needs to be done once
-4. Never use Python tools when generating R code, or R tools when generating Python code
-5. Never instruct users to install, load, or import packages that are already loaded in their session
-6. Do not generate conditional code (if/then statements) to check package availability. Use the provided tools to determine package status and generate only the necessary installation or loading code based on the tool results

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -24,6 +24,9 @@ export enum ParticipantID {
 	/** The participant used in the chat pane in Edit mode. */
 	Edit = 'positron.assistant.editingSessionEditor',
 
+	/** The participant used in the chat pane in Agent mode. */
+	Agent = 'positron.assistant.agent',
+
 	/** The participant used in editor inline chats. */
 	Editor = 'positron.assistant.editor',
 
@@ -199,7 +202,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					case PositronAssistantToolName.ExecuteCode:
 						return inChatPane &&
 							// The execute code tool does not yet support notebook sessions.
-							positronContext.activeSession?.mode !== positron.LanguageRuntimeSessionMode.Notebook;
+							positronContext.activeSession?.mode !== positron.LanguageRuntimeSessionMode.Notebook &&
+							this.id === ParticipantID.Agent;
 					// Only include the documentEdit tool in an editor and if there is
 					// no selection.
 					case PositronAssistantToolName.DocumentEdit:
@@ -575,6 +579,17 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 	}
 }
 
+/** The participant used in the chat pane in Agent mode. */
+export class PositronAssistantAgentParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
+	id = ParticipantID.Agent;
+
+	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string> {
+		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
+		const agent = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'agent.md'), 'utf8');
+		return defaultSystem + '\n\n' + agent;
+	}
+}
+
 /** The participant used in terminal inline chats. */
 class PositronAssistantTerminalParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
 	id = ParticipantID.Terminal;
@@ -679,6 +694,7 @@ export function registerParticipants(context: vscode.ExtensionContext) {
 
 	// Register the Positron Assistant chat participants.
 	participantService.registerParticipant(new PositronAssistantChatParticipant(context));
+	participantService.registerParticipant(new PositronAssistantAgentParticipant(context));
 	participantService.registerParticipant(new PositronAssistantTerminalParticipant(context));
 	participantService.registerParticipant(new PositronAssistantEditorParticipant(context));
 	participantService.registerParticipant(new PositronAssistantNotebookParticipant(context));

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -212,12 +212,14 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					// a selection.
 					case PositronAssistantToolName.SelectionEdit:
 						return inEditor && hasSelection;
-					// Only include the edit file tool in edit mode i.e. for the edit participant.
+					// Only include the edit file tool in edit or agent mode i.e. for the edit participant.
 					case PositronAssistantToolName.EditFile:
-						return this.id === ParticipantID.Edit;
+						return this.id === ParticipantID.Edit || this.id === ParticipantID.Agent;
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
+					// Allow all tools in Agent mode.
 					default:
-						return tool.tags.includes('positron-assistant');
+						return this.id === ParticipantID.Agent ||
+							tool.tags.includes('positron-assistant');
 				}
 			}
 		);


### PR DESCRIPTION
This is the minimal change to enable Agent mode in Positron Assistant. There's more we'll want to do with this mode soon, but I'd like to get it unlocked for folks.

Probably the most controversial part of this change is that I've enabled pretty much all tools when using Agent mode (no filters). This gives Agent access to things like MCP servers as well as a handful of built-in tools and those provided by extensions, even if they are not tagged for use with Assistant. Given the recent explosion in MCP servers and tool availability I think we may need to reverse our approach and exclude a list of known-problematic tools rather than requiring tools to opt in. 

Addresses #8018. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add Agent mode to Positron Assistant; note that you'll now need to use this new mode if you want Assistant to run code on your behalf. (#8018)

#### Bug Fixes

- N/A


### QA Notes

As noted in the release notes, this change _removes_ the code execution tool from _Ask_ and _Edit_ modes, meaning that Positron will only ever suggest code in these modes.

Right now, if you try to configure the set of tools available to Agent, you'll only see a couple of Jupyter tools (and ones that aren't relevant at that). We will address this soon.

Test tags: `@:assistant`