### PR TITLE
Bump ark to 0.1.193

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -815,7 +815,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.192"
+      "ark": "0.1.193"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
* https://github.com/posit-dev/ark/pull/819
* https://github.com/posit-dev/ark/pull/842
* https://github.com/posit-dev/ark/pull/847

Notable features/fixes are outlined below

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R completions are more responsive to text that has already been typed, i.e. text to the right of the cursor. It is easier to edit a function reference (call or value, with or without a namespace) without getting an extra set of parentheses or inserting the name of a second function (#2417, #2574, #4441).

#### Bug Fixes

- A regression in code folding inside brackets has been fixed (#8059).

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
