### PR TITLE
Fix e2e watcher task not clearing problem

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,7 +97,10 @@
 			},
 			"problemMatcher": [
 				{
-					"owner": "typescript-watch",
+					"base": "$tsc-watch",
+					"owner": "typescript",
+					"source": "watch-e2e",
+					"applyTo": "allDocuments",
 					"fileLocation": ["relative", "${workspaceFolder}/test/e2e"],
 					"pattern": {
 						"regexp": "\\[watch-e2e\\] ([^(]+)\\((\\d+),(\\d+)\\): (error TS\\d+: .+)",


### PR DESCRIPTION
The E2E Build watcher task wasn't correctly clearing the problems tab.

I had to add a `base` so vs code knew how to detect and clear the errors.

Also added a few more fields to help keep it clear.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
