### PR TITLE
Bump bundled Quarto to 1.7.32

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -126,7 +126,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.7.31';
+    const version = '1.7.32';
     (0, fancy_log_1.default)(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -96,7 +96,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.7.31';
+	const version = '1.7.32';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
Addresses #7566 (after I did another recent bump in #7757)


'@:quarto' '@:r-markdown'

### Release Notes

#### New Features

- Updated bundled Quarto to 1.7.32, the current release version

#### Bug Fixes

- N/A


### QA Notes

I added the tags for Quarto and `.Rmd`, but we'll want to make sure any other coverage we have related to Quarto gets run.
