### PR TITLE
Only open release notes after update for releases channel

### DIFF
--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -232,11 +232,11 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	 * @returns the release notes as a string
 	 */
 	async getReleaseNotes(): Promise<string> {
-		const channel = process.env.POSITRON_RELEASE_NOTES_CHANNEL ?? 'releases';
+		const channel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
 		const url = `${this.productService.releaseNotesUrl}/${channel}/release-notes/release-${this.productService.positronVersion}.md`;
 		const releaseNotesResponse = await this.requestService.request({ url }, CancellationToken.None);
 
-		if (process.env.POSITRON_RELEASE_NOTES_CHANNEL) {
+		if (process.env.POSITRON_UPDATE_CHANNEL) {
 			this.logService.info('update#getReleaseNotes - using release notes channel from environment variable:', process.env.POSITRON_RELEASE_NOTES_CHANNEL);
 		}
 

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -72,7 +72,7 @@ export class ShowCurrentReleaseNotesAction extends Action2 {
 		try {
 			await showReleaseNotesInEditor(instantiationService, productService.positronVersion, false);
 		} catch (err) {
-			throw new Error(localize('update.noReleaseNotesOnline', "This version of {0} does not have release notes online", productService.nameLong));
+			throw new Error(localize('update.noReleaseNotesOnline', "This version of {0} does not have release notes available", productService.nameLong));
 		}
 		// --- End Positron ---
 	}

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -141,9 +141,14 @@ export class ProductContribution implements IWorkbenchContribution {
 			const currentVersion = parseVersion(productService.positronVersion);
 			const shouldShowReleaseNotes = configurationService.getValue<boolean>('update.showReleaseNotes');
 			const downloadUrl = productService.downloadUrl;
+			const channel = configurationService.getValue<string>('update.positron.channel');
 
 			// was there a major/minor update? if so, open release notes
-			if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes && downloadUrl && lastVersion && currentVersion && isMajorMinorUpdate(lastVersion, currentVersion)) {
+			if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes
+				&& downloadUrl && lastVersion && currentVersion
+				&& isMajorMinorUpdate(lastVersion, currentVersion)
+				&& channel === 'releases'
+			) {
 				showReleaseNotesInEditor(instantiationService, productService.positronVersion, false)
 					.then(undefined, () => {
 						notificationService.prompt(


### PR DESCRIPTION
Address #8352 

`POSITRON_UPDATE_CHANNEL` is now used to check for release notes. This allows for release notes for the other release channels if we wanted. Otherwise, the Show Release Notes action will display an error that there are no release notes for this version.

![image](https://github.com/user-attachments/assets/f2421b79-5c64-49fb-b059-1f462e98f96f)

The image above is the error when trying to view release notes (a release build will say "Positron" instead of "Positron Dev".

The startup check to see if Positron was updated now checks if it is on the `releases` update channel before attempting to show release notes. This stops the toast notification from guiding the user to the downloads page to view the release notes online.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix asking to view release notes online when updating to a daily build


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
