### PR TITLE
python upstream merge v2025.8.1

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -9,7 +9,7 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": false,
-            "description": "The Python extension is not available in untrusted workspaces. Use Pylance to get partial IntelliSense support for Python files."
+            "description": "The Python extension is not available in untrusted workspaces."
         },
         "virtualWorkspaces": {
             "supported": "limited",

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -8,8 +8,8 @@
     },
     "capabilities": {
         "untrustedWorkspaces": {
-            "supported": "limited",
-            "description": "Only Partial IntelliSense with Pylance is supported. Cannot execute Python with untrusted files."
+            "supported": false,
+            "description": "The Python extension is not available in untrusted workspaces. Use Pylance to get partial IntelliSense support for Python files."
         },
         "virtualWorkspaces": {
             "supported": "limited",

--- a/extensions/positron-python/python_files/ipykernel_requirements/py3-requirements.txt
+++ b/extensions/positron-python/python_files/ipykernel_requirements/py3-requirements.txt
@@ -121,8 +121,8 @@ traitlets==5.14.3 \
     #   jupyter-client
     #   jupyter-core
     #   matplotlib-inline
-typing-extensions==4.14.0 \
-    --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
+typing-extensions==4.14.1 \
+    --hash=sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76
     # via
     #   exceptiongroup
     #   ipython


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Here's a small change that merges in https://github.com/microsoft/vscode-python/releases/tag/v2025.8.1. Fixes #8457.

It disables the python extension in untrusted workspaces to address [CVE-2025-49714](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-49714).

It looks like this doesn't meaningfully change any behavior from `main`. When you open an untrusted workspace, the console never starts up, but you can browse files. You get basic syntax highlighting but no hovers, etc.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
