### PR TITLE
Python: Safely and efficiently compute variable display values

### DIFF
--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -39,6 +39,7 @@ pyarrow==20.0.0
 pytest==8.4.1
 pytest-asyncio==1.0.0
 pytest-mock==3.14.1
+syrupy==4.9.1
 torch==2.7.1
 scipy==1.13.1; python_version == '3.9'
 scipy==1.15.3; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -315,7 +315,7 @@ class BytesInspector(PositronInspector[Bytes]):
     @classmethod
     def value_from_json(cls, type_name: str, data: JsonData) -> Bytes:
         if isinstance(data, str):
-            return cast(Bytes, data.encode())
+            return cast("Bytes", data.encode())
         return super().value_from_json(type_name, data)
 
 
@@ -432,17 +432,17 @@ class NumberInspector(PositronInspector[NT], ABC):
         if type_name == "int":
             if not isinstance(data, numbers.Integral):
                 raise ValueError(f"Expected data to be int, got {data}")
-            return cast(NT, data)
+            return cast("NT", data)
 
         if type_name == "float":
             if not isinstance(data, numbers.Real):
                 raise ValueError(f"Expected data to be float, got {data}")
-            return cast(NT, data)
+            return cast("NT", data)
 
         if type_name == "complex":
             if not isinstance(data, str):
                 raise ValueError(f"Expected data to be str, got {data}")
-            return cast(NT, complex(data))
+            return cast("NT", complex(data))
 
         return super().value_from_json(type_name, data)
 

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1277,7 +1277,8 @@ def _get_string_display_value(
 
     # If the string fits the limit, return it as is.
     # NOTE: We check the actual string length but return the repr which may differ e.g.
-    #       some characters may be escaped.
+    #       some characters may be escaped. We don't check `len(repr(value))` to avoid
+    #       possibly copying a huge string.
     if len(value) <= max_characters:
         return repr(value), False
 

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1261,7 +1261,7 @@ def _get_default_display_value(value: Any, *, level: int = 0) -> tuple[str, bool
             display_value = object.__repr__(value)
         except Exception:
             try:
-                display_value = f"<no repr available for {get_qualname(value)}>"
+                display_value = f"<no preview available for {get_qualname(value)}>"
             except Exception:
                 display_value = "<no repr available for object>"
 

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -102,7 +102,8 @@ SIMPLER_NAMES = {
     "pandas.core.indexes.datetimes.DatetimeIndex": "pandas.DatetimeIndex",
     "pandas.core.indexes.range.RangeIndex": "pandas.RangeIndex",
     "pandas.core.indexes.multi.MultiIndex": "pandas.MultiIndex",
-    "pandas.core.indexes.numeric.Int64Index": "pandas.Int64Index",
+    # Just display Int64Index as pandas.Index, since the former is deprecated since pandas v1.4.0.
+    "pandas.core.indexes.numeric.Int64Index": "pandas.Index",
 }
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/__snapshots__/test_inspectors.ambr
+++ b/extensions/positron-python/python_files/posit/positron/tests/__snapshots__/test_inspectors.ambr
@@ -1,0 +1,306 @@
+# serializer version: 1
+# name: test_truncated_display_value[bytearray]
+  "bytearray(b'The quick bro…zy dog')"
+# ---
+# name: test_truncated_display_value[bytearray].1
+  "[bytearray(b'The qu…dog')]"
+# ---
+# name: test_truncated_display_value[bytearray].2
+  "[[bytearray(b'The qu…dog')]]"
+# ---
+# name: test_truncated_display_value[bytes]
+  "b'The quick bro…zy dog'"
+# ---
+# name: test_truncated_display_value[bytes].1
+  "[b'The qu…dog']"
+# ---
+# name: test_truncated_display_value[bytes].2
+  "[[b'The qu…dog']]"
+# ---
+# name: test_truncated_display_value[class]
+  "<class 'posit…Long'>"
+# ---
+# name: test_truncated_display_value[class].1
+  "[<class…g'>]"
+# ---
+# name: test_truncated_display_value[class].2
+  "[[<class…g'>]]"
+# ---
+# name: test_truncated_display_value[complex]
+  '(2.2250738585…+308j)'
+# ---
+# name: test_truncated_display_value[complex].1
+  '[(2.225…8j)]'
+# ---
+# name: test_truncated_display_value[complex].2
+  '[[(2.225…8j)]]'
+# ---
+# name: test_truncated_display_value[fastcore_list]
+  '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …]'
+# ---
+# name: test_truncated_display_value[fastcore_list].1
+  '[[0, 1, 2, 3, 4, 5, 6, 7, 8, …]]'
+# ---
+# name: test_truncated_display_value[fastcore_list].2
+  '[[[…]]]'
+# ---
+# name: test_truncated_display_value[fastcore_list_cycle]
+  '[1, 2, […]]'
+# ---
+# name: test_truncated_display_value[fastcore_list_cycle].1
+  '[[1, 2, […]]]'
+# ---
+# name: test_truncated_display_value[fastcore_list_cycle].2
+  '[[[…]]]'
+# ---
+# name: test_truncated_display_value[float]
+  '1.79769313486…7e+308'
+# ---
+# name: test_truncated_display_value[float].1
+  '[1.7976…308]'
+# ---
+# name: test_truncated_display_value[float].2
+  '[[1.7976…308]]'
+# ---
+# name: test_truncated_display_value[frozenset]
+  '{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …}'
+# ---
+# name: test_truncated_display_value[frozenset].1
+  '[{0, 1, 2, 3, 4, 5, 6, 7, 8, …}]'
+# ---
+# name: test_truncated_display_value[frozenset].2
+  '[[{…}]]'
+# ---
+# name: test_truncated_display_value[int]
+  '9223372036854…580700'
+# ---
+# name: test_truncated_display_value[int].1
+  '[922337…700]'
+# ---
+# name: test_truncated_display_value[int].2
+  '[[922337…700]]'
+# ---
+# name: test_truncated_display_value[list]
+  '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …]'
+# ---
+# name: test_truncated_display_value[list].1
+  '[[0, 1, 2, 3, 4, 5, 6, 7, 8, …]]'
+# ---
+# name: test_truncated_display_value[list].2
+  '[[[…]]]'
+# ---
+# name: test_truncated_display_value[list_cycle]
+  '[1, 2, […]]'
+# ---
+# name: test_truncated_display_value[list_cycle].1
+  '[[1, 2, […]]]'
+# ---
+# name: test_truncated_display_value[list_cycle].2
+  '[[[…]]]'
+# ---
+# name: test_truncated_display_value[map]
+  "{'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9, '10': 10, '11': 11, '12': 12, '13': 13, '14': 14, '15': 15, '16': 16, '17': 17, '18': 18, …}"
+# ---
+# name: test_truncated_display_value[map].1
+  "[{'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, …}]"
+# ---
+# name: test_truncated_display_value[map].2
+  '[[{…}]]'
+# ---
+# name: test_truncated_display_value[map_cycle]
+  "{'cycle': {…}}"
+# ---
+# name: test_truncated_display_value[map_cycle].1
+  "[{'cycle': {…}}]"
+# ---
+# name: test_truncated_display_value[map_cycle].2
+  '[[{…}]]'
+# ---
+# name: test_truncated_display_value[numpy_array]
+  '''
+  [[1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   ...,
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.]]
+  '''
+# ---
+# name: test_truncated_display_value[numpy_array].1
+  '''
+  [[[1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   ...,
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.],
+   [1.,1.,1.,1.,1.,1.,1.,1.,1.,...,1.,1.,1.,1.,1.,1.,1.,1.,1.]]]
+  '''
+# ---
+# name: test_truncated_display_value[numpy_array].2
+  '[[numpy.array(…)]]'
+# ---
+# name: test_truncated_display_value[pandas_dataframe]
+  '[20 rows x 2 …aFrame'
+# ---
+# name: test_truncated_display_value[pandas_dataframe].1
+  '[[20 ro…ame]'
+# ---
+# name: test_truncated_display_value[pandas_dataframe].2
+  '[[[20 ro…ame]]'
+# ---
+# name: test_truncated_display_value[pandas_index]
+  'pandas.Index [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …]'
+# ---
+# name: test_truncated_display_value[pandas_index].1
+  '[pandas.Index [0, 1, 2, 3, 4, 5, 6, 7, 8, …]]'
+# ---
+# name: test_truncated_display_value[pandas_index].2
+  '[[pandas.Index […]]]'
+# ---
+# name: test_truncated_display_value[pandas_series]
+  'pandas.Series [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …]'
+# ---
+# name: test_truncated_display_value[pandas_series].1
+  '[pandas.Series [0, 1, 2, 3, 4, 5, 6, 7, 8, …]]'
+# ---
+# name: test_truncated_display_value[pandas_series].2
+  '[[pandas.Series […]]]'
+# ---
+# name: test_truncated_display_value[polars_dataframe]
+  '[20 rows x 2 …aFrame'
+# ---
+# name: test_truncated_display_value[polars_dataframe].1
+  '[[20 ro…ame]'
+# ---
+# name: test_truncated_display_value[polars_dataframe].2
+  '[[[20 ro…ame]]'
+# ---
+# name: test_truncated_display_value[polars_series]
+  'polars.Series [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …]'
+# ---
+# name: test_truncated_display_value[polars_series].1
+  '[polars.Series [0, 1, 2, 3, 4, 5, 6, 7, 8, …]]'
+# ---
+# name: test_truncated_display_value[polars_series].2
+  '[[polars.Series […]]]'
+# ---
+# name: test_truncated_display_value[range]
+  'range(0, 1234…78901)'
+# ---
+# name: test_truncated_display_value[range].1
+  '[range(…01)]'
+# ---
+# name: test_truncated_display_value[range].2
+  '[[range(…01)]]'
+# ---
+# name: test_truncated_display_value[set]
+  '{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, …}'
+# ---
+# name: test_truncated_display_value[set].1
+  '[{0, 1, 2, 3, 4, 5, 6, 7, 8, …}]'
+# ---
+# name: test_truncated_display_value[set].2
+  '[[{…}]]'
+# ---
+# name: test_truncated_display_value[string]
+  "'The quick bro…zy dog'"
+# ---
+# name: test_truncated_display_value[string].1
+  "['The qu…dog']"
+# ---
+# name: test_truncated_display_value[string].2
+  "[['The qu…dog']]"
+# ---
+# name: test_truncated_display_value[timestamp_datetime]
+  'datetime.date…e.utc)'
+# ---
+# name: test_truncated_display_value[timestamp_datetime].1
+  '[dateti…tc)]'
+# ---
+# name: test_truncated_display_value[timestamp_datetime].2
+  '[[dateti…tc)]]'
+# ---
+# name: test_truncated_display_value[timestamp_pandas]
+  "Timestamp('20…3:45')"
+# ---
+# name: test_truncated_display_value[timestamp_pandas].1
+  "[Timest…5')]"
+# ---
+# name: test_truncated_display_value[timestamp_pandas].2
+  "[[Timest…5')]]"
+# ---
+# name: test_truncated_display_value[torch_tensor]
+  '''
+  [[1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          ...,
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.]]
+  '''
+# ---
+# name: test_truncated_display_value[torch_tensor].1
+  '''
+  [[[1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          ...,
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
+          [1., 1., 1., 1., 1., 1., 1., 1., 1.,  ..., 1., 1., 1., 1., 1., 1., 1., 1., 1.]]]
+  '''
+# ---
+# name: test_truncated_display_value[torch_tensor].2
+  '[[torch.Tensor(…)]]'
+# ---

--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -691,7 +691,7 @@ def test_inspect_pandas_series(value: pd.Series) -> None:
     (rows,) = value.shape
 
     def mutate(x):
-        x[0] = 1
+        x.iloc[0] = 1
 
     verify_inspector(
         value=value,
@@ -724,7 +724,7 @@ def test_inspect_geopandas_series(value: geopandas.GeoSeries) -> None:
     (rows,) = value.shape
 
     def mutate(x):
-        x[0] = x[1]
+        x.iloc[0] = x.iloc[1]
 
     verify_inspector(
         value=value,

--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -5,9 +5,6 @@
 import copy
 import datetime
 import inspect
-import pprint
-import random
-import string
 import sys
 import types
 from typing import Any, Callable, Iterable, Optional, Tuple
@@ -21,11 +18,8 @@ import torch
 from fastcore.foundation import L
 from shapely.geometry import Polygon
 
-from positron.inspectors import (
-    PRINT_WIDTH,
-    TRUNCATE_AT,
-    get_inspector,
-)
+from positron import inspectors
+from positron.inspectors import _get_simplified_qualname, get_inspector
 from positron.utils import get_qualname
 from positron.variables_comm import VariableKind
 
@@ -161,20 +155,6 @@ def test_inspect_string(value: str) -> None:
     )
 
 
-def test_inspect_string_truncated() -> None:
-    value = "".join(random.choices(string.ascii_letters, k=(TRUNCATE_AT + 10)))
-    length = len(value)
-    verify_inspector(
-        value=value,
-        display_value=f"'{value[:TRUNCATE_AT]}'",
-        kind=VariableKind.String,
-        display_type="str",
-        type_info="str",
-        length=length,
-        is_truncated=True,
-    )
-
-
 #
 # Test Numbers
 #
@@ -296,22 +276,6 @@ def test_inspect_bytearray(value: bytearray) -> None:
     )
 
 
-def test_inspect_bytearray_truncated() -> None:
-    value = bytearray(TRUNCATE_AT * 2)
-    length = len(value)
-    verify_inspector(
-        value=value,
-        display_value=str(value)[:TRUNCATE_AT],
-        kind=VariableKind.Bytes,
-        display_type=f"bytearray [{length}]",
-        type_info="bytearray",
-        length=length,
-        is_truncated=True,
-        mutable=True,
-        mutate=lambda x: x.append(0),
-    )
-
-
 def test_inspect_memoryview() -> None:
     byte_array = bytearray("東京", "utf-8")
     value = memoryview(byte_array)
@@ -388,26 +352,11 @@ def test_inspect_set(value: set) -> None:
     verify_inspector(
         value=value,
         is_truncated=False,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True),
+        display_value=repr(value),
         kind=VariableKind.Collection,
         display_type=f"set {{{length}}}",
         type_info="set",
         length=length,
-        supports_deepcopy=False,
-    )
-
-
-def test_inspect_set_truncated() -> None:
-    value = set(range(TRUNCATE_AT * 2))
-    length = len(value)
-    verify_inspector(
-        value=value,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[:TRUNCATE_AT],
-        kind=VariableKind.Collection,
-        display_type=f"set {{{length}}}",
-        type_info="set",
-        length=length,
-        is_truncated=True,
         supports_deepcopy=False,
     )
 
@@ -424,7 +373,6 @@ LIST_CASES = [
     BYTES_CASES,
     BYTEARRAY_CASES,
     STRING_CASES,
-    LIST_WITH_CYCLE,
 ]
 
 
@@ -434,28 +382,12 @@ def test_inspect_list(value: list) -> None:
     verify_inspector(
         value=value,
         is_truncated=False,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True),
+        display_value=repr(value),
         kind=VariableKind.Collection,
         display_type=f"list [{length}]",
         type_info="list",
         length=length,
         has_children=length > 0,
-        supports_deepcopy=False,
-    )
-
-
-def test_inspect_list_truncated() -> None:
-    value = list(range(TRUNCATE_AT * 2))
-    length = len(value)
-    verify_inspector(
-        value=value,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[:TRUNCATE_AT],
-        kind=VariableKind.Collection,
-        display_type=f"list [{length}]",
-        type_info="list",
-        length=length,
-        has_children=True,
-        is_truncated=True,
         supports_deepcopy=False,
     )
 
@@ -466,7 +398,7 @@ def test_inspect_range(value: range) -> None:
     verify_inspector(
         value=value,
         is_truncated=False,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True),
+        display_value=repr(value),
         kind=VariableKind.Collection,
         display_type=f"range [{length}]",
         type_info="range",
@@ -474,6 +406,8 @@ def test_inspect_range(value: range) -> None:
     )
 
 
+FASTCORE_LIST_WITH_CYCLE = L([1, 2])
+FASTCORE_LIST_WITH_CYCLE.append(FASTCORE_LIST_WITH_CYCLE)  # type: ignore
 FASTCORE_LIST_CASES = [
     L(),
     L(NONE_CASES),
@@ -493,7 +427,7 @@ def test_inspect_fastcore_list(value: L) -> None:
     verify_inspector(
         value=value,
         is_truncated=False,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True),
+        display_value=repr(value),
         kind=VariableKind.Collection,
         display_type=f"L [{length}]",
         type_info="fastcore.foundation.L",
@@ -526,7 +460,6 @@ MAP_CASES = [
     {"J": {1, 2, 3}},  # set value
     {"K": range(3)},  # range value
     {"L": {"L1": 1, "L2": 2, "L3": 3}},  # nested dict value
-    MAP_WITH_CYCLE,
 ]
 
 
@@ -536,7 +469,7 @@ def test_inspect_map(value: dict) -> None:
     verify_inspector(
         value=value,
         is_truncated=False,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True),
+        display_value=repr(value),
         kind=VariableKind.Map,
         display_type=f"dict [{length}]",
         type_info="dict",
@@ -736,61 +669,72 @@ def test_inspect_pandas_index(value: pd.Index) -> None:
 
     verify_inspector(
         value=value,
-        display_value=str(value.to_list() if not_range_index else value),
+        display_value=f"{_get_simplified_qualname(value)} {value.to_list()}"
+        if not_range_index
+        else repr(value),
         kind=VariableKind.Map,
         display_type=f"{value.dtype} [{rows}]",
         type_info=get_qualname(value),
         has_children=not_range_index,
-        is_truncated=not_range_index,
+        is_truncated=False,
         length=rows,
     )
 
 
-def test_inspect_pandas_series() -> None:
-    value = pd.Series({"a": 0, "b": 1})
+@pytest.mark.parametrize(
+    "value",
+    [
+        pd.Series({"a": 0, "b": 1}),
+    ],
+)
+def test_inspect_pandas_series(value: pd.Series) -> None:
     (rows,) = value.shape
 
     def mutate(x):
-        x["a"] = 1
+        x[0] = 1
 
     verify_inspector(
         value=value,
-        display_value="pandas.Series [0, 1]",
+        display_value=f"pandas.Series {value.to_list()!r}",
         kind=VariableKind.Table,
         display_type=f"int64 [{rows}]",
         type_info=get_type_as_str(value),
         has_children=True,
         has_viewer=True,
-        is_truncated=True,
+        is_truncated=False,
         length=rows,
         mutable=True,
         mutate=mutate,
     )
 
 
-def test_inspect_geopandas_series() -> None:
-    import geopandas
-    from shapely.geometry import Polygon
-
-    p1 = Polygon([(0, 0), (1, 0), (1, 1)])
-    p2 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-    p3 = Polygon([(2, 0), (3, 0), (3, 1), (2, 1)])
-    value = geopandas.GeoSeries([p1, p2, p3])
-
+@pytest.mark.parametrize(
+    "value",
+    [
+        geopandas.GeoSeries(
+            [
+                Polygon([(0, 0), (1, 0), (1, 1)]),
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
+            ]
+        ),
+    ],
+)
+def test_inspect_geopandas_series(value: geopandas.GeoSeries) -> None:
     (rows,) = value.shape
 
     def mutate(x):
-        x[0] = p2
+        x[0] = x[1]
 
     verify_inspector(
         value=value,
-        display_value=f"geopandas.GeoSeries {[p1, p2, p3]!r}",
+        display_value=f"geopandas.GeoSeries {value.to_list()!r}",
         kind=VariableKind.Table,
         display_type=f"geometry [{rows}]",
         type_info=get_type_as_str(value),
         has_children=True,
         has_viewer=True,
-        is_truncated=True,
+        is_truncated=False,
         length=rows,
         mutable=True,
         mutate=mutate,
@@ -815,8 +759,13 @@ def test_inspect_pandas_series_duplicate_labels() -> None:
     assert inspector.get_display_name(3) == "1"
 
 
-def test_inspect_polars_dataframe() -> None:
-    value = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+@pytest.mark.parametrize(
+    "value",
+    [
+        pl.DataFrame({"a": [1, 2], "b": [3, 4]}),
+    ],
+)
+def test_inspect_polars_dataframe(value: pl.DataFrame) -> None:
     rows, cols = value.shape
     verify_inspector(
         value=value,
@@ -829,12 +778,17 @@ def test_inspect_polars_dataframe() -> None:
         is_truncated=True,
         length=rows,
         mutable=True,
-        mutate=lambda x: x.drop_in_place("a"),
+        mutate=lambda x: x.drop_in_place(x.columns[0]),
     )
 
 
-def test_inspect_polars_series() -> None:
-    value = pl.Series([0, 1])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pl.Series([0, 1]),
+    ],
+)
+def test_inspect_polars_series(value: pl.Series) -> None:
     (rows,) = value.shape
 
     def mutate(x):
@@ -842,12 +796,12 @@ def test_inspect_polars_series() -> None:
 
     verify_inspector(
         value=value,
-        display_value="polars.Series [0, 1]",
+        display_value=f"polars.Series {value.to_list()!r}",
         kind=VariableKind.Map,
         display_type=f"Int64 [{rows}]",
         type_info=get_type_as_str(value),
         has_children=True,
-        is_truncated=True,
+        is_truncated=False,
         length=rows,
         mutable=True,
         mutate=mutate,
@@ -980,3 +934,60 @@ def test_arrays_maps_get_size(value: Any, expected: int) -> None:
         return
     inspector = get_inspector(value)
     assert inspector.get_size() == expected
+
+
+class VeryLongClassNameThatShouldDefinitelyBeTruncatedBecauseItIsWayTooLong:
+    pass
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("The quick brown fox jumps over the lazy dog", id="string"),
+        pytest.param(sys.maxsize * 100, id="int"),
+        pytest.param(sys.float_info.max, id="float"),
+        pytest.param(complex(sys.float_info.min, sys.float_info.max), id="complex"),
+        pytest.param(
+            VeryLongClassNameThatShouldDefinitelyBeTruncatedBecauseItIsWayTooLong, id="class"
+        ),
+        pytest.param(b"The quick brown fox jumps over the lazy dog", id="bytes"),
+        pytest.param(bytearray(b"The quick brown fox jumps over the lazy dog"), id="bytearray"),
+        pytest.param(set(range(20)), id="set"),
+        pytest.param(frozenset(range(20)), id="frozenset"),
+        pytest.param(list(range(20)), id="list"),
+        pytest.param(LIST_WITH_CYCLE, id="list_cycle"),
+        pytest.param(range(12345678901), id="range"),
+        pytest.param(L(range(20)), id="fastcore_list"),
+        pytest.param(FASTCORE_LIST_WITH_CYCLE, id="fastcore_list_cycle"),
+        pytest.param({str(i): i for i in range(20)}, id="map"),
+        pytest.param(MAP_WITH_CYCLE, id="map_cycle"),
+        pytest.param(
+            datetime.datetime(2021, 1, 1, 1, 23, 45, tzinfo=datetime.timezone.utc),
+            id="timestamp_datetime",
+        ),
+        pytest.param(pd.Timestamp("2021-01-01 01:23:45"), id="timestamp_pandas"),
+        pytest.param(pd.Index(list(range(20))), id="pandas_index"),
+        pytest.param(pd.Series(list(range(20))), id="pandas_series"),
+        pytest.param(
+            pd.DataFrame({"a": list(range(20)), "b": list(range(20))}), id="pandas_dataframe"
+        ),
+        pytest.param(pl.Series(list(range(20))), id="polars_series"),
+        pytest.param(
+            pl.DataFrame({"a": list(range(20)), "b": list(range(20))}), id="polars_dataframe"
+        ),
+        pytest.param(np.ones((20, 20)), id="numpy_array"),
+        pytest.param(torch.ones((20, 20)), id="torch_tensor"),
+    ],
+)
+def test_truncated_display_value(value, snapshot, monkeypatch) -> None:
+    # Patch the maximum string length for faster and more readable tests.
+    monkeypatch.setattr(inspectors, "MAX_ITEMS_BY_LEVEL", (20, 10))
+    monkeypatch.setattr(inspectors, "MAX_CHARACTERS", 20)
+    monkeypatch.setattr(inspectors, "MAX_CHARACTERS_NESTED", 10)
+
+    for _ in range(3):
+        display_value, is_truncated = get_inspector(value).get_display_value()
+        assert display_value == snapshot
+        assert is_truncated, f"Expected value to be truncated: {value!r}, got {display_value!r}"
+
+        value = [value]

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -226,7 +226,8 @@ def test_change_detection_over_limit(shell: PositronShell, variables_comm: Dummy
     _assert_assigned(shell, big_array, varname, variables_comm, "unevaluated")
 
 
-def test_change_detection_run_cell_performance(shell: PositronShell, variables_comm) -> None:  # noqa: ARG001 need the variables comm to be connected but don't actually use it
+@pytest.mark.usefixtures("variables_comm")
+def test_change_detection_run_cell_performance(shell: PositronShell) -> None:
     # Test that change detection hooks do not cause unreasonable performance overhead: https://github.com/posit-dev/positron/issues/8245
 
     # First, measure baseline performance without large objects.

--- a/extensions/positron-python/python_files/posit/positron/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/utils.py
@@ -8,14 +8,9 @@ import concurrent.futures
 import functools
 import inspect
 import logging
-import numbers
-import pprint
 import sys
 import threading
-import types
 import uuid
-from binascii import b2a_base64
-from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
@@ -25,7 +20,6 @@ from typing import (
     List,
     Optional,
     Set,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -122,103 +116,7 @@ def is_numpy_ufunc(object_: Any) -> bool:
     return object_type.__module__ == "numpy" and object_type.__name__ == "ufunc"
 
 
-def pretty_format(
-    value,
-    print_width: Optional[int] = None,
-    truncate_at: Optional[int] = None,
-) -> Tuple[str, bool]:
-    if print_width is not None:
-        s = pprint.pformat(value, width=print_width, compact=True)
-    else:
-        s = str(value)
-
-    # TODO: Add type aware truncation
-    if truncate_at is not None:
-        return truncate_string(s, truncate_at)
-
-    return s, False
-
-
-def truncate_string(value: str, max_: int) -> Tuple[str, bool]:
-    if len(value) > max_:
-        return (value[:max_], True)
-    else:
-        return (value, False)
-
-
 ISO8601 = "%Y-%m-%dT%H:%M:%S.%f"
-
-
-# We can't use ipykernel's json_clean function directly as it has since been
-# deactivated. JSON message cleaning in jupyter_client will also be removed in
-# the near future. We keep a copy below and adjust it for display-only use.
-#
-# The original function is available in the ipykernel module and was made
-# available under the following license:
-#
-# Copyright (c) IPython Development Team.
-# Distributed under the terms of the Modified BSD License.
-#
-def json_clean(obj):
-    # types that are 'atomic' and ok in json as-is.
-    atomic_ok = (str, type(None))
-
-    # containers that we need to convert into lists
-    container_to_list = (tuple, set, types.GeneratorType)
-
-    # Since bools are a subtype of Integrals, which are a subtype of Reals,
-    # we have to check them in that order.
-
-    if isinstance(obj, bool):
-        return obj
-
-    if isinstance(obj, numbers.Integral):
-        # cast int to int, in case subclasses override __str__ (e.g. boost enum, #4598)
-        return int(obj)
-
-    if isinstance(obj, numbers.Real):
-        # use string repr to avoid precision issues with JSON
-        return repr(obj)
-
-    if isinstance(obj, atomic_ok):
-        return obj
-
-    if isinstance(obj, bytes):
-        # unanmbiguous binary data is base64-encoded
-        # (this probably should have happened upstream)
-        return b2a_base64(obj, newline=False).decode("ascii")
-
-    if isinstance(obj, container_to_list) or (
-        hasattr(obj, "__iter__") and hasattr(obj, "__next__")
-    ):
-        obj = list(obj)
-
-    if isinstance(obj, list):
-        return [json_clean(x) for x in obj]
-
-    if isinstance(obj, dict):
-        # First, validate that the dict won't lose data in conversion due to
-        # key collisions after stringification.  This can happen with keys like
-        # True and 'true' or 1 and '1', which collide in JSON.
-        nkeys = len(obj)
-        nkeys_collapsed = len(set(map(str, obj)))
-        if nkeys != nkeys_collapsed:
-            msg = (
-                "dict cannot be safely converted to JSON: "
-                "key collision would lead to dropped values"
-            )
-            raise ValueError(msg)
-        # If all OK, proceed by making the new dict that will be json-safe
-        out = {}
-        for k, v in obj.items():
-            out[str(k)] = json_clean(v)
-        return out
-
-    if isinstance(obj, datetime):
-        return obj.strftime(ISO8601)
-
-    # we don't understand it, it's probably an unserializable object
-    raise ValueError(f"Can't clean for JSON: {obj!r}")
 
 
 def create_task(coro: Coroutine, pending_tasks: Set[asyncio.Task], **kwargs) -> asyncio.Task:

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -19,6 +19,7 @@ pyarrow
 pytest
 pytest-asyncio
 pytest-mock
+syrupy
 torch
 scipy
 sqlalchemy


### PR DESCRIPTION
Addresses #8245. The approach is inspired by pydevd which backs the debugger used by most Python IDEs today.

The focus is on safely (i.e. no hangs) and efficiently calculating and sending display values over the wire, _not_ on perfectly formatting those display values, hence the large max character values. The idea is that further formatting would be handled in the UI, although we can change this if needed.

I've mostly left the display formatting of the larger third party objects as is (numpy, pandas, etc). The lower level changes here should make refinements to those easier in future.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Improved the performance of Python variable updates (#8245).

### QA Notes

See the repro steps in #8245 as well as the new unit tests.

@:variables @:data-explorer @:console