### PR TITLE
Assistant: Chat status hides when not applicable

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -47,6 +47,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { ILanguageModelsService } from '../common/languageModels.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IEditorGroupsService, IEditorPart } from '../../../services/editor/common/editorGroupsService.js';
 // --- End Positron ---
 
 const gaugeBackground = registerColor('gauge.background', {
@@ -108,7 +109,43 @@ const defaultChat = {
 	manageOverageUrl: product.defaultChatAgent?.manageOverageUrl ?? '',
 };
 
+// --- Start Positron ---
+// This is a wrapper around the ChatStatus class
+// which creates a ChatStatus instance for each editor part (window)\
+// See src/vs/workbench/contrib/languageStatus/browser/languageStatus.ts for inspiration
 export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.chatStatusBarEntry';
+
+	constructor(
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
+	) {
+		super();
+
+		for (const part of editorGroupService.parts) {
+			this.createChatStatus(part);
+		}
+
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.createChatStatus(part)));
+	}
+
+	private createChatStatus(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		part.onWillDispose(() => {
+			if (!disposables.isDisposed) {
+				disposables.dispose();
+			}
+		});
+
+		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
+		disposables.add(scopedInstantiationService.createInstance(ChatStatus));
+	}
+}
+
+// Rename this class to avoid needing to modify other files that import it
+
+// export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribution {
+export class ChatStatus extends Disposable {
+	// --- End Positron ---
 
 	static readonly ID = 'workbench.contrib.chatStatusBarEntry';
 
@@ -133,6 +170,14 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	private update(): void {
 		// --- Start Positron ---
+		// Remove the Chat status if the active editor is not a code editor
+		const codeEditor = getCodeEditor(this.editorService.activeEditorPane?.getControl());
+		if (!codeEditor) {
+			this.entry?.dispose();
+			this.entry = undefined;
+			return;
+		}
+
 		// We only need the part that displays the status. No need to hide it based on the chat entitlement setting the right context keys
 		if (!this.entry) {
 			this.entry = this.statusbarService.addEntry(this.getEntryProps(), 'chat.statusBarEntry', StatusbarAlignment.RIGHT, { location: { id: 'status.editor.mode', priority: 100.1 }, alignment: StatusbarAlignment.RIGHT });
@@ -218,7 +263,11 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 			text,
 			ariaLabel,
 			command: ShowTooltipCommand,
-			showInAllWindows: true,
+			// --- Start Positron ---
+			// Do not show status in all windows; allows us to create a new status item
+			// for each window manually
+			// showInAllWindows: true,
+			// --- End Positron ---
 			kind,
 			tooltip: { element: token => this.dashboard.value.show(token) }
 		};

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -173,8 +173,7 @@ export class ChatStatus extends Disposable {
 	private update(): void {
 		// --- Start Positron ---
 		// Remove the Chat status if the active editor is not a code editor
-		const codeEditor = getCodeEditor(this.editorService.activeEditorPane?.getControl());
-		if (!codeEditor) {
+		if (!this.shouldShowStatus()) {
 			this.entry?.dispose();
 			this.entry = undefined;
 			return;
@@ -216,6 +215,16 @@ export class ChatStatus extends Disposable {
 			});
 		}
 	}
+
+	// --- Start Positron ---
+	private shouldShowStatus(): boolean {
+		// Show the Chat status item if:
+		// - a Code editor is active
+		// - a Chat session is open in editor
+		return getCodeEditor(this.editorService.activeEditorPane?.getControl()) !== null ||
+			this.editorService.activeEditor?.editorId === 'workbench.editor.chatSession';
+	}
+	// --- End Positron ---
 
 	private getEntryProps(): IStatusbarEntry {
 		// --- Start Positron ---

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -130,11 +130,13 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	private createChatStatus(part: IEditorPart): void {
 		const disposables = new DisposableStore();
-		part.onWillDispose(() => {
-			if (!disposables.isDisposed) {
-				disposables.dispose();
-			}
-		});
+		this._register(
+			part.onWillDispose(() => {
+				if (!disposables.isDisposed) {
+					disposables.dispose();
+				}
+			})
+		);
 
 		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
 		disposables.add(scopedInstantiationService.createInstance(ChatStatus));


### PR DESCRIPTION
The Chat status item in the bottom bar is now hidden if only a Plot or Data Explorer editor is open _and_ the user does not have an active chat session in the window.

We can consider other setups that may warrant hiding the Chat status, too.


https://github.com/user-attachments/assets/7a77b2a0-58fe-427d-b5fb-d9cdb3bacfc8



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #8159 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:assistant