### PR TITLE
hotfix for dealing with externally-managed pythons

### DIFF
--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -293,7 +293,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                 const spawnOptions: SpawnOptions = { token };
                 executionResult = await processService.exec(command, args, spawnOptions);
             }
-            if (executionResult.stderr?.startsWith('error: externally-managed-environment')) {
+            if (executionResult.stderr?.includes('error: externally-managed-environment')) {
                 throw new ExternallyManagedEnvironmentError(executionResult.stderr);
             }
             // --- End Positron ---


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
This is a tiny PR that addresses an issue that came up in https://github.com/posit-dev/positron/issues/6701#issuecomment-2971324962.

When we automatically install Python packages into the environment, if the environment is [externally-managed](https://packaging.python.org/en/latest/specifications/externally-managed-environments), then the first attempt will fail, and we read the stdout. If it indicates that the failure was because it's externally-managed, then we try again with the `--break-system-packages` flag. 

This has always worked for certain flavors of externally-managed environments. Now that we [discover](https://github.com/posit-dev/positron/pull/7839) uv-managed environments, the stdout looks a little different. This PR fixes the logic to read that stdout.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

- Turn off the `python.useBundledIpykernel` setting
- Reload Positron
- Try to start a new session with an interpreter that lives in your `$(uv python dir)` (for mac these look like `~/.local/share/uv/python/cpython-3.11.12-macos-aarch64-none/bin/python`)
- Say yes when asked to install pip/ipykernel
- Console should start up instead of failing

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
