### PR TITLE
PositroNB config with editor associations

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -11,20 +11,20 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
 import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../../../common/editor.js';
 
 import { parse } from '../../../../base/common/marshalling.js';
 import { assertType } from '../../../../base/common/types.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { INotebookService } from '../../notebook/common/notebookService.js';
-import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { PositronNotebookEditorInput, PositronNotebookEditorInputOptions } from './PositronNotebookEditorInput.js';
-import { positronConfigurationNodeBase } from '../../../services/languageRuntime/common/languageRuntime.js';
+
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ICommandAndKeybindingRule, KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
@@ -32,52 +32,7 @@ import { IPositronNotebookService } from '../../../services/positronNotebook/bro
 import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
 import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../services/positronNotebook/common/positronNotebookUtils.js';
 
-// Configuration constants
-const LEGACY_CONFIG_KEY = 'positron.notebooks.usePositronNotebooksExperimental';
 
-// Register the new configuration
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	...positronConfigurationNodeBase,
-	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
-	properties: {
-		[POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]: {
-			type: 'string',
-			enum: ['positron', 'vscode'],
-			enumDescriptions: [
-				localize('positron.notebooks.defaultEditor.positron', 'Use Positron\'s notebook editor for .ipynb files'),
-				localize('positron.notebooks.defaultEditor.vscode', 'Use VS Code\'s built-in notebook editor for .ipynb files')
-			],
-			default: 'vscode',
-			markdownDescription: localize(
-				'positron.notebooks.defaultEditor.description',
-				'Choose which editor to use for notebook (.ipynb) files. You can always use "Open With..." to override this setting for specific files.'
-			),
-			scope: ConfigurationScope.MACHINE_OVERRIDABLE
-		}
-	}
-});
-
-/**
- * Handle migration from old experimental setting (log-only approach)
- */
-class PositronNotebookConfigMigration implements IWorkbenchContribution {
-	static readonly ID = 'workbench.contrib.positronNotebookConfigMigration';
-
-	constructor(@IConfigurationService private readonly configurationService: IConfigurationService) {
-		this.checkForLegacyConfiguration();
-	}
-
-	private checkForLegacyConfiguration(): void {
-		const legacyValue = this.configurationService.getValue<boolean>(LEGACY_CONFIG_KEY);
-		if (legacyValue === true) {
-			console.log(
-				'Positron: The setting "positron.notebooks.usePositronNotebooksExperimental" has been replaced. ' +
-				'Please use "positron.notebooks.defaultEditor" instead. ' +
-				'Set it to "positron" to continue using Positron notebooks as your default.'
-			);
-		}
-	}
-}
 
 
 
@@ -351,6 +306,4 @@ function registerNotebookKeybinding({ id, onRun, ...opts }: {
 }
 //#endregion Keybindings
 
-// Register the migration
-const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchRegistry.registerWorkbenchContribution(PositronNotebookConfigMigration, LifecyclePhase.Restored);
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -30,9 +30,9 @@ import { ICommandAndKeybindingRule, KeybindingsRegistry, KeybindingWeight } from
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../services/positronNotebook/common/positronNotebookUtils.js';
 
 // Configuration constants
-export const POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY = 'positron.notebooks.defaultEditor';
 const LEGACY_CONFIG_KEY = 'positron.notebooks.usePositronNotebooksExperimental';
 
 // Register the new configuration
@@ -56,16 +56,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		}
 	}
 });
-
-/**
- * Get the user's preferred notebook editor
- * @param configurationService Configuration service
- * @returns 'positron' | 'vscode'
- */
-export function getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode' {
-	const value = configurationService.getValue<'positron' | 'vscode'>(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY) || 'vscode';
-	return value === 'positron' || value === 'vscode' ? value : 'vscode';
-}
 
 /**
  * Handle migration from old experimental setting (log-only approach)

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -22,9 +22,9 @@ Positron Notebooks represents a parallel notebook implementation within Positron
 ### Quick Start for Contributors
 
 **To enable Positron Notebooks:**
-1. Set `"positron.notebooks.defaultEditor": "positron"` in your settings
+1. Set `"workbench.editorAssociations": {"*.ipynb": "workbench.editor.positronNotebook"}` in your settings
 2. Open any `.ipynb` file - it will use Positron's notebook editor
-3. To switch back: Use "Open With..." or change the setting to `"vscode"`
+3. To switch back: Remove the editor association or use "Open With..." menu
 
 **Key files to understand:**
 - `positronNotebook.contribution.ts`: Entry point, configuration, editor registration
@@ -50,16 +50,15 @@ Positron Notebooks represents a parallel notebook implementation within Positron
 
 #### Adding New Configuration Options
 1. Define in `positronNotebook.contribution.ts`
-2. Implement reader function similar to `getPreferredNotebookEditor`
-3. Add configuration change listener
-4. Update editor registration if needed
+2. Update editor registration if needed
+3. Consider using VS Code's standard configuration patterns
 
 ### Development Workflows
 
 #### Local Development Setup
 ```bash
 # Enable Positron notebooks
-"positron.notebooks.defaultEditor": "positron"
+"workbench.editorAssociations": {"*.ipynb": "workbench.editor.positronNotebook"}
 
 # Key files to modify:
 - PositronNotebookInstance.ts    # Core state management
@@ -88,22 +87,12 @@ Positron Notebooks represents a parallel notebook implementation within Positron
 
 ### 1. Configuration Layer
 
-**Configuration Key**: `positron.notebooks.defaultEditor`
-**Location**: `src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts`
+**Configuration Access**: Editor associations are controlled via VS Code's standard `workbench.editorAssociations` setting
+- Set `"*.ipynb": "workbench.editor.positronNotebook"` to use Positron notebooks as default
+- Remove or don't set the association to use VS Code's standard notebook editor
+- Located in user/workspace settings
 
-```typescript
-'positron.notebooks.defaultEditor': {
-    type: 'string',
-    enum: ['positron', 'vscode'],
-    default: 'vscode',
-    markdownDescription: 'Choose which editor to use for notebook (.ipynb) files...'
-}
-```
-
-**Configuration Reader**: `getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode'`
-- Returns user's preferred default notebook editor
-- Located in `positronNotebook.contribution.ts`
-- Defaults to 'vscode' if not configured or invalid value
+**Location**: User or workspace settings.json file
 
 ### 2. Editor Registration and Resolution
 
@@ -150,37 +139,37 @@ graph TB
         Editor[PositronNotebookEditor]
         TextModel[NotebookTextModel]
     end
-    
+
     subgraph "Core Components"
         Instance[PositronNotebookInstance]
         CodeCell[PositronNotebookCodeCell]
         MarkdownCell[PositronNotebookMarkdownCell]
     end
-    
+
     subgraph "Service Layer"
         NotebookService[IPositronNotebookService]
         RuntimeService[IRuntimeSessionService]
         KernelService[INotebookKernelService]
         ExecutionService[INotebookExecutionService]
     end
-    
+
     %% Primary relationships
     EditorInput -->|"owns"| Instance
     Editor -->|"renders"| Instance
     Instance -->|"manages"| TextModel
     Instance -->|"creates"| CodeCell
     Instance -->|"creates"| MarkdownCell
-    
+
     %% Service connections
     Instance -->|"registers with"| NotebookService
     Instance -->|"executes via"| RuntimeService
     Instance -->|"kernel management"| KernelService
     CodeCell -->|"execution"| ExecutionService
-    
+
     %% Data flow
     TextModel -->|"provides cells"| Instance
     EditorInput -->|"resolves"| TextModel
-    
+
     style Instance fill:#f9f,stroke:#333,stroke-width:4px
     style EditorInput fill:#bbf,stroke:#333,stroke-width:2px
     style Editor fill:#bbf,stroke:#333,stroke-width:2px
@@ -316,8 +305,8 @@ if (preloadMessageType) {
 **From PositronNotebookInstance.ts**:
 ```typescript
 await this.notebookExecutionService.executeNotebookCells(
-    this.textModel, 
-    Array.from(cells).map(c => c.cellModel as NotebookCellTextModel), 
+    this.textModel,
+    Array.from(cells).map(c => c.cellModel as NotebookCellTextModel),
     this._contextKeyService
 );
 ```
@@ -346,8 +335,8 @@ IPositronNotebookCell (interface)
 The `createNotebookCell` function serves as a factory that instantiates the correct cell type based on the cell model:
 ```typescript
 export function createNotebookCell(
-    cell: NotebookCellTextModel, 
-    instance: PositronNotebookInstance, 
+    cell: NotebookCellTextModel,
+    instance: PositronNotebookInstance,
     instantiationService: IInstantiationService
 ) {
     if (cell.cellKind === CellKind.Code) {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
@@ -8,32 +8,24 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IConfigurationService, IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
 import { EditorResolverService } from '../../../../services/editor/browser/editorResolverService.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
 import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
-import { Event } from '../../../../../base/common/event.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
-import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
+import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
 
-// Mock implementation for testing configuration-driven editor registration
+// Mock implementation for testing static editor registration
 class MockPositronNotebookContribution extends DisposableStore {
 	private _currentRegistration: any;
 	private _registrationCount = 0;
 
 	constructor(
 		private editorResolverService: IEditorResolverService,
-		private configurationService: IConfigurationService,
 		private instantiationService: ITestInstantiationService
 	) {
 		super();
 		this.registerEditor();
-		this.add(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY)) {
-				this.registerEditor();
-			}
-		}));
 	}
 
 	private registerEditor(): void {
@@ -41,13 +33,13 @@ class MockPositronNotebookContribution extends DisposableStore {
 		this._currentRegistration?.dispose();
 		this._registrationCount++;
 
-		// Register with current priority
+		// Register with static option priority
 		this._currentRegistration = this.editorResolverService.registerEditor(
 			'*.ipynb',
 			{
 				id: PositronNotebookEditorInput.EditorID,
 				label: 'Positron Notebook',
-				priority: this.getEditorPriority()
+				priority: RegisteredEditorPriority.option
 			},
 			{
 				singlePerResource: true,
@@ -68,13 +60,6 @@ class MockPositronNotebookContribution extends DisposableStore {
 				}
 			}
 		);
-	}
-
-	private getEditorPriority(): RegisteredEditorPriority {
-		const defaultEditor = getPreferredNotebookEditor(this.configurationService);
-		return defaultEditor === 'positron'
-			? RegisteredEditorPriority.default
-			: RegisteredEditorPriority.option;
 	}
 
 	get registrationCount(): number {
@@ -109,110 +94,41 @@ suite('Positron Notebook Configuration Handling', () => {
 		// Create mock notebook contribution that handles registration
 		notebookContribution = new MockPositronNotebookContribution(
 			editorResolverService,
-			configurationService,
 			instantiationService
 		);
 		disposables.add(notebookContribution);
 	}
 
-	test('Editor re-registration occurs when configuration changes', async () => {
+	test('usingPositronNotebooks returns true when editor association is set', async () => {
 		await createTestServices();
 
-		const initialRegistrationCount = notebookContribution.registrationCount;
+		// Set editor association for Positron notebooks
+		configurationService.setUserConfiguration('workbench.editorAssociations', {
+			'*.ipynb': 'workbench.editor.positronNotebook'
+		});
 
-		// Change configuration
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
-
-		// Trigger configuration change event
-		configurationService.onDidChangeConfigurationEmitter.fire({
-			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
-			source: 6, // ConfigurationTarget.USER
-			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
-			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
-		} as IConfigurationChangeEvent);
-
-		// Should have triggered a new registration
-		assert.strictEqual(notebookContribution.registrationCount, initialRegistrationCount + 1);
+		const isUsing = usingPositronNotebooks(configurationService);
+		assert.strictEqual(isUsing, true);
 	});
 
-	test('Editor priority changes correctly with configuration', async () => {
+	test('usingPositronNotebooks returns false when editor association is not set', async () => {
 		await createTestServices();
 
-		// Start with vscode (option priority)
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'vscode');
-		configurationService.onDidChangeConfigurationEmitter.fire({
-			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
-			source: 6,
-			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
-			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
-		} as IConfigurationChangeEvent);
-
-		let editors = editorResolverService.getEditors();
-		let positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
-		assert.ok(positronEditor);
-		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.option);
-
-		// Change to positron (default priority)
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
-		configurationService.onDidChangeConfigurationEmitter.fire({
-			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY,
-			source: 6,
-			affectedKeys: new Set([POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY]),
-			change: { keys: [POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY], overrides: [] }
-		} as IConfigurationChangeEvent);
-
-		editors = editorResolverService.getEditors();
-		positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
-		assert.ok(positronEditor);
-		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.default);
+		// No editor associations set
+		const isUsing = usingPositronNotebooks(configurationService);
+		assert.strictEqual(isUsing, false);
 	});
 
-	test('Configuration changes not affecting notebook setting do not trigger re-registration', async () => {
+	test('usingPositronNotebooks returns false when editor association is set to different editor', async () => {
 		await createTestServices();
 
-		const initialRegistrationCount = notebookContribution.registrationCount;
+		// Set editor association to VS Code notebook
+		configurationService.setUserConfiguration('workbench.editorAssociations', {
+			'*.ipynb': 'jupyter-notebook'
+		});
 
-		// Change unrelated configuration
-		configurationService.setUserConfiguration('workbench.editor.enablePreview', false);
-		configurationService.onDidChangeConfigurationEmitter.fire({
-			affectsConfiguration: (key: string) => key === 'workbench.editor.enablePreview',
-			source: 6,
-			affectedKeys: new Set(['workbench.editor.enablePreview']),
-			change: { keys: ['workbench.editor.enablePreview'], overrides: [] }
-		} as IConfigurationChangeEvent);
-
-		// Should not have triggered a new registration
-		assert.strictEqual(notebookContribution.registrationCount, initialRegistrationCount);
-	});
-
-	test('Handles null/undefined configuration values gracefully', async () => {
-		await createTestServices();
-
-		// Set configuration to null/undefined
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, null);
-
-		// Should default to 'vscode'
-		const preferred = getPreferredNotebookEditor(configurationService);
-		assert.strictEqual(preferred, 'vscode');
-
-		// Verify editor is registered with option priority
-		const editors = editorResolverService.getEditors();
-		const positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
-		assert.ok(positronEditor);
-		assert.strictEqual(positronEditor.priority, RegisteredEditorPriority.option);
-	});
-
-	test('Handles configuration service returning undefined', async () => {
-		await createTestServices();
-
-		// Create a configuration service that returns undefined
-		const emptyConfigService = {
-			getValue: () => undefined,
-			onDidChangeConfiguration: Event.None
-		} as any;
-
-		const preferred = getPreferredNotebookEditor(emptyConfigService);
-		assert.strictEqual(preferred, 'vscode');
+		const isUsing = usingPositronNotebooks(configurationService);
+		assert.strictEqual(isUsing, false);
 	});
 
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
@@ -14,7 +14,7 @@ import { IEditorResolverService, RegisteredEditorPriority } from '../../../../se
 import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { Event } from '../../../../../base/common/event.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
-import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../browser/positronNotebook.contribution.js';
+import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
 
 // Mock implementation for testing configuration-driven editor registration

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -42,7 +42,7 @@ import { RegisteredEditorPriority, ResolvedStatus } from '../../../../services/e
 import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
-import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../browser/positronNotebook.contribution.js';
+import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
 
 suite('Positron Notebook Editor Resolution', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -28,7 +28,7 @@
  * levels, including error conditions, edge cases, and proper resource cleanup.
  *
  * @see {@link PositronNotebookEditorInput} - The editor input class being tested
- * @see {@link getPreferredNotebookEditor} - Configuration utility function
+ * @see {@link usingPositronNotebooks} - Configuration utility function
  * @see {@link EditorResolverService} - Core service for editor resolution
  */
 
@@ -36,20 +36,18 @@ import assert from 'assert';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { EditorResolverService } from '../../../../services/editor/browser/editorResolverService.js';
 import { RegisteredEditorPriority, ResolvedStatus } from '../../../../services/editor/common/editorResolverService.js';
 import { ITestInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
-import { POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, getPreferredNotebookEditor } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
+import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
 
 suite('Positron Notebook Editor Resolution', () => {
 
 	const disposables = new DisposableStore();
 	let instantiationService: ITestInstantiationService;
-	let configurationService: TestConfigurationService;
 	let editorResolverService: EditorResolverService;
 	let part: EditorPart;
 
@@ -60,7 +58,6 @@ suite('Positron Notebook Editor Resolution', () => {
 	async function createTestServices(): Promise<void> {
 		const services = await createPositronNotebookTestServices(disposables);
 		instantiationService = services.instantiationService;
-		configurationService = services.configurationService;
 		editorResolverService = services.editorResolverService;
 		part = services.part;
 	}
@@ -96,28 +93,9 @@ suite('Positron Notebook Editor Resolution', () => {
 	}
 
 
-	test('getPreferredNotebookEditor defaults to vscode when no setting', async () => {
-		await createTestServices();
-
-		const preferred = getPreferredNotebookEditor(configurationService);
-		assert.strictEqual(preferred, 'vscode');
-	});
-
-
-	test('Invalid configuration value defaults to vscode', async () => {
-		await createTestServices();
-
-		// Set invalid value
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'invalid-value');
-
-		const preferred = getPreferredNotebookEditor(configurationService);
-		assert.strictEqual(preferred, 'vscode');
-	});
-
 	test('Only ipynb files are handled by Positron notebook editor', async () => {
 		await createTestServices();
 
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY, 'positron');
 		registerPositronNotebookEditor(RegisteredEditorPriority.default);
 
 		// Test .ipynb file - should resolve

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -7,21 +7,20 @@
  * @fileoverview Tests for Positron Notebook editor resolution logic.
  *
  * This test suite verifies that the Positron Notebook editor correctly resolves and handles
- * file types based on user configuration. These tests are critical for ensuring that:
+ * file types with static editor registration. These tests are critical for ensuring that:
  *
  * 1. **File Type Specificity**: Only .ipynb files are handled by the Positron Notebook editor,
  *    while other file types (like .py, .js, etc.) are properly delegated to their appropriate editors.
  *
- * 2. **Configuration Defaults**: The system gracefully handles missing or invalid configuration
- *    values by falling back to sensible defaults (VS Code's default notebook editor).
+ * 2. **Static Registration**: The editor is registered with option priority, making it available
+ *    in the "Open With..." menu while relying on workbench.editorAssociations for default behavior.
  *
- * 3. **Editor Priority Resolution**: The editor resolver service correctly prioritizes and
- *    instantiates the appropriate editor based on file type and user preferences.
+ * 3. **Editor Resolution**: The editor resolver service correctly instantiates the appropriate
+ *    editor based on file type and editor associations.
  *
- * **Context**: This is part of Positron Notebooks 2.0's transition from intercepting/hijacking
- * the existing NotebookEditor to registering as a separate editor that receives priority for
- * .ipynb files. This approach eliminates the previous "hijacking" behavior and allows users
- * to opt out without modifying global settings.
+ * **Context**: This is part of the transition away from feature flag configuration to using
+ * VS Code's standard workbench.editorAssociations for controlling which notebook editor opens
+ * .ipynb files by default.
  *
  * **Why These Tests Matter**: Unlike end-to-end tests that verify user-facing behavior, these
  * unit tests focus on the internal resolution mechanics that are difficult to test at higher
@@ -93,38 +92,121 @@ suite('Positron Notebook Editor Resolution', () => {
 	}
 
 
-	test('Only ipynb files are handled by Positron notebook editor', async () => {
+	test('Editor is registered with static option priority', async () => {
 		await createTestServices();
 
-		registerPositronNotebookEditor(RegisteredEditorPriority.default);
+		// Register with option priority (static registration)
+		registerPositronNotebookEditor(RegisteredEditorPriority.option);
 
-		// Test .ipynb file - should resolve
+		// With option priority and no editor association configured,
+		// the resolver should return NONE to continue with default resolution
 		const ipynbResult = await editorResolverService.resolveEditor(
 			{ resource: URI.file('/test/notebook.ipynb') },
 			part.activeGroup
 		);
 
-		assert.ok(ipynbResult);
-		assert.notStrictEqual(typeof ipynbResult, 'number');
-		if (ipynbResult !== ResolvedStatus.ABORT && ipynbResult !== ResolvedStatus.NONE) {
-			assert.strictEqual(ipynbResult.editor.typeId, PositronNotebookEditorInput.ID);
-			// Ensure proper cleanup of the editor and its internal components
-			if (ipynbResult.editor instanceof PositronNotebookEditorInput) {
-				ipynbResult.editor.notebookInstance?.dispose();
-			}
-			ipynbResult.editor.dispose();
-		}
+		// Should return ResolvedStatus.NONE when no editor association is configured
+		// This allows VS Code's default notebook editor to handle the file
+		assert.strictEqual(ipynbResult, ResolvedStatus.NONE);
+	});
 
-		// Test .py file - should not resolve to Positron notebook
+	test('Editor registration pattern matches only ipynb files', async () => {
+		await createTestServices();
+
+		registerPositronNotebookEditor(RegisteredEditorPriority.option);
+
+		// Test .ipynb file - should return NONE (allowing default resolution) when no association is set
+		const ipynbResult = await editorResolverService.resolveEditor(
+			{ resource: URI.file('/test/notebook.ipynb') },
+			part.activeGroup
+		);
+
+		// With option priority and no editor association, should return NONE
+		assert.strictEqual(ipynbResult, ResolvedStatus.NONE);
+
+		// Test .py file - should also return NONE as it doesn't match our pattern
 		const pyResult = await editorResolverService.resolveEditor(
 			{ resource: URI.file('/test/script.py') },
 			part.activeGroup
 		);
 
-		// Should resolve but not to Positron notebook editor
-		if (pyResult !== ResolvedStatus.ABORT && pyResult !== ResolvedStatus.NONE && typeof pyResult !== 'number') {
-			assert.notStrictEqual(pyResult.editor.typeId, PositronNotebookEditorInput.ID);
-			pyResult.editor.dispose();
-		}
+		// Should return NONE for non-matching files
+		assert.strictEqual(pyResult, ResolvedStatus.NONE);
+	});
+
+	test('Editor registration supports file scheme resources', async () => {
+		await createTestServices();
+
+		registerPositronNotebookEditor(RegisteredEditorPriority.option);
+
+		// Test file:// scheme - with option priority and no editor association, should return NONE
+		const fileResult = await editorResolverService.resolveEditor(
+			{ resource: URI.file('/test/notebook.ipynb') },
+			part.activeGroup
+		);
+
+		// Should return NONE when no editor association is configured
+		assert.strictEqual(fileResult, ResolvedStatus.NONE);
+
+		// Test non-file scheme - should also return NONE as it doesn't match our pattern
+		const httpResult = await editorResolverService.resolveEditor(
+			{ resource: URI.parse('http://example.com/notebook.ipynb') },
+			part.activeGroup
+		);
+
+		// Should return NONE for non-file scheme resources
+		assert.strictEqual(httpResult, ResolvedStatus.NONE);
+	});
+
+	test('Editor registration behavior with option priority', async () => {
+		await createTestServices();
+
+		registerPositronNotebookEditor(RegisteredEditorPriority.option);
+
+		const resource = URI.file('/test/notebook.ipynb');
+
+		// With option priority and no editor association configured,
+		// multiple resolutions should consistently return NONE
+		const firstResult = await editorResolverService.resolveEditor(
+			{ resource },
+			part.activeGroup
+		);
+
+		// Should return NONE when no editor association is configured
+		assert.strictEqual(firstResult, ResolvedStatus.NONE);
+
+		// Second resolution for same resource should also return NONE
+		const secondResult = await editorResolverService.resolveEditor(
+			{ resource },
+			part.activeGroup
+		);
+
+		// Should consistently return NONE
+		assert.strictEqual(secondResult, ResolvedStatus.NONE);
+	});
+
+	test('Static registration allows editor to be available in Open With menu', async () => {
+		await createTestServices();
+
+		// Register with option priority - this makes the editor available as an option
+		// but doesn't make it the default unless configured via workbench.editorAssociations
+		registerPositronNotebookEditor(RegisteredEditorPriority.option);
+
+		// The editor should be registered and available for selection
+		// even though it returns NONE for default resolution
+		const resource = URI.file('/test/notebook.ipynb');
+		const result = await editorResolverService.resolveEditor(
+			{ resource },
+			part.activeGroup
+		);
+
+		// Returns NONE to allow default resolution, but the editor is still registered
+		// and would be available in the "Open With..." menu
+		assert.strictEqual(result, ResolvedStatus.NONE);
+
+		// This test verifies that the static registration approach works as expected:
+		// - Editor is registered with option priority
+		// - Default behavior is controlled by workbench.editorAssociations
+		// - Editor remains available as an option for users
 	});
 });

--- a/src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts
@@ -5,9 +5,11 @@
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { usingPositronNotebooks as utilUsingPositronNotebooks } from '../common/positronNotebookUtils.js';
 
 export const IPositronNotebookService = createDecorator<IPositronNotebookService>('positronNotebookService');
 export interface IPositronNotebookService {
@@ -47,6 +49,12 @@ export interface IPositronNotebookService {
 	 * Get instance by resource if it exists.
 	 */
 	getInstance(resource: URI): IPositronNotebookInstance | undefined;
+
+	/**
+	 * Check if Positron notebooks are configured as the default editor for .ipynb files
+	 * @returns true if Positron notebooks are the default editor, false otherwise
+	 */
+	usingPositronNotebooks(): boolean;
 }
 
 class PositronNotebookService extends Disposable implements IPositronNotebookService {
@@ -60,7 +68,9 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
-	constructor() {
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService
+	) {
 		// Call the disposable constrcutor.
 		super();
 	}
@@ -104,6 +114,10 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 			}
 		}
 		return undefined;
+	}
+
+	public usingPositronNotebooks(): boolean {
+		return utilUsingPositronNotebooks(this._configurationService);
 	}
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
+++ b/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
+++ b/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
@@ -6,21 +6,6 @@
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 /**
- * Configuration key for the default notebook editor setting
- */
-export const POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY = 'positron.notebooks.defaultEditor';
-
-/**
- * Get the user's preferred notebook editor from the feature flag
- * @param configurationService Configuration service
- * @returns 'positron' | 'vscode'
- */
-export function getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode' {
-	const value = configurationService.getValue<'positron' | 'vscode'>(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY) || 'vscode';
-	return value === 'positron' || value === 'vscode' ? value : 'vscode';
-}
-
-/**
  * Check if Positron notebooks are configured as the default editor for .ipynb files
  * @param configurationService Configuration service
  * @returns true if Positron notebooks are the default editor, false otherwise

--- a/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
+++ b/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+
+/**
+ * Configuration key for the default notebook editor setting
+ */
+export const POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY = 'positron.notebooks.defaultEditor';
+
+/**
+ * Get the user's preferred notebook editor
+ * @param configurationService Configuration service
+ * @returns 'positron' | 'vscode'
+ */
+export function getPreferredNotebookEditor(configurationService: IConfigurationService): 'positron' | 'vscode' {
+	const value = configurationService.getValue<'positron' | 'vscode'>(POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY) || 'vscode';
+	return value === 'positron' || value === 'vscode' ? value : 'vscode';
+}
+
+/**
+ * Check if Positron notebooks are configured as the default editor for .ipynb files
+ * @param configurationService Configuration service
+ * @returns true if Positron notebooks are the default editor, false otherwise
+ */
+export function usingPositronNotebooks(configurationService: IConfigurationService): boolean {
+	return getPreferredNotebookEditor(configurationService) === 'positron';
+}

--- a/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
+++ b/src/vs/workbench/services/positronNotebook/common/positronNotebookUtils.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 export const POSITRON_NOTEBOOK_DEFAULT_EDITOR_CONFIG_KEY = 'positron.notebooks.defaultEditor';
 
 /**
- * Get the user's preferred notebook editor
+ * Get the user's preferred notebook editor from the feature flag
  * @param configurationService Configuration service
  * @returns 'positron' | 'vscode'
  */
@@ -26,5 +26,6 @@ export function getPreferredNotebookEditor(configurationService: IConfigurationS
  * @returns true if Positron notebooks are the default editor, false otherwise
  */
 export function usingPositronNotebooks(configurationService: IConfigurationService): boolean {
-	return getPreferredNotebookEditor(configurationService) === 'positron';
+	const editorAssociations = configurationService.getValue<Record<string, string>>('workbench.editorAssociations') || {};
+	return editorAssociations['*.ipynb'] === 'workbench.editor.positronNotebook';
 }

--- a/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
+++ b/test/e2e/tests/notebook/notebook-editor-configuration.test.ts
@@ -20,12 +20,12 @@ test.describe('Notebook Editor Configuration', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Verify default editor is VS Code notebook', async function ({ app, settings }) {
+	test('Verify default editor is VS Code notebook when no association is set', async function ({ app, settings }) {
 		const { notebooks, notebooksVscode } = app.workbench;
 
-		// Set default editor to VS Code notebook
+		// Ensure no editor association is set for .ipynb files
 		await settings.set({
-			'positron.notebooks.defaultEditor': 'vscode'
+			'workbench.editorAssociations': {}
 		});
 
 		// Open the notebook file and verify it opens as a VS Code notebook
@@ -33,12 +33,14 @@ test.describe('Notebook Editor Configuration', {
 		await notebooksVscode.expectToBeVisible();
 	});
 
-	test('Verify setting `positron.notebooks.defaultEditor` to `positron` opens positron notebook', async function ({ app, settings }) {
+	test('Verify setting editor association to positron notebook opens positron notebook', async function ({ app, settings }) {
 		const { notebooks, notebooksPositron } = app.workbench;
 
 		// Set default editor to Positron notebook
 		await settings.set({
-			'positron.notebooks.defaultEditor': 'positron'
+			'workbench.editorAssociations': {
+				'*.ipynb': 'workbench.editor.positronNotebook'
+			}
 		});
 
 		// Open the notebook file and verify it opens as a Positron notebook
@@ -51,17 +53,19 @@ test.describe('Notebook Editor Configuration', {
 
 		// First, set default editor to Positron notebook
 		await settings.set({
-			'positron.notebooks.defaultEditor': 'positron'
+			'workbench.editorAssociations': {
+				'*.ipynb': 'workbench.editor.positronNotebook'
+			}
 		});
 
 		// Open the notebook file and verify it opens as a Positron notebook
 		await notebooks.openNotebook(NOTEBOOK_PATH, false);
 		await notebooksPositron.expectToBeVisible();
 
-		// Revert default editor to VS Code notebook
+		// Revert default editor to VS Code notebook by removing the association
 		await hotKeys.closeAllEditors();
 		await settings.set({
-			'positron.notebooks.defaultEditor': 'vscode'
+			'workbench.editorAssociations': {}
 		});
 
 		// Open notebook again and verify it opens as a VS Code notebook


### PR DESCRIPTION
Addresses #8506.

Removes the positron notebook feature flag in favor of using the existing "open-with" menu functionality.
This change simplifies the user experience by eliminating the need for a feature flag and instead allows
users to right-click on .ipynb files and select "Positron Notebook Editor" from the context menu, with an
easy option to set it as the default.

The PR also adds an abstraction function to the positron notebooks service (`usingPositronNotebooks()`) that determines when positron notebooks should be used, providing a cleaner API for future features like new file creation without
requiring complex configuration checks.

<img width="645" height="224" alt="image" src="https://github.com/user-attachments/assets/0dc2140a-92cf-4a93-8cee-9b62c7f5f72f" />

### Release Notes

#### New Features
- Added right-click "open-with" menu support for Positron Notebook Editor with option to set as default

#### Bug Fixes
- N/A

### QA Notes

Test the open-with menu functionality and default editor setting. After opening a .ipynb file, both
editors should work correctly and the default should persist.

```python
# Create a test notebook
import pandas as pd
df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
df.head()

Manual testing steps:
1. Right-click on any .ipynb file
2. Select "Open With..." → "Positron Notebook Editor"
3. Verify the notebook opens in Positron editor
4. Right-click again and select "Configure default editor"
5. Set Positron as default
6. Double-click the notebook file to verify it opens with Positron by default