### PR TITLE
assistant: rename the `/quarto` command to `/exportQuarto`

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -32,8 +32,8 @@
         "isDefault": true,
         "commands": [
           {
-            "name": "quarto",
-            "description": "%chatParticipants.commands.quarto.description%"
+            "name": "exportQuarto",
+            "description": "%chatParticipants.commands.exportQuarto.description%"
           }
         ],
         "locations": [

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -14,7 +14,7 @@
 	"chatParticipants.ask.description": "Ask Assistant",
 	"chatParticipants.agent.description": "Complete tasks in your workspace",
 	"chatParticipants.edit.description": "Edit files in your workspace",
-	"chatParticipants.commands.quarto.description": "Convert the conversation so far into a new Quarto document.",
+	"chatParticipants.commands.exportQuarto.description": "Export the conversation so far into a new Quarto document.",
 	"configuration.title": "Positron Assistant",
 	"configuration.enable.markdownDescription": "Enable [Positron Assistant](https://positron.posit.co/assistant), an AI assistant for Positron.",
 	"configuration.toolDetails.enable": "Enable tool call input and output details in the chat view. Must be enabled to include tool call details in the chat export.",

--- a/extensions/positron-assistant/src/commands/quarto.ts
+++ b/extensions/positron-assistant/src/commands/quarto.ts
@@ -11,8 +11,10 @@ import { toLanguageModelChatMessage } from '../utils';
 
 const mdDir = `${EXTENSION_ROOT_DIR}/src/md/`;
 
+export const EXPORT_QUARTO_COMMAND = 'exportQuarto';
+
 /**
- * Handler for the custom chat participant command `/quarto`.
+ * Handler for the custom chat participant command `/exportQuarto`.
  */
 export async function quartoHandler(
 	request: vscode.ChatRequest,

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -11,7 +11,7 @@ import * as xml from './xml.js';
 
 import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_WORKSPACE } from './constants';
 import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString } from './utils';
-import { quartoHandler } from './commands/quarto';
+import { EXPORT_QUARTO_COMMAND, quartoHandler } from './commands/quarto';
 import { PositronAssistantToolName } from './types.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
@@ -172,7 +172,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		// Select request handler based on the command issued by the user for this request
 		try {
 			switch (request.command) {
-				case 'quarto':
+				case EXPORT_QUARTO_COMMAND:
 					return await quartoHandler(request, context, response, token);
 				default:
 					return await this.defaultRequestHandler(request, context, response, token);

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -770,7 +770,7 @@ Always verify results. AI assistants can sometimes produce incorrect code.`);
 
 Click on $(attach) or type \`#\` to add context, such as files to your chat.
 
-Type \`/\` to use predefined commands such as \`/help\` or \`/quarto\`.`,
+Type \`/\` to use predefined commands such as \`/help\`.`,
 			), { supportThemeIcons: true, isTrusted: true });
 			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](https://positron.posit.co/assistant)`);
 		}


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8433
- renames the chat command from `/quarto` to `/exportQuarto` to better align with the command behaviour

### Release Notes

#### Bug Fixes

- Assistant: renamed chat command from `/quarto` to `/exportQuarto` (#8433)

### QA Notes

@:assistant

The chat command is now `/exportQuarto` and should not be included in the welcome screen anymore (only `/help` should be suggested).