### PR TITLE
Turn off Run in Shell by default

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -94,7 +94,7 @@
         "kernelSupervisor.runInShell": {
           "scope": "window",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%configuration.runInShell.description%"
         },
         "kernelSupervisor.sleepOnStartup": {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -415,7 +415,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		// Whether to run the kernel in a login shell. Kallichore ignores this
 		// on Windows.
-		const runInShell = config.get('runInShell', true);
+		const runInShell = config.get('runInShell', false);
 
 		// Create the session in the underlying API
 		const session: NewSession = {


### PR DESCRIPTION
Changes the default of Run in Shell. 

Addresses https://github.com/posit-dev/positron/issues/8166.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R and Python are no longer run in a login shell by default; if you want to use shell startup scripts to customize R and Python session startup, set the Kernel Supervisor -> Run in Shell option. (#8166)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
