### PR TITLE
Don't leak RUST_LOG into supervisor

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -331,13 +331,6 @@ export class KCApi implements PositronSupervisorApi {
 		// error if the server binary cannot be found.
 		const shellPath = this.getKallichorePath();
 
-		// Get the log level from the configuration
-		const config = vscode.workspace.getConfiguration('kernelSupervisor');
-		const logLevel = config.get<string>('logLevel') ?? 'warn';
-		const env = {
-			'RUST_LOG': logLevel,
-		};
-
 		// Create a server session ID (8 characters)
 		const sessionId = `${createUniqueId()}-${process.pid}`;
 
@@ -351,6 +344,7 @@ export class KCApi implements PositronSupervisorApi {
 		const startTime = Date.now();
 
 		// Consult configuration to see if we should show this terminal
+		const config = vscode.workspace.getConfiguration('kernelSupervisor');
 		const showTerminal = config.get<boolean>('showTerminal', false);
 
 		// Create a temporary file with a random name to use for logs
@@ -385,6 +379,9 @@ export class KCApi implements PositronSupervisorApi {
 				shellArgs.unshift('nohup');
 			}
 		}
+
+		// Get the log level from the configuration
+		const logLevel = config.get<string>('logLevel') ?? 'warn';
 
 		// Add the path to Kallichore itself
 		shellArgs.push(shellPath);
@@ -429,7 +426,6 @@ export class KCApi implements PositronSupervisorApi {
 			name: 'Kallichore',
 			shellPath: wrapperPath,
 			shellArgs,
-			env,
 			message: `*** Kallichore Server (${shellPath}) ***`,
 			hideFromUser: !showTerminal,
 			isTransient: false

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -236,16 +236,6 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			value: positron.version
 		});
 
-		// RUST_LOG sets the log level for Rust components started by the
-		// supervisor; it mirrors our own log level.
-		const config = vscode.workspace.getConfiguration('kernelSupervisor');
-		const logLevel = config.get<string>('logLevel') ?? 'warn';
-		varActions.push({
-			action: VarActionType.Replace,
-			name: 'RUST_LOG',
-			value: logLevel
-		});
-
 		// The long form of the Positron version (includes build number).
 		varActions.push({
 			action: VarActionType.Replace, name: 'POSITRON_LONG_VERSION',


### PR DESCRIPTION
This change removes the `RUST_LOG` environment variable from the kernel supervisor's environment. It is (now) unnecessary since we already use a command-line argument to set the log level, and because kernels inherit the supervisor's environment, it can affect the log level of Rust-based programs invoked from the kernels (such as uv).

Addresses #8538.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Remove superfluous `RUST_LOG` environment variable from R and Python sessions

### QA Notes

- It should still be possible to specify `RUST_LOG` manually via e.g. the Environment Variables feature
- The R extension sets a value for `RUST_LOG` as well, so you'll see that value in R sessions
- The main thing to verify here, in addition to `RUST_LOG` no longer being overridden, is that the kernel's log level setting still works