### PR TITLE
assistant: fix copilot inline completions for ipynb

### DIFF
--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -190,7 +190,7 @@ class OpenAILegacyCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -386,7 +386,7 @@ abstract class FimPromptCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -649,7 +649,7 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 		return await this._copilotService.inlineCompletion(document, position, context, token);

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2120,10 +2120,10 @@ declare module 'positron' {
 		}
 
 		/**
-		 * Checks the file for exclusion from AI completion.
-		 * @param file The file to check for exclusion.
-		 * @returns A Thenable that resolves to true if the file should be excluded, false otherwise.
+		 * Checks if completions are enabled for the given file.
+		 * @param uri The file URI to check if completions are enabled.
+		 * @returns A Thenable that resolves to true if completions should be enabled for the file, false otherwise.
 		 */
-		export function areCompletionsEnabled(file: vscode.Uri): Thenable<boolean>;
+		export function areCompletionsEnabled(uri: vscode.Uri): Thenable<boolean>;
 	}
 }

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -116,7 +116,7 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	}
 
 	/**
-	 * Check if a file should be excluded from AI completions based on configuration settings.
+	 * Check if a file should be enabled for AI completions based on configuration settings.
 	 */
 	async $areCompletionsEnabled(file: UriComponents): Promise<boolean> {
 		const uri = URI.revive(file);

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -217,17 +217,17 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		const globPattern = this._configurationService.getValue<string[]>('positron.assistant.inlineCompletionExcludes');
 
 		if (!globPattern || globPattern.length === 0) {
-			return false; // No glob patterns configured, so no files are excluded
+			return true; // No glob patterns configured, so completions are enabled
 		}
 
-		// Check all of the glob patterns and return true if any match
+		// Check all of the glob patterns and return false if any match
 		for (const pattern of globPattern) {
 			if (glob.match(pattern, uri.path)) {
-				return true; // File matches an exclusion pattern
+				return false; // File matches an exclusion pattern, so it is excluded from completions
 			}
 		}
 
-		return false; // No patterns matched, so the file is not excluded
+		return true; // No patterns matched, so completions are enabled
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -139,9 +139,9 @@ export interface IPositronAssistantService {
 	removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 
 	/**
-	 * Check if a file should be excluded from AI completions.
-	 * @param uri The URI of the file to check.
-	 * @returns True if the file should be excluded from the Positron Assistant, false otherwise.
+	 * Checks if completions are enabled for the given file.
+	 * @param uri The file URI to check if completions are enabled.
+	 * @returns true if completions should be enabled for the file, false otherwise.
 	 */
 	areCompletionsEnabled(uri: URI): boolean;
 


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8061

### Release Notes

> [!NOTE]
> TBD if this is a feature or a bugfix 😆  

#### New Features

- Assistant: Copilot editor inline completions are now available for `ipynb` files (#8061)

#### Bug Fixes

- Assistant: fixed bug causing completions to error for `ipynb` files (#8061)

### QA Notes

@:assistant

- inline completions should be available for ipynb files when authenticated with GitHub Copilot
- the `positron.assistant.inlineCompletionExcludes` setting should continue to work