### PR TITLE
Support functions in `View()`

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -815,7 +815,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.193"
+      "ark": "0.1.194"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/src/virtual-documents.ts
+++ b/extensions/positron-r/src/virtual-documents.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { RequestType } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
+import { LOGGER } from './extension';
 
 interface VirtualDocumentParams {
 	path: string;
@@ -27,6 +28,11 @@ export class VirtualDocumentProvider implements vscode.TextDocumentContentProvid
 			path: uri.path,
 		};
 
-		return await this._client.sendRequest(VIRTUAL_DOCUMENT_REQUEST_TYPE, params, token);
+		try {
+		  return await this._client.sendRequest(VIRTUAL_DOCUMENT_REQUEST_TYPE, params, token);
+		} catch (err) {
+      LOGGER.warn(`Failed to provide document for URI '${uri}': ${err}`);
+      return 'Error: This document does not exist';
+		}
 	}
 }

--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -186,7 +186,8 @@
 				"schema": {
 					"description": "The ID of the viewer that was opened.",
 					"type": "string"
-				}
+				},
+				"required": false
 			}
 		}
 	],

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -230,8 +230,15 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 			} else if (ev.name === UiFrontendEvent.OpenEditor) {
 				// Open an editor
 				const ed = ev.data as OpenEditorEvent;
+
+				let file = URI.parse(ed.file);
+				if (!file.scheme) {
+					// If the URI doesn't have a scheme, assume it's a file URI
+					file = URI.file(ed.file);
+				}
+
 				const editor: ITextResourceEditorInput = {
-					resource: URI.file(ed.file),
+					resource: file,
 					options: { selection: { startLineNumber: ed.line, startColumn: ed.column } }
 				};
 				this._editorService.openEditor(editor);

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -281,14 +281,14 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 	}
 
 	async createDocument(contents: string, languageId: string): Promise<null> {
-
 		const uri = await this.documents.createDocumentData({
-			content: contents, language: languageId
+			content: contents,
+			language: languageId,
 		});
+		const documentData = await this.documents.ensureDocumentData(uri);
+
 		const opts: TextEditorOpenOptions = { preview: true };
-		this.documents.ensureDocumentData(uri).then(documentData => {
-			this.editors.showTextDocument(documentData.document, opts);
-		});
+		await this.editors.showTextDocument(documentData.document, opts);
 
 		// TODO: Return a document ID
 		return null;

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -137,7 +137,11 @@ export const VariableItem = (props: VariableItemProps) => {
 				));
 			}
 
-			// If a binding was returned, save the binding between the viewer and the variable item.
+			// If a binding was returned, save the binding between the viewer and the
+			// variable item. Note that we intentionally treat `""` as falsy here so
+			// that backends can return an empty ID if no comm was open. This happens
+			// with Ark when the user views a function object: a virtual document is
+			// opened in an editor but is not managed by a comm.
 			if (viewerId) {
 				explorerService.setInstanceForVar(viewerId, item.id);
 			}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -138,10 +138,10 @@ export const VariableItem = (props: VariableItemProps) => {
 			}
 
 			// If a binding was returned, save the binding between the viewer and the
-			// variable item. Note that we intentionally treat `""` as falsy here so
-			// that backends can return an empty ID if no comm was open. This happens
-			// with Ark when the user views a function object: a virtual document is
-			// opened in an editor but is not managed by a comm.
+			// variable item. Note that it's valid for backends to not return any ID
+			// if no comm was open. This happens with Ark when the user views a
+			// function object: a virtual document is opened in an editor but is not
+			// managed by a comm.
 			if (viewerId) {
 				explorerService.setInstanceForVar(viewerId, item.id);
 			}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
@@ -76,9 +76,9 @@ export class PositronVariable {
 	/**
 	 * Requests that the language runtime open a viewer for this variable.
 	 *
-	 * @returns The ID of the viewer that was opened.
+	 * @returns The ID of the viewer that was opened, if any.
 	 */
-	async view(): Promise<string> {
+	async view(): Promise<string | undefined> {
 		const path = this.parentKeys.concat(this.data.access_key);
 		return this._comm.view(path);
 	}
@@ -268,4 +268,3 @@ export class VariablesClientInstance extends Disposable {
 		}));
 	}
 }
-

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -415,7 +415,7 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @returns The ID of the viewer that was opened.
 	 */
-	view(path: Array<string>): Promise<string> {
+	view(path: Array<string>): Promise<string | undefined> {
 		return super.performRpc('view', ['path'], [path]);
 	}
 

--- a/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
+++ b/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
@@ -324,7 +324,7 @@ export class VariableItem implements IVariableItem {
 	/**
 	 * Requests that a viewer be opened for this variable.
 	 */
-	async view(): Promise<string> {
+	async view(): Promise<string | undefined> {
 		return this._variable.view();
 	}
 

--- a/src/vs/workbench/services/positronVariables/common/interfaces/variableItem.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/variableItem.ts
@@ -85,5 +85,5 @@ export interface IVariableItem {
 	/**
 	 * Requests that a data viewer be opened for this variable.
 	 */
-	view(): Promise<string>;
+	view(): Promise<string | undefined>;
 }


### PR DESCRIPTION
Addresses posit-dev/positron#2945.
Companion PR for https://github.com/posit-dev/ark/pull/848.

The main change needed on the frontend side is to detect non-file schemes in the `OpenEditor` event handler of the UI comm. This way we preserve `ark:` URIs, which allows Ark to request the frontend to open documents via its own vdoc provider.

I also improved vdoc provider errors to be more user friendly. The error is mentioned in the virtual editor and the error message is logged.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- `View()` now supports function objects (posit-dev/positron#2945). It takes you directly to the original source, if the function has source references, or to a virtual document containing the deparsed function code otherwise.

- Functions are now also viewable from the Variables pane. Click on the "view" button on the right hand side of a variable entry to view its source definition in an editor.


#### Bug Fixes

- N/A


### QA Notes

See companion PR: https://github.com/posit-dev/ark/pull/848.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:variables
