### PR TITLE
Address issues selecting a port for the kernel supervisor

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -150,7 +150,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.48"
+      "kallichore": "0.1.49"
     }
   },
   "extensionDependencies": [

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -150,7 +150,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.47"
+      "kallichore": "0.1.48"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
Prior to this change, during supervisor start, Positron picked a port and generated an auth token, then passed them to the supervisor. This created a race condition, as something else could bind to the port between the time that Positron selects it and the time Kallichore tries to bind to it.

The fix is to:
- start Kallichore with `--connection-file` instead of `--port` and `--token`
- add a poll at startup to wait for Kallichore to write connection details to the file (this is my least favorite part of this change)
- update to a new Kallichore version that has an improved port selection algorithm (does not use portpicker, lets OS pick the port); this should also fix connectivity on machines where portpicker isn't working

Note that using connection files with Kallichore isn't new and is already what we do under remote host configurations (Workbench & remote SSH). This change unifies the codepaths so that now we _always_ use connection files.

Ideally we would use something like domain sockets that doesn't require port picking at all; see #5800. 

Addresses #7157 
Addresses #8230 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix issue connecting to supervisor on some Linux systems (#8230)


### QA Notes

We do not have a reproducible case for the issue, but based on my investigation I suspect the problem is due to the Linux system having UDP disabled on all ports. This causes us to be unable to find a free port since (until these changes) Kallichore's port picker required the port to be available on both TCP and UDP. Would recommend pursuing that route if you'd like to try to reproduce this before trying the fix.


