### PR TITLE
assistant: remove empty text parts from tool messages

### DIFF
--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -283,15 +283,42 @@ function processEmptyToolResults(message: vscode.LanguageModelChatMessage2) {
 		return part;
 	});
 
-	if (replacedEmptyToolResult) {
-		return new vscode.LanguageModelChatMessage2(
-			message.role,
-			updatedContent,
-			message.name,
-		);
+	if (!replacedEmptyToolResult) {
+		// If no empty tool result parts were found, we can return the message as is.
+		return message;
 	}
 
-	return message;
+	return new vscode.LanguageModelChatMessage2(
+		message.role,
+		updatedContent,
+		message.name,
+	);
+}
+
+/**
+ * Removes empty text parts from a message.
+ * This should only be used if the message has other non-empty content,
+ * as it will remove all text parts that are empty or contain only whitespace.
+ * @param message The message to process
+ * @returns
+ */
+function removeEmptyTextParts(message: vscode.LanguageModelChatMessage2) {
+	const updatedContent = message.content.filter(part => {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			return part.value.trim() !== '';
+		}
+		return true;
+	});
+
+	if (updatedContent.length === message.content.length) {
+		return message;
+	}
+
+	return new vscode.LanguageModelChatMessage2(
+		message.role,
+		updatedContent,
+		message.name,
+	);
 }
 
 /**
@@ -317,7 +344,11 @@ function hasContent(message: vscode.LanguageModelChatMessage2) {
  */
 export function processMessages(messages: vscode.LanguageModelChatMessage2[]) {
 	return messages
+		// Remove messages that have no content
 		.filter(hasContent)
+		// Remove empty text parts from messages that have other non-empty content
+		.map(removeEmptyTextParts)
+		// Process empty tool results, replacing them with a placeholder
 		.map(processEmptyToolResults);
 }
 

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -300,7 +300,7 @@ function processEmptyToolResults(message: vscode.LanguageModelChatMessage2) {
  * This should only be used if the message has other non-empty content,
  * as it will remove all text parts that are empty or contain only whitespace.
  * @param message The message to process
- * @returns
+ * @returns The message with empty text parts removed or the original message if no empty text parts were found.
  */
 function removeEmptyTextParts(message: vscode.LanguageModelChatMessage2) {
 	const updatedContent = message.content.filter(part => {


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7842
- updates assistant extension integration tests to cover case in #7842, where the message contains an empty text part and a tool call

### Release Notes

#### Bug Fixes

- Assistant: remove empty text parts from messages containing other tool response types (#7842)

### QA Notes

@:assistant

Noted in #7842, this may not be reproducible in the Positron Assistant UI, but I have added an integration test case that should cover the case described.