### PR TITLE
Hide command that launches vs code walkthrough

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -34,7 +34,10 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { GettingStartedAccessibleView } from './gettingStartedAccessibleView.js';
 
-//
+// --- Start Positron ---
+import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
+// --- End Positron ---
+
 export * as icons from './gettingStartedIcons.js';
 
 registerAction2(class extends Action2 {
@@ -303,6 +306,9 @@ registerAction2(class extends Action2 {
 			id: 'welcome.showNewWelcome',
 			title: localize2('welcome.showNewWelcome', 'Open New Welcome Experience'),
 			f1: true,
+			// --- Start Positron ---
+			precondition: IsDevelopmentContext,
+			// --- End Positron ---
 		});
 	}
 


### PR DESCRIPTION
@midleman noticed there is a command `welcome.showNewWelcome` that opens the "Get started with VS Code" walkthrough. The title of the command is "Open New Welcome Experience" which is misleading since it doesn't take users to our welcome page.

This command is being disabled on release builds so this walkthrough can't be launched.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- Hide command to open "Get started with VS Code" walkthrough


### QA Notes

@:welcome @:web @:win

We'll want to verify this command doesn't show up on a release build. I've kicked off the creation of a release build for this branch that we can use for testing.
