### PR TITLE
e2e Test: Assistant test flake fix

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -17,8 +17,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	test.beforeAll('Enable Assistant', async function ({ userSettings }) {
 		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
 		await userSettings.set([['positron.assistant.enable', 'true'],
-		['positron.assistant.newModelConfiguration', 'true'],
-		['positron.assistant.testModels', 'true']], true);
+		['positron.assistant.testModels', 'true']], false);
 	});
 
 	/**
@@ -47,6 +46,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickSignInButton();
 		await expect(app.workbench.assistant.verifySignOutButtonVisible(5000)).rejects.toThrow();
 		await app.workbench.assistant.clickDoneButton();
+		await app.code.driver.page.locator('.positron-button:has-text("Yes")').click();
 	});
 
 	/**


### PR DESCRIPTION
This test started flaking because of #7404

The bad api key tests passed, but left a dialog box open, which caused the next test to fail.  But on retry that dailog got cleared, so it would pass on retry.

This accounts for the dialog and all tests should pass on first try now.

### QA Notes
@:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
