### PR TITLE
Fix failing test with IPython < 9.0.0

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/pydoc.py
+++ b/extensions/positron-python/python_files/posit/positron/pydoc.py
@@ -1,3 +1,4 @@
+# noqa: A005
 #
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.

--- a/extensions/positron-python/python_files/posit/positron/pydoc.py
+++ b/extensions/positron-python/python_files/posit/positron/pydoc.py
@@ -1,4 +1,3 @@
-# noqa: A005
 #
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.

--- a/extensions/positron-python/python_files/posit/positron/tests/conftest.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/conftest.py
@@ -50,7 +50,7 @@ class DummyComm(comm.base_comm.BaseComm):
                     raise AssertionError(error["message"])
 
 
-class TestSession(Session):
+class MockSession(Session):
     """A session that records sent messages for testing purposes."""
 
     def __init__(self, *args, **kwargs):
@@ -92,7 +92,7 @@ def kernel() -> PositronIPyKernel:
     app.session_mode = SessionMode.CONSOLE
 
     # Use a test session to capture sent messages.
-    session = TestSession()
+    session = MockSession()
 
     try:
         kernel = PositronIPyKernel.instance(parent=app, session=session)
@@ -128,8 +128,8 @@ def shell(kernel) -> Iterable[PositronShell]:
 
 
 @pytest.fixture
-def session(kernel) -> TestSession:
-    session: TestSession = kernel.session
+def session(kernel) -> MockSession:
+    session: MockSession = kernel.session
 
     # Clear all messages from previous tests.
     session.messages.clear()

--- a/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_bokeh.py
@@ -9,7 +9,7 @@ import pytest
 
 from positron.positron_ipkernel import PositronShell
 
-from ..conftest import TestSession
+from ..conftest import MockSession
 
 MIME_TYPE_POSITRON_WEBVIEW_FLAG = "application/positron-webview-load.v0+json"
 
@@ -43,7 +43,7 @@ show(p)
     )
 
 
-def test_model_repr_html_disabled(shell: PositronShell, session: TestSession):
+def test_model_repr_html_disabled(shell: PositronShell, session: MockSession):
     """
     Test to make sure that the text/html mime type is excluded from Bokeh Model subclass instances.
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -214,7 +214,7 @@ def traceback_result(
 
 
 @pytest.mark.xfail(
-    cast(Tuple[int, int], (IPython.version_info[:2])) >= (9, 0),
+    cast("Tuple[int, int]", (IPython.version_info[:2])) >= (9, 0),
     reason="IPython >= 9.0.0 does not support the old traceback format",
 )
 def test_console_traceback(shell: PositronShell, traceback_result) -> None:
@@ -261,7 +261,7 @@ def test_console_traceback(shell: PositronShell, traceback_result) -> None:
 
 
 @pytest.mark.xfail(
-    cast(Tuple[int, int], (IPython.version_info[:2])) < (9, 0),
+    cast("Tuple[int, int]", (IPython.version_info[:2])) < (9, 0),
     reason="IPython < 9.0.0 does not support the new traceback format",
 )
 def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:


### PR DESCRIPTION
This PR fixes a test that's failing for me on `main` with an older IPython version. Also fixes some linting errors and a test warning (by renaming `TestSession`).