### PR TITLE
Move e2e out of build group

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -90,6 +90,7 @@
 			"script": "watch-e2ed",
 			"label": "E2E Tests - Build",
 			"isBackground": true,
+			"group": "test",
 			"presentation": {
 				"reveal": "never",
 				"group": "testWatchers",
@@ -117,13 +118,11 @@
 				}
 			]
 		},
-
 		{
 			"label": "VS Code - Build",
 			"dependsOn": [
 				"Core - Build",
-				"Ext - Build",
-				"E2E Tests - Build",
+				"Ext - Build"
 			],
 			"group": {
 				"kind": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -117,10 +117,22 @@
 					}
 				}
 			]
+		},		{
+			"label": "Positron Only - Build",
+			"dependsOn": [
+				"Core - Build",
+				"Ext - Build"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": []
 		},
 		{
-			"label": "VS Code - Build",
+			"label": "Positron with E2E Tests - Build",
 			"dependsOn": [
+				"E2E Tests - Build",
 				"Core - Build",
 				"Ext - Build"
 			],


### PR DESCRIPTION
Moves the "E2E Tests - Build" task out of the default build group. 

It now needs to be run manually from "Run Task" in command palette, or you can assign a keyboard shortcut.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
