### PR TITLE
Bump Ark to 0.1.195

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -815,7 +815,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.194"
+      "ark": "0.1.195"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/852.
Addresses #2689.

### Release Notes

#### New Features

- When debugging functions that don't have source references, the virtual source editors now behave like R files. They are highlighted as R code and features like evaluation commands now behave as expected (#2689).

#### Bug Fixes

- N/A


### QA Notes

See notes in companion PR https://github.com/posit-dev/ark/pull/852