### PR TITLE
remote SSH: clarify error msg if server not available

### DIFF
--- a/extensions/open-remote-ssh/src/authResolver.ts
+++ b/extensions/open-remote-ssh/src/authResolver.ts
@@ -244,13 +244,15 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
 				if (context.resolveAttempt === 1) {
 					this.logger.show();
 
-					const closeRemote = 'Close Remote';
-					const retry = 'Retry';
-					const result = await vscode.window.showErrorMessage(`Could not establish connection to "${sshDest.hostname}"`, { modal: true }, closeRemote, retry);
-					if (result === closeRemote) {
-						await vscode.commands.executeCommand('workbench.action.remote.close');
-					} else if (result === retry) {
-						await vscode.commands.executeCommand('workbench.action.reloadWindow');
+					if (!(e instanceof ServerInstallError)) {
+						const closeRemote = 'Close Remote';
+						const retry = 'Retry';
+						const result = await vscode.window.showErrorMessage(`Could not establish connection to "${sshDest.hostname}"`, { modal: true }, closeRemote, retry);
+						if (result === closeRemote) {
+							await vscode.commands.executeCommand('workbench.action.remote.close');
+						} else if (result === retry) {
+							await vscode.commands.executeCommand('workbench.action.reloadWindow');
+						}
 					}
 				}
 

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -151,7 +151,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
     const exitCode = parseInt(resultMap.exitCode, 10);
     if (exitCode === 66) {
         throw new ServerInstallError(
-            `There is no available Positron server with version '${installOptions.version}' for ${resultMap.platform} (${resultMap.arch}).`
+            `There is no available Positron server with version ${installOptions.version} for ${resultMap.platform} ${resultMap.arch}.`
             + `\nPlease check the [system requirements](https://positron.posit.co/remote-ssh.html#system-requirements) and [troubleshooting guides](https://positron.posit.co/remote-ssh.html#how-it-works-troubleshooting).`
         );
     } else if (exitCode !== 0) {

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -149,8 +149,13 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
     }
 
     const exitCode = parseInt(resultMap.exitCode, 10);
-    if (exitCode !== 0) {
-        throw new ServerInstallError(`Couldn't install vscode server on remote server, install script returned non-zero exit status`);
+    if (exitCode === 66) {
+        throw new ServerInstallError(
+            `There is no available Positron server with version '${installOptions.version}' for ${resultMap.platform} (${resultMap.arch}).`
+            + `\nPlease check the [system requirements](https://positron.posit.co/remote-ssh.html#system-requirements) and [troubleshooting guides](https://positron.posit.co/remote-ssh.html#how-it-works-troubleshooting).`
+        );
+    } else if (exitCode !== 0) {
+        throw new ServerInstallError(`Couldn't install Positron server on remote server, install script returned non-zero exit status`);
     }
 
     const listeningOn = resultMap.listeningOn.match(/^\d+$/)
@@ -334,7 +339,7 @@ if [[ ! -f $SERVER_SCRIPT ]]; then
 
     if (( $? > 0 )); then
         echo "Error downloading server from $SERVER_DOWNLOAD_URL"
-        print_install_results_and_exit 1
+        print_install_results_and_exit 66
     fi
 
     tar -xf vscode-server.tar.gz --strip-components 1
@@ -517,7 +522,7 @@ if(!(Test-Path $SERVER_SCRIPT)) {
 
     if(!(Test-Path $SERVER_SCRIPT)) {
         "Error while installing the server binary"
-        exit 1
+        exit 66
     }
 }
 else {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Addresses #4798. Clarifies the error that appears when you try to connect to a Remote SSH host and it can't find the server to download. Now you don't get the first scary popup - you'll only get this message:

![Screenshot 2025-06-18 at 12 59 31](https://github.com/user-attachments/assets/fbd00cdf-dd87-4045-b08c-c982b8899f47)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Clarified error message when Remote SSH can't find a matching remote server to download #4798


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Steps to reproduce are in the original issue, but I found it easiest to set up a docker container (my notes [here](https://connect.posit.it/positron-wiki/dev-notes/remote-ssh-dev.html)) and try to connect to it using a dev build of Positron. Since it's a dev build, it shouldn't be able to find a corresponding server, and this behavior should trigger.