### PR TITLE
tell users to install numpy for polars histograms

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -105,10 +105,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-class DataExplorerImportWarning(UserWarning):
+class DataExplorerWarning(UserWarning):
     """
-    Warning raised when there are import-related issues
-    in the Data Explorer relevant to the user.
+    Warning raised when there are issues in the Data Explorer relevant to the user.
+
     This type of warning is shown once in the Console per session.
     """
 
@@ -1942,7 +1942,7 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
         warnings.warn(
             "Numpy not installed, histogram computation will not work. "
             "Please install NumPy to enable this feature.",
-            category=DataExplorerImportWarning,
+            category=DataExplorerWarning,
             stacklevel=1,
         )
         raise e

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class DataExplorerWarning(UserWarning):
     """
     Warning raised when there are issues in the Data Explorer relevant to the user.

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -483,6 +483,7 @@ class PositronIPyKernel(IPythonKernel):
         )
 
         warnings.showwarning = self._showwarning
+        self._show_dataexplorer_warning = True
 
         # Ignore warnings that the user can't do anything about
         warnings.filterwarnings(
@@ -498,8 +499,6 @@ class PositronIPyKernel(IPythonKernel):
             message=r"Module [^\s]+ not importable in path",
             module="jedi",
         )
-
-        warnings.filterwarnings("once", category=DataExplorerWarning)
 
         # Patch holoviews to use our custom notebook extension.
         set_holoviews_extension(self.ui_service)
@@ -578,6 +577,13 @@ class PositronIPyKernel(IPythonKernel):
         console_dir = get_tmp_directory()
         if console_dir in str(filename):
             filename = f"<positron-console-cell-{self.execution_count}>"
+
+        # switch to only show the "numpy not installed" data explorer warning only once
+        if isinstance(message, DataExplorerWarning):
+            if not self._show_dataexplorer_warning:
+                return None
+            else:
+                self._show_dataexplorer_warning = False
 
         # unless it is a DataExplorerImportWarning (which we want to show)
         # send to logs if warning is coming from Positron files

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -30,7 +30,7 @@ from IPython.utils import PyColorize
 
 from .access_keys import encode_access_key
 from .connections import ConnectionsService
-from .data_explorer import DataExplorerImportWarning, DataExplorerService
+from .data_explorer import DataExplorerWarning, DataExplorerService
 from .help import HelpService, help  # noqa: A004
 from .lsp import LSPService
 from .patch.bokeh import handle_bokeh_output, patch_bokeh_no_access
@@ -499,7 +499,7 @@ class PositronIPyKernel(IPythonKernel):
             module="jedi",
         )
 
-        warnings.filterwarnings("once", category=DataExplorerImportWarning)
+        warnings.filterwarnings("once", category=DataExplorerWarning)
 
         # Patch holoviews to use our custom notebook extension.
         set_holoviews_extension(self.ui_service)
@@ -584,7 +584,7 @@ class PositronIPyKernel(IPythonKernel):
         # also send warnings from attempted compiles from IPython to logs
         # https://github.com/ipython/ipython/blob/8.24.0/IPython/core/async_helpers.py#L151
         if (str(positron_files_path) in str(filename) or str(filename) == "<>") and not isinstance(
-            message, DataExplorerImportWarning
+            message, DataExplorerWarning
         ):
             msg = f"{filename}-{lineno}: {category}: {message}"
             logger.warning(msg)

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -30,7 +30,7 @@ from IPython.utils import PyColorize
 
 from .access_keys import encode_access_key
 from .connections import ConnectionsService
-from .data_explorer import DataExplorerWarning, DataExplorerService
+from .data_explorer import DataExplorerService, DataExplorerWarning
 from .help import HelpService, help  # noqa: A004
 from .lsp import LSPService
 from .patch.bokeh import handle_bokeh_output, patch_bokeh_no_access


### PR DESCRIPTION
supersedes #8392 

This is motivated by the fact all the data explorer Python code assumes you have numpy installed, but numpy is not actually required for polars. Since the histogram method we would need to use for polars is [unstable](https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.hist.html), and we do not want to be the keepers/implementers of this type of code, we'll just tell users to install numpy for now if they want histograms in the data explorer.

Future work to move to polars-native histograms tracked here:  https://github.com/posit-dev/positron/issues/8446

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8203 Inform users to install `numpy` if they want histograms in the Data Explorer for `polars` data frames.


### QA Notes


```python
# do NOT have numpy installed

import polars as pl

sample_data_error = {"float": 3.14, "int": 1}
df = pl.DataFrame(sample_data_error)

%view df
```