### PR TITLE
Anthropic token usage displayed in chat history

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -285,6 +285,21 @@ export function clearTokenUsage(context: vscode.ExtensionContext, provider: stri
 	tokenTracker.clearTokens(provider);
 }
 
+// Registry to store token usage by request ID for individual requests
+const requestTokenUsage = new Map<string, { inputTokens: number; outputTokens: number }>();
+
+export function recordRequestTokenUsage(requestId: string, inputTokens: number, outputTokens: number) {
+	requestTokenUsage.set(requestId, { inputTokens, outputTokens });
+	// Clean up old entries to prevent memory leaks
+	setTimeout(() => {
+		requestTokenUsage.delete(requestId);
+	}, 30000); // Clean up after 30 seconds
+}
+
+export function getRequestTokenUsage(requestId: string): { inputTokens: number; outputTokens: number } | undefined {
+	return requestTokenUsage.get(requestId);
+}
+
 export function activate(context: vscode.ExtensionContext) {
 	// Create the log output channel.
 	context.subscriptions.push(log);

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -484,6 +484,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else {
 				templateData.detail.textContent = localize('working', "Working");
 			}
+			// --- Start Positron ---
+		} else if (element.isComplete && element.tokenUsage) {
+			// Display token usage information when response is complete
+			const tokenText = localize('tokenUsage', "Input tokens: {0}, Output tokens: {1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens);
+			templateData.detail.textContent = tokenText;
+			// --- End Positron ---
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -484,12 +484,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else {
 				templateData.detail.textContent = localize('working', "Working");
 			}
-			// --- Start Positron ---
-		} else if (element.isComplete && element.tokenUsage) {
-			// Display token usage information when response is complete
-			const tokenText = localize('tokenUsage', "Input tokens: {0}, Output tokens: {1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens);
-			templateData.detail.textContent = tokenText;
-			// --- End Positron ---
 		}
 	}
 
@@ -630,6 +624,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				templateData.value.appendChild(renderedError.domNode);
 			}
 		}
+
+		// --- Start Positron ---
+		if (isResponseVM(element) && element.tokenUsage && element.isComplete) {
+			templateData.value.appendChild(dom.$('.token-usage', undefined, localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens)));
+		}
+		// --- End Positron ---
 
 		const newHeight = templateData.rowContainer.offsetHeight;
 		const fireEvent = !element.currentRenderedHeight || element.currentRenderedHeight !== newHeight;

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1135,6 +1135,9 @@ export interface ISerializableChatRequestData {
 	timestamp?: number;
 	confirmation?: string;
 	editedFileEvents?: IChatAgentEditedFileEvent[];
+	// --- Start Positron ---
+	tokenUsage?: IChatTokenUsage;
+	// --- End Positron ---
 }
 
 export interface IExportableChatData {
@@ -1558,6 +1561,11 @@ export class ChatModel extends Disposable implements IChatModel {
 						restoredId: raw.responseId
 					});
 					request.response.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
+					// --- Start Positron ---
+					if (raw.tokenUsage) {
+						request.response.setTokenUsage(raw.tokenUsage);
+					}
+					// --- End Positron ---
 					if (raw.usedContext) { // @ulugbekna: if this's a new vscode sessions, doc versions are incorrect anyway?
 						request.response.applyReference(revive(raw.usedContext));
 					}
@@ -1878,6 +1886,9 @@ export class ChatModel extends Disposable implements IChatModel {
 					timestamp: r.timestamp,
 					confirmation: r.confirmation,
 					editedFileEvents: r.editedFileEvents,
+					// --- Start Positron ---
+					tokenUsage: r.response?.tokenUsage,
+					// --- End Positron ---
 				};
 			}),
 		};

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -338,6 +338,13 @@ export interface IResponse {
 	toString(): string;
 }
 
+// --- Start Positron ---
+export interface IChatTokenUsage {
+	readonly inputTokens: number;
+	readonly outputTokens: number;
+}
+// --- End Positron ---
+
 export interface IChatResponseModel {
 	readonly onDidChange: Event<ChatResponseModelChangeReason>;
 	readonly id: string;
@@ -368,6 +375,9 @@ export interface IChatResponseModel {
 	readonly voteDownReason: ChatAgentVoteDownReason | undefined;
 	readonly followups?: IChatFollowup[] | undefined;
 	readonly result?: IChatAgentResult;
+	// --- Start Positron ---
+	readonly tokenUsage?: IChatTokenUsage;
+	// --- End Positron ---
 	addUndoStop(undoStop: IChatUndoStop): void;
 	setVote(vote: ChatAgentVoteDirection): void;
 	setVoteDownReason(reason: ChatAgentVoteDownReason | undefined): void;
@@ -769,6 +779,9 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	private _voteDownReason?: ChatAgentVoteDownReason;
 	private _result?: IChatAgentResult;
 	private _shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
+	// --- Start Positron ---
+	private _tokenUsage?: IChatTokenUsage;
+	// --- End Positron ---
 	public readonly isCompleteAddedRequest: boolean;
 
 	public get session() {
@@ -813,6 +826,12 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	public get result(): IChatAgentResult | undefined {
 		return this._result;
 	}
+
+	// --- Start Positron ---
+	public get tokenUsage(): IChatTokenUsage | undefined {
+		return this._tokenUsage;
+	}
+	// --- End Positron ---
 
 	public get username(): string {
 		return this.session.responderUsername;
@@ -958,6 +977,14 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 
 	setResult(result: IChatAgentResult): void {
 		this._result = result;
+
+		// --- Start Positron ---
+		// Extract token usage from result metadata if available
+		if (result.metadata && result.metadata.tokenUsage) {
+			this.setTokenUsage(result.metadata.tokenUsage);
+		}
+		// --- End Positron ---
+
 		this._onDidChange.fire(defaultChatResponseModelChangeReason);
 	}
 
@@ -990,6 +1017,13 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 		this._voteDownReason = reason;
 		this._onDidChange.fire(defaultChatResponseModelChangeReason);
 	}
+
+	// --- Start Positron ---
+	setTokenUsage(tokenUsage: IChatTokenUsage | undefined): void {
+		this._tokenUsage = tokenUsage;
+		this._onDidChange.fire(defaultChatResponseModelChangeReason);
+	}
+	// --- End Positron ---
 
 	setEditApplied(edit: IChatTextEditGroup, editCount: number): boolean {
 		if (!this.response.value.includes(edit)) {
@@ -1933,3 +1967,10 @@ export interface IChatAgentEditedFileEvent {
 	readonly uri: URI;
 	readonly eventKind: ChatRequestEditedFileEventKind;
 }
+
+// --- Start Positron ---
+export interface IChatTokenUsage {
+	readonly inputTokens: number;
+	readonly outputTokens: number;
+}
+// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -20,7 +20,10 @@ import { IParsedChatRequest } from './chatParserTypes.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
 import { countWords } from './chatWordCounter.js';
 import { CodeBlockModelCollection } from './codeBlockModelCollection.js';
-
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { IChatTokenUsage } from './chatModel.js';
+// --- End Positron ---
 export function isRequestVM(item: unknown): item is IChatRequestViewModel {
 	return !!item && typeof item === 'object' && 'message' in item;
 }
@@ -190,6 +193,9 @@ export interface IChatResponseViewModel {
 	readonly shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
 	readonly isCompleteAddedRequest: boolean;
 	readonly isPaused: IObservable<boolean>;
+	// --- Start Positron ---
+	readonly tokenUsage?: IChatTokenUsage;
+	// --- End Positron ---
 	renderData?: IChatResponseRenderData;
 	currentRenderedHeight: number | undefined;
 	setVote(vote: ChatAgentVoteDirection): void;
@@ -527,6 +533,12 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 	get isStale() {
 		return this._model.isStale;
 	}
+
+	// --- Start Positron ---
+	get tokenUsage() {
+		return this._model.tokenUsage;
+	}
+	// --- End Positron ---
 
 	get isLast(): boolean {
 		return this._chatViewModel.getItems().at(-1) === this;


### PR DESCRIPTION
Address #8233

Adds a token summary for the last message. This is persisted through window reloads and is included in chat exports.

### Release Notes

#### New Features

- Show chat message token usage for the Anthropic provider #8233 

#### Bug Fixes

- N/A


### QA Notes