### PR TITLE
Set the plot metadata with new zoom level

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -473,6 +473,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 
 	set zoomLevel(level: ZoomLevel) {
 		if (this.metadata.zoom_level !== level) {
+			this.metadata.zoom_level = level;
 			this._zoomLevelEmitter.fire(level);
 		}
 	}

--- a/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
+++ b/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
@@ -85,7 +85,10 @@ export class StaticPlotClient extends Disposable implements IPositronPlotClient,
 	}
 
 	set zoomLevel(zoom: ZoomLevel) {
-		this._zoomLevelEventEmitter.fire(zoom);
+		if (this.metadata.zoom_level !== zoom) {
+			this.metadata.zoom_level = zoom; // Update the zoom level in metadata.
+			this._zoomLevelEventEmitter.fire(zoom);
+		}
 	}
 
 	get zoomLevel(): ZoomLevel {


### PR DESCRIPTION
Address #8318

Missing updating the plot metadata with the zoom level. This caused the plot to not re-render with the new zoom level.

### Release Notes


#### New Features

- N/A

#### Bug Fixes

- Fix Plots pane zoom to fit #8318


### QA Notes
