### PR TITLE
Add `positron.r.symbols.includeAssignmentsInBlocks` setting

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -194,6 +194,11 @@
             "type": "boolean",
             "default": false,
             "description": "%r.configuration.symbols.includeAssignmentsInBlocks.description%"
+          },
+          "positron.r.workspaceSymbols.includeCommentSections": {
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.workspaceSymbols.includeCommentSections.description%"
           }
         }
       },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -189,6 +189,11 @@
             "type": "boolean",
             "default": true,
             "description": "%r.configuration.diagnostics.enable.description%"
+          },
+          "positron.r.symbols.includeAssignmentsInBlocks": {
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.symbols.includeAssignmentsInBlocks.description%"
           }
         }
       },

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -64,6 +64,7 @@
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
+	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
 	"r.configuration.defaultRepositories.description": "The default repositories to use for R package installation, if no repository is otherwise specified in R startup scripts (restart Positron to apply).\n\nThe default repositories will be set as the `repos` option in R.",
 	"r.configuration.defaultRepositories.auto.description": "Automatically choose a default repository, or use a repos.conf file if it exists.",
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",
@@ -81,4 +82,3 @@
 	"r.walkthrough.migrateFromRStudio.formatting.description": "  \n[Configure Air to format on save](command:r.walkthrough.formatOnSave)"
 
 }
-

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -65,6 +65,7 @@
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
 	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
+	"r.configuration.workspaceSymbols.includeCommentSections.description": "Controls whether comment sections like `# My section ---` are included as workspace symbols.",
 	"r.configuration.defaultRepositories.description": "The default repositories to use for R package installation, if no repository is otherwise specified in R startup scripts (restart Positron to apply).\n\nThe default repositories will be set as the `repos` option in R.",
 	"r.configuration.defaultRepositories.auto.description": "Automatically choose a default repository, or use a repos.conf file if it exists.",
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",


### PR DESCRIPTION
For https://github.com/posit-dev/positron/issues/8330
Extension side of https://github.com/posit-dev/ark/pull/859

Can be merged separately.