### PR TITLE
assistant: enable by default

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -125,9 +125,8 @@
         "properties": {
           "positron.assistant.enable": {
             "type": "boolean",
-            "default": false,
-            "description": "%configuration.enable.description%",
-            "tags": ["experimental"]
+            "default": true,
+            "markdownDescription": "%configuration.enable.markdownDescription%"
           },
           "positron.assistant.useAnthropicSdk": {
             "type": "boolean",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -12,7 +12,7 @@
 	"chatParticipants.edit.description": "Edit files in your workspace",
 	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document.",
 	"configuration.title": "Positron Assistant",
-	"configuration.enable.description": "Enable Positron Assistant, an experimental AI assistant for Positron.",
+	"configuration.enable.markdownDescription": "Enable [Positron Assistant](https://positron.posit.co/assistant), an AI assistant for Positron.",
 	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats."
 }

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -5,7 +5,6 @@
     "python.languageServerLogLevel": "debug",
     "remote.autoForwardPortsFallback": 0,
     "files.simpleDialog.enable": true,
-    "positron.importSettings.enable": false,
-    "positron.assistant.enable": true,
+	"positron.importSettings.enable": false,
     "positron.assistant.testModels": true
 }

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -5,6 +5,6 @@
     "python.languageServerLogLevel": "debug",
     "remote.autoForwardPortsFallback": 0,
     "files.simpleDialog.enable": true,
-	"positron.importSettings.enable": false,
+    "positron.importSettings.enable": false,
     "positron.assistant.testModels": true
 }


### PR DESCRIPTION
### Summary

- addresses: https://github.com/posit-dev/positron/issues/8140

### Release Notes

#### New Features

- Positron Assistant is now enabled by default! (#8140)

### QA Notes

@:assistant

- remove the `positron.assistant.enable` entry from your settings.json and confirm that assistant is still enabled