### PR TITLE
assistant: export chat log to file (request, response, tool call input/output)

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -120,6 +120,12 @@
     },
     "commands": [
       {
+        "command": "positron-assistant.exportChatToFile",
+        "title": "%commands.exportChatToFile.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && config.positron.assistant.exportChatLogs.enable"
+      },
+      {
         "command": "positron-assistant.configureModels",
         "title": "%commands.configureModels.title%",
         "category": "%commands.category%",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -123,7 +123,7 @@
         "command": "positron-assistant.exportChatToFileInWorkspace",
         "title": "%commands.exportChatToFileInWorkspace.title%",
         "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable"
+        "enablement": "config.positron.assistant.enable && workspaceFolderCount != 0"
       },
       {
         "command": "positron-assistant.exportChatTo",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -123,7 +123,13 @@
         "command": "positron-assistant.exportChatToFileInWorkspace",
         "title": "%commands.exportChatToFileInWorkspace.title%",
         "category": "%commands.category%",
-        "enablement": "config.positron.assistant.enable && config.positron.assistant.exportChatLogs.enable"
+        "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.exportChatTo",
+        "title": "%commands.exportChatTo.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
       },
       {
         "command": "positron-assistant.configureModels",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -120,8 +120,8 @@
     },
     "commands": [
       {
-        "command": "positron-assistant.exportChatToFile",
-        "title": "%commands.exportChatToFile.title%",
+        "command": "positron-assistant.exportChatToFileInWorkspace",
+        "title": "%commands.exportChatToFileInWorkspace.title%",
         "category": "%commands.category%",
         "enablement": "config.positron.assistant.enable && config.positron.assistant.exportChatLogs.enable"
       },

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -169,6 +169,11 @@
             "markdownDescription": "%configuration.enable.markdownDescription%",
             "tags": ["preview"]
           },
+          "positron.assistant.toolDetails.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.toolDetails.enable%"
+          },
           "positron.assistant.useAnthropicSdk": {
             "type": "boolean",
             "default": true,

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -1,6 +1,7 @@
 {
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
+	"commands.exportChatToFile.title": "Export the current chat to a file",
 	"commands.configureModels.title": "Configure Language Model Providers",
 	"commands.logStoredModels.title": "Log the stored language models",
 	"commands.generateCommitMessage.title": "Generate Commit Message",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -17,6 +17,7 @@
 	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document.",
 	"configuration.title": "Positron Assistant",
 	"configuration.enable.markdownDescription": "Enable [Positron Assistant](https://positron.posit.co/assistant), an AI assistant for Positron.",
+	"configuration.toolDetails.enable": "Enable tool call input and output details in the chat view. Must be enabled to include tool call details in the chat export.",
 	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -1,7 +1,7 @@
 {
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
-	"commands.exportChatToFile.title": "Export the current chat to a file",
+	"commands.exportChatToFileInWorkspace.title": "Export the current chat to a file in the workspace",
 	"commands.configureModels.title": "Configure Language Model Providers",
 	"commands.logStoredModels.title": "Log the stored language models",
 	"commands.generateCommitMessage.title": "Generate Commit Message",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -2,6 +2,7 @@
 	"displayName": "Positron Assistant",
 	"description": "Provides default assistant and language models for Positron.",
 	"commands.exportChatToFileInWorkspace.title": "Export the current chat to a file in the workspace",
+	"commands.exportChatTo.title": "Export the current chat to...",
 	"commands.configureModels.title": "Configure Language Model Providers",
 	"commands.logStoredModels.title": "Log the stored language models",
 	"commands.generateCommitMessage.title": "Generate Commit Message",

--- a/extensions/positron-assistant/src/export.ts
+++ b/extensions/positron-assistant/src/export.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
+function getDefaultChatLogFileName(): string {
+	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+	return `positron-chat-export-${timestamp}.json`;
+}
+
+async function writeChatFile(fileUri: vscode.Uri): Promise<void> {
+	const chatJson = await positron.ai.getChatExport();
+	const fileBuffer = Buffer.from(JSON.stringify(chatJson, null, 2));
+	await vscode.workspace.fs.writeFile(fileUri, fileBuffer);
+}
+
+async function showExportNotification(fileUri: vscode.Uri): Promise<void> {
+	const chatExportedMessage = vscode.l10n.t('Chat log exported to: {0}', fileUri.path);
+	const openFileButtonText = vscode.l10n.t('Open chat log');
+	const selection = await vscode.window.showInformationMessage(
+		chatExportedMessage,
+		openFileButtonText
+	);
+	if (selection === openFileButtonText) {
+		await vscode.window.showTextDocument(fileUri);
+	}
+}
+
+/**
+ * Exports the currently focused chat conversation to a file in the workspace.
+ */
+export async function exportChatToFileInWorkspace(): Promise<void> {
+	const fileName = getDefaultChatLogFileName();
+	const fileUri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders?.[0].uri || vscode.Uri.file('.'), fileName);
+	await writeChatFile(fileUri);
+	await showExportNotification(fileUri);
+}
+
+/**
+ * Exports the currently focused chat conversation to a user-selected file.
+ * Prompts the user for a file name and location to save the chat log.
+ */
+export async function exportChatToUserSpecifiedLocation(): Promise<void> {
+	// Ask the user for the file name and location to export the chat log.
+	const fileName = await vscode.window.showInputBox({
+		prompt: vscode.l10n.t('Enter the file name to export the chat log to'),
+		value: getDefaultChatLogFileName(),
+	});
+	if (!fileName) {
+		return; // User cancelled the input.
+	}
+	const fileUri = await vscode.window.showSaveDialog({
+		defaultUri: vscode.Uri.file(fileName),
+		filters: {
+			'JSON files': ['json']
+		},
+	});
+	if (!fileUri) {
+		return; // User cancelled the save dialog.
+	}
+
+	// Write the file and show a notification when done.
+	await writeChatFile(fileUri);
+	await showExportNotification(fileUri);
+}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,6 +16,7 @@ import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js
 import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
 import { TokenTracker } from './tokens.js';
+import { exportChatToFile } from './utils.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -219,6 +220,14 @@ function registerGenerateCommitMessageCommand(context: vscode.ExtensionContext) 
 	);
 }
 
+function registerExportChatToFileCommand(context: vscode.ExtensionContext) {
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron-assistant.exportChatToFile', async () => {
+			await exportChatToFile();
+		})
+	);
+}
+
 function registerAssistant(context: vscode.ExtensionContext) {
 
 	// Initialize secret storage. In web mode, we currently need to use global
@@ -242,6 +251,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// Commands
 	registerConfigureModelsCommand(context, storage);
 	registerGenerateCommitMessageCommand(context);
+	registerExportChatToFileCommand(context);
 
 	// Register mapped edits provider
 	registerMappedEditsProvider(context, participantService, log);

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,7 +16,7 @@ import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js
 import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
 import { TokenTracker } from './tokens.js';
-import { exportChatToFileInWorkspace } from './utils.js';
+import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -226,7 +226,11 @@ function registerExportChatCommands(context: vscode.ExtensionContext) {
 			await exportChatToFileInWorkspace();
 		})
 	);
-	// TODO register command to select a location to export the chat to
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron-assistant.exportChatTo', async () => {
+			await exportChatToUserSpecifiedLocation();
+		})
+	);
 }
 
 function registerAssistant(context: vscode.ExtensionContext) {

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,7 +16,7 @@ import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js
 import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
 import { TokenTracker } from './tokens.js';
-import { exportChatToFile } from './utils.js';
+import { exportChatToFileInWorkspace } from './utils.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -220,12 +220,13 @@ function registerGenerateCommitMessageCommand(context: vscode.ExtensionContext) 
 	);
 }
 
-function registerExportChatToFileCommand(context: vscode.ExtensionContext) {
+function registerExportChatCommands(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.exportChatToFile', async () => {
-			await exportChatToFile();
+		vscode.commands.registerCommand('positron-assistant.exportChatToFileInWorkspace', async () => {
+			await exportChatToFileInWorkspace();
 		})
 	);
+	// TODO register command to select a location to export the chat to
 }
 
 function registerAssistant(context: vscode.ExtensionContext) {
@@ -251,7 +252,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// Commands
 	registerConfigureModelsCommand(context, storage);
 	registerGenerateCommitMessageCommand(context);
-	registerExportChatToFileCommand(context);
+	registerExportChatCommands(context);
 
 	// Register mapped edits provider
 	registerMappedEditsProvider(context, participantService, log);

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -197,7 +197,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 		// Get the IDE context for the request.
 		const positronContext = await positron.ai.getPositronChatContext(request);
-		log.trace(`[context] Positron context for request ${request.id}:\n${JSON.stringify(positronContext, null, 2)}`);
+		log.debug(`[context] Positron context for request ${request.id}:\n${JSON.stringify(positronContext, null, 2)}`);
 
 		// List of tools for use by the language model.
 		const tools: vscode.LanguageModelChatTool[] = vscode.lm.tools.filter(
@@ -259,7 +259,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		);
 
-		log.trace(`[tools] Available tools for participant ${this.id}:\n${tools.map((tool, i) => `${i + 1}. ${tool.name}`).join('\n')}`);
+		log.debug(`[tools] Available tools for participant ${this.id}:\n${tools.map((tool, i) => `${i + 1}. ${tool.name}`).join('\n')}`);
 
 		// Construct the transient message thread sent to the language model.
 		// Note that this is not the same as the chat history shown in the UI.
@@ -605,12 +605,14 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					break;
 				}
 
+				log.debug(`[tool] Invoking tool ${req.name} with input: ${JSON.stringify(req.input, null, 2)}`);
 				const result = await vscode.lm.invokeTool(req.name, {
 					input: req.input,
 					toolInvocationToken: request.toolInvocationToken,
 					model: request.model,
 					chatRequestId: request.id,
 				}, token);
+				log.debug(`[tool] Tool ${req.name} returned result: ${JSON.stringify(result.content, null, 2)}`);
 				toolResponses[req.callId] = result;
 			}
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -197,6 +197,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 		// Get the IDE context for the request.
 		const positronContext = await positron.ai.getPositronChatContext(request);
+		log.trace(`[context] Positron context for request ${request.id}:\n${JSON.stringify(positronContext, null, 2)}`);
 
 		// List of tools for use by the language model.
 		const tools: vscode.LanguageModelChatTool[] = vscode.lm.tools.filter(
@@ -258,7 +259,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			}
 		);
 
-		log.trace(`Available tools for participant ${this.id}:\n${tools.map(t => `- ${t.name}`).join('\n')}`);
+		log.trace(`[tools] Available tools for participant ${this.id}:\n${tools.map((tool, i) => `${i + 1}. ${tool.name}`).join('\n')}`);
 
 		// Construct the transient message thread sent to the language model.
 		// Note that this is not the same as the chat history shown in the UI.

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -447,11 +447,23 @@ export function languageModelCacheBreakpointPart(): vscode.LanguageModelDataPart
 /**
  * Exports the current chat to a file in the workspace.
  */
-export async function exportChatToFile(): Promise<void> {
+export async function exportChatToFileInWorkspace(): Promise<void> {
+	// Write the chat export to a file in the workspace.
 	const chatJson = await positron.ai.getChatExport();
 	const fileBuffer = Buffer.from(JSON.stringify(chatJson, null, 2));
 	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 	const fileName = `positron-chat-export-${timestamp}.json`;
 	const fileUri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders?.[0].uri || vscode.Uri.file('.'), fileName);
 	await vscode.workspace.fs.writeFile(fileUri, fileBuffer);
+
+	// Show a message to the user with an option to open the file.
+	const chatExportedMessage = vscode.l10n.t('Chat log exported to: {0}', fileName);
+	const openFileButtonText = vscode.l10n.t('Open chat log');
+	const selection = await vscode.window.showInformationMessage(
+		chatExportedMessage,
+		openFileButtonText
+	);
+	if (selection === openFileButtonText) {
+		await vscode.window.showTextDocument(fileUri);
+	}
 }

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -443,27 +443,3 @@ export function languageModelCacheBreakpointPart(): vscode.LanguageModelDataPart
 	// See: https://github.com/microsoft/vscode-copilot-chat/blob/6aeac371813be9037e74395186ec5b5b94089245/src/extension/byok/vscode-node/anthropicMessageConverter.ts#L22
 	return vscode.LanguageModelDataPart.text(LanguageModelCacheBreakpointType.Ephemeral, LanguageModelDataPartMimeType.CacheControl);
 }
-
-/**
- * Exports the current chat to a file in the workspace.
- */
-export async function exportChatToFileInWorkspace(): Promise<void> {
-	// Write the chat export to a file in the workspace.
-	const chatJson = await positron.ai.getChatExport();
-	const fileBuffer = Buffer.from(JSON.stringify(chatJson, null, 2));
-	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-	const fileName = `positron-chat-export-${timestamp}.json`;
-	const fileUri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders?.[0].uri || vscode.Uri.file('.'), fileName);
-	await vscode.workspace.fs.writeFile(fileUri, fileBuffer);
-
-	// Show a message to the user with an option to open the file.
-	const chatExportedMessage = vscode.l10n.t('Chat log exported to: {0}', fileName);
-	const openFileButtonText = vscode.l10n.t('Open chat log');
-	const selection = await vscode.window.showInformationMessage(
-		chatExportedMessage,
-		openFileButtonText
-	);
-	if (selection === openFileButtonText) {
-		await vscode.window.showTextDocument(fileUri);
-	}
-}

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as ai from 'ai';
+import * as positron from 'positron';
 import { LanguageModelCacheBreakpoint, LanguageModelCacheBreakpointType, LanguageModelDataPartMimeType, PositronAssistantToolName } from './types.js';
 import { isLanguageModelImagePart } from './languageModelParts.js';
 import { log } from './extension.js';
@@ -441,4 +442,16 @@ export function languageModelCacheBreakpointPart(): vscode.LanguageModelDataPart
 	// or Positron Assistant can set cache breakpoints with the same schema.
 	// See: https://github.com/microsoft/vscode-copilot-chat/blob/6aeac371813be9037e74395186ec5b5b94089245/src/extension/byok/vscode-node/anthropicMessageConverter.ts#L22
 	return vscode.LanguageModelDataPart.text(LanguageModelCacheBreakpointType.Ephemeral, LanguageModelDataPartMimeType.CacheControl);
+}
+
+/**
+ * Exports the current chat to a file in the workspace.
+ */
+export async function exportChatToFile(): Promise<void> {
+	const chatJson = await positron.ai.getChatExport();
+	const fileBuffer = Buffer.from(JSON.stringify(chatJson, null, 2));
+	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+	const fileName = `positron-chat-export-${timestamp}.json`;
+	const fileUri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders?.[0].uri || vscode.Uri.file('.'), fileName);
+	await vscode.workspace.fs.writeFile(fileUri, fileBuffer);
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2065,6 +2065,11 @@ declare module 'positron' {
 		export function getSupportedProviders(): Thenable<string[]>;
 
 		/**
+		 * Get the chat export as a JSON object (IExportableChatData).
+		 */
+		export function getChatExport(): Thenable<object | undefined>;
+
+		/**
 		 * Show a modal dialog for language model configuration.
 		 */
 		export function showLanguageModelConfig(

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js'
 import { revive } from '../../../../base/common/marshalling.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IChatAgentData, IChatAgentService } from '../../../contrib/chat/common/chatAgents.js';
-import { ChatModel } from '../../../contrib/chat/common/chatModel.js';
+import { ChatModel, IExportableChatData } from '../../../contrib/chat/common/chatModel.js';
 import { IChatProgress, IChatService } from '../../../contrib/chat/common/chatService.js';
 import { IChatRequestData, IPositronAssistantService, IPositronChatContext, IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
@@ -96,6 +96,13 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	 */
 	async $getSupportedProviders(): Promise<string[]> {
 		return this._positronAssistantService.getSupportedProviders();
+	}
+
+	/**
+	 * Get the chat export as a JSON object (IExportableChatData).
+	 */
+	async $getChatExport(): Promise<IExportableChatData | undefined> {
+		return this._positronAssistantService.getChatExport();
 	}
 
 	$addLanguageModelConfig(source: IPositronLanguageModelSource): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -281,6 +281,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			getSupportedProviders(): Thenable<string[]> {
 				return extHostAiFeatures.getSupportedProviders();
 			},
+			getChatExport(): Thenable<object | undefined> {
+				return extHostAiFeatures.getChatExport();
+			},
 			addLanguageModelConfig(source: IPositronLanguageModelSource): void {
 				return extHostAiFeatures.addLanguageModelConfig(source);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -153,6 +153,7 @@ export interface MainThreadAiFeaturesShape {
 	$responseProgress(sessionId: string, dto: IChatProgressDto): void;
 	$languageModelConfig(id: string, sources: IPositronLanguageModelSource[]): Thenable<void>;
 	$getSupportedProviders(): Thenable<string[]>;
+	$getChatExport(): Thenable<object | undefined>;
 	$addLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$areCompletionsEnabled(file: UriComponents): Thenable<boolean>;

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -93,6 +93,10 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 		return this._proxy.$getSupportedProviders();
 	}
 
+	async getChatExport(): Promise<object | undefined> {
+		return this._proxy.$getChatExport();
+	}
+
 	addLanguageModelConfig(source: IPositronLanguageModelSource): void {
 		this._proxy.$addLanguageModelConfig(source);
 	}

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -362,11 +362,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	private ensureToolDetails(dto: IToolInvocation, toolResult: IToolResult, toolData: IToolData): void {
 		// --- Start Positron ---
-		const isExportChatLogsEnabled = this._configurationService.getValue<boolean>('positron.assistant.exportChatLogs.enable');
+		const areToolDetailsEnabled = this._configurationService.getValue<boolean>('positron.assistant.toolDetails.enable');
 		/*
 		if (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput) {
 		*/
-		if (isExportChatLogsEnabled || (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput)) {
+		if (areToolDetailsEnabled || (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput)) {
 			// --- End Positron ---
 			toolResult.toolResultDetails = {
 				input: this.formatToolInput(dto),

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -362,11 +362,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	private ensureToolDetails(dto: IToolInvocation, toolResult: IToolResult, toolData: IToolData): void {
 		// --- Start Positron ---
-		const isVerboseChatLogsEnabled = this._configurationService.getValue<boolean>('positron.assistant.verboseChatLogs.enable');
+		const isExportChatLogsEnabled = this._configurationService.getValue<boolean>('positron.assistant.exportChatLogs.enable');
 		/*
 		if (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput) {
 		*/
-		if (isVerboseChatLogsEnabled || (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput)) {
+		if (isExportChatLogsEnabled || (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput)) {
 			// --- End Positron ---
 			toolResult.toolResultDetails = {
 				input: this.formatToolInput(dto),

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -361,7 +361,13 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	private ensureToolDetails(dto: IToolInvocation, toolResult: IToolResult, toolData: IToolData): void {
+		// --- Start Positron ---
+		const isVerboseChatLogsEnabled = this._configurationService.getValue<boolean>('positron.assistant.verboseChatLogs.enable');
+		/*
 		if (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput) {
+		*/
+		if (isVerboseChatLogsEnabled || (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput)) {
+			// --- End Positron ---
 			toolResult.toolResultDetails = {
 				input: this.formatToolInput(dto),
 				output: this.toolResultToIO(toolResult),

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -22,6 +22,8 @@ import { IPositronModalDialogsService } from '../../../services/positronModalDia
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as glob from '../../../../base/common/glob.js';
+import { IChatService } from '../../chat/common/chatService.js';
+import { IChatWidgetService } from '../../chat/browser/chat.js';
 
 /**
  * PositronAssistantService class.
@@ -48,6 +50,8 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		@IExecutionHistoryService private readonly _historyService: IExecutionHistoryService,
 		@IPositronModalDialogsService private readonly _positronModalDialogsService: IPositronModalDialogsService,
 		@IProductService protected readonly _productService: IProductService,
+		@IChatService private readonly _chatService: IChatService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 	) {
 		super();
 	}
@@ -245,6 +249,20 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 			providers.push('bedrock', 'error', 'echo', 'google');
 		}
 		return providers;
+	}
+
+	getChatExport() {
+		const chatWidget = this._chatWidgetService.lastFocusedWidget;
+		if (!chatWidget || !chatWidget.viewModel) {
+			return undefined;
+		}
+
+		const model = this._chatService.getSession(chatWidget.viewModel.sessionId);
+		if (!model) {
+			return undefined;
+		}
+
+		return model.toExport();
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -9,6 +9,7 @@ import { ChatAgentLocation } from '../../../chat/common/constants.js';
 import { Variable } from '../../../../services/languageRuntime/common/positronVariablesComm.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IExportableChatData } from '../../../chat/common/chatModel.js';
 
 // Create the decorator for the Positron assistant service (used in dependency injection).
 export const IPositronAssistantService = createDecorator<IPositronAssistantService>('positronAssistantService');
@@ -121,6 +122,11 @@ export interface IPositronAssistantService {
 	 * Get the supported providers for Positron Assistant.
 	 */
 	getSupportedProviders(): string[];
+
+	/**
+	 * Get the chat export as a JSON object (IExportableChatData).
+	 */
+	getChatExport(): IExportableChatData | undefined;
 
 	/**
 	 * Add a language model configuration.


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8033
- system prompts and session context will be addressed separately https://github.com/posit-dev/positron/issues/8429
- leverages the handling for existing command `Chat: Export Chat...` to include the tool call info and log directly to a new file in the workspace; also enables file picker flow
- once the chat log is exported, a notification is shown with the log file path and a button to open the file
    - <img width="400" alt="image" src="https://github.com/user-attachments/assets/af21939a-6f3b-47d9-b3ab-c8e879cab651" />


<details><summary>Sample Log Output</summary>

<img width="541" alt="image" src="https://github.com/user-attachments/assets/e48f8626-5d46-4a73-b114-2dd990892a3a" />

File: `positron-chat-export-2025-07-07T21-52-49-484Z.json`

```json
{
  "requesterUsername": "",
  "responderUsername": "Positron Assistant",
  "responderAvatarIconUri": {
    "id": "positron-assistant"
  },
  "initialLocation": "panel",
  "requests": [
    {
      "requestId": "request_8eac55c1-dd42-4a30-9b98-44e21553e940",
      "message": {
        "parts": [
          {
            "range": {
              "start": 0,
              "endExclusive": 53
            },
            "editorRange": {
              "startLineNumber": 1,
              "startColumn": 1,
              "endLineNumber": 1,
              "endColumn": 54
            },
            "text": "are there any penguins-related files in this project?",
            "kind": "text"
          }
        ],
        "text": "are there any penguins-related files in this project?"
      },
      "variableData": {
        "variables": []
      },
      "response": [
        {
          "kind": "toolInvocationSerialized",
          "invocationMessage": "Constructing project tree",
          "pastTenseMessage": "Constructed project tree",
          "isConfirmed": true,
          "isComplete": true,
          "resultDetails": {
            "input": "{}",
            "output": [
              {
                "type": "text",
                "value": "{\"folder\":{\"uri\":{\"$mid\":1,\"fsPath\":\"/Users/sashimi/qa-example-content\",\"external\":\"file:///Users/sashimi/qa-example-content\",\"path\":\"/Users/sashimi/qa-example-content\",\"scheme\":\"file\"},\"name\":\"qa-example-content\",\"index\":0},\"items\":[\"qa-example-content\",[\".gitattributes\",\".gitignore\",\".Rprofile\",[\"data-files\",[[\"100x100\",[\"100x100_broken.parquet\",\"100x100.parquet\",\"pandas-100x100.tsv\",\"polars-100x100.tsv\",\"r-100x100-linux.tsv\",\"r-100x100.tsv\"]],[\"20x1000\",[\"parquet1kx20.parquet\"]],[\"chinook\",[\"chinook.db\",\"LICENSE.md\"]],[\"data_explorer\",[\"data_columns.csv\"]],[\"flights\",[\"flights_piped.csv\",\"flights.csv\",\"flights.csv.gz\",\"flights.parquet\",\"flights.tsv\",\"flights.tsv.gz\"]],[\"misc-parquet\",[\"decimal_types.parquet\"]],\"README.md\",\"small_file.csv\",[\"spotify_data\",[\"data.csv\"]],[\"supermarkt_sales\",[\"LICENSE.md\",\"supermarkt_sales.xlsx\"]]]],\"DESCRIPTION\",\"positron-chat-export-2025-07-07T21-51-28-827Z.json\",\"README.md\",\"requirements.txt\",[\"static-test-data-files\",[\"lineCount.txt\"]],[\"utilities\",[[\"parquet-maker\",[\".gitignore\",\"Cargo.lock\",\"Cargo.toml\",[\"src\",[\"main.rs\"]]]],\"README.md\"]],[\"workspaces\",[[\"ai\",[\"chatlas_example.py\",\"generate_swift_chatlas.py\",\"test_account.py\"]],[\"basic-rmd-file\",[\"basicRmd.rmd\"]],[\"bitmap-notebook\",[\"bitmap-notebook.ipynb\",\"sample1.bmp\"]],[\"bokeh-samples\",[\"README.md\"]],[\"chinook-db-py\",[\"chinook-sqlite.py\"]],[\"chinook-db-r\",[\"chinook-sqlite.r\"]],[\"dash-py-example\",[\".gitignore\",\"app.py\",[\"assets\",[\"dash-logo.png\",\"resizing_script.js\",\"s1.css\",\"styles.css\"]],\"controls.py\",[\"data\",[\"dash-logo copy.png\",\"OilandGasMetadata.html\"]],\"LICENSE\",\"Procfile\",\"README.md\",\"requirements.txt\"]],[\"data-explorer-update-datasets\",[\"pandas-update-dataframe.ipynb\"]],[\"diagrammeR-sample\",[\"diagrammeR-sample.r\"]],[\"fast-statement-execution\",[\"fast-execution.r\"]],[\"generate-data-frames-py\",[\"generate-data-frames.py\",\"simple-data-frames.py\"]],[\"generate-data-frames-r\",[\"generate-data-frames.r\",\"simple-data-frames.r\"]],[\"graphviz\",[\"example.dot\",\"pydotSample.py\"]],[\"hvplot-sample\",[\"hvplot-sample.py\"]],[\"large_py_notebook\",[\"README.md\",\"spotify_hvplot.ipynb\",\"spotify_matplotlib.ipynb\",\"spotify.ipynb\"]],[\"large_r_notebook\",[\"duplicate_plotly.ipynb\",\"spotify.ipynb\"]],[\"long-running-loop\",[\"loop.py\",\"loop.r\"]],[\"matplotlib\",[\"interact.ipynb\"]],[\"nyc-flights-data-py\",[\"flights-33million.py\",\"flights-data-frame.py\"]],[\"nyc-flights-data-r\",[\"flights-data-frame.r\"]],[\"outline\",[\"basic-outline-with-vars.py\",\"basic-outline-with-vars.r\"]],[\"performance\",[\"loadBigParquet.py\",\"loadBigParquet.r\",\"multiplyParquet.py\",\"multiplyParquet.r\",\"plotPerformance.py\"]],[\"polars-dataframe-py\",[\"polars_basic.py\"]],[\"python_apps\",[[\"dash_example\",[\"dash_example.py\"]],[\"fastapi_example\",[\"fastapi_example.py\"]],[\"flask_example\",[\"__init__.py\",\"auth.py\",[\"static\",[\"style.css\"]],[\"templates\",[[\"auth\",[\"login.html\",\"register.html\"]],\"base.html\",[\"blog\",[\"index.html\"]]]]]],[\"gradio_example\",[\"gradio_example.py\"]],[\"streamlit_example\",[\"streamlit_example.py\"]]]],[\"python_module_caching\",[\"app.py\",[\"helper\",[\"__init__.py\",\"helper_functions.py\"]]]],[\"python-plots-widgets-notebook\",[\"plots-widgets-notebook.ipynb\"]],[\"python-plots\",[\"altair-plots.py\",\"plotly-example.py\"]],[\"python-widgets\",[\"bqplot-example.py\",\"ipydatagrid-example.py\",\"ipyleaflet-example.py\",\"ipympl-example.py\",\"ipytree,py-example\",\"ipywidgets-example.py\",\"leafmap-example.py\",\"matplotlib-example.py\"]],[\"quarto_basic\",[\"quarto_basic.qmd\"]],[\"quarto_interactive\",[[\"images\",[\"penguins.png\"]],\"penguins.csv\",\"quarto_interactive.qmd\"]],[\"quarto_python\",[\"report.qmd\"]],[\"quarto_shiny\",[\"mini-app.qmd\"]],[\"r_notebooks\",[\"Introduction+to+R.ipynb\"]],[\"r_testing\",[\".gitignore\",\".Rbuildignore\",\".Rprofile\",\"DESCRIPTION\",[\"man\",[\"addition.Rd\"]],\"NAMESPACE\",[\"R\",[\"apple.R\",\"mathstuff.R\"]],\"testfun.Rproj\",[\"tests\",[\"testthat.R\",[\"testthat\",[\"test-apple-wtf.R\",\"test-banana.R\",\"test-cherry.R\",\"test-durian.R\",\"test-mathstuff.R\"]]]]]],[\"r-debugging\",[\"fruit_avg_browser.r\",\"fruit_avg.r\"]],[\"r-formatting\",[\"bad-formatting.r\"]],[\"r-plots\",[\"corrr-example.r\",\"ggplot-example.R\",\"highcharter-example.r\",\"leaflet-example.r\",\"plotly-example.r\"]],[\"read-xlsx-py\",[\"supermarket-sales.py\"]],[\"read-xlsx-r\",[\"supermarket-sales.r\"]],\"README.md\",[\"references_tests\",[[\"python\",[\"another_script.py\",\"helper.py\",\"main.py\"]],[\"r\",[\"another_script.R\",\"helper.R\",\"main.R\"]]]],[\"search-tests\",[\"search-matches.js\",\"search-matches.txt\"]],[\"shiny-py-example\",[\"app.py\",\"README.md\",\"requirements.txt\",\"shared.py\",\"styles.css\",\"tips.csv\"]],[\"shiny-r-example\",[\"app.R\",\"gen_table.R\",\"gen_word.R\",[\"images\",[\"00.png\",\"01.png\",\"010.png\",\"02.png\",\"03.png\",\"04.png\",\"05.png\",\"06.png\",\"07.png\",\"08.png\",\"09.png\"]],\"most-common-nouns-english.csv\",\"README.md\"]],[\"sparklines\",[\"sparklines.r\"]],[\"streamlit-py-example\",[\"LICENSE\",\"README.md\",\"requirements.txt\",\"streamlit_app.py\"]],[\"visual-mode\",[\"visual-mode.md\",\"visual-mode.qmd\",\"visual-mode.rmd\"]]]]]],\"totalFiles\":183}"
              }
            ]
          },
          "toolCallId": "c2ef16e1-b196-4cd5-a4cd-53539f75bfb6",
          "toolId": "getProjectTree"
        },
        {
          "kind": "toolInvocationSerialized",
          "invocationMessage": "Searching for text in project",
          "pastTenseMessage": "Searched for text in project",
          "isConfirmed": true,
          "isComplete": true,
          "resultDetails": {
            "input": "{\n  \"pattern\": \"penguins\",\n  \"isCaseSensitive\": false,\n  \"isRegExp\": false,\n  \"isWordMatch\": false\n}",
            "output": [
              {
                "type": "text",
                "value": "{\"results\":[{\"resource\":{\"$mid\":1,\"external\":\"file:///Users/sashimi/qa-example-content/DESCRIPTION\",\"path\":\"/Users/sashimi/qa-example-content/DESCRIPTION\",\"scheme\":\"file\"},\"results\":[{\"previewText\":\"    palmerpenguins,\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":10,\"endLineNumber\":0,\"endColumn\":18},\"source\":{\"startLineNumber\":22,\"startColumn\":10,\"endLineNumber\":22,\"endColumn\":18}}]}]},{\"resource\":{\"$mid\":1,\"external\":\"file:///Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd\",\"path\":\"/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd\",\"scheme\":\"file\"},\"results\":[{\"previewText\":\"title: \\\"Palmer Penguins\\\"\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":15,\"endLineNumber\":0,\"endColumn\":23},\"source\":{\"startLineNumber\":1,\"startColumn\":15,\"endLineNumber\":1,\"endColumn\":23}}]},{\"previewText\":\"data = FileAttachment(\\\"penguins.csv\\\")\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":23,\"endLineNumber\":0,\"endColumn\":31},\"source\":{\"startLineNumber\":9,\"startColumn\":23,\"endLineNumber\":9,\"endColumn\":31}}]},{\"previewText\":\"![](images/penguins.png){width=\\\"80%\\\"}\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":11,\"endLineNumber\":0,\"endColumn\":19},\"source\":{\"startLineNumber\":20,\"startColumn\":11,\"endLineNumber\":20,\"endColumn\":19}}]}]},{\"resource\":{\"$mid\":1,\"external\":\"file:///Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json\",\"path\":\"/Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json\",\"scheme\":\"file\"},\"results\":[{\"previewText\":\"                \\\"value\\\": \\\"{\\\\\\\"folder\\\\\\\":{\\\\\\\"uri\\\\\\\":{\\\\\\\"$mid\\\\\\\":1,\\\\\\\"fsPath\\\\\\\":\\\\\\\"/Users/sashimi/qa-example-content\\\\\\\",\\\\\\\"external\\\\\\\":\\\\\\\"file:///Users/sashimi/qa-example-content\\\\\\\",\\\\\\\"path\\\\\\\":\\\\\\\"/Users/sashimi/qa-example-content\\\\\\\",\\\\\\\"scheme\\\\\\\":\\\\\\\"file\\\\\\\"},\\\\\\\"name\\\\\\\":\\\\\\\"qa-example-content\\\\\\\",\\\\\\\"index\\\\\\\":0},\\\\\\\"items\\\\\\\":[\\\\\\\"qa-example-content\\\\\\\",[\\\\\\\".gitattributes\\\\\\\",\\\\\\\".gitignore\\\\\\\",\\\\\\\".Rprofile\\\\\\\",[\\\\\\\"data-files\\\\\\\",[[\\\\\\\"100x100\\\\\\\",[\\\\\\\"100x100_broken.parquet\\\\\\\",\\\\\\\"100x100.parquet\\\\\\\",\\\\\\\"pandas-100x100.tsv\\\\\\\",\\\\\\\"polars-100x100.tsv\\\\\\\",\\\\\\\"r-100x100-linux.tsv\\\\\\\",\\\\\\\"r-100x100.tsv\\\\\\\"]],[\\\\\\\"20x1000\\\\\\\",[\\\\\\\"parquet1kx20.parquet\\\\\\\"]],[\\\\\\\"chinook\\\\\\\",[\\\\\\\"chinook.db\\\\\\\",\\\\\\\"LICENSE.md\\\\\\\"]],[\\\\\\\"data_explorer\\\\\\\",[\\\\\\\"data_columns.csv\\\\\\\"]],[\\\\\\\"flights\\\\\\\",[\\\\\\\"flights_piped.csv\\\\\\\",\\\\\\\"flights.csv\\\\\\\",\\\\\\\"flights.csv.gz\\\\\\\",\\\\\\\"flights.parquet\\\\\\\",\\\\\\\"flights.tsv\\\\\\\",\\\\\\\"flights.tsv.gz\\\\\\\"]],[\\\\\\\"misc-parquet\\\\\\\",[\\\\\\\"decimal_types.parquet\\\\\\\"]],\\\\\\\"README.md\\\\\\\",\\\\\\\"small_file.csv\\\\\\\",[\\\\\\\"spotify_data\\\\\\\",[\\\\\\\"data.csv\\\\\\\"]],[\\\\\\\"supermarkt_sales\\\\\\\",[\\\\\\\"LICENSE.md\\\\\\\",\\\\\\\"supermarkt_sales.xlsx\\\\\\\"]]]],\\\\\\\"DESCRIPTION\\\\\\\",\\\\\\\"README.md\\\\\\\",\\\\\\\"requirements.txt\\\\\\\",[\\\\\\\"static-test-data-files\\\\\\\",[\\\\\\\"lineCount.txt\\\\\\\"]],[\\\\\\\"utilities\\\\\\\",[[\\\\\\\"parquet-maker\\\\\\\",[\\\\\\\".gitignore\\\\\\\",\\\\\\\"Cargo.lock\\\\\\\",\\\\\\\"Cargo.toml\\\\\\\",[\\\\\\\"src\\\\\\\",[\\\\\\\"main.rs\\\\\\\"]]]],\\\\\\\"README.md\\\\\\\"]],[\\\\\\\"workspaces\\\\\\\",[[\\\\\\\"ai\\\\\\\",[\\\\\\\"chatlas_example.py\\\\\\\",\\\\\\\"generate_swift_chatlas.py\\\\\\\",\\\\\\\"test_account.py\\\\\\\"]],[\\\\\\\"basic-rmd-file\\\\\\\",[\\\\\\\"basicRmd.rmd\\\\\\\"]],[\\\\\\\"bitmap-notebook\\\\\\\",[\\\\\\\"bitmap-notebook.ipynb\\\\\\\",\\\\\\\"sample1.bmp\\\\\\\"]],[\\\\\\\"bokeh-samples\\\\\\\",[\\\\\\\"README.md\\\\\\\"]],[\\\\\\\"chinook-db-py\\\\\\\",[\\\\\\\"chinook-sqlite.py\\\\\\\"]],[\\\\\\\"chinook-db-r\\\\\\\",[\\\\\\\"chinook-sqlite.r\\\\\\\"]],[\\\\\\\"dash-py-example\\\\\\\",[\\\\\\\".gitignore\\\\\\\",\\\\\\\"app.py\\\\\\\",[\\\\\\\"assets\\\\\\\",[\\\\\\\"dash-logo.png\\\\\\\",\\\\\\\"resizing_script.js\\\\\\\",\\\\\\\"s1.css\\\\\\\",\\\\\\\"styles.css\\\\\\\"]],\\\\\\\"controls.py\\\\\\\",[\\\\\\\"data\\\\\\\",[\\\\\\\"dash-logo copy.png\\\\\\\",\\\\\\\"OilandGasMetadata.html\\\\\\\"]],\\\\\\\"LICENSE\\\\\\\",\\\\\\\"Procfile\\\\\\\",\\\\\\\"README.md\\\\\\\",\\\\\\\"requirements.txt\\\\\\\"]],[\\\\\\\"data-explorer-update-datasets\\\\\\\",[\\\\\\\"pandas-update-dataframe.ipynb\\\\\\\"]],[\\\\\\\"diagrammeR-sample\\\\\\\",[\\\\\\\"diagrammeR-sample.r\\\\\\\"]],[\\\\\\\"fast-statement-execution\\\\\\\",[\\\\\\\"fast-execution.r\\\\\\\"]],[\\\\\\\"generate-data-frames-py\\\\\\\",[\\\\\\\"generate-data-frames.py\\\\\\\",\\\\\\\"simple-data-frames.py\\\\\\\"]],[\\\\\\\"generate-data-frames-r\\\\\\\",[\\\\\\\"generate-data-frames.r\\\\\\\",\\\\\\\"simple-data-frames.r\\\\\\\"]],[\\\\\\\"graphviz\\\\\\\",[\\\\\\\"example.dot\\\\\\\",\\\\\\\"pydotSample.py\\\\\\\"]],[\\\\\\\"hvplot-sample\\\\\\\",[\\\\\\\"hvplot-sample.py\\\\\\\"]],[\\\\\\\"large_py_notebook\\\\\\\",[\\\\\\\"README.md\\\\\\\",\\\\\\\"spotify_hvplot.ipynb\\\\\\\",\\\\\\\"spotify_matplotlib.ipynb\\\\\\\",\\\\\\\"spotify.ipynb\\\\\\\"]],[\\\\\\\"large_r_notebook\\\\\\\",[\\\\\\\"duplicate_plotly.ipynb\\\\\\\",\\\\\\\"spotify.ipynb\\\\\\\"]],[\\\\\\\"long-running-loop\\\\\\\",[\\\\\\\"loop.py\\\\\\\",\\\\\\\"loop.r\\\\\\\"]],[\\\\\\\"matplotlib\\\\\\\",[\\\\\\\"interact.ipynb\\\\\\\"]],[\\\\\\\"nyc-flights-data-py\\\\\\\",[\\\\\\\"flights-33million.py\\\\\\\",\\\\\\\"flights-data-frame.py\\\\\\\"]],[\\\\\\\"nyc-flights-data-r\\\\\\\",[\\\\\\\"flights-data-frame.r\\\\\\\"]],[\\\\\\\"outline\\\\\\\",[\\\\\\\"basic-outline-with-vars.py\\\\\\\",\\\\\\\"basic-outline-with-vars.r\\\\\\\"]],[\\\\\\\"performance\\\\\\\",[\\\\\\\"loadBigParquet.py\\\\\\\",\\\\\\\"loadBigParquet.r\\\\\\\",\\\\\\\"multiplyParquet.py\\\\\\\",\\\\\\\"multiplyParquet.r\\\\\\\",\\\\\\\"plotPerformance.py\\\\\\\"]],[\\\\\\\"polars-dataframe-py\\\\\\\",[\\\\\\\"polars_basic.py\\\\\\\"]],[\\\\\\\"python_apps\\\\\\\",[[\\\\\\\"dash_example\\\\\\\",[\\\\\\\"dash_example.py\\\\\\\"]],[\\\\\\\"fastapi_example\\\\\\\",[\\\\\\\"fastapi_example.py\\\\\\\"]],[\\\\\\\"flask_example\\\\\\\",[\\\\\\\"__init__.py\\\\\\\",\\\\\\\"auth.py\\\\\\\",[\\\\\\\"static\\\\\\\",[\\\\\\\"style.css\\\\\\\"]],[\\\\\\\"templates\\\\\\\",[[\\\\\\\"auth\\\\\\\",[\\\\\\\"login.html\\\\\\\",\\\\\\\"register.html\\\\\\\"]],\\\\\\\"base.html\\\\\\\",[\\\\\\\"blog\\\\\\\",[\\\\\\\"index.html\\\\\\\"]]]]]],[\\\\\\\"gradio_example\\\\\\\",[\\\\\\\"gradio_example.py\\\\\\\"]],[\\\\\\\"streamlit_example\\\\\\\",[\\\\\\\"streamlit_example.py\\\\\\\"]]]],[\\\\\\\"python_module_caching\\\\\\\",[\\\\\\\"app.py\\\\\\\",[\\\\\\\"helper\\\\\\\",[\\\\\\\"__init__.py\\\\\\\",\\\\\\\"helper_functions.py\\\\\\\"]]]],[\\\\\\\"python-plots-widgets-notebook\\\\\\\",[\\\\\\\"plots-widgets-notebook.ipynb\\\\\\\"]],[\\\\\\\"python-plots\\\\\\\",[\\\\\\\"altair-plots.py\\\\\\\",\\\\\\\"plotly-example.py\\\\\\\"]],[\\\\\\\"python-widgets\\\\\\\",[\\\\\\\"bqplot-example.py\\\\\\\",\\\\\\\"ipydatagrid-example.py\\\\\\\",\\\\\\\"ipyleaflet-example.py\\\\\\\",\\\\\\\"ipympl-example.py\\\\\\\",\\\\\\\"ipytree,py-example\\\\\\\",\\\\\\\"ipywidgets-example.py\\\\\\\",\\\\\\\"leafmap-example.py\\\\\\\",\\\\\\\"matplotlib-example.py\\\\\\\"]],[\\\\\\\"quarto_basic\\\\\\\",[\\\\\\\"quarto_basic.qmd\\\\\\\"]],[\\\\\\\"quarto_interactive\\\\\\\",[[\\\\\\\"images\\\\\\\",[\\\\\\\"penguins.png\\\\\\\"]],\\\\\\\"penguins.csv\\\\\\\",\\\\\\\"quarto_interactive.qmd\\\\\\\"]],[\\\\\\\"quarto_python\\\\\\\",[\\\\\\\"report.qmd\\\\\\\"]],[\\\\\\\"quarto_shiny\\\\\\\",[\\\\\\\"mini-app.qmd\\\\\\\"]],[\\\\\\\"r_notebooks\\\\\\\",[\\\\\\\"Introduction+to+R.ipynb\\\\\\\"]],[\\\\\\\"r_testing\\\\\\\",[\\\\\\\".gitignore\\\\\\\",\\\\\\\".Rbuildignore\\\\\\\",\\\\\\\".Rprofile\\\\\\\",\\\\\\\"DESCRIPTION\\\\\\\",[\\\\\\\"man\\\\\\\",[\\\\\\\"addition.Rd\\\\\\\"]],\\\\\\\"NAMESPACE\\\\\\\",[\\\\\\\"R\\\\\\\",[\\\\\\\"apple.R\\\\\\\",\\\\\\\"mathstuff.R\\\\\\\"]],\\\\\\\"testfun.Rproj\\\\\\\",[\\\\\\\"tests\\\\\\\",[\\\\\\\"testthat.R\\\\\\\",[\\\\\\\"testthat\\\\\\\",[\\\\\\\"test-apple-wtf.R\\\\\\\",\\\\\\\"test-banana.R\\\\\\\",\\\\\\\"test-cherry.R\\\\\\\",\\\\\\\"test-durian.R\\\\\\\",\\\\\\\"test-mathstuff.R\\\\\\\"]]]]]],[\\\\\\\"r-debugging\\\\\\\",[\\\\\\\"fruit_avg_browser.r\\\\\\\",\\\\\\\"fruit_avg.r\\\\\\\"]],[\\\\\\\"r-formatting\\\\\\\",[\\\\\\\"bad-formatting.r\\\\\\\"]],[\\\\\\\"r-plots\\\\\\\",[\\\\\\\"corrr-example.r\\\\\\\",\\\\\\\"ggplot-example.R\\\\\\\",\\\\\\\"highcharter-example.r\\\\\\\",\\\\\\\"leaflet-example.r\\\\\\\",\\\\\\\"plotly-example.r\\\\\\\"]],[\\\\\\\"read-xlsx-py\\\\\\\",[\\\\\\\"supermarket-sales.py\\\\\\\"]],[\\\\\\\"read-xlsx-r\\\\\\\",[\\\\\\\"supermarket-sales.r\\\\\\\"]],\\\\\\\"README.md\\\\\\\",[\\\\\\\"references_tests\\\\\\\",[[\\\\\\\"python\\\\\\\",[\\\\\\\"another_script.py\\\\\\\",\\\\\\\"helper.py\\\\\\\",\\\\\\\"main.py\\\\\\\"]],[\\\\\\\"r\\\\\\\",[\\\\\\\"another_script.R\\\\\\\",\\\\\\\"helper.R\\\\\\\",\\\\\\\"main.R\\\\\\\"]]]],[\\\\\\\"search-tests\\\\\\\",[\\\\\\\"search-matches.js\\\\\\\",\\\\\\\"search-matches.txt\\\\\\\"]],[\\\\\\\"shiny-py-example\\\\\\\",[\\\\\\\"app.py\\\\\\\",\\\\\\\"README.md\\\\\\\",\\\\\\\"requirements.txt\\\\\\\",\\\\\\\"shared.py\\\\\\\",\\\\\\\"styles.css\\\\\\\",\\\\\\\"tips.csv\\\\\\\"]],[\\\\\\\"shiny-r-example\\\\\\\",[\\\\\\\"app.R\\\\\\\",\\\\\\\"gen_table.R\\\\\\\",\\\\\\\"gen_word.R\\\\\\\",[\\\\\\\"images\\\\\\\",[\\\\\\\"00.png\\\\\\\",\\\\\\\"01.png\\\\\\\",\\\\\\\"010.png\\\\\\\",\\\\\\\"02.png\\\\\\\",\\\\\\\"03.png\\\\\\\",\\\\\\\"04.png\\\\\\\",\\\\\\\"05.png\\\\\\\",\\\\\\\"06.png\\\\\\\",\\\\\\\"07.png\\\\\\\",\\\\\\\"08.png\\\\\\\",\\\\\\\"09.png\\\\\\\"]],\\\\\\\"most-common-nouns-english.csv\\\\\\\",\\\\\\\"README.md\\\\\\\"]],[\\\\\\\"sparklines\\\\\\\",[\\\\\\\"sparklines.r\\\\\\\"]],[\\\\\\\"streamlit-py-example\\\\\\\",[\\\\\\\"LICENSE\\\\\\\",\\\\\\\"README.md\\\\\\\",\\\\\\\"requirements.txt\\\\\\\",\\\\\\\"streamlit_app.py\\\\\\\"]],[\\\\\\\"visual-mode\\\\\\\",[\\\\\\\"visual-mode.md\\\\\\\",\\\\\\\"visual-mode.qmd\\\\\\\",\\\\\\\"visual-mode.rmd\\\\\\\"]]]]]],\\\\\\\"totalFiles\\\\\\\":182}\\\"\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":3808,\"endLineNumber\":0,\"endColumn\":3816},\"source\":{\"startLineNumber\":44,\"startColumn\":3808,\"endLineNumber\":44,\"endColumn\":3816}},{\"preview\":{\"startLineNumber\":0,\"startColumn\":3827,\"endLineNumber\":0,\"endColumn\":3835},\"source\":{\"startLineNumber\":44,\"startColumn\":3827,\"endLineNumber\":44,\"endColumn\":3835}}]}]},{\"resource\":{\"$mid\":1,\"external\":\"file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv\",\"path\":\"/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv\",\"scheme\":\"file\"},\"results\":[{\"previewText\":\"0.466,1996,0.865,['The Penguins'],0.524,179427,0.177,0,11XR0tRT4g5ov4u8M92wbF,0.0,8,0.21,-12.306,1,Earth Angel (Will You Be Mine),59,1996-01-01,0.0302,69.125\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":23,\"endLineNumber\":0,\"endColumn\":31},\"source\":{\"startLineNumber\":14859,\"startColumn\":23,\"endLineNumber\":14859,\"endColumn\":31}}]},{\"previewText\":\"0.307,1971,0.994,['Michael Hurley'],0.633,207333,0.016,0,6bGMai7fcmgBAS9AASU15T,0.914,5,0.103,-18.242,1,Penguins,39,1971-09-01,0.0596,70.995\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":104,\"endLineNumber\":0,\"endColumn\":112},\"source\":{\"startLineNumber\":47462,\"startColumn\":104,\"endLineNumber\":47462,\"endColumn\":112}}]},{\"previewText\":\"0.5479999999999999,2000,0.0039,['Millencolin'],0.368,173360,0.977,0,3jRsoe4Vkxa4BMYqGHX8L0,0.0,11,0.35,-2.757,0,Penguins & Polarbears,52,2000-02-22,0.127,165.889\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":112,\"endLineNumber\":0,\"endColumn\":120},\"source\":{\"startLineNumber\":104783,\"startColumn\":112,\"endLineNumber\":104783,\"endColumn\":120}}]},{\"previewText\":\"0.197,2005,0.00136,['Chiodos'],0.424,273507,0.917,0,7ggui6l9tJaUixcqr7pQIK,0.0,7,0.0501,-5.593,1,There's No Penguins In Alaska,41,2005,0.109,101.012\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":108,\"endLineNumber\":0,\"endColumn\":116},\"source\":{\"startLineNumber\":137904,\"startColumn\":108,\"endLineNumber\":137904,\"endColumn\":116}}]},{\"previewText\":\"0.5579999999999999,1990,0.493,['Camping with Penguins'],0.6509999999999999,167893,0.17800000000000002,0,0Jv27yLnuuLxwVfIiTvXmn,1.54e-06,8,0.147,-17.816,0,Spider,29,1990,0.0324,120.052\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":45,\"endLineNumber\":0,\"endColumn\":53},\"source\":{\"startLineNumber\":149715,\"startColumn\":45,\"endLineNumber\":149715,\"endColumn\":53}}]},{\"previewText\":\"0.0781,2012,0.00031800000000000003,['Max Freegrant'],0.6759999999999999,397500,0.897,0,1XXFYfsPAPYMw3Ukr5KPQN,0.804,7,0.149,-8.078,1,Penguins Dancing Too - Danny Rockin & DJ Volsky Remix,0,2012-12-31,0.0427,127.996\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":133,\"endLineNumber\":0,\"endColumn\":141},\"source\":{\"startLineNumber\":153991,\"startColumn\":133,\"endLineNumber\":153991,\"endColumn\":141}}]},{\"previewText\":\"0.501,1996,0.8690000000000001,['The Penguins'],0.444,182333,0.278,0,4MRt9ZxfcWnqL1clGJe6WN,0.0,7,0.119,-10.465,1,Devil That I See,31,1996-01-01,0.0271,74.643\\n\",\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":36,\"endLineNumber\":0,\"endColumn\":44},\"source\":{\"startLineNumber\":165888,\"startColumn\":36,\"endLineNumber\":165888,\"endColumn\":44}}]}]}],\"messages\":[]}"
              }
            ]
          },
          "toolCallId": "a27f9fd9-254a-456e-b040-ea1b1211f3d8",
          "toolId": "positron_findTextInProject_internal"
        },
        {
          "value": "Yes, there are several penguin-related files in this project:\n\n1. **workspaces/quarto_interactive/** - A Quarto project about Palmer Penguins:\n   - `penguins.csv` - CSV data file with penguin data\n   - `penguins.png` - Image file of penguins  \n   - `quarto_interactive.qmd` - Quarto document titled \"Palmer Penguins\"\n\n2. **DESCRIPTION** - References the `palmerpenguins` R package\n\n3. **data-files/spotify_data/data.csv** - Contains several song entries with \"penguins\" in the title or artist name\n\nThe main penguin-related content appears to be in the `workspaces/quarto_interactive/` directory, which contains what looks like a complete Palmer Penguins data analysis project with both data and visualization components.",
          "supportThemeIcons": false,
          "supportHtml": false
        }
      ],
      "responseId": "response_40cc67f8-014e-40f4-adba-0cf3327befa9",
      "result": {
        "timings": {
          "firstProgress": 20769,
          "totalElapsed": 25452
        },
        "metadata": {
          "modelId": "39b64d15-9e6f-4f5a-a4b2-270ca1c21a3f-claude-sonnet-4-20250514"
        }
      },
      "followups": [],
      "isCanceled": false,
      "agent": {
        "extensionId": {
          "value": "positron.positron-assistant",
          "_lower": "positron.positron-assistant"
        },
        "publisherDisplayName": "positron",
        "extensionPublisherId": "positron",
        "extensionDisplayName": "Positron Assistant",
        "id": "positron.assistant.chat",
        "description": "Ask Assistant",
        "metadata": {
          "isSticky": false,
          "themeIcon": {
            "id": "positron-assistant"
          },
          "hasFollowups": true
        },
        "name": "assistant",
        "fullName": "Positron Assistant",
        "isDefault": true,
        "locations": [
          "panel"
        ],
        "modes": [
          "ask"
        ],
        "slashCommands": [
          {
            "name": "quarto",
            "description": "Convert the conversation so far into a new Quarto document."
          }
        ],
        "disambiguation": []
      },
      "contentReferences": [
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/DESCRIPTION",
              "external": "file:///Users/sashimi/qa-example-content/DESCRIPTION",
              "path": "/Users/sashimi/qa-example-content/DESCRIPTION",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 23,
              "startColumn": 11,
              "endLineNumber": 23,
              "endColumn": 19
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "external": "file:///Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "path": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 2,
              "startColumn": 16,
              "endLineNumber": 2,
              "endColumn": 24
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "external": "file:///Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "path": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 10,
              "startColumn": 24,
              "endLineNumber": 10,
              "endColumn": 32
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "external": "file:///Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "path": "/Users/sashimi/qa-example-content/workspaces/quarto_interactive/quarto_interactive.qmd",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 21,
              "startColumn": 12,
              "endLineNumber": 21,
              "endColumn": 20
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "external": "file:///Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "path": "/Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 45,
              "startColumn": 3809,
              "endLineNumber": 45,
              "endColumn": 3817
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "fsPath": "/Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "external": "file:///Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "path": "/Users/sashimi/qa-example-content/positron-chat-export-2025-07-07T21-51-28-827Z.json",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 45,
              "startColumn": 3828,
              "endLineNumber": 45,
              "endColumn": 3836
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 14860,
              "startColumn": 24,
              "endLineNumber": 14860,
              "endColumn": 32
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 47463,
              "startColumn": 105,
              "endLineNumber": 47463,
              "endColumn": 113
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 104784,
              "startColumn": 113,
              "endLineNumber": 104784,
              "endColumn": 121
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 137905,
              "startColumn": 109,
              "endLineNumber": 137905,
              "endColumn": 117
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 149716,
              "startColumn": 46,
              "endLineNumber": 149716,
              "endColumn": 54
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 153992,
              "startColumn": 134,
              "endLineNumber": 153992,
              "endColumn": 142
            }
          }
        },
        {
          "kind": "reference",
          "reference": {
            "uri": {
              "$mid": 1,
              "external": "file:///Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "path": "/Users/sashimi/qa-example-content/data-files/spotify_data/data.csv",
              "scheme": "file"
            },
            "range": {
              "startLineNumber": 165889,
              "startColumn": 37,
              "endLineNumber": 165889,
              "endColumn": 45
            }
          }
        }
      ],
      "codeCitations": [],
      "timestamp": 1751925126460
    }
  ]
}
```

</details> 

### Release Notes

#### New Features

- Assistant: chat log can be exported for debugging/testing (#8033)

### QA Notes

@:assistant

#### QA Assistant testing notes

1. Set `"positron.assistant.toolDetails.enable": true` (includes tool call details in the chat view, which allows the tool call details to be logged in the exportable chat log as well)
2. Use Positron Assistant Chat
3. Run the command `positron-assistant.exportChatToFile` which will create a JSON log file in the workspace with the assistant chat contents
4. Parse the request, response and tool call details from the JSON file as needed

#### User export debug logs notes

1. Optionally set `"positron.assistant.toolDetails.enable": true`: Enable tool call input and output details in the chat view. Must be enabled to include tool call details in the chat export.
    - <img width="424" alt="image" src="https://github.com/user-attachments/assets/aedbffbb-eb9c-4315-bb4d-56411751480f" />
2. Chat in sidebar, inline in the editor or inline in the terminal
3. Run one the following commands to export the chat log for the last focused chat widget
    - `Positron Assistant: Export the current chat to a file in the workspace`: exports the chat to a timestamped file in the workspace (not available when in a workspace-less window)
    - `Positron Assistant: Export the current chat to...`: choose the file name and location to export the chat log to