### PR TITLE
Fix a few tiny details in the Python walkthrough

### DIFF
--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -113,7 +113,7 @@
     "walkthrough.positron.migrateFromVSCode.title": "Migrating from VSCode to Positron",
     "walkthrough.positron.migrateFromVSCode.description": "Learn how to get started with Python in Positron as a VSCode user!",
     "walkthrough.positron.step.migrateFromVSCode.autoReload.title": "Configure your console with autoreload",
-    "walkthrough.positron.step.migrateFromVSCode.autoReload.description": "Enable or disable automatic reloading of Python modules in console sessions\n[Enable module autoreloading](command:python.walkthrough.autoreload)",
+    "walkthrough.positron.step.migrateFromVSCode.autoReload.description": "Enable or disable automatic reloading of Python modules in console sessions\n[Configure module autoreloading](command:python.walkthrough.autoreload)",
     "walkthrough.positron.step.migrateFromVSCode.bundledExtensions.title": "Search built-in extensions",
     "walkthrough.positron.step.migrateFromVSCode.bundledExtensions.description": "Understand the extensions already included in Positron\n[Search for extensions](command:workbench.extensions.action.focusExtensionsView)",
     "walkthrough.positron.step.migrateFromVSCode.bundleIpykernel.title": "Customize your console kernel",

--- a/extensions/positron-python/resources/walkthrough/interpreterManagement.md
+++ b/extensions/positron-python/resources/walkthrough/interpreterManagement.md
@@ -1,5 +1,5 @@
 Interpreters are the Python runtimes that Positron uses to run your code.
-Your interpreter can be a virtual environment created via `venv`, `uv`, `pyenv`, `conda`, another Python installation.
+Your interpreter can be a virtual environment created via `venv`, `uv`, `pyenv`, `conda`, or another Python installation.
 
 A few common tasks you might want to do with interpreters include:
 - **Select an interpreter**: You can select a specific interpreter for your project by using the command ["Select Interpreter Session"](command:workbench.action.language.runtime.selectSession). This will show you a list of available interpreters, and you can choose the one you want to use.


### PR DESCRIPTION
Related to #8227 

When I was reviewing #8165, I noticed a few tiny details we need to update in this walkthrough but didn't get them added there in time.

- The button on the step for the autoreload behavior doesn't really enable anything, since it is enabled by default. Let's say "configure" there instead.
- We were missing an "or" on the interpreter management step.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
