### PR TITLE
e2e test - more interpreter actions

### DIFF
--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -8,6 +8,8 @@ Summary:
 - This test suite verifies the functionality of interpreter commands via Force Quit, Interrupt, and Shutdown for both Python and R.
 - Tests confirm that each quick input command triggers the expected behavior, verified through console outputs (see Table below).
 - After each test, console is cleared and session is fully deleted. Doing both for each test makes the tests more robust indeed.
+- Additional tests, as shown below, have been included for verifying clear interpreter, rename active session, and show interpreter
+output for both Python and R.
 
  * |Command   |Language|Targeted Console Output    |
  * |----------|--------|---------------------------|
@@ -20,7 +22,9 @@ Summary:
  * |Clear     |Python  |'int... has been cleared'  |
  * |Clear     |R       |'int... has been cleared'  |
  * |Rename Act|Python  |'RenamedActive_Python'     |
- * |Rename Act|R.      |'RenamedActive_R'          |
+ * |Rename Act|R       |'RenamedActive_R'          |
+ * |ShowOutput|Python  |'[Python]'                 |
+ * |ShowOutput|R       |'[R]'                      |
  */
 
 import { test, tags, expect } from '../_test.setup';
@@ -29,7 +33,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', {
+test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Interpreter, and Rename Active Session', {
 	tag: [tags.WEB, tags.INTERPRETER]
 }, () => {
 
@@ -122,15 +126,23 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', {
 	});
 });
 
+test.describe('Interpreter Commands: Show Active Interpreter Session Output', {
+	tag: [tags.WEB, tags.INTERPRETER, tags.WIN]
+}, () => {
+
+	test('Verify Show Active Interpreter Session Output command works (→ [Python]) - Python', async function ({ app, python, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
+		await expect(page.getByText('[Python] [', { exact: false }).first()).toBeVisible();
+	});
+
+	test('Verify Show Active Interpreter Session Output command works (→ [R]) - R', async function ({ app, r, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
+		await expect(page.getByText('[R] [', { exact: false }).first()).toBeVisible();
+	});
+
+});
+
 /*
 A couple questions for next week:
 1. What would be relevant to add to the POM here? Any suggestions are welcome. Or anything I used that I could have adopted from the codebase?
-2. Having trouble with session output test, to find the output pane... I've tried multiple ways, but the structure seems complex. Any ideas?
-	test('Verify Show Active Interpreter Session Output command works (→ [Python]) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
-	});
-
-	test('Verify Show Active Interpreter Session Output command works (→ [R]?) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
-	});
 */

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -17,6 +17,10 @@ Summary:
  * |Interrupt |R       |Empty error line (visible) |
  * |Shutdown  |Python  |'exited'                   |
  * |Shutdown  |R       |'exited'                   |
+ * |Clear     |Python  |'int... has been cleared'  |
+ * |Clear     |R       |'int... has been cleared'  |
+ * |Rename Act|Python  |'RenamedActive_Python'     |
+ * |Rename Act|R.      |'RenamedActive_R'          |
  */
 
 import { test, tags, expect } from '../_test.setup';
@@ -68,4 +72,65 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, and Shutdown', {
 		await page.keyboard.press('Enter');
 		await app.workbench.console.waitForConsoleContents('exited');
 	});
+
+	test('Verify Clear Saved Interpreter command works (→ interpreter has been cleared) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		const anyPythonSession = app.workbench.quickInput.quickInputList.getByText(/Python:/);
+		await anyPythonSession.waitFor({ state: 'visible' });
+		await page.keyboard.press('Enter');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+		await app.workbench.popups.toastLocator
+			.locator('span', { hasText: /(Python|interpreter has been cleared)/ })
+			.waitFor({ state: 'visible', timeout: 2000 });
+	});
+
+	test('Verify Clear Saved Interpreter command works (→ interpreter has been cleared) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		const anyRSession = app.workbench.quickInput.quickInputList.getByText(/R:/);
+		await anyRSession.waitFor({ state: 'visible' });
+		await page.keyboard.press('Enter');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+		await app.workbench.popups.toastLocator
+			.locator('span', { hasText: /(R|interpreter has been cleared)/ })
+			.waitFor({ state: 'visible', timeout: 2000 });
+	});
+
+	test('Verify Rename Active Session command works (→ RenamedActive_Python) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.language.runtime.renameActiveSession', { keepOpen: true });
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		await app.workbench.quickInput.type('RenamedActive_Python');
+		await page.keyboard.press('Enter');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+		const renamedInterpreter = page.getByRole('button', {
+			name: 'Select Interpreter Session'
+		}).locator('.action-bar-button-label', { hasText: 'RenamedActive_Python' });
+		await renamedInterpreter.waitFor({ state: 'visible' });
+	});
+
+	test('Verify Rename Active Session command works (→ RenamedActive_R) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.language.runtime.renameActiveSession', { keepOpen: true });
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		await app.workbench.quickInput.type('RenamedActive_R');
+		await page.keyboard.press('Enter');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+		const renamedInterpreter = page.getByRole('button', {
+			name: 'Select Interpreter Session'
+		}).locator('.action-bar-button-label', { hasText: 'RenamedActive_R' });
+		await renamedInterpreter.waitFor({ state: 'visible' });
+	});
 });
+
+/*
+A couple questions for next week:
+1. What would be relevant to add to the POM here? Any suggestions are welcome. Or anything I used that I could have adopted from the codebase?
+2. Having trouble with session output test, to find the output pane... I've tried multiple ways, but the structure seems complex. Any ideas?
+	test('Verify Show Active Interpreter Session Output command works (→ [Python]) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
+	});
+
+	test('Verify Show Active Interpreter Session Output command works (→ [R]?) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
+		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
+	});
+*/

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -5,26 +5,16 @@
 
 /*
 Summary:
-- This test suite verifies the functionality of interpreter commands via Force Quit, Interrupt, and Shutdown for both Python and R.
+- This test suite verifies the functionality of interpreter commands via Interrupt and Clear for both Python and R.
 - Tests confirm that each quick input command triggers the expected behavior, verified through console outputs (see Table below).
 - After each test, console is cleared and session is fully deleted. Doing both for each test makes the tests more robust indeed.
-- Additional tests, as shown below, have been included for verifying clear interpreter, rename active session, and show interpreter
-output for both Python and R.
 
  * |Command   |Language|Targeted Console Output    |
  * |----------|--------|---------------------------|
- * |Force Quit|Python  |'was forced to quit'       |
- * |Force Quit|R       |'was forced to quit'       |
  * |Interrupt |Python  |'KeyboardInterrupt'        |
  * |Interrupt |R       |Empty error line (visible) |
- * |Shutdown  |Python  |'exited'                   |
- * |Shutdown  |R       |'exited'                   |
  * |Clear     |Python  |'int... has been cleared'  |
  * |Clear     |R       |'int... has been cleared'  |
- * |Rename Act|Python  |'RenamedActive_Python'     |
- * |Rename Act|R       |'RenamedActive_R'          |
- * |ShowOutput|Python  |'[Python]'                 |
- * |ShowOutput|R       |'[R]'                      |
  */
 
 import { test, tags, expect } from '../_test.setup';
@@ -42,16 +32,6 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await app.workbench.sessions.deleteAll();
 	});
 
-	test('Verify Force Quit Interpreter command works (→ was forced to quit) - Python', { tag: [tags.WIN] }, async function ({ app, python }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
-		await app.workbench.console.waitForConsoleContents('was forced to quit');
-	});
-
-	test('Verify Force Quit Interpreter command works (→ was forced to quit) - R', { tag: [tags.WIN] }, async function ({ app, r }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.forceQuit');
-		await app.workbench.console.waitForConsoleContents('was forced to quit');
-	});
-
 	// Skip this test for tags.WIN (e2e-windows) due to Bug #4604
 	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }) {
 		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
@@ -63,18 +43,6 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
 		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
 		await expect(page.locator('div.activity-error-stream')).toBeVisible();
-	});
-
-	test('Verify Shutdown Interpreter command works (→ exited) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
-		await app.workbench.console.pasteCodeToConsole('exit()');
-		await page.keyboard.press('Enter');
-		await app.workbench.console.waitForConsoleContents('exited');
-	});
-
-	test('Verify Shutdown Interpreter command works (→ exited) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
-		await app.workbench.console.pasteCodeToConsole('q()');
-		await page.keyboard.press('Enter');
-		await app.workbench.console.waitForConsoleContents('exited');
 	});
 
 	test('Verify Clear Saved Interpreter command works (→ interpreter has been cleared) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
@@ -99,45 +67,6 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await app.workbench.popups.toastLocator
 			.locator('span', { hasText: /(R|interpreter has been cleared)/ })
 			.waitFor({ state: 'visible', timeout: 2000 });
-	});
-
-	test('Verify Rename Active Session command works (→ RenamedActive_Python) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.language.runtime.renameActiveSession', { keepOpen: true });
-		await app.workbench.quickInput.waitForQuickInputOpened();
-		await app.workbench.quickInput.type('RenamedActive_Python');
-		await page.keyboard.press('Enter');
-		await app.workbench.quickInput.waitForQuickInputClosed();
-		const renamedInterpreter = page.getByRole('button', {
-			name: 'Select Interpreter Session'
-		}).locator('.action-bar-button-label', { hasText: 'RenamedActive_Python' });
-		await renamedInterpreter.waitFor({ state: 'visible' });
-	});
-
-	test('Verify Rename Active Session command works (→ RenamedActive_R) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.language.runtime.renameActiveSession', { keepOpen: true });
-		await app.workbench.quickInput.waitForQuickInputOpened();
-		await app.workbench.quickInput.type('RenamedActive_R');
-		await page.keyboard.press('Enter');
-		await app.workbench.quickInput.waitForQuickInputClosed();
-		const renamedInterpreter = page.getByRole('button', {
-			name: 'Select Interpreter Session'
-		}).locator('.action-bar-button-label', { hasText: 'RenamedActive_R' });
-		await renamedInterpreter.waitFor({ state: 'visible' });
-	});
-});
-
-test.describe('Interpreter Commands: Show Active Interpreter Session Output', {
-	tag: [tags.WEB, tags.INTERPRETER, tags.WIN]
-}, () => {
-
-	test('Verify Show Active Interpreter Session Output command works (→ [Python]) - Python', async function ({ app, python, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
-		await expect(page.getByText('[Python] [', { exact: false }).first()).toBeVisible();
-	});
-
-	test('Verify Show Active Interpreter Session Output command works (→ [R]) - R', async function ({ app, r, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.showOutput', { keepOpen: false });
-		await expect(page.getByText('[R] [', { exact: false }).first()).toBeVisible();
 	});
 
 });


### PR DESCRIPTION
###QA Notes

This pull request enhances the test coverage for interpreter commands in the file `test/e2e/tests/interpreters/interpreter-commands.test.ts`. It introduces new tests for verifying the functionality of commands related to clearing and renaming interpreter sessions.

![image](https://github.com/user-attachments/assets/aa473322-8a85-4e3b-be3d-25cc6f710f3b)

@:web @:win @:interpreter

### TO DO

- [x] Figure out how to handle the output pane 
- [x] Remove all except Interrupt and Clear
> I'd expect this spec to only contain coverage for: clear, interrupt.
- [x] POMerize (no need for it for now)