### PR TITLE
Update download link for emulated x64 build on ARM

### DIFF
--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -248,10 +248,13 @@ export class NativeWindow extends BaseWindow {
 				[{
 					label: localize('downloadArmBuild', "Download"),
 					run: () => {
-						const quality = this.productService.quality;
-						const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
-						const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
-						this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
+						// --- Start Positron ---
+						// const quality = this.productService.quality;
+						// const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
+						// const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
+						// this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
+						this.openerService.open('https://positron.posit.co/download');
+						// --- End Positron ---
 					}
 				}],
 				{

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -249,11 +249,11 @@ export class NativeWindow extends BaseWindow {
 					label: localize('downloadArmBuild', "Download"),
 					run: () => {
 						// --- Start Positron ---
-						// const quality = this.productService.quality;
-						// const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
-						// const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
-						// this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
-						this.openerService.open('https://positron.posit.co/download');
+/* 						const quality = this.productService.quality;
+						const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
+						const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
+						this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
+ */						this.openerService.open('https://positron.posit.co/download');
 						// --- End Positron ---
 					}
 				}],


### PR DESCRIPTION
Addresses #8214

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

If you install the x64 build on your ARM Mac, you should get a link in that button to <https://positron.posit.co/download>