### PR TITLE
Switch the default for `positron.assistant.enable` back to false

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -125,8 +125,9 @@
         "properties": {
           "positron.assistant.enable": {
             "type": "boolean",
-            "default": true,
-            "markdownDescription": "%configuration.enable.markdownDescription%"
+            "default": false,
+            "markdownDescription": "%configuration.enable.markdownDescription%",
+            "tags": ["preview"]
           },
           "positron.assistant.useAnthropicSdk": {
             "type": "boolean",

--- a/src/vs/workbench/contrib/chat/browser/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatViewWelcome.css
@@ -72,6 +72,18 @@ div.chat-welcome-view {
 		justify-content: center;
 	}
 
+	/* --- Start Positron --- */
+	/* Copied styling from .setting-indicator.setting-item-preview src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css */
+	& > .chat-welcome-view-preview-badge {
+		color: var(--vscode-badge-foreground);
+		background: var(--vscode-badge-background);
+		font-style: italic;
+		margin: 8px 0; /* The margin was adapted for better spacing in the Chat pane */
+		padding: 0px 4px 2px;
+		border-radius: 4px;
+	}
+	/* --- End Positron --- */
+
 	& > .chat-welcome-view-message {
 		text-align: center;
 		max-width: 350px;

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -149,6 +149,10 @@ export class ChatViewWelcomePart extends Disposable {
 			title.textContent = content.title;
 
 			// Preview indicator
+			// --- Start Positron ---
+			// Added a Preview badge to the welcome chat view, with th same styling as the Preview badge in the Settings UI.
+			dom.append(this.element, $('.chat-welcome-view-preview-badge', undefined, localize('chatViewWelcomePreview', "Preview")));
+			// --- End Positron ---
 			if (typeof content.message !== 'function' && options?.isWidgetAgentWelcomeViewContent) {
 				const container = dom.append(this.element, $('.chat-welcome-view-indicator-container'));
 				dom.append(container, $('.chat-welcome-view-subtitle', undefined, localize('agentModeSubtitle', "Agent Mode")));

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -6,6 +6,6 @@
     "remote.autoForwardPortsFallback": 0,
     "files.simpleDialog.enable": true,
     "positron.importSettings.enable": false,
-	"positron.assistant.enable": true,
+    "positron.assistant.enable": true,
     "positron.assistant.testModels": true
 }

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -6,5 +6,6 @@
     "remote.autoForwardPortsFallback": 0,
     "files.simpleDialog.enable": true,
     "positron.importSettings.enable": false,
+	"positron.assistant.enable": true,
     "positron.assistant.testModels": true
 }


### PR DESCRIPTION
Addresses #8269 

![Screenshot 2025-06-24 at 1 41 10 PM](https://github.com/user-attachments/assets/4943f4fe-7d90-4726-9c6e-d80e87021d6e)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron Assistant is back to opt in, for now! 🤖 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
