### PR TITLE
add Posit Connect Cloud domains for Publisher extension

### DIFF
--- a/product.json
+++ b/product.json
@@ -296,8 +296,11 @@
 		"https://open-vsx.org",
 		"https://github.com/posit-dev/positron",
 		"https://positron.posit.co",
-		"https://github.com/login/device"
-	],
+		"https://github.com/login/device",
+		"https://login.posit.cloud",
+		"https://connect.posit.cloud",
+		"https://login.staging.posit.cloud",
+		"https://staging.connect.posit.cloud"	],
 	"extensionsEnabledWithApiProposalVersion": [
 		"GitHub.copilot-chat"
 	],

--- a/product.json
+++ b/product.json
@@ -300,7 +300,8 @@
 		"https://login.posit.cloud",
 		"https://connect.posit.cloud",
 		"https://login.staging.posit.cloud",
-		"https://staging.connect.posit.cloud"	],
+		"https://staging.connect.posit.cloud"
+	],
 	"extensionsEnabledWithApiProposalVersion": [
 		"GitHub.copilot-chat"
 	],


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

We're working on adding support in https://github.com/posit-dev/publisher to publish to Connect Cloud. The process of authenticating will involve opening a browser window to login.posit.cloud to log in, and may open another window to connect.posit.cloud to create a Connect Cloud account. This change would make that process smoother by avoiding the link protection prompt:

<img width="271" alt="Screenshot 2025-07-09 at 08 41 56" src="https://github.com/user-attachments/assets/52e9750a-8d5d-49f0-b8a1-49212492a924" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added login.posit.cloud and connect.posit.cloud to the predefined list of trusted domains.



#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
