### PR TITLE
Assistant: Basic Anthropic prompt caching

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -15,7 +15,7 @@ import { log } from './extension.js';
 /**
  * Options for controlling cache behavior in the Anthropic language model.
  */
-interface CacheControlOptions {
+export interface CacheControlOptions {
 	/** Add a cache control point to the last tool description (default: true). */
 	lastTool?: boolean;
 
@@ -55,11 +55,14 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		},
 	};
 
-	constructor(private readonly _config: ModelConfig) {
+	constructor(
+		private readonly _config: ModelConfig,
+		client?: Anthropic,
+	) {
 		this.name = _config.name;
 		this.provider = _config.provider;
 		this.identifier = _config.id;
-		this._client = new Anthropic({
+		this._client = client ?? new Anthropic({
 			apiKey: _config.apiKey,
 		});
 		this.maxOutputTokens = _config.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT;

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -428,15 +428,13 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				.map((e) => xml.node('execution', JSON.stringify(e)))
 				.join('\n');
 			const sessionNode = xml.node('session',
-				xml.node('session',
-					xml.node('executions', executions ?? ''), {
-					description: 'Current active session',
-					language: positronContext.activeSession.language,
-					version: positronContext.activeSession.version,
-					mode: positronContext.activeSession.mode,
-					identifier: positronContext.activeSession.identifier,
-				})
-			);
+				xml.node('executions', executions ?? ''), {
+				description: 'Current active session',
+				language: positronContext.activeSession.language,
+				version: positronContext.activeSession.version,
+				mode: positronContext.activeSession.mode,
+				identifier: positronContext.activeSession.identifier,
+			});
 			positronContextPrompts.push(sessionNode);
 			log.debug(
 				`[context] adding active ${positronContext.activeSession.mode} ${positronContext.activeSession.language} session context: ` +

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -30,7 +30,8 @@ suite('AnthropicLanguageModel', () => {
 				stream: sinon.stub().returns({
 					on: sinon.stub(),
 					abort: sinon.stub(),
-					done: sinon.stub().resolves()
+					done: sinon.stub().resolves(),
+					finalMessage: sinon.stub().resolves({}),
 				})
 			}
 		};

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -289,7 +289,6 @@ suite('AnthropicLanguageModel', () => {
 				name: toolB.name,
 				description: toolB.description,
 				input_schema: toolB.inputSchema,
-				cache_control: { type: 'ephemeral' },
 			},
 		] satisfies Anthropic.ToolUnion[], 'Unexpected tools in request body');
 
@@ -304,34 +303,6 @@ suite('AnthropicLanguageModel', () => {
 		assert.deepStrictEqual(body.messages, [
 			{ role: 'user', content: [{ type: 'text', text: 'Hi' }] },
 			{ role: 'user', content: [{ type: 'text', text: 'Bye' }] },
-		] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
-	});
-
-	test('provideLanguageModelResponse cache_control last user message enabled', async () => {
-		// Call the method under test.
-		await model.provideLanguageModelResponse(
-			[
-				vscode.LanguageModelChatMessage.User('Hi'),
-				vscode.LanguageModelChatMessage.User('Bye'),
-			],
-			{
-				modelOptions: {
-					cacheControl: {
-						lastUserMessage: true,
-					} satisfies CacheControlOptions,
-				},
-			},
-			'test-extension',
-			mockProgress,
-			mockCancellationToken
-		);
-
-		sinon.assert.calledOnce(mockClient.messages.stream);
-		const body = mockClient.messages.stream.getCall(0).args[0];
-
-		assert.deepStrictEqual(body.messages, [
-			{ role: 'user', content: [{ type: 'text', text: 'Hi' }] },
-			{ role: 'user', content: [{ type: 'text', text: 'Bye', cache_control: { type: 'ephemeral' } }] },
 		] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 	});
 
@@ -360,9 +331,7 @@ suite('AnthropicLanguageModel', () => {
 				modelOptions: {
 					system,
 					cacheControl: {
-						lastTool: false,
 						system: false,
-						lastUserMessage: false,
 					} satisfies CacheControlOptions,
 				},
 			},


### PR DESCRIPTION
This PR uses Anthropic's prompt caching API to reduce costs and alleviate organization rate limit pressure – particularly in Databot.

By default, we add a cache control point after the system prompt. Callers (e.g. Databot) can disable that if needed.

This PR also adds more Assistant logging:

* The entire Anthropic API request/response at trace level, and summaries (including token usage) at debug level.
* Elements added to the user context message.

### Release Notes

#### New Features

- Assistant caches prompts for Anthropic models (#8077).

#### Bug Fixes

- N/A

### QA Notes

Try out Assistant and Databot and check the cache read/write debug logs in the "Assistant" output channel.