### PR TITLE
Disable view actions while a viewer is already loading

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -123,7 +123,12 @@
 	background-color: transparent;
 }
 
-.variable-item .details-column .right-column .viewer-icon:hover {
+.variable-item .details-column .right-column .viewer-icon.enabled:hover {
 	border: 1px solid var(--vscode-button-foreground, #ffffff);
-	background-color: var(--vscode-button-background, #0e639c);
+	background-color: var(--vscode-button-background, #b7c7d1);
+}
+
+.variable-item .details-column .right-column .viewer-icon.disabled {
+	cursor: auto;
+	opacity: 0.6;
 }

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -69,6 +69,28 @@ export const formatSize = (size: number) => {
 	return localize('positron.sizeTB', "{0} TB", (size / TB).toFixed(2));
 };
 
+const viewQueuedLabel = (variableItem: IVariableItem) => {
+	switch (variableItem.kind) {
+		case 'table':
+			return localize('positron.variables.viewTableQueued', 'Data Table Queued...');
+		case 'connection':
+			return localize('positron.variables.viewConnectionQueued', 'Connection Queued...');
+		default:
+			return localize('positron.variables.viewQueued', 'View Queued...');
+	}
+};
+
+const viewLabel = (variableItem: IVariableItem) => {
+	switch (variableItem.kind) {
+		case 'table':
+			return localize('positron.variables.viewTable', 'View Data Table');
+		case 'connection':
+			return localize('positron.variables.viewConnection', 'View Connection');
+		default:
+			return localize('positron.variables.view', 'View');
+	}
+};
+
 /**
  * VariableItemProps interface.
  */
@@ -280,7 +302,7 @@ export const VariableItem = (props: VariableItemProps) => {
 		if (!props.disabled && props.variableItem.hasViewer) {
 			actions.push({
 				id: POSITRON_VARIABLES_VIEW,
-				label: localize('positron.variables.view', "View"),
+				label: viewLabel(props.variableItem),
 				tooltip: '',
 				class: undefined,
 				enabled: !isViewLoading,
@@ -397,7 +419,9 @@ export const VariableItem = (props: VariableItemProps) => {
 	const RightColumn = () => {
 		if (!props.disabled && props.variableItem.hasViewer) {
 			let icon = 'codicon codicon-open-preview';
-			if (props.variableItem.kind === 'table') {
+			if (isViewLoading) {
+				icon = 'codicon codicon-notebook-state-pending';
+			} else if (props.variableItem.kind === 'table') {
 				icon = 'codicon codicon-table';
 			} else if (props.variableItem.kind === 'connection') {
 				icon = 'codicon codicon-database';
@@ -410,8 +434,8 @@ export const VariableItem = (props: VariableItemProps) => {
 					<div
 						className={icon}
 						title={isViewLoading ?
-							localize('positron.variables.pendingView', "Loading...") :
-							localize('positron.variables.clickToView', "Click to view")}
+							viewQueuedLabel(props.variableItem) :
+							viewLabel(props.variableItem)}
 						onMouseDown={isViewLoading ? undefined : viewerMouseDownHandler}
 					></div>
 				</div>

--- a/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
+++ b/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
@@ -42,6 +42,11 @@ export class VariableItem implements IVariableItem {
 	 */
 	private readonly _isRecent: ISettableObservable<boolean>;
 
+	/**
+	 * Whether a viewer is currently loading for the variable item.
+	 */
+	private readonly _isViewLoading: ISettableObservable<boolean>;
+
 	//#endregion Private Properties
 
 	//#region Public Properties
@@ -182,6 +187,13 @@ export class VariableItem implements IVariableItem {
 	}
 
 	/**
+	 * Whether a viewer is currently loading for the variable item.
+	 */
+	get isViewLoading() {
+		return this._isViewLoading;
+	}
+
+	/**
 	 * Get the raw data of the variable from the language runtime.
 	 */
 	get variable(): Variable {
@@ -200,6 +212,7 @@ export class VariableItem implements IVariableItem {
 	constructor(variable: PositronVariable, isRecent: boolean) {
 		this._variable = variable;
 		this._isRecent = observableValue(variable.data.access_key, isRecent);
+		this._isViewLoading = observableValue(this, false);
 
 		// Clear recent flag after 2 seconds.
 		setTimeout(() => this._isRecent.set(false, undefined), 2000);
@@ -325,7 +338,12 @@ export class VariableItem implements IVariableItem {
 	 * Requests that a viewer be opened for this variable.
 	 */
 	async view(): Promise<string | undefined> {
-		return this._variable.view();
+		this._isViewLoading.set(true, undefined);
+		try {
+			return await this._variable.view();
+		} finally {
+			this._isViewLoading.set(false, undefined);
+		}
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronVariables/common/interfaces/variableItem.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/variableItem.ts
@@ -76,6 +76,11 @@ export interface IVariableItem {
 	readonly isRecent: IObservable<boolean>;
 
 	/**
+	 * Whether a viewer is currently loading for the variable item.
+	 */
+	readonly isViewLoading: IObservable<boolean>;
+
+	/**
 	 * Formats the value of this variable item in a format suitable for placing on the clipboard.
 	 * @param mime The desired MIME type of the format, such as 'text/plain' or 'text/html'.
 	 * @returns A promise that resolves to the formatted value of this variable.


### PR DESCRIPTION
This PR disables view actions in the variables pane when a view request is already in-progress to avoid unintended duplicate requests.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- "View" actions are disabled in the variables pane while one is already in-progress (#4547).

### QA Notes

Run `import time; time.sleep(10)` in a Python console and check:

1. If there is no viewer open for the variable, the following should be disabled after the first click:
  1. The viewer button (e.g. table icon)
  2. Right click -> "View"
  3. Double-click to view
2. If there is a viewer open for the variable, any of the above view actions should focus the viewer pane.
3. You should be able to queue view actions for multiple variables.

@:data-explorer @:variables