### PR TITLE
Smarter assistant python pkg install

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -360,6 +360,28 @@
             }
           }
         }
+      },
+      {
+        "name": "installPythonPackage",
+        "displayName": "Install Python Package",
+        "modelDescription": "Install Python packages using pip. Provide an array of package names to install.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "packages": {
+              "type": "array",
+              "description": "Array of Python package names to install.",
+              "items": {
+                "type": "string",
+                "description": "Name of the Python package to install."
+              }
+            }
+          }
+        }
       }
     ]
   },

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -13,7 +13,6 @@ You ONLY use the execute code tool as a way to learn about the environment as a 
 The execute code tool runs code in the currently active session(s). You do not try to execute any other programming language.
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
-
 </tools>
 
 <communication>
@@ -22,6 +21,8 @@ results, generate the code and return it directly without trying to execute it.
 </communication>
 
 <package-management>
+You adhere to the following workflow when dealing with package management:
+
 **Package Management Workflow:**
 
 1. Before generating code that requires packages, you must first use the appropriate tool to check if each required package is installed. To do so, first determine the target language from the user's request or context

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -13,6 +13,7 @@ You ONLY use the execute code tool as a way to learn about the environment as a 
 The execute code tool runs code in the currently active session(s). You do not try to execute any other programming language.
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
+
 </tools>
 
 <communication>
@@ -21,8 +22,6 @@ results, generate the code and return it directly without trying to execute it.
 </communication>
 
 <package-management>
-You adhere to the following workflow when dealing with package management:
-
 **Package Management Workflow:**
 
 1. Before generating code that requires packages, you must first use the appropriate tool to check if each required package is installed. To do so, first determine the target language from the user's request or context

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
@@ -14,6 +14,64 @@ You prefer to show tabular data using the great tables package.
 If the USER asks you to use matplotlib or any other Python packages or frameworks, you switch to using these frameworks without mentioning anything else about it. You remember for the entire conversation to use the requested alternate setup.
 </style-python>
 
+<python-package-management>
+**Python Package Installation Rules:**
+- NEVER use !pip install commands in Python code blocks
+- NEVER suggest installing packages within Python scripts using ! commands
+- For Python packages that need installation, use the installPythonPackage tool
+- The installPythonPackage tool automatically detects the environment and selects the appropriate installer (pip, conda, uv, poetry, etc.)
+- Only provide import/library code after successful installation
+- Separate installation from code examples
+
+**When to Use installPythonPackage Tool:**
+
+✅ **DO use installPythonPackage when:**
+- User gets `ModuleNotFoundError: No module named 'pandas'`
+- User asks "How do I install matplotlib?"
+- Code requires packages like `numpy`, `scikit-learn`, `plotnine` that aren't in standard library
+- User says "I need to work with data visualization" (likely needs matplotlib/plotnine)
+
+❌ **DON'T use installPythonPackage for:**
+- Standard library modules (`os`, `sys`, `json`, `datetime`, etc.)
+- Built-in functions (`print`, `len`, `range`, etc.)
+
+**Example Workflows:**
+
+**Scenario 1: User asks for data analysis**
+```
+User: "Can you help me analyze some CSV data with pandas?"
+
+Assistant response:
+1. First use installPythonPackage tool with ["pandas"]
+2. Wait for installation success
+3. Then provide code:
+   ```python
+   import pandas as pd
+   df = pd.read_csv('your_file.csv')
+   ```
+```
+
+**Scenario 2: Import error occurs**
+```
+User: "I'm getting ModuleNotFoundError for seaborn"
+
+Assistant response:
+1. Use installPythonPackage tool with ["seaborn"]
+2. Confirm installation succeeded
+3. Suggest re-running the import
+```
+
+**Scenario 3: Multiple packages needed**
+```
+User: "I want to create a machine learning model"
+
+Assistant response:
+1. Use installPythonPackage tool with ["scikit-learn", "pandas", "numpy"]
+2. Wait for all installations
+3. Provide ML code using all packages
+```
+</python-package-management>
+
 <examples-python>
 # Create a base DataFrame
 

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -289,8 +289,11 @@ export function registerAssistantTools(
 		prepareInvocation2: async (options, _token) => {
 			const packageNames = options.input.packages.join(', ');
 			const result: vscode.PreparedTerminalToolInvocation = {
-				command: `pip install ${options.input.packages.join(' ')}`,
-				language: 'bash',
+				// Display a generic command description rather than a specific pip command
+				// The actual implementation uses environment-aware package management (pip, conda, poetry, etc.)
+				// via the Python extension's installPackages command, not direct pip execution
+				command: `Install Python packages: ${packageNames}`,
+				language: 'text', // Not actually a bash command
 				confirmationMessages: {
 					title: vscode.l10n.t('Install Python Packages'),
 					message: vscode.l10n.t('Positron Assistant wants to install {0}, is this okay?', packageNames)

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -296,7 +296,9 @@ export function registerAssistantTools(
 				language: 'text', // Not actually a bash command
 				confirmationMessages: {
 					title: vscode.l10n.t('Install Python Packages'),
-					message: vscode.l10n.t('Positron Assistant wants to install {0}, is this okay?', packageNames)
+					message: options.input.packages.length === 1
+						? vscode.l10n.t('Positron Assistant wants to install the package {0}. Is this okay?', packageNames)
+						: vscode.l10n.t('Positron Assistant wants to install the following packages: {0}. Is this okay?', packageNames)
 				},
 			};
 			return result;

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -8,6 +8,7 @@ export enum PositronAssistantToolName {
 	EditFile = 'positron_editFile_internal',
 	ExecuteCode = 'executeCode',
 	GetPlot = 'getPlot',
+	InstallPythonPackage = 'installPythonPackage',
 	InspectVariables = 'inspectVariables',
 	SelectionEdit = 'selectionEdit',
 	ProjectTree = 'getProjectTree',

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -360,6 +360,11 @@
                 "title": "%python.command.python.createEnvironment.title%"
             },
             {
+                "command": "python.installPackages",
+                "title": "Install Python Packages",
+                "category": "Python"
+            },
+            {
                 "category": "Python",
                 "command": "python.createEnvironment-button",
                 "title": "%python.command.python.createEnvironment.title%"

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -64,10 +64,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                installPreReleaseVersion?: boolean;
-                donotSync?: boolean;
-            }
+                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                  installPreReleaseVersion?: boolean;
+                  donotSync?: boolean;
+              }
             | undefined
         ),
     ];

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -56,6 +56,7 @@ export type AllCommands = keyof ICommandNameArgumentTypeMapping;
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
     [Commands.Create_Environment]: [CreateEnvironmentOptions];
+    [Commands.InstallPackages]: [string[]];
     ['vscode.openWith']: [Uri, string];
     ['workbench.action.quickOpen']: [string];
     ['workbench.action.openWalkthrough']: [string | { category: string; step: string }, boolean | undefined];
@@ -63,10 +64,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                  installPreReleaseVersion?: boolean;
-                  donotSync?: boolean;
-              }
+                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                installPreReleaseVersion?: boolean;
+                donotSync?: boolean;
+            }
             | undefined
         ),
     ];

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -56,7 +56,6 @@ export type AllCommands = keyof ICommandNameArgumentTypeMapping;
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
     [Commands.Create_Environment]: [CreateEnvironmentOptions];
-    [Commands.InstallPackages]: [string[]];
     ['vscode.openWith']: [Uri, string];
     ['workbench.action.quickOpen']: [string];
     ['workbench.action.openWalkthrough']: [string | { category: string; step: string }, boolean | undefined];
@@ -64,10 +63,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                  installPreReleaseVersion?: boolean;
-                  donotSync?: boolean;
-              }
+                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                installPreReleaseVersion?: boolean;
+                donotSync?: boolean;
+            }
             | undefined
         ),
     ];
@@ -112,6 +111,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_In_Console]: [];
     [Commands.Focus_Positron_Console]: [];
     [Commands.Create_Pyproject_Toml]: [string | undefined];
+    [Commands.InstallPackages]: [string[]];
     // --- End Positron ---
     [Commands.Tests_Configure]: [undefined, undefined | CommandSource, undefined | Uri];
     [Commands.Tests_CopilotSetup]: [undefined | Uri];

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -63,10 +63,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                installPreReleaseVersion?: boolean;
-                donotSync?: boolean;
-            }
+                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                  installPreReleaseVersion?: boolean;
+                  donotSync?: boolean;
+              }
             | undefined
         ),
     ];

--- a/extensions/positron-python/src/client/common/application/commands/installPackages.ts
+++ b/extensions/positron-python/src/client/common/application/commands/installPackages.ts
@@ -61,7 +61,9 @@ export class InstallPackagesCommandHandler implements IExtensionSingleActivation
         // 3. Detailed per-package feedback helps the Assistant make better decisions
         for (const packageName of packages) {
             try {
-                await installer.installModule(packageName, undefined, undefined, ModuleInstallFlags.none, undefined);
+                await installer.installModule(packageName, undefined, undefined, ModuleInstallFlags.none, {
+                    waitForCompletion: true,
+                });
                 results.push(`${packageName} installed successfully using ${installer.displayName}`);
             } catch (error) {
                 const errorMsg = error instanceof Error ? error.message : String(error);

--- a/extensions/positron-python/src/client/common/application/commands/installPackages.ts
+++ b/extensions/positron-python/src/client/common/application/commands/installPackages.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { injectable, inject } from 'inversify';
 import { IExtensionSingleActivationService } from '../../../activation/types';
 import { Commands } from '../../constants';

--- a/extensions/positron-python/src/client/common/application/commands/installPackages.ts
+++ b/extensions/positron-python/src/client/common/application/commands/installPackages.ts
@@ -1,0 +1,72 @@
+import { injectable, inject } from 'inversify';
+import { IExtensionSingleActivationService } from '../../../activation/types';
+import { Commands } from '../../constants';
+import { ICommandManager } from '../types';
+import { IDisposableRegistry } from '../../types';
+import { IInstallationChannelManager, ModuleInstallFlags } from '../../installer/types';
+import { Product } from '../../types';
+
+@injectable()
+export class InstallPackagesCommandHandler implements IExtensionSingleActivationService {
+	public readonly supportedWorkspaceTypes = { untrustedWorkspace: false, virtualWorkspace: false };
+
+	constructor(
+		@inject(ICommandManager) private readonly commandManager: ICommandManager,
+		@inject(IInstallationChannelManager) private readonly channelManager: IInstallationChannelManager,
+		@inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+	) { }
+
+	public async activate(): Promise<void> {
+		this.disposables.push(
+			this.commandManager.registerCommand(Commands.InstallPackages, this.installPackages, this)
+		);
+	}
+
+	/**
+	 * Installs Python packages using the appropriate package manager for the current environment.
+	 * @param packages Array of package names to install
+	 * @returns Promise resolving to array of installation result messages
+	 * @throws Error with prefixed error codes for structured error handling:
+	 *   - `[NO_INSTALLER]` - No compatible package installer found for environment
+	 *   - `[VALIDATION_ERROR]` - Invalid or missing package names provided
+	 *   - Other errors may be thrown by underlying installation system without prefixes
+	 */
+	public async installPackages(
+		packages: string[]
+	): Promise<string[]> {
+		// Input validation
+		if (!packages || packages.length === 0) {
+			throw new Error('[VALIDATION_ERROR] At least one package name must be provided');
+		}
+
+		const invalidPackages = packages.filter(pkg => !pkg || typeof pkg !== 'string' || pkg.trim().length === 0);
+		if (invalidPackages.length > 0) {
+			throw new Error('[VALIDATION_ERROR] All package names must be non-empty strings');
+		}
+		const results: string[] = [];
+
+		// Get installer once upfront to avoid repeated calls
+		const installer = await this.channelManager.getInstallationChannel(Product.pip, undefined);
+		if (!installer) {
+			throw new Error('[NO_INSTALLER] No compatible package installer found for current environment');
+		}
+
+		// Process each package individually, continuing on failures
+		// Note: We don't throw on individual package failures because:
+		// 1. The Assistant can intelligently parse mixed success/failure results
+		// 2. Partial success is often valuable (e.g., pandas works even if matplotlib fails)
+		// 3. Detailed per-package feedback helps the Assistant make better decisions
+		for (const packageName of packages) {
+			try {
+				await installer.installModule(packageName, undefined, undefined, ModuleInstallFlags.none, undefined);
+				results.push(`${packageName} installed successfully using ${installer.displayName}`);
+			} catch (error) {
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				results.push(`${packageName}: Installation failed - ${errorMsg}`);
+				// Continue with next package to provide complete installation report
+			}
+		}
+
+		return results;
+	}
+}

--- a/extensions/positron-python/src/client/common/application/commands/installPackages.ts
+++ b/extensions/positron-python/src/client/common/application/commands/installPackages.ts
@@ -13,65 +13,63 @@ import { Product } from '../../types';
 
 @injectable()
 export class InstallPackagesCommandHandler implements IExtensionSingleActivationService {
-	public readonly supportedWorkspaceTypes = { untrustedWorkspace: false, virtualWorkspace: false };
+    public readonly supportedWorkspaceTypes = { untrustedWorkspace: false, virtualWorkspace: false };
 
-	constructor(
-		@inject(ICommandManager) private readonly commandManager: ICommandManager,
-		@inject(IInstallationChannelManager) private readonly channelManager: IInstallationChannelManager,
-		@inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
-	) { }
+    constructor(
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IInstallationChannelManager) private readonly channelManager: IInstallationChannelManager,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+    ) {}
 
-	public async activate(): Promise<void> {
-		this.disposables.push(
-			this.commandManager.registerCommand(Commands.InstallPackages, this.installPackages, this)
-		);
-	}
+    public async activate(): Promise<void> {
+        this.disposables.push(
+            this.commandManager.registerCommand(Commands.InstallPackages, this.installPackages, this),
+        );
+    }
 
-	/**
-	 * Installs Python packages using the appropriate package manager for the current environment.
-	 * @param packages Array of package names to install
-	 * @returns Promise resolving to array of installation result messages
-	 * @throws Error with prefixed error codes for structured error handling:
-	 *   - `[NO_INSTALLER]` - No compatible package installer found for environment
-	 *   - `[VALIDATION_ERROR]` - Invalid or missing package names provided
-	 *   - Other errors may be thrown by underlying installation system without prefixes
-	 */
-	public async installPackages(
-		packages: string[]
-	): Promise<string[]> {
-		// Input validation
-		if (!packages || packages.length === 0) {
-			throw new Error('[VALIDATION_ERROR] At least one package name must be provided');
-		}
+    /**
+     * Installs Python packages using the appropriate package manager for the current environment.
+     * @param packages Array of package names to install
+     * @returns Promise resolving to array of installation result messages
+     * @throws Error with prefixed error codes for structured error handling:
+     *   - `[NO_INSTALLER]` - No compatible package installer found for environment
+     *   - `[VALIDATION_ERROR]` - Invalid or missing package names provided
+     *   - Other errors may be thrown by underlying installation system without prefixes
+     */
+    public async installPackages(packages: string[]): Promise<string[]> {
+        // Input validation
+        if (!packages || packages.length === 0) {
+            throw new Error('[VALIDATION_ERROR] At least one package name must be provided');
+        }
 
-		const invalidPackages = packages.filter(pkg => !pkg || typeof pkg !== 'string' || pkg.trim().length === 0);
-		if (invalidPackages.length > 0) {
-			throw new Error('[VALIDATION_ERROR] All package names must be non-empty strings');
-		}
-		const results: string[] = [];
+        const invalidPackages = packages.filter((pkg) => !pkg || typeof pkg !== 'string' || pkg.trim().length === 0);
+        if (invalidPackages.length > 0) {
+            throw new Error('[VALIDATION_ERROR] All package names must be non-empty strings');
+        }
+        const results: string[] = [];
 
-		// Get installer once upfront to avoid repeated calls
-		const installer = await this.channelManager.getInstallationChannel(Product.pip, undefined);
-		if (!installer) {
-			throw new Error('[NO_INSTALLER] No compatible package installer found for current environment');
-		}
+        // Get installer once upfront to avoid repeated calls
+        const installer = await this.channelManager.getInstallationChannel(Product.pip, undefined);
+        if (!installer) {
+            throw new Error('[NO_INSTALLER] No compatible package installer found for current environment');
+        }
 
-		// Process each package individually, continuing on failures
-		// Note: We don't throw on individual package failures because:
-		// 1. The Assistant can intelligently parse mixed success/failure results
-		// 2. Partial success is often valuable (e.g., pandas works even if matplotlib fails)
-		// 3. Detailed per-package feedback helps the Assistant make better decisions
-		for (const packageName of packages) {
-			try {
-				await installer.installModule(packageName, undefined, undefined, ModuleInstallFlags.none, undefined);
-				results.push(`${packageName} installed successfully using ${installer.displayName}`);
-			} catch (error) {
-				const errorMsg = error instanceof Error ? error.message : String(error);
-				results.push(`${packageName}: Installation failed - ${errorMsg}`);
-				// Continue with next package to provide complete installation report
-			}
-		}
+        // Process each package individually, continuing on failures
+        // Note: We don't throw on individual package failures because:
+        // 1. The Assistant can intelligently parse mixed success/failure results
+        // 2. Partial success is often valuable (e.g., pandas works even if matplotlib fails)
+        // 3. Detailed per-package feedback helps the Assistant make better decisions
+        for (const packageName of packages) {
+            try {
+                await installer.installModule(packageName, undefined, undefined, ModuleInstallFlags.none, undefined);
+                results.push(`${packageName} installed successfully using ${installer.displayName}`);
+            } catch (error) {
+                const errorMsg = error instanceof Error ? error.message : String(error);
+                results.push(`${packageName}: Installation failed - ${errorMsg}`);
+                // Continue with next package to provide complete installation report
+            }
+        }
 
-		return results;
-	}
+        return results;
+    }
 }

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -88,6 +88,7 @@ export namespace Commands {
     export const Create_Pyproject_Toml = 'python.createPyprojectToml';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
+    export const InstallPackages = 'python.installPackages';
     export const InstallPython = 'python.installPython';
     export const InstallPythonOnLinux = 'python.installPythonOnLinux';
     export const InstallPythonOnMac = 'python.installPythonOnMac';

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -86,9 +86,9 @@ export namespace Commands {
     export const Is_Global_Python = 'python.isGlobalPython';
     export const Show_Interpreter_Debug_Info = 'python.interpreters.debugInfo';
     export const Create_Pyproject_Toml = 'python.createPyprojectToml';
+    export const InstallPackages = 'python.installPackages';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
-    export const InstallPackages = 'python.installPackages';
     export const InstallPython = 'python.installPython';
     export const InstallPythonOnLinux = 'python.installPythonOnLinux';
     export const InstallPythonOnMac = 'python.installPythonOnMac';

--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -29,7 +29,7 @@ import { IModuleInstaller, InstallOptions, InterpreterUri, ModuleInstallFlags } 
 // --- Start Positron ---
 // eslint-disable-next-line import/newline-after-import
 import { IWorkspaceService } from '../application/types';
-class ExternallyManagedEnvironmentError extends Error {}
+class ExternallyManagedEnvironmentError extends Error { }
 // --- End Positron ---
 
 @injectable()
@@ -42,7 +42,15 @@ export abstract class ModuleInstaller implements IModuleInstaller {
 
     public abstract get type(): ModuleInstallerType;
 
-    constructor(protected serviceContainer: IServiceContainer) {}
+    // --- Start Positron ---
+    // This is a temporary flag to allow for the installation to wait for
+    // completion. It can be used to override the behavior that the
+    // python.installModulesInTerminal setting typically controls. This is used
+    // when installing packages using the assistant to make sure it knows how
+    // the installation went.
+    private _waitForCompletion?: boolean;
+    // --- End Positron ---
+    constructor(protected serviceContainer: IServiceContainer) { }
 
     public async installModule(
         productOrModuleName: Product | string,
@@ -53,6 +61,12 @@ export abstract class ModuleInstaller implements IModuleInstaller {
     ): Promise<void> {
         // --- Start Positron ---
         const shouldExecuteInTerminal = this.installModulesInTerminal() || !options?.installAsProcess;
+        // Store the waitForCompletion option so that we can use it in the
+        // executeCommand method. This is temporary and is immediately unset
+        // (before any awaits) in the executeCommand method which takes place in
+        // a single call stack, thus it's not at risk for race conditions with
+        // other calls to installModule..
+        this._waitForCompletion = options?.waitForCompletion;
         // --- End Positron ---
         const name =
             typeof productOrModuleName === 'string'
@@ -159,7 +173,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                 if (ex instanceof ExternallyManagedEnvironmentError) {
                     traceWarn(
                         `Failed to install ${name} in ${resource?.path} because it is an ` +
-                            `externally-managed environment. Retrying with the --break-system-packages flag.`,
+                        `externally-managed environment. Retrying with the --break-system-packages flag.`,
                     );
                     await _install(token, (flags ?? ModuleInstallFlags.none) | ModuleInstallFlags.breakSystemPackages);
                 } else {
@@ -259,13 +273,20 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                 .getTerminalService(options);
 
             // --- Start Positron ---
-            // When running with the `python.installModulesInTerminal` setting enabled, we want to
-            // ensure that the terminal command is fully executed before returning. Otherwise, the
-            // calling code of the install will not be able to tell when the installation is complete.
-            if (this.installModulesInTerminal()) {
+            // When running with the `python.installModulesInTerminal` setting
+            // enabled or when the `waitForCompletion` option was set to true in
+            // the parent `installModule` call, we want to ensure that the
+            // terminal command is fully executed before returning. Otherwise,
+            // the calling code of the install will not be able to tell when the
+            // installation is complete.
+
+            if (this.installModulesInTerminal() || this._waitForCompletion) {
                 // Ensure we pass a cancellation token so that we await the full terminal command
                 // execution before returning.
                 const cancelToken = token ?? new CancellationTokenSource().token;
+                // Unset the waitForCompletion flag so that future calls are not blocked if not desired.
+                // If a call needs to be blocked this will be set to true again in the installModule method.
+                this._waitForCompletion = undefined;
                 await terminalService.sendCommand(command, args, token ?? cancelToken);
                 return;
             }

--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -29,7 +29,7 @@ import { IModuleInstaller, InstallOptions, InterpreterUri, ModuleInstallFlags } 
 // --- Start Positron ---
 // eslint-disable-next-line import/newline-after-import
 import { IWorkspaceService } from '../application/types';
-class ExternallyManagedEnvironmentError extends Error { }
+class ExternallyManagedEnvironmentError extends Error {}
 // --- End Positron ---
 
 @injectable()
@@ -50,7 +50,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
     // the installation went.
     private _waitForCompletion?: boolean;
     // --- End Positron ---
-    constructor(protected serviceContainer: IServiceContainer) { }
+    constructor(protected serviceContainer: IServiceContainer) {}
 
     public async installModule(
         productOrModuleName: Product | string,
@@ -173,7 +173,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                 if (ex instanceof ExternallyManagedEnvironmentError) {
                     traceWarn(
                         `Failed to install ${name} in ${resource?.path} because it is an ` +
-                        `externally-managed environment. Retrying with the --break-system-packages flag.`,
+                            `externally-managed environment. Retrying with the --break-system-packages flag.`,
                     );
                     await _install(token, (flags ?? ModuleInstallFlags.none) | ModuleInstallFlags.breakSystemPackages);
                 } else {

--- a/extensions/positron-python/src/client/common/installer/types.ts
+++ b/extensions/positron-python/src/client/common/installer/types.ts
@@ -90,4 +90,7 @@ export enum ModuleInstallFlags {
 
 export type InstallOptions = {
     installAsProcess?: boolean;
+    // --- Start Positron ---
+    waitForCompletion?: boolean;
+    // --- End Positron ---
 };

--- a/extensions/positron-python/src/client/common/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/common/serviceRegistry.ts
@@ -86,6 +86,7 @@ import { IMultiStepInputFactory, MultiStepInputFactory } from './utils/multiStep
 import { Random } from './utils/random';
 import { ContextKeyManager } from './application/contextKeyManager';
 import { CreatePythonFileCommandHandler } from './application/commands/createPythonFile';
+import { InstallPackagesCommandHandler } from './application/commands/installPackages';
 import { RequireJupyterPrompt } from '../jupyter/requireJupyterPrompt';
 import { isWindows } from './utils/platform';
 import { PixiActivationCommandProvider } from './terminal/environmentActivationProviders/pixiActivationProvider';
@@ -119,6 +120,10 @@ export function registerTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         CreatePythonFileCommandHandler,
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        InstallPackagesCommandHandler,
     );
     serviceManager.addSingleton<ICommandManager>(ICommandManager, CommandManager);
     serviceManager.addSingleton<IContextKeyManager>(IContextKeyManager, ContextKeyManager);

--- a/extensions/positron-python/src/client/common/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/common/serviceRegistry.ts
@@ -86,11 +86,11 @@ import { IMultiStepInputFactory, MultiStepInputFactory } from './utils/multiStep
 import { Random } from './utils/random';
 import { ContextKeyManager } from './application/contextKeyManager';
 import { CreatePythonFileCommandHandler } from './application/commands/createPythonFile';
-import { InstallPackagesCommandHandler } from './application/commands/installPackages';
 import { RequireJupyterPrompt } from '../jupyter/requireJupyterPrompt';
 import { isWindows } from './utils/platform';
 import { PixiActivationCommandProvider } from './terminal/environmentActivationProviders/pixiActivationProvider';
 // --- Start Positron ---
+import { InstallPackagesCommandHandler } from './application/commands/installPackages';
 import { registerPositronTypes } from '../positron/serviceRegistry';
 // --- End Positron ---
 
@@ -121,10 +121,12 @@ export function registerTypes(serviceManager: IServiceManager): void {
         IExtensionSingleActivationService,
         CreatePythonFileCommandHandler,
     );
+    // --- Start Positron ---
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         InstallPackagesCommandHandler,
     );
+    // --- End Positron ---
     serviceManager.addSingleton<ICommandManager>(ICommandManager, CommandManager);
     serviceManager.addSingleton<IContextKeyManager>(IContextKeyManager, ContextKeyManager);
     serviceManager.addSingleton<IConfigurationService>(IConfigurationService, ConfigurationService);


### PR DESCRIPTION
Addresses #8174.

Adds a new `installPythonPackage` tool that enables the Assistant to directly install Python packages instead of suggesting `!pip` commands that don't work in Positron's environment. The Assistant can now handle package installation requests by invoking the appropriate package manager (pip, uv, conda) through the integrated tool.

_Note: This may be way too intense of a fix for a simple behavior change. Not at all married to the whole new tool at all._

## Release Notes

### New Features

- N/A

### Bug Fixes

- Assistant can now directly install Python packages instead of suggesting non-functional
!pip commands

## QA Notes

Ask the Assistant to install Python packages like `palmerpenguins` and `plotnine`. The Assistant should now use the built-in installation tool rather than suggesting !pip commands.

Test in assistant
```
# Ask: "Install palmerpenguins and plotnine for me"
# Expected: Assistant uses the installPythonPackage tool to install packages directly
# Packages should be installed successfully without user needing to run terminal commands
```

The Assistant should no longer suggest `!pip install` commands and instead handle package installation automatically using the new tool.
