### PR TITLE
Bump ark to 0.1.192

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -757,7 +757,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.191"
+      "ark": "0.1.192"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/test/e2e/tests/diagnostics/diagnostics.test.ts
+++ b/test/e2e/tests/diagnostics/diagnostics.test.ts
@@ -83,18 +83,18 @@ test.describe('Diagnostics', {
 
 		// Session 2 - verify both problems (circos and syntax) are present
 		await sessions.select(rSessionAlt.id);
-		await problems.expectDiagnosticsToBe({ badgeCount: 3, warningCount: 2, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - verify only syntax error is present
 		await sessions.select(rSession.id);
-		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
 		// Session 1 - restart session and verify both problems (circos and syntax) are present
 		// Diagnostics engine is not aware of the circlize package, this is expected
 		await sessions.restart(rSession.id);
-		await problems.expectDiagnosticsToBe({ badgeCount: 3, warningCount: 2, errorCount: 1 });
+		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});
 });


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/843
- https://github.com/posit-dev/ark/pull/837
- https://github.com/posit-dev/ark/pull/839
- https://github.com/posit-dev/ark/pull/832
- https://github.com/posit-dev/ark/pull/830
- https://github.com/posit-dev/ark/pull/834

Notable features/fixes are outlined below

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R: Pressing `Cmd+Enter` to run a statement of R code now falls back to running one line at a time when there are parse errors in the file (https://github.com/posit-dev/positron/issues/5023)
- R: R 4.6.0's graphics engine (version 17) is now supported

#### Bug Fixes

- R: Requesting completions on non-parseable strings no longer crashes the language server (https://github.com/posit-dev/positron/issues/6584)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
