### PR TITLE
E2E Test: try to catch Interrupt text but don't require it

### DIFF
--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -144,8 +144,10 @@ export class Notebooks {
 		await test.step('Run all cells', async () => {
 			await this.code.driver.page.getByLabel('Run All').click();
 			const stopExecutionLocator = this.code.driver.page.locator('a').filter({ hasText: /Stop Execution|Interrupt/ });
-			await expect(stopExecutionLocator).toBeVisible();
-			await expect(stopExecutionLocator).not.toBeVisible({ timeout: timeout });
+			try {
+				await expect(stopExecutionLocator).toBeVisible();
+				await expect(stopExecutionLocator).not.toBeVisible({ timeout: timeout });
+			} catch { } // can be normal with very fast execution
 		});
 	}
 

--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 // test is too heavy for web
-test.describe.skip('Large Python Notebook', {
+test.describe('Large Python Notebook', {
 	tag: [tags.NOTEBOOKS, tags.WIN]
 }, () => {
 

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -11,7 +11,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () => {
+test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () => {
 
 	test('Python - Matplotlib Interact Test', {
 		tag: [tags.CRITICAL, tags.WEB, tags.WIN],


### PR DESCRIPTION
Allow catch of interrupt text to fail when running all cells

### QA Notes

@:notebooks