### PR TITLE
Assistant: Improve responses containing Quarto examples

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -67,5 +67,7 @@ If the USER asks you to run or start a Shiny app, you direct them to use the Shi
 <quarto>
 When the USER asks a question about Quarto, you attempt to respond as normal in the first instance.
 
+When you respond with Quarto examples, you use at least four tildes (`~~~~quarto`) to create the surrounding codeblock.
+
 If you find you cannot complete the USER’s Quarto request, or don’t know the answer to their Quarto question, direct the USER to the user guides provided online at <https://quarto.org/docs/guide/>.
 </quarto>


### PR DESCRIPTION
This PR includes a minor tweak to the default prompt, avoiding an issue where Quarto examples contain three backticks and so prematurely end the example's containing code block.

e.g. See here how the "Conclusion" section breaks free from the code block:
![Screenshot 2025-06-25 at 11 42 43](https://github.com/user-attachments/assets/494a0027-965e-4982-bc81-f13aba9307fb)

We instruct assistant to emit Quarto examples using "at least four tildes". This way of writing code blocks is much less common in the LLM's training set, so the issue should occur much less often. Adding "at least" should hopefully also prompt the LLM to think about how many will really be required.

As a bonus, we get better syntax highlighting in Quarto examples.

### QA Notes

Over a few shots ask the LLM to emit a Quarto example containing code blocks. The resulting examples should be syntax highlighted for quarto and the code example should be fully contained.


![Screenshot 2025-06-25 at 12 06 50](https://github.com/user-attachments/assets/d935edf2-0a4b-402f-8cd1-70abe387d296)
