### PR TITLE
Updates positron-dark theme to show highlighted text in a code cell

### DIFF
--- a/extensions/theme-defaults/themes/positron_dark.json
+++ b/extensions/theme-defaults/themes/positron_dark.json
@@ -28,5 +28,6 @@
 		"terminalCursor.foreground": "#32485B",
 		"terminal.tab.activeBorder": "#32485B",
 		"welcomePage.progress.foreground": "#32485B",
+		"notebook.selectedCellBackground": "#d3dbcd50",
 	},
 }


### PR DESCRIPTION
Highlighted text is now visible in the dark theme.

<img width="693" alt="Screenshot 2025-06-16 at 11 28 33 AM" src="https://github.com/user-attachments/assets/00800978-e561-46c3-ad32-92eb9af3b310" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #7825 


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
