### PR TITLE
Assistant: Enable streaming inline edits by default

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -135,7 +135,7 @@
           },
           "positron.assistant.streamingEdits.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "%configuration.streamingEdits.enable%",
             "tags": ["experimental"]
           }

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -136,8 +136,7 @@
           "positron.assistant.streamingEdits.enable": {
             "type": "boolean",
             "default": true,
-            "description": "%configuration.streamingEdits.enable%",
-            "tags": ["experimental"]
+            "description": "%configuration.streamingEdits.enable%"
           }
         }
       }

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -769,7 +769,7 @@ export function getDefaultContextItems(): string[] {
  * Whether the experimental streaming edit mode is enabled.
  */
 function isStreamingEditsEnabled(): boolean {
-	return vscode.workspace.getConfiguration('positron.assistant.streamingEdits').get('enable', false);
+	return vscode.workspace.getConfiguration('positron.assistant.streamingEdits').get('enable', true);
 }
 
 /** Processes streaming text. */


### PR DESCRIPTION
I haven't encountered any issues with this enabled in my testing. Also haven't gotten any bug reports from testers.

### Release Notes

#### New Features

- Enabled streaming edits in Assistant inline editor chats by default.

#### Bug Fixes

- N/A