### PR TITLE
assistant: don't register `vscode_editFile_internal`

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/tools.ts
@@ -7,7 +7,12 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
+// --- Start Positron ---
+// Import is not used because the vscode_editFile_internal tool is not used in Positron.
+/*
 import { EditTool, EditToolData } from './editFileTool.js';
+*/
+// --- End Positron ---
 
 // --- Start Positron ---
 /**
@@ -26,9 +31,15 @@ export class BuiltinToolsContribution extends Disposable implements IWorkbenchCo
 	) {
 		super();
 
+		// --- Start Positron ---
+		// Don't register the vscode_editFile_internal in Positron, as it is not used: src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+		// Instead, the positron_editFile_internal tool is used: src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+		/*
 		const editTool = instantiationService.createInstance(EditTool);
 		this._register(toolsService.registerToolData(EditToolData));
 		this._register(toolsService.registerToolImplementation(EditToolData.id, editTool));
+		*/
+		// --- End Positron ---
 	}
 }
 


### PR DESCRIPTION
### Summary

- addresses #8097 by commenting out the registration of the tool

### QA Notes

I tested this by adding a log statement right after the line where we register the log output channel in the assistant extension:

https://github.com/posit-dev/positron/blob/18bab8b068f20dcc7ee7b820bb04def872dfa783/extensions/positron-assistant/src/extension.ts#L264-L267

- add this line
    ```ts
    log.info(`vscode.lm.tools: ${JSON.stringify(vscode.lm.tools, null, 2)}`);
    ```

Then, build and open up Positron, go to the Output pane and look at the Assistant logs.

Searching for `editFile` in the logs should only yield the `positron_editFile_internal` tool and not the `vscode_editFile_internal` one as well.