### PR TITLE
E2E test: fix for connections test for docker

### DIFF
--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
+import * as fs from 'fs';
 
 test.use({
 	suiteId: __filename
@@ -22,6 +23,12 @@ const viewLine = '.lines-content .view-line';
 const dbName = process.env.E2E_POSTGRES_DB || 'testdb';
 const user = process.env.E2E_POSTGRES_USER || 'testuser';
 const password = process.env.E2E_POSTGRES_PASSWORD || 'testpassword';
+let host: string;
+if (fs.existsSync('/.dockerenv')) {
+	host = 'db';
+} else {
+	host = 'localhost';
+}
 
 test.describe('Postgres DB Connection', {
 	tag: [tags.WEB, tags.CONNECTIONS]
@@ -35,7 +42,7 @@ test.describe('Postgres DB Connection', {
 
 		await app.workbench.connections.fillConnectionsInputs({
 			'Database Name': dbName,
-			'Host': 'localhost',
+			'Host': host,
 			'User': user,
 			'Password': password,
 		});
@@ -91,7 +98,7 @@ test.describe('Postgres DB Connection', {
 
 		await app.workbench.connections.fillConnectionsInputs({
 			'Database Name': dbName,
-			'Host': 'localhost',
+			'Host': host,
 			'User': user,
 			'Password': password,
 		});


### PR DESCRIPTION
Use a hostname for docker with connections test instead of localhost

### QA Notes

@:connections @:web
