### PR TITLE
Disable dark filter by default

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -84,7 +84,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		properties: {
 			'positron.plots.darkFilter': {
 				type: 'string',
-				default: 'auto',
+				default: 'off',
 				enum: [
 					'on',
 					'off',


### PR DESCRIPTION
The dark filter on the Plots pane makes things look pretty cool if you're just doing EDA, and keeps the IDE in glittering black, but user feedback indicates that it can be confusing if you're trying to set specific colors in dark mode. 

This change defaults the filter from `auto` to `off` -- still easy to opt into for folks that prefer it, but not on by default. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Disable Dark Filter on Plots by default (re-enable in Settings if you prefer dark plots)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
