### PR TITLE
Assistant: remove duplicate provider config command and remove old modal

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -106,14 +106,14 @@
     ],
     "commands": [
       {
-        "command": "positron-assistant.addModelConfiguration",
-        "title": "%commands.addModelConfiguration.title%",
-        "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable && !config.positron.assistant.newModelConfiguration"
-      },
-      {
         "command": "positron-assistant.configureModels",
         "title": "%commands.configureModels.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.logStoredModels",
+        "title": "%commands.logStoredModels.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable"
       }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -1,8 +1,8 @@
 {
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
-	"commands.addModelConfiguration.title": "Add Language Model Provider",
 	"commands.configureModels.title": "Configure Language Model Providers",
+	"commands.logStoredModels.title": "Log the stored language models",
 	"commands.copilot.signin.title": "Copilot Sign In",
 	"commands.copilot.signout.title": "Copilot Sign Out",
 	"commands.category": "Positron Assistant",

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -10,7 +10,6 @@ import { completionModels } from './completion';
 import { disposeModels, log, registerModel } from './extension';
 import { CopilotService } from './copilot.js';
 
-// this is the regular storage, and we store the apikey in the secret storage, so it is omitted here
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
 }

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -10,6 +10,7 @@ import { completionModels } from './completion';
 import { disposeModels, log, registerModel } from './extension';
 import { CopilotService } from './copilot.js';
 
+// this is the regular storage, and we store the apikey in the secret storage, so it is omitted here
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
 }

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -292,6 +292,10 @@ async function oauthSignout(userConfig: positron.ai.LanguageModelConfig, sources
 
 }
 
+/**
+ * Note: the LanguageModelSource object returned by this function is not the same as the original
+ * one that was used to create the configuration.
+ */
 export function expandConfigToSource(config: StoredModelConfig): positron.ai.LanguageModelSource {
 	return {
 		...config,

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { EncryptedSecretStorage, expandConfigToSource, getEnabledProviders, getModelConfiguration, getModelConfigurations, getStoredModels, GlobalSecretStorage, ModelConfig, SecretStorage, showConfigurationDialog, showModelList, StoredModelConfig } from './config';
+import { EncryptedSecretStorage, expandConfigToSource, getEnabledProviders, getModelConfiguration, getModelConfigurations, getStoredModels, GlobalSecretStorage, logStoredModels, ModelConfig, SecretStorage, showConfigurationDialog, StoredModelConfig } from './config';
 import { availableModels, newLanguageModel } from './models';
 import { registerMappedEditsProvider } from './edits';
 import { registerParticipants } from './participants';
@@ -196,25 +196,15 @@ async function registerModelWithAPI(modelConfig: ModelConfig, context: vscode.Ex
 	}
 }
 
-function registerAddModelConfigurationCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.addModelConfiguration', async () => {
-			await showConfigurationDialog(context, storage);
-		})
-	);
-}
-
 function registerConfigureModelsCommand(context: vscode.ExtensionContext, storage: SecretStorage) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-assistant.configureModels', async () => {
-			if (vscode.workspace.getConfiguration('positron.assistant').get('newModelConfiguration', true)) {
-				// The new model configuration UI lets users sign out of providers as well,
-				// so there's no need to show the model list.
-				await showConfigurationDialog(context, storage);
-			} else {
-				await showModelList(context, storage);
-			}
-		})
+			await showConfigurationDialog(context, storage);
+		}),
+		vscode.commands.registerCommand('positron-assistant.logStoredModels', async () => {
+			logStoredModels(context);
+			log.show();
+		}),
 	);
 }
 
@@ -239,7 +229,6 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	registerHistoryTracking(context);
 
 	// Commands
-	registerAddModelConfigurationCommand(context, storage);
 	registerConfigureModelsCommand(context, storage);
 
 	// Register mapped edits provider

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2013,6 +2013,8 @@ declare module 'positron' {
 
 		/**
 		 * Positron Language Model configuration.
+		 * this doesn't get persisted or the other one LanguageModelConfigOptions
+		 * doesn't get persisted.
 		 */
 		export interface LanguageModelConfig extends LanguageModelConfigOptions {
 			type: PositronLanguageModelType;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2013,8 +2013,6 @@ declare module 'positron' {
 
 		/**
 		 * Positron Language Model configuration.
-		 * this doesn't get persisted or the other one LanguageModelConfigOptions
-		 * doesn't get persisted.
 		 */
 		export interface LanguageModelConfig extends LanguageModelConfigOptions {
 			type: PositronLanguageModelType;

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -57,7 +57,6 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 					await this._proxy.$responseLanguageModelConfig(id, config, action);
 					resolve();
 				},
-				() => reject('User cancelled language model configuration.'),
 				() => this._proxy.$onCompleteLanguageModelConfig(id),
 			);
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -747,7 +747,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			firstLinkToButton = true;
 			// create a multi-line message
 			welcomeText = localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n");
-			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.addModelConfiguration)`;
+			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.configureModels)`;
 		} else {
 			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");
 			welcomeTitle = localize('positronAssistant.welcomeMessageTitle', "Welcome to Positron Assistant");

--- a/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
+++ b/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
@@ -54,7 +54,7 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 			class: undefined,
 			tooltip: addModelProviderTooltip(),
 			run: async () => {
-				await positronActionBarContext.commandService.executeCommand('positron-assistant.addModelConfiguration');
+				await positronActionBarContext.commandService.executeCommand('positron-assistant.configureModels');
 			}
 		}];
 
@@ -67,7 +67,7 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 				label={addModelProviderLabel()}
 				tooltip={addModelProviderTooltip()}
 				onPressed={async () => {
-					await positronActionBarContext.commandService.executeCommand('positron-assistant.addModelConfiguration');
+					await positronActionBarContext.commandService.executeCommand('positron-assistant.configureModels');
 				}}
 			/>;
 		}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -163,7 +163,6 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 				) : null
 			}
 		</div>
-		{/* this is the only usage of source..maybe don't need it anymore? */}
 		<ProviderNotice provider={source.provider} />
 	</>;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -140,6 +140,8 @@ function interpolate(text: string, value: (key: string) => React.ReactNode | und
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const { authMethod, authStatus, config, source } = props;
 	const { apiKey } = config;
+	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN;
+	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN;
 
 	// This currently only updates the API key for the provider, but in the future it may be extended to support
 	// additional configuration options for language models.
@@ -149,18 +151,12 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 
 	return <>
 		<div className='language-model-container input'>
-			{
-				authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN ? (
-					<ApiKey apiKey={apiKey} onChange={onChange} />
-				) : null
-			}
+			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onChange} />}
 			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
-			{
-				props.authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.IN_PROGRESS ? (
-					<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
-						{localize('positron.languageModelConfig.cancel', "Cancel")}
-					</Button>
-				) : null
+			{showCancelButton &&
+				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
+					{localize('positron.languageModelConfig.cancel', "Cancel")}
+				</Button>
 			}
 		</div>
 		<ProviderNotice provider={source.provider} />
@@ -183,10 +179,10 @@ const ApiKey = (props: { apiKey?: string, onChange: (newApiKey: string) => void 
 const SignInButton = (props: { authMethod: AuthMethod, authStatus: AuthStatus, onSignIn: () => void }) => {
 	// Use the default button style when the auth method is 'apiKey' and authentication is in progress (user
 	// is entering an API key). This allows the Enter key to submit the API key input field.
-	const useDefaultButtonStyle = props.authMethod === AuthMethod.API_KEY && props.authStatus === AuthStatus.IN_PROGRESS;
+	const useDefaultButtonStyle = props.authMethod === AuthMethod.API_KEY && props.authStatus === AuthStatus.SIGN_IN_PENDING;
 	return <Button
 		className={`language-model button sign-in ${useDefaultButtonStyle ? 'default' : ''}`}
-		disabled={props.authStatus === AuthStatus.IN_PROGRESS}
+		disabled={props.authStatus === AuthStatus.SIGNING_IN}
 		onPressed={props.onSignIn}
 	>
 		{props.authStatus === AuthStatus.SIGNED_IN ? signOutButtonLabel : signInButtonLabel}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -181,8 +181,8 @@ const ApiKey = (props: { apiKey?: string, onChange: (newApiKey: string) => void 
 }
 
 const SignInButton = (props: { authMethod: AuthMethod, authStatus: AuthStatus, onSignIn: () => void }) => {
-	// When the auth method is 'apiKey' and the user is not signed in, we use the default button style, so that the
-	// Enter key can be used to sign in with the text input provided.
+	// Use the default button style when the auth method is 'apiKey' and authentication is in progress (user
+	// is entering an API key). This allows the Enter key to submit the API key input field.
 	const useDefaultButtonStyle = props.authMethod === AuthMethod.API_KEY && props.authStatus === AuthStatus.IN_PROGRESS;
 	return <Button
 		className={`language-model button sign-in ${useDefaultButtonStyle ? 'default' : ''}`}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -176,13 +176,13 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	/** Derive the auth method from the selected provider */
 	const getAuthMethod = () => {
-		// We don't currently support more than one auth method per provider,
-		// so if OAuth is supported, it is the only auth method.
+		// We don't currently support more than one auth method per provider.
 		if (selectedProvider.supportedOptions.includes(AuthMethod.OAUTH)) {
 			return AuthMethod.OAUTH;
+		} else if (selectedProvider.supportedOptions.includes(AuthMethod.API_KEY)) {
+			return AuthMethod.API_KEY;
 		}
-		// Otherwise, we assume API key auth is supported.
-		return AuthMethod.API_KEY;
+		return AuthMethod.NONE;
 	}
 
 	/** When the user clicks a different provider in the modal */
@@ -237,6 +237,8 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		setErrorMessage(undefined);
 		if (providerConfig) {
 			switch (getAuthMethod()) {
+				case AuthMethod.NONE:
+				// Use the same actions as API_KEY
 				case AuthMethod.API_KEY:
 					await props.onAction(providerConfig, isSignedIn() ? 'delete' : 'save')
 						.catch((e) => {
@@ -341,17 +343,20 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			<label className='language-model-section'>
 				{(() => localize('positron.languageModelProviderModalDialog.authentication', "Authentication"))()}
 			</label>
-			<div className='language-model-authentication-method-container'>
-				<RadioGroup
-					entries={authMethodRadioButtons}
-					initialSelectionId={getAuthMethod()}
-					name='authMethod'
-					onSelectionChanged={(authMethod) => {
-						// TODO: it's not currently possible to change the auth method, as each provider only
-						// supports one auth method at a time. This is a placeholder for future support.
-					}}
-				/>
-			</div>
+			{
+				getAuthMethod() !== AuthMethod.NONE &&
+				<div className='language-model-authentication-method-container'>
+					<RadioGroup
+						entries={authMethodRadioButtons}
+						initialSelectionId={getAuthMethod()}
+						name='authMethod'
+						onSelectionChanged={(authMethod) => {
+							// TODO: it's not currently possible to change the auth method, as each provider only
+							// supports one auth method at a time. This is a placeholder for future support.
+						}}
+					/>
+				</div>
+			}
 			<LanguageModelConfigComponent
 				authMethod={getAuthMethod()}
 				authStatus={getAuthStatus()}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -131,7 +131,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		return () => { disposables.forEach(d => d.dispose()); }
 	}, [props.positronAssistantService]);
 
-	// Keep selectedProvider and providerConfig in sync with providerSources
+	// Keep selectedProvider in sync with providerSources
 	useEffect(() => {
 		const updatedSource = providerSources.find(source => source.provider.id === selectedProvider.provider.id);
 		if (updatedSource) {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -143,7 +143,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				}
 			});
 		}
-	}, [providerSources, selectedProvider]);
+	}, [providerSources, selectedProvider.provider.id]);
 
 	/** Check if the current provider is one of the signed in providers */
 	const isSignedIn = () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -173,13 +173,12 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	/** Derive the auth method from the selected provider */
 	const getAuthMethod = () => {
-		// Currently, if the provider supports OAuth, we use that as the auth method.
-		// If it does not support OAuth, we use API key auth.
-		// There is not currently a way to have more than one auth method per provider,
-		// so we can assume that if OAuth is supported, it is the only auth method.
+		// We don't currently support more than one auth method per provider,
+		// so if OAuth is supported, it is the only auth method.
 		if (selectedProvider.supportedOptions.includes(AuthMethod.OAUTH)) {
 			return AuthMethod.OAUTH;
 		}
+		// Otherwise, we assume API key auth is supported.
 		return AuthMethod.API_KEY;
 	}
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -147,7 +147,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	/** Check if the current provider is one of the signed in providers */
 	const isSignedIn = () => {
-		return providerSources.some(source => source.provider.id === providerConfig.provider && source.signedIn);
+		return providerSources.some(source => source.provider.id === selectedProvider.provider.id && source.signedIn);
 	}
 
 	/** Check if OAuth is in progress */
@@ -157,7 +157,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	/** Check if API key auth is in progress */
 	const isApiKeyAuthInProgress = () => {
-		return showProgress && getAuthMethod() === AuthMethod.API_KEY && !!providerConfig.apiKey && providerConfig.apiKey.length > 0;
+		return getAuthMethod() === AuthMethod.API_KEY && !!providerConfig.apiKey && providerConfig.apiKey.length > 0;
 	}
 
 	/** Derive the auth status from the selected provider or progress state */
@@ -166,7 +166,10 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			return AuthStatus.SIGNED_IN;
 		}
 		if (showProgress) {
-			return AuthStatus.IN_PROGRESS;
+			return AuthStatus.SIGNING_IN;
+		}
+		if (isApiKeyAuthInProgress()) {
+			return AuthStatus.SIGN_IN_PENDING;
 		}
 		return AuthStatus.SIGNED_OUT;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -213,10 +213,9 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 	showLanguageModelModalDialog(
 		sources: IPositronLanguageModelSource[],
 		onAction: (config: IPositronLanguageModelConfig, action: string) => Promise<void>,
-		onCancel: () => void,
 		onClose: () => void,
 	): void {
-		showLanguageModelModalDialog(this._keybindingService, this._layoutService, this._configurationService, this, this._positronModalDialogsService, sources, onAction, onCancel, onClose);
+		showLanguageModelModalDialog(this._keybindingService, this._layoutService, this._configurationService, this, this._positronModalDialogsService, sources, onAction, onClose);
 	}
 
 	getSupportedProviders(): string[] {

--- a/src/vs/workbench/contrib/positronAssistant/browser/types.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/types.ts
@@ -9,7 +9,12 @@ export enum AuthMethod {
 }
 
 export enum AuthStatus {
+	/** Currently signed in */
 	SIGNED_IN = 'signedIn',
-	IN_PROGRESS = 'inProgress',
+	/** User input entered, but not yet submitted for auth */
+	SIGN_IN_PENDING = 'signInPending',
+	/** Sign in submitted, waiting for response from auth process */
+	SIGNING_IN = 'signingIn',
+	/** Currently signed out */
 	SIGNED_OUT = 'signedOut',
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/types.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/types.ts
@@ -6,6 +6,7 @@
 export enum AuthMethod {
 	API_KEY = 'apiKey',
 	OAUTH = 'oauth',
+	NONE = 'none',
 }
 
 export enum AuthStatus {

--- a/src/vs/workbench/contrib/positronAssistant/browser/types.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/types.ts
@@ -7,3 +7,9 @@ export enum AuthMethod {
 	API_KEY = 'apiKey',
 	OAUTH = 'oauth',
 }
+
+export enum AuthStatus {
+	SIGNED_IN = 'signedIn',
+	IN_PROGRESS = 'inProgress',
+	SIGNED_OUT = 'signedOut',
+}

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -53,6 +53,7 @@ export type PositronLanguageModelOptions = Exclude<{
 	[K in keyof IPositronLanguageModelConfig]: undefined extends IPositronLanguageModelConfig[K] ? K : never
 }[keyof IPositronLanguageModelConfig], undefined>;
 
+// Equivalent in positron.d.ts API: LanguageModelSource
 export interface IPositronLanguageModelSource {
 	type: PositronLanguageModelType;
 	provider: { id: string; displayName: string };
@@ -62,8 +63,7 @@ export interface IPositronLanguageModelSource {
 	authMethods?: string[];
 }
 
-// this is redefined in the positron api in src/positron-dts/positron.d.ts
-// as LanguageModelConfig which extends LanguageModelConfigOptions
+// Equivalent in positron.d.ts API: LanguageModelConfig
 export interface IPositronLanguageModelConfig {
 	type: PositronLanguageModelType;
 	provider: string;

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -62,6 +62,8 @@ export interface IPositronLanguageModelSource {
 	authMethods?: string[];
 }
 
+// this is redefined in the positron api in src/positron-dts/positron.d.ts
+// as LanguageModelConfig which extends LanguageModelConfigOptions
 export interface IPositronLanguageModelConfig {
 	type: PositronLanguageModelType;
 	provider: string;

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -112,7 +112,6 @@ export interface IPositronAssistantService {
 	showLanguageModelModalDialog(
 		sources: IPositronLanguageModelSource[],
 		onAction: (config: IPositronLanguageModelConfig, action: string) => Promise<void>,
-		onCancel: () => void,
 		onClose: () => void,
 	): void;
 

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -7,11 +7,11 @@
 import { expect, test } from '@playwright/test';
 import { Code } from '../infra/code';
 
-const CHATBUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
+const CHAT_BUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
 const CONFIGURE_MODELS_LINK = 'a[data-href="command:positron-assistant.configureModels"]';
 const ADD_MODEL_BUTTON = '[id="workbench.panel.chat"] button[aria-label="Add Model Provider..."]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
-const DONE_BUTTON = 'button.positron-button.action-bar-button.default';
+const CLOSE_BUTTON = 'button.positron-button.action-bar-button.default:has-text("Close")';
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
 const SIGN_OUT_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign out")';
 const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anthropic-provider-button)';
@@ -40,7 +40,7 @@ export class Assistant {
 	constructor(private code: Code) { }
 
 	async verifyChatButtonVisible() {
-		await expect(this.code.driver.page.locator(CHATBUTTON)).toBeVisible();
+		await expect(this.code.driver.page.locator(CHAT_BUTTON)).toBeVisible();
 	}
 
 	async openPositronAssistantChat() {
@@ -48,7 +48,7 @@ export class Assistant {
 			await this.verifyChatButtonVisible();
 			const addModelLinkIsVisible = await this.code.driver.page.locator(CHAT_PANEL).isVisible();
 			if (!addModelLinkIsVisible) {
-				await this.code.driver.page.locator(CHATBUTTON).click();
+				await this.code.driver.page.locator(CHAT_BUTTON).click();
 			}
 		});
 	}
@@ -127,8 +127,8 @@ export class Assistant {
 		await this.code.driver.page.locator(SIGN_IN_BUTTON).click();
 	}
 
-	async clickDoneButton() {
-		await this.code.driver.page.locator(DONE_BUTTON).click();
+	async clickCloseButton() {
+		await this.code.driver.page.locator(CLOSE_BUTTON).click();
 	}
 
 	async clickSignOutButton() {

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -8,7 +8,7 @@ import { expect, test } from '@playwright/test';
 import { Code } from '../infra/code';
 
 const CHATBUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
-const ADD_MODEL_LINK = 'a[data-href="command:positron-assistant.addModelConfiguration"]';
+const CONFIGURE_MODELS_LINK = 'a[data-href="command:positron-assistant.configureModels"]';
 const ADD_MODEL_BUTTON = '[id="workbench.panel.chat"] button[aria-label="Add Model Provider..."]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
 const DONE_BUTTON = 'button.positron-button.action-bar-button.default';
@@ -60,7 +60,7 @@ export class Assistant {
 	}
 
 	async clickAddModelLink() {
-		await this.code.driver.page.locator(ADD_MODEL_LINK).click();
+		await this.code.driver.page.locator(CONFIGURE_MODELS_LINK).click();
 	}
 
 	async clickAddModelButton() {
@@ -68,8 +68,8 @@ export class Assistant {
 	}
 
 	async verifyAddModelLinkVisible() {
-		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toBeVisible();
-		await expect(this.code.driver.page.locator(ADD_MODEL_LINK)).toHaveText('Add a Language Model.');
+		await expect(this.code.driver.page.locator(CONFIGURE_MODELS_LINK)).toBeVisible();
+		await expect(this.code.driver.page.locator(CONFIGURE_MODELS_LINK)).toHaveText('Add a Language Model.');
 	}
 
 	async verifyAddModelButtonVisible() {

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -28,7 +28,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 
 
 	/**
-	 * Verifies an error is returned when a bad api key is unput.
+	 * Verifies an error is returned when a bad api key is input.
 	 *
 	 * @param app - Application fixture providing access to UI elements
 	 */
@@ -39,7 +39,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.enterApiKey('1234');
 		await app.workbench.assistant.clickSignInButton();
 		await expect(app.workbench.assistant.verifySignOutButtonVisible(5000)).rejects.toThrow();
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 		await app.code.driver.page.locator('.positron-button:has-text("Yes")').click();
 	});
 
@@ -57,7 +57,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.verifySignOutButtonVisible();
 		await app.workbench.assistant.clickSignOutButton();
 		await app.workbench.assistant.verifySignInButtonVisible();
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 	});
 
 	/**
@@ -72,7 +72,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickAddModelButton();
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 		await openFile(join('workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 		await app.workbench.editor.clickOnTerm('chinook-sqlite.py', 'data_file_path', 4);
 		const inlineChatShortcut = process.platform === 'darwin' ? 'Meta+I' : 'Control+I';
@@ -82,7 +82,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 		await app.workbench.assistant.closeInlineChat();
 	});
 
@@ -93,7 +93,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.verifyAuthMethod('oauth');
 		await app.workbench.assistant.selectModelProvider('Anthropic');
 		await app.workbench.assistant.verifyAuthMethod('apiKey');
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 	});
 
 });
@@ -106,7 +106,7 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickDoneButton();
+		await app.workbench.assistant.clickCloseButton();
 	});
 
 	test.beforeEach('How to clear chat', async function ({ app }) {

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -79,7 +79,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.code.driver.page.keyboard.press(inlineChatShortcut);
 		await app.code.driver.page.locator('.chat-widget > .interactive-session').isVisible();
 		await app.workbench.assistant.verifyInlineChatInputsVisible();
-		await app.workbench.quickaccess.runCommand('positron-assistant.addModelConfiguration');
+		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignOutButton();
 		await app.workbench.assistant.clickDoneButton();
@@ -101,13 +101,9 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
  * Test suite Positron Assistant actions from the chat interface.
  */
 test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
-	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
-		// Need to turn on the assistant for these tests to work. Can remove once it's on by default.
-		await settings.set({
-			'positron.assistant.newModelConfiguration': true,
-		}, { reload: true });
+	test.beforeAll('Enable Assistant', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.quickaccess.runCommand('positron-assistant.addModelConfiguration');
+		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
 		await app.workbench.assistant.selectModelProvider('echo');
 		await app.workbench.assistant.clickSignInButton();
 		await app.workbench.assistant.clickDoneButton();


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8014
- should be merged after #8030
- `positron-assistant.configureModels` is now the only command that brings up the language model provider modal
- `positron-assistant.logStoredModels` is a 🆕 command that logs the stored models to the Assistant output
    - yay or nay?
    - keep this as a command or just log this on every change to the providers? both?
- refactors `languageModelConfigComponent.tsx` to remove the old modal code, clean up the react state, and hopefully be a bit simpler to work with

### Release Notes

#### Bug Fixes

- Assistant: removed duplicate provider config command (#8014)

### QA Notes

@:assistant

- the provider modal should open via the command `positron-assistant.configureModels` and via the chat pane
- no regressions with signing in / out of providers
- new command `positron-assistant.logStoredModels` should output the chat and completion models you're authenticated with
