### PR TITLE
Assistant: Shows all providers on launch

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/positron/chatState.tsx
+++ b/src/vs/workbench/contrib/chat/browser/positron/chatState.tsx
@@ -20,10 +20,13 @@ export interface PositronChatState extends PositronChatServices {
 
 export const usePositronChatState = (services: PositronChatServices): PositronChatState => {
 	const [providers, setProviders] = useState<IPositronChatProvider[]>([]);
-	const [currentProvider, setCurrentProvider] = useState<IPositronChatProvider | undefined>(services.languageModelsService.currentProvider);
+	const [currentProvider, setCurrentProvider] = useState<IPositronChatProvider | undefined>(undefined);
 
 	useEffect(() => {
 		const disposableStore = new DisposableStore();
+
+		setProviders(services.languageModelsService.getLanguageModelProviders());
+		setCurrentProvider(services.languageModelsService.currentProvider);
 
 		disposableStore.add(services.languageModelsService.onDidChangeLanguageModels((event) => {
 			const newProviders = services.languageModelsService.getLanguageModelProviders();


### PR DESCRIPTION
In the `usePositronChatState` hook, the providers list is now initialized directly within the effect hook instead of waiting for the first change event, which may fire before the hook sets up event listeners.

This is a similar issue to #6843 (resolved in #7993), whereby a race can happen between an event firing & initial component mounting. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8124 

### QA Notes

This bug seems to be transient. It was only replicable on my machine every ~1/5 launches; others see more regularly. 

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant