### PR TITLE
Fix broken `window.getPlotsRenderSettings()` method in API

### DIFF
--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -101,6 +101,7 @@ import './positron/mainThreadContextKeyService.js';
 import './positron/mainThreadConnections.js';
 import './positron/mainThreadEnvironment.js';
 import './positron/mainThreadAiFeatures.js';
+import './positron/mainThreadPlotsService.js';
 // --- End Positron ---
 
 export class ExtensionPoints implements IWorkbenchContribution {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

Previously if extensions tried to run the method `window.getPlotsRenderSettings()` in the positron API the call would error with `Unknown actor MainThreadPlotsService`. This PR adds the necessary import so that the call actually works. 

You can test this with the following extension command:
```typescript
  context.subscriptions.push(
    vscode.commands.registerCommand("demoExtension.plotSettings", async () => {
      const positronApi = tryAcquirePositronApi();
      if (!positronApi) {
        vscode.window.showInformationMessage("Positron API not available");
        return;
      }
      // Get plot rendering settings for custom visualizations
      const plotSettings = await positronApi.window.getPlotsRenderSettings();
      vscode.window.showInformationMessage(
        `Render plots at ${plotSettings.size.width}x${plotSettings.size.height}`
      );
    })
  );
  ```

Prior to this PR this errors, after it, it returns the plot sizes as expected. 

You can also test this out by using the cloning the demo extension and running it followed by: Command Palette → "Positron Plot Settings Demo"  

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- `positron.window.getPlotsRenderSettings()` no longer errors on use. 


### QA Notes

Not sure if we'd want to somehow test this? It seems minor enough that it doesn't need it (at least for this specific api endpoint.)
