### PR TITLE
Allow variables to be inspected by name in addition to access key

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/variables.py
+++ b/extensions/positron-python/python_files/posit/positron/variables.py
@@ -75,7 +75,10 @@ def _resolve_value_from_path(context: Any, path: Iterable[str]) -> Any:
     for access_key in path:
         # Check for membership via inspector
         inspector = get_inspector(context)
-        key = decode_access_key(access_key)
+        try:
+            key = decode_access_key(access_key)
+        except Exception as err:
+            raise ValueError(f"Invalid access key: {access_key!r}. Reason: {err!r}") from err
         is_known = inspector.has_child(key)
         if is_known:
             value = inspector.get_child(key)


### PR DESCRIPTION
### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Assistant sometimes failing to inspect variables (#8052).

### QA Notes

See the repro steps in the linked issue. I found it quite hard to reliably repro this bug on main. It seemed more likely with Claude 4 Sonnet and with a large Python file active (possibly because it deemphasizes the variables context provided to the model).