### PR TITLE
e2e test - fix test setup type (ts keeps throwing error)

### DIFF
--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -344,7 +344,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 
 		// wait for the archive to finalize and the output stream to close
 		await new Promise((resolve, reject) => {
-			output.on('close', resolve);
+			output.on('close', () => resolve(undefined));
 			output.on('error', reject);
 			archive.finalize();
 		});


### PR DESCRIPTION
### QA Notes

One-line change to address an error that Typescript Server kept throwing:
`Argument of type '(value: unknown) => void' is not assignable to parameter of type '() => void'.`

With this change, we can ensure that the type promise is called out explicitly, avoiding my TS Server from misbehaving (common workarounds I was adopting included restarting TS server and VS Code). 

@:web @:win
