### PR TITLE
Add new `RuntimeCodeExecutionMode` of `NonInteractive` and use it for R actions that execute code

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Lint and Check Formatting with Ruff
         run: |
-          uv pip install ruff
+          uv pip install ruff==0.11.13
           ruff check .
           ruff format --check
         working-directory: ${{ env.PYTHON_SRC_DIR }}

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -11,11 +11,41 @@ export enum LanguageRuntimeSessionMode {
     Background = 'background',
 }
 
+/**
+ * Possible code execution modes for a language runtime
+ */
 export enum RuntimeCodeExecutionMode {
+    /**
+     * Interactive code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: Yes
+     *          Stored in history: Yes
+     */
     Interactive = 'interactive',
+
+    /**
+     * Non-interactive code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: No
+     *          Stored in history: Yes
+     */
     NonInteractive = 'non-interactive',
+
+    /**
+     * Transient code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: No
+     *          Stored in history: No
+     */
     Transient = 'transient',
-    Silent = 'silent'
+
+    /**
+     * Silent code execution:
+     *          Displayed to user: No
+     * Combined with pending code: No
+     *          Stored in history: No
+     */
+    Silent = 'silent',
 }
 
 export enum RuntimeErrorBehavior {

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -11,10 +11,41 @@ export enum LanguageRuntimeSessionMode {
     Background = 'background',
 }
 
+/**
+ * Possible code execution modes for a language runtime
+ */
 export enum RuntimeCodeExecutionMode {
+    /**
+     * Interactive code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: Yes
+     *          Stored in history: Yes
+     */
     Interactive = 'interactive',
+
+    /**
+     * Non-interactive code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: No
+     *          Stored in history: Yes
+     */
+    NonInteractive = 'non-interactive',
+
+    /**
+     * Transient code execution:
+     *          Displayed to user: Yes
+     * Combined with pending code: No
+     *          Stored in history: No
+     */
     Transient = 'transient',
-    Silent = 'silent',
+
+    /**
+     * Silent code execution:
+     *          Displayed to user: No
+     * Combined with pending code: No
+     *          Stored in history: No
+     */
+    Silent = 'silent'
 }
 
 export enum RuntimeErrorBehavior {

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -11,40 +11,10 @@ export enum LanguageRuntimeSessionMode {
     Background = 'background',
 }
 
-/**
- * Possible code execution modes for a language runtime
- */
 export enum RuntimeCodeExecutionMode {
-    /**
-     * Interactive code execution:
-     *          Displayed to user: Yes
-     * Combined with pending code: Yes
-     *          Stored in history: Yes
-     */
     Interactive = 'interactive',
-
-    /**
-     * Non-interactive code execution:
-     *          Displayed to user: Yes
-     * Combined with pending code: No
-     *          Stored in history: Yes
-     */
     NonInteractive = 'non-interactive',
-
-    /**
-     * Transient code execution:
-     *          Displayed to user: Yes
-     * Combined with pending code: No
-     *          Stored in history: No
-     */
     Transient = 'transient',
-
-    /**
-     * Silent code execution:
-     *          Displayed to user: No
-     * Combined with pending code: No
-     *          Stored in history: No
-     */
     Silent = 'silent'
 }
 

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -330,7 +330,15 @@ function insertSection() {
 async function executeCodeForCommand(pkg: string, code: string) {
 	const isInstalled = await checkInstalled(pkg);
 	if (isInstalled) {
-		positron.runtime.executeCode('r', code, true);
+		positron.runtime.executeCode(
+			'r',	// R code
+			code,	// The code to execute.
+			true,	// Focus the console after executing the code.
+			true,	// Do not check the code for completeness before executing.
+			// Specify the runtime execution mode as NonInteractive so that the
+			// code is not combined with pending code before being executed.
+			positron.RuntimeCodeExecutionMode.NonInteractive
+		);
 	}
 }
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -136,13 +136,36 @@ declare module 'positron' {
 	 * Possible code execution modes for a language runtime
 	 */
 	export enum RuntimeCodeExecutionMode {
-		/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+		/**
+		 * Interactive code execution:
+		 *          Displayed to user: Yes
+		 * Combined with pending code: Yes
+		 *          Stored in history: Yes
+		 */
 		Interactive = 'interactive',
 
-		/** The code should be executed but not stored in history. */
+		/**
+		 * Non-interactive code execution:
+		 *          Displayed to user: Yes
+		 * Combined with pending code: No
+		 *          Stored in history: Yes
+		 */
+		NonInteractive = 'non-interactive',
+
+		/**
+		 * Transient code execution:
+		 *          Displayed to user: Yes
+		 * Combined with pending code: No
+		 *          Stored in history: No
+		 */
 		Transient = 'transient',
 
-		/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+		/**
+		 * Silent code execution:
+		 *          Displayed to user: No
+		 * Combined with pending code: No
+		 *          Stored in history: No
+		 */
 		Silent = 'silent'
 	}
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4578,13 +4578,36 @@ export enum LanguageRuntimeMessageType {
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {
-	/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+	/**
+	 * Interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: Yes
+	 *          Stored in history: Yes
+	 */
 	Interactive = 'interactive',
 
-	/** The code should be executed but not stored in history. */
+	/**
+	 * Non-interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: Yes
+	 */
+	NonInteractive = 'non-interactive',
+
+	/**
+	 * Transient code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Transient = 'transient',
 
-	/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+	/**
+	 * Silent code execution:
+	 *          Displayed to user: No
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Silent = 'silent'
 }
 

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -221,13 +221,36 @@ export enum RuntimeClientState {
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {
-	/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+	/**
+	 * Interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: Yes
+	 *          Stored in history: Yes
+	 */
 	Interactive = 'interactive',
 
-	/** The code should be executed but not stored in history. */
+	/**
+	 * Non-interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: Yes
+	 */
+	NonInteractive = 'non-interactive',
+
+	/**
+	 * Transient code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Transient = 'transient',
 
-	/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+	/**
+	 * Silent code execution:
+	 *          Displayed to user: No
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Silent = 'silent'
 }
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -361,13 +361,36 @@ export enum RuntimeState {
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {
-	/** The code was entered interactively, and should be executed and stored in the runtime's history. */
+	/**
+	 * Interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: Yes
+	 *          Stored in history: Yes
+	 */
 	Interactive = 'interactive',
 
-	/** The code should be executed but not stored in history. */
+	/**
+	 * Non-interactive code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: Yes
+	 */
+	NonInteractive = 'non-interactive',
+
+	/**
+	 * Transient code execution:
+	 *          Displayed to user: Yes
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Transient = 'transient',
 
-	/** The code execution should be fully silent, neither displayed to the user nor stored in history. */
+	/**
+	 * Silent code execution:
+	 *          Displayed to user: No
+	 * Combined with pending code: No
+	 *          Stored in history: No
+	 */
 	Silent = 'silent'
 }
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1470,54 +1470,58 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		}
 
 		// Code should be executed if the caller skips checks, or if the runtime says the code is complete.
-		const shouldExecuteCode = async (code: string) => {
-			if (allowIncomplete) {
-				return true;
-			}
+		const shouldExecuteCode = async (codeToCheck: string) => {
+			// If there is no session, we cannot check if the code is complete or execute it,
+			// so return false.
 			if (!this.session) {
 				return false;
 			}
-			const codeStatus = await this.session.isCodeFragmentComplete(code);
-			return codeStatus === RuntimeCodeFragmentStatus.Complete;
+
+			// If allow incomplete is true, skip the code completeness check and return true.
+			if (allowIncomplete) {
+				return true;
+			}
+
+			// Return true if the code fragment is complete, false otherwise.
+			return await this.session.isCodeFragmentComplete(codeToCheck) === RuntimeCodeFragmentStatus.Complete;
 		};
 
-		// Get the pending code from the code editor. If there is pending code in the code editor,
-		// see if adding this code to it creates code that can be executed.
-		let pendingCode = this.codeEditor?.getValue();
-		if (pendingCode) {
-
-			// No ID supplied; check if there's a stored execution ID for this
-			// code.
-			if (!executionId) {
-				const storedExecutionId = this._pendingExecutionIds.get(code);
-				if (storedExecutionId) {
-					executionId = storedExecutionId;
+		// Handle interactive mode first.
+		if (mode === RuntimeCodeExecutionMode.Interactive) {
+			// If there is pending code in the code editor, see if adding this code to it creates
+			// code that can be executed.
+			let pendingCode = this.codeEditor?.getValue();
+			if (pendingCode) {
+				// No ID supplied; check if there's a stored execution ID for this code.
+				if (!executionId) {
+					const storedExecutionId = this._pendingExecutionIds.get(code);
+					if (storedExecutionId) {
+						executionId = storedExecutionId;
+					}
 				}
-			}
 
-			// Figure out whether adding this code to the pending code results in code that can be
-			// executed. If so, execute it.
-			pendingCode += '\n' + code;
-			if (await shouldExecuteCode(pendingCode)) {
-				this.setPendingCode();
-				this.doExecuteCode(pendingCode, attribution, mode, errorBehavior, executionId);
-			} else {
-				// Update the pending code. More will be revealed.
-				this.setPendingCode(pendingCode, executionId);
-			}
+				// Figure out whether adding this code to the pending code results in code that can
+				// be executed. If so, execute it.
+				pendingCode += '\n' + code;
+				if (await shouldExecuteCode(pendingCode)) {
+					this.setPendingCode();
+					this.doExecuteCode(pendingCode, attribution, mode, errorBehavior, executionId);
+				} else {
+					// Update the pending code. More will be revealed.
+					this.setPendingCode(pendingCode, executionId);
+				}
 
-			// In either case, return.
-			return;
+				// In either case, return.
+				return;
+			}
 		}
 
-		// Figure out whether this code can be executed. If it can be, execute it immediately.
+		// Execute the code if it is complete, or set it as pending if it is not.
 		if (await shouldExecuteCode(code)) {
 			this.doExecuteCode(code, attribution, mode, errorBehavior, executionId);
-			return;
+		} else {
+			this.setPendingCode(code, executionId);
 		}
-
-		// The code cannot be executed. Set the pending code.
-		this.setPendingCode(code, executionId);
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR addresses #6680 by adding a new `RuntimeCodeExecutionMode` of `NonInteractive` and using it for R actions that execute code.

In this screen recording, you will see that `devtools::load_all()` is executed immediately and that the call to `stop("bad robot")` isn't executed until the user presses enter.

https://github.com/user-attachments/assets/6054f167-dc5b-4cb1-92a6-6cb65561e257

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6680 Add a new `RuntimeCodeExecutionMode` of `NonInteractive` and use it for R actions that execute code.

### QA Notes

Tests:
@:console
@:r-pkg-development
