### PR TITLE
Assistant: Fix adding experimental providers

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -84,6 +84,7 @@ interface LanguageModelConfigurationProps {
 
 const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModelConfigurationProps>) => {
 	// Construct the list of providers from the sources, which are defined in the extension. See extensions/positron-assistant/src/models.ts
+	const allProviders = props.sources;
 	const providers = props.sources
 		.filter(source => source.type === 'chat' || (source.type === 'completion' && source.provider.id === 'copilot'))
 		.sort((a, b) => {
@@ -270,7 +271,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		if (providerConfig.completions) {
 			setShowProgress(true);
 			// Assume a completion source exists with the same provider ID and compatible auth details
-			const completionSource = providerSources.find((source) => source.provider.id === providerConfig.provider && source.type === 'completion')!;
+			const completionSource = allProviders.find((source) => source.provider.id === providerConfig.provider && source.type === 'completion')!;
 			const completionConfig = {
 				provider: providerConfig.provider,
 				type: PositronLanguageModelType.Completion,


### PR DESCRIPTION
Follow-up to #8139, fixes a regression when adding the hidden experimental providers.

### QA Notes

Enable an experimental provider with FIM completion support (e.g. Mistral, OpenAI), then sign in. The model should not hang when adding the completion provider.