### PR TITLE
WIP: add notebook.workingDirectory setting

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -127,6 +127,12 @@
             "%configuration.transport.tcp.label%"
           ],
           "default": "ipc"
+        },
+        "notebook.workingDirectory": {
+          "scope": "resource",
+          "type": "string",
+          "default": "${fileDirname}",
+          "markdownDescription": "%configuration.notebook.workingDirectory.description%"
         }
       }
     },

--- a/extensions/positron-supervisor/package.nls.json
+++ b/extensions/positron-supervisor/package.nls.json
@@ -27,6 +27,7 @@
 	"configuration.transport.ipc.label": "Native IPC",
 	"configuration.transport.tcp.description": "Use local TCP sockets",
 	"configuration.transport.tcp.label": "Local TCP",
+	"configuration.notebook.workingDirectory.description": "The initial working directory for notebook kernels",
 	"command.positron.supervisor.category": "Kernel Supervisor",
 	"command.showKernelSupervisorLog.title": "Show the Kernel Supervisor Log",
 	"command.reconnectSession.title": "Reconnect the Current Session",

--- a/extensions/positron-supervisor/src/test/variableSubstitution.test.ts
+++ b/extensions/positron-supervisor/src/test/variableSubstitution.test.ts
@@ -1,0 +1,209 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import { substituteVariables } from '../variableSubstitution';
+
+suite('Variable Substitution', () => {
+
+	const mockWorkspaceFolder1 = {
+		uri: vscode.Uri.file('/workspace/project1'),
+		name: 'project1',
+		index: 0
+	};
+
+	const mockWorkspaceFolder2 = {
+		uri: vscode.Uri.file('/workspace/project2'),
+		name: 'project2',
+		index: 1
+	};
+
+	const mockNotebookUri = vscode.Uri.file('/workspace/project1/notebooks/analysis.ipynb');
+
+	// Mock vscode.workspace for testing
+	let originalWorkspaceFolders: readonly vscode.WorkspaceFolder[] | undefined;
+	let originalGetWorkspaceFolder: typeof vscode.workspace.getWorkspaceFolder;
+
+	suiteSetup(() => {
+		// Store original values
+		originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+		originalGetWorkspaceFolder = vscode.workspace.getWorkspaceFolder;
+	});
+
+	suiteTeardown(() => {
+		// Restore original values
+		Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+			value: originalWorkspaceFolders
+		});
+		vscode.workspace.getWorkspaceFolder = originalGetWorkspaceFolder;
+	});
+
+	setup(() => {
+		// Setup mock workspace folders
+		Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+			value: [mockWorkspaceFolder1, mockWorkspaceFolder2],
+			configurable: true
+		});
+
+		vscode.workspace.getWorkspaceFolder = (uri: vscode.Uri) => {
+			if (uri.fsPath.startsWith('/workspace/project1')) {
+				return mockWorkspaceFolder1;
+			}
+			if (uri.fsPath.startsWith('/workspace/project2')) {
+				return mockWorkspaceFolder2;
+			}
+			return undefined;
+		};
+	});
+
+	test('Returns original value when no variables present', () => {
+		const result = substituteVariables('/absolute/path/to/directory');
+		assert.strictEqual(result, '/absolute/path/to/directory');
+	});
+
+	test('Returns empty string for empty input', () => {
+		const result = substituteVariables('');
+		assert.strictEqual(result, '');
+	});
+
+	test('Substitutes ${workspaceFolder} with first workspace folder', () => {
+		const result = substituteVariables('${workspaceFolder}/data');
+		assert.strictEqual(result, '/workspace/project1/data');
+	});
+
+	test('Substitutes ${workspaceFolder:name} with specific workspace folder', () => {
+		const result = substituteVariables('${workspaceFolder:project2}/config');
+		assert.strictEqual(result, '/workspace/project2/config');
+	});
+
+	test('Returns original text for non-existent workspace folder name', () => {
+		const result = substituteVariables('${workspaceFolder:nonexistent}/path');
+		assert.strictEqual(result, '${workspaceFolder:nonexistent}/path');
+	});
+
+	test('Substitutes ${fileDirname} with notebook directory', () => {
+		const result = substituteVariables('${fileDirname}', mockNotebookUri);
+		assert.strictEqual(result, '/workspace/project1/notebooks');
+	});
+
+	test('Substitutes ${file} with full notebook path', () => {
+		const result = substituteVariables('${file}', mockNotebookUri);
+		assert.strictEqual(result, '/workspace/project1/notebooks/analysis.ipynb');
+	});
+
+	test('Substitutes ${fileBasename} with notebook filename', () => {
+		const result = substituteVariables('${fileBasename}', mockNotebookUri);
+		assert.strictEqual(result, 'analysis.ipynb');
+	});
+
+	test('Substitutes ${fileBasenameNoExtension} with filename without extension', () => {
+		const result = substituteVariables('${fileBasenameNoExtension}', mockNotebookUri);
+		assert.strictEqual(result, 'analysis');
+	});
+
+	test('Substitutes ${fileExtname} with file extension', () => {
+		const result = substituteVariables('${fileExtname}', mockNotebookUri);
+		assert.strictEqual(result, '.ipynb');
+	});
+
+	test('Substitutes ${relativeFile} with relative path from workspace', () => {
+		const result = substituteVariables('${relativeFile}', mockNotebookUri);
+		assert.strictEqual(result, 'notebooks/analysis.ipynb');
+	});
+
+	test('Substitutes ${relativeFileDirname} with relative directory from workspace', () => {
+		const result = substituteVariables('${relativeFileDirname}', mockNotebookUri);
+		assert.strictEqual(result, 'notebooks');
+	});
+
+	test('Substitutes ${cwd} with current working directory', () => {
+		const result = substituteVariables('${cwd}/temp');
+		assert.strictEqual(result, `${process.cwd()}/temp`);
+	});
+
+	test('Substitutes ${userHome} with user home directory', () => {
+		const result = substituteVariables('${userHome}/Documents');
+		assert.strictEqual(result, `${os.homedir()}/Documents`);
+	});
+
+	test('Substitutes ${pathSeparator} with OS path separator', () => {
+		const result = substituteVariables('path${pathSeparator}to${pathSeparator}file');
+		assert.strictEqual(result, `path${path.sep}to${path.sep}file`);
+	});
+
+	test('Substitutes ${/} with OS path separator', () => {
+		const result = substituteVariables('path${/}to${/}file');
+		assert.strictEqual(result, `path${path.sep}to${path.sep}file`);
+	});
+
+	test('Substitutes ${env:VARIABLE_NAME} with environment variable', () => {
+		const originalValue = process.env.TEST_VAR;
+		process.env.TEST_VAR = 'test_value';
+		
+		try {
+			const result = substituteVariables('${env:TEST_VAR}/path');
+			assert.strictEqual(result, 'test_value/path');
+		} finally {
+			if (originalValue !== undefined) {
+				process.env.TEST_VAR = originalValue;
+			} else {
+				delete process.env.TEST_VAR;
+			}
+		}
+	});
+
+	test('Returns empty string for non-existent environment variable', () => {
+		const result = substituteVariables('${env:NON_EXISTENT_VAR}/path');
+		assert.strictEqual(result, '/path');
+	});
+
+	test('Handles multiple variable substitutions', () => {
+		const result = substituteVariables('${workspaceFolder}${pathSeparator}${fileDirname}', mockNotebookUri);
+		assert.strictEqual(result, `/workspace/project1${path.sep}/workspace/project1/notebooks`);
+	});
+
+	test('Returns original text for unrecognized variables', () => {
+		const result = substituteVariables('${unknownVariable}/path');
+		assert.strictEqual(result, '${unknownVariable}/path');
+	});
+
+	test('Handles file variables without notebook URI gracefully', () => {
+		const result = substituteVariables('${fileDirname}/fallback');
+		assert.strictEqual(result, '${fileDirname}/fallback');
+	});
+
+	test('Handles workspace variables when no workspace folders exist', () => {
+		// Temporarily remove workspace folders
+		Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+			value: undefined,
+			configurable: true
+		});
+
+		const result = substituteVariables('${workspaceFolder}/path');
+		assert.strictEqual(result, '${workspaceFolder}/path');
+	});
+
+	test('Complex substitution scenario - VS Code compatibility', () => {
+		// Test the VS Code equivalent: jupyter.notebookFileRoot = "${workspaceFolder}"
+		const result = substituteVariables('${workspaceFolder}', mockNotebookUri);
+		assert.strictEqual(result, '/workspace/project1');
+	});
+
+	test('Complex substitution scenario - default behavior', () => {
+		// Test the default behavior: notebook.workingDirectory = "${fileDirname}"
+		const result = substituteVariables('${fileDirname}', mockNotebookUri);
+		assert.strictEqual(result, '/workspace/project1/notebooks');
+	});
+
+	test('Complex substitution scenario - multi-root workspace', () => {
+		// Test multi-root workspace scenario
+		const result = substituteVariables('${workspaceFolder:project2}${pathSeparator}shared');
+		assert.strictEqual(result, `/workspace/project2${path.sep}shared`);
+	});
+
+});

--- a/extensions/positron-supervisor/src/variableSubstitution.ts
+++ b/extensions/positron-supervisor/src/variableSubstitution.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Substitutes variables in a string with their resolved values.
+ * Supports common variables like ${workspaceFolder}, ${fileDirname}, etc.
+ *
+ * @param value The string containing variables to substitute
+ * @param notebookUri The URI of the notebook file (optional)
+ * @returns The string with variables substituted
+ */
+export function substituteVariables(value: string, notebookUri?: vscode.Uri): string {
+	if (!value) {
+		return value;
+	}
+
+	const variableRegex = /\$\{([^}]+)\}/g;
+
+	return value.replace(variableRegex, (match, variable) => {
+		// Handle ${workspaceFolder} - the first workspace folder
+		if (variable === 'workspaceFolder') {
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			return workspaceFolder ? workspaceFolder.uri.fsPath : match;
+		}
+
+		// Handle ${workspaceFolder:name} - specific workspace folder by name
+		if (variable.startsWith('workspaceFolder:')) {
+			const folderName = variable.substring('workspaceFolder:'.length);
+			const workspaceFolder = vscode.workspace.workspaceFolders?.find(
+				folder => folder.name === folderName
+			);
+			return workspaceFolder ? workspaceFolder.uri.fsPath : match;
+		}
+
+		// Handle ${fileDirname} - directory of the current notebook
+		if (variable === 'fileDirname' && notebookUri) {
+			return path.dirname(notebookUri.fsPath);
+		}
+
+		// Handle ${fileBasename} - name of the current notebook file
+		if (variable === 'fileBasename' && notebookUri) {
+			return path.basename(notebookUri.fsPath);
+		}
+
+		// Handle ${fileBasenameNoExtension} - name without extension
+		if (variable === 'fileBasenameNoExtension' && notebookUri) {
+			const basename = path.basename(notebookUri.fsPath);
+			const extname = path.extname(basename);
+			return basename.slice(0, -extname.length);
+		}
+
+		// Handle ${fileExtname} - extension of the current notebook
+		if (variable === 'fileExtname' && notebookUri) {
+			return path.extname(notebookUri.fsPath);
+		}
+
+		// Handle ${file} - full path of the current notebook
+		if (variable === 'file' && notebookUri) {
+			return notebookUri.fsPath;
+		}
+
+		// Handle ${relativeFile} - relative path from workspace folder
+		if (variable === 'relativeFile' && notebookUri) {
+			const workspaceFolder = vscode.workspace.getWorkspaceFolder(notebookUri);
+			if (workspaceFolder) {
+				return path.relative(workspaceFolder.uri.fsPath, notebookUri.fsPath);
+			}
+			return notebookUri.fsPath;
+		}
+
+		// Handle ${relativeFileDirname} - relative directory from workspace folder
+		if (variable === 'relativeFileDirname' && notebookUri) {
+			const workspaceFolder = vscode.workspace.getWorkspaceFolder(notebookUri);
+			if (workspaceFolder) {
+				const dirname = path.dirname(notebookUri.fsPath);
+				return path.relative(workspaceFolder.uri.fsPath, dirname);
+			}
+			return path.dirname(notebookUri.fsPath);
+		}
+
+		// Handle ${cwd} - current working directory
+		if (variable === 'cwd') {
+			return process.cwd();
+		}
+
+		// Handle ${userHome} - user home directory
+		if (variable === 'userHome') {
+			return os.homedir();
+		}
+
+		// Handle ${pathSeparator} - OS path separator
+		if (variable === 'pathSeparator') {
+			return path.sep;
+		}
+
+		// Handle ${/} - alias for path separator
+		if (variable === '/') {
+			return path.sep;
+		}
+
+		// Handle ${env:VARIABLE_NAME} - environment variables
+		if (variable.startsWith('env:')) {
+			const envVar = variable.substring('env:'.length);
+			return process.env[envVar] || '';
+		}
+
+		// Return the original match if we couldn't resolve the variable
+		return match;
+	});
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #7988. Adds a `notebook.workingDirectory` setting to the supervisor extension.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:notebooks @:vscode-settings @:console @:extensions @:interpreter @:win

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
