### PR TITLE
do not autoresize plots that take a long time to render

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -82,17 +82,11 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 					});
 				}
 
-				let result;
-				// If the plot will probably take a long time to render, do not
-				// automatically resize it unless requested to do so.
-				if (props.plotClient.renderEstimateMs < 1000 || forceRerender) {
-					result = await props.plotClient.renderWithSizingPolicy(
-						plotSize,
-						ratio
-					);
-				} else {
-					return;
-				}
+				const result = await props.plotClient.renderWithSizingPolicy(
+					plotSize,
+					ratio
+				);
+
 
 				// Update the URI to the URI of the new plot.
 				setUri(result.uri);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -100,6 +100,17 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		}
 	});
 
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		properties: {
+			'positron.plots.freezeSlowPlots': {
+				type: 'boolean',
+				default: true,
+				description: localize('positron.plots.freezeSlowPlotsSetting', "Freeze slow plots to prevent them from being re-rendered when the viewport size changes. This can improve performance for large plots."),
+			}
+		}
+	});
+
 Registry.
 	as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).
 	registerWorkbenchContribution(PositronPlotsContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -103,10 +103,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
 		properties: {
-			'positron.plots.freezeSlowPlots': {
+			'positron.plots.frozenSlowPlots': {
 				type: 'boolean',
 				default: true,
-				description: localize('positron.plots.freezeSlowPlotsSetting', "Freeze slow plots to prevent them from being re-rendered when the viewport size changes. This can improve performance for large plots."),
+				description: localize('positron.plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -583,7 +583,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	/**
-	 * Clears the custom plot size, if one is set. If the custom plot size policy is in used,
+	 * Clears the custom plot size, if one is set. If the custom plot size policy is in use,
 	 * switch to the automatic sizing policy.
 	 */
 	clearCustomPlotSize(): void {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -1498,7 +1498,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			id: sizingPolicy.id,
 			size: sizingPolicy instanceof PlotSizingPolicyCustom ? sizingPolicy.size : undefined
 		};
-		const plotClient = new PlotClientInstance(comm, sizingPolicy ?? this._selectedSizingPolicy, { ...metadata, location: location });
+		const plotClient = new PlotClientInstance(comm, this._configurationService, sizingPolicy ?? this._selectedSizingPolicy, { ...metadata, location: location });
 		let plotClients = this._plotClientsByComm.get(metadata.id);
 
 		if (!plotClients) {

--- a/src/vs/workbench/contrib/positronPlots/test/electron-sandbox/positronPlotsService.test.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-sandbox/positronPlotsService.test.ts
@@ -18,6 +18,7 @@ import { startTestLanguageRuntimeSession } from '../../../../services/runtimeSes
 import { PositronPlotCommProxy } from '../../../../services/languageRuntime/common/positronPlotCommProxy.js';
 import { PlotSizingPolicyAuto } from '../../../../services/positronPlots/common/sizingPolicyAuto.js';
 import { PlotSizingPolicyFill } from '../../../../services/positronPlots/common/sizingPolicyFill.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 suite('Positron - Plots Service', () => {
 
@@ -121,7 +122,7 @@ suite('Positron - Plots Service', () => {
 		sinon.stub(plotCommProxyStub, 'onDidRenderUpdate').value(() => { });
 		sinon.stub(plotCommProxyStub, 'onDidShowPlot').value(() => { });
 
-		const plotClientInstance = new PlotClientInstance(plotCommProxyStub as unknown as PositronPlotCommProxy, new PlotSizingPolicyAuto(), {} as IPositronPlotMetadata);
+		const plotClientInstance = new PlotClientInstance(plotCommProxyStub as unknown as PositronPlotCommProxy, {} as IConfigurationService, new PlotSizingPolicyAuto(), {} as IPositronPlotMetadata);
 		disposables.add(plotClientInstance);
 
 		let sizingPolicyChanged = false;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -343,6 +343,10 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			this._stateEmitter.fire(PlotClientState.Rendering);
 
 			request.promise.then((rendered) => {
+				if (rendered.renderTimeMs > 3000 && rendered.size && !this._lastRender) {
+					// Set sizing policy to the current size to avoid redraws
+					this.sizingPolicy = new PlotSizingPolicyCustom(rendered.size, true);
+				}
 				this._stateEmitter.fire(PlotClientState.Rendered);
 				if (!preview) {
 					this._lastRender = rendered;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -11,6 +11,9 @@ import { IPlotSize, IPositronPlotSizingPolicy } from '../../positronPlots/common
 import { PositronPlotCommProxy } from './positronPlotCommProxy.js';
 import { PlotSizingPolicyCustom } from '../../positronPlots/common/sizingPolicyCustom.js';
 import { DeferredRender, IRenderedPlot, RenderRequest } from './positronPlotRenderQueue.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+
+const FreezeSlowPlotsConfigKey = 'positron.plots.freezeSlowPlots';
 
 export enum PlotClientLocation {
 	/** The plot is in the editor */
@@ -164,8 +167,10 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 */
 	constructor(
 		private readonly _commProxy: PositronPlotCommProxy,
+		private readonly _configurationService: IConfigurationService,
 		private _sizingPolicy: IPositronPlotSizingPolicy,
 		public readonly metadata: IPositronPlotMetadata
+
 	) {
 		super();
 		// If the plot comes with a pre-rendering, set it as the last render. This
@@ -343,8 +348,11 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			this._stateEmitter.fire(PlotClientState.Rendering);
 
 			request.promise.then((rendered) => {
-				if (rendered.renderTimeMs > 3000 && rendered.size && !this._lastRender) {
+				const frozen = this._configurationService.getValue(FreezeSlowPlotsConfigKey);
+
+				if (rendered.renderTimeMs > 3000 && rendered.size && !this._lastRender && frozen) {
 					// Set sizing policy to the current size to avoid redraws
+
 					this.sizingPolicy = new PlotSizingPolicyCustom(rendered.size, true);
 				}
 				this._stateEmitter.fire(PlotClientState.Rendered);

--- a/src/vs/workbench/services/positronPlots/common/sizingPolicyCustom.ts
+++ b/src/vs/workbench/services/positronPlots/common/sizingPolicyCustom.ts
@@ -19,7 +19,7 @@ export class PlotSizingPolicyCustom implements IPositronPlotSizingPolicy {
 
 	constructor(public readonly size: IPlotSize, slow: boolean = false) {
 		const name = slow
-			? nls.localize('plotSizingPolicy.CustomSlow', "{0}×{1} (slow plot, no resizing)", size.width, size.height)
+			? nls.localize('plotSizingPolicy.CustomSlow', "{0}×{1} (frozen)", size.width, size.height)
 			: nls.localize('plotSizingPolicy.Custom', "{0}×{1} (custom)", size.width, size.height);
 
 		this._name = name;

--- a/src/vs/workbench/services/positronPlots/common/sizingPolicyCustom.ts
+++ b/src/vs/workbench/services/positronPlots/common/sizingPolicyCustom.ts
@@ -17,8 +17,12 @@ export class PlotSizingPolicyCustom implements IPositronPlotSizingPolicy {
 	public readonly id = PlotSizingPolicyCustom.ID;
 	private readonly _name: string;
 
-	constructor(public readonly size: IPlotSize) {
-		this._name = nls.localize('plotSizingPolicy.Custom', "{0}×{1} (custom)", size.width, size.height);
+	constructor(public readonly size: IPlotSize, slow: boolean = false) {
+		const name = slow
+			? nls.localize('plotSizingPolicy.CustomSlow', "{0}×{1} (slow plot, no resizing)", size.width, size.height)
+			: nls.localize('plotSizingPolicy.Custom', "{0}×{1} (custom)", size.width, size.height);
+
+		this._name = name;
 	}
 
 	public getName(plot: PlotClientInstance): string {


### PR DESCRIPTION
Right now, plots taking longer than 1000ms to render will NOT auto-resize unless the user changes the sizing policy. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #4546 

#### Bug Fixes

- N/A


### QA Notes

note: downloading the file takes like 10 mins
```bash
pip install scanpy
curl https://datasets.cellxgene.cziscience.com/981bcf57-30cb-4a85-b905-e04373432fef.h5ad -o test.h5ad`
```

```python
import scanpy as sc
test=sc.read_h5ad("test.h5ad")
sc.set_figure_params(dpi=80,dpi_save=300)
sc.pl.umap(test,color=['ENSG00000081237','ENSG00000119888','ENSG00000261371','ENSG00000164692','ENSG00000107796'],use_raw=True,legend_loc="on data")
sc.pl.umap(test,color=['ENSG00000081237','ENSG00000119888','ENSG00000261371','ENSG00000164692','ENSG00000107796'],use_raw=True,legend_loc="on data")
sc.pl.umap(test,color=['ENSG00000081237','ENSG00000119888','ENSG00000261371','ENSG00000164692','ENSG00000107796'],use_raw=True,legend_loc="on data")
```
