### PR TITLE
e2e test: fix flake on shiny test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -424,8 +424,7 @@ export class Sessions {
 			await this.code.driver.page.mouse.move(0, 0);
 
 			if (waitForReady) {
-				await expect(this.page.getByText(/starting/)).toBeVisible();
-				await expect(this.page.getByText(/starting/)).not.toBeVisible({ timeout: 90000 });
+				await expect(this.page.getByText(/started/)).toBeVisible({ timeout: 90000 });
 			}
 			return this.getCurrentSessionId();
 		});

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -424,7 +424,7 @@ export class Sessions {
 			await this.code.driver.page.mouse.move(0, 0);
 
 			if (waitForReady) {
-				await expect(this.page.getByText(/started/)).toBeVisible({ timeout: 90000 });
+				await expect(this.console.activeConsole.getByText(/started/)).toBeVisible({ timeout: 90000 });
 			}
 			return this.getCurrentSessionId();
 		});


### PR DESCRIPTION
### Summary
Waiting for "started" instead of relying on "starting" to show and disappear.


### QA Notes

n/a