### PR TITLE
assistant: disable run/debug play button when chat is in an editor

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -66,6 +66,10 @@ import { BREAK_WHEN_VALUE_CHANGES_ID, BREAK_WHEN_VALUE_IS_ACCESSED_ID, BREAK_WHE
 import { ADD_WATCH_ID, ADD_WATCH_LABEL, REMOVE_WATCH_EXPRESSIONS_COMMAND_ID, REMOVE_WATCH_EXPRESSIONS_LABEL, WatchExpressionsView } from './watchExpressionsView.js';
 import { WelcomeView } from './welcomeView.js';
 
+// --- Start Positron ---
+import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
+// --- End Positron ---
+
 const debugCategory = nls.localize('debugCategory', "Debug");
 registerColors();
 registerSingleton(IDebugService, DebugService, InstantiationType.Delayed);
@@ -249,7 +253,13 @@ if (isMacintosh) {
 
 // Editor Title Menu's "Run/Debug" dropdown item
 
+// --- Start Positron ---
+/*
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, rememberDefaultAction: true, title: nls.localize2('run', "Run or Debug..."), icon: icons.debugRun, group: 'navigation', order: -1 });
+*/
+// Only include the Run/Debug menu item (play button) in the editor actions when **not** in a chat session. https://github.com/posit-dev/positron/issues/7638
+MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, rememberDefaultAction: true, title: nls.localize2('run', "Run or Debug..."), icon: icons.debugRun, group: 'navigation', order: -1, when: ChatContextKeys.inChatSession.toNegated() });
+// --- End Positron ---
 
 // Debug menu
 


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7638
- removes the run/debug play button from the editor actions when a chat session is open in an editor

### Release Notes

#### Bug Fixes

- Assistant: run/debug play button removed from editor actions when a chat session is open in an editor (#7638)

### QA Notes

@:assistant

1. Chat with Assistant in the sidebar to get some R and Python code suggestions in the chat (Ask mode is probably best here)
2. Run the command `Chat: Open Chat in Editor` to open the conversation in an editor
3. Scroll through the chat to bring the R and Python code into focus
4. The play button should not appear at any point when interacting with the chat in an editor