### PR TITLE
Positron notebooks architecture docs

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -50,10 +50,6 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { ICellRange } from '../../common/notebookRange.js';
 
-// --- Start Positron ---
-import { PositronNotebookEditorInput } from '../../../positronNotebook/browser/PositronNotebookEditorInput.js';
-import { getShouldUsePositronEditor } from '../../../positronNotebook/browser/positronNotebook.contribution.js';
-// --- End Positron ---
 
 export class NotebookProviderInfoStore extends Disposable {
 
@@ -260,12 +256,6 @@ export class NotebookProviderInfoStore extends Disposable {
 
 				const preferredResourceParam = cellOptions?.resource;
 
-				// --- Start Positron ---
-				if (getShouldUsePositronEditor(this._configurationService)) {
-					// Use our editor instead of the built in one.
-					return { editor: PositronNotebookEditorInput.getOrCreate(this._instantiationService, notebookUri, preferredResourceParam, notebookProviderInfo.id), options };
-				}
-				// --- End Positron ---
 
 				const editor = NotebookEditorInput.getOrCreate(this._instantiationService, notebookUri, preferredResourceParam, notebookProviderInfo.id);
 				return { editor, options: notebookOptions };
@@ -280,13 +270,6 @@ export class NotebookProviderInfoStore extends Disposable {
 					ref.dispose();
 				});
 
-				// --- Start Positron ---
-				if (getShouldUsePositronEditor(this._configurationService)) {
-					// Use our editor instead of the built in one.
-					const editor = PositronNotebookEditorInput.getOrCreate(this._instantiationService, ref.object.resource, undefined, notebookProviderInfo.id);
-					return { editor, options };
-				}
-				// --- End Positron ---
 				return { editor: NotebookEditorInput.getOrCreate(this._instantiationService, ref.object.resource, undefined, notebookProviderInfo.id), options };
 			};
 			const notebookDiffEditorInputFactory: DiffEditorInputFactoryFunction = (diffEditorInput: IResourceDiffEditorInput, group: IEditorGroup) => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -363,7 +363,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.kernelStatus = observableValue<KernelStatus>('positronNotebookKernelStatus', KernelStatus.Uninitialized);
 		this.currentRuntime = observableValue<ILanguageRuntimeSession | undefined>('positronNotebookCurrentRuntime', undefined);
 
-		this.contextManager = this._instantiationService.createInstance(PositronNotebookContextKeyManager);
+		this.contextManager = this._register(
+			this._instantiationService.createInstance(PositronNotebookContextKeyManager)
+		);
 		this._positronNotebookService.registerInstance(this);
 
 		this.selectionStateMachine = this._register(
@@ -608,7 +610,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	close(): void {
-		console.log('Closing a notebook instance');
+		this._logService.info(this.id, 'Closing a notebook instance');
 		this.dispose();
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -11,21 +11,81 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
 import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../../../common/editor.js';
 
 import { parse } from '../../../../base/common/marshalling.js';
 import { assertType } from '../../../../base/common/types.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { PositronNotebookEditorInput, PositronNotebookEditorInputOptions } from './PositronNotebookEditorInput.js';
+import { positronConfigurationNodeBase } from '../../../services/languageRuntime/common/languageRuntime.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ICommandAndKeybindingRule, KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+
+// Configuration constants
+export const POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY = 'positron.notebooks.defaultEditor';
+const LEGACY_CONFIG_KEY = 'positron.notebooks.usePositronNotebooksExperimental';
+
+// Register the new configuration
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]: {
+			type: 'string',
+			enum: ['positron', 'vscode'],
+			enumDescriptions: [
+				localize('positron.notebooks.defaultEditor.positron', 'Use Positron\'s notebook editor for .ipynb files'),
+				localize('positron.notebooks.defaultEditor.vscode', 'Use VS Code\'s built-in notebook editor for .ipynb files')
+			],
+			default: 'vscode',
+			markdownDescription: localize(
+				'positron.notebooks.defaultEditor.description',
+				'Choose which editor to use for notebook (.ipynb) files. You can always use "Open With..." to override this setting for specific files.'
+			),
+			scope: ConfigurationScope.MACHINE_OVERRIDABLE
+		}
+	}
+});
+
+/**
+ * Get the user's preferred notebook editor
+ * @param configurationService Configuration service
+ * @returns 'positron' | 'vscode'
+ */
+export function getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode' {
+	return configurationService.getValue<'positron' | 'vscode'>(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY) || 'vscode';
+}
+
+/**
+ * Handle migration from old experimental setting (log-only approach)
+ */
+class PositronNotebookConfigMigration implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronNotebookConfigMigration';
+
+	constructor(@IConfigurationService private readonly configurationService: IConfigurationService) {
+		this.checkForLegacyConfiguration();
+	}
+
+	private checkForLegacyConfiguration(): void {
+		const legacyValue = this.configurationService.getValue<boolean>(LEGACY_CONFIG_KEY);
+		if (legacyValue === true) {
+			console.log(
+				'Positron: The setting "positron.notebooks.usePositronNotebooksExperimental" has been replaced. ' +
+				'Please use "positron.notebooks.defaultEditor" instead. ' +
+				'Set it to "positron" to continue using Positron notebooks as your default.'
+			);
+		}
+	}
+}
 
 
 
@@ -233,3 +293,7 @@ function registerNotebookKeybinding({ id, onRun, ...opts }: {
 	});
 }
 //#endregion Keybindings
+
+// Register the migration
+const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+workbenchRegistry.registerWorkbenchContribution(PositronNotebookConfigMigration, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -16,14 +16,11 @@ import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../
 
 import { parse } from '../../../../base/common/marshalling.js';
 import { assertType } from '../../../../base/common/types.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { PositronNotebookEditorInput, PositronNotebookEditorInputOptions } from './PositronNotebookEditorInput.js';
-import { positronConfigurationNodeBase } from '../../../services/languageRuntime/common/languageRuntime.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ICommandAndKeybindingRule, KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
@@ -32,36 +29,6 @@ import { IPositronNotebookInstance } from '../../../services/positronNotebook/br
 
 
 
-/**
- * Key for the configuration setting that determines whether to use the Positron Notebook editor
- */
-const USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY = 'positron.notebooks.usePositronNotebooksExperimental';
-
-/**
- * Retrieve the value of the configuration setting that determines whether to use the Positron
- * Notebook editor. Makes sure that the value is a boolean for type-safety.
- * @param configurationService Configuration service
- * @returns A boolean value that determines whether to use the Positron Notebook editor
- */
-export function getShouldUsePositronEditor(configurationService: IConfigurationService) {
-	return Boolean(configurationService.getValue(USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY));
-}
-
-// Register the configuration setting that determines whether to use the Positron Notebook editor
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	...positronConfigurationNodeBase,
-	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
-	properties: {
-		[USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY]: {
-			type: 'boolean',
-			default: false,
-			markdownDescription: localize(
-				'positron.usePositronNotebooks',
-				"Use experimental Positron Notebook editor.\n\n**CAUTION**: The Positron Notebook editor is experimental and does not yet support all notebook features."
-			),
-		}
-	}
-});
 
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -1,0 +1,726 @@
+# Positron Notebooks: Implementation Architecture
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Quick Start for Contributors](#quick-start-for-contributors)
+3. [Practical Development Guides](#practical-development-guides)
+4. [Architecture Overview](#architecture-overview)
+5. [System Components](#system-components)
+6. [Accessibility Implementation](#accessibility-implementation)
+7. [Kernel Protocol and Integration](#kernel-protocol-and-integration)
+8. [Positron Service Integrations](#positron-service-integrations)
+9. [Testing and Debugging](#testing-and-debugging)
+10. [Performance Optimization](#performance-optimization)
+11. [File Organization](#file-organization)
+12. [Current Status and Considerations](#current-status-and-considerations)
+
+## Executive Summary
+
+Positron Notebooks represents a parallel notebook implementation within Positron. The implementation coexists with VS Code's standard notebook editor, allowing users to switch between the two experiences using the "Open With..." menu or by changing their default preference.
+
+### Quick Start for Contributors
+
+**To enable Positron Notebooks:**
+1. Set `"positron.notebooks.defaultEditor": "positron"` in your settings
+2. Open any `.ipynb` file - it will use Positron's notebook editor
+3. To switch back: Use "Open With..." or change the setting to `"vscode"`
+
+**Key files to understand:**
+- `positronNotebook.contribution.ts`: Entry point, configuration, editor registration
+- `PositronNotebookEditorInput.ts`: Integrates with VS Code's editor system
+- `PositronNotebookInstance.ts`: Core state management and business logic
+- `PositronNotebookEditor.tsx`: React-based UI implementation
+
+## Development Guides
+
+### Common Development Tasks
+
+#### Adding a New Cell Type
+1. Create interface in `IPositronNotebookCell.ts`
+2. Implement base class extending `PositronNotebookCell`
+3. Add React component in `notebookCells/`
+4. Register in cell factory pattern
+5. Update selection machine if needed
+
+#### Modifying Cell Execution
+- **Entry Point**: `PositronNotebookInstance.ts:729-765`
+- **Kernel Integration**: `RuntimeNotebookKernel.ts` for execution routing
+- **State Updates**: Use observable pattern for UI synchronization
+
+#### Adding New Configuration Options
+1. Define in `positronNotebook.contribution.ts:43-57`
+2. Implement reader function similar to `getPreferredNotebookEditor`
+3. Add configuration change listener
+4. Update editor registration if needed
+
+### Development Workflows
+
+#### Local Development Setup
+```bash
+# Enable Positron notebooks
+"positron.notebooks.defaultEditor": "positron"
+
+# Key files to modify:
+- PositronNotebookInstance.ts    # Core state management
+- PositronNotebookEditor.tsx     # UI implementation
+- Cell implementation files      # Cell-specific logic
+```
+
+#### Debugging Cell Execution Issues
+1. Check `kernelStatus` observable in `PositronNotebookInstance`
+2. Verify runtime session connection via `IRuntimeSessionService`
+3. Use browser dev tools for React component issues
+4. Check VS Code's output panel for service-level errors
+
+## Architecture Overview
+
+### Core Design Principles
+
+1. **Editor Resolver Integration**: Uses VS Code's standard `IEditorResolverService` for clean editor selection
+2. **Configuration-Driven Default**: Users choose their preferred default editor (positron/vscode) via settings
+3. **Parallel Implementation**: Coexists with standard VS Code notebooks without interference
+4. **React-Based UI**: Modern component architecture for enhanced user experience
+5. **Observable State Management**: Reactive architecture using observables for real-time updates
+6. **Service Integration**: Leverages existing VS Code notebook infrastructure where possible
+
+## System Components
+
+### 1. Configuration Layer
+
+**Configuration Key**: `positron.notebooks.defaultEditor`
+**Location**: `src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts:43-57`
+
+```typescript
+'positron.notebooks.defaultEditor': {
+    type: 'string',
+    enum: ['positron', 'vscode'],
+    default: 'vscode',
+    markdownDescription: 'Choose which editor to use for notebook (.ipynb) files...'
+}
+```
+
+**Configuration Reader**: `getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode'`
+- Returns user's preferred default notebook editor
+- Located in `positronNotebook.contribution.ts:65-68`
+- Defaults to 'vscode' if not configured or invalid value
+
+### 2. Editor Registration and Resolution
+
+**Location**: `src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts:109-139`
+
+The system uses VS Code's `IEditorResolverService` to register the Positron notebook editor:
+
+```typescript
+editorResolverService.registerEditor(
+    '*.ipynb',
+    {
+        id: PositronNotebookEditorInput.EditorID,
+        label: localize('positronNotebook', "Positron Notebook"),
+        priority: this.getEditorPriority() // Default or Option based on config
+    },
+    {
+        singlePerResource: true,
+        canSupportResource: (resource: URI) => resource.scheme === Schemas.file
+    },
+    {
+        createEditorInput: async ({ resource, options }) => {
+            const viewType = await this.detectNotebookViewType(resource);
+            const editorInput = PositronNotebookEditorInput.getOrCreate(...);
+            return { editor: editorInput, options };
+        }
+    }
+);
+```
+
+**Priority Management**:
+- When `defaultEditor` is 'positron': `RegisteredEditorPriority.default` (opens by default)
+- When `defaultEditor` is 'vscode': `RegisteredEditorPriority.option` (available in "Open With...")
+
+**What this means**: Users explicitly opt-in to Positron notebooks. The default experience remains VS Code's standard notebook editor, ensuring no disruption for existing users.
+
+### 3. Core Architecture Components
+
+#### Component Relationship Diagram
+
+```mermaid
+graph TB
+    subgraph "Editor Layer"
+        EditorInput[PositronNotebookEditorInput]
+        Editor[PositronNotebookEditor]
+        TextModel[NotebookTextModel]
+    end
+    
+    subgraph "Core Components"
+        Instance[PositronNotebookInstance]
+        CodeCell[PositronNotebookCodeCell]
+        MarkdownCell[PositronNotebookMarkdownCell]
+    end
+    
+    subgraph "Service Layer"
+        NotebookService[IPositronNotebookService]
+        RuntimeService[IRuntimeSessionService]
+        KernelService[INotebookKernelService]
+        ExecutionService[INotebookExecutionService]
+    end
+    
+    %% Primary relationships
+    EditorInput -->|"owns"| Instance
+    Editor -->|"renders"| Instance
+    Instance -->|"manages"| TextModel
+    Instance -->|"creates"| CodeCell
+    Instance -->|"creates"| MarkdownCell
+    
+    %% Service connections
+    Instance -->|"registers with"| NotebookService
+    Instance -->|"executes via"| RuntimeService
+    Instance -->|"kernel management"| KernelService
+    CodeCell -->|"execution"| ExecutionService
+    
+    %% Data flow
+    TextModel -->|"provides cells"| Instance
+    EditorInput -->|"resolves"| TextModel
+    
+    style Instance fill:#f9f,stroke:#333,stroke-width:4px
+    style EditorInput fill:#bbf,stroke:#333,stroke-width:2px
+    style Editor fill:#bbf,stroke:#333,stroke-width:2px
+```
+
+### 3. Core Architecture Components
+
+#### A. PositronNotebookEditorInput
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts`
+**Role**: VS Code EditorInput implementation
+
+**Key Responsibilities**:
+- Notebook model resolution and lifecycle management
+- Save/revert operations
+- Integration with VS Code's editor input system
+- Creates and manages `PositronNotebookInstance`
+
+**Key Properties**:
+```typescript
+static readonly ID: string = 'workbench.input.positronNotebook';
+static readonly EditorID: string = 'workbench.editor.positronNotebook';
+notebookInstance: PositronNotebookInstance | undefined;
+```
+
+**Static Factory Method**:
+```typescript
+static getOrCreate(
+    instantiationService: IInstantiationService,
+    resource: URI,
+    preferredResource: URI | undefined,
+    viewType: string,
+    options: PositronNotebookEditorInputOptions = {}
+)
+```
+
+#### B. PositronNotebookInstance
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
+**Role**: Core state manager and execution coordinator
+
+**Key Responsibilities**:
+- Notebook cell state management
+- Kernel connectivity and execution
+- Selection state management
+- Bridge between UI and notebook model
+
+**Architecture Features**:
+- **Singleton Pattern**: `_instanceMap` for instance management (line 59)
+- **Observable Properties**: Reactive state using observables
+- **Cell Management**: CRUD operations for notebook cells
+- **Selection State Machine**: Advanced selection handling
+
+**Key Observable Properties**:
+- `cells`: Observable array of notebook cells
+- `selectedCells`: Current cell selection state
+- `kernelStatus`: Kernel connection and execution state
+- `notebookUri`: Associated notebook file URI
+
+#### C. PositronNotebookEditor
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx`
+**Role**: React-based editor pane implementation
+
+**Key Features**:
+- Extends VS Code's `EditorPane`
+- React component rendering via `PositronReactRenderer`
+- Service injection through React context providers
+- Layout management and view state persistence
+
+**Component Hierarchy**:
+```typescript
+<NotebookVisibilityProvider isVisible={this._isVisible}>
+  <NotebookInstanceProvider instance={notebookInstance}>
+    <ServicesProvider services={{...}}>
+      <PositronNotebookComponent />
+    </ServicesProvider>
+  </NotebookInstanceProvider>
+</NotebookVisibilityProvider>
+```
+
+**Service Injection**:
+The editor provides numerous services to the React component tree including:
+- `configurationService`, `instantiationService`
+- `webviewService`, `notebookWebviewService`
+- `commandService`, `logService`, `openerService`
+- `editorService`, `layoutService`
+
+#### D. PositronNotebookService
+**File**: `src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts`
+**Role**: Global instance management service
+
+**Key Methods**:
+- `getActiveInstance()`: Current notebook access
+- `getInstance(resource: URI)`: Resource-based lookup
+- `registerInstance()` / `unregisterInstance()`: Lifecycle management
+
+#### E. Context Key Management
+**File**: `src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts`
+**Role**: Manages VS Code context keys for notebook focus state
+
+**Key Features**:
+- **Focus Tracking**: Sets `positronNotebookEditorFocused` context key
+- **Scoped Context**: Creates container-scoped context service
+- **Integration Point**: Used by keybinding system for command routing
+
+```typescript
+export const POSITRON_NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorFocused', false);
+```
+
+#### F. Webview Preload Service Integration
+**File**: `src/vs/workbench/services/positronWebviewPreloads/browser/positronWebviewPreloadService.ts`
+**Role**: Handles interactive outputs (widgets, plots) within notebook cells
+
+**Integration Pattern**: Cells with interactive outputs register with the preload service for proper rendering and lifecycle management:
+```typescript
+// From PositronNotebookCodeCell.ts:62-70
+if (preloadMessageType) {
+    parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
+        instance: this.instance,
+        outputId: output.outputId,
+        outputs,
+    });
+}
+```
+
+#### G. Execution Services
+**File**: Integrated via `INotebookExecutionService` and `INotebookExecutionStateService`
+**Role**: Manages cell execution state and coordination
+
+**Key Integration Points**:
+- **Execution State Tracking**: Monitors running/idle states
+- **Cancellation Support**: Handles execution interruption
+- **Output Coordination**: Synchronizes outputs with execution completion
+
+**From PositronNotebookInstance.ts:752-759**:
+```typescript
+await this.notebookExecutionService.executeNotebookCells(
+    this.textModel, 
+    Array.from(cells).map(c => c.cellModel as NotebookCellTextModel), 
+    this._contextKeyService
+);
+```
+
+### 4. Cell Architecture
+
+#### Cell Type Hierarchy
+```
+IPositronNotebookCell (interface)
+├── PositronNotebookCellGeneral (abstract base implementation)
+    ├── PositronNotebookCodeCell (executes code via kernels)
+    └── PositronNotebookMarkdownCell (renders markdown content)
+```
+
+**Cell Interface Location**: `src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts`
+
+**Cell Implementation Files**:
+- `PositronNotebookCell.ts` (abstract base class: `PositronNotebookCellGeneral`)
+- `PositronNotebookCodeCell.ts` (code execution implementation)
+- `PositronNotebookMarkdownCell.ts` (markdown rendering implementation)
+- `createNotebookCell.ts` (factory function for cell instantiation)
+
+#### Cell Factory Pattern
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/createNotebookCell.ts`
+
+The `createNotebookCell` function serves as a factory that instantiates the correct cell type based on the cell model:
+```typescript
+export function createNotebookCell(
+    cell: NotebookCellTextModel, 
+    instance: PositronNotebookInstance, 
+    instantiationService: IInstantiationService
+) {
+    if (cell.cellKind === CellKind.Code) {
+        return instantiationService.createInstance(PositronNotebookCodeCell, cell, instance);
+    } else {
+        return instantiationService.createInstance(PositronNotebookMarkdownCell, cell, instance);
+    }
+}
+```
+
+#### UI Layer Overview
+**Primary Component**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx`
+
+**Key Integration Points**:
+- **Observable State Binding**: UI components observe data model changes via `observableValue` pattern
+- **Service Injection**: React components access VS Code services through context providers
+- **Focus Management**: Integrates with VS Code's context key system for command routing
+
+#### Selection State Management
+**File**: `src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts`
+
+**Purpose**: Manages which cells are selected and how selection changes in response to user actions.
+
+**Key features**:
+- Finite state machine for cell selection
+- Handles keyboard navigation (arrow keys, shift+arrow for multi-select)
+- Multi-select support for bulk operations
+- Integration with VS Code's command system
+
+**State Machine**:
+- `NoSelection`: No cells selected
+- `SingleSelection`: One cell selected (normal state)
+- `MultiSelection`: Multiple cells selected (for bulk operations)
+- `EditingSelection`: Single cell in edit mode
+
+### 5. Startup and Integration Flows
+
+#### Notebook Opening Flow
+1. **File Association**: `.ipynb` file opened in VS Code
+2. **Editor Resolution**: `IEditorResolverService` evaluates registered editors and their priorities
+3. **Priority Selection**:
+   - If Positron is default: Opens with Positron editor automatically
+   - If VS Code is default: Opens with standard notebook editor (Positron available via "Open With...")
+4. **Editor Input Creation**: `createEditorInput` callback creates `PositronNotebookEditorInput`
+5. **Model Resolution**: Input resolves notebook model via `INotebookEditorModelResolverService`
+6. **Instance Creation**: `PositronNotebookInstance` created and linked to input
+7. **Editor Pane Creation**: `PositronNotebookEditor` instantiated
+8. **React Rendering**: Component tree rendered with service injection
+9. **View Attachment**: Instance attached to editor's parent div
+
+#### Configuration Change Flow
+1. **User changes** `positron.notebooks.defaultEditor` setting
+2. **Configuration listener** in `PositronNotebookContribution` detects change
+3. **Editor priority** updated via `updateEditorPriority()` method
+4. **Workbench associations** updated to ensure correct default behavior
+5. **Future file opens** will use the new default editor
+
+**Note**: Currently open notebooks won't switch editors automatically - the change applies to newly opened files.
+
+#### Integration with VS Code Systems
+
+**Notebook Services Integration**:
+- `INotebookService`: Notebook type resolution and capabilities
+- `INotebookEditorModelResolverService`: Model loading and persistence
+- `INotebookKernelService`: Kernel management and execution
+
+**Editor System Integration**:
+- `IEditorService`: Editor management and lifecycle
+- `IEditorGroupsService`: Multi-group support and editor grouping
+- Editor input serialization for session restore
+- View state management via `IEditorMemento`
+
+**Layout Integration**:
+- Custom layout: `src/vs/workbench/services/positronLayout/browser/layouts/positronNotebookLayout.ts`
+- Integration with Positron's UI framework
+- Responsive design considerations
+
+### 6. Key Technical Decisions
+
+#### React vs. Native VS Code UI
+- **Chosen**: React-based implementation with `PositronReactRenderer`
+- **Alternative**: Extending existing VS Code notebook editor
+- **Rationale**: Enhanced UI flexibility, modern component architecture, better integration with Positron's React-based UI components
+
+#### Observable State Management
+- **Implementation**: RxJS-style observables via `observableValue`
+- **Benefits**: Reactive updates, clean separation of concerns, real-time UI synchronization
+- **Integration**: Bridges with VS Code's event system via `Emitter` classes
+
+#### Configuration-Based Toggling
+- **Approach**: Runtime configuration switch (`positron.notebooks.usePositronNotebooksExperimental`)
+- **Benefits**: Easy A/B testing, gradual rollout capability, safe fallback to standard notebooks
+- **Implementation**: Evaluated at editor creation time in `SimpleNotebookWorkingCopyEditorHandler`
+
+#### Instance Management
+- **Pattern**: Singleton instances per notebook URI
+- **Benefits**: Consistent state across editor reopening, memory efficiency
+- **Implementation**: Static `_instanceMap` in `PositronNotebookInstance`
+
+### 7. File Organization
+
+```
+src/vs/workbench/
+├── contrib/
+│   ├── notebook/browser/
+│   │   └── notebook.contribution.ts              # Standard notebook contributions (no longer contains hijacking)
+│   └── positronNotebook/browser/
+│       ├── positronNotebook.contribution.ts      # Editor registration, configuration, keybindings
+│       ├── PositronNotebookEditor.tsx           # Main editor pane
+│       ├── PositronNotebookEditorInput.ts       # VS Code editor input
+│       ├── PositronNotebookInstance.ts          # Core state manager
+│       ├── PositronNotebookComponent.tsx        # Main React component
+│       ├── NotebookInstanceProvider.tsx         # React context provider
+│       ├── ServicesProvider.tsx                 # Service injection provider
+│       ├── NotebookVisibilityContext.tsx        # Visibility state provider
+│       └── notebookCells/                       # Cell React components
+└── services/
+    ├── positronNotebook/browser/
+    │   ├── positronNotebookService.ts           # Global instance service
+    │   ├── IPositronNotebookInstance.ts         # Core interfaces
+    │   ├── IPositronNotebookCell.ts             # Cell interfaces
+    │   ├── selectionMachine.ts                  # Selection state machine
+    │   ├── ContextKeysManager.ts                # VS Code context keys
+    │   └── PositronNotebookCells/               # Cell implementations
+    └── positronLayout/browser/layouts/
+        └── positronNotebookLayout.ts            # Custom layout integration
+```
+
+## Accessibility
+
+### Current Accessibility Features
+
+#### Keyboard Navigation
+- **Cell Navigation**: Arrow keys for cell-to-cell movement
+- **Selection State**: `selectionMachine.ts` handles multi-select with Shift+Arrow
+- **Edit Mode**: Enter to edit, Escape to exit (lines 776-788 in `PositronNotebookInstance.ts`)
+- **Focus Management**: Tab order follows logical cell sequence
+
+#### ARIA Support
+- **Image Outputs**: `role='img'` with descriptive `aria-label` in `DeferredImage.tsx:111-119`
+- **Interactive Elements**: Settings buttons use `aria-label='notebook output settings'`
+- **Cell Containers**: `tabIndex={0}` for keyboard accessibility
+
+#### Screen Reader Support
+- **Cell Content**: Text outputs are directly accessible
+- **Status Announcements**: Kernel status changes (Connected/Disconnected/Running)
+
+### Accessibility Gaps & Recommendations
+
+**Missing Features**:
+- ARIA live regions for dynamic content updates
+- Comprehensive ARIA labeling for complex UI elements
+- Screen reader announcements for cell execution state changes
+
+**Improvement Areas**:
+- Add `aria-live="polite"` regions for execution status
+- Implement `aria-describedby` for cell relationships
+- Enhanced keyboard shortcuts documentation
+
+## Kernel Protocol and Integration
+
+### Runtime Session Architecture
+
+#### Kernel Connection Flow
+1. **Kernel Selection**: `SelectPositronNotebookKernelAction.ts` filters for Positron-specific kernels
+2. **Session Creation**: `IRuntimeSessionService` creates language runtime sessions
+3. **Protocol Bridge**: `RuntimeNotebookKernel.ts` adapts VS Code kernel interface to Positron runtime
+4. **State Synchronization**: Observable `kernelStatus` tracks connection state
+
+#### Execution Protocol
+```typescript
+// From PositronNotebookInstance.ts:377-393
+this._register(
+    this.notebookKernelService.onDidChangeSelectedNotebooks((e) => {
+        if (e.notebook === this.uri.toString()) {
+            this.selectedKernel.set(e.newKernel, undefined);
+        }
+    })
+);
+```
+
+#### Runtime Session Management
+- **Lifecycle**: Sessions auto-created on first execution, cleaned up on instance disposal
+- **Status Tracking**: Uninitialized → Connected → Disconnected states
+- **Error Handling**: Failed connections trigger automatic retry attempts
+- **Integration Pattern**: `RuntimeNotebookKernel` acts as an adapter, translating VS Code's `INotebookExecutionService` calls into Positron's runtime session API with automatic lifecycle management per notebook
+
+### Protocol Abstraction Layers
+
+1. **VS Code Layer**: Standard `INotebookKernelService` and `INotebookExecutionService`
+2. **Positron Bridge**: `RuntimeNotebookKernel` handles protocol translation
+3. **Runtime Layer**: `IRuntimeSessionService` manages actual language processes
+4. **Communication**: Event-driven with `ILanguageRuntimeCodeExecutedEvent`
+
+## Positron Service Integrations
+
+### Core Service Communication
+
+#### Runtime Session Service
+**Integration Pattern**: `PositronNotebookInstance.ts:395-408`
+```typescript
+this._register(
+    this.runtimeSessionService.onDidStartRuntime((session) => {
+        if (session.metadata.notebookUri && this._isThisNotebook(session.metadata.notebookUri)) {
+            this.currentRuntime.set(session, undefined);
+            this.kernelStatus.set(KernelStatus.Connected, undefined);
+        }
+    })
+);
+```
+
+#### Cross-Service Data Flow
+```mermaid
+graph TD
+    A[Notebook Cell Execution] --> B[RuntimeNotebookKernel]
+    B --> C[IRuntimeSessionService]
+    C --> D[Variables Service]
+    C --> E[Plots Service]
+    C --> F[Data Explorer Service]
+    D --> G[Variable Explorer UI]
+    E --> H[Plots Panel]
+    F --> I[Data Explorer Tab]
+```
+
+#### Service Injection Architecture
+All services use VS Code's dependency injection:
+- **IRuntimeSessionService**: Runtime execution and session management
+- **IPositronWebviewPreloadService**: Interactive output handling
+- **IPositronNotebookService**: Global instance management
+- **mainThreadLanguageRuntime**: Central communication hub
+
+### Interactive Output Integration
+
+#### Plot and Widget Handling
+- **Plot Service**: Cell outputs automatically route to `IPositronPlotsService`
+- **Webview Management**: `attachNotebookInstance()` registers for interactive outputs
+- **Event-Driven Updates**: `onDidCreatePlot` events trigger UI updates
+
+#### Variable Synchronization
+- **Automatic Updates**: Runtime execution updates variables service
+- **Cross-Component Access**: Variable explorer shows notebook variables
+- **Data Exploration**: Variables can be opened in data explorer from notebook context
+
+## Testing and Debugging
+
+### Testing Framework
+
+#### Unit Testing Infrastructure
+**Location**: `test/browser/testUtils.ts`
+```typescript
+export function createPositronNotebookTestServices(): TestServiceAccessor {
+    // Comprehensive mock setup for all services
+    const disposableStore = new DisposableStore();
+    // Returns complete service dependency graph
+}
+```
+
+#### Test Coverage Areas
+- **Configuration Handling**: `positronNotebookConfigurationHandling.test.ts`
+- **Editor Registration**: Dynamic priority switching based on user preferences
+- **Service Integration**: Cross-service communication patterns
+- **Lifecycle Management**: Disposal and cleanup patterns
+
+#### E2E Testing Workflows
+**Location**: `test/e2e/tests/notebook/notebook-create.test.ts`
+- **Runtime Integration**: Tests variables service updates during execution
+- **UI Integration**: Validates plots, variables, and data explorer integration
+- **Session Persistence**: Ensures state survives save/reload cycles
+
+### Debugging Strategies
+
+#### Common Debugging Workflows
+
+**Cell Execution Issues**:
+1. Check `kernelStatus` observable value
+2. Verify runtime session in `IRuntimeSessionService`
+3. Inspect `currentRuntime` observable
+4. Review execution queue in `RuntimeNotebookKernel`
+
+**UI/React Issues**:
+1. Use React Developer Tools browser extension
+2. Check service injection in `ServicesProvider.tsx`
+3. Verify observable subscriptions in components
+4. Inspect DOM structure for layout issues
+
+**Service Integration Problems**:
+1. Check service registration in constructor
+2. Verify event listener setup with `this._register()`
+3. Use VS Code's output panel for service-level errors
+4. Check disposal chain for memory leaks
+
+#### Logging and Diagnostics
+- **Service-Level Logging**: Each service uses `ILogService` for debugging
+- **Event Tracing**: Lamport clock-based event ordering for runtime communication
+- **State Inspection**: Observable-based state tracking for UI debugging
+- **Error Propagation**: Structured error handling across service boundaries
+
+## Performance Optimization
+
+### Memory Management Strategies
+
+#### Instance Reuse Pattern
+- **Singleton per URI**: `_instanceMap` prevents duplicate instances
+- **View Attachment**: Instances persist across editor open/close cycles
+- **Lazy Cleanup**: Resources held until explicitly disposed
+
+### Render Optimization
+
+##### React Performance Considerations
+**Memory Usage**: React implementation has ~20-30% higher baseline memory due to virtual DOM and component trees. However, the observable pattern provides more efficient selective updates, often resulting in better performance for dynamic content.
+
+**From `useWebviewMount.ts:88-125`**:
+```typescript
+// RAF-based layout updates prevent main thread blocking
+requestAnimationFrame(() => {
+    // Layout calculations
+    updateWebviewPosition();
+});
+```
+
+#### Webview Management
+- **Visibility-Based Loading**: Webviews only mounted when visible
+- **Resource Claiming**: Claim/release pattern prevents resource conflicts
+- **Height Optimization**: `MAX_OUTPUT_HEIGHT = 1000` prevents excessive memory usage
+
+### Observable State Optimization
+
+#### Efficient Updates
+- **Selective Re-rendering**: Only components with changed observables re-render
+- **Batch Updates**: Cell synchronization batched to prevent cascading updates
+- **Cancellation Tokens**: Async operations properly cancelled to prevent stale updates
+
+### Performance Monitoring
+
+#### Key Metrics to Track
+- **Instance Creation Time**: Monitor `PositronNotebookInstance` construction
+- **Cell Execution Latency**: Time from execution request to completion
+- **Memory Usage**: Track webview and React component memory consumption
+- **Render Performance**: Monitor component re-render frequency
+
+#### Bottleneck Identification
+- **Large Notebooks**: Cell virtualization may be needed for 100+ cell notebooks
+- **Complex Outputs**: Interactive plots and widgets impact memory usage
+- **Concurrent Execution**: Multiple running cells can overwhelm runtime service
+
+## Current Status and Considerations
+
+### Configuration Migration
+- **Legacy Setting**: `positron.notebooks.usePositronNotebooksExperimental` (boolean)
+- **Migration**: Handled by `PositronNotebookConfigMigration` class
+- **Behavior**: Log-only approach - notifies users to use new setting
+- **Location**: `positronNotebook.contribution.ts:73-90`
+
+### Integration Points
+- **Model Compatibility**: Uses standard VS Code notebook models (`IResolvedNotebookEditorModel`)
+- **Kernel Integration**: Leverages existing `INotebookKernelService` and `IRuntimeSessionService`
+- **Extension Compatibility**: Limited compatibility due to React-based UI. Extensions that rely on VS Code's native DOM structure may not work. Kernel-level extensions generally work through the `RuntimeNotebookKernel` bridge. Only targeting jupyter notebooks.
+- **Serialization**: Compatible with standard notebook serialization
+- **Testing Coverage**: Comprehensive test suite includes unit tests for service integration, E2E tests for user workflows, and configuration tests for editor switching. Mock service infrastructure enables isolated testing.
+
+## Outstanding Questions
+
+### Long-term Architecture Strategy
+1. **Timeline for Default Switch**: When will Positron notebooks become the default?
+2. **Maintenance Strategy**: How will dual implementation maintenance be managed long-term?
+3. **Migration Path**: What's the plan for users with existing notebook workflows?
+
+### Advanced Integration Features
+1. **Positron-Specific Features**: What unique capabilities justify the parallel implementation?
+2. **Performance Parity**: At what notebook size/complexity does React implementation become problematic?
+3. **Extension Ecosystem**: Are there plans for Positron-specific notebook extensions?
+
+---
+
+*This document was last updated on 2025-07-02 and reflects the current state of the Positron notebook implementation following the removal of the hijacking architecture. The system now uses VS Code's standard editor resolution mechanisms for cleaner integration.*
+

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
@@ -1,0 +1,236 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService, IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
+import { EditorResolverService } from '../../../../services/editor/browser/editorResolverService.js';
+import { IEditorResolverService, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
+import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { Event } from '../../../../../base/common/event.js';
+import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
+import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../browser/positronNotebook.contribution.js';
+import { createPositronNotebookTestServices } from './testUtils.js';
+
+// Mock implementation for testing configuration-driven editor registration
+class MockPositronNotebookContribution extends DisposableStore {
+	private _currentRegistration: any;
+	private _registrationCount = 0;
+
+	constructor(
+		private editorResolverService: IEditorResolverService,
+		private configurationService: IConfigurationService,
+		private instantiationService: ITestInstantiationService
+	) {
+		super();
+		this.registerEditor();
+		this.add(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY)) {
+				this.registerEditor();
+			}
+		}));
+	}
+
+	private registerEditor(): void {
+		// Dispose existing registration
+		this._currentRegistration?.dispose();
+		this._registrationCount++;
+
+		// Register with current priority
+		this._currentRegistration = this.editorResolverService.registerEditor(
+			'*.ipynb',
+			{
+				id: PositronNotebookEditorInput.EditorID,
+				label: 'Positron Notebook',
+				priority: this.getEditorPriority()
+			},
+			{
+				singlePerResource: true,
+				canSupportResource: (resource: URI) => {
+					return resource.scheme === 'file';
+				}
+			},
+			{
+				createEditorInput: async ({ resource }) => {
+					const editorInput = PositronNotebookEditorInput.getOrCreate(
+						this.instantiationService,
+						resource,
+						undefined,
+						'jupyter-notebook',
+						{ startDirty: false }
+					);
+					return { editor: editorInput };
+				}
+			}
+		);
+	}
+
+	private getEditorPriority(): RegisteredEditorPriority {
+		const defaultEditor = getPreferredNotebookEditor(this.configurationService);
+		return defaultEditor === 'positron'
+			? RegisteredEditorPriority.default
+			: RegisteredEditorPriority.option;
+	}
+
+	get registrationCount(): number {
+		return this._registrationCount;
+	}
+
+	override dispose(): void {
+		this._currentRegistration?.dispose();
+		super.dispose();
+	}
+}
+
+suite('Positron Notebook Configuration Handling', () => {
+
+	const disposables = new DisposableStore();
+	let instantiationService: ITestInstantiationService;
+	let configurationService: TestConfigurationService;
+	let editorResolverService: EditorResolverService;
+
+	let notebookContribution: MockPositronNotebookContribution;
+
+	teardown(() => disposables.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function createTestServices(): Promise<void> {
+		const services = await createPositronNotebookTestServices(disposables);
+		instantiationService = services.instantiationService;
+		configurationService = services.configurationService;
+		editorResolverService = services.editorResolverService;
+
+		// Create mock notebook contribution that handles registration
+		notebookContribution = new MockPositronNotebookContribution(
+			editorResolverService,
+			configurationService,
+			instantiationService
+		);
+		disposables.add(notebookContribution);
+	}
+
+	test('Editor re-registration occurs when configuration changes', async () => {
+		await createTestServices();
+
+		const initialRegistrationCount = notebookContribution.registrationCount;
+
+		// Change configuration
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
+
+		// Trigger configuration change event
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
+			source: 6, // ConfigurationTarget.USER
+			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
+			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
+		} as IConfigurationChangeEvent);
+
+		// Should have triggered a new registration
+		assert.strictEqual(notebookContribution.registrationCount, initialRegistrationCount + 1);
+	});
+
+	test('Editor priority changes correctly with configuration', async () => {
+		await createTestServices();
+
+		// Start with vscode (option priority)
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'vscode');
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
+			source: 6,
+			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
+			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
+		} as IConfigurationChangeEvent);
+
+		let editors = editorResolverService.getEditors();
+		let positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		assert.ok(positronEditor);
+		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.option);
+
+		// Change to positron (default priority)
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
+			source: 6,
+			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
+			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
+		} as IConfigurationChangeEvent);
+
+		editors = editorResolverService.getEditors();
+		positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		assert.ok(positronEditor);
+		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.default);
+	});
+
+	test('Configuration changes not affecting notebook setting do not trigger re-registration', async () => {
+		await createTestServices();
+
+		const initialRegistrationCount = notebookContribution.registrationCount;
+
+		// Change unrelated configuration
+		configurationService.setUserConfiguration('workbench.editor.enablePreview', false);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === 'workbench.editor.enablePreview',
+			source: 6,
+			affectedKeys: new Set(['workbench.editor.enablePreview']),
+			change: { keys: ['workbench.editor.enablePreview'], overrides: [] }
+		} as IConfigurationChangeEvent);
+
+		// Should not have triggered a new registration
+		assert.strictEqual(notebookContribution.registrationCount, initialRegistrationCount);
+	});
+
+	test('Handles null/undefined configuration values gracefully', async () => {
+		await createTestServices();
+
+		// Set configuration to null/undefined
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, null);
+
+		// Should default to 'vscode'
+		const preferred = getPreferredNotebookEditor(configurationService);
+		assert.strictEqual(preferred, 'vscode');
+
+		// Verify editor is registered with option priority
+		const editors = editorResolverService.getEditors();
+		const positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		assert.ok(positronEditor);
+		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.option);
+	});
+
+	test('Handles configuration service returning undefined', async () => {
+		await createTestServices();
+
+		// Create a configuration service that returns undefined
+		const emptyConfigService = {
+			getValue: () => undefined,
+			onDidChangeConfiguration: Event.None
+		} as any;
+
+		const preferred = getPreferredNotebookEditor(emptyConfigService);
+		assert.strictEqual(preferred, 'vscode');
+	});
+
+
+	test('Cleanup disposes editor registrations properly', async () => {
+		await createTestServices();
+
+		// Verify editor is registered
+		let editors = editorResolverService.getEditors();
+		let positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		assert.ok(positronEditor);
+
+		// Dispose contribution
+		notebookContribution.dispose();
+
+		// Verify editor is no longer registered
+		editors = editorResolverService.getEditors();
+		positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		assert.strictEqual(positronEditor, undefined);
+	});
+});
+

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -3,6 +3,35 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * @fileoverview Tests for Positron Notebook editor resolution logic.
+ *
+ * This test suite verifies that the Positron Notebook editor correctly resolves and handles
+ * file types based on user configuration. These tests are critical for ensuring that:
+ *
+ * 1. **File Type Specificity**: Only .ipynb files are handled by the Positron Notebook editor,
+ *    while other file types (like .py, .js, etc.) are properly delegated to their appropriate editors.
+ *
+ * 2. **Configuration Defaults**: The system gracefully handles missing or invalid configuration
+ *    values by falling back to sensible defaults (VS Code's default notebook editor).
+ *
+ * 3. **Editor Priority Resolution**: The editor resolver service correctly prioritizes and
+ *    instantiates the appropriate editor based on file type and user preferences.
+ *
+ * **Context**: This is part of Positron Notebooks 2.0's transition from intercepting/hijacking
+ * the existing NotebookEditor to registering as a separate editor that receives priority for
+ * .ipynb files. This approach eliminates the previous "hijacking" behavior and allows users
+ * to opt out without modifying global settings.
+ *
+ * **Why These Tests Matter**: Unlike end-to-end tests that verify user-facing behavior, these
+ * unit tests focus on the internal resolution mechanics that are difficult to test at higher
+ * levels, including error conditions, edge cases, and proper resource cleanup.
+ *
+ * @see {@link PositronNotebookEditorInput} - The editor input class being tested
+ * @see {@link getPreferredNotebookEditor} - Configuration utility function
+ * @see {@link EditorResolverService} - Core service for editor resolution
+ */
+
 import assert from 'assert';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { EditorResolverService } from '../../../../services/editor/browser/editorResolverService.js';
+import { RegisteredEditorPriority, ResolvedStatus } from '../../../../services/editor/common/editorResolverService.js';
+import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
+import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
+import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../browser/positronNotebook.contribution.js';
+import { createPositronNotebookTestServices } from './testUtils.js';
+
+suite('Positron Notebook Editor Resolution', () => {
+
+	const disposables = new DisposableStore();
+	let instantiationService: ITestInstantiationService;
+	let configurationService: TestConfigurationService;
+	let editorResolverService: EditorResolverService;
+	let part: EditorPart;
+
+	teardown(() => disposables.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function createTestServices(): Promise<void> {
+		const services = await createPositronNotebookTestServices(disposables);
+		instantiationService = services.instantiationService;
+		configurationService = services.configurationService;
+		editorResolverService = services.editorResolverService;
+		part = services.part;
+	}
+
+	function registerPositronNotebookEditor(priority: RegisteredEditorPriority): void {
+		const registration = editorResolverService.registerEditor(
+			'*.ipynb',
+			{
+				id: PositronNotebookEditorInput.EditorID,
+				label: 'Positron Notebook',
+				priority: priority
+			},
+			{
+				singlePerResource: true,
+				canSupportResource: (resource: URI) => {
+					return resource.scheme === 'file';
+				}
+			},
+			{
+				createEditorInput: async ({ resource }) => {
+					const editorInput = PositronNotebookEditorInput.getOrCreate(
+						instantiationService,
+						resource,
+						undefined,
+						'jupyter-notebook',
+						{ startDirty: false }
+					);
+					return { editor: editorInput };
+				}
+			}
+		);
+		disposables.add(registration);
+	}
+
+
+	test('getPreferredNotebookEditor defaults to vscode when no setting', async () => {
+		await createTestServices();
+
+		const preferred = getPreferredNotebookEditor(configurationService);
+		assert.strictEqual(preferred, 'vscode');
+	});
+
+
+	test('Invalid configuration value defaults to vscode', async () => {
+		await createTestServices();
+
+		// Set invalid value
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'invalid-value');
+
+		const preferred = getPreferredNotebookEditor(configurationService);
+		assert.strictEqual(preferred, 'vscode');
+	});
+
+	test('Only ipynb files are handled by Positron notebook editor', async () => {
+		await createTestServices();
+
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
+		registerPositronNotebookEditor(RegisteredEditorPriority.default);
+
+		// Test .ipynb file - should resolve
+		const ipynbResult = await editorResolverService.resolveEditor(
+			{ resource: URI.file('/test/notebook.ipynb') },
+			part.activeGroup
+		);
+
+		assert.ok(ipynbResult);
+		assert.notStrictEqual(typeof ipynbResult, 'number');
+		if (ipynbResult !== ResolvedStatus.ABORT && ipynbResult !== ResolvedStatus.NONE) {
+			assert.strictEqual(ipynbResult.editor.typeId, PositronNotebookEditorInput.ID);
+			// Ensure proper cleanup of the editor and its internal components
+			if (ipynbResult.editor instanceof PositronNotebookEditorInput) {
+				ipynbResult.editor.notebookInstance?.dispose();
+			}
+			ipynbResult.editor.dispose();
+		}
+
+		// Test .py file - should not resolve to Positron notebook
+		const pyResult = await editorResolverService.resolveEditor(
+			{ resource: URI.file('/test/script.py') },
+			part.activeGroup
+		);
+
+		// Should resolve but not to Positron notebook editor
+		if (pyResult !== ResolvedStatus.ABORT && pyResult !== ResolvedStatus.NONE && typeof pyResult !== 'number') {
+			assert.notStrictEqual(pyResult.editor.typeId, PositronNotebookEditorInput.ID);
+			pyResult.editor.dispose();
+		}
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testUtils.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { EditorResolverService } from '../../../../services/editor/browser/editorResolverService.js';
+import { IEditorResolverService } from '../../../../services/editor/common/editorResolverService.js';
+import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { createEditorPart, ITestInstantiationService, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
+import { INotebookService } from '../../../notebook/common/notebookService.js';
+import { INotebookEditorModelResolverService } from '../../../notebook/common/notebookEditorModelResolverService.js';
+import { INotebookKernelService } from '../../../notebook/common/notebookKernelService.js';
+import { INotebookExecutionService } from '../../../notebook/common/notebookExecutionService.js';
+import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronNotebookService } from '../../../../services/positronNotebook/browser/positronNotebookService.js';
+import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
+import { Event } from '../../../../../base/common/event.js';
+
+export interface TestServices {
+	instantiationService: ITestInstantiationService;
+	configurationService: TestConfigurationService;
+	editorResolverService: EditorResolverService;
+	part: EditorPart;
+}
+
+/**
+ * Creates a complete set of test services for Positron Notebook testing.
+ * This includes all necessary mocks and service stubs.
+ */
+export async function createPositronNotebookTestServices(disposables: DisposableStore): Promise<TestServices> {
+	const instantiationService = workbenchInstantiationService(undefined, disposables);
+
+	// Create configuration service with test defaults
+	const configurationService = new TestConfigurationService();
+	instantiationService.stub(IConfigurationService, configurationService);
+
+	// Create editor part and resolver service
+	const part = await createEditorPart(instantiationService, disposables);
+	instantiationService.stub(IEditorGroupsService, part);
+
+	const editorResolverService = instantiationService.createInstance(EditorResolverService);
+	instantiationService.stub(IEditorResolverService, editorResolverService);
+	disposables.add(editorResolverService);
+
+	// Mock notebook service to support jupyter-notebook view type
+	const mockNotebookService: Partial<INotebookService> = {
+		canResolve: (viewType: string) => Promise.resolve(viewType === 'jupyter-notebook'),
+		onWillAddNotebookDocument: Event.None,
+		onDidAddNotebookDocument: Event.None,
+		onWillRemoveNotebookDocument: Event.None,
+		onDidRemoveNotebookDocument: Event.None,
+		registerNotebookSerializer: () => ({ dispose: () => { } }),
+		withNotebookDataProvider: () => Promise.resolve({} as any),
+		getContributedNotebookTypes: () => [],
+		getNotebookTextModel: () => undefined,
+		listNotebookDocuments: () => [],
+		getNotebookTextModels: () => []
+	};
+	instantiationService.stub(INotebookService, mockNotebookService);
+
+	// Mock notebook model resolver service
+	const mockModelResolverService: Partial<INotebookEditorModelResolverService> = {
+		resolve: () => Promise.resolve({
+			object: {
+				notebook: {
+					viewType: 'jupyter-notebook',
+					uri: URI.file('/test/notebook.ipynb'),
+					cells: [],
+					onDidChangeContent: Event.None,
+					onDidChangeNotebook: Event.None,
+					getCells: () => [],
+					length: 0
+				} as any,
+				resource: URI.file('/test/notebook.ipynb'),
+				viewType: 'jupyter-notebook',
+				isResolved: () => true,
+				isDirty: () => false,
+				load: () => Promise.resolve(),
+				save: () => Promise.resolve(),
+				revert: () => Promise.resolve(),
+				onDidChangeDirty: Event.None,
+				onDidChangeReadonly: Event.None,
+				onDidRevertUntitled: Event.None,
+				dispose: () => { }
+			} as any,
+			dispose: () => { }
+		})
+	};
+	instantiationService.stub(INotebookEditorModelResolverService, mockModelResolverService);
+
+	// Mock Positron notebook service
+	const mockPositronNotebookService = {
+		registerInstance: () => { },
+		unregisterInstance: () => { },
+		getNotebookInstance: () => undefined
+	};
+	instantiationService.stub(IPositronNotebookService, mockPositronNotebookService);
+
+	// Mock additional services required by PositronNotebookInstance
+	const mockNotebookKernelService = {
+		onDidChangeSelectedNotebooks: Event.None,
+		getSelectedOrSuggestedKernel: () => undefined,
+		selectKernelForNotebook: () => { }
+	};
+	instantiationService.stub(INotebookKernelService, mockNotebookKernelService);
+
+	const mockNotebookExecutionService = {
+		executeNotebookCells: () => Promise.resolve(),
+		cancelNotebookCells: () => Promise.resolve()
+	};
+	instantiationService.stub(INotebookExecutionService, mockNotebookExecutionService);
+
+	const mockNotebookExecutionStateService = {
+		onDidChangeCellExecution: Event.None,
+		getCellExecution: () => undefined
+	};
+	instantiationService.stub(INotebookExecutionStateService, mockNotebookExecutionStateService);
+
+	const mockCommandService: Partial<ICommandService> = {
+		onWillExecuteCommand: Event.None,
+		onDidExecuteCommand: Event.None,
+		executeCommand: <T = any>(_commandId: string, ..._args: any[]) => Promise.resolve(undefined as T | undefined)
+	};
+	instantiationService.stub(ICommandService, mockCommandService);
+
+	const mockRuntimeSessionService: Partial<IRuntimeSessionService> = {
+		onDidChangeRuntimeState: Event.None,
+		onDidStartRuntime: Event.None,
+		getSession: () => undefined
+	};
+	instantiationService.stub(IRuntimeSessionService, mockRuntimeSessionService);
+
+	const mockWebviewPreloadService: Partial<IPositronWebviewPreloadService> = {
+		initialize: () => { },
+		attachNotebookInstance: () => { }
+	};
+	instantiationService.stub(IPositronWebviewPreloadService, mockWebviewPreloadService);
+
+	return {
+		instantiationService,
+		configurationService,
+		editorResolverService,
+		part
+	};
+}

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -90,13 +90,16 @@ export class Notebooks {
 	}
 
 	// Opens a Notebook that lives in the current workspace
-	async openNotebook(path: string) {
+	// checkForActiveCell is set to false for Positron notebooks which don't have the same cell structure as VS Code notebooks.
+	async openNotebook(path: string, checkForActiveCell = true) {
 		await test.step(`Open notebook: ${path}`, async () => {
 			await this.quickaccess.openFileQuickAccessAndWait(basename(path), 1);
 			await this.quickinput.selectQuickInputElement(0);
 
-			await expect(this.code.driver.page.locator(ACTIVE_ROW_SELECTOR)).toBeVisible();
-			await this.focusFirstCell();
+			if (checkForActiveCell) {
+				await expect(this.code.driver.page.locator(ACTIVE_ROW_SELECTOR)).toBeVisible();
+				await this.focusFirstCell();
+			}
 		});
 	}
 

--- a/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
+++ b/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
@@ -10,37 +10,12 @@ test.use({
 	suiteId: __filename
 });
 
-// Tests:
-// - Start by creating a new notebook file that can be used for all tests. This Should have a single cell with print("test") in it
-//     this is needed because the current positron editor does not support creating a _new_ notebook. (Make a note of this in the code.)
-// There should be a helper function reports which notebook is open:
-//    - If there is an element for generating code (as given by  <a class="action-label codicon codicon-sparkle" role="button" aria-label="Start Chat to Generate Code (⌘I)" tabindex="0"></a>) then we're in vscode notebooks.
-//    - If there is a div with the class "positron-notebook" then we're in positron notebooks
-//    - It's important this is a function that can be easily updated as dom structures may change.
-// The tests should then test the following:
-// 1. The default editor is VS Code notebook.
-// 2. When the setting 'positron.notebooks.defaultEditor' is set to 'positron' then we open in a positron notebook
-// 3. When we go back to the default value we can open the editor again and it's back to vscode.
-
 test.describe('Notebook Editor Configuration', {
 	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
 }, () => {
 
-	// test.beforeAll(async function ({ app, settings }) {
-	// 	if (app.web) {
-	// 		await settings.set({
-	// 			'files.simpleDialog.enable': true,
-	// 		});
-	// 	}
-	// });
-
-	// test.beforeEach(async function ({ app, python, settings }) {
-	// 	// Set up layout for notebook testing
-	// 	await app.workbench.layouts.enterLayout('notebook');
-	// });
-
 	test.afterEach(async function ({ settings }) {
-		// Reset the setting to default
+		// Reset the notebook editor setting to default
 		await settings.set({
 			'positron.notebooks.defaultEditor': 'vscode'
 		});
@@ -73,7 +48,6 @@ test.describe('Notebook Editor Configuration', {
 	}
 
 	test('default editor is VS Code notebook', async function ({ app, page }) {
-		// Get test notebook path
 		const notebookPath = getTestNotebookPath(app);
 
 		// Close the current editor to start fresh
@@ -92,7 +66,6 @@ test.describe('Notebook Editor Configuration', {
 			'positron.notebooks.defaultEditor': 'positron'
 		});
 
-		// Get test notebook path
 		const notebookPath = getTestNotebookPath(app);
 
 		// Close the current editor to start fresh
@@ -111,7 +84,6 @@ test.describe('Notebook Editor Configuration', {
 			'positron.notebooks.defaultEditor': 'positron'
 		});
 
-		// Get test notebook path
 		const notebookPath = getTestNotebookPath(app);
 
 		// Open in Positron first

--- a/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
+++ b/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// Tests:
+// - Start by creating a new notebook file that can be used for all tests. This Should have a single cell with print("test") in it
+//     this is needed because the current positron editor does not support creating a _new_ notebook. (Make a note of this in the code.)
+// There should be a helper function reports which notebook is open:
+//    - If there is an element for generating code (as given by  <a class="action-label codicon codicon-sparkle" role="button" aria-label="Start Chat to Generate Code (⌘I)" tabindex="0"></a>) then we're in vscode notebooks.
+//    - If there is a div with the class "positron-notebook" then we're in positron notebooks
+//    - It's important this is a function that can be easily updated as dom structures may change.
+// The tests should then test the following:
+// 1. The default editor is VS Code notebook.
+// 2. When the setting 'positron.notebooks.defaultEditor' is set to 'positron' then we open in a positron notebook
+// 3. When we go back to the default value we can open the editor again and it's back to vscode.
+
+test.describe('Notebook Editor Configuration', {
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+
+	// test.beforeAll(async function ({ app, settings }) {
+	// 	if (app.web) {
+	// 		await settings.set({
+	// 			'files.simpleDialog.enable': true,
+	// 		});
+	// 	}
+	// });
+
+	// test.beforeEach(async function ({ app, python, settings }) {
+	// 	// Set up layout for notebook testing
+	// 	await app.workbench.layouts.enterLayout('notebook');
+	// });
+
+	test.afterEach(async function ({ settings }) {
+		// Reset the setting to default
+		await settings.set({
+			'positron.notebooks.defaultEditor': 'vscode'
+		});
+	});
+
+	/**
+	 * Helper function to detect if Positron notebook is open
+	 * @param page The Playwright page object
+	 */
+	async function detectPositronNotebook(page: any): Promise<void> {
+		const positronIndicator = page.locator('.positron-notebook').first();
+		await positronIndicator.waitFor({ timeout: 5000 });
+	}
+
+	/**
+	 * Helper function to detect if VS Code notebook is open
+	 * @param page The Playwright page object
+	 */
+	async function detectVSCodeNotebook(page: any): Promise<void> {
+		const vscodeIndicator = page.getByLabel(/Start Chat to Generate Code/).first();
+		await vscodeIndicator.waitFor({ timeout: 5000 });
+	}
+
+	/**
+	 * Helper function to get the test notebook file path
+	 * Uses existing notebook at workspaces/bitmap-notebook/bitmap-notebook.ipynb
+	 */
+	function getTestNotebookPath(app: any): string {
+		return path.join(app.workspacePathOrFolder, 'workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');
+	}
+
+	test('default editor is VS Code notebook', async function ({ app, page }) {
+		// Get test notebook path
+		const notebookPath = getTestNotebookPath(app);
+
+		// Close the current editor to start fresh
+		await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+
+		// Open the notebook file
+		await app.workbench.notebooks.openNotebook(notebookPath, false);
+
+		// Wait for VS Code notebook to load
+		await detectVSCodeNotebook(page);
+	});
+
+	test('setting positron.notebooks.defaultEditor to positron opens positron notebook', async function ({ app, page, settings }) {
+		// Set the setting to use Positron notebooks
+		await settings.set({
+			'positron.notebooks.defaultEditor': 'positron'
+		});
+
+		// Get test notebook path
+		const notebookPath = getTestNotebookPath(app);
+
+		// Close the current editor to start fresh
+		await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+
+		// Open the notebook file
+		await app.workbench.notebooks.openNotebook(notebookPath, false);
+
+		// Wait for Positron notebook to load
+		await detectPositronNotebook(page);
+	});
+
+	test('reverting to default setting opens VS Code notebook again', async function ({ app, page, settings }) {
+		// First set to Positron
+		await settings.set({
+			'positron.notebooks.defaultEditor': 'positron'
+		});
+
+		// Get test notebook path
+		const notebookPath = getTestNotebookPath(app);
+
+		// Open in Positron first
+		await app.workbench.notebooks.openNotebook(notebookPath, false);
+		await detectPositronNotebook(page);
+
+		// Close editor
+		await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+
+		// Revert to default (VS Code)
+		await settings.set({
+			'positron.notebooks.defaultEditor': 'vscode'
+		});
+
+		// Open notebook again
+		await app.workbench.notebooks.openNotebook(notebookPath, false);
+		await detectVSCodeNotebook(page);
+	});
+
+});


### PR DESCRIPTION
Add a document containing the architecture of the positron notebooks 2.0 project. 

This PR is just a markdown file and should have no impact on the editor. 

This relies on #8348 to be up-to-date with current architecture. 