### PR TITLE
data explorer: change `APPLY FILTER` to title case

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.css
@@ -26,7 +26,6 @@
 	border-radius: 4px;
 	align-items: center;
 	justify-content: center;
-	text-transform: uppercase;
 	color: var(--vscode-positronModalDialog-defaultButtonForeground);
 	background-color: var(--vscode-positronModalDialog-defaultButtonBackground);
 }


### PR DESCRIPTION
### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #2871 Change `APPLY FILTER` to title case.

#### Bug Fixes

- N/A


### QA Notes

in R console 

```r
c <- cars
```

and then view `c` in data explorer. Should see title case.

![Screenshot 2025-06-30 at 1 36 57 PM](https://github.com/user-attachments/assets/21e30c90-7084-4198-845b-90f7bd224c2d)
