### PR TITLE
Section headers now end code cells

### DIFF
--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -62,6 +62,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
+const rIsSectionHeaderRegExp = new RegExp(/^#+\s+.+\s*[-=]{4,}\s*$/)
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
@@ -76,7 +77,7 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line),
+	isCellStart: (line) => rIsCellStartRegExp.test(line) || rIsSectionHeaderRegExp.test(line),
 	isCellEnd: (_line) => false,
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -78,7 +78,6 @@ const pythonCellParser: CellParser = {
 
 const rCellParser: CellParser = {
 	isCellStart: (line) => rIsCellStartRegExp.test(line),
-	// isCellEnd: (_line) => false,
 	isCellEnd: (_line) => rIsSectionHeaderRegExp.test(_line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -62,7 +62,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
-const rIsSectionHeaderRegExp = new RegExp(/^#+\s+.+\s*[-=]{4,}\s*$/)
+const rIsSectionHeaderRegExp = new RegExp(/^#+.*[-=]{4,}\s*$/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
@@ -77,8 +77,9 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line) || rIsSectionHeaderRegExp.test(line),
-	isCellEnd: (_line) => false,
+	isCellStart: (line) => rIsCellStartRegExp.test(line),
+	// isCellEnd: (_line) => false,
+	isCellEnd: (_line) => rIsSectionHeaderRegExp.test(_line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
 	newCell: () => '\n# %%\n'

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -146,12 +146,11 @@ And a [link](target)`;
 			});
 		});
 
-		test('Parses section headers as cells', async () => {
-			const content = [codeCell3, codeCell2].join('\n\n');
+		test('Section headers end code cells', async () => {
+			const content = [codeCell2, codeCell3].join('\n\n');
 			const document = await vscode.workspace.openTextDocument({ language, content });
 			assert.deepStrictEqual(parseCells(document), [
-				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code },
-				{ range: new vscode.Range(5, 0, 8, 3), type: CellType.Code }
+				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code }
 			]);
 		});
 

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -98,6 +98,7 @@ And a [link](target)`;
 		const codeCellBody = '\n123\n456';
 		const codeCell1 = `#+\n${codeCellBody}`;
 		const codeCell2 = `# %%\n789\n\n012`;
+		const codeCell3 = `# Header ----\n\n123\n456`;
 
 		const parser = getParser(language);
 
@@ -143,6 +144,15 @@ And a [link](target)`;
 				const cell = singleCell(document, expectedType);
 				assert.strictEqual(parser?.getCellText(cell, document), expectedText);
 			});
+		});
+
+		test('Parses section headers as cells', async () => {
+			const content = [codeCell3, codeCell2].join('\n\n');
+			const document = await vscode.workspace.openTextDocument({ language, content });
+			assert.deepStrictEqual(parseCells(document), [
+				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code },
+				{ range: new vscode.Range(5, 0, 8, 3), type: CellType.Code }
+			]);
 		});
 
 		test('New cell', async () => {


### PR DESCRIPTION
- Addresses https://github.com/posit-dev/positron/issues/7974
- Closes #8021

This is an internal PR applying the commits from #8021, because of the problems outlined in #6628.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Section headers in `.R` files (from special comments like `# A section ----`) now act as end boundaries for code cells, thanks to @kylebutts 

#### Bug Fixes

- N/A


### QA Notes

If we have an `.R` file such as this:

```r
# A section but not a code cell ----
1

## A subsection but not a code cell ----
2

# %% A code cell
3

# A new section but not a code cell ----
4

#+ A new code cell
5

# Another new section but not a code cell ----
6
```

we should have code cells for 3 and 5, but not for 1, 2, 4, or 6.

