### PR TITLE
Assistant: direct user to sign into anthropic when no chat providers available

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -451,7 +451,13 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		if (!model) {
 			model = await this._languageModels.getDefaultLanguageModel(extension);
 			if (!model) {
+				// --- Start Positron ---
+				// TODO: make this more generic once we support more model providers https://github.com/posit-dev/positron/issues/8301
+				throw new Error('No language models available for chat. Please ensure you have logged into Anthropic as a language model provider by clicking `Add Model Provider...` or running the command `Positron Assistant: Configure Language Model Providers` and authenticating with Anthropic.');
+				/*
 				throw new Error('Language model unavailable');
+				*/
+				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -741,12 +741,20 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (!this.configurationService.getValue('positron.assistant.enable')) {
 			welcomeTitle = localize('positronAssistant.comingSoonTitle', "Coming Soon");
 			welcomeText = localize('positronAssistant.comingSoonMessage', "Positron Assistant is under development and will be available in a future version of Positron.\n");
-		} else if (this.languageModelsService.getLanguageModelIds().length === 0) {
+		} else if (!this.languageModelsService.currentProvider) {
+			// When Anthropic is the only supported provider, we can use a more specific message.
+			// TODO: remove this custom handling https://github.com/posit-dev/positron/issues/8301
+			const hasAdditionalModels = this.configurationService.getValue<boolean>('positron.assistant.testModels') ||
+				this.configurationService.getValue<string[]>('positron.assistant.enabledProviders')?.length > 0;
+
 			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
-			const addLanguageModelMessage = localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider");
+			const addLanguageModelMessage = hasAdditionalModels
+				? localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider")
+				: localize('positronAssistant.addLanguageModelMessageAnthropic', "Add Anthropic as a Chat Provider");
 			firstLinkToButton = true;
-			// create a multi-line message
-			welcomeText = localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n");
+			welcomeText = hasAdditionalModels
+				? localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n")
+				: localize('positronAssistant.welcomeMessageAnthropic', "To use Positron Assistant Chat, you must first authenticate with Anthropic.\n");
 			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.configureModels)`;
 		} else {
 			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8256
- stop gap in place of https://github.com/posit-dev/positron/pull/8292 which may be revived in https://github.com/posit-dev/positron/issues/8301 

https://github.com/user-attachments/assets/f769c080-0b92-48ad-be00-62ce7ab3bf08

### Release Notes

#### Bug Fixes

- Assistant: guidance to sign into Anthropic when no Chat providers are registered (#8256)

### QA Notes

@:assistant

When the user has no Chat providers (not signed into any providers or only signed into Copilot), the user should see:
- the "Set Up Positron Assistant" welcome page with Anthropic-specific guidance
- an error message directing the user to sign in with Anthropic if input is submitted in the chat