### PR TITLE
Assistant: Initial pass at implementing a data summary tool for Python

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -361,6 +361,39 @@
         ]
       },
       {
+        "name": "getDataSummary",
+        "displayName": "Get Data Summary",
+        "modelDescription": "Get structured information about data objects in the current session.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionIdentifier": {
+              "type": "string",
+              "description": "The identifier of the session that contains the data."
+            },
+            "accessKeys": {
+              "type": "array",
+              "description": "An array of data variables to summarize.",
+              "items": {
+                "type": "array",
+                "description": "A list of access keys that identify a variable by specifying its path.",
+                "items": {
+                  "type": "string",
+                  "description": "An access key that uniquely identifies a variable among its siblings."
+                }
+              }
+            }
+          },
+          "required": [
+            "sessionIdentifier",
+            "accessKeys"
+          ]
+        },
+        "tags": [
+          "positron-assistant"
+        ]
+      },
+      {
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
         "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree.",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -361,19 +361,19 @@
         ]
       },
       {
-        "name": "getDataSummary",
-        "displayName": "Get Data Summary",
-        "modelDescription": "Get structured information about data objects in the current session.",
+        "name": "getTableSummary",
+        "displayName": "Get Table Summary",
+        "modelDescription": "Get structured information about table variables in the current session.",
         "inputSchema": {
           "type": "object",
           "properties": {
             "sessionIdentifier": {
               "type": "string",
-              "description": "The identifier of the session that contains the data."
+              "description": "The identifier of the session that contains the tables."
             },
             "accessKeys": {
               "type": "array",
-              "description": "An array of data variables to summarize.",
+              "description": "An array of table variables to summarize.",
               "items": {
                 "type": "array",
                 "description": "A list of access keys that identify a variable by specifying its path.",

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -23,6 +23,21 @@ results, generate the code and return it directly without trying to execute it.
 <package-management>
 You adhere to the following workflow when dealing with package management:
 
+**Data Object Information Workflow:**
+
+When the user asks questions that require detailed information about data objects (DataFrames, arrays, matrices, etc.), use the `getDataSummary` tool to retrieve structured information such as data summaries and statistics.
+
+To use the tool effectively:
+
+1. First ensure you have the correct `sessionIdentifier` from the user context
+2. Provide the `accessKeys` array with the path to the specific data objects
+   - Each access key is an array of strings representing the path to the variable
+   - If the user references a variable by name, determine the access key from context or previous tool results
+3. Do not call this tool when:
+   - The variables do not appear in the user context
+   - There is no active session
+   - The user only wants to see the structure/children of objects (use `inspectVariables` instead)
+
 **Package Management Workflow:**
 
 1. Before generating code that requires packages, you must first use the appropriate tool to check if each required package is installed. To do so, first determine the target language from the user's request or context

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -20,14 +20,15 @@ If the user asks you _how_ to do something, or asks for code rather than
 results, generate the code and return it directly without trying to execute it.
 </communication>
 
-<package-management>
-You adhere to the following workflow when dealing with package management:
+<data-querying>
 
 **Data Object Information Workflow:**
 
 When the user asks questions that require detailed information about tabular
 data objects (DataFrames, arrays, matrices, etc.), use the `getTableSummary`
 tool to retrieve structured information such as data summaries and statistics.
+Currently, this tool is only available for Python so in R sessions you will need
+to execute code to query in-memory data.
 
 To use the tool effectively:
 
@@ -39,6 +40,11 @@ To use the tool effectively:
    - The variables do not appear in the user context
    - There is no active session
    - The user only wants to see the structure/children of objects (use `inspectVariables` instead)
+
+</data-querying>
+
+<package-management>
+You adhere to the following workflow when dealing with package management:
 
 **Package Management Workflow:**
 

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -25,7 +25,9 @@ You adhere to the following workflow when dealing with package management:
 
 **Data Object Information Workflow:**
 
-When the user asks questions that require detailed information about data objects (DataFrames, arrays, matrices, etc.), use the `getDataSummary` tool to retrieve structured information such as data summaries and statistics.
+When the user asks questions that require detailed information about tabular
+data objects (DataFrames, arrays, matrices, etc.), use the `getTableSummary`
+tool to retrieve structured information such as data summaries and statistics.
 
 To use the tool effectively:
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -285,7 +285,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return inChatPane && (isEditMode || isAgentMode);
 					// Only include the getTableSummary tool for Python sessions until supported in R
 					case PositronAssistantToolName.GetTableSummary:
-						return positronContext.activeSession?.language.toLowerCase() === 'python';
+						// TODO: Remove this restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
+						// The logic above with TOOL_TAG_REQUIRES_ACTIVE_SESSION will handle checking for active sessions once this is removed.
+						return activeSessions.has('python');
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -283,6 +283,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					// Only include the documentCreate tool in the chat pane in edit or agent mode.
 					case PositronAssistantToolName.DocumentCreate:
 						return inChatPane && (isEditMode || isAgentMode);
+					// Only include the getTableSummary tool for Python sessions until supported in R
+					case PositronAssistantToolName.GetTableSummary:
+						return positronContext.activeSession?.language.toLowerCase() === 'python';
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -299,9 +299,9 @@ export function registerAssistantTools(
 
 	context.subscriptions.push(inspectVariablesTool);
 
-	const getDataSummaryTool = vscode.lm.registerTool<{ sessionIdentifier: string; accessKeys: Array<Array<string>> }>(PositronAssistantToolName.GetDataSummary, {
+	const getTableSummaryTool = vscode.lm.registerTool<{ sessionIdentifier: string; accessKeys: Array<Array<string>> }>(PositronAssistantToolName.GetTableSummary, {
 		/**
-		 * Called to get a data summary of one or more variables in the current session.
+		 * Called to get a summary information for one or more tabular datasets in the current session.
 		 * @param options The options for the tool invocation.
 		 * @param token The cancellation token.
 		 * @returns A vscode.LanguageModelToolResult containing the data summary.
@@ -336,7 +336,7 @@ export function registerAssistantTools(
 			}
 
 			// Call the Positron API to get the session variable data summaries
-			const result = await positron.runtime.querySessionVariable(
+			const result = await positron.runtime.querySessionTables(
 				options.input.sessionIdentifier,
 				options.input.accessKeys,
 				['summary_stats']);
@@ -347,7 +347,7 @@ export function registerAssistantTools(
 			]);
 		}
 	});
-	context.subscriptions.push(getDataSummaryTool);
+	context.subscriptions.push(getTableSummaryTool);
 
 	const installPythonPackageTool = vscode.lm.registerTool<{
 		packages: string[];

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -299,6 +299,56 @@ export function registerAssistantTools(
 
 	context.subscriptions.push(inspectVariablesTool);
 
+	const getDataSummaryTool = vscode.lm.registerTool<{ sessionIdentifier: string; accessKeys: Array<Array<string>> }>(PositronAssistantToolName.GetDataSummary, {
+		/**
+		 * Called to get a data summary of one or more variables in the current session.
+		 * @param options The options for the tool invocation.
+		 * @param token The cancellation token.
+		 * @returns A vscode.LanguageModelToolResult containing the data summary.
+		 */
+		invoke: async (options, token) => {
+
+			// If no session identifier is provided, return an empty array.
+			if (!options.input.sessionIdentifier || options.input.sessionIdentifier === 'undefined') {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('[[]]')
+				]);
+			}
+
+			// temporarily only enable for Python sessions
+			let session: positron.LanguageRuntimeSession | undefined;
+			const sessions = await positron.runtime.getActiveSessions();
+			if (sessions && sessions.length > 0) {
+				session = sessions.find(
+					(session) => session.metadata.sessionId === options.input.sessionIdentifier,
+				);
+			}
+			if (!session) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('[[]]')
+				]);
+			}
+
+			if (session.runtimeMetadata.languageId !== 'python') {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('[[]]')
+				]);
+			}
+
+			// Call the Positron API to get the session variable data summaries
+			const result = await positron.runtime.querySessionVariable(
+				options.input.sessionIdentifier,
+				options.input.accessKeys,
+				['summary_stats']);
+
+			// Return the result as a JSON string to the model
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(JSON.stringify(result))
+			]);
+		}
+	});
+	context.subscriptions.push(getDataSummaryTool);
+
 	const installPythonPackageTool = vscode.lm.registerTool<{
 		packages: string[];
 	}>(PositronAssistantToolName.InstallPythonPackage, {

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -7,7 +7,7 @@ export enum PositronAssistantToolName {
 	DocumentEdit = 'documentEdit',
 	EditFile = 'positron_editFile_internal',
 	ExecuteCode = 'executeCode',
-	GetDataSummary = 'getDataSummary',
+	GetTableSummary = 'getTableSummary',
 	GetPlot = 'getPlot',
 	InstallPythonPackage = 'installPythonPackage',
 	InspectVariables = 'inspectVariables',

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -7,6 +7,7 @@ export enum PositronAssistantToolName {
 	DocumentEdit = 'documentEdit',
 	EditFile = 'positron_editFile_internal',
 	ExecuteCode = 'executeCode',
+	GetDataSummary = 'getDataSummary',
 	GetPlot = 'getPlot',
 	InstallPythonPackage = 'installPythonPackage',
 	InspectVariables = 'inspectVariables',

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -751,7 +751,7 @@ class DataExplorerTableView:
 
     _SUMMARIZERS: MappingProxyType[str, SummarizerType] = MappingProxyType({})
 
-    def _prof_summary_stats(self, column_index: int, options: FormatOptions):
+    def _prof_summary_stats(self, column_index: int, options: FormatOptions) -> ColumnSummaryStats:
         col_schema = self._get_single_column_schema(column_index)
         col = self._get_column(column_index)
 
@@ -3098,7 +3098,7 @@ def _get_column_profiles(table_view, schema, query_types, format_options):
             {
                 "column_name": column.column_name,
                 "type_display": column.type_display,
-                "summary_stats": summary_stats,
+                "summary_stats": summary_stats.dict() if summary_stats else None,
             }
         )
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -276,7 +276,7 @@ class DataExplorerTableView:
             column_schemas.append(self._get_single_column_schema(column_index))
 
         # Return the column schemas.
-        return TableSchema(columns=column_schemas).dict()
+        return TableSchema(columns=column_schemas)
 
     def _get_single_column_schema(self, column_index: int) -> ColumnSchema:
         raise NotImplementedError
@@ -298,7 +298,7 @@ class DataExplorerTableView:
         return SearchSchemaResult(
             matches=TableSchema(columns=[self._get_single_column_schema(i) for i in matches_slice]),
             total_num_matches=len(matches),
-        ).dict()
+        )
 
     def _column_filter_get_matches(self, filters: list[ColumnFilter]):
         matchers = self._get_column_filter_functions(filters)
@@ -438,7 +438,7 @@ class DataExplorerTableView:
             # Simply reset if empty filter set passed
             self.filtered_indices = None
             self._update_row_view_indices()
-            return FilterResult(selected_num_rows=len(self.table), had_errors=False).dict()
+            return FilterResult(selected_num_rows=len(self.table), had_errors=False)
 
         # Evaluate all the filters and combine them using the
         # indicated conditions
@@ -478,7 +478,7 @@ class DataExplorerTableView:
 
         # Update the view indices, re-sorting if needed
         self._update_row_view_indices()
-        return FilterResult(selected_num_rows=selected_num_rows, had_errors=had_errors).dict()
+        return FilterResult(selected_num_rows=selected_num_rows, had_errors=had_errors)
 
     def _mask_to_indices(self, mask):
         raise NotImplementedError
@@ -591,7 +591,7 @@ class DataExplorerTableView:
             row_filters=self.state.row_filters,
             sort_keys=self.state.sort_keys,
             supported_features=self.FEATURES,
-        ).dict()
+        )
 
     def _recompute(self):
         # Re-setting the column filters will trigger filtering AND
@@ -1592,10 +1592,10 @@ class PandasView(DataExplorerTableView):
         if result[-1] == "\n":
             result = result[:-1]
 
-        return ExportedData(data=result, format=fmt).dict()
+        return ExportedData(data=result, format=fmt)
 
     def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
-        return ExportedData(data=str(self.table.iloc[row_index, column_index]), format=fmt).dict()
+        return ExportedData(data=str(self.table.iloc[row_index, column_index]), format=fmt)
 
     def _mask_to_indices(self, mask):
         if mask is not None:
@@ -2438,10 +2438,10 @@ class PolarsView(DataExplorerTableView):
         elif fmt == ExportFormat.Html:
             raise NotImplementedError(f"Unsupported export format {fmt}")
 
-        return ExportedData(data=result, format=fmt).dict()
+        return ExportedData(data=result, format=fmt)
 
     def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
-        return ExportedData(data=str(self.table[row_index, column_index]), format=fmt).dict()
+        return ExportedData(data=str(self.table[row_index, column_index]), format=fmt)
 
     SUPPORTED_FILTERS = frozenset(
         {
@@ -3055,6 +3055,9 @@ class DataExplorerService:
 
         # To help remember to convert pydantic types to dicts
         if result is not None:
+            # Convert pydantic types to dict
+            if not isinstance(result, dict):
+                result = result.dict()
             if isinstance(result, list):
                 for x in result:
                     assert isinstance(x, dict)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -915,7 +915,7 @@ def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variabl
 def test_query_table_summary(shell: PositronShell, variables_comm: DummyComm):
     from .test_data_explorer import SIMPLE_PANDAS_DF
 
-    _assign_variables(shell, variables_comm, df=SIMPLE_PANDAS_DF)
+    _assign_variables(shell, variables_comm, df=SIMPLE_PANDAS_DF.iloc[:, :2])
 
     msg = json_rpc_request(
         "query_table_summary",
@@ -927,8 +927,16 @@ def test_query_table_summary(shell: PositronShell, variables_comm: DummyComm):
     assert variables_comm.messages == [
         json_rpc_response(
             {
-                "summary": ANY,
-                "version": 0,
+                "num_rows": 5,
+                "num_columns": 2,
+                "column_schemas": [
+                    '{"column_name": "a", "column_index": 0, "type_name": "int64", "type_display": "number", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
+                    '{"column_name": "b", "column_index": 1, "type_name": "bool", "type_display": "boolean", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
+                ],
+                "column_profiles": [
+                    '{"column_name": "a", "type_display": "number", "summary_stats": {"type_display": "number", "number_stats": {"min_value": "1.0000", "max_value": "5.0000", "mean": "3.0000", "median": "3.0000", "stdev": "1.5811"}, "string_stats": null, "boolean_stats": null, "date_stats": null, "datetime_stats": null, "other_stats": null}}',
+                    '{"column_name": "b", "type_display": "boolean", "summary_stats": {"type_display": "boolean", "number_stats": null, "string_stats": null, "boolean_stats": {"true_count": 3, "false_count": 1}, "date_stats": null, "datetime_stats": null, "other_stats": null}}',
+                ],
             }
         )
     ]

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -137,3 +137,7 @@ def get_type_as_str(value: Any) -> str:
 
 def percent_difference(actual: float, expected: float) -> float:
     return abs(actual - expected) / actual
+
+
+def dummy_rpc_request(*args):
+    return json_rpc_request(*args, comm_id="dummy_comm_id")

--- a/extensions/positron-python/python_files/posit/positron/variables.py
+++ b/extensions/positron-python/python_files/posit/positron/variables.py
@@ -714,12 +714,14 @@ class VariablesService:
 
     def _perform_get_table_summary(self, path: list[str], query_types: list[str]) -> None:
         """RPC handler for getting table summary."""
+        import traceback
+
         try:
             self._get_table_summary(path, query_types)
         except Exception as err:
             self._send_error(
                 JsonRpcErrorCode.INTERNAL_ERROR,
-                f"Error summarizing table at '{path}': {err}",
+                f"Error summarizing table at '{path}': {err}\n{traceback.format_exc()}",
             )
 
     def _get_table_summary(self, path: list[str], query_types: list[str]) -> None:
@@ -750,7 +752,7 @@ class VariablesService:
         # Get schema using the helper function
         num_rows = table_view.table.shape[0]
         num_columns = table_view.table.shape[1]
-        schema = table_view.get_schema(GetSchemaParams(list(range(num_columns))))
+        schema = table_view.get_schema(GetSchemaParams(column_indices=list(range(num_columns))))
 
         # Create default format options
         format_options = FormatOptions(

--- a/extensions/positron-python/python_files/posit/positron/variables.py
+++ b/extensions/positron-python/python_files/posit/positron/variables.py
@@ -727,11 +727,10 @@ class VariablesService:
         from .data_explorer import (
             DataExplorerState,
             _get_column_profiles,
-            _get_table_schema_from_view,
             _get_table_view,
             _value_type_is_supported,
         )
-        from .data_explorer_comm import FormatOptions
+        from .data_explorer_comm import FormatOptions, GetSchemaParams
 
         is_known, value = self._find_var(path)
         if not is_known:
@@ -749,9 +748,9 @@ class VariablesService:
             raise ValueError(f"Failed to create table view: {e}") from e
 
         # Get schema using the helper function
-        schema = _get_table_schema_from_view(table_view)
         num_rows = table_view.table.shape[0]
         num_columns = table_view.table.shape[1]
+        schema = table_view.get_schema(GetSchemaParams(list(range(num_columns))))
 
         # Create default format options
         format_options = FormatOptions(

--- a/extensions/positron-python/python_files/posit/positron/variables_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/variables_comm.py
@@ -105,17 +105,25 @@ class FormattedVariable(BaseModel):
     )
 
 
-class SummarizedData(BaseModel):
+class QueryTableSummaryResult(BaseModel):
     """
     Result of the summarize operation
     """
 
-    children: List[Variable] = Field(
-        description="An array of summarized variables, each containing a summary of the data.",
+    num_rows: StrictInt = Field(
+        description="The total number of rows in the table.",
     )
 
-    length: StrictInt = Field(
-        description="The total number of summarized variables. This may be greater than the number of variables in the 'children' array if the array is truncated.",
+    num_columns: StrictInt = Field(
+        description="The total number of columns in the table.",
+    )
+
+    column_schemas: List[StrictStr] = Field(
+        description="The column schemas in the table.",
+    )
+
+    column_profiles: List[StrictStr] = Field(
+        description="The column profiles in the table.",
     )
 
 
@@ -197,8 +205,8 @@ class VariablesBackendRequest(str, enum.Enum):
     # Request a viewer for a variable
     View = "view"
 
-    # Query variable data
-    QueryVariableData = "query_variable_data"
+    # Query table summary
+    QueryTableSummary = "query_table_summary"
 
 
 class ListRequest(BaseModel):
@@ -369,31 +377,31 @@ class ViewRequest(BaseModel):
     )
 
 
-class QueryVariableDataParams(BaseModel):
+class QueryTableSummaryParams(BaseModel):
     """
-    Request a data summary for a variable or variables.
+    Request a data summary for a table variable.
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to inspect, as an array of access keys.",
+        description="The path to the table to summarize, as an array of access keys.",
     )
 
     query_types: List[StrictStr] = Field(
-        description="A list of types to summarize.",
+        description="A list of query types.",
     )
 
 
-class QueryVariableDataRequest(BaseModel):
+class QueryTableSummaryRequest(BaseModel):
     """
-    Request a data summary for a variable or variables.
+    Request a data summary for a table variable.
     """
 
-    params: QueryVariableDataParams = Field(
-        description="Parameters to the QueryVariableData method",
+    params: QueryTableSummaryParams = Field(
+        description="Parameters to the QueryTableSummary method",
     )
 
-    method: Literal[VariablesBackendRequest.QueryVariableData] = Field(
-        description="The JSON-RPC method name (query_variable_data)",
+    method: Literal[VariablesBackendRequest.QueryTableSummary] = Field(
+        description="The JSON-RPC method name (query_table_summary)",
     )
 
     jsonrpc: str = Field(
@@ -411,7 +419,7 @@ class VariablesBackendMessageContent(BaseModel):
         InspectRequest,
         ClipboardFormatRequest,
         ViewRequest,
-        QueryVariableDataRequest,
+        QueryTableSummaryRequest,
     ] = Field(..., discriminator="method")
 
 
@@ -474,7 +482,7 @@ InspectedVariable.update_forward_refs()
 
 FormattedVariable.update_forward_refs()
 
-SummarizedData.update_forward_refs()
+QueryTableSummaryResult.update_forward_refs()
 
 Variable.update_forward_refs()
 
@@ -500,9 +508,9 @@ ViewParams.update_forward_refs()
 
 ViewRequest.update_forward_refs()
 
-QueryVariableDataParams.update_forward_refs()
+QueryTableSummaryParams.update_forward_refs()
 
-QueryVariableDataRequest.update_forward_refs()
+QueryTableSummaryRequest.update_forward_refs()
 
 UpdateParams.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/variables_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/variables_comm.py
@@ -105,6 +105,20 @@ class FormattedVariable(BaseModel):
     )
 
 
+class SummarizedData(BaseModel):
+    """
+    Result of the summarize operation
+    """
+
+    children: List[Variable] = Field(
+        description="An array of summarized variables, each containing a summary of the data.",
+    )
+
+    length: StrictInt = Field(
+        description="The total number of summarized variables. This may be greater than the number of variables in the 'children' array if the array is truncated.",
+    )
+
+
 class Variable(BaseModel):
     """
     A single variable in the runtime.
@@ -182,6 +196,9 @@ class VariablesBackendRequest(str, enum.Enum):
 
     # Request a viewer for a variable
     View = "view"
+
+    # Query variable data
+    QueryVariableData = "query_variable_data"
 
 
 class ListRequest(BaseModel):
@@ -352,6 +369,39 @@ class ViewRequest(BaseModel):
     )
 
 
+class QueryVariableDataParams(BaseModel):
+    """
+    Request a data summary for a variable or variables.
+    """
+
+    path: List[StrictStr] = Field(
+        description="The path to the variable to inspect, as an array of access keys.",
+    )
+
+    query_types: List[StrictStr] = Field(
+        description="A list of types to summarize.",
+    )
+
+
+class QueryVariableDataRequest(BaseModel):
+    """
+    Request a data summary for a variable or variables.
+    """
+
+    params: QueryVariableDataParams = Field(
+        description="Parameters to the QueryVariableData method",
+    )
+
+    method: Literal[VariablesBackendRequest.QueryVariableData] = Field(
+        description="The JSON-RPC method name (query_variable_data)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
+
+
 class VariablesBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
@@ -361,6 +411,7 @@ class VariablesBackendMessageContent(BaseModel):
         InspectRequest,
         ClipboardFormatRequest,
         ViewRequest,
+        QueryVariableDataRequest,
     ] = Field(..., discriminator="method")
 
 
@@ -423,6 +474,8 @@ InspectedVariable.update_forward_refs()
 
 FormattedVariable.update_forward_refs()
 
+SummarizedData.update_forward_refs()
+
 Variable.update_forward_refs()
 
 ListRequest.update_forward_refs()
@@ -446,6 +499,10 @@ ClipboardFormatRequest.update_forward_refs()
 ViewParams.update_forward_refs()
 
 ViewRequest.update_forward_refs()
+
+QueryVariableDataParams.update_forward_refs()
+
+QueryVariableDataRequest.update_forward_refs()
 
 UpdateParams.update_forward_refs()
 

--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -191,13 +191,13 @@
 			}
 		},
 		{
-			"name": "query_variable_data",
-			"summary": "Query variable data",
-			"description": "Request a data summary for a variable or variables.",
+			"name": "query_table_summary",
+			"summary": "Query table summary",
+			"description": "Request a data summary for a table variable.",
 			"params": [
 				{
 					"name": "path",
-					"description": "The path to the variable to inspect, as an array of access keys.",
+					"description": "The path to the table to summarize, as an array of access keys.",
 					"schema": {
 						"type": "array",
 						"items": {
@@ -207,7 +207,7 @@
 				},
 				{
 					"name": "query_types",
-					"description": "A list of types to summarize.",
+					"description": "A list of query types.",
 					"schema": {
 						"type": "array",
 						"items": {
@@ -218,25 +218,38 @@
 			],
 			"result": {
 				"schema": {
-					"name": "summarized_data",
+					"name": "query_table_summary_result",
 					"description": "Result of the summarize operation",
 					"type": "object",
 					"properties": {
-						"children": {
+						"num_rows": {
+							"type": "integer",
+							"description": "The total number of rows in the table."
+						},
+						"num_columns": {
+							"type": "integer",
+							"description": "The total number of columns in the table."
+						},
+						"column_schemas": {
 							"type": "array",
-							"description": "An array of summarized variables, each containing a summary of the data.",
+							"description": "The column schemas in the table.",
 							"items": {
-								"$ref": "#/components/schemas/variable"
+								"type": "string"
 							}
 						},
-						"length": {
-							"type": "integer",
-							"description": "The total number of summarized variables. This may be greater than the number of variables in the 'children' array if the array is truncated."
+						"column_profiles": {
+							"type": "array",
+							"description": "The column profiles in the table.",
+							"items": {
+								"type": "string"
+							}
 						}
 					},
 					"required": [
-						"children",
-						"length"
+						"num_rows",
+						"num_columns",
+						"column_schemas",
+						"column_profiles"
 					]
 				}
 			}

--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -189,6 +189,57 @@
 				},
 				"required": false
 			}
+		},
+		{
+			"name": "query_variable_data",
+			"summary": "Query variable data",
+			"description": "Request a data summary for a variable or variables.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to the variable to inspect, as an array of access keys.",
+					"schema": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				},
+				{
+					"name": "query_types",
+					"description": "A list of types to summarize.",
+					"schema": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"name": "summarized_data",
+					"description": "Result of the summarize operation",
+					"type": "object",
+					"properties": {
+						"children": {
+							"type": "array",
+							"description": "An array of summarized variables, each containing a summary of the data.",
+							"items": {
+								"$ref": "#/components/schemas/variable"
+							}
+						},
+						"length": {
+							"type": "integer",
+							"description": "The total number of summarized variables. This may be greater than the number of variables in the 'children' array if the array is truncated."
+						}
+					},
+					"required": [
+						"children",
+						"length"
+					]
+				}
+			}
 		}
 	],
 	"components": {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1788,6 +1788,12 @@ declare module 'positron' {
 			accessKeys?: Array<Array<string>>):
 			Thenable<Array<Array<RuntimeVariable>>>;
 
+		export function querySessionVariable(
+			sessionId: string,
+			accessKeys: Array<Array<string>>,
+			queryTypes: Array<string>):
+			Thenable<Array<string>>;
+
 		/**
 		 * Register a handler for runtime client instances. This handler will be called
 		 * whenever a new client instance is created by a language runtime of the given

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -709,6 +709,32 @@ declare module 'positron' {
 	}
 
 	/**
+	 * A result of calling the QuerySessionTables API.
+	 */
+	export interface QueryTableSummaryResult {
+		/**
+		 * The total number of rows in the table.
+		 */
+		num_rows: number;
+
+		/**
+		 * The total number of columns in the table.
+		 */
+		num_columns: number;
+
+		/**
+		 * The column schemas in the table.
+		 */
+		column_schemas: Array<string>;
+
+		/**
+		 * The column profiles in the table.
+		 */
+		column_profiles: Array<string>;
+
+	}
+
+	/**
 	 * The possible types of language model that can be used with the Positron Assistant.
 	 */
 	export enum PositronLanguageModelType {
@@ -1788,11 +1814,21 @@ declare module 'positron' {
 			accessKeys?: Array<Array<string>>):
 			Thenable<Array<Array<RuntimeVariable>>>;
 
-		export function querySessionVariable(
+		/**
+		 * Query a table in a session.
+		 *
+		 * @param sessionId The session ID of the session to query tables.
+		 * @param accessKeys The access keys of the tables to query.
+		 * @param queryTypes The types of data to query for the tables.
+		 *
+		 * @returns A Thenable that resolves with an array of runtime
+		 * table query results.
+		 */
+		export function querySessionTables(
 			sessionId: string,
 			accessKeys: Array<Array<string>>,
 			queryTypes: Array<string>):
-			Thenable<Array<string>>;
+			Thenable<Array<QueryTableSummaryResult>>;
 
 		/**
 		 * Register a handler for runtime client instances. This handler will be called

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -46,7 +46,7 @@ import { basename } from '../../../../base/common/resources.js';
 import { RuntimeOnlineState } from '../../common/extHostTypes.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
-import { Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
+import { QueryTableSummaryResult, Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
 import { IPositronVariablesInstance } from '../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
 import { isWebviewPreloadMessage, isWebviewReplayMessage } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 
@@ -1590,19 +1590,19 @@ export class MainThreadLanguageRuntime
 		}
 	}
 
-	$querySessionVariable(handle: number, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<string>> {
+	$querySessionTables(handle: number, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<QueryTableSummaryResult>> {
 		const sessionId = this.findSession(handle).sessionId;
 		const instances = this._positronVariablesService.positronVariablesInstances;
 		for (const instance of instances) {
 			if (instance.session.sessionId === sessionId) {
-				return this.querySessionVariable(instance, accessKeys, queryTypes);
+				return this.querySessionTables(instance, accessKeys, queryTypes);
 			}
 		}
 		throw new Error(`No variables provider found for session ${sessionId}`);
 	}
 
-	async querySessionVariable(instance: IPositronVariablesInstance, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
-		Promise<Array<string>> {
+	async querySessionTables(instance: IPositronVariablesInstance, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
+		Promise<Array<QueryTableSummaryResult>> {
 		const client = instance.getClientInstance();
 		if (!client) {
 			throw new Error(`No variables provider available for session ${instance.session.sessionId}`);
@@ -1612,7 +1612,7 @@ export class MainThreadLanguageRuntime
 		}
 		const result = [];
 		for (const accessKey of accessKeys) {
-			result.push(JSON.stringify(await client.comm.queryVariableData(accessKey, queryTypes)));
+			result.push(await client.comm.queryTableSummary(accessKey, queryTypes));
 		}
 		return result;
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -140,9 +140,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				Thenable<Array<Array<positron.RuntimeVariable>>> {
 				return extHostLanguageRuntime.getSessionVariables(sessionId, accessKeys);
 			},
-			querySessionVariable(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
-				Thenable<Array<string>> {
-				return extHostLanguageRuntime.querySessionVariable(sessionId, accessKeys, queryTypes);
+			querySessionTables(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
+				Thenable<Array<positron.QueryTableSummaryResult>> {
+				return extHostLanguageRuntime.querySessionTables(sessionId, accessKeys, queryTypes);
 			},
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -140,6 +140,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				Thenable<Array<Array<positron.RuntimeVariable>>> {
 				return extHostLanguageRuntime.getSessionVariables(sessionId, accessKeys);
 			},
+			querySessionVariable(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
+				Thenable<Array<string>> {
+				return extHostLanguageRuntime.querySessionVariable(sessionId, accessKeys, queryTypes);
+			},
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -16,7 +16,7 @@ import { IAvailableDriverMethods } from '../../browser/positron/mainThreadConnec
 import { IChatRequestData, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { IChatAgentData } from '../../../contrib/chat/common/chatAgents.js';
 import { PlotRenderSettings } from '../../../services/positronPlots/common/positronPlots.js';
-import { Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
+import { QueryTableSummaryResult, Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 
 // NOTE: This check is really to ensure that extHost.protocol is included by the TypeScript compiler
@@ -53,7 +53,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$interruptSession(handle: number): Promise<void>;
 	$focusSession(handle: number): void;
 	$getSessionVariables(handle: number, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
-	$querySessionVariable(handle: number, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<string>>;
+	$querySessionTables(handle: number, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<QueryTableSummaryResult>>;
 	$emitLanguageRuntimeMessage(handle: number, handled: boolean, message: SerializableObjectWithBuffers<ILanguageRuntimeMessage>): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;
 	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -53,6 +53,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$interruptSession(handle: number): Promise<void>;
 	$focusSession(handle: number): void;
 	$getSessionVariables(handle: number, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
+	$querySessionVariable(handle: number, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<string>>;
 	$emitLanguageRuntimeMessage(handle: number, handled: boolean, message: SerializableObjectWithBuffers<ILanguageRuntimeMessage>): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;
 	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -21,7 +21,7 @@ import { SerializableObjectWithBuffers } from '../../../services/extensions/comm
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
+import { QueryTableSummaryResult, Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 
 /**
@@ -1224,11 +1224,11 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		throw new Error(`Session with ID '${sessionId}' not found`);
 	}
 
-	public querySessionVariable(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
-		Promise<Array<string>> {
+	public querySessionTables(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
+		Promise<Array<QueryTableSummaryResult>> {
 		for (let i = 0; i < this._runtimeSessions.length; i++) {
 			if (this._runtimeSessions[i].metadata.sessionId === sessionId) {
-				return this._proxy.$querySessionVariable(i, accessKeys, queryTypes);
+				return this._proxy.$querySessionTables(i, accessKeys, queryTypes);
 			}
 		}
 		throw new Error(`Session with ID '${sessionId}' not found`);

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1224,6 +1224,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		throw new Error(`Session with ID '${sessionId}' not found`);
 	}
 
+	public querySessionVariable(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>):
+		Promise<Array<string>> {
+		for (let i = 0; i < this._runtimeSessions.length; i++) {
+			if (this._runtimeSessions[i].metadata.sessionId === sessionId) {
+				return this._proxy.$querySessionVariable(i, accessKeys, queryTypes);
+			}
+		}
+		throw new Error(`Session with ID '${sessionId}' not found`);
+	}
+
 	/**
 	 * Interrupts an active session.
 	 *

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -411,5 +411,5 @@ export enum CodeAttributionSource {
 	Script = 'script',
 }
 
-export { UiRuntimeNotifications } from '../../../services/languageRuntime/common/languageRuntimeService.js'
+export { UiRuntimeNotifications } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 export { PlotRenderSettings, PlotRenderFormat } from '../../../services/positronPlots/common/positronPlots.js';

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -65,18 +65,26 @@ export interface FormattedVariable {
 /**
  * Result of the summarize operation
  */
-export interface SummarizedData {
+export interface QueryTableSummaryResult {
 	/**
-	 * An array of summarized variables, each containing a summary of the
-	 * data.
+	 * The total number of rows in the table.
 	 */
-	children: Array<Variable>;
+	num_rows: number;
 
 	/**
-	 * The total number of summarized variables. This may be greater than the
-	 * number of variables in the 'children' array if the array is truncated.
+	 * The total number of columns in the table.
 	 */
-	length: number;
+	num_columns: number;
+
+	/**
+	 * The column schemas in the table.
+	 */
+	column_schemas: Array<string>;
+
+	/**
+	 * The column profiles in the table.
+	 */
+	column_profiles: Array<string>;
 
 }
 
@@ -235,16 +243,16 @@ export interface ViewParams {
 }
 
 /**
- * Parameters for the QueryVariableData method.
+ * Parameters for the QueryTableSummary method.
  */
-export interface QueryVariableDataParams {
+export interface QueryTableSummaryParams {
 	/**
-	 * The path to the variable to inspect, as an array of access keys.
+	 * The path to the table to summarize, as an array of access keys.
 	 */
 	path: Array<string>;
 
 	/**
-	 * A list of types to summarize.
+	 * A list of query types.
 	 */
 	query_types: Array<string>;
 }
@@ -357,7 +365,7 @@ export enum VariablesBackendRequest {
 	Inspect = 'inspect',
 	ClipboardFormat = 'clipboard_format',
 	View = 'view',
-	QueryVariableData = 'query_variable_data'
+	QueryTableSummary = 'query_table_summary'
 }
 
 export class PositronVariablesComm extends PositronBaseComm {
@@ -454,18 +462,18 @@ export class PositronVariablesComm extends PositronBaseComm {
 	}
 
 	/**
-	 * Query variable data
+	 * Query table summary
 	 *
-	 * Request a data summary for a variable or variables.
+	 * Request a data summary for a table variable.
 	 *
-	 * @param path The path to the variable to inspect, as an array of access
+	 * @param path The path to the table to summarize, as an array of access
 	 * keys.
-	 * @param queryTypes A list of types to summarize.
+	 * @param queryTypes A list of query types.
 	 *
 	 * @returns Result of the summarize operation
 	 */
-	queryVariableData(path: Array<string>, queryTypes: Array<string>): Promise<SummarizedData> {
-		return super.performRpc('query_variable_data', ['path', 'query_types'], [path, queryTypes]);
+	queryTableSummary(path: Array<string>, queryTypes: Array<string>): Promise<QueryTableSummaryResult> {
+		return super.performRpc('query_table_summary', ['path', 'query_types'], [path, queryTypes]);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -63,6 +63,24 @@ export interface FormattedVariable {
 }
 
 /**
+ * Result of the summarize operation
+ */
+export interface SummarizedData {
+	/**
+	 * An array of summarized variables, each containing a summary of the
+	 * data.
+	 */
+	children: Array<Variable>;
+
+	/**
+	 * The total number of summarized variables. This may be greater than the
+	 * number of variables in the 'children' array if the array is truncated.
+	 */
+	length: number;
+
+}
+
+/**
  * A single variable in the runtime.
  */
 export interface Variable {
@@ -217,6 +235,21 @@ export interface ViewParams {
 }
 
 /**
+ * Parameters for the QueryVariableData method.
+ */
+export interface QueryVariableDataParams {
+	/**
+	 * The path to the variable to inspect, as an array of access keys.
+	 */
+	path: Array<string>;
+
+	/**
+	 * A list of types to summarize.
+	 */
+	query_types: Array<string>;
+}
+
+/**
  * Parameters for the Update method.
  */
 export interface UpdateParams {
@@ -323,7 +356,8 @@ export enum VariablesBackendRequest {
 	Delete = 'delete',
 	Inspect = 'inspect',
 	ClipboardFormat = 'clipboard_format',
-	View = 'view'
+	View = 'view',
+	QueryVariableData = 'query_variable_data'
 }
 
 export class PositronVariablesComm extends PositronBaseComm {
@@ -417,6 +451,21 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 */
 	view(path: Array<string>): Promise<string | undefined> {
 		return super.performRpc('view', ['path'], [path]);
+	}
+
+	/**
+	 * Query variable data
+	 *
+	 * Request a data summary for a variable or variables.
+	 *
+	 * @param path The path to the variable to inspect, as an array of access
+	 * keys.
+	 * @param queryTypes A list of types to summarize.
+	 *
+	 * @returns Result of the summarize operation
+	 */
+	queryVariableData(path: Array<string>, queryTypes: Array<string>): Promise<SummarizedData> {
+		return super.performRpc('query_variable_data', ['path', 'query_types'], [path, queryTypes]);
 	}
 
 


### PR DESCRIPTION
First pass at #7114 

Provides Assistant with a `getDataSummary` tool, currently only implemented for Python, that provides a JSON structured summary of a data object by using the Positron API to communicate with the Variables Comm. I updated the variable's python backend to reuse existing functionality from the data explorer. 

I used the `inspectVariables` tool as a guide for retrieving info from the variables comm.

<img width="832" alt="image" src="https://github.com/user-attachments/assets/eb2051f8-4716-4030-a685-9853cc2eb2e6" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:data-explorer
@:assistant
@:variables
@:plots
@:viewer

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
