### PR TITLE
assistant: enable `documentCreate` tool in Edit mode

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -210,6 +210,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				const inChatPane = request.location2 === undefined;
 				const inEditor = request.location2 instanceof vscode.ChatRequestEditorData;
 				const hasSelection = inEditor && request.location2.selection?.isEmpty === false;
+				const isEditMode = this.id === ParticipantID.Edit;
 				const isAgentMode = this.id === ParticipantID.Agent;
 
 				// If streaming edits are enabled, don't allow any tools in inline editor chats.
@@ -244,10 +245,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return inEditor && hasSelection;
 					// Only include the edit file tool in edit or agent mode i.e. for the edit participant.
 					case PositronAssistantToolName.EditFile:
-						return this.id === ParticipantID.Edit || isAgentMode;
-					// Only include the documentCreate tool in the chat pane and if the user is an agent.
+						return isEditMode || isAgentMode;
+					// Only include the documentCreate tool in the chat pane in edit or agent mode.
 					case PositronAssistantToolName.DocumentCreate:
-						return inChatPane && isAgentMode;
+						return inChatPane && (isEditMode || isAgentMode);
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8465

### Release Notes

#### New Features

- Assistant: `documentCreate` tool is now available in Edit mode (#8465)

### QA Notes

@:assistant

The `documentCreate` tool is now available in both Edit and Agent modes.

1. Use Edit mode in chat
2. Submit a prompt involving the creation of a file
3. The file should be created with the expected content