### PR TITLE
python: unskip plotnine test

### DIFF
--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -37,6 +37,7 @@ pytest==8.3.5
 pytest-asyncio==0.26.0
 pytest-mock==3.14.0
 torch==2.7.0
+scipy<=1.15.3
 SQLAlchemy==2.0.41
 
 # putting this last like test-requirements.txt

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -352,9 +352,6 @@ def test_mpl_shutdown(shell: PositronShell, plots_service: PlotsService) -> None
     assert all(comm._closed for comm in plot_comms)  # noqa: SLF001
 
 
-@pytest.mark.skip(
-    reason="Test is breaking, see https://github.com/posit-dev/positron/actions/runs/15813946095/"
-)
 def test_plotnine_close_then_show(shell: PositronShell, plots_service: PlotsService) -> None:
     """Test that a plotnine plot renders and then closes comm correctly."""
     shell.run_cell("""\

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -20,6 +20,7 @@ pytest
 pytest-asyncio
 pytest-mock
 torch
+scipy<=1.15.3
 sqlalchemy
 
 # putting this last because holoviews is picky about dependency versions (including bokeh),


### PR DESCRIPTION
Closes #8239. Breaking change in `plotnine` dependency -> `statsmodels` dependency -> `scipy` 🐛 . Pinning to earlier versions until `statsmodels` does a new release.

⏫ specifically choosing to use closing keywords since green CI is all we need to verify we are back! Added a note in https://github.com/posit-dev/positron/issues/8184 to check if we can unpin this.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8239 Re-enable `plotnine` test in Python CI.


### QA Notes

Green CI