### PR TITLE
Assistant token counts

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -33,6 +33,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 	provider: string;
 	identifier: string;
 	maxOutputTokens: number;
+	tokenCount: number = 0;
 
 	capabilities = {
 		vision: true,
@@ -93,6 +94,12 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			system,
 			messages: anthropicMessages,
 		};
+
+		for (const message of messages) {
+			this.tokenCount += await this.provideTokenCount(message, token);
+		}
+		vscode.commands.executeCommand('setContext', `assistant.${this._config.provider}.tokenCount`, this.tokenCount);
+
 		const stream = this._client.messages.stream(body);
 
 		// Log request information - the request ID is only available upon connection.
@@ -189,7 +196,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		});
 	}
 
-	async provideTokenCount(text: string | vscode.LanguageModelChatMessage, token: vscode.CancellationToken): Promise<number> {
+	async provideTokenCount(text: string | vscode.LanguageModelChatMessage2, token: vscode.CancellationToken): Promise<number> {
 		const messages: Anthropic.MessageParam[] = [];
 		if (typeof text === 'string') {
 			// For empty string, return 0 tokens

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -7,7 +7,7 @@ import * as positron from 'positron';
 import { randomUUID } from 'crypto';
 import { getLanguageModels } from './models';
 import { completionModels } from './completion';
-import { disposeModels, log, registerModel } from './extension';
+import { clearTokenUsage, disposeModels, log, registerModel } from './extension';
 import { CopilotService } from './copilot.js';
 
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
@@ -329,6 +329,8 @@ export async function deleteConfiguration(context: vscode.ExtensionContext, stor
 	await storage.delete(`apiKey-${id}`);
 
 	disposeModels(id);
+
+	clearTokenUsage(context, targetConfig.provider);
 
 	positron.ai.removeLanguageModelConfig(expandConfigToSource(targetConfig));
 }

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -309,7 +309,6 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			}
 		}
 
-		// Record token usage if context is available
 		if (this._context) {
 			const outputCount = await this.provideTokenCount(await result.text, token);
 			let inputCount = 0;

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -55,7 +55,7 @@ suite('AnthropicLanguageModel', () => {
 		};
 
 		// Create an instance of the AnthropicLanguageModel
-		model = new AnthropicLanguageModel(config, mockClient as unknown as Anthropic);
+		model = new AnthropicLanguageModel(config, undefined, mockClient as unknown as Anthropic);
 
 		// Create mock progress
 		progress = {

--- a/extensions/positron-assistant/src/test/tokens.test.ts
+++ b/extensions/positron-assistant/src/test/tokens.test.ts
@@ -1,0 +1,432 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { TokenTracker } from '../tokens';
+import { mock } from './utils';
+
+suite('TokenTracker', () => {
+	let mockContext: vscode.ExtensionContext;
+	let mockWorkspaceState: vscode.Memento;
+	let mockConfiguration: vscode.WorkspaceConfiguration;
+	let executeCommandStub: sinon.SinonStub;
+	let getConfigurationStub: sinon.SinonStub;
+	let onDidChangeConfigurationStub: sinon.SinonStub;
+
+	const ANTHROPIC_PROVIDER_ID = 'anthropic';
+	const TEST_PROVIDER_ID = 'test-provider';
+	const TOKEN_COUNT_KEY = 'positron.assistant.tokenCounts';
+
+	setup(() => {
+		// Mock workspace state
+		mockWorkspaceState = mock<vscode.Memento>({
+			get: sinon.stub() as any,
+			update: sinon.stub().resolves()
+		});
+
+		// Mock extension context
+		mockContext = mock<vscode.ExtensionContext>({
+			workspaceState: mockWorkspaceState
+		});
+
+		// Mock workspace configuration
+		mockConfiguration = mock<vscode.WorkspaceConfiguration>({
+			get: sinon.stub() as any
+		});
+
+		// Mock VS Code APIs
+		executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves();
+		getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns(mockConfiguration);
+		onDidChangeConfigurationStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration');
+
+		// Set up default configuration behavior
+		(mockConfiguration.get as sinon.SinonStub).withArgs('approximateTokenCount', [] as string[]).returns([]);
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	suite('Constructor', () => {
+		test('should initialize with empty token usage when no stored data', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should not set any context initially
+			assert.strictEqual(executeCommandStub.callCount, 0);
+		});
+
+		test('should initialize with empty token usage when stored data is not a string', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns({ invalid: 'data' });
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should not set any context initially
+			assert.strictEqual(executeCommandStub.callCount, 0);
+		});
+
+		test('should restore valid token usage from stored data', () => {
+			const storedData = JSON.stringify([
+				[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }],
+				[TEST_PROVIDER_ID, { input: 200, output: 75 }]
+			]);
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should set context for both providers
+			assert.strictEqual(executeCommandStub.callCount, 4);
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 200));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 75));
+		});
+
+		test('should filter out invalid entries from stored data', () => {
+			const storedData = JSON.stringify([
+				[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }], // valid
+				['invalid-entry'], // invalid - missing usage data
+				[TEST_PROVIDER_ID, { input: 'not-a-number', output: 75 }], // invalid - input not a number
+				['another-provider', { input: 200, output: 100 }] // valid
+			]);
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should only set context for valid entries (2 providers * 2 context keys each)
+			assert.strictEqual(executeCommandStub.callCount, 4);
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.another-provider.tokenCount.input`, 200));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.another-provider.tokenCount.output`, 100));
+		});
+
+		test('should handle JSON parse errors gracefully', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns('invalid-json{');
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should not set any context when JSON parsing fails
+			assert.strictEqual(executeCommandStub.callCount, 0);
+		});
+
+		test('should handle non-array parsed data gracefully', () => {
+			const storedData = JSON.stringify({ not: 'an-array' });
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should not set any context when parsed data is not an array
+			assert.strictEqual(executeCommandStub.callCount, 0);
+		});
+
+		test('should set up configuration change listener', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Should register configuration change listener
+			assert.strictEqual(onDidChangeConfigurationStub.callCount, 1);
+		});
+	});
+
+	suite('Configuration Changes', () => {
+		test('should update enabled providers when configuration changes', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			let configurationListener: (event: vscode.ConfigurationChangeEvent) => void;
+			onDidChangeConfigurationStub.callsFake((listener) => {
+				configurationListener = listener;
+				return mock<vscode.Disposable>({});
+			});
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Simulate configuration change
+			const mockEvent = mock<vscode.ConfigurationChangeEvent>({
+				affectsConfiguration: sinon.stub().withArgs('positron.assistant.approximateTokenCount').returns(true)
+			});
+
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([TEST_PROVIDER_ID]);
+
+			configurationListener!(mockEvent);
+
+			// Verify configuration was checked
+			assert.ok(getConfigurationStub.calledWith('positron.assistant'));
+			assert.ok((mockConfiguration.get as sinon.SinonStub).calledWith('approximateTokenCount', [] as string[]));
+		});
+
+		test('should clear tokens for disabled providers when configuration changes', () => {
+			// Set up initial state with tokens for test provider
+			const storedData = JSON.stringify([
+				[TEST_PROVIDER_ID, { input: 100, output: 50 }]
+			]);
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			let configurationListener: (event: vscode.ConfigurationChangeEvent) => void;
+			onDidChangeConfigurationStub.callsFake((listener) => {
+				configurationListener = listener;
+				return mock<vscode.Disposable>({});
+			});
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			// Simulate configuration change that removes test provider
+			const mockEvent = mock<vscode.ConfigurationChangeEvent>({
+				affectsConfiguration: sinon.stub().withArgs('positron.assistant.approximateTokenCount').returns(true)
+			});
+
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([]); // Empty array - no providers enabled
+
+			configurationListener!(mockEvent);
+
+			// Should clear context for the disabled provider
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+
+			// Should update workspace state
+			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, sinon.match.string));
+		});
+
+		test('should not affect configuration when unrelated setting changes', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			let configurationListener: (event: vscode.ConfigurationChangeEvent) => void;
+			onDidChangeConfigurationStub.callsFake((listener) => {
+				configurationListener = listener;
+				return mock<vscode.Disposable>({});
+			});
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			getConfigurationStub.resetHistory();
+
+			// Simulate configuration change for unrelated setting
+			const mockEvent = mock<vscode.ConfigurationChangeEvent>({
+				affectsConfiguration: sinon.stub().withArgs('positron.assistant.approximateTokenCount').returns(false)
+			});
+
+			configurationListener!(mockEvent);
+
+			// Should not check configuration for unrelated changes
+			assert.strictEqual(getConfigurationStub.callCount, 0);
+		});
+	});
+
+	suite('addTokens', () => {
+		test('should add tokens for enabled provider', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+
+			// First, set up the configuration to return the test provider as enabled
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([TEST_PROVIDER_ID]);
+
+			// Create the tracker which should read the configuration
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			// Now add tokens for the enabled provider
+			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+
+			// Should set context for the provider
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 100));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 50));
+
+			// Should update workspace state
+			const expectedData = JSON.stringify([[TEST_PROVIDER_ID, { input: 100, output: 50 }]]);
+			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
+		});
+
+		test('should accumulate tokens for multiple calls', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+
+			// Set up the configuration to return the test provider as enabled
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([TEST_PROVIDER_ID]);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+
+			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+			tracker.addTokens(TEST_PROVIDER_ID, 75, 25);
+
+			// Should set context with accumulated values
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 175));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 75));
+		});
+
+		test('should skip adding tokens for disabled provider', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([]); // No additional providers enabled
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+
+			// Should not set context or update state for disabled provider
+			assert.strictEqual(executeCommandStub.callCount, 0);
+			assert.strictEqual((mockWorkspaceState.update as sinon.SinonStub).callCount, 0);
+		});
+
+		test('should always allow Anthropic provider (default enabled)', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([]); // No additional providers enabled
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			tracker.addTokens(ANTHROPIC_PROVIDER_ID, 100, 50);
+
+			// Should set context for Anthropic provider even when not in config
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+
+			// Should update workspace state
+			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }]]);
+			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
+		});
+	});
+
+	suite('clearTokens', () => {
+		test('should clear tokens for existing provider', () => {
+			const storedData = JSON.stringify([
+				[TEST_PROVIDER_ID, { input: 100, output: 50 }]
+			]);
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			tracker.clearTokens(TEST_PROVIDER_ID);
+
+			// Should delete context for the provider
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+
+			// Should update workspace state with empty data
+			const expectedData = JSON.stringify([]);
+			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
+		});
+
+		test('should handle clearing tokens for non-existent provider', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			tracker.clearTokens(TEST_PROVIDER_ID);
+
+			// Should not call any methods for non-existent provider
+			assert.strictEqual(executeCommandStub.callCount, 0);
+			assert.strictEqual((mockWorkspaceState.update as sinon.SinonStub).callCount, 0);
+		});
+
+		test('should preserve other providers when clearing one', () => {
+			const storedData = JSON.stringify([
+				[TEST_PROVIDER_ID, { input: 100, output: 50 }],
+				[ANTHROPIC_PROVIDER_ID, { input: 200, output: 75 }]
+			]);
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Reset call count after initialization
+			executeCommandStub.resetHistory();
+			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
+
+			tracker.clearTokens(TEST_PROVIDER_ID);
+
+			// Should delete context for the cleared provider
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+
+			// Should update workspace state with remaining provider
+			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { input: 200, output: 75 }]]);
+			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
+		});
+	});
+
+	suite('Integration Tests', () => {
+		test('should handle complete workflow: init -> add -> clear', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([TEST_PROVIDER_ID]);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Add tokens
+			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+			tracker.addTokens(TEST_PROVIDER_ID, 25, 10);
+
+			// Clear tokens
+			tracker.clearTokens(TEST_PROVIDER_ID);
+
+			// Final state should have no tokens
+			const updateCalls = (mockWorkspaceState.update as sinon.SinonStub).getCalls();
+			const lastCall = updateCalls[updateCalls.length - 1];
+			assert.ok(lastCall, 'Expected at least one call to update');
+			assert.strictEqual(lastCall.args[1], JSON.stringify([]));
+		});
+
+		test('should handle multiple providers independently', () => {
+			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(undefined);
+			(mockConfiguration.get as sinon.SinonStub)
+				.withArgs('approximateTokenCount', [] as string[])
+				.returns([TEST_PROVIDER_ID, 'another-provider']);
+
+			const tracker = new TokenTracker(mockContext);
+
+			// Add tokens for both providers
+			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+			tracker.addTokens('another-provider', 200, 75);
+
+			// Clear only one provider
+			tracker.clearTokens(TEST_PROVIDER_ID);
+
+			// Should only have the other provider remaining
+			const updateCalls = (mockWorkspaceState.update as sinon.SinonStub).getCalls();
+			const lastCall = updateCalls[updateCalls.length - 1];
+			assert.ok(lastCall, 'Expected at least one call to update');
+			const finalData = JSON.parse(lastCall.args[1]);
+			assert.strictEqual(finalData.length, 1);
+			assert.deepStrictEqual(finalData[0], ['another-provider', { input: 200, output: 75 }]);
+		});
+	});
+});

--- a/extensions/positron-assistant/src/tokens.ts
+++ b/extensions/positron-assistant/src/tokens.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class TokenTracker {
+	private _tokenUsage: Map<string, { input: number; output: number }> = new Map();
+
+	private readonly TOKEN_COUNT_KEY = 'positron.assistant.tokenCounts';
+
+	constructor(private _context: vscode.ExtensionContext) {
+		const tokenTrackerData = this._context.workspaceState.get(this.TOKEN_COUNT_KEY);
+
+		if (!tokenTrackerData || typeof tokenTrackerData !== 'string') {
+			// Initialize with an empty Map if no data is found
+			this._tokenUsage = new Map<string, { input: number; output: number }>();
+		} else {
+
+			try {
+				const parsedData = JSON.parse(tokenTrackerData);
+				if (Array.isArray(parsedData)) {
+					// Validate each entry has the expected structure
+					const validEntries = parsedData.filter(entry =>
+						Array.isArray(entry) &&
+						entry.length === 2 &&
+						typeof entry[0] === 'string' &&
+						typeof entry[1] === 'object' &&
+						entry[1] !== null &&
+						typeof entry[1].input === 'number' &&
+						typeof entry[1].output === 'number'
+					);
+					this._tokenUsage = new Map(validEntries);
+				} else {
+					this._tokenUsage = new Map<string, { input: number; output: number }>();
+				}
+			} catch (error) {
+				// Handle JSON parse errors or undefined tokenTrackerData
+				this._tokenUsage = new Map<string, { input: number; output: number }>();
+			}
+		}
+
+		// set context for each provider's token count
+		for (const [provider, tokens] of this._tokenUsage.entries()) {
+			this.updateContext(provider, tokens.input, tokens.output);
+		}
+	}
+
+	public addTokens(provider: string, inputTokens: number, outputTokens: number): void {
+		if (!this._tokenUsage.has(provider)) {
+			this._tokenUsage.set(provider, { input: 0, output: 0 });
+		}
+
+		const currentTokens = this._tokenUsage.get(provider)!;
+		currentTokens.input += inputTokens;
+		currentTokens.output += outputTokens;
+
+		this._tokenUsage.set(provider, currentTokens);
+		this.updateContext(provider, currentTokens.input, currentTokens.output);
+		this._context.workspaceState.update(this.TOKEN_COUNT_KEY, JSON.stringify(Array.from(this._tokenUsage.entries())));
+	}
+
+	public clearTokens(provider: string): void {
+		if (this._tokenUsage.has(provider)) {
+			this._tokenUsage.delete(provider);
+			this.updateContext(provider, 0, 0);
+			this._context.workspaceState.update(this.TOKEN_COUNT_KEY, JSON.stringify(Array.from(this._tokenUsage.entries())));
+		}
+	}
+
+	private updateContext(provider: string, input: number, output: number): void {
+		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.input`, input);
+		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.output`, output);
+	}
+}

--- a/extensions/positron-assistant/src/tokens.ts
+++ b/extensions/positron-assistant/src/tokens.ts
@@ -91,17 +91,12 @@ export class TokenTracker {
 	public clearTokens(provider: string): void {
 		if (this._tokenUsage.has(provider)) {
 			this._tokenUsage.delete(provider);
-			this.deleteContext(provider);
+			this.updateContext(provider);
 			this._context.workspaceState.update(this.TOKEN_COUNT_KEY, JSON.stringify(Array.from(this._tokenUsage.entries())));
 		}
 	}
 
-	private deleteContext(provider: string): void {
-		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.input`, undefined);
-		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.output`, undefined);
-	}
-
-	private updateContext(provider: string, input: number, output: number): void {
+	private updateContext(provider: string, input?: number, output?: number): void {
 		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.input`, input);
 		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.output`, output);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -432,11 +432,12 @@ class ChatStatusDashboard extends Disposable {
 			const providers = this.languageModelsService.getLanguageModelProviders();
 			const details = new Array<HTMLSpanElement>();
 			providers.forEach(provider => {
-				const tokenCount = this.contextKeyService.getContextKeyValue(`assistant.${provider.id}.tokenCount`);
-				if (tokenCount && typeof tokenCount === 'number') {
+				const inputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.input`);
+				const outputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.output`);
+				if (inputCount && typeof inputCount === 'number') {
 					const span = document.createElement('div');
 
-					span.innerText = `${provider.displayName}: ${tokenCount} tokens`;
+					span.innerText = `${provider.displayName}: ↑${inputCount} ↓${outputCount ?? 0}`;
 					details.push(span);
 				} else {
 					// add an element to the container with the name and a message

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -434,10 +434,10 @@ class ChatStatusDashboard extends Disposable {
 			providers.forEach(provider => {
 				const inputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.input`);
 				const outputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.output`);
-				if (inputCount && typeof inputCount === 'number') {
+				if (typeof inputCount === 'number' && typeof outputCount === 'number') {
 					const span = document.createElement('div');
 
-					span.innerText = `${provider.displayName}: ↑${inputCount} ↓${outputCount ?? 0}`;
+					span.innerText = `${provider.displayName}: ↑${inputCount} ↓${outputCount}`;
 					details.push(span);
 				} else {
 					// add an element to the container with the name and a message


### PR DESCRIPTION
Address #7817 

Context keys are used to record the token usage for each provider. The data is persisted to storage as they are updated so that session reloads will still track usage. The token counts are cleared when signing out of the provider.

Displays the token counts for each provider in the chat status. By default, Anthropic will track token usage as reported from their message responses. Other providers can have their usage reported as a general approximation (string length) but must be enabled in the settings using:

```json
"positron.assistant.approximateTokenCount":
[
  "echo",
  "bedrock"
],
```

![image](https://github.com/user-attachments/assets/d6ecaeef-dc06-4def-9a06-3b4175f401e4)

Token usage is reported as input (up) and output (down) tokens.

Unit tests were AI generated.

### Release Notes

#### New Features

- Add token usage to Assistant for the Anthropic provider #7817 

#### Bug Fixes

- N/A


### QA Notes
Automation can use this selector: `.chat-status-bar-entry-tooltip` to access the tooltip. The DOM updates to create this element once clicking on the chat status icon `#chat.statusBarEntry` or hovering over it. It is removed when it loses focus or the hover state is removed.