### PR TITLE
Assistant: Disable R diagnostics in code confirmation widgets

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -100,6 +100,8 @@ export class PythonLsp implements vscode.Disposable {
             : [
                   { language: 'python', scheme: 'untitled' },
                   { language: 'python', scheme: 'inmemory' }, // Console
+                  // Assistant code confirmation widget: https://github.com/posit-dev/positron/issues/7750
+                  { language: 'python', scheme: 'assistant-code-confirmation-widget' },
                   { language: 'python', pattern: '**/*.py' },
               ];
 

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -118,7 +118,17 @@ export class ArkLsp implements vscode.Disposable {
 				},
 			errorHandler: new RErrorHandler(this._version, port),
 			outputChannel: outputChannel,
-			revealOutputChannelOn: RevealOutputChannelOn.Never
+			revealOutputChannelOn: RevealOutputChannelOn.Never,
+			middleware: {
+				handleDiagnostics(uri, diagnostics, next) {
+					// Disable diagnostics for Assistant code confirmation widgets:
+					// https://github.com/posit-dev/positron/issues/7750
+					if (uri.scheme === 'assistant-code-confirmation-widget') {
+						return undefined;
+					}
+					return next(uri, diagnostics);
+				},
+			}
 		};
 
 		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -24,6 +24,8 @@ import { discoverCondaBinaries } from './provider-conda.js';
 export const R_DOCUMENT_SELECTORS = [
 	{ language: 'r', scheme: 'untitled' },
 	{ language: 'r', scheme: 'inmemory' },  // Console
+	// Assistant code confirmation widget: https://github.com/posit-dev/positron/issues/7750
+	{ language: 'r', scheme: 'assistant-code-confirmation-widget' },
 	{ language: 'r', pattern: '**/*.{r,R}' },
 	{ language: 'r', pattern: '**/*.{rprofile,Rprofile}' },
 ];

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -444,7 +444,16 @@ class ChatToolInvocationSubPart extends Disposable {
 			}
 		};
 		const langId = this.languageService.getLanguageIdByLanguageName(terminalData.language ?? 'sh') ?? 'shellscript';
-		const model = this.modelService.createModel(terminalData.command, this.languageService.createById(langId));
+		// --- Start Positron ---
+		// Pass a resource with a custom scheme so that language packs can ignore these code blocks.
+		// See: https://github.com/posit-dev/positron/issues/7750.
+		// const model = this.modelService.createModel(terminalData.command, this.languageService.createById(langId));
+		const resource = URI.from({
+			scheme: 'assistant-code-confirmation-widget',
+			path: generateUuid(),
+		});
+		const model = this.modelService.createModel(terminalData.command, this.languageService.createById(langId), resource);
+		// --- End Positron ---
 		const editor = this._register(this.editorPool.get());
 		const renderPromise = editor.object.render({
 			codeBlockIndex: this.codeBlockStartIndex,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -447,7 +447,9 @@ class ChatToolInvocationSubPart extends Disposable {
 		// --- Start Positron ---
 		// Pass a resource with a custom scheme so that language packs can ignore these code blocks.
 		// See: https://github.com/posit-dev/positron/issues/7750.
-		// const model = this.modelService.createModel(terminalData.command, this.languageService.createById(langId));
+		/*
+		const model = this.modelService.createModel(terminalData.command, this.languageService.createById(langId));
+		*/
 		const resource = URI.from({
 			scheme: 'assistant-code-confirmation-widget',
 			path: generateUuid(),


### PR DESCRIPTION
Disable diagnostics in R code confirmation widgets. I've left other R language features and all Python language features enabled since they're all still useful. Addresses #7750.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed spurious R diagnostics in Assistant code confirmation widgets (#7750).

### QA Notes

Ask Assistant to generate a plot using ggplot in Ask mode. There should be no spurious diagnostics in the code confirmation widget or the confirmed code block thereafter.