### PR TITLE
e2e test: notebook pom & skip web

### DIFF
--- a/test/e2e/infra/index.ts
+++ b/test/e2e/infra/index.ts
@@ -18,6 +18,8 @@ export * from '../pages/dataExplorer';
 export * from '../pages/sideBar';
 export * from '../pages/plots';
 export * from '../pages/notebooks';
+export * from '../pages/notebooksVscode';
+export * from '../pages/notebooksPositron';
 export * from '../pages/newFolderFlow';
 export * from '../pages/connections';
 export * from '../pages/help';

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -10,7 +10,6 @@ import { Variables } from '../pages/variables';
 import { DataExplorer } from '../pages/dataExplorer';
 import { SideBar } from '../pages/sideBar';
 import { Plots } from '../pages/plots';
-import { Notebooks } from '../pages/notebooks';
 import { NewFolderFlow } from '../pages/newFolderFlow';
 import { Explorer } from '../pages/explorer';
 import { Connections } from '../pages/connections';
@@ -40,6 +39,9 @@ import { Search } from '../pages/search.js';
 import { Assistant } from '../pages/positronAssistant.js';
 import { HotKeys } from '../pages/hotKeys.js';
 import { PositConnect } from '../pages/connect.js';
+import { Notebooks } from '../pages/notebooks.js';
+import { PositronNotebooks } from '../pages/notebooksPositron.js';
+import { VsCodeNotebooks } from '../pages/notebooksVscode.js';
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -54,6 +56,8 @@ export class Workbench {
 	readonly sideBar: SideBar;
 	readonly plots: Plots;
 	readonly notebooks: Notebooks;
+	readonly notebooksVscode: VsCodeNotebooks;
+	readonly notebooksPositron: PositronNotebooks;
 	readonly newFolderFlow: NewFolderFlow;
 	readonly explorer: Explorer;
 	readonly connections: Connections;
@@ -104,6 +108,8 @@ export class Workbench {
 		this.console = new Console(code, this.quickInput, this.quickaccess, this.hotKeys);
 		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess);
+		this.notebooksVscode = new VsCodeNotebooks(code, this.quickInput, this.quickaccess);
+		this.notebooksPositron = new PositronNotebooks(code, this.quickInput, this.quickaccess);
 		this.welcome = new Welcome(code);
 		this.clipboard = new Clipboard(code, this.hotKeys);
 		this.terminal = new Terminal(code, this.quickaccess, this.clipboard, this.popups);

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -7,7 +7,7 @@ import { Code } from '../infra/code';
 import { QuickInput } from './quickInput';
 import { QuickAccess } from './quickaccess';
 import { basename } from 'path';
-import test, { expect } from '@playwright/test';
+import test, { expect, FrameLocator, Locator } from '@playwright/test';
 
 const KERNEL_DROPDOWN = 'a.kernel-label';
 const KERNEL_LABEL = '.codicon-notebook-kernel-select';
@@ -23,17 +23,30 @@ const MARKDOWN_TEXT = '#preview';
 const ACTIVE_ROW_SELECTOR = `.notebook-editor .monaco-list-row.focused`;
 
 /*
- *  Reuseable Positron notebook functionality for tests to leverage.  Includes selecting the notebook's interpreter.
+ * Shared Notebooks functionality for both Vscode and Positron notebooks.
  */
 export class Notebooks {
-	kernelLabel = this.code.driver.page.locator(KERNEL_LABEL);
-	kernelDropdown = this.code.driver.page.locator(KERNEL_DROPDOWN);
-	frameLocator = this.code.driver.page.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME);
-	notebookProgressBar = this.code.driver.page.locator('[id="workbench\\.parts\\.editor"]').getByRole('progressbar');
-	cellIndex = (num = 0) => this.code.driver.page.locator('.cell-inner-container > .cell').nth(num);
+	protected code: Code;
+	protected quickinput: QuickInput;
+	protected quickaccess: QuickAccess;
 
+	kernelLabel: Locator;
+	kernelDropdown: Locator;
+	frameLocator: FrameLocator;
+	notebookProgressBar: Locator;
+	cellIndex: (num?: number) => Locator;
 
-	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess) { }
+	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess) {
+		this.code = code;
+		this.quickinput = quickinput;
+		this.quickaccess = quickaccess;
+
+		this.kernelLabel = this.code.driver.page.locator(KERNEL_LABEL);
+		this.kernelDropdown = this.code.driver.page.locator(KERNEL_DROPDOWN);
+		this.frameLocator = this.code.driver.page.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME);
+		this.notebookProgressBar = this.code.driver.page.locator('[id="workbench\\.parts\\.editor"]').getByRole('progressbar');
+		this.cellIndex = (num = 0) => this.code.driver.page.locator('.cell-inner-container > .cell').nth(num);
+	}
 
 	async selectInterpreter(
 		kernelGroup: 'Python' | 'R',
@@ -149,7 +162,7 @@ export class Notebooks {
 			const stopExecutionLocator = this.code.driver.page.locator('a').filter({ hasText: /Stop Execution|Interrupt/ });
 			try {
 				await expect(stopExecutionLocator).toBeVisible();
-				await expect(stopExecutionLocator).not.toBeVisible({ timeout: timeout });
+				await expect(stopExecutionLocator).not.toBeVisible({ timeout });
 			} catch { } // can be normal with very fast execution
 		});
 	}
@@ -221,20 +234,5 @@ export class Notebooks {
 
 	async focusNextCell() {
 		await this.code.driver.page.keyboard.press('ArrowDown');
-	}
-
-	/**
-	 * Verify: that the specified notebook type is visible on the page.
-	 * @param type The type of notebook to check for ('positron' or 'vscode')
-	 * @param timeout Optional timeout in milliseconds (default: 5000)
-	 */
-	async expectNotebookTypeToBe(type: 'positron' | 'vscode', timeout = 5000): Promise<void> {
-		await test.step(`Expect notebook to be type: ${type}`, async () => {
-			const selector = type === 'positron'
-				? this.code.driver.page.locator('.positron-notebook').first()
-				: this.code.driver.page.getByLabel(/Start Chat to Generate Code/).first();
-
-			await expect(selector).toBeVisible({ timeout });
-		});
 	}
 }

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -222,4 +222,19 @@ export class Notebooks {
 	async focusNextCell() {
 		await this.code.driver.page.keyboard.press('ArrowDown');
 	}
+
+	/**
+	 * Verify: that the specified notebook type is visible on the page.
+	 * @param type The type of notebook to check for ('positron' or 'vscode')
+	 * @param timeout Optional timeout in milliseconds (default: 5000)
+	 */
+	async expectNotebookTypeToBe(type: 'positron' | 'vscode', timeout = 5000): Promise<void> {
+		await test.step(`Expect notebook to be type: ${type}`, async () => {
+			const selector = type === 'positron'
+				? this.code.driver.page.locator('.positron-notebook').first()
+				: this.code.driver.page.getByLabel(/Start Chat to Generate Code/).first();
+
+			await expect(selector).toBeVisible({ timeout });
+		});
+	}
 }

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Notebooks } from './notebooks';
+import { Code } from '../infra/code';
+import { QuickInput } from './quickInput';
+import { QuickAccess } from './quickaccess';
+import test, { expect, Locator } from '@playwright/test';
+
+/**
+ * Notebooks functionality exclusive to Positron notebooks.
+ */
+export class PositronNotebooks extends Notebooks {
+	positronNotebook: Locator;
+
+	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess) {
+		super(code, quickinput, quickaccess);
+
+		this.positronNotebook = this.code.driver.page.locator('.positron-notebook').first();
+	}
+
+	// -- Actions --
+
+	/**
+	 * Action: Open a Positron notebook.
+	 * It does not check for an active cell, as Positron notebooks do not have the same cell structure as VS Code notebooks.
+	 *
+	 * @param path - The path to the notebook to open.
+	 */
+	async openNotebook(path: string): Promise<void> {
+		await super.openNotebook(path, false);
+		await this.expectToBeVisible();
+	}
+
+	// -- Verifications --
+
+	/**
+	 * Verify: a Positron notebook is visible on the page.
+	 */
+	async expectToBeVisible(timeout = 5000): Promise<void> {
+		await test.step('Verify Positron notebook is visible', async () => {
+			await expect(this.positronNotebook).toBeVisible({ timeout });
+		});
+	}
+
+
+}

--- a/test/e2e/pages/notebooksVscode.ts
+++ b/test/e2e/pages/notebooksVscode.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/pages/notebooksVscode.ts
+++ b/test/e2e/pages/notebooksVscode.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Notebooks } from './notebooks';
+import { Code } from '../infra/code';
+import { QuickInput } from './quickInput';
+import { QuickAccess } from './quickaccess';
+import test, { expect, Locator } from '@playwright/test';
+
+/**
+ * Notebooks functionality exclusive to VS Code notebooks.
+ */
+export class VsCodeNotebooks extends Notebooks {
+	startChatButton: Locator;
+
+	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess) {
+		super(code, quickinput, quickaccess);
+
+		this.startChatButton = this.code.driver.page.getByLabel(/Start Chat to Generate Code/).first();
+	}
+
+	/**
+	 * Verify: a VS Code notebook is visible on the page.
+	 */
+	async expectToBeVisible(timeout = 5000): Promise<void> {
+		await test.step('Verify VS Code notebook is visible', async () => {
+			await expect(this.startChatButton).toBeVisible({ timeout });
+		});
+	}
+}

--- a/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
+++ b/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
@@ -13,7 +13,7 @@ test.use({
 });
 
 test.describe('Notebook Editor Configuration', {
-	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
 }, () => {
 
 	test.afterEach(async function ({ hotKeys }) {

--- a/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
+++ b/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
@@ -21,7 +21,7 @@ test.describe('Notebook Editor Configuration', {
 	});
 
 	test('Verify default editor is VS Code notebook', async function ({ app, settings }) {
-		const { notebooks } = app.workbench;
+		const { notebooks, notebooksVscode } = app.workbench;
 
 		// Set default editor to VS Code notebook
 		await settings.set({
@@ -30,11 +30,11 @@ test.describe('Notebook Editor Configuration', {
 
 		// Open the notebook file and verify it opens as a VS Code notebook
 		await notebooks.openNotebook(NOTEBOOK_PATH, false);
-		await notebooks.expectNotebookTypeToBe('vscode');
+		await notebooksVscode.expectToBeVisible();
 	});
 
 	test('Verify setting `positron.notebooks.defaultEditor` to `positron` opens positron notebook', async function ({ app, settings }) {
-		const { notebooks } = app.workbench;
+		const { notebooks, notebooksPositron } = app.workbench;
 
 		// Set default editor to Positron notebook
 		await settings.set({
@@ -43,11 +43,11 @@ test.describe('Notebook Editor Configuration', {
 
 		// Open the notebook file and verify it opens as a Positron notebook
 		await notebooks.openNotebook(NOTEBOOK_PATH, false);
-		await notebooks.expectNotebookTypeToBe('positron');
+		await notebooksPositron.expectToBeVisible();
 	});
 
 	test('Verify reverting to default setting opens VS Code notebook again', async function ({ app, hotKeys, settings }) {
-		const { notebooks } = app.workbench;
+		const { notebooks, notebooksVscode, notebooksPositron } = app.workbench;
 
 		// First, set default editor to Positron notebook
 		await settings.set({
@@ -56,7 +56,7 @@ test.describe('Notebook Editor Configuration', {
 
 		// Open the notebook file and verify it opens as a Positron notebook
 		await notebooks.openNotebook(NOTEBOOK_PATH, false);
-		await notebooks.expectNotebookTypeToBe('positron');
+		await notebooksPositron.expectToBeVisible();
 
 		// Revert default editor to VS Code notebook
 		await hotKeys.closeAllEditors();
@@ -66,7 +66,7 @@ test.describe('Notebook Editor Configuration', {
 
 		// Open notebook again and verify it opens as a VS Code notebook
 		await notebooks.openNotebook(NOTEBOOK_PATH, false);
-		await notebooks.expectNotebookTypeToBe('vscode');
+		await notebooksVscode.expectToBeVisible();
 	});
 });
 

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -15,8 +15,8 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () =
 
 	test('Python - Matplotlib Interact Test', {
 		tag: [tags.CRITICAL, tags.WEB, tags.WIN],
-	}, async function ({ app, runCommand, hotKeys, python }) {
-		const { notebooks, quickaccess } = app.workbench;
+	}, async function ({ app, hotKeys, python }) {
+		const { notebooks: notebooks, quickaccess } = app.workbench;
 
 		// open the Matplotlib Interact notebook and run all cells
 		await quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'matplotlib', 'interact.ipynb'));

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -16,7 +16,7 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () =
 	test('Python - Matplotlib Interact Test', {
 		tag: [tags.CRITICAL, tags.WEB, tags.WIN],
 	}, async function ({ app, hotKeys, python }) {
-		const { notebooks: notebooks, quickaccess } = app.workbench;
+		const { notebooks, quickaccess } = app.workbench;
 
 		// open the Matplotlib Interact notebook and run all cells
 		await quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'matplotlib', 'interact.ipynb'));


### PR DESCRIPTION
### Summary
* Skipping the positron notebook test on web 
* Added PositronNotebooks POM for future use
* Small cleanup of test

### QA Notes

@:notebooks
