### PR TITLE
python CI: unpin ruff

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Lint and Check Formatting with Ruff
         run: |
-          uv pip install ruff==0.11.13
+          uv pip install ruff
           ruff check .
           ruff format --check
         working-directory: ${{ env.PYTHON_SRC_DIR }}

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2551,8 +2551,8 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             # decimal
             "f12": [
                 Decimal("1.5"),
-                Decimal("2"),
-                Decimal("2"),
+                Decimal(2),
+                Decimal(2),
                 None,
                 Decimal("3.5"),
             ]

--- a/extensions/positron-python/python_files/printEnvVariablesToFile.py
+++ b/extensions/positron-python/python_files/printEnvVariablesToFile.py
@@ -12,5 +12,5 @@ else:
     raise ValueError("Missing output file argument")
 
 with open(output_file, "w") as outfile:  # noqa: PTH123
-    for key, val in os.environ.items():
+    for key, val in os.environ.items():  # noqa: FURB122
         outfile.write(f"{key}={val}\n")

--- a/extensions/positron-python/python_files/unittestadapter/execution.py
+++ b/extensions/positron-python/python_files/unittestadapter/execution.py
@@ -189,8 +189,8 @@ def run_tests(
     pattern: str,
     top_level_dir: Optional[str],
     verbosity: int,
-    failfast: Optional[bool],
-    locals_: Optional[bool] = None,
+    failfast: Optional[bool],  # noqa: FBT001
+    locals_: Optional[bool] = None,  # noqa: FBT001
 ) -> ExecutionPayloadDict:
     cwd = os.path.abspath(start_dir)  # noqa: PTH100
     if "/" in start_dir:  #  is a subdir


### PR DESCRIPTION
Fixes #8175. Unpins `ruff` to get 0.12.0, and corresponding linting.

Three of the changes are how upstream did it in https://github.com/microsoft/vscode-python/commit/2faa16417084e4b3f9a448127f361dcb336d3ce6.

### QA Notes

I used the magic keyword "fixes" because if CI passes, this issue doesn't need verification.