### PR TITLE
Update default release channel

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -51,11 +51,12 @@ configurationRegistry.registerConfiguration({
 		},
 		'update.positron.channel': {
 			type: 'string',
-			default: 'prereleases',
-			enum: ['dailies', 'prereleases'],
+			default: 'releases',
+			enum: ['dailies', 'prereleases', 'releases'],
 			enumDescriptions: [
 				localize('dailies', "The latest daily build. This is the most up-to-date version of Positron."),
-				localize('prereleases', "Receive pre-release updates.")
+				localize('prereleases', "Receive pre-release updates."),
+				localize('releases', "Receive stable releases only."),
 			],
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('update.positron.channel', "Configure the release stream for receiving updates. Requires a restart after change to take effect."),

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -196,6 +196,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 		this.requestService.request({ url: releaseMetadataUrl }, CancellationToken.None)
 			.then<IUpdate | null>(asJson)
+			.catch(err => {
+				this.logService.trace('update#checkForUpdates, update request did not return valid update metadata:', err.message);
+			})
 			.then(update => {
 				if (!update || !update.url || !update.version) {
 					this.setState(State.Idle(this.getUpdateType()));


### PR DESCRIPTION
Updates the default value for the release channel to `releases`. The directory has already been created (not sure who did this).

The push to S3 does need an update to allow pushing to `releases`.

Without any releases published, this _will not_ display an error when checking for an update. There is a trace level message that can show the error message from checking for updates if needed. Initiating the update check manually is also treated like no updates available.

![image](https://github.com/user-attachments/assets/9285f616-aea1-44f4-815e-9d968644fde5)

When users update to a build with this change, they will be on the `releases` channel if they have not changed their preferences from the default.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
