### PR TITLE
Assistant: Fix model using invalid URIs for unsaved file

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as xml from './xml.js';
 
 import { MARKDOWN_DIR } from './constants';
-import { isChatImageMimeType, isTextEditRequest, toLanguageModelChatMessage } from './utils';
+import { isChatImageMimeType, isTextEditRequest, toLanguageModelChatMessage, uriToString } from './utils';
 import { quartoHandler } from './commands/quarto';
 import { PositronAssistantToolName } from './types.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
@@ -288,7 +288,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					// usually the automatically attached visible region of the active file.
 
 					const document = await vscode.workspace.openTextDocument(value.uri);
-					const path = vscode.workspace.asRelativePath(value.uri);
+					const path = uriToString(value.uri);
 					const documentText = document.getText();
 					const visibleText = document.getText(value.range);
 
@@ -325,7 +325,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 							}
 							return name;
 						}).join('\n');
-						const path = vscode.workspace.asRelativePath(value);
+						const path = uriToString(value);
 
 						// TODO: Adding a URI as a response reference shows it in the "Used N references" block.
 						//       Files render with the correct icons and when clicked open in the editor.
@@ -341,7 +341,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					} else {
 						// The user attached a file - usually a manually attached file in the workspace.
 						const document = await vscode.workspace.openTextDocument(value);
-						const path = vscode.workspace.asRelativePath(value);
+						const path = uriToString(value);
 						const documentText = document.getText();
 
 						// Add the file as a reference in the response.
@@ -701,7 +701,7 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 		const selection = request.location2.selection;
 		const selectedText = document.getText(selection);
 		const documentText = document.getText();
-		const filePath = vscode.workspace.asRelativePath(document.uri);
+		const filePath = uriToString(document.uri);
 		return xml.node('editor',
 			[
 				xml.node('document', documentText, {

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -339,3 +339,16 @@ export function isTextEditRequest(request: vscode.ChatRequest):
 	request is vscode.ChatRequest & { location2: vscode.ChatRequestEditorData } {
 	return request.location2 instanceof vscode.ChatRequestEditorData;
 }
+
+/**
+ * Convert a URI to a string suitable for language models.
+ *
+ * Currently, file URIs are converted to workspace-relative paths and
+ * other URIs are converted to their string representation.
+ */
+export function uriToString(uri: vscode.Uri): string {
+	if (uri.scheme === 'file') {
+		return vscode.workspace.asRelativePath(uri);
+	}
+	return uri.toString();
+}

--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -20,7 +20,13 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../base/common/resources.js';
+// --- Start Positron ---
+// Remove unused import.
+/*
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
+*/
+import { URI } from '../../../../../base/common/uri.js';
+// --- End Positron ---
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize } from '../../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
@@ -121,21 +127,25 @@ export class EditTool implements IToolImpl {
 			throw new Error('filePath is required for this tool');
 		}
 		const filePath = input.filePath;
-		const updatedParams = {
+		// const parameters = invocation.parameters as EditToolParams;
+		const parameters: EditToolParams = {
 			file: filePath.startsWith('untitled:') ? URI.parse(filePath) : URI.file(filePath),
 			explanation: input.explanation,
 			code: input.code,
 		};
-		// const parameters = invocation.parameters as EditToolParams;
-		const parameters = updatedParams as EditToolParams;
 
 		// const fileUri = URI.revive(parameters.file); // TODO@roblourens do revive in MainThreadLanguageModelTools
-		// Use the same logic as the fileContentsTool to get the URI for the file.
+		// For untitled files, use the URI directly.
+		// Otherwise, use the same logic as the fileContentsTool to get the URI for the file.
 		let fileUri: URI | undefined = undefined;
-		try {
-			fileUri = getUriForFileOpenOrInsideWorkspace(filePath, this.workspaceContextService, this.editorGroupsService);
-		} catch (error) {
-			throw new Error(`Can't edit file: ${error.message}`);
+		if (parameters.file.scheme === 'untitled') {
+			fileUri = parameters.file;
+		} else {
+			try {
+				fileUri = getUriForFileOpenOrInsideWorkspace(filePath, this.workspaceContextService, this.editorGroupsService);
+			} catch (error) {
+				throw new Error(`Can't edit file: ${error.message}`);
+			}
 		}
 		// --- End Positron ---
 
@@ -268,7 +278,13 @@ export class EditTool implements IToolImpl {
 }
 
 export interface EditToolParams {
+	// --- Start Positron ---
+	// Since this is constructed via URI.parse or URI.file, it is a URI.
+	/*
 	file: UriComponents;
+	*/
+	file: URI;
+	// --- End Positron ---
 	explanation: string;
 	code: string;
 }


### PR DESCRIPTION
### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed Assistant using invalid URIs for unsaved files (#8212).

### QA Notes

See the linked issue. Note that this does not attempt to fix #7635.