### PR TITLE
e2e test: custom keybinding for reload window

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -33,5 +33,9 @@
     },{
         "key": "cmd+j b",
         "command": "workbench.action.showAuxiliaryBar" // Views: Show Secondary Side Bar
+    },
+    {
+        "key": "cmd+r r",
+        "command": "workbench.action.reloadWindow"
     }
 ]

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -216,7 +216,7 @@ export class HotKeys {
 	 * Reload the window
 	 */
 	public async reloadWindow() {
-		await this.pressHotKeys(`Cmd+R`);
+		await this.pressHotKeys(`Cmd+R R`);
 	}
 
 	/**

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -30,18 +30,17 @@ test.use({
 
 test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] }, () => {
 	test.beforeAll(async ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings, hotKeys }) => {
-		await positronUserSettings.remove(['positron.importSettings.enable']);
 		await vscodeUserSettings.append({
 			'test': 'vs-code-settings',
-			'editor.fontSize': 8,
+			'editor.fontSize': 12,
 			'workbench.colorTheme': 'Default Dark',
 		});
 		await positronUserSettings.set({
+			'positron.importSettings.enable': true,
 			'test': 'positron-settings',
 			'editor.fontSize': 16,
-			'workbench.colorTheme': 'Default Light+'
-		});
-		await hotKeys.reloadWindow();
+			'workbench.colorTheme': 'Default Light+',
+		}, { reload: true, waitMs: 1000 });
 	});
 
 	test.beforeEach(async ({ sessions, hotKeys }) => {


### PR DESCRIPTION
### Summary

Working around an issue of keybinding `Cmd+R` (`Developer: Reload Window`) not working on Positron builds by overriding System default with custom keybinding `Cmd+R R`. This was causing our e2e tests running against build to fail.

### QA Notes

@:vscode-settings
