### PR TITLE
Add up / down console input history navigation actions so users can bind custom keys to them

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -575,6 +575,31 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				break;
 			}
 
+			// Up arrow processing.
+			case KeyCode.UpArrow: {
+				if (cmdOrCtrlKey && !historyBrowserActiveRef.current) {
+					// If the cmd or ctrl key is pressed, and the history
+					// browser is not up, engage the history browser with the
+					// prefix match strategy. This behavior mimics RStudio.
+					const entries =
+						positronConsoleContext.executionHistoryService.getInputEntries(
+							props.positronConsoleInstance.runtimeMetadata.languageId
+						);
+					engageHistoryBrowser(new HistoryPrefixMatchStrategy(entries));
+					consumeEvent();
+					break;
+				} else {
+					navigateHistoryUp(e);
+				}
+				break;
+			}
+
+			// Down arrow processing.
+			case KeyCode.DownArrow: {
+				navigateHistoryDown(e);
+				break;
+			}
+
 			// Bind Home key to `cursorLineStart` (same as Ctrl+A)
 			case KeyCode.Home: {
 				if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -634,6 +634,12 @@ export function registerPositronConsoleActions() {
 			const positronConsoleService = accessor.get(IPositronConsoleService);
 			if (positronConsoleService.activePositronConsoleInstance) {
 				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryDown();
+			} else {
+				accessor.get(INotificationService).notify({
+					severity: Severity.Info,
+					message: localize('positron.navigateInputHistory.noActiveConsole', "Cannot navigate input history. A console is not active."),
+					sticky: false
+				});
 			}
 		}
 	});
@@ -666,6 +672,12 @@ export function registerPositronConsoleActions() {
 			const positronConsoleService = accessor.get(IPositronConsoleService);
 			if (positronConsoleService.activePositronConsoleInstance) {
 				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryUp(false);
+			} else {
+				accessor.get(INotificationService).notify({
+					severity: Severity.Info,
+					message: localize('positron.navigateInputHistory.noActiveConsole', "Cannot navigate input history. A console is not active."),
+					sticky: false
+				});
 			}
 		}
 	});
@@ -698,6 +710,12 @@ export function registerPositronConsoleActions() {
 			const positronConsoleService = accessor.get(IPositronConsoleService);
 			if (positronConsoleService.activePositronConsoleInstance) {
 				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryUp(true);
+			} else {
+				accessor.get(INotificationService).notify({
+					severity: Severity.Info,
+					message: localize('positron.navigateInputHistory.noActiveConsole', "Cannot navigate input history. A console is not active."),
+					sticky: false
+				});
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -623,11 +623,6 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				keybinding: {
-					when: PositronConsoleFocused,
-					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyCode.DownArrow,
-				},
 			});
 		}
 
@@ -660,11 +655,6 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				keybinding: {
-					when: PositronConsoleFocused,
-					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyCode.UpArrow,
-				},
 			});
 		}
 
@@ -697,11 +687,6 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				keybinding: {
-					when: PositronConsoleFocused,
-					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyMod.CtrlCmd | KeyCode.UpArrow
-				},
 			});
 		}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -40,6 +40,9 @@ const enum PositronConsoleCommandId {
 	ClearInputHistory = 'workbench.action.positronConsole.clearInputHistory',
 	ExecuteCode = 'workbench.action.positronConsole.executeCode',
 	FocusConsole = 'workbench.action.positronConsole.focusConsole',
+	NavigateInputHistoryDown = 'workbench.action.positronConsole.navigateInputHistoryDown',
+	NavigateInputHistoryUp = 'workbench.action.positronConsole.navigateInputHistoryUp',
+	NavigateInputHistoryUpUsingPrefixMatch = 'workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch',
 }
 
 /**
@@ -110,46 +113,6 @@ export function registerPositronConsoleActions() {
 					sticky: false
 				});
 			}
-		}
-	});
-
-	/**
-	 * Register the focus console action. This action places focus in the active console,
-	 * if one exists.
-	 *
-	 * This action is equivalent to the `workbench.panel.positronConsole.focus` command.
-	 */
-	registerAction2(class extends Action2 {
-		/**
-		 * Constructor.
-		 */
-		constructor() {
-			super({
-				id: PositronConsoleCommandId.FocusConsole,
-				title: {
-					value: localize('workbench.action.positronConsole.focusConsole', "Focus Console"),
-					original: 'Focus Console'
-				},
-				f1: true,
-				keybinding: {
-					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyF)
-				},
-				category,
-			});
-		}
-
-		/**
-		 * Runs action; places focus in the console's input control.
-		 *
-		 * @param accessor The services accessor.
-		 */
-		async run(accessor: ServicesAccessor) {
-			const viewsService = accessor.get(IViewsService);
-
-			// Ensure that the panel and console are visible. This is essentially
-			// equivalent to what `workbench.panel.positronConsole.focus` does.
-			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
 		}
 	});
 
@@ -600,6 +563,157 @@ export function registerPositronConsoleActions() {
 				text: '\n'
 			};
 			model.pushEditOperations([], [editOperation], () => []);
+		}
+	});
+
+	/**
+	 * Register the focus console action. This action places focus in the active console,
+	 * if one exists.
+	 *
+	 * This action is equivalent to the `workbench.panel.positronConsole.focus` command.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.FocusConsole,
+				title: {
+					value: localize('workbench.action.positronConsole.focusConsole', "Focus Console"),
+					original: 'Focus Console'
+				},
+				f1: true,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyF)
+				},
+				category,
+			});
+		}
+
+		/**
+		 * Runs action; places focus in the console's input control.
+		 *
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const viewsService = accessor.get(IViewsService);
+
+			// Ensure that the panel and console are visible. This is essentially
+			// equivalent to what `workbench.panel.positronConsole.focus` does.
+			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
+		}
+	});
+
+	/**
+	 * Register the navigate input history down action. This action moves the cursor to the next
+	 * entry in the input history.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.NavigateInputHistoryDown,
+				title: {
+					value: localize('workbench.action.positronConsole.navigateInputHistoryDown', "Navigate Input History Down"),
+					original: 'Navigate Input History Down'
+				},
+				f1: true,
+				category,
+				keybinding: {
+					when: PositronConsoleFocused,
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyCode.DownArrow,
+				},
+			});
+		}
+
+		/**
+		 * Runs action.
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const positronConsoleService = accessor.get(IPositronConsoleService);
+			if (positronConsoleService.activePositronConsoleInstance) {
+				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryDown();
+			}
+		}
+	});
+
+	/**
+	 * Register the navigate input history up action. This action moves the cursor to the previous
+	 * entry in the input history.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.NavigateInputHistoryUp,
+				title: {
+					value: localize('workbench.action.positronConsole.navigateInputHistoryUp', "Navigate Input History Up"),
+					original: 'Navigate Input History Up'
+				},
+				f1: true,
+				category,
+				keybinding: {
+					when: PositronConsoleFocused,
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyCode.UpArrow,
+				},
+			});
+		}
+
+		/**
+		 * Runs action.
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const positronConsoleService = accessor.get(IPositronConsoleService);
+			if (positronConsoleService.activePositronConsoleInstance) {
+				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryUp(false);
+			}
+		}
+	});
+
+	/**
+	 * Register the navigate history up prefix match action. This action moves the cursor to the previous
+	 * entry in the input history using the prefix match strategy.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.NavigateInputHistoryUpUsingPrefixMatch,
+				title: {
+					value: localize('workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch', "Navigate Input History Up (Prefix Match)"),
+					original: 'Navigate Input History Up (Prefix Match)'
+				},
+				f1: true,
+				category,
+				keybinding: {
+					when: PositronConsoleFocused,
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.CtrlCmd | KeyCode.UpArrow
+				},
+			});
+		}
+
+		/**
+		 * Runs action.
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const positronConsoleService = accessor.get(IPositronConsoleService);
+			if (positronConsoleService.activePositronConsoleInstance) {
+				positronConsoleService.activePositronConsoleInstance.navigateInputHistoryUp(true);
+			}
 		}
 	});
 }

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -65,7 +65,6 @@ export interface IPositronConsoleService {
 	 */
 	readonly onDidStartPositronConsoleInstance: Event<IPositronConsoleInstance>;
 
-
 	/**
 	 * The onDidDeletePositronConsoleInstance event.
 	 */
@@ -161,6 +160,16 @@ export enum SessionAttachMode {
 	/** The console is reattaching to a connected session */
 	Connected = 'connected',
 }
+
+/**
+ * Event arguments for the onDidNavigateInputHistoryUp event.
+ */
+export type DidNavigateInputHistoryUpEventArgs = {
+	/**
+	 * A value which indicates whether to use the prefix match strategy.
+	 */
+	usingPrefixMatch: boolean;
+};
 
 /**
  * IPositronConsoleInstance interface.
@@ -273,6 +282,16 @@ export interface IPositronConsoleInstance {
 	readonly onDidClearConsole: Event<void>;
 
 	/**
+	 * The onDidNavigateInputHistoryDown event.
+	 */
+	readonly onDidNavigateInputHistoryDown: Event<void>;
+
+	/**
+	 * The onDidNavigateInputHistoryUp event.
+	 */
+	readonly onDidNavigateInputHistoryUp: Event<DidNavigateInputHistoryUpEventArgs>;
+
+	/**
 	 * The onDidClearInputHistory event.
 	 */
 	readonly onDidClearInputHistory: Event<void>;
@@ -353,6 +372,17 @@ export interface IPositronConsoleInstance {
 	 * Clears the console.
 	 */
 	clearConsole(): void;
+
+	/**
+	 * Navigates the input history down.
+	 */
+	navigateInputHistoryDown(): void;
+
+	/**
+	 * Navigates the input history up.
+	 * @param usingPrefixMatch A value which indicates whether to use the prefix match strategy.
+	 */
+	navigateInputHistoryUp(usingPrefixMatch: boolean): void;
 
 	/**
 	 * Clears the input history.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -35,7 +35,7 @@ import { RuntimeItemStartupFailure } from './classes/runtimeItemStartupFailure.j
 import { ActivityItem, ActivityItemOutput, RuntimeItemActivity } from './classes/runtimeItemActivity.js';
 import { ActivityItemInput, ActivityItemInputState } from './classes/activityItemInput.js';
 import { ActivityItemStream, ActivityItemStreamType } from './classes/activityItemStream.js';
-import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
+import { DidNavigateInputHistoryUpEventArgs, IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
 import { ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageOutputData, ILanguageRuntimeMessageUpdateOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, RuntimeStartMode } from '../../runtimeSession/common/runtimeSessionService.js';
 import { UiFrontendEvent } from '../../languageRuntime/common/positronUiComm.js';
@@ -950,6 +950,16 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private readonly _onDidClearConsoleEmitter = this._register(new Emitter<void>);
 
 	/**
+	 * The onDidNavigateInputHistoryDown event emitter.
+	 */
+	private readonly _onDidNavigateInputHistoryDown = this._register(new Emitter<void>());
+
+	/**
+	 * The onDidNavigateInputHistoryUp event emitter.
+	 */
+	private readonly _onDidNavigateInputHistoryUp = this._register(new Emitter<DidNavigateInputHistoryUpEventArgs>());
+
+	/**
 	 * The onDidClearInputHistory event emitter.
 	 */
 	private readonly _onDidClearInputHistoryEmitter = this._register(new Emitter<void>);
@@ -1237,6 +1247,16 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	readonly onDidClearConsole = this._onDidClearConsoleEmitter.event;
 
 	/**
+	 * onDidNavigateInputHistoryDown event.
+	 */
+	readonly onDidNavigateInputHistoryDown = this._onDidNavigateInputHistoryDown.event;
+
+	/**
+	 * onDidNavigateInputHistoryUp event.
+	 */
+	readonly onDidNavigateInputHistoryUp = this._onDidNavigateInputHistoryUp.event;
+
+	/**
 	 * onDidClearInputHistory event.
 	 */
 	readonly onDidClearInputHistory = this._onDidClearInputHistoryEmitter.event;
@@ -1332,6 +1352,23 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this._onDidChangeRuntimeItemsEmitter.fire();
 			this._onDidClearConsoleEmitter.fire();
 		}
+	}
+
+	/**
+	 * Navigates the input history down.
+	 */
+	navigateInputHistoryDown(): void {
+		this._onDidNavigateInputHistoryDown.fire();
+	}
+
+	/**
+	 * Navigates the input history up.
+	 * @param usingPrefixMatch A value which indicates whether to use the prefix match strategy.
+	 */
+	navigateInputHistoryUp(usingPrefixMatch: boolean): void {
+		this._onDidNavigateInputHistoryUp.fire({
+			usingPrefixMatch,
+		});
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -952,12 +952,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * The onDidNavigateInputHistoryDown event emitter.
 	 */
-	private readonly _onDidNavigateInputHistoryDown = this._register(new Emitter<void>());
+	private readonly _onDidNavigateInputHistoryDownEmitter = this._register(new Emitter<void>());
 
 	/**
 	 * The onDidNavigateInputHistoryUp event emitter.
 	 */
-	private readonly _onDidNavigateInputHistoryUp = this._register(new Emitter<DidNavigateInputHistoryUpEventArgs>());
+	private readonly _onDidNavigateInputHistoryUpEmitter = this._register(new Emitter<DidNavigateInputHistoryUpEventArgs>());
 
 	/**
 	 * The onDidClearInputHistory event emitter.
@@ -1249,12 +1249,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * onDidNavigateInputHistoryDown event.
 	 */
-	readonly onDidNavigateInputHistoryDown = this._onDidNavigateInputHistoryDown.event;
+	readonly onDidNavigateInputHistoryDown = this._onDidNavigateInputHistoryDownEmitter.event;
 
 	/**
 	 * onDidNavigateInputHistoryUp event.
 	 */
-	readonly onDidNavigateInputHistoryUp = this._onDidNavigateInputHistoryUp.event;
+	readonly onDidNavigateInputHistoryUp = this._onDidNavigateInputHistoryUpEmitter.event;
 
 	/**
 	 * onDidClearInputHistory event.
@@ -1358,7 +1358,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Navigates the input history down.
 	 */
 	navigateInputHistoryDown(): void {
-		this._onDidNavigateInputHistoryDown.fire();
+		this._onDidNavigateInputHistoryDownEmitter.fire();
 	}
 
 	/**
@@ -1366,7 +1366,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param usingPrefixMatch A value which indicates whether to use the prefix match strategy.
 	 */
 	navigateInputHistoryUp(usingPrefixMatch: boolean): void {
-		this._onDidNavigateInputHistoryUp.fire({
+		this._onDidNavigateInputHistoryUpEmitter.fire({
 			usingPrefixMatch,
 		});
 	}

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -6,7 +6,7 @@
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState, SessionAttachMode } from '../../browser/interfaces/positronConsoleService.js';
+import { DidNavigateInputHistoryUpEventArgs, IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState, SessionAttachMode } from '../../browser/interfaces/positronConsoleService.js';
 import { RuntimeItem } from '../../browser/classes/runtimeItem.js';
 import { ILanguageRuntimeMetadata, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata } from '../../../runtimeSession/common/runtimeSessionService.js';
@@ -258,6 +258,8 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 	private readonly _onDidPasteTextEmitter = new Emitter<string>();
 	private readonly _onDidSelectAllEmitter = new Emitter<void>();
 	private readonly _onDidClearConsoleEmitter = new Emitter<void>();
+	private readonly _onDidNavigateInputHistoryDownEmitter = new Emitter<void>();
+	private readonly _onDidNavigateInputHistoryUpEmitter = new Emitter<DidNavigateInputHistoryUpEventArgs>();
 	private readonly _onDidClearInputHistoryEmitter = new Emitter<void>();
 	private readonly _onDidSetPendingCodeEmitter = new Emitter<string | undefined>();
 	private readonly _onDidExecuteCodeEmitter = new Emitter<ILanguageRuntimeCodeExecutedEvent>();
@@ -314,6 +316,14 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 
 	get onDidClearConsole(): Event<void> {
 		return this._onDidClearConsoleEmitter.event;
+	}
+
+	get onDidNavigateInputHistoryDown(): Event<void> {
+		return this._onDidNavigateInputHistoryDownEmitter.event;
+	}
+
+	get onDidNavigateInputHistoryUp(): Event<DidNavigateInputHistoryUpEventArgs> {
+		return this._onDidNavigateInputHistoryUpEmitter.event;
 	}
 
 	get onDidClearInputHistory(): Event<void> {
@@ -427,6 +437,16 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 
 	clearConsole(): void {
 		this._onDidClearConsoleEmitter.fire();
+	}
+
+	navigateInputHistoryDown(): void {
+		this._onDidNavigateInputHistoryDownEmitter.fire();
+	}
+
+	navigateInputHistoryUp(usingPrefixMatch: boolean): void {
+		this._onDidNavigateInputHistoryUpEmitter.fire({
+			usingPrefixMatch,
+		});
 	}
 
 	clearInputHistory(): void {


### PR DESCRIPTION
## Description

This PR addresses #6650 by adding up / down console input history navigation actions so that users can bind custom keys to them, if desired.

Three new console actions have been added to the Command Palette:

**Console: Navigate Input History Down**
**Console: Navigate Input History Up**
**Console: Navigate Input History Up (Prefix Match)**

Programmatically, these actions are:

```
PositronConsoleCommandId.NavigateInputHistoryDown
PositronConsoleCommandId.NavigateInputHistoryUp
PositronConsoleCommandId.NavigateInputHistoryUpUsingPrefixMatch
```

By default, there are no keyboard bindings for these actions:

![image](https://github.com/user-attachments/assets/9854f83a-2797-4722-8545-cf78f86cb32f)

Users can add whatever keybindings and when conditions they prefer. For example:

![image](https://github.com/user-attachments/assets/eb0ccbad-b54e-4369-aa08-42a6377a24a2)

Tests:
@:console

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6650 Move up/down console input history navigation into actions so users can bind custom keys to them.

### QA Notes

Over time, more functionality with keyboard bindings should be added as actions so that our users can bind custom keys to them, if desired. This is the start of that work.
