### PR TITLE
assistant: add `documentCreate` tool for Agent mode

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -205,6 +205,10 @@
               "type": "string",
               "description": "The workspace folder to create the document in. If not specified, the document will be created in the first workspace folder."
             },
+            "content": {
+              "type": "string",
+              "description": "The initial content of the document. If not specified, the document will be created empty."
+            },
             "errorIfExists": {
               "type": "boolean",
               "description": "Whether to throw an error if the document already exists. If false, the existing document will be opened instead.",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -187,6 +187,33 @@
         }
       },
       {
+        "name": "documentCreate",
+        "displayName": "Create Document",
+        "modelDescription": "Create a new document in the workspace. Do not use this tool when no workspace folders are open.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The path to the document to create, including the file name and extension. This path must be relative to the workspace folder."
+            },
+            "workspaceFolder": {
+              "type": "string",
+              "description": "The workspace folder to create the document in. If not specified, the document will be created in the first workspace folder."
+            },
+            "errorIfExists": {
+              "type": "boolean",
+              "description": "Whether to throw an error if the document already exists. If false, the existing document will be opened instead.",
+              "default": true
+            }
+          }
+        }
+      },
+      {
         "name": "selectionEdit",
         "displayName": "Edit Selection",
         "modelDescription": "Output an edited version of the selected text.",
@@ -272,7 +299,7 @@
       {
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
-        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree.",
+        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree. Do not use this tool when no workspace folders are open.",
         "canBeReferencedInPrompt": false,
         "tags": [
           "positron-assistant"

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -189,10 +189,11 @@
       {
         "name": "documentCreate",
         "displayName": "Create Document",
-        "modelDescription": "Create a new document in the workspace. Do not use this tool when no workspace folders are open.",
+        "modelDescription": "Create a new document in the workspace.",
         "canBeReferencedInPrompt": false,
         "tags": [
-          "positron-assistant"
+          "positron-assistant",
+          "requires-workspace"
         ],
         "inputSchema": {
           "type": "object",
@@ -303,10 +304,11 @@
       {
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
-        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree. Do not use this tool when no workspace folders are open.",
+        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree.",
         "canBeReferencedInPrompt": false,
         "tags": [
-          "positron-assistant"
+          "positron-assistant",
+          "requires-workspace"
         ],
         "inputSchema": {
           "type": "object",

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -17,3 +17,6 @@ export const ALL_DOCUMENTS_SELECTOR: DocumentSelector = [{ scheme: '*' }];
 
 /** The default max token output if a model's maximum is unknown */
 export const DEFAULT_MAX_TOKEN_OUTPUT = 4_096;
+
+/** Tag used by tools to indicate a workspace must be open in order to use the tool */
+export const TOOL_TAG_REQUIRES_WORKSPACE = 'requires-workspace';

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -13,8 +13,6 @@ You ONLY use the execute code tool as a way to learn about the environment as a 
 The execute code tool runs code in the currently active session(s). You do not try to execute any other programming language.
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
-
-Use the create document tool when the user asks you to create a new file or document. To add content to a newly created file, use the edit file tool. Do not show the user the code you are using to create or edit files, as they can see it in the file itself.
 </tools>
 
 <communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -13,6 +13,8 @@ You ONLY use the execute code tool as a way to learn about the environment as a 
 The execute code tool runs code in the currently active session(s). You do not try to execute any other programming language.
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
+
+Use the create document tool when the user asks you to create a new file or document. To add content to a newly created file, use the edit file tool. Do not show the user the code you are using to create or edit files, as they can see it in the file itself.
 </tools>
 
 <communication>

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -209,6 +209,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				const inChatPane = request.location2 === undefined;
 				const inEditor = request.location2 instanceof vscode.ChatRequestEditorData;
 				const hasSelection = inEditor && request.location2.selection?.isEmpty === false;
+				const isAgentMode = this.id === ParticipantID.Agent;
 
 				// If streaming edits are enabled, don't allow any tools in inline editor chats.
 				if (isStreamingEditsEnabled() && this.id === ParticipantID.Editor) {
@@ -226,7 +227,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return inChatPane &&
 							// The execute code tool does not yet support notebook sessions.
 							positronContext.activeSession?.mode !== positron.LanguageRuntimeSessionMode.Notebook &&
-							this.id === ParticipantID.Agent;
+							isAgentMode;
 					// Only include the documentEdit tool in an editor and if there is
 					// no selection.
 					case PositronAssistantToolName.DocumentEdit:
@@ -237,11 +238,14 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return inEditor && hasSelection;
 					// Only include the edit file tool in edit or agent mode i.e. for the edit participant.
 					case PositronAssistantToolName.EditFile:
-						return this.id === ParticipantID.Edit || this.id === ParticipantID.Agent;
+						return this.id === ParticipantID.Edit || isAgentMode;
+					// Only include the documentCreate tool in the chat pane and if the user is an agent.
+					case PositronAssistantToolName.DocumentCreate:
+						return inChatPane && isAgentMode;
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:
-						return this.id === ParticipantID.Agent ||
+						return isAgentMode ||
 							tool.tags.includes('positron-assistant');
 				}
 			}

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -9,13 +9,14 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as xml from './xml.js';
 
-import { MARKDOWN_DIR } from './constants';
-import { isChatImageMimeType, isTextEditRequest, toLanguageModelChatMessage, uriToString } from './utils';
+import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_WORKSPACE } from './constants';
+import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, toLanguageModelChatMessage, uriToString } from './utils';
 import { quartoHandler } from './commands/quarto';
 import { PositronAssistantToolName } from './types.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
 import { ReplaceSelectionProcessor } from './replaceSelectionProcessor.js';
+import { log } from './extension.js';
 
 export enum ParticipantID {
 	/** The participant used in the chat pane in Ask mode. */
@@ -216,6 +217,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					return false;
 				}
 
+				// If the tool requires a workspace, but no workspace is open, don't allow the tool.
+				if (tool.tags.includes(TOOL_TAG_REQUIRES_WORKSPACE) && !isWorkspaceOpen()) {
+					return false;
+				}
+
 				switch (tool.name) {
 					// Only include the execute code tool in the Chat pane; the other
 					// panes do not have an affordance for confirming executions.
@@ -250,6 +256,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				}
 			}
 		);
+
+		log.trace(`Available tools for participant ${this.id}:\n${tools.map(t => `- ${t.name}`).join('\n')}`);
 
 		// Construct the transient message thread sent to the language model.
 		// Note that this is not the same as the chat history shown in the UI.
@@ -476,11 +484,6 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		if (customPrompt.length > 0) {
 			prompts.push(customPrompt);
 		}
-
-		// Add default context items to the prompt just before the prompts are joined.
-		// This ordering helps with verifying the context items in tests, as we can expect
-		// them to be at the end of the prompt.
-		prompts.push(...getDefaultContextItems());
 
 		const parts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [];
 		if (prompts.length > 0) {
@@ -807,20 +810,6 @@ async function openLlmsTextDocument(): Promise<vscode.TextDocument | undefined> 
 
 	const llmsDocument = await vscode.workspace.openTextDocument(fileUri);
 	return llmsDocument;
-}
-
-/**
- * Retrieve the default context items to include in the prompt.
- * @returns A list of default context items to include in the prompt.
- */
-export function getDefaultContextItems(): string[] {
-	const defaultPrompts = [];
-
-	// Note if any folders are open in the workspace.
-	const areFoldersOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
-	defaultPrompts.push(xml.node('workspace', `Workspace folders are open: ${areFoldersOpen}`));
-
-	return defaultPrompts;
 }
 
 /**

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { getDefaultContextItems, PositronAssistantChatParticipant, PositronAssistantEditorParticipant, ParticipantService } from '../participants.js';
+import { PositronAssistantChatParticipant, PositronAssistantEditorParticipant, ParticipantService } from '../participants.js';
 import { mock } from './utils.js';
 import { readFile } from 'fs/promises';
 import { MARKDOWN_DIR } from '../constants.js';
@@ -456,8 +456,7 @@ function assertContextMessage(
 	assertMessageRole(message, vscode.LanguageModelChatMessageRole.User);
 
 	// The first part should be a text part with the formatted context.
-	const fullPrompt = `${expectedPrompt}${expectedPrompt.length > 0 ? '\n\n' : ''}${getDefaultContextItems().join('\n')}`;
-	assertMessageTextPart(message.content[0], fullPrompt);
+	assertMessageTextPart(message.content[0], expectedPrompt);
 
 	if (expectedImage) {
 		// If an image is expected, the second part should be a data part with the image.

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -9,6 +9,7 @@ import { LanguageModelImage } from './languageModelParts.js';
 import { ParticipantService } from './participants.js';
 import { PositronAssistantToolName } from './types.js';
 import { ProjectTreeTool } from './tools/projectTreeTool.js';
+import { DocumentCreateTool } from './tools/documentCreate.js';
 
 
 /**
@@ -283,6 +284,8 @@ export function registerAssistantTools(
 	context.subscriptions.push(inspectVariablesTool);
 
 	context.subscriptions.push(ProjectTreeTool);
+
+	context.subscriptions.push(DocumentCreateTool);
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/documentCreate.ts
+++ b/extensions/positron-assistant/src/tools/documentCreate.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { PositronAssistantToolName } from '../types.js';
+import { log } from '../extension.js';
+
+interface CreateDocumentInput {
+	filePath: string;
+	workspaceFolder?: string;
+	errorIfExists?: boolean;
+}
+
+export const DocumentCreateTool = vscode.lm.registerTool<CreateDocumentInput>(PositronAssistantToolName.DocumentCreate, {
+	prepareInvocation: async (_options, _token) => {
+		return {
+			// The message shown when the code is actually executing.
+			// Positron appends '...' to this message.
+			invocationMessage: vscode.l10n.t('Creating document'),
+			pastTenseMessage: vscode.l10n.t('Created document'),
+		};
+	},
+	invoke: async (options, _token) => {
+		log.trace(`[${PositronAssistantToolName.DocumentCreate}] Invoked with options: ${JSON.stringify(options.input, null, 2)}`);
+
+		const { filePath, workspaceFolder, errorIfExists } = options.input;
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (!workspaceFolders || workspaceFolders.length === 0) {
+			throw new Error(vscode.l10n.t(`Can't create document ${filePath} because no workspace folders are open. Open a workspace folder before using this tool.`));
+		}
+
+		// Determine the file URI based on the workspace folder
+		const folder = (!!workspaceFolder && workspaceFolders.find(folder => folder.name === workspaceFolder)) || workspaceFolders[0];
+		const fileUri = vscode.Uri.joinPath(folder.uri, filePath);
+
+		// Handle the existence of the file
+		const documentExists = await fileExists(fileUri);
+		if (documentExists && errorIfExists) {
+			log.error(`[${PositronAssistantToolName.DocumentCreate}] Cannot create file "${fileUri.fsPath}" as it already exists in the workspace`);
+			throw new Error(vscode.l10n.t('Cannot create file "{0}" as it already exists in the workspace.', fileUri.fsPath));
+		}
+		if (!documentExists) {
+			try {
+				log.trace(`[${PositronAssistantToolName.DocumentCreate}] File does not exist at ${fileUri.fsPath}, creating new document.`);
+				await vscode.workspace.fs.writeFile(fileUri, new Uint8Array());
+				log.info(`[${PositronAssistantToolName.DocumentCreate}] Created document at ${fileUri.fsPath}`);
+			} catch (error) {
+				if ((error as vscode.FileSystemError).code !== 'FileNotFound') {
+					throw error; // Re-throw if it's not a "file not found" error
+				}
+			}
+		}
+
+		return new vscode.LanguageModelToolResult([
+			new vscode.LanguageModelTextPart(`Document ${documentExists ? 'already exists ' : 'created '} at: ${fileUri}`)
+		]);
+	}
+});
+
+const fileExists = async (filePath: vscode.Uri): Promise<boolean> => {
+	try {
+		await vscode.workspace.fs.stat(filePath);
+		return true;
+	} catch (error) {
+		if ((error as vscode.FileSystemError).code === 'FileNotFound') {
+			return false; // File does not exist
+		}
+		throw error; // Re-throw if it's a different error
+	}
+};

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -11,4 +11,7 @@ export enum PositronAssistantToolName {
 	InspectVariables = 'inspectVariables',
 	SelectionEdit = 'selectionEdit',
 	ProjectTree = 'getProjectTree',
+	DocumentCreate = 'documentCreate',
+	TextSearch = 'positron_findTextInProject_internal',
+	FileContents = 'positron_getFileContents_internal',
 }

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -352,3 +352,13 @@ export function uriToString(uri: vscode.Uri): string {
 	}
 	return uri.toString();
 }
+
+/**
+ * Checks if there is an open workspace folder.
+ * This is useful to determine if certain tools can be used, as they require an open workspace folder.
+ * @returns Whether there is an open workspace folder.
+ */
+export function isWorkspaceOpen(): boolean {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	return !!workspaceFolders && workspaceFolders.length > 0;
+}

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -19,7 +19,6 @@ This tool returns the contents of the specified file in the project.
 The provided file path must be a path to a file in the workspace or a file that is currently open in the editor.
 The file path can be either absolute or relative to the workspace root.
 The tool will return the contents of the file as a string, along with its size and encoding.
-Do not use this tool when no workspace folders are open.
 `;
 
 export const ExtensionFileContentsToolId = 'positron_getFileContents';
@@ -29,7 +28,7 @@ export const FileContentsToolData: IToolData = {
 	displayName: localize('chat.tools.getFileContents', "Get File Contents"),
 	source: { type: 'internal' },
 	modelDescription: getFileContentsModelDescription,
-	tags: ['positron-assistant'],
+	tags: ['positron-assistant', 'requires-workspace'],
 	canBeReferencedInPrompt: false,
 	inputSchema: {
 		type: 'object',

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -21,7 +21,6 @@ Do not use this tool to find files or directories in the workspace, as it is spe
 The search is performed across all files in the project, excluding files and directories that are ignored by the workspace settings.
 The provided pattern is interpreted as text unless indicated to be a regular expression.
 Other search options such as case sensitivity, whole word matching, and multiline matching can be specified.
-Do not use this tool when no workspace folders are open.
 `;
 
 export const ExtensionTextSearchToolId = 'positron_findTextInProject';
@@ -31,7 +30,7 @@ export const TextSearchToolData: IToolData = {
 	displayName: localize('chat.tools.findTextInProject', "Find Text In Project"),
 	source: { type: 'internal' },
 	modelDescription: findTextInProjectModelDescription,
-	tags: ['positron-assistant'],
+	tags: ['positron-assistant', 'requires-workspace'],
 	canBeReferencedInPrompt: false,
 	inputSchema: {
 		type: 'object',


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8240
- I took the approach of adding a tool for creating documents (available in Agent mode only)
- tools that should only run when the user has a workspace open should include `requires-workspace` in their tool tags, so that the tools can be filtered out if the user is not in a workspace

### Release Notes

#### New Features

- Assistant: Agent mode now includes a `documentCreate` tool (#8240)

### QA Notes

@:assistant

#### Happy Path
1. Use `Agent` mode in chat
2. Submit a prompt involving the creation of a file
3. The file should be created with the expected content

#### Other Cases
- `documentCreate` tool should only be available in Agent mode
- `documentCreate`, `projectTree`, `positron_getFileContents_internal` and `positron_findTextInProject_internal` should only be available when a workspace is open