### PR TITLE
Remove Format Document from the Editor Action Bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -101,7 +101,6 @@ export class EditorActionBarControl extends Disposable {
 		// Create the editor action bar factory.
 		const editorActionBarFactory = this._register(new EditorActionBarFactory(
 			this._editorGroup,
-			this._commandService,
 			this._contextKeyService,
 			this._keybindingService,
 			this._menuService,

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -159,10 +159,10 @@ export class EditorActionBarFactory extends Disposable {
 		// Create the set of processed actions.
 		const processedActions = new Set<string>();
 
-		// Create the left action bar elements from the editor title menu's editor title run action
-		// and the editor actions left menu.
+		// Create the left action bar elements from the editor title menu's editor title run submenu
+		// item and the editor actions left menu.
 		const leftActionBarElements = [
-			// Build action bar elements from the editor title run menu.
+			// Build action bar elements from the editor title run submenu item.
 			...this.buildActionBarElements(
 				processedActions,
 				false,


### PR DESCRIPTION
## Description

This PR addresses #8189 by removing the Format Document action from the Editor Action Bar.

Tests:
@:editor-action-bar

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #8189 Remove the Format Document action from the Editor Action Bar.

### QA Notes

- N/A
