### PR TITLE
Assistant: Anthropic prompt caching extension API

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import Anthropic from '@anthropic-ai/sdk';
 import { ModelConfig } from './config';
 import { isLanguageModelImagePart, LanguageModelImagePart } from './languageModelParts.js';
-import { isChatImagePart, isCacheBreakpointDataPart, parseCacheBreakpoint, processMessages } from './utils.js';
+import { isChatImagePart, isCacheBreakpointPart, parseCacheBreakpoint, processMessages } from './utils.js';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { log } from './extension.js';
 
@@ -489,7 +489,7 @@ function withCacheControl<T extends CacheControllableBlockParam>(
 	source: string,
 	dataPart: vscode.LanguageModelDataPart | undefined,
 ): T {
-	if (!isCacheBreakpointDataPart(dataPart)) {
+	if (!isCacheBreakpointPart(dataPart)) {
 		return part;
 	}
 

--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -498,10 +498,7 @@ function withCacheControl<T extends CacheControllableBlockParam>(
 		log.debug(`[anthropic] Adding cache breakpoint to ${part.type} part. Source: ${source}`);
 		return {
 			...part,
-			// Pass the data through without validation, let the Anthropic API handle errors.
-			cache_control: {
-				type: cachBreakpoint.type,
-			},
+			cache_control: cachBreakpoint,
 		};
 	} catch (error) {
 		log.error(`[anthropic] Failed to parse cache breakpoint: ${error}`);

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -102,7 +102,7 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 		token: vscode.CancellationToken
 	): Promise<any> {
 		const _messages = toAIMessage(messages);
-		const message = _messages[_messages.length - 1];
+		const message = _messages[0];
 
 		if (typeof message.content === 'string') {
 			message.content = [{ type: 'text', text: message.content }];

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -10,14 +10,13 @@ import * as fs from 'fs';
 import * as xml from './xml.js';
 
 import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_WORKSPACE } from './constants';
-import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, toLanguageModelChatMessage, uriToString } from './utils';
+import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString } from './utils';
 import { quartoHandler } from './commands/quarto';
 import { PositronAssistantToolName } from './types.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
 import { ReplaceSelectionProcessor } from './replaceSelectionProcessor.js';
 import { log } from './extension.js';
-import { languageModelCacheControlPart } from './anthropic.js';
 
 export enum ParticipantID {
 	/** The participant used in the chat pane in Ask mode. */
@@ -271,8 +270,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const userPromptPart = new vscode.LanguageModelTextPart(request.prompt);
 		messages.push(vscode.LanguageModelChatMessage.User([userPromptPart]));
 
-		// Add cache control parts to at-most the last 2 user messages.
-		addCacheControlPartsToLastUserMessages(messages, 2);
+		// Add cache breakpoints to at-most the last 2 user messages.
+		addCacheControlBreakpointPartsToLastUserMessages(messages, 2);
 
 		// Add a user message containing context about the request, workspace, running sessions, etc.
 		// NOTE: We add the context message after the user prompt so that the context message is
@@ -852,16 +851,16 @@ export interface TextProcessor {
 }
 
 /**
- * Add cache control parts (for Anthropic prompt caching) to the last few user messages.
+ * Add cache breakpoints (for Anthropic prompt caching) to the last few user messages.
  *
  * @param messages The chat messages to modify.
- * @param maxCacheControlParts The maximum number of cache control parts to add.
+ * @param maxCacheBreakpointParts The maximum number of cache breakpoints to add.
  *   Note that Anthropic supports a maximum of 4 cache controls per request and that
  *   we may also cache tools and the system prompt.
  */
-function addCacheControlPartsToLastUserMessages(
+function addCacheControlBreakpointPartsToLastUserMessages(
 	messages: vscode.LanguageModelChatMessage2[],
-	maxCacheControlParts: number,
+	maxCacheBreakpointParts: number,
 ) {
 	let numCacheControlParts = 0;
 	for (let i = messages.length - 1; i >= 0; i--) {
@@ -873,10 +872,10 @@ function addCacheControlPartsToLastUserMessages(
 		if (!lastPart) {
 			continue;
 		}
-		log.debug(`[participant] Adding cache control part to user message: ${messages.length - i}`);
-		message.content.push(languageModelCacheControlPart());
+		log.debug(`[participant] Adding cache breakpoint to user message part: ${lastPart.constructor.name}`);
+		message.content.push(languageModelCacheBreakpointPart());
 		numCacheControlParts++;
-		if (numCacheControlParts >= maxCacheControlParts) {
+		if (numCacheControlParts >= maxCacheBreakpointParts) {
 			// We only want to cache the last two user messages.
 			break;
 		}

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -873,7 +873,7 @@ function addCacheControlPartsToLastUserMessages(
 		if (!lastPart) {
 			continue;
 		}
-		log.debug(`[participant] Adding cache control extra data part to user message: ${messages.length - i}`);
+		log.debug(`[participant] Adding cache control part to user message: ${messages.length - i}`);
 		message.content.push(languageModelCacheControlPart());
 		numCacheControlParts++;
 		if (numCacheControlParts >= maxCacheControlParts) {

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -376,15 +376,15 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
 		test('applies cache_control to previous tool call part in same message', async () => {
-			const toolCallPart = new vscode.LanguageModelToolCallPart('call-1', 'test-tool', { input: 'test' });
-			const cacheControlPart = languageModelCacheControlPart();
-
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.Assistant([toolCallPart, cacheControlPart])
+				vscode.LanguageModelChatMessage2.Assistant([
+					new vscode.LanguageModelToolCallPart('call-1', 'test-tool', { input: 'test' }),
+					languageModelCacheControlPart(),
+				])
 			]);
 
 			assert.deepStrictEqual(body.messages, [
@@ -400,15 +400,15 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
 		test('applies cache_control to previous tool result part in same message', async () => {
-			const toolResultPart = new vscode.LanguageModelToolResultPart('call-1', [new vscode.LanguageModelTextPart('result')]);
-			const cacheControlPart = languageModelCacheControlPart();
-
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.User([toolResultPart, cacheControlPart])
+				vscode.LanguageModelChatMessage2.User([
+					new vscode.LanguageModelToolResultPart('call-1', [new vscode.LanguageModelTextPart('result')]),
+					languageModelCacheControlPart()
+				])
 			]);
 
 			assert.deepStrictEqual(body.messages, [
@@ -423,27 +423,27 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
 		test('ignores cache_control when there is no previous part', async () => {
-			const cacheControlPart = languageModelCacheControlPart();
-
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.User([cacheControlPart])
+				vscode.LanguageModelChatMessage2.User([
+					(languageModelCacheControlPart()),
+				])
 			]);
 
-			assert.deepStrictEqual(body.messages, []);
+			assert.deepStrictEqual(body.messages, [] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
 		test('applies multiple cache_control parts to respective previous parts', async () => {
-			const textPart1 = new vscode.LanguageModelTextPart('First part');
-			const cacheControlPart1 = languageModelCacheControlPart();
-			const textPart2 = new vscode.LanguageModelTextPart('Second part');
-			const cacheControlPart2 = languageModelCacheControlPart();
-
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.User([textPart1, cacheControlPart1, textPart2, cacheControlPart2])
+				vscode.LanguageModelChatMessage2.User([
+					new vscode.LanguageModelTextPart('First part'),
+					languageModelCacheControlPart(),
+					new vscode.LanguageModelTextPart('Second part'),
+					languageModelCacheControlPart(),
+				])
 			]);
 
 			assert.deepStrictEqual(body.messages, [
@@ -462,15 +462,15 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
-		test('ignores non-cache_control LanguageModelExtraDataPart', async () => {
-			const textPart = new vscode.LanguageModelTextPart('Hello world');
-			const otherExtraDataPart = new vscode.LanguageModelExtraDataPart('other_kind', { data: 'value' });
-
+		test('ignores non-cache_control LanguageModelDataPart', async () => {
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.User([textPart, otherExtraDataPart])
+				vscode.LanguageModelChatMessage2.User([
+					new vscode.LanguageModelTextPart('Hello world'),
+					vscode.LanguageModelDataPart.json({ data: 'value' })
+				])
 			]);
 
 			assert.deepStrictEqual(body.messages, [
@@ -483,17 +483,16 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 
-		// TODO: This may surprise users.
 		test('cache_control part applies to most recent valid content part', async () => {
-			const textPart = new vscode.LanguageModelTextPart('Hello world');
-			const emptyTextPart = new vscode.LanguageModelTextPart('');
-			const cacheControlPart = languageModelCacheControlPart();
-
 			const { body } = await provideLanguageModelResponse([
-				vscode.LanguageModelChatMessage2.User([textPart, emptyTextPart, cacheControlPart])
+				vscode.LanguageModelChatMessage2.User([
+					new vscode.LanguageModelTextPart('Hello world'),
+					new vscode.LanguageModelTextPart(''),
+					languageModelCacheControlPart(),
+				])
 			]);
 
 			assert.deepStrictEqual(body.messages, [
@@ -507,7 +506,7 @@ suite('AnthropicLanguageModel', () => {
 						}
 					]
 				}
-			]);
+			] satisfies Anthropic.MessageCreateParams['messages'], 'Unexpected user messages in request body');
 		});
 	});
 });

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -7,9 +7,9 @@ import * as assert from 'assert';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { AnthropicLanguageModel, CacheControlOptions, languageModelCacheControlPart } from '../anthropic';
+import { AnthropicLanguageModel, CacheControlOptions } from '../anthropic';
 import { ModelConfig } from '../config';
-import { EMPTY_TOOL_RESULT_PLACEHOLDER } from '../utils.js';
+import { EMPTY_TOOL_RESULT_PLACEHOLDER, languageModelCacheBreakpointPart } from '../utils.js';
 import Anthropic from '@anthropic-ai/sdk';
 import { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream.js';
 import { mock } from './utils.js';
@@ -361,7 +361,7 @@ suite('AnthropicLanguageModel', () => {
 			const { body } = await provideLanguageModelResponse([
 				vscode.LanguageModelChatMessage2.User([
 					new vscode.LanguageModelTextPart('Hello world'),
-					languageModelCacheControlPart(),
+					languageModelCacheBreakpointPart(),
 				])
 			]);
 
@@ -383,7 +383,7 @@ suite('AnthropicLanguageModel', () => {
 			const { body } = await provideLanguageModelResponse([
 				vscode.LanguageModelChatMessage2.Assistant([
 					new vscode.LanguageModelToolCallPart('call-1', 'test-tool', { input: 'test' }),
-					languageModelCacheControlPart(),
+					languageModelCacheBreakpointPart(),
 				])
 			]);
 
@@ -407,7 +407,7 @@ suite('AnthropicLanguageModel', () => {
 			const { body } = await provideLanguageModelResponse([
 				vscode.LanguageModelChatMessage2.User([
 					new vscode.LanguageModelToolResultPart('call-1', [new vscode.LanguageModelTextPart('result')]),
-					languageModelCacheControlPart()
+					languageModelCacheBreakpointPart()
 				])
 			]);
 
@@ -429,7 +429,7 @@ suite('AnthropicLanguageModel', () => {
 		test('ignores cache_control when there is no previous part', async () => {
 			const { body } = await provideLanguageModelResponse([
 				vscode.LanguageModelChatMessage2.User([
-					(languageModelCacheControlPart()),
+					(languageModelCacheBreakpointPart()),
 				])
 			]);
 
@@ -440,9 +440,9 @@ suite('AnthropicLanguageModel', () => {
 			const { body } = await provideLanguageModelResponse([
 				vscode.LanguageModelChatMessage2.User([
 					new vscode.LanguageModelTextPart('First part'),
-					languageModelCacheControlPart(),
+					languageModelCacheBreakpointPart(),
 					new vscode.LanguageModelTextPart('Second part'),
-					languageModelCacheControlPart(),
+					languageModelCacheBreakpointPart(),
 				])
 			]);
 
@@ -491,7 +491,7 @@ suite('AnthropicLanguageModel', () => {
 				vscode.LanguageModelChatMessage2.User([
 					new vscode.LanguageModelTextPart('Hello world'),
 					new vscode.LanguageModelTextPart(''),
-					languageModelCacheControlPart(),
+					languageModelCacheBreakpointPart(),
 				])
 			]);
 

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -167,7 +167,7 @@ suite('PositronAssistantParticipant', () => {
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const c = positronChatContext;
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<context>
 <session description="Current active session" language="${c.activeSession!.language}" version="${c.activeSession!.version}" mode="console" identifier="${c.activeSession!.identifier}">
 <executions>
@@ -224,7 +224,7 @@ Today's date is: Wednesday 11 June 2025 at 13:30:00 BST
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Full contents of the file" language="${document.languageId}">
@@ -255,7 +255,7 @@ ${document.getText()}
 		const filePath = vscode.workspace.asRelativePath(folderReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Contents of the directory">
@@ -290,7 +290,7 @@ subfolder/
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Visible region of the active file" language="${document.languageId}" startLine="${range.start.line + 1}" endLine="${range.end.line + 1}">
@@ -326,7 +326,7 @@ ${document.getText()}
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<attachments>
 ${attachmentsText}
 <img src="${reference.name}" />
@@ -357,7 +357,7 @@ It should be included in the chat message.`;
 			sinon.assert.calledOnce(sendRequestSpy);
 			const [messages,] = sendRequestSpy.getCall(0).args;
 			assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-			assertContextMessage(messages[0],
+			assertContextMessage(messages.at(-1)!,
 				`<instructions>
 ${llmsTxtContent}
 </instructions>`);
@@ -386,7 +386,7 @@ ${llmsTxtContent}
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
-		assertContextMessage(messages[0],
+		assertContextMessage(messages.at(-1)!,
 			`<editor description="Current active editor" filePath="${filePath}" language="${document.languageId}" line="${selection.active.line + 1}" column="${selection.active.character + 1}" documentOffset="${document.offsetAt(selection.active)}">
 <document description="Full contents of the active file">
 ${document.getText()}

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -23,8 +23,12 @@ export enum PositronAssistantToolName {
 export enum LanguageModelDataPartMimeType {
 	/**
 	 * Defines a cache breakpoint (e.g. for Anthropic's manual prompt caching).
+	 *
+	 * By matching the Copilot extension, other extensions that use models from either Copilot
+	 * or Positron Assistant can set cache breakpoints with the same mime type.
+	 * See: https://github.com/microsoft/vscode-copilot-chat/blob/6aeac371813be9037e74395186ec5b5b94089245/src/platform/endpoint/common/endpointTypes.ts#L7
 	 */
-	CacheBreakpoint = 'application/cache-control+json',
+	CacheControl = 'cache_control',
 }
 
 /**

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -16,3 +16,33 @@ export enum PositronAssistantToolName {
 	TextSearch = 'positron_findTextInProject_internal',
 	FileContents = 'positron_getFileContents_internal',
 }
+
+/**
+ * Custom LanguageModelDataPart mime types.
+ */
+export enum LanguageModelDataPartMimeType {
+	/**
+	 * Defines a cache breakpoint (e.g. for Anthropic's manual prompt caching).
+	 */
+	CacheBreakpoint = 'application/cache-control+json',
+}
+
+/**
+ * The type of cache breakpoint.
+ */
+export enum LanguageModelCacheBreakpointType {
+	/**
+	 * Defines a short-lived cache.
+	 */
+	Ephemeral = 'ephemeral',
+}
+
+/**
+ * Represents a cache breakpoint in a LanguageModelDataPart.
+ */
+export interface LanguageModelCacheBreakpoint {
+	/**
+	 * The type of cache breakpoint.
+	 */
+	type: LanguageModelCacheBreakpointType;
+}

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -337,7 +337,7 @@ function hasContent(message: vscode.LanguageModelChatMessage2) {
 		!message.content.every(
 			part => (part instanceof vscode.LanguageModelTextPart && part.value.trim() === '') ||
 				// If the only other parts are cache breakpoints, consider the message to have no content.
-				isCacheBreakpointDataPart(part)
+				isCacheBreakpointPart(part)
 		);
 }
 
@@ -403,7 +403,7 @@ export function isWorkspaceOpen(): boolean {
 /**
  * Checks if a given language model part defines a cache breakpoint.
  */
-export function isCacheBreakpointDataPart(part: unknown): part is vscode.LanguageModelDataPart & { mimeType: LanguageModelDataPartMimeType.CacheBreakpoint } {
+export function isCacheBreakpointPart(part: unknown): part is vscode.LanguageModelDataPart & { mimeType: LanguageModelDataPartMimeType.CacheBreakpoint } {
 	return (part instanceof vscode.LanguageModelDataPart) &&
 		part.mimeType === LanguageModelDataPartMimeType.CacheBreakpoint;
 }

--- a/src/vs/base/common/marshallingIds.ts
+++ b/src/vs/base/common/marshallingIds.ts
@@ -27,5 +27,4 @@ export const enum MarshalledId {
 	LanguageModelTextPart,
 	LanguageModelPromptTsxPart,
 	LanguageModelDataPart,
-	LanguageModelExtraDataPart,
 }

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -231,7 +231,7 @@ const _allApiProposals = {
 	},
 	languageModelDataPart: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts',
-		version: 2
+		version: 3
 	},
 	languageModelSystem: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.languageModelSystem.d.ts',

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1833,7 +1833,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			LanguageModelToolResult: extHostTypes.LanguageModelToolResult,
 			LanguageModelToolResult2: extHostTypes.LanguageModelToolResult2,
 			LanguageModelDataPart: extHostTypes.LanguageModelDataPart,
-			LanguageModelExtraDataPart: extHostTypes.LanguageModelExtraDataPart,
 			ExtendedLanguageModelToolResult: extHostTypes.ExtendedLanguageModelToolResult,
 			PreparedTerminalToolInvocation: extHostTypes.PreparedTerminalToolInvocation,
 			LanguageModelChatToolMode: extHostTypes.LanguageModelChatToolMode,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -45,7 +45,7 @@ import { IChatRequestVariableEntry, isImageVariableEntry } from '../../contrib/c
 import { IChatAgentMarkdownContentWithVulnerability, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMoveMessage, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatTaskDto, IChatTaskResult, IChatTextEdit, IChatTreeData, IChatUserActionEvent, IChatWarningMessage } from '../../contrib/chat/common/chatService.js';
 import { IToolData, IToolResult } from '../../contrib/chat/common/languageModelToolsService.js';
 import * as chatProvider from '../../contrib/chat/common/languageModels.js';
-import { IChatResponseDataPart, IChatResponsePromptTsxPart, IChatResponseTextPart } from '../../contrib/chat/common/languageModels.js';
+import { IChatMessageDataPart, IChatResponseDataPart, IChatResponsePromptTsxPart, IChatResponseTextPart } from '../../contrib/chat/common/languageModels.js';
 import { DebugTreeItemCollapsibleState, IDebugVisualizationTreeItem } from '../../contrib/debug/common/debug.js';
 import * as notebooks from '../../contrib/notebook/common/notebookCommon.js';
 import { CellEditType } from '../../contrib/notebook/common/notebookCommon.js';
@@ -2330,12 +2330,14 @@ export namespace LanguageModelChatMessage {
 					}
 				});
 				return new types.LanguageModelToolResultPart(c.toolCallId, content, c.isError);
-			} else if (c.type === 'image_url' || c.type === 'extra_data') {
+			} else if (c.type === 'image_url') {
 				// Non-stable types
 				return undefined;
-			} else {
+			} else if (c.type === 'tool_use') {
 				return new types.LanguageModelToolCallPart(c.toolCallId, c.name, c.parameters);
 			}
+
+			return undefined;
 		}).filter(c => c !== undefined);
 
 		const role = LanguageModelChatMessageRole.to(message.role);
@@ -2427,8 +2429,8 @@ export namespace LanguageModelChatMessage2 {
 				return new types.LanguageModelToolResultPart2(c.toolCallId, content, c.isError);
 			} else if (c.type === 'image_url') {
 				return new types.LanguageModelDataPart(c.value.data.buffer, c.value.mimeType);
-			} else if (c.type === 'extra_data') {
-				return new types.LanguageModelExtraDataPart(c.kind, c.data);
+			} else if (c.type === 'data') {
+				return new types.LanguageModelDataPart(c.data.buffer, c.mimeType);
 			} else {
 				return new types.LanguageModelToolCallPart(c.toolCallId, c.name, c.parameters);
 			}
@@ -2480,15 +2482,23 @@ export namespace LanguageModelChatMessage2 {
 					isError: c.isError
 				};
 			} else if (c instanceof types.LanguageModelDataPart) {
-				const value: chatProvider.IChatImageURLPart = {
-					mimeType: c.mimeType as chatProvider.ChatImageMimeType,
-					data: VSBuffer.wrap(c.data),
-				};
+				if (isImageDataPart(c)) {
+					const value: chatProvider.IChatImageURLPart = {
+						mimeType: c.mimeType as chatProvider.ChatImageMimeType,
+						data: VSBuffer.wrap(c.data),
+					};
 
-				return {
-					type: 'image_url',
-					value: value
-				};
+					return {
+						type: 'image_url',
+						value: value
+					};
+				} else {
+					return {
+						type: 'data',
+						mimeType: c.mimeType,
+						data: VSBuffer.wrap(c.data),
+					} satisfies IChatMessageDataPart;
+				}
 			} else if (c instanceof types.LanguageModelToolCallPart) {
 				return {
 					type: 'tool_use',
@@ -2501,12 +2511,6 @@ export namespace LanguageModelChatMessage2 {
 					type: 'text',
 					value: c.value
 				};
-			} else if (c instanceof types.LanguageModelExtraDataPart) {
-				return {
-					type: 'extra_data',
-					kind: c.kind,
-					data: c.data
-				} satisfies chatProvider.IChatMessagePart;
 			} else {
 				if (typeof c !== 'string') {
 					throw new Error('Unexpected chat message content type llm 2');
@@ -2524,6 +2528,19 @@ export namespace LanguageModelChatMessage2 {
 			name,
 			content
 		};
+	}
+}
+
+function isImageDataPart(part: types.LanguageModelDataPart): boolean {
+	switch (part.mimeType) {
+		case types.ChatImageMimeType.PNG:
+		case types.ChatImageMimeType.JPEG:
+		case types.ChatImageMimeType.GIF:
+		case types.ChatImageMimeType.WEBP:
+		case types.ChatImageMimeType.BMP:
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -5012,19 +5012,19 @@ export class LanguageModelChatMessage implements vscode.LanguageModelChatMessage
 
 export class LanguageModelChatMessage2 implements vscode.LanguageModelChatMessage2 {
 
-	static User(content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[], name?: string): LanguageModelChatMessage2 {
+	static User(content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[], name?: string): LanguageModelChatMessage2 {
 		return new LanguageModelChatMessage2(LanguageModelChatMessageRole.User, content, name);
 	}
 
-	static Assistant(content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[], name?: string): LanguageModelChatMessage2 {
+	static Assistant(content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[], name?: string): LanguageModelChatMessage2 {
 		return new LanguageModelChatMessage2(LanguageModelChatMessageRole.Assistant, content, name);
 	}
 
 	role: vscode.LanguageModelChatMessageRole;
 
-	private _content: (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[] = [];
+	private _content: (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[] = [];
 
-	set content(value: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[]) {
+	set content(value: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[]) {
 		if (typeof value === 'string') {
 			// we changed this and still support setting content with a string property. this keep the API runtime stable
 			// despite the breaking change in the type definition.
@@ -5034,7 +5034,7 @@ export class LanguageModelChatMessage2 implements vscode.LanguageModelChatMessag
 		}
 	}
 
-	get content(): (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[] {
+	get content(): (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[] {
 		return this._content;
 	}
 
@@ -5050,7 +5050,7 @@ export class LanguageModelChatMessage2 implements vscode.LanguageModelChatMessag
 		}
 	}
 
-	get content2(): (string | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[] | undefined {
+	get content2(): (string | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[] | undefined {
 		return this.content.map(part => {
 			if (part instanceof LanguageModelTextPart) {
 				return part.value;
@@ -5061,7 +5061,7 @@ export class LanguageModelChatMessage2 implements vscode.LanguageModelChatMessag
 
 	name: string | undefined;
 
-	constructor(role: vscode.LanguageModelChatMessageRole, content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart)[], name?: string) {
+	constructor(role: vscode.LanguageModelChatMessageRole, content: string | (LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart)[], name?: string) {
 		this.role = role;
 		this.content = content;
 		this.name = name;
@@ -5110,13 +5110,13 @@ export class LanguageModelDataPart implements vscode.LanguageModelDataPart {
 		return new LanguageModelDataPart(data, mimeType as string);
 	}
 
-	static json(value: object): vscode.LanguageModelDataPart {
+	static json(value: object, mime: string = 'text/x-json'): vscode.LanguageModelDataPart {
 		const rawStr = JSON.stringify(value, undefined, '\t');
-		return new LanguageModelDataPart(VSBuffer.fromString(rawStr).buffer, 'json');
+		return new LanguageModelDataPart(VSBuffer.fromString(rawStr).buffer, mime);
 	}
 
-	static text(value: string): vscode.LanguageModelDataPart {
-		return new LanguageModelDataPart(VSBuffer.fromString(value).buffer, 'text/plain');
+	static text(value: string, mime: string = Mimes.text): vscode.LanguageModelDataPart {
+		return new LanguageModelDataPart(VSBuffer.fromString(value).buffer, mime);
 	}
 
 	toJSON() {
@@ -5134,24 +5134,6 @@ export enum ChatImageMimeType {
 	GIF = 'image/gif',
 	WEBP = 'image/webp',
 	BMP = 'image/bmp',
-}
-
-export class LanguageModelExtraDataPart implements vscode.LanguageModelExtraDataPart {
-	kind: string;
-	data: any;
-
-	constructor(kind: string, data: any) {
-		this.kind = kind;
-		this.data = data;
-	}
-
-	toJSON() {
-		return {
-			$mid: MarshalledId.LanguageModelExtraDataPart,
-			kind: this.kind,
-			data: this.data,
-		};
-	}
 }
 
 

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -40,10 +40,10 @@ export interface IChatMessageImagePart {
 	value: IChatImageURLPart;
 }
 
-export interface IChatMessageExtraDataPart {
-	type: 'extra_data';
-	kind: string;
-	data: any;
+export interface IChatMessageDataPart {
+	type: 'data';
+	mimeType: string;
+	data: VSBuffer;
 }
 
 export interface IChatImageURLPart {
@@ -85,7 +85,7 @@ export interface IChatMessageToolResultPart {
 	isError?: boolean;
 }
 
-export type IChatMessagePart = IChatMessageTextPart | IChatMessageToolResultPart | IChatResponseToolUsePart | IChatMessageImagePart | IChatMessageExtraDataPart;
+export type IChatMessagePart = IChatMessageTextPart | IChatMessageToolResultPart | IChatResponseToolUsePart | IChatMessageImagePart | IChatMessageDataPart;
 
 export interface IChatMessage {
 	readonly name?: string | undefined;

--- a/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 2
+// version: 3
 
 declare module 'vscode' {
 
@@ -23,7 +23,7 @@ declare module 'vscode' {
 		 * @param content The content of the message.
 		 * @param name The optional name of a user for the message.
 		 */
-		static User(content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelDataPart | LanguageModelExtraDataPart>, name?: string): LanguageModelChatMessage2;
+		static User(content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelDataPart>, name?: string): LanguageModelChatMessage2;
 
 		/**
 		 * Utility to create a new assistant message.
@@ -31,7 +31,7 @@ declare module 'vscode' {
 		 * @param content The content of the message.
 		 * @param name The optional name of a user for the message.
 		 */
-		static Assistant(content: string | Array<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart>, name?: string): LanguageModelChatMessage2;
+		static Assistant(content: string | Array<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart>, name?: string): LanguageModelChatMessage2;
 
 		/**
 		 * The role of this message.
@@ -42,7 +42,7 @@ declare module 'vscode' {
 		 * A string or heterogeneous array of things that a message can contain as content. Some parts may be message-type
 		 * specific for some models.
 		 */
-		content: Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart>;
+		content: Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart>;
 
 		/**
 		 * The optional name of a user for this message.
@@ -56,7 +56,7 @@ declare module 'vscode' {
 		 * @param content The content of the message.
 		 * @param name The optional name of a user for the message.
 		 */
-		constructor(role: LanguageModelChatMessageRole, content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelExtraDataPart>, name?: string);
+		constructor(role: LanguageModelChatMessageRole, content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart2 | LanguageModelToolCallPart | LanguageModelDataPart>, name?: string);
 	}
 
 	/**
@@ -70,9 +70,9 @@ declare module 'vscode' {
 		 */
 		static image(data: Uint8Array, mimeType: ChatImageMimeType): LanguageModelDataPart;
 
-		static json(value: object): LanguageModelDataPart;
+		static json(value: any, mime?: string): LanguageModelDataPart;
 
-		static text(value: string): LanguageModelDataPart;
+		static text(value: string, mime?: string): LanguageModelDataPart;
 
 		/**
 		 * The mime type which determines how the data property is interpreted.
@@ -101,31 +101,6 @@ declare module 'vscode' {
 		WEBP = 'image/webp',
 		BMP = 'image/bmp',
 	}
-
-	/**
-	 * Tagging onto this proposal, because otherwise managing two different extensions of LanguageModelChatMessage could be confusing.
-	 * A language model response part containing arbitrary model-specific data, returned from a {@link LanguageModelChatResponse}.
-	 * TODO@API naming, looking at LanguageModelChatRequestOptions.modelOptions, but LanguageModelModelData is not very good.
-	 * LanguageModelOpaqueData from prompt-tsx?
-	 */
-	export class LanguageModelExtraDataPart {
-		/**
-		 * The type of data. The allowed values and data types here are model-specific.
-		 */
-		kind: string;
-
-		/**
-		 * Extra model-specific data.
-		 */
-		data: any;
-
-		/**
-		 * Construct an extra data part with the given content.
-		 * @param value The image content of the part.
-		 */
-		constructor(kind: string, data: any);
-	}
-
 
 	/**
 	 * The result of a tool call. This is the counterpart of a {@link LanguageModelToolCallPart tool call} and


### PR DESCRIPTION
This PR makes it possible for extensions to manually define cache breakpoints everywhere that's supported by Anthropic, except tool definitions (although tools will often be cached via system prompt cache breakpoints). Addresses #8325;

This PR also moves the user context message from _before_ the user query to _after_ for better prompt caching. @wch mentioned that he noticed no changes to model responses when experimenting with the context/query order, but we should double-check.

I cherry-picked an upstream commit to bring in updates to `LanguageModelDataPart` so that we can implement this in the same way as the Copilot extension. That gives us the added benefit that when the `LanguageModelDataPart` API proposal is accepted, extensions like `shiny-vscode` will be able to set cache breakpoints for Anthropic models contributed by both the Copilot extension and Positron Assistant.

### Release Notes

#### New Features

- Extensions can set Anthropic prompt cache breakpoints in the message history (#8325).

#### Bug Fixes

- N/A

### QA Notes

Since this PR also moves the user context message from _before_ the user query to _after_ for better prompt caching, we should also double-check that the quality of responses is roughly the same.

In the cases below, if caching is working, you should see logs indicating cache writes followed by cache reads, for example:

```
2025-06-27 18:58:33.965 [debug] [anthropic] Adding cache breakpoint to text part. Source: User message 0
2025-06-27 18:58:40.010 [debug] [anthropic] SEND messages.stream [req_011CQZ5f35yWxARapzaM565V]: model: claude-3-5-sonnet-latest; cache options: default; tools: <snip>; tool choice: {"type":"auto"}; system chars: 0; user messages: 1; user message characters: 151384; assistant messages: 0; assistant message characters: 2
2025-06-27 18:58:41.896 [debug] [anthropic] RECV messages.stream [req_011CQZ5f35yWxARapzaM565V]: usage: {"input_tokens":4,"cache_creation_input_tokens":45353,"cache_read_input_tokens":0,"output_tokens":74,"service_tier":"standard"}
2025-06-27 18:59:05.508 [debug] [anthropic] Adding cache breakpoint to text part. Source: User message 0
2025-06-27 18:59:07.680 [debug] [anthropic] SEND messages.stream [req_011CQZ5hNZZE1XbxccZ8pvh6]: model: claude-3-5-sonnet-latest; cache options: default; tools: <snip>; tool choice: {"type":"auto"}; system chars: 0; user messages: 1; user message characters: 151384; assistant messages: 0; assistant message characters: 2
2025-06-27 18:59:14.208 [debug] [anthropic] RECV messages.stream [req_011CQZ5hNZZE1XbxccZ8pvh6]: usage: {"input_tokens":4,"cache_creation_input_tokens":0,"cache_read_input_tokens":45353,"output_tokens":289,"service_tier":"standard"}
```

Step-by-step instructions:

1. Positron Assistant participants cache write/read the last 2 user messages when using Anthropic models
2. Positron Assistant participants should behave as before for Vercel models (e.g. after disabling `positron.assistant.useAnthropicSdk` and restarting)
3. Requires a bit more setup to test the Shiny extension in Positron:
    1. Start a Positron dev instance at branch `feature/anthropic-cache-messages`
    2. In Positron, open the Shiny extension repo at this branch: https://github.com/posit-dev/shiny-vscode/pull/94. Open the `src/extension.ts` file and press F5 to start debugging
    3. Try the `@shiny` participant in the Positron Assistant chat pane, with Anthropic and Vercel models
4. Similarly, the Shiny extension can be tested in VSCode by following the same steps as above in VSCode. There will be no caching but nothing should break.

@:assistant