### PR TITLE
e2e test: switch data explorer test from beforeAll to beforeEach for better retry-ability

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -14,7 +14,7 @@ test.describe('Data Explorer - Python Polars', {
 	tag: [tags.WIN, tags.WEB, tags.CRITICAL, tags.DATA_EXPLORER]
 }, () => {
 
-	test.beforeAll(async function ({ app, openFile, runCommand, python }) {
+	test.beforeEach(async function ({ app, openFile, runCommand, python }) {
 		const { variables, dataExplorer, editors } = app.workbench;
 
 		await openFile(join('workspaces', 'polars-dataframe-py', 'polars_basic.py'));
@@ -26,8 +26,9 @@ test.describe('Data Explorer - Python Polars', {
 		await dataExplorer.maximizeDataExplorer(true);
 	});
 
-	test.afterEach(async function ({ app }) {
-		app.workbench.dataExplorer.clearAllFilters();
+	test.afterEach(async function ({ app, hotKeys }) {
+		await app.workbench.dataExplorer.clearAllFilters();
+		await hotKeys.closeAllEditors();
 	});
 
 	test('Python Polars - Verify table data, copy to clipboard, sparkline hover, null percentage hover', async function ({ app }) {


### PR DESCRIPTION
### Summary
Update data explorer test to use `beforeEach` in favor of `beforeAll` for retry-ability if the before block fails.

### QA Notes

@:data-explorer
