### PR TITLE
ci: fix Conda ToS error

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -44,6 +44,14 @@ runs:
         echo "source \"${HOME}/conda/etc/profile.d/conda.sh\"" >> ~/.bashrc
         source "${HOME}/conda/etc/profile.d/conda.sh"
 
+        # Remove problematic channels to avoid ToS issues
+        conda config --remove channels https://repo.anaconda.com/pkgs/main || true
+        conda config --remove channels https://repo.anaconda.com/pkgs/r || true
+
+        # Just to be sure, set conda-forge explicitly
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+
     - name: Setup Python
       uses: ./.github/actions/install-python
       with:

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -37,38 +37,11 @@ runs:
         tinytex: true
 
     - name: Setup Conda (Miniforge3)
-      shell: bash
-      run: |
-        # Download and install Miniforge to $HOME/conda
-        wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-        sudo bash Miniforge3.sh -b -p "${HOME}/conda"
-
-        # Source conda so it's usable in this shell
-        echo "source \"${HOME}/conda/etc/profile.d/conda.sh\"" >> ~/.bashrc
-        source "${HOME}/conda/etc/profile.d/conda.sh"
-
-        # Debug: show base version
-        echo "✅ Conda installed at: $(which conda)"
-        conda --version
-
-        # Install the conda-anaconda-tos plugin (requires temporarily enabling 'defaults')
-        conda config --add channels defaults
-        conda install -n base -y conda-anaconda-tos
-        conda config --remove channels defaults || true
-
-        # Accept Anaconda ToS in CI (required as of July 15, 2025)
-        conda tos accept --channel https://repo.anaconda.com/pkgs/main
-        conda tos accept --channel https://repo.anaconda.com/pkgs/r
-
-        # Clean up all other channels and enforce conda-forge only
-        conda config --remove-key channels || true
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
-
-        # Final verification logs
-        echo "🔍 Conda config:"
-        conda config --show channels
-        conda info
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Miniforge3
+        miniforge-version: latest
+        auto-activate-base: false
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -39,23 +39,24 @@ runs:
     - name: Setup Conda (Miniforge3)
       shell: bash
       run: |
+        # Download and install Miniforge to $HOME/conda
         wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
         sudo bash Miniforge3.sh -b -p "${HOME}/conda"
+
+        # Source conda so it's usable in this shell
         echo "source \"${HOME}/conda/etc/profile.d/conda.sh\"" >> ~/.bashrc
         source "${HOME}/conda/etc/profile.d/conda.sh"
 
-        # 1. Clean up default config
-        conda config --remove channels https://repo.anaconda.com/pkgs/main || true
-        conda config --remove channels https://repo.anaconda.com/pkgs/r || true
+        # Clean up all channel config and enforce conda-forge only
+        conda config --remove-key channels || true
         conda config --add channels conda-forge
         conda config --set channel_priority strict
 
-        # 2. Accept ToS in case some script still forces those channels
-        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main || true
-        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r || true
-
-        # 3. Debug: show effective channels
+        # Debug info to confirm config and version
+        echo "✅ Conda installed at: $(which conda)"
+        conda --version
         conda config --show channels
+        conda info
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -47,14 +47,26 @@ runs:
         echo "source \"${HOME}/conda/etc/profile.d/conda.sh\"" >> ~/.bashrc
         source "${HOME}/conda/etc/profile.d/conda.sh"
 
-        # Clean up all channel config and enforce conda-forge only
+        # Debug: show base version
+        echo "✅ Conda installed at: $(which conda)"
+        conda --version
+
+        # Install the conda-anaconda-tos plugin (requires temporarily enabling 'defaults')
+        conda config --add channels defaults
+        conda install -n base -y conda-anaconda-tos
+        conda config --remove channels defaults || true
+
+        # Accept Anaconda ToS in CI (required as of July 15, 2025)
+        conda tos accept --channel https://repo.anaconda.com/pkgs/main
+        conda tos accept --channel https://repo.anaconda.com/pkgs/r
+
+        # Clean up all other channels and enforce conda-forge only
         conda config --remove-key channels || true
         conda config --add channels conda-forge
         conda config --set channel_priority strict
 
-        # Debug info to confirm config and version
-        echo "✅ Conda installed at: $(which conda)"
-        conda --version
+        # Final verification logs
+        echo "🔍 Conda config:"
         conda config --show channels
         conda info
 

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -44,13 +44,18 @@ runs:
         echo "source \"${HOME}/conda/etc/profile.d/conda.sh\"" >> ~/.bashrc
         source "${HOME}/conda/etc/profile.d/conda.sh"
 
-        # Remove problematic channels to avoid ToS issues
+        # 1. Clean up default config
         conda config --remove channels https://repo.anaconda.com/pkgs/main || true
         conda config --remove channels https://repo.anaconda.com/pkgs/r || true
-
-        # Just to be sure, set conda-forge explicitly
         conda config --add channels conda-forge
         conda config --set channel_priority strict
+
+        # 2. Accept ToS in case some script still forces those channels
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main || true
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r || true
+
+        # 3. Debug: show effective channels
+        conda config --show channels
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -186,6 +186,13 @@ jobs:
       - name: Alter AppArmor Restrictions for Playwright (Electron)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      - name: Debug Conda Fun
+        run: |
+          which conda
+          conda --version
+          conda config --show channels
+          ls -l "$(which conda)"
+
       - name: Run Playwright Tests (Electron)
         env:
           POSITRON_PY_VER_SEL: 3.12.6

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -186,13 +186,6 @@ jobs:
       - name: Alter AppArmor Restrictions for Playwright (Electron)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Debug Conda Fun
-        run: |
-          which conda
-          conda --version
-          conda config --show channels
-          ls -l "$(which conda)"
-
       - name: Run Playwright Tests (Electron)
         env:
           POSITRON_PY_VER_SEL: 3.12.6

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -59,7 +59,7 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 		await verifyPyprojectTomlCreated(app);
 	});
 
-	test.skip('New env: Conda environment', async function ({ app }) {
+	test('New env: Conda environment', async function ({ app }) {
 		const folderName = addRandomNumSuffix('conda-installed');
 		await createNewFolder(app, {
 			folderTemplate,


### PR DESCRIPTION
### Summary

Replaced the manual Miniforge3 installation with the `conda-incubator/setup-miniconda` GitHub Action. This avoids permission errors and interactive TOS prompts during install, while keeping the same Miniforge3 variant and latest version.

### QA Notes

@:new-folder-flow
