### PR TITLE
e2e test: refactor data explorer pandas test for independence

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -57,5 +57,8 @@
     {
         "key": "cmd+j c",
         "command": "workbench.action.togglePanel"
+    }, {
+        "key": "cmd+j n",
+        "command": "workbench.action.positronNotebookLayout" // View: Notebook Layout
     }
 ]

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -87,7 +87,7 @@ export class Workbench {
 	constructor(code: Code) {
 		this.hotKeys = new HotKeys(code);
 		this.popups = new Popups(code);
-		this.variables = new Variables(code);
+		this.variables = new Variables(code, this.hotKeys);
 		this.dataExplorer = new DataExplorer(code, this);
 		this.sideBar = new SideBar(code);
 		this.plots = new Plots(code);

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -254,23 +254,6 @@ export class DataExplorer {
 		});
 	}
 
-	async verifyTab(
-		tabName: string,
-		{ isVisible = true, isSelected = true }: { isVisible?: boolean; isSelected?: boolean }
-	): Promise<void> {
-		await test.step(`Verify tab: ${tabName} is ${isVisible ? '' : 'not'} visible, is ${isSelected ? '' : 'not'} selected`, async () => {
-			const tabLocator = this.code.driver.page.getByRole('tab', { name: tabName });
-
-			await (isVisible
-				? expect(tabLocator).toBeVisible()
-				: expect(tabLocator).not.toBeVisible());
-
-			await (isSelected
-				? expect(tabLocator).toHaveClass(/selected/)
-				: expect(tabLocator).not.toHaveClass(/selected/));
-		});
-	}
-
 	async verifyTableData(expectedData, timeout = 60000) {
 		await test.step('Verify data explorer data', async () => {
 			await expect(async () => {

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -271,6 +271,28 @@ export class DataExplorer {
 		});
 	}
 
+	async verifyTableDataLength(expectedLength: number) {
+		await test.step('Verify data explorer table data length', async () => {
+			await expect(async () => {
+				const tableData = await this.getDataExplorerTableData();
+				expect(tableData.length).toBe(expectedLength);
+			}).toPass({ timeout: 60000 });
+		});
+	}
+
+	async verifyTableDataRowValue(rowIndex: number, expectedData: CellData) {
+		await test.step(`Verify data explorer row ${rowIndex} data`, async () => {
+			await expect(async () => {
+				const tableData = await this.getDataExplorerTableData();
+				const rowData = tableData[rowIndex];
+
+				for (const [key, value] of Object.entries(expectedData)) {
+					expect(rowData[key]).toBe(value);
+				}
+			}).toPass({ timeout: 60000 });
+		});
+	}
+
 	async verifyMissingPercent(expectedValues: Array<{ column: number; expected: string }>) {
 		await test.step('Verify missing percent values', async () => {
 			for (const { column, expected } of expectedValues) {

--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -16,6 +16,31 @@ export class Editors {
 
 	constructor(private code: Code) { }
 
+	async clickTab(tabName: string): Promise<void> {
+		await test.step(`Click tab: ${tabName}`, async () => {
+			const tabLocator = this.code.driver.page.getByRole('tab', { name: tabName });
+			await expect(tabLocator).toBeVisible();
+			await tabLocator.click();
+		});
+	}
+
+	async verifyTab(
+		tabName: string,
+		{ isVisible = true, isSelected = true }: { isVisible?: boolean; isSelected?: boolean }
+	): Promise<void> {
+		await test.step(`Verify tab: ${tabName} is ${isVisible ? '' : 'not'} visible, is ${isSelected ? '' : 'not'} selected`, async () => {
+			const tabLocator = this.code.driver.page.getByRole('tab', { name: tabName });
+
+			await (isVisible
+				? expect(tabLocator).toBeVisible()
+				: expect(tabLocator).not.toBeVisible());
+
+			await (isSelected
+				? expect(tabLocator).toHaveClass(/selected/)
+				: expect(tabLocator).not.toHaveClass(/selected/));
+		});
+	}
+
 	async waitForActiveTab(fileName: string, isDirty: boolean = false): Promise<void> {
 		await expect(this.code.driver.page.locator(`.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"][data-resource-name$="${fileName}"]`)).toBeVisible();
 	}

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -134,6 +134,10 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+J C', 'Toggle bottom panel');
 	}
 
+	public async notebookLayout() {
+		await this.pressHotKeys('Cmd+J N', 'Notebook layout');
+	}
+
 	// ----------------------
 	// --- Workspace Actions ---
 	// ----------------------

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -86,20 +86,6 @@ export class Variables {
 		return await progressBar.isVisible();
 	}
 
-	// /**
-	//  * Action: Show or hide the secondary side bar (variables pane).
-	//  * @param action show or hide the secondary side bar
-	//  */
-	// async togglePane(action: 'show' | 'hide') {
-	// 	await test.step(`Toggle variables pane: ${action}`, async () => {
-	// 		const variablesSectionIsVisible = await this.code.driver.page.getByRole('button', { name: 'Variables Section' }).isVisible();
-
-	// 		if (action === 'show' && !variablesSectionIsVisible || action === 'hide' && variablesSectionIsVisible) {
-	// 			await this.code.driver.page.keyboard.press(os.platform() === 'darwin' ? 'Meta+Alt+B' : 'Control+Alt+B');
-	// 		}
-	// 	});
-	// }
-
 	async toggleVariable({ variableName, action }: { variableName: string; action: 'expand' | 'collapse' }) {
 		await test.step(`${action} variable: ${variableName}`, async () => {
 			await this.waitForVariableRow(variableName);

--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -18,11 +18,11 @@ test.describe('Autocomplete', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Python - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
-		const { variables, editors, console } = app.workbench;
+	test('Python - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions, hotKeys }) {
+		const { editors, console } = app.workbench;
 
 		const [pySession1, pySession2, pyAltSession] = await sessions.start(['python', 'python', 'pythonAlt']);
-		await variables.togglePane('hide');
+		await hotKeys.hideSecondarySidebar();
 
 		// Session 1 - trigger and verify console autocomplete
 		await sessions.select(pySession1.id);
@@ -56,10 +56,10 @@ test.describe('Autocomplete', {
 	});
 
 	test('Python - Verify autocomplete suggestions (LSP is alive) after restart', async function ({ app, hotKeys, sessions }) {
-		const { variables, console } = app.workbench;
+		const { console } = app.workbench;
 
 		const [pySession, pyAltSession] = await sessions.start(['python', 'pythonAlt']);
-		await variables.togglePane('hide');
+		await hotKeys.hideSecondarySidebar();
 
 		// Session 1 - verify console autocomplete
 		await sessions.select(pySession.id);
@@ -88,11 +88,11 @@ test.describe('Autocomplete', {
 		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 	});
 
-	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions }) {
-		const { variables, editors, console } = app.workbench;
+	test('R - Verify autocomplete suggestions in Console and Editor', async function ({ app, runCommand, sessions, hotKeys }) {
+		const { editors, console } = app.workbench;
 
 		const [rSession1, rSession2, rSessionAlt] = await sessions.start(['r', 'r', 'rAlt']);
-		await variables.togglePane('hide');
+		await hotKeys.hideSecondarySidebar();
 
 		// Session 1 - verify console autocomplete
 		await sessions.select(rSession1.id);
@@ -125,11 +125,11 @@ test.describe('Autocomplete', {
 		await editors.expectSuggestionListCount(0);
 	});
 
-	test('R - Verify autocomplete suggestions (LSP is alive) after restart', async function ({ app, sessions }) {
-		const { variables, console } = app.workbench;
+	test('R - Verify autocomplete suggestions (LSP is alive) after restart', async function ({ app, sessions, hotKeys }) {
+		const { console } = app.workbench;
 
 		const [rSession, rSessionAlt] = await sessions.start(['r', 'rAlt']);
-		await variables.togglePane('hide');
+		await hotKeys.hideSecondarySidebar();
 
 		// Session 1 - verify console autocomplete
 		await sessions.select(rSession.id);

--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -51,7 +51,7 @@ test.describe('Postgres DB Connection', {
 			const connectionName = app.code.driver.page.locator('.connections-details', { hasText: 'public' });
 			await connectionName.locator('..').locator('.expand-collapse-area .codicon-chevron-right').click();
 			await app.code.driver.page.locator('.codicon-positron-table-connection').click();
-			await app.workbench.dataExplorer.verifyTab('Data: periodic_table', { isVisible: true });
+			await app.workbench.editors.verifyTab('Data: periodic_table', { isVisible: true });
 		});
 
 		await test.step('Verify connection data from periodic table', async () => {
@@ -112,7 +112,7 @@ test.describe('Postgres DB Connection', {
 			await publicNode.locator('..').locator('.expand-collapse-area .codicon-chevron-right').click();
 
 			await app.code.driver.page.locator('.codicon-positron-table-connection').click();
-			await app.workbench.dataExplorer.verifyTab('Data: periodic_table', { isVisible: true });
+			await app.workbench.editors.verifyTab('Data: periodic_table', { isVisible: true });
 		});
 
 		await test.step('Verify connection data from periodic table', async () => {

--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -43,7 +43,7 @@ test.describe('Headless Data Explorer', {
 	testCases.forEach(({ name, file, copyValue }) => {
 		test(`Verify can open and view data with large ${name} file`, async function ({ app, openDataFile }) {
 			await openDataFile(`${file}`);
-			await app.workbench.dataExplorer.verifyTab(file.split('/').pop()!, { isVisible: true, isSelected: true });
+			await app.workbench.editors.verifyTab(file.split('/').pop()!, { isVisible: true, isSelected: true });
 			await verifyCopyFromCell(app, copyValue);
 			await verifyDataIsPresent(app);
 			await verifyPlainTextButtonInActionBar(app, file.endsWith('.csv') || file.endsWith('.tsv'));
@@ -61,7 +61,7 @@ test.describe('Headless Data Explorer', {
 
 	test(`Verify can open parquet decimal data`, async function ({ app, openDataFile }) {
 		await openDataFile(`data-files/misc-parquet/decimal_types.parquet`);
-		await app.workbench.dataExplorer.verifyTab('decimal_types.parquet', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('decimal_types.parquet', { isVisible: true, isSelected: true });
 		await verifyCopyFromCell(app, '123456789012345.678');
 		await expect(async () => {
 			// Validate full grid by checking bottom right corner data

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -24,11 +24,13 @@ test.describe('Data Explorer - Python Pandas', {
 	test('Python Pandas - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app, executeCode, hotKeys, python }) {
 		const { dataExplorer, variables, editors } = app.workbench;
 
+		// execute code to create a DataFrame
 		await executeCode('Python', df);
 		await variables.doubleClickVariableRow('df');
 		await editors.verifyTab('Data: df', { isVisible: true });
 		await hotKeys.hideSecondarySidebar();
 
+		// verify table data, clipboard, sparkline hover, and null percentage hover
 		await dataExplorer.verifyTableData([
 			{ 'Name': 'Jai', 'Age': '27', 'Address': 'Delhi' },
 			{ 'Name': 'Princi', 'Age': '24', 'Address': 'Kanpur' },
@@ -43,11 +45,13 @@ test.describe('Data Explorer - Python Pandas', {
 	test('Python Pandas - Verify data explorer functionality with empty fields', async function ({ app, python }) {
 		const { dataExplorer, console, variables, editors } = app.workbench;
 
+		// execute code to create a DataFrame with empty fields
 		await console.executeCode('Python', emptyFieldsScript);
 		await variables.doubleClickVariableRow('emptyFields');
 		await editors.verifyTab('Data: emptyFields', { isVisible: true, isSelected: true });
-
 		await dataExplorer.maximizeDataExplorer(true);
+
+		// verify table data with empty fields
 		await dataExplorer.verifyTableData([
 			{ 'A': '1.00', 'B': 'foo', 'C': 'NaN', 'D': 'NaT', 'E': 'None' },
 			{ 'A': '2.00', 'B': 'NaN', 'C': '2.50', 'D': 'NaT', 'E': 'text' },
@@ -56,6 +60,7 @@ test.describe('Data Explorer - Python Pandas', {
 			{ 'A': '5.00', 'B': 'None', 'C': '4.80', 'D': '2023-02-01 00:00:00', 'E': 'even more text' }
 		]);
 
+		// verify missing percentages
 		await dataExplorer.expandSummary();
 		await dataExplorer.verifyMissingPercent([
 			{ column: 1, expected: '20%' },
@@ -65,6 +70,7 @@ test.describe('Data Explorer - Python Pandas', {
 			{ column: 5, expected: '40%' }
 		]);
 
+		// verify column profile data
 		await dataExplorer.verifyProfileData([
 			{ column: 1, expected: { 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' } },
 			{ column: 2, expected: { 'Missing': '2', 'Empty': '0', 'Unique': '3' } },
@@ -78,42 +84,48 @@ test.describe('Data Explorer - Python Pandas', {
 	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, sessions, hotKeys, python }) {
 		const { dataExplorer, notebooks, variables, editors } = app.workbench;
 
-		const filename = 'pandas-update-dataframe.ipynb';
-		await notebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', filename));
+		// open a notebook and execute a cell to create a DataFrame
+		const pythonNotebook = 'pandas-update-dataframe.ipynb';
+		await notebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', pythonNotebook));
 		await notebooks.selectInterpreter('Python', process.env.POSITRON_PY_VER_SEL!);
 		await notebooks.focusFirstCell();
 		await notebooks.executeActiveCell();
+
+		// open the DataFrame in data explorer and verify data
 		await variables.doubleClickVariableRow('df');
 		await editors.verifyTab('Data: df', { isVisible: true });
-
 		await hotKeys.notebookLayout();
 		await dataExplorer.verifyTableDataLength(11);
 
-		await editors.clickTab(filename);
+		// execute the next cell and verify data in the data explorer
+		await editors.clickTab(pythonNotebook);
 		await notebooks.focusNextCell();
 		await notebooks.executeActiveCell();
 		await editors.clickTab('Data: df');
 		await dataExplorer.verifyTableDataLength(12);
 
-		await editors.clickTab(filename);
+		// execute the next cell to sort the DataFrame and verify sorted data
+		await editors.clickTab(pythonNotebook);
 		await notebooks.focusNextCell();
 		await notebooks.executeActiveCell();
-		await app.code.driver.page.locator('.label-name:has-text("Data: df")').click();
+		await editors.clickTab('Data: df');
 		await dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 		await dataExplorer.verifyTableDataLength(12);
 		await dataExplorer.verifyTableDataRowValue(0, { 'Year': '2025' });
+
 		await dataExplorer.closeDataExplorer();
 	});
 
 	test('Python Pandas - Verify opening Data Explorer for the second time brings focus back', async function ({ app, python }) {
 		const { dataExplorer, variables, console, editors } = app.workbench;
 
+		// execute code to create a DataFrame
 		await console.executeCode('Python', mtcarsDf);
 		await variables.focusVariablesView();
 		await variables.doubleClickVariableRow('Data_Frame');
 		await editors.verifyTab('Data: Data_Frame', { isVisible: true });
 
-		// Now move focus out of the the data explorer pane
+		// move focus out of the the data explorer pane and verify focus returns via variable double click
 		await editors.newUntitledFile();
 		await variables.focusVariablesView();
 		await variables.doubleClickVariableRow('Data_Frame');
@@ -126,10 +138,10 @@ test.describe('Data Explorer - Python Pandas', {
 		const { dataExplorer, console, variables, editors } = app.workbench;
 		const [session] = await sessions.start(['python']);
 
+		// execute code to create a DataFrame with blank spaces
 		await console.executeCode('Python', blankSpacesScript);
 		await variables.doubleClickVariableRow('df');
 		await editors.verifyTab('Data: df', { isVisible: true });
-
 		await dataExplorer.verifyTableData([
 			{ 'x': 'a·' },
 			{ 'x': 'a' },

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -81,7 +81,7 @@ test.describe('Data Explorer - Python Pandas', {
 	});
 
 
-	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, sessions, hotKeys, python }) {
+	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, hotKeys, python }) {
 		const { dataExplorer, notebooks, variables, editors } = app.workbench;
 
 		// open a notebook and execute a cell to create a DataFrame

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -5,6 +5,7 @@
 
 import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
+import { Application } from '../../infra/index.js';
 
 test.use({
 	suiteId: __filename
@@ -13,76 +14,40 @@ test.use({
 test.describe('Data Explorer - Python Pandas', {
 	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER]
 }, () => {
-	test.describe.configure({ mode: 'serial' });
-	test('Python Pandas - Verify can send code to console, open data grid, and data present', async function ({ app, python, logger }) {
-		// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
-		const script = `import pandas as pd
-data = {'Name':['Jai', 'Princi', 'Gaurav', 'Anuj'],
-		'Age':[27, 24, 22, 32],
-		'Address':['Delhi', 'Kanpur', 'Allahabad', 'Kannauj']}
-df = pd.DataFrame(data)`;
 
-		logger.log('Sending code to console');
-		await app.workbench.console.executeCode('Python', script);
-
-		logger.log('Opening data grid');
-		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true });
-
-		await app.workbench.sideBar.closeSecondarySideBar();
-
-		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
-
-			expect(tableData[0]).toStrictEqual({ 'Name': 'Jai', 'Age': '27', 'Address': 'Delhi' });
-			expect(tableData[1]).toStrictEqual({ 'Name': 'Princi', 'Age': '24', 'Address': 'Kanpur' });
-			expect(tableData[2]).toStrictEqual({ 'Name': 'Gaurav', 'Age': '22', 'Address': 'Allahabad' });
-			expect(tableData[3]).toStrictEqual({ 'Name': 'Anuj', 'Age': '32', 'Address': 'Kannauj' });
-			expect(tableData.length).toBe(4);
-		}).toPass({ timeout: 60000 });
-
-		await test.step('Verify copy to clipboard', async () => {
-			await expect(async () => {
-				await app.code.driver.page.locator('#data-grid-row-cell-content-0-0 .text-container .text-value').click();
-				await app.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+C' : 'Control+C');
-				const clipboardText = await app.workbench.clipboard.getClipboardText();
-				expect(clipboardText).toBe('Jai');
-			}).toPass({ timeout: 20000 });
-		});
-
-		await app.workbench.dataExplorer.verifySparklineHoverDialog(['Value', 'Count']);
-
-		await app.workbench.dataExplorer.verifyNullPercentHoverDialog();
-
-		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.variables.togglePane('show');
+	test.afterEach(async function ({ app }) {
+		await app.workbench.dataExplorer.clearAllFilters();
 	});
 
-	test('Python Pandas - Verify data explorer functionality with empty fields', async function ({ app, logger }) {
-		const script = `import numpy as np
-import pandas as pd
+	test('Python Pandas - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app, executeCode, hotKeys, python }) {
+		const { dataExplorer, variables, editors } = app.workbench;
 
-data = {
-		'A': [1, 2, np.nan, 4, 5],
-		'B': ['foo', np.nan, 'bar', 'baz', None],
-		'C': [np.nan, 2.5, 3.1, None, 4.8],
-		'D': [np.nan, pd.NaT, pd.Timestamp('2023-01-01'), pd.NaT, pd.Timestamp('2023-02-01')],
-		'E': [None, 'text', 'more text', np.nan, 'even more text']
-}
-df2 = pd.DataFrame(data)`;
+		await executeCode('Python', df);
+		await variables.doubleClickVariableRow('df');
+		await editors.verifyTab('Data: df', { isVisible: true });
+		await hotKeys.hideSecondarySidebar();
 
-		logger.log('Sending code to console');
-		await app.workbench.console.executeCode('Python', script);
+		await dataExplorer.verifyTableData([
+			{ 'Name': 'Jai', 'Age': '27', 'Address': 'Delhi' },
+			{ 'Name': 'Princi', 'Age': '24', 'Address': 'Kanpur' },
+			{ 'Name': 'Gaurav', 'Age': '22', 'Address': 'Allahabad' },
+			{ 'Name': 'Anuj', 'Age': '32', 'Address': 'Kannauj' }
+		]);
+		await verifyCanCopyDataToClipboard(app, 'Jai');
+		await dataExplorer.verifySparklineHoverDialog(['Value', 'Count']);
+		await dataExplorer.verifyNullPercentHoverDialog();
+	});
 
-		logger.log('Opening data grid');
-		await app.workbench.variables.doubleClickVariableRow('df2');
-		await app.workbench.dataExplorer.verifyTab('Data: df2', { isVisible: true });
+	test('Python Pandas - Verify data explorer functionality with empty fields', async function ({ app, python }) {
+		const { dataExplorer, console, variables, editors } = app.workbench;
 
-		// Need to make sure the data explorer is visible test.beforeAll we can interact with it
-		await app.workbench.dataExplorer.maximizeDataExplorer(true);
+		await console.executeCode('Python', scriptWithEmptyFields);
+		await variables.doubleClickVariableRow('df2');
+		await editors.verifyTab('Data: df2', { isVisible: true, isSelected: true });
+		await dataExplorer.maximizeDataExplorer(true);
 
 		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+			const tableData = await dataExplorer.getDataExplorerTableData();
 
 			expect(tableData[0]).toStrictEqual({ 'A': '1.00', 'B': 'foo', 'C': 'NaN', 'D': 'NaT', 'E': 'None' });
 			expect(tableData[1]).toStrictEqual({ 'A': '2.00', 'B': 'NaN', 'C': '2.50', 'D': 'NaT', 'E': 'text' });
@@ -92,88 +57,134 @@ df2 = pd.DataFrame(data)`;
 			expect(tableData.length).toBe(5);
 		}).toPass({ timeout: 60000 });
 
-		// Need to expand summary for next test
-		await app.workbench.dataExplorer.expandSummary();
+		await dataExplorer.expandSummary();
+		await dataExplorer.verifyMissingPercent([
+			{ column: 1, expected: '20%' },
+			{ column: 2, expected: '40%' },
+			{ column: 3, expected: '40%' },
+			{ column: 4, expected: '60%' },
+			{ column: 5, expected: '40%' }
+		]);
 
+		await dataExplorer.verifyProfileData([
+			{ column: 1, expected: { 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' } },
+			{ column: 2, expected: { 'Missing': '2', 'Empty': '0', 'Unique': '3' } },
+			{ column: 3, expected: { 'Missing': '2', 'Min': '2.50', 'Median': '3.10', 'Mean': '3.47', 'Max': '4.80', 'SD': '1.19' } },
+			{ column: 4, expected: { 'Missing': '3', 'Min': '2023-01-01 00:00:00', 'Median': 'NaT', 'Max': '2023-02-01 00:00:00', 'Timezone': 'None' } },
+			{ column: 5, expected: { 'Missing': '2', 'Empty': '0', 'Unique': '3' } }
+		]);
 	});
 
-	// Cannot be run by itself, relies on the previous test
-	test('Python Pandas - Verify data explorer column info functionality', async function ({ app }) {
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(1)).toBe('20%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(2)).toBe('40%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(3)).toBe('40%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(4)).toBe('60%');
-		expect(await app.workbench.dataExplorer.getColumnMissingPercent(5)).toBe('40%');
 
-		const col1ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(1);
-		expect(col1ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' });
+	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, sessions, hotKeys, python }) {
+		const { dataExplorer, notebooks, variables, layouts, editors } = app.workbench;
 
-		const col2ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(2);
-		expect(col2ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
-
-		const col3ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(3);
-		expect(col3ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Min': '2.50', 'Median': '3.10', 'Mean': '3.47', 'Max': '4.80', 'SD': '1.19' });
-
-		const col4ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(4);
-		expect(col4ProfileInfo.profileData).toStrictEqual({ 'Missing': '3', 'Min': '2023-01-01 00:00:00', 'Median': 'NaT', 'Max': '2023-02-01 00:00:00', 'Timezone': 'None' });
-
-		const col5ProfileInfo = await app.workbench.dataExplorer.getColumnProfileInfo(5);
-		expect(col5ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
-	});
-
-	// This test is not dependent on the previous test, so it refreshes the python environment
-	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, runCommand, sessions }) {
 		// Restart python for clean environment & open the file
-		await runCommand('workbench.action.closeAllEditors', { keepOpen: false });
-		await runCommand('workbench.action.toggleAuxiliaryBar');
+		await hotKeys.closeAllEditors();
+		await hotKeys.showSecondarySidebar();
 		await sessions.restart('Python');
 
 		const filename = 'pandas-update-dataframe.ipynb';
-		await app.workbench.notebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', filename));
-		await app.workbench.notebooks.selectInterpreter('Python', process.env.POSITRON_PY_VER_SEL!);
-		await app.workbench.notebooks.focusFirstCell();
-		await app.workbench.notebooks.executeActiveCell();
-		// is this an issue? the variables pane does not open up automatically after running cell
-		await app.workbench.variables.focusVariablesView();
-		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true });
+		await notebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', filename));
+		await notebooks.selectInterpreter('Python', process.env.POSITRON_PY_VER_SEL!);
+		await notebooks.focusFirstCell();
+		await notebooks.executeActiveCell();
+		await variables.doubleClickVariableRow('df');
+		await editors.verifyTab('Data: df', { isVisible: true });
 
-		await app.workbench.layouts.enterLayout('notebook');
-
+		await hotKeys.notebookLayout();
 		await expect(async () => {
 			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
 			expect(tableData.length).toBe(11);
 		}).toPass({ timeout: 60000 });
 
-		await app.code.driver.page.locator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
-		await app.workbench.notebooks.focusNextCell();
-		await app.workbench.notebooks.executeActiveCell();
-		await app.code.driver.page.locator('.label-name:has-text("Data: df")').click();
+		await editors.clickTab(filename);
+		await notebooks.focusNextCell();
+		await notebooks.executeActiveCell();
+		await editors.clickTab('Data: df');
 
 		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+			const tableData = await dataExplorer.getDataExplorerTableData();
 			expect(tableData.length).toBe(12);
 		}).toPass({ timeout: 60000 });
 
-		await app.code.driver.page.locator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
-		await app.workbench.notebooks.focusNextCell();
-		await app.workbench.notebooks.executeActiveCell();
+		await editors.clickTab(filename);
+		await notebooks.focusNextCell();
+		await notebooks.executeActiveCell();
 		await app.code.driver.page.locator('.label-name:has-text("Data: df")').click();
-		await app.workbench.dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
+		await dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 
 		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+			const tableData = await dataExplorer.getDataExplorerTableData();
 			expect(tableData[0]).toStrictEqual({ 'Year': '2025' });
 			expect(tableData.length).toBe(12);
 		}).toPass({ timeout: 60000 });
 
-		await app.workbench.layouts.enterLayout('stacked');
-		await app.workbench.dataExplorer.closeDataExplorer();
+		await layouts.enterLayout('stacked');
+		await dataExplorer.closeDataExplorer();
 	});
 
-	test('Python Pandas - Verify opening Data Explorer for the second time brings focus back', async function ({ app }) {
+	test('Python Pandas - Verify opening Data Explorer for the second time brings focus back', async function ({ app, python }) {
+		const { dataExplorer, variables, console, editors } = app.workbench;
+		await console.executeCode('Python', mtcarsDf);
+		await variables.focusVariablesView();
+		await variables.doubleClickVariableRow('Data_Frame');
+		await editors.verifyTab('Data: Data_Frame', { isVisible: true });
 
-		const script = `import pandas as pd
+		// Now move focus out of the the data explorer pane
+		await editors.newUntitledFile();
+		await variables.focusVariablesView();
+		await variables.doubleClickVariableRow('Data_Frame');
+		await editors.verifyTab('Data: Data_Frame', { isVisible: true });
+
+		await dataExplorer.closeDataExplorer();
+		await variables.focusVariablesView();
+	});
+
+	test('Python Pandas - Verify blank spaces in data explorer and disconnect behavior', async function ({ app, runCommand, python }) {
+		const { dataExplorer, console, variables, editors } = app.workbench;
+
+		await console.executeCode('Python', blankSpacesScript);
+		await variables.doubleClickVariableRow('df');
+		await editors.verifyTab('Data: df', { isVisible: true });
+
+		await dataExplorer.verifyTableData([
+			{ 'x': 'a·' },
+			{ 'x': 'a' },
+			{ 'x': '···' },
+			{ 'x': '<empty>' }
+		]);
+
+		await test.step('Verify disconnect dialog', async () => {
+			await runCommand('workbench.action.toggleAuxiliaryBar');
+			await console.trashButton.click();
+			await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
+		});
+
+		await dataExplorer.closeDataExplorer();
+	});
+});
+
+
+async function verifyCanCopyDataToClipboard(app: Application, expectedText?: string) {
+	await test.step('Verify can copy data to clipboard', async () => {
+		await expect(async () => {
+			await app.code.driver.page.locator('#data-grid-row-cell-content-0-0 .text-container .text-value').click();
+			await app.workbench.hotKeys.copy();
+			const clipboardText = await app.workbench.clipboard.getClipboardText();
+			expect(clipboardText).toBe(expectedText || 'Jai');
+		}).toPass({ timeout: 20000 });
+	});
+}
+
+// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
+const df = `import pandas as pd
+data = {'Name':['Jai', 'Princi', 'Gaurav', 'Anuj'],
+		'Age':[27, 24, 22, 32],
+		'Address':['Delhi', 'Kanpur', 'Allahabad', 'Kannauj']}
+df = pd.DataFrame(data)`;
+
+const mtcarsDf = `import pandas as pd
 Data_Frame = pd.DataFrame({
 	"mpg": [21.0, 21.0, 22.8, 21.4, 18.7],
 	"cyl": [6, 6, 4, 6, 8],
@@ -187,45 +198,18 @@ Data_Frame = pd.DataFrame({
 	"gear": [4, 4, 4, 3, 3],
 	"carb": [4, 4, 1, 1, 2]
 })`;
-		await app.workbench.console.executeCode('Python', script);
-		await app.workbench.variables.focusVariablesView();
-		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true });
 
-		// Now move focus out of the the data explorer pane
-		await app.workbench.editors.newUntitledFile();
-		await app.workbench.variables.focusVariablesView();
-		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true });
-
-		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.variables.focusVariablesView();
-	});
-
-	test('Python Pandas - Verify blank spaces in data explorer and disconnect behavior', async function ({ app }) {
-
-		const script = `import pandas as pd
+const blankSpacesScript = `import pandas as pd
 df = pd.DataFrame({'x': ["a ", "a", "   ", ""]})`;
-		await app.workbench.console.executeCode('Python', script);
-		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true });
 
-		await expect(async () => {
-			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();
+const scriptWithEmptyFields = `import numpy as np
+import pandas as pd
 
-			expect(tableData[0]).toStrictEqual({ 'x': 'a·' });
-			expect(tableData[1]).toStrictEqual({ 'x': 'a' });
-			expect(tableData[2]).toStrictEqual({ 'x': '···' });
-			expect(tableData[3]).toStrictEqual({ 'x': '<empty>' });
-			expect(tableData.length).toBe(4);
-		}).toPass({ timeout: 60000 });
-
-		await test.step('Verify disconnect dialog', async () => {
-			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-			await app.workbench.console.trashButton.click();
-			await expect(app.code.driver.page.locator('.dialog-box .message')).toHaveText('Connection Closed');
-		});
-
-		await app.workbench.dataExplorer.closeDataExplorer();
-	});
-});
+data = {
+		'A': [1, 2, np.nan, 4, 5],
+		'B': ['foo', np.nan, 'bar', 'baz', None],
+		'C': [np.nan, 2.5, 3.1, None, 4.8],
+		'D': [np.nan, pd.NaT, pd.Timestamp('2023-01-01'), pd.NaT, pd.Timestamp('2023-02-01')],
+		'E': [None, 'text', 'more text', np.nan, 'even more text']
+}
+df2 = pd.DataFrame(data)`;

--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -16,14 +16,14 @@ test.describe('Data Explorer - Python Polars', {
 }, () => {
 
 	test.beforeAll(async function ({ app, openFile, runCommand, python }) {
-		const { variables, dataExplorer } = app.workbench;
+		const { variables, dataExplorer, editors } = app.workbench;
 
 		await openFile(join('workspaces', 'polars-dataframe-py', 'polars_basic.py'));
 		await runCommand('python.execInConsole');
 
 		// open the data frame in the data explorer
 		await variables.doubleClickVariableRow('df');
-		await dataExplorer.verifyTab('Data: df', { isVisible: true });
+		await editors.verifyTab('Data: df', { isVisible: true });
 		await dataExplorer.maximizeDataExplorer(true);
 	});
 

--- a/test/e2e/tests/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-r.test.ts
@@ -29,7 +29,7 @@ test.describe('Data Explorer - R ', {
 
 		// Open Data Explorer
 		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: df', { isVisible: true, isSelected: true });
 
 		// Verify the data in the table
 		await app.workbench.dataExplorer.maximizeDataExplorer(true);
@@ -65,14 +65,14 @@ test.describe('Data Explorer - R ', {
 
 		// Open Data Explorer
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });
 
 		// Now move focus out of the the data explorer pane
 		await app.workbench.editors.newUntitledFile();
 		await app.workbench.variables.focusVariablesView();
-		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: false });
+		await app.workbench.editors.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: false });
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });
 	});
 
 	test('R - Verify blank spaces in data explorer and disconnect behavior', async function ({ app, r, executeCode }) {
@@ -81,7 +81,7 @@ test.describe('Data Explorer - R ', {
 
 		// Open Data Explorer
 		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: df', { isVisible: true, isSelected: true });
 
 		// Verify blank spaces in the table
 		await expect(async () => {

--- a/test/e2e/tests/data-explorer/helpers/100x100.ts
+++ b/test/e2e/tests/data-explorer/helpers/100x100.ts
@@ -25,7 +25,7 @@ export const testDataExplorer = async (
 
 	// Open the data frame.
 	await app.workbench.variables.doubleClickVariableRow(dataFrameName);
-	await app.workbench.dataExplorer.verifyTab(dataFrameName, { isVisible: true });
+	await app.workbench.editors.verifyTab(dataFrameName, { isVisible: true });
 
 	// Maximize the data explorer.
 	await app.workbench.dataExplorer.maximizeDataExplorer();

--- a/test/e2e/tests/data-explorer/large-data-frame.test.ts
+++ b/test/e2e/tests/data-explorer/large-data-frame.test.ts
@@ -30,7 +30,7 @@ test.describe('Data Explorer - Large Data Frame', {
 		await app.workbench.quickaccess.runCommand('python.execInConsole');
 
 		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: df', { isVisible: true, isSelected: true });
 
 		await expect(async () => {
 			// Validate full grid by checking bottom right corner data
@@ -59,7 +59,7 @@ test.describe('Data Explorer - Large Data Frame', {
 		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
 
 		await app.workbench.variables.doubleClickVariableRow('df2');
-		await app.workbench.dataExplorer.verifyTab('Data: df2', { isVisible: true, isSelected: true });
+		await app.workbench.editors.verifyTab('Data: df2', { isVisible: true, isSelected: true });
 
 		await expect(async () => {
 			// Validate full grid by checking bottom right corner data

--- a/test/e2e/tests/data-explorer/sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/sparklines.test.ts
@@ -39,7 +39,7 @@ test.describe('Data Explorer - Sparklines', {
 async function openDataExplorerColumnProfile(app: Application, variableName: string) {
 
 	await app.workbench.variables.doubleClickVariableRow(variableName);
-	await app.workbench.dataExplorer.verifyTab(`Data: ${variableName}`, { isVisible: true });
+	await app.workbench.editors.verifyTab(`Data: ${variableName}`, { isVisible: true });
 
 	await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 	await app.workbench.sideBar.closeSecondarySideBar();

--- a/test/e2e/tests/data-explorer/very-large-data-frame.test.ts
+++ b/test/e2e/tests/data-explorer/very-large-data-frame.test.ts
@@ -33,9 +33,9 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 		}
 	});
 
-	test.afterEach(async function ({ app }) {
+	test.afterEach(async function ({ app, hotKeys }) {
 		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.variables.togglePane('show');
+		await hotKeys.showSecondarySidebar();
 	});
 
 	if (githubActions && process.platform !== 'win32') {
@@ -46,7 +46,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 			const startTime = performance.now();
 
 			await app.workbench.variables.doubleClickVariableRow('df');
-			await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true, isSelected: true });
+			await app.workbench.editors.verifyTab('Data: df', { isVisible: true, isSelected: true });
 			await app.workbench.sideBar.closeSecondarySideBar();
 
 			// awaits table load completion
@@ -67,7 +67,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 			const startTime = performance.now();
 
 			await app.workbench.variables.doubleClickVariableRow('df2');
-			await app.workbench.dataExplorer.verifyTab('Data: df2', { isVisible: true, isSelected: true });
+			await app.workbench.editors.verifyTab('Data: df2', { isVisible: true, isSelected: true });
 			await app.workbench.sideBar.closeSecondarySideBar();
 
 			// awaits table load completion
@@ -90,7 +90,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 			const startTime = performance.now();
 
 			await app.workbench.variables.doubleClickVariableRow('df_large');
-			await app.workbench.dataExplorer.verifyTab('Data: df_large', { isVisible: true, isSelected: true });
+			await app.workbench.editors.verifyTab('Data: df_large', { isVisible: true, isSelected: true });
 			await app.workbench.sideBar.closeSecondarySideBar();
 
 			// awaits table load completion
@@ -111,7 +111,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 			const startTime = performance.now();
 
 			await app.workbench.variables.doubleClickVariableRow('df3_large');
-			await app.workbench.dataExplorer.verifyTab('Data: df3_large', { isVisible: true, isSelected: true });
+			await app.workbench.editors.verifyTab('Data: df3_large', { isVisible: true, isSelected: true });
 			await app.workbench.sideBar.closeSecondarySideBar();
 
 			// awaits table load completion

--- a/test/e2e/tests/data-explorer/xlsx-data-frame.test.ts
+++ b/test/e2e/tests/data-explorer/xlsx-data-frame.test.ts
@@ -14,9 +14,9 @@ test.describe('Data Explorer - XLSX', {
 	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
 
-	test.afterEach(async function ({ app }) {
+	test.afterEach(async function ({ app, hotKeys }) {
 		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.variables.togglePane('show');
+		await hotKeys.showSecondarySidebar();
 	});
 
 	test('Python - Verify data explorer functionality with XLSX input', async function ({ app, python, logger }) {
@@ -25,7 +25,7 @@ test.describe('Data Explorer - XLSX', {
 
 		logger.log('Opening data grid');
 		await app.workbench.variables.doubleClickVariableRow('df');
-		await app.workbench.dataExplorer.verifyTab('Data: df', { isVisible: true });
+		await app.workbench.editors.verifyTab('Data: df', { isVisible: true });
 
 		await app.workbench.sideBar.closeSecondarySideBar();
 		await app.workbench.dataExplorer.selectColumnMenuItem(1, 'Sort Descending');
@@ -40,7 +40,7 @@ test.describe('Data Explorer - XLSX', {
 
 		logger.log('Opening data grid');
 		await app.workbench.variables.doubleClickVariableRow('df2');
-		await app.workbench.dataExplorer.verifyTab('Data: df2', { isVisible: true });
+		await app.workbench.editors.verifyTab('Data: df2', { isVisible: true });
 
 		await app.workbench.sideBar.closeSecondarySideBar();
 		await app.workbench.dataExplorer.selectColumnMenuItem(1, 'Sort Descending');

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -22,13 +22,13 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 
 	test.describe('Outline: Sessions', { tag: [tags.SESSIONS] }, () => {
 
-		test.beforeAll(async function ({ app, openFile }) {
-			const { variables, outline } = app.workbench;
+		test.beforeAll(async function ({ app, openFile, hotKeys }) {
+			const { outline } = app.workbench;
 
 			await openFile(`workspaces/outline/${PY_FILE}`);
 			await openFile(`workspaces/outline/${R_FILE}`);
 
-			await variables.togglePane('hide');
+			await hotKeys.hideSecondarySidebar();
 			await outline.focus();
 		});
 

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -20,7 +20,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 		await hotKeys.closeAllEditors();
 	});
 
-	test.describe('Outline: Sessions', { tag: [tags.SESSIONS] }, () => {
+	test.describe('Outline: Sessions', { tag: [tags.SESSIONS, tags.ARK] }, () => {
 
 		test.beforeAll(async function ({ app, openFile, hotKeys }) {
 			const { outline } = app.workbench;

--- a/test/e2e/tests/sessions/session-accessibility.test.ts
+++ b/test/e2e/tests/sessions/session-accessibility.test.ts
@@ -12,8 +12,8 @@ test.use({
 
 test.describe('Sessions: Accessibility',
 	{ tag: [tags.WIN, tags.WEB, tags.ACCESSIBILITY, tags.SESSIONS, tags.CONSOLE] }, () => {
-		test.beforeEach(async function ({ app }) {
-			await app.workbench.variables.togglePane('hide');
+		test.beforeEach(async function ({ hotKeys }) {
+			await hotKeys.hideSecondarySidebar();
 		});
 
 		test.afterEach(async function ({ sessions }) {

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -14,8 +14,8 @@ test.describe('Sessions: Management', {
 	tag: [tags.WIN, tags.WEB, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL]
 }, () => {
 
-	test.beforeEach(async function ({ app }) {
-		await app.workbench.variables.togglePane('hide');
+	test.beforeEach(async function ({ hotKeys }) {
+		await hotKeys.hideSecondarySidebar();
 	});
 
 	test.afterEach(async function ({ sessions }) {

--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -17,8 +17,8 @@ test.describe('Sessions: Rename', {
 	],
 }, () => {
 
-	test.beforeEach(async function ({ app }) {
-		await app.workbench.variables.togglePane('hide');
+	test.beforeEach(async function ({ hotKeys }) {
+		await hotKeys.hideSecondarySidebar();
 	});
 
 	test('Validate can rename sessions and name persists', async function ({ sessions, runCommand }) {

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -13,8 +13,8 @@ test.describe('Sessions: State', {
 	tag: [tags.WIN, tags.WEB, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL]
 }, () => {
 
-	test.beforeEach(async function ({ app, sessions }) {
-		await app.workbench.variables.togglePane('hide');
+	test.beforeEach(async function ({ hotKeys, sessions }) {
+		await hotKeys.hideSecondarySidebar();
 		await sessions.deleteDisconnectedSessions();
 		await sessions.clearConsoleAllSessions();
 	});

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -19,7 +19,7 @@ test.describe('Sessions: State', {
 		await sessions.clearConsoleAllSessions();
 	});
 
-	test('Validate session states during start, restart, and shutdown', async function ({ app, sessions }) {
+	test('Validate session states during start, restart, and shutdown', { tag: [tags.ARK] }, async function ({ app, sessions }) {
 		const { console } = app.workbench;
 		// using this session to trigger session tab list view below to verify session states
 		await sessions.start(['r']);

--- a/test/e2e/tests/variables/variables-sessions.test.ts
+++ b/test/e2e/tests/variables/variables-sessions.test.ts
@@ -13,8 +13,8 @@ test.describe('Variables: Sessions', {
 	tag: [tags.WIN, tags.WEB, tags.CRITICAL, tags.VARIABLES, tags.SESSIONS]
 }, () => {
 
-	test.beforeEach(async function ({ app }) {
-		await app.workbench.variables.togglePane('hide');
+	test.beforeEach(async function ({ hotKeys }) {
+		await hotKeys.hideSecondarySidebar();
 	});
 
 	test.afterEach(async function ({ sessions }) {


### PR DESCRIPTION
### Summary
Recently I updated the `data-explorer-python-polars.test.ts`  to have independent tests - this is a continuation of clean up doing the same for `data-explorer-python-pandas.test.ts`. Each test in this spec is easier to read/maintain and can be run independently w/o dependencies.

### QA Notes

@:data-explorer @:web @:win

Also kicked off the full suite here: https://github.com/posit-dev/positron/actions/runs/15935116650