### PR TITLE
data explorer: avoid polars panic when using numeric values without numpy

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1963,6 +1963,10 @@ def _get_histogram_polars(data: pl.Series, num_bins: int, method="fd"):
         if n_bins > num_bins:
             n_bins = num_bins
 
+    if n_bins > len(data_clean):
+        # If number of bins exceeds number of data points, limit to number of data points
+        n_bins = len(data_clean)
+
     # Handle integer data specially to avoid too many bins
     if method != "fixed" and data.dtype.is_integer():
         data_range = data_clean.max() - data_clean.min()

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1925,7 +1925,7 @@ def _get_histogram_method(method: ColumnHistogramParamsMethod):
     }[method]
 
 
-def _get_histogram_polars(data, num_bins: int, method="fd"):
+def _get_histogram_polars(data: pl.Series, num_bins: int, method="fd"):
     """
     Compute histogram using pure Polars operations.
 
@@ -1941,11 +1941,13 @@ def _get_histogram_polars(data, num_bins: int, method="fd"):
 
     assert num_bins is not None
 
-    # Handle object/string dtype by converting to float (like numpy version)
-    if data.dtype == pl.Object or data.dtype == pl.Utf8:
+    # Handle object/string dtype by converting to float
+    if data.dtype == pl.Object:
+        data = pl.Series(data.to_list())
+    if (data.dtype == pl.Utf8) or (data.dtype == pl.Decimal):
         data = data.cast(pl.Float64)
 
-    # Filter out null, inf, and -inf values (like numpy version does with np.isfinite)
+    # Filter out null, inf, and -inf values
     data_clean = data.filter(data.is_finite())
 
     if len(data_clean) == 0:
@@ -1957,13 +1959,12 @@ def _get_histogram_polars(data, num_bins: int, method="fd"):
         n_bins = num_bins
     else:
         n_bins = _calculate_optimal_bins(data_clean, method)
-        # Like numpy version: if method returns more bins than requested, limit it
+        # if method returns more bins than requested, limit it
         if n_bins > num_bins:
             n_bins = num_bins
 
-    # Handle integer data specially to avoid too many bins (like numpy version)
-    # But only apply this limitation when method is not "fixed"
-    if data.dtype.is_integer() and method != "fixed":
+    # Handle integer data specially to avoid too many bins
+    if method != "fixed" and data.dtype.is_integer():
         data_range = data_clean.max() - data_clean.min()
         if data_range is not None and data_range > 0:
             # For integers, don't create more bins than the range of values
@@ -1979,7 +1980,7 @@ def _get_histogram_polars(data, num_bins: int, method="fd"):
         bin_counts = pl.Series("counts", [len(data_clean)], dtype=pl.Int64)
         return bin_counts, bin_edges
 
-    # Create bin edges
+    # Create bin edges - need n_bins+1 edges to create n_bins bins
     bin_width = (data_max - data_min) / n_bins
     bin_edges = pl.Series(
         "edges", [data_min + i * bin_width for i in range(n_bins + 1)], dtype=pl.Float64
@@ -2007,7 +2008,7 @@ def _calculate_optimal_bins(data, method):
         q25 = data.quantile(0.25)
         iqr = q75 - q25
         if iqr == 0:
-            return 0  # Return 1 instead of 0 to avoid division by zero
+            return 1  # Return 1 instead of 0 to avoid division by zero
         width = 2.0 * iqr * n ** (-1.0 / 3.0)
     elif method == "scott":  # Scott's rule
         std = data.std()
@@ -2822,10 +2823,14 @@ class PolarsView(DataExplorerTableView):
         else:
             cast_bin_edges = False
 
+        method = _get_histogram_method(params.method)
+
         bin_counts, bin_edges = _get_histogram_polars(
             data,
             params.num_bins,
+            method=method,
         )
+
         bin_edges = pl.Series(bin_edges)
 
         if cast_bin_edges:


### PR DESCRIPTION
The [data.to_numpy() call was what is causing the actual panic](https://github.com/posit-dev/positron/blob/59d6fb0a125937994eccce5e2f8d01873c94ba80/extensions/positron-python/python_files/posit/positron/data_explorer.py#L2694), but numpy was used immediately after as well.

Previously, all of the histograms are based off the assumption that numpy is available, but unfortunately it is an [optional dependency for](https://github.com/pola-rs/polars/blob/bfcb40e629e4e3a3d2ee4ab8f0653886fa4a7dd8/py-polars/pyproject.toml#L46) polars.

Unfortunately, the `hist()` method for polars series is still unstable/experimental and does not have different types of binning, so we are in a situation where we have to write our own. It's not too bad, but probably less efficient, so we might want to rely on numpy if it is installed.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8203 The summary panel in the Data Explorer can handle `polars` numeric values without `numpy` installed.


### QA Notes

```python
# do NOT have numpy installed
import polars as pl

sample_data_error = {"float": 3.14, "int": 1}
df = pl.DataFrame(sample_data_error)

%view df
```

should successfully see histograms in the summary panel.