### PR TITLE
Add token usage preference

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -197,6 +197,11 @@
             "default": false,
             "description": "%configuration.gitIntegration.description%",
             "tags": ["experimental"]
+          },
+          "positron.assistant.showTokenUsage": {
+            "type":"boolean",
+            "default": false,
+            "description": "%configuration.showTokenUsage.description%"
           }
         }
       }

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -198,8 +198,8 @@
             "description": "%configuration.gitIntegration.description%",
             "tags": ["experimental"]
           },
-          "positron.assistant.showTokenUsage": {
-            "type":"boolean",
+          "positron.assistant.showTokenUsage.enable": {
+            "type": "boolean",
             "default": false,
             "description": "%configuration.showTokenUsage.description%"
           }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -21,5 +21,6 @@
 	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",
-	"configuration.gitIntegration.description": "Enable Positron Assistant git integration."
+	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
+	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers."
 }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -22,5 +22,5 @@
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
-	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers."
+	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for each message and response including prompts. Check with your provider for detailed usage."
 }

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -159,7 +159,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,
 		overflowWidgetsDomNode: HTMLElement | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService configService: IConfigurationService,
+		// --- Start Positron ---
+		@IConfigurationService private readonly configService: IConfigurationService,
+		// --- End Positron ---
 		@ILogService private readonly logService: ILogService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IThemeService private readonly themeService: IThemeService,
@@ -626,7 +628,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		// --- Start Positron ---
-		if (isResponseVM(element) && element.tokenUsage && element.isComplete) {
+		if (isResponseVM(element) && element.tokenUsage && element.isComplete && this.configService.getValue<boolean>('positron.assistant.showTokenUsage')) {
 			templateData.value.appendChild(dom.$('.token-usage', undefined, localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens)));
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -627,8 +627,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 		}
 
+		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
 		// --- Start Positron ---
-		if (isResponseVM(element) && element.tokenUsage && element.isComplete && this.configService.getValue<boolean>('positron.assistant.showTokenUsage')) {
+		if (isResponseVM(element) && element.tokenUsage && element.isComplete && showTokens) {
 			templateData.value.appendChild(dom.$('.token-usage', undefined, localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens)));
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -627,8 +627,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 		}
 
-		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
 		// --- Start Positron ---
+		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
 		if (isResponseVM(element) && element.tokenUsage && element.isComplete && showTokens) {
 			templateData.value.appendChild(dom.$('.token-usage', undefined, localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens)));
 		}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -102,7 +102,8 @@
       codeCitations: [  ],
       timestamp: undefined,
       confirmation: undefined,
-      editedFileEvents: undefined
+      editedFileEvents: undefined,
+      tokenUsage: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
@@ -86,7 +86,8 @@
       codeCitations: [  ],
       timestamp: undefined,
       confirmation: undefined,
-      editedFileEvents: undefined
+      editedFileEvents: undefined,
+      tokenUsage: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -109,7 +109,8 @@
       codeCitations: [  ],
       timestamp: undefined,
       confirmation: undefined,
-      editedFileEvents: undefined
+      editedFileEvents: undefined,
+      tokenUsage: undefined
     },
     {
       requestId: undefined,
@@ -164,7 +165,8 @@
       codeCitations: [  ],
       timestamp: undefined,
       confirmation: undefined,
-      editedFileEvents: undefined
+      editedFileEvents: undefined,
+      tokenUsage: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
@@ -86,7 +86,8 @@
       codeCitations: [  ],
       timestamp: undefined,
       confirmation: undefined,
-      editedFileEvents: undefined
+      editedFileEvents: undefined,
+      tokenUsage: undefined
     }
   ]
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -177,5 +177,25 @@ export class Assistant {
 		await expect(this.code.driver.page.locator(CHAT_INPUT)).toBeVisible();
 	}
 
+	async verifyTokenUsageVisible() {
+		await expect(this.code.driver.page.locator('.token-usage')).toBeVisible();
+		await expect(this.code.driver.page.locator('.token-usage')).toHaveText(/Tokens: ↑\d+ ↓\d+/);
+	}
 
+	async verifyTokenUsageNotVisible() {
+		await expect(this.code.driver.page.locator('.token-usage')).not.toBeVisible();
+	}
+
+	async getTokenUsage() {
+		const tokenUsageElement = this.code.driver.page.locator('.token-usage');
+		await expect(tokenUsageElement).toBeVisible();
+		const text = await tokenUsageElement.textContent();
+		expect(text).not.toBeNull();
+		const inputMatch = text ? text.match(/↑(\d+)/) : null;
+		const outputMatch = text ? text.match(/↓(\d+)/) : null;
+		return {
+			inputTokens: inputMatch ? parseInt(inputMatch[1], 10) : 0,
+			outputTokens: outputMatch ? parseInt(outputMatch[1], 10) : 0
+		};
+	}
 }

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -144,3 +144,36 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 	});
 });
 
+test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
+	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
+		await app.workbench.assistant.selectModelProvider('echo');
+		await app.workbench.assistant.clickSignInButton();
+		await app.workbench.assistant.clickCloseButton();
+
+		await settings.set({ 'positron.assistant.showTokenUsage': true });
+	});
+
+	test.beforeEach('Clear chat', async function ({ app }) {
+		await app.workbench.assistant.clickNewChatButton();
+	});
+
+	test('Token usage is displayed in chat response', async function ({ app }) {
+		const message = 'What is the meaning of life?';
+		await app.workbench.assistant.enterChatMessage(message);
+		await app.workbench.assistant.verifyTokenUsageVisible();
+		const tokenUsage = await app.workbench.assistant.getTokenUsage();
+		expect(tokenUsage).toMatchObject({
+			inputTokens: message.length,
+			outputTokens: message.length
+		});
+	});
+
+	test('Token usage is not displayed when setting is disabled', async function ({ app, settings }) {
+		await settings.set({ 'positron.assistant.showTokenUsage': false });
+		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
+
+		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
+	});
+});

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -152,7 +152,7 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 		await app.workbench.assistant.clickSignInButton();
 		await app.workbench.assistant.clickCloseButton();
 
-		await settings.set({ 'positron.assistant.showTokenUsage': true });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': true });
 	});
 
 	test.beforeEach('Clear chat', async function ({ app }) {
@@ -171,7 +171,7 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 	});
 
 	test('Token usage is not displayed when setting is disabled', async function ({ app, settings }) {
-		await settings.set({ 'positron.assistant.showTokenUsage': false });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': false });
 		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());


### PR DESCRIPTION
Follow-up for #8233 

Adds a preference to display the token usage. It's disabled by default.

There's no listener on the setting so the chat history won't update with previous usage despite the chat metadata containing the token usage. Only new responses will show token usage.

Switching between chats will re-render the chat and will display token usage if available.

<img width="1019" height="283" alt="image" src="https://github.com/user-attachments/assets/6a04144a-a665-413c-b77a-ed2101a8f19b" />

### Release Notes

#### New Features

- Add preference to display chat token usage

#### Bug Fixes

- N/A


### QA Notes