### PR TITLE
Assistant: Remove "Insert into Terminal" action in non-shell code blocks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -371,6 +371,12 @@ export function registerChatCodeBlockActions() {
 						ChatContextKeys.inChatSession,
 						ContextKeyExpr.or(...shellLangIds.map(e => ContextKeyExpr.equals(EditorContextKeys.languageId.key, e)))
 					),
+				}],
+				// --- Start Positron ---
+				// In code blocks with non-shell languages, don't show this action at all.
+				// We already have a separate action for running code in the console.
+				// See: https://github.com/posit-dev/positron/issues/7751.
+				/*
 				},
 				{
 					id: MenuId.ChatCodeBlock,
@@ -381,6 +387,8 @@ export function registerChatCodeBlockActions() {
 						...shellLangIds.map(e => ContextKeyExpr.notEquals(EditorContextKeys.languageId.key, e))
 					)
 				}],
+				*/
+				// --- End Positron ---
 				keybinding: [{
 					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter,
 					mac: {

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -20,6 +20,9 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
+
+const consoleLanguageIds = ['r', 'python'];
 
 class PositronAssistantContribution extends Disposable implements IWorkbenchContribution {
 	constructor(
@@ -44,7 +47,12 @@ class PositronAssistantContribution extends Disposable implements IWorkbenchCont
 						order: 5,
 						when: ContextKeyExpr.and(
 							ContextKeyExpr.equals(ChatContextKeys.location.key, ChatAgentLocation.Panel),
-							ChatContextKeys.Editing.hasToolConfirmation.toNegated())
+							ChatContextKeys.Editing.hasToolConfirmation.toNegated(),
+							// TODO: We should use a context key so that we can dynamically include languages
+							//       that can execute code in the console i.e. with registered interpreters.
+							//       See: https://github.com/posit-dev/positron/issues/8219.
+							ContextKeyExpr.or(...consoleLanguageIds.map(e => ContextKeyExpr.equals(EditorContextKeys.languageId.key, e))),
+						),
 					},
 				});
 			}


### PR DESCRIPTION
### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Removed the "Insert into Terminal" action in non-shell code blocks (#7751).