### PR TITLE
python ci: unpin scipy

### DIFF
--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -10,10 +10,10 @@
 #
 # Then iterate through supported PYTHON_VERSIONS to make sure we covered the latest versions.
 
-fastcore==1.8.4
+fastcore==1.8.5
 geopandas==1.0.1; python_version == '3.9'
 geopandas==1.1.1; python_version >= '3.10'
-haystack-ai==2.15.1
+haystack-ai==2.15.2
 holoviews==1.20.2; python_version == '3.9'
 holoviews==1.21.0; python_version >= '3.10'
 hvplot==0.11.3
@@ -29,7 +29,7 @@ matplotlib==3.10.3; python_version >= '3.10'
 numpy==2.0.2; python_version == '3.9'
 numpy==2.2.6; python_version == '3.10'
 numpy==2.3.1; python_version >= '3.11'
-pandas==2.3.0
+pandas==2.3.1
 plotly==6.2.0
 plotnine==0.13.6; python_version == '3.9'
 plotnine==0.14.6; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -20,7 +20,7 @@ pytest
 pytest-asyncio
 pytest-mock
 torch
-scipy<=1.15.3
+scipy
 sqlalchemy
 
 # putting this last because holoviews is picky about dependency versions (including bokeh),


### PR DESCRIPTION
Fixes #8406.

https://github.com/statsmodels/statsmodels/issues/9584 is fixed and they've created a release. I validated that our previously-failing `plotnine` test does succeed with scipy 1.16.0 and the newest statsmodels, so we can unpin scipy.

Funny enough, even with unpinning, we still pick up scipy 1.15.3, because the latest plotnine has also put a ceiling of scipy<1.16. But they'll probably unpin that soon due to the fix, so our nightlies should then automatically pick up the latest everything.