### PR TITLE
Add `notebook.workingDirectory` setting

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -248,7 +248,6 @@ class HelpTopicRequest:
 class PositronInitializationOptions:
     """Positron-specific language server initialization options."""
 
-    notebook_path: Optional[Path] = attrs.field(default=None)
     working_directory: Optional[str] = attrs.field(default=None)
 
 
@@ -286,16 +285,7 @@ class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
             server.show_message_log(msg, msg_type=MessageType.Error)
             initialization_options = PositronInitializationOptions()
 
-        # Set the project path to the notebook's parent if `working_directory` is not provided.
-        # See https://github.com/posit-dev/positron/issues/5948 and https://github.com/posit-dev/positron/issues/7988.
-        working_directory = initialization_options.working_directory
-        notebook_path = initialization_options.notebook_path
-        if working_directory:
-            path = working_directory
-        elif notebook_path:
-            path = notebook_path.parent
-        else:
-            path = self._server.workspace.root_path
+        path = initialization_options.working_directory or self._server.workspace.root_path
 
         # Create the Jedi Project.
         # Note that this overwrites a Project already created in the parent class.

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -249,6 +249,7 @@ class PositronInitializationOptions:
     """Positron-specific language server initialization options."""
 
     notebook_path: Optional[Path] = attrs.field(default=None)
+    working_directory: Optional[str] = attrs.field(default=None)
 
 
 class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
@@ -285,10 +286,16 @@ class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
             server.show_message_log(msg, msg_type=MessageType.Error)
             initialization_options = PositronInitializationOptions()
 
-        # If a notebook path was provided, set the project path to the notebook's parent.
-        # See https://github.com/posit-dev/positron/issues/5948.
+        # Set the project path to the notebook's parent if `working_directory` is not provided.
+        # See https://github.com/posit-dev/positron/issues/5948 and https://github.com/posit-dev/positron/issues/7988.
+        working_directory = initialization_options.working_directory
         notebook_path = initialization_options.notebook_path
-        path = notebook_path.parent if notebook_path else self._server.workspace.root_path
+        if working_directory:
+            path = working_directory
+        elif notebook_path:
+            path = notebook_path.parent
+        else:
+            path = self._server.workspace.root_path
 
         # Create the Jedi Project.
         # Note that this overwrites a Project already created in the parent class.

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -11,7 +11,6 @@ import re
 import threading
 import warnings
 from functools import lru_cache
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast
 
 from comm.base_comm import BaseComm

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -103,7 +103,7 @@ def _reduce_debounce_time(monkeypatch):
 def create_server(
     namespace: Optional[Dict[str, Any]] = None,
     root_path: Optional[Path] = None,
-    notebook_path: Optional[Path] = None,
+    working_directory: Optional[str] = None,
 ) -> PositronJediLanguageServer:
     # Create a server.
     server = create_positron_server()
@@ -128,7 +128,7 @@ def create_server(
                 # to test deserialization too.
                 "positron": cattrs.unstructure(
                     PositronInitializationOptions(
-                        notebook_path=notebook_path,
+                        working_directory=working_directory,
                     )
                 ),
             },
@@ -476,7 +476,7 @@ def assert_has_path_completion(
     expected_completion: str,
     chars_from_end=1,
     root_path: Optional[Path] = None,
-    notebook_path: Optional[Path] = None,
+    working_directory: Optional[str] = None,
 ):
     # Replace separators for testing cross-platform.
     source = source.replace("/", os.path.sep)
@@ -486,7 +486,7 @@ def assert_has_path_completion(
     if os.name == "nt":
         expected_completion = expected_completion.replace("/", "\\" + os.path.sep)
 
-    server = create_server(root_path=root_path, notebook_path=notebook_path)
+    server = create_server(root_path=root_path, working_directory=working_directory)
     text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
     character = len(source) - chars_from_end
     completions = _completions(server, text_document, character)
@@ -721,14 +721,31 @@ def test_notebook_path_completions(tmp_path) -> None:
     notebook_parent = tmp_path / "notebooks"
     notebook_parent.mkdir()
 
-    notebook_path = notebook_parent / "notebook.ipynb"
-
     # Create a file in the notebook's parent.
     file_to_complete = notebook_parent / "data.csv"
     file_to_complete.write_text("")
 
     assert_has_path_completion(
-        '""', file_to_complete.name, root_path=tmp_path, notebook_path=notebook_path
+        '""', file_to_complete.name, root_path=tmp_path, working_directory=str(notebook_parent)
+    )
+
+
+def test_notebook_path_completions_different_wd(tmp_path) -> None:
+    notebook_parent = tmp_path / "notebooks"
+    notebook_parent.mkdir()
+
+    # Make a different working directory.
+    working_directory = tmp_path / "different-working-directory"
+    working_directory.mkdir()
+
+    # Create files in the notebook's parent and the working directory.
+    bad_file = notebook_parent / "bad-data.csv"
+    bad_file.write_text("")
+    good_file = working_directory / "good-data.csv"
+    good_file.write_text("")
+
+    assert_has_path_completion(
+        '""', good_file.name, root_path=tmp_path, working_directory=working_directory
     )
 
 

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
@@ -90,7 +90,7 @@ export class PythonLsp implements vscode.Disposable {
             return out.promise;
         };
 
-        const { notebookUri } = this._metadata;
+        const { notebookUri, workingDirectory } = this._metadata;
 
         // If this client belongs to a notebook, set the document selector to only include that notebook.
         // Otherwise, this is the main client for this language, so set the document selector to include
@@ -128,6 +128,7 @@ export class PythonLsp implements vscode.Disposable {
         if (notebookUri) {
             this._clientOptions.initializationOptions.positron = {
                 notebook_path: notebookUri.fsPath,
+                working_directory: workingDirectory,
             };
         }
 

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -127,7 +127,6 @@ export class PythonLsp implements vscode.Disposable {
         // If this server is for a notebook, set the notebook path option.
         if (notebookUri) {
             this._clientOptions.initializationOptions.positron = {
-                notebook_path: notebookUri.fsPath,
                 working_directory: workingDirectory,
             };
         }

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -331,21 +331,9 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		const varActions = await this.buildEnvVarActions(false);
 
 		let workingDir = this.metadata.workingDirectory;
-
 		if (!workingDir) {
 			// Use the workspace root if available, otherwise the home directory
 			workingDir = vscode.workspace.workspaceFolders?.[0].uri.fsPath || os.homedir();
-
-			// If we have a notebook URI, use its parent directory as the working
-			// directory instead. Note that not all notebooks have valid on-disk
-			// URIs since they may be transient or not yet saved; for these, we fall
-			// back to the workspace root or home directory.
-			if (this.metadata.notebookUri?.fsPath) {
-				const notebookPath = this.metadata.notebookUri.fsPath;
-				if (fs.existsSync(notebookPath)) {
-					workingDir = path.dirname(notebookPath);
-				}
-			}
 		}
 
 		// Form the command-line arguments to the kernel process

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -330,18 +330,21 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		this._kernelSpec = kernelSpec;
 		const varActions = await this.buildEnvVarActions(false);
 
-		// Prepare the working directory; use the workspace root if available,
-		// otherwise the home directory
-		let workingDir = vscode.workspace.workspaceFolders?.[0].uri.fsPath || os.homedir();
+		let workingDir = this.metadata.workingDirectory;
 
-		// If we have a notebook URI, use its parent directory as the working
-		// directory instead. Note that not all notebooks have valid on-disk
-		// URIs since they may be transient or not yet saved; for these, we fall
-		// back to the workspace root or home directory.
-		if (this.metadata.notebookUri?.fsPath) {
-			const notebookPath = this.metadata.notebookUri.fsPath;
-			if (fs.existsSync(notebookPath)) {
-				workingDir = path.dirname(notebookPath);
+		if (!workingDir) {
+			// Use the workspace root if available, otherwise the home directory
+			workingDir = vscode.workspace.workspaceFolders?.[0].uri.fsPath || os.homedir();
+
+			// If we have a notebook URI, use its parent directory as the working
+			// directory instead. Note that not all notebooks have valid on-disk
+			// URIs since they may be transient or not yet saved; for these, we fall
+			// back to the workspace root or home directory.
+			if (this.metadata.notebookUri?.fsPath) {
+				const notebookPath = this.metadata.notebookUri.fsPath;
+				if (fs.existsSync(notebookPath)) {
+					workingDir = path.dirname(notebookPath);
+				}
 			}
 		}
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -540,6 +540,9 @@ declare module 'positron' {
 
 		/** The URI of the notebook document associated with the session, if any */
 		readonly notebookUri?: vscode.Uri;
+
+		/** The starting working directory of the session, if any */
+		readonly workingDirectory?: string;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -44,6 +44,7 @@ const IGNORED_JUPYTER_CONFIGURATION_PROPERTIES = new Set([
 	'jupyter.interactiveWindow.textEditor.executeSelection',
 	'jupyter.interactiveWindow.textEditor.magicCommandsAsComments',
 	'jupyter.interactiveWindow.viewColumn',
+	'jupyter.notebookFileRoot',
 ]);
 // --- End Positron ---
 const jsonRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -1318,7 +1318,7 @@ configurationRegistry.registerConfiguration({
 		},
 		// --- Start Positron ---
 		[NotebookSetting.workingDirectory]: {
-			markdownDescription: nls.localize('notebook.workingDirectory', "Default working directory for notebook kernels. Supports variables like `${workspaceFolder}`. When empty, uses the notebook file's directory. Any change to this setting will apply to future opened notebooks."),
+			markdownDescription: nls.localize('notebook.workingDirectory', "Default working directory for notebook kernels. Supports [variables](https://code.visualstudio.com/docs/reference/variables-reference) like `${workspaceFolder}`. When empty, uses the notebook file's directory. Any change to this setting will apply to future opened notebooks."),
 			type: 'string',
 			default: '',
 			scope: ConfigurationScope.RESOURCE

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -1318,7 +1318,7 @@ configurationRegistry.registerConfiguration({
 		},
 		// --- Start Positron ---
 		[NotebookSetting.workingDirectory]: {
-			markdownDescription: nls.localize('notebook.workingDirectory', "Default working directory for notebook kernels. Supports [variables](https://code.visualstudio.com/docs/reference/variables-reference) like `${workspaceFolder}`. When empty, uses the notebook file's directory. Any change to this setting will apply to future opened notebooks."),
+			markdownDescription: nls.localize('notebook.workingDirectory', "Default working directory for notebook kernels. Supports [variables](https://code.visualstudio.com/docs/reference/variables-reference) like `${workspaceFolder}`. If this setting doesn't resolve to an existing directory, it defaults to the notebook file's directory. Any change to this setting will apply to future opened notebooks."),
 			type: 'string',
 			default: '',
 			scope: ConfigurationScope.RESOURCE

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -15,6 +15,10 @@ import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILanguageSelection, ILanguageService } from '../../../../editor/common/languages/language.js';
 import { ITextModelContentProvider, ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import * as nls from '../../../../nls.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
+// --- End Positron ---
 import { Extensions, IConfigurationPropertySchema, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -1311,6 +1315,14 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			default: '',
 			tags: ['notebookLayout']
+		},
+		// --- Start Positron ---
+		[NotebookSetting.workingDirectory]: {
+			markdownDescription: nls.localize('notebook.workingDirectory', "Default working directory for notebook kernels. Supports variables like `${workspaceFolder}`. When empty, uses the notebook file's directory. Any change to this setting will apply to future opened notebooks."),
+			type: 'string',
+			default: '',
+			scope: ConfigurationScope.RESOURCE
 		}
+		// --- End Positron ---
 	}
 });

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -1065,6 +1065,9 @@ export const NotebookSetting = {
 	outputBackupSizeLimit: 'notebook.backup.sizeLimit',
 	multiCursor: 'notebook.multiCursor.enabled',
 	markupFontFamily: 'notebook.markup.fontFamily',
+	// --- Start Positron ---
+	workingDirectory: 'notebook.workingDirectory',
+	// --- End Positron ---
 } as const;
 
 export const enum CellStatusbarAlignment {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -85,6 +85,9 @@ export interface IRuntimeSessionMetadata {
 	/** The notebook associated with the session, if any */
 	readonly notebookUri: URI | undefined;
 
+	/** The starting working directory of the session, if any */
+	readonly workingDirectory?: string;
+
 	/**
 	 * A timestamp (in milliseconds since the Epoch) representing the time at
 	 * which the runtime session was created.

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -28,6 +28,7 @@ suite('Positron - RuntimeSessionService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	const startReason = 'Test requested to start a runtime session';
 	const notebookUri = URI.file('/path/to/notebook');
+	const notebookParent = '/path/to';
 	let instantiationService: TestInstantiationService;
 	let languageRuntimeService: ILanguageRuntimeService;
 	let runtimeSessionService: IRuntimeSessionService;
@@ -1206,20 +1207,20 @@ suite('Positron - RuntimeSessionService', () => {
 			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for console sessions');
 		});
 
-		test('working directory is undefined when configuration is empty string', async () => {
+		test('working directory is default when configuration is empty string', async () => {
 			configService.setUserConfiguration(NotebookSetting.workingDirectory, '');
 
 			const session = await startNotebook(runtime);
 
-			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for empty string');
+			assert.strictEqual(session.metadata.workingDirectory, notebookParent, 'Working directory should be default for empty string');
 		});
 
-		test('working directory is undefined when configuration is whitespace only', async () => {
+		test('working directory is default when configuration is whitespace only', async () => {
 			configService.setUserConfiguration(NotebookSetting.workingDirectory, '   ');
 
 			const session = await startNotebook(runtime);
 
-			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for whitespace only');
+			assert.strictEqual(session.metadata.workingDirectory, notebookParent, 'Working directory should be default for whitespace only');
 		});
 
 		test('working directory supports variable resolution for notebook sessions', async () => {
@@ -1236,7 +1237,7 @@ suite('Positron - RuntimeSessionService', () => {
 			sinon.assert.calledOnce(mockConfigResolver.resolveAsync);
 		});
 
-		test('working directory falls back to original value when resolution fails for notebook sessions', async () => {
+		test('working directory falls back to default when resolution fails for notebook sessions', async () => {
 			const workingDir = '/workspace/folder';
 			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
 
@@ -1246,8 +1247,17 @@ suite('Positron - RuntimeSessionService', () => {
 
 			const session = await startNotebook(runtime);
 
-			assert.strictEqual(session.metadata.workingDirectory, workingDir, 'Working directory should fall back to original value');
+			assert.strictEqual(session.metadata.workingDirectory, notebookParent, 'Working directory should fall back to default');
 			sinon.assert.calledOnce(mockConfigResolver.resolveAsync);
+		});
+
+		test('working directory falls back to default when it doesnt exist', async () => {
+			const workingDir = '/non/existent/directory';
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, notebookParent, 'Working directory should fall back to default for non-existent directory');
 		});
 
 		test('working directory is resource-scoped for notebook sessions', async () => {

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -19,6 +19,8 @@ import { TestLanguageRuntimeSession, waitForRuntimeState } from './testLanguageR
 import { createRuntimeServices, createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from './testRuntimeSessionService.js';
 import { TestRuntimeSessionManager } from '../../../../test/common/positronWorkbenchTestServices.js';
 import { TestWorkspaceTrustManagementService } from '../../../../test/common/workbenchTestServices.js';
+import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';
+import { NotebookSetting } from '../../../../contrib/notebook/common/notebookCommon.js';
 
 type IStartSessionTask = (runtime: ILanguageRuntimeMetadata) => Promise<TestLanguageRuntimeSession>;
 
@@ -31,6 +33,7 @@ suite('Positron - RuntimeSessionService', () => {
 	let runtimeSessionService: IRuntimeSessionService;
 	let configService: TestConfigurationService;
 	let workspaceTrustManagementService: TestWorkspaceTrustManagementService;
+	let configurationResolverService: IConfigurationResolverService;
 	let manager: TestRuntimeSessionManager;
 	let runtime: ILanguageRuntimeMetadata;
 	let anotherRuntime: ILanguageRuntimeMetadata;
@@ -44,6 +47,7 @@ suite('Positron - RuntimeSessionService', () => {
 		runtimeSessionService = instantiationService.get(IRuntimeSessionService);
 		configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
 		workspaceTrustManagementService = instantiationService.get(IWorkspaceTrustManagementService) as TestWorkspaceTrustManagementService;
+		configurationResolverService = instantiationService.get(IConfigurationResolverService);
 		manager = TestRuntimeSessionManager.instance;
 
 		// Dispose all sessions on teardown.
@@ -1181,5 +1185,92 @@ suite('Positron - RuntimeSessionService', () => {
 		// Verify the session's name has been updated
 		assert.strictEqual(session.dynState.sessionName, newName, 'Session name should be updated correctly');
 		assert.strictEqual(otherSession.dynState.sessionName, runtime.runtimeName, 'Other session name should remain unchanged');
+	});
+
+	suite('Working Directory Configuration', () => {
+		test('working directory is applied to notebook sessions when configured', async () => {
+			const workingDir = '/custom/working/directory';
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, workingDir, 'Working directory should be set for notebook sessions');
+		});
+
+		test('working directory is default for console sessions even when notebook working directory is configured', async () => {
+			const workingDir = '/custom/working/directory';
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
+
+			const session = await startConsole(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for console sessions');
+		});
+
+		test('working directory is undefined when configuration is empty string', async () => {
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, '');
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for empty string');
+		});
+
+		test('working directory is undefined when configuration is whitespace only', async () => {
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, '   ');
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, undefined, 'Working directory should be undefined for whitespace only');
+		});
+
+		test('working directory supports variable resolution for notebook sessions', async () => {
+			const workingDir = '/workspace/folder';
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
+
+			// Create a mock that actually resolves variables
+			const mockConfigResolver = configurationResolverService as any;
+			mockConfigResolver.resolveAsync = sinon.stub().resolves('/resolved/workspace/folder');
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, '/resolved/workspace/folder', 'Working directory should be resolved');
+			sinon.assert.calledOnce(mockConfigResolver.resolveAsync);
+		});
+
+		test('working directory falls back to original value when resolution fails for notebook sessions', async () => {
+			const workingDir = '/workspace/folder';
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir);
+
+			// Create a mock that throws an error during resolution
+			const mockConfigResolver = configurationResolverService as any;
+			mockConfigResolver.resolveAsync = sinon.stub().rejects(new Error('Resolution failed'));
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, workingDir, 'Working directory should fall back to original value');
+			sinon.assert.calledOnce(mockConfigResolver.resolveAsync);
+		});
+
+		test('working directory is resource-scoped for notebook sessions', async () => {
+			const workingDir = '/notebook/specific/directory';
+			await configService.setUserConfiguration(NotebookSetting.workingDirectory, workingDir, notebookUri);
+
+			const session = await startNotebook(runtime);
+
+			assert.strictEqual(session.metadata.workingDirectory, workingDir, 'Working directory should be resource-scoped');
+		});
+
+		test('working directory differs between console and notebook sessions', async () => {
+			const consoleWorkingDir = '/console/directory';
+			const notebookWorkingDir = '/notebook/directory';
+
+			await configService.setUserConfiguration(NotebookSetting.workingDirectory, consoleWorkingDir);
+			await configService.setUserConfiguration(NotebookSetting.workingDirectory, notebookWorkingDir, notebookUri);
+
+			const consoleSession = await startConsole(runtime);
+			const notebookSession = await startNotebook(runtime);
+
+			assert.strictEqual(consoleSession.metadata.workingDirectory, undefined, 'Console session should not use working directory configuration');
+			assert.strictEqual(notebookSession.metadata.workingDirectory, notebookWorkingDir, 'Notebook session should use resource-scoped configuration');
+		});
 	});
 });

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -26,12 +26,13 @@ import { IPositronModalDialogsService } from '../../../positronModalDialogs/comm
 import { RuntimeSessionService } from '../../common/runtimeSession.js';
 import { IRuntimeSessionService, RuntimeStartMode } from '../../common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession } from './testLanguageRuntimeSession.js';
-import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService } from '../../../../test/common/positronWorkbenchTestServices.js';
+import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService, TestDirectoryFileService } from '../../../../test/common/positronWorkbenchTestServices.js';
 import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService, TestContextService } from '../../../../test/common/workbenchTestServices.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
 
 export function createRuntimeServices(
 	instantiationService: TestInstantiationService,
@@ -46,6 +47,7 @@ export function createRuntimeServices(
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	instantiationService.stub(IWorkspaceContextService, new TestContextService());
 	instantiationService.stub(IConfigurationResolverService, new TestConfigurationResolverService());
+	instantiationService.stub(IFileService, disposables.add(new TestDirectoryFileService()));
 	instantiationService.stub(ILanguageRuntimeService, disposables.add(instantiationService.createInstance(LanguageRuntimeService)));
 	instantiationService.stub(IPositronModalDialogsService, new TestPositronModalDialogService());
 	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -26,10 +26,12 @@ import { IPositronModalDialogsService } from '../../../positronModalDialogs/comm
 import { RuntimeSessionService } from '../../common/runtimeSession.js';
 import { IRuntimeSessionService, RuntimeStartMode } from '../../common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession } from './testLanguageRuntimeSession.js';
-import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager } from '../../../../test/common/positronWorkbenchTestServices.js';
-import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService } from '../../../../test/common/workbenchTestServices.js';
+import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService } from '../../../../test/common/positronWorkbenchTestServices.js';
+import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService, TestContextService } from '../../../../test/common/workbenchTestServices.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
+import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 
 export function createRuntimeServices(
 	instantiationService: TestInstantiationService,
@@ -42,6 +44,8 @@ export function createRuntimeServices(
 	instantiationService.stub(ILogService, new NullLogService());
 	instantiationService.stub(IWorkspaceTrustManagementService, disposables.add(new TestWorkspaceTrustManagementService()));
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	instantiationService.stub(IWorkspaceContextService, new TestContextService());
+	instantiationService.stub(IConfigurationResolverService, new TestConfigurationResolverService());
 	instantiationService.stub(ILanguageRuntimeService, disposables.add(instantiationService.createInstance(LanguageRuntimeService)));
 	instantiationService.stub(IPositronModalDialogsService, new TestPositronModalDialogService());
 	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -5,14 +5,17 @@
 
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { IProcessEnvironment } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { ICommandService, ICommandEvent, CommandsRegistry } from '../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService, IOpener, IValidator, IExternalUriResolver, IExternalOpener, OpenInternalOptions, OpenExternalOptions, ResolveExternalUriOptions, IResolvedExternalUri } from '../../../platform/opener/common/opener.js';
+import { IWorkspaceFolder, IWorkspaceFolderData } from '../../../platform/workspace/common/workspace.js';
 import { NotebookCellTextModel } from '../../contrib/notebook/common/model/notebookCellTextModel.js';
 import { INotebookTextModel } from '../../contrib/notebook/common/notebookCommon.js';
 import { ICellExecutionParticipant, IDidEndNotebookCellsExecutionEvent, IDidStartNotebookCellsExecutionEvent, INotebookExecutionService } from '../../contrib/notebook/common/notebookExecutionService.js';
+import { IConfigurationResolverService } from '../../services/configurationResolver/common/configurationResolver.js';
 import { ILanguageRuntimeMetadata } from '../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronModalDialogsService, ShowConfirmationModalDialogOptions, IModalDialogPromptInstance } from '../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { ILanguageRuntimeSessionManager, IRuntimeSessionMetadata, ILanguageRuntimeSession } from '../../services/runtimeSession/common/runtimeSessionService.js';
@@ -146,6 +149,38 @@ export class TestRuntimeSessionManager implements ILanguageRuntimeSessionManager
 
 	setValidateMetadata(handler: (metadata: ILanguageRuntimeMetadata) => Promise<ILanguageRuntimeMetadata>): void {
 		this._validateMetadata = handler;
+	}
+}
+
+export class TestConfigurationResolverService implements IConfigurationResolverService {
+	_serviceBrand: undefined;
+
+	get resolvableVariables(): ReadonlySet<string> {
+		return new Set();
+	}
+
+	resolveAny(_folder: IWorkspaceFolder | undefined, value: any): any {
+		return value;
+	}
+
+	async resolveAsync(_folder: IWorkspaceFolder | undefined, value: any): Promise<any> {
+		return value;
+	}
+
+	resolveWithInteraction(_folder: IWorkspaceFolder | undefined, config: any): Promise<any> {
+		return Promise.resolve(config);
+	}
+
+	resolveWithEnvironment(_environment: IProcessEnvironment, _folder: IWorkspaceFolderData | undefined, value: string): Promise<string> {
+		return Promise.resolve(value);
+	}
+
+	resolveWithInteractionReplace(_folder: IWorkspaceFolder | undefined, config: any): Promise<any> {
+		return Promise.resolve(config);
+	}
+
+	contributeVariable(_variable: string, _resolver: () => Promise<string | undefined>): void {
+		// Mock implementation - does nothing
 	}
 }
 

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -8,6 +8,8 @@ import { IDisposable } from '../../../base/common/lifecycle.js';
 import { IProcessEnvironment } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { ICommandService, ICommandEvent, CommandsRegistry } from '../../../platform/commands/common/commands.js';
+import { TestFileService } from '../browser/workbenchTestServices.js';
+import { createFileStat } from './workbenchTestServices.js';
 import { IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService, IOpener, IValidator, IExternalUriResolver, IExternalOpener, OpenInternalOptions, OpenExternalOptions, ResolveExternalUriOptions, IResolvedExternalUri } from '../../../platform/opener/common/opener.js';
@@ -181,6 +183,30 @@ export class TestConfigurationResolverService implements IConfigurationResolverS
 
 	contributeVariable(_variable: string, _resolver: () => Promise<string | undefined>): void {
 		// Mock implementation - does nothing
+	}
+}
+
+/**
+ * Custom file service for runtime session tests that makes all paths appear as directories.
+ * This is needed because the resolveWorkingDirectory method checks if the path is a directory.
+ */
+export class TestDirectoryFileService extends TestFileService {
+	override async stat(resource: URI) {
+		if (resource.fsPath === '/non/existent/directory') {
+			// Simulate a non-existent directory by returning an empty stat
+			return createFileStat(resource, this.readonly, false, false, false);
+		}
+		// Override to make all other paths appear as directories
+		return createFileStat(resource, this.readonly, false, true, false);
+	}
+
+	override async resolve(resource: URI, _options?: any) {
+		if (resource.fsPath === '/non/existent/directory') {
+			// Simulate a non-existent directory by returning an empty stat
+			return createFileStat(resource, this.readonly, false, false, false);
+		}
+		// Override to make all other paths appear as directories
+		return createFileStat(resource, this.readonly, false, true, false);
 	}
 }
 

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -142,7 +142,7 @@ export class Notebooks {
 		});
 	}
 
-	async assertCellOutput(text: string): Promise<void> {
+	async assertCellOutput(text: string | RegExp): Promise<void> {
 		await expect(this.frameLocator.getByText(text)).toBeVisible({ timeout: 15000 });
 	}
 

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { test, tags } from '../_test.setup';
+import { Notebooks } from '../../pages/notebooks.js';
+
+const NOTEBOOK_PARENT_DIR = path.join('qa-example-content', 'workspaces', 'working-directory-notebook');
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Working Directory Configuration', {
+	tag: [tags.WIN, tags.WEB, tags.NOTEBOOKS]
+}, () => {
+
+	test.afterEach(async function ({ app }) {
+		await app.workbench.notebooks.closeNotebookWithoutSaving();
+	});
+
+	test('Default working directory is the notebook parent', async function ({ app, settings }) {
+		await settings.clear();
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+	});
+
+	test('workspaceFolder works', async function ({ app, settings }) {
+		await settings.set({
+			'notebook.workingDirectory': '${workspaceFolder}'
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'qa-example-content');
+	});
+
+	test('fileDirname works', async function ({ app, settings }) {
+		await settings.set({
+			'notebook.workingDirectory': '${fileDirname}'
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+	});
+
+	test('userHome works', async function ({ app, settings }) {
+		await settings.set({
+			'notebook.workingDirectory': '${userHome}'
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, process.env.HOME || process.env.USERPROFILE || '~');
+	});
+
+	test('A hardcoded path works', async function ({ app, settings }) {
+		// Make a temp dir
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notebook-test'));
+
+		await settings.set({
+			'notebook.workingDirectory': tempDir
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, tempDir);
+	});
+
+	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {
+		await settings.set({
+			'notebook.workingDirectory': '/does/not/exist'
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+	});
+
+	test('Bad variables result in the default notebook parent', async function ({ app, settings }) {
+		await settings.set({
+			'notebook.workingDirectory': '${asdasd}'
+		});
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+	});
+});
+
+async function verifyWorkingDirectoryEndsWith(notebooks: Notebooks, expectedEnd: string) {
+	await notebooks.openNotebook('working-directory.ipynb');
+	await notebooks.runAllCells();
+	await notebooks.assertCellOutput(new RegExp(`^'.*${expectedEnd}'$`));
+}

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -40,13 +40,6 @@ test.describe('Notebook Working Directory Configuration', {
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
-	test('userHome works', async function ({ app, settings }) {
-		await settings.set({
-			'notebook.workingDirectory': '${userHome}'
-		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(process.env.HOME || process.env.USERPROFILE || '~'));
-	});
-
 	test('A hardcoded path works', async function ({ app, settings }) {
 		// Make a temp dir
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notebook-test'));
@@ -54,7 +47,7 @@ test.describe('Notebook Working Directory Configuration', {
 		await settings.set({
 			'notebook.workingDirectory': tempDir
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'notebook-test');
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(tempDir));
 	});
 
 	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -9,8 +9,6 @@ import os from 'os';
 import { test, tags } from '../_test.setup';
 import { Notebooks } from '../../pages/notebooks.js';
 
-const NOTEBOOK_PARENT_DIR = path.join('qa-example-content', 'workspaces', 'working-directory-notebook');
-
 test.use({
 	suiteId: __filename
 });
@@ -25,7 +23,7 @@ test.describe('Notebook Working Directory Configuration', {
 
 	test('Default working directory is the notebook parent', async function ({ app, settings }) {
 		await settings.clear();
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('workspaceFolder works', async function ({ app, settings }) {
@@ -39,14 +37,14 @@ test.describe('Notebook Working Directory Configuration', {
 		await settings.set({
 			'notebook.workingDirectory': '${fileDirname}'
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('userHome works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${userHome}'
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, process.env.HOME || process.env.USERPROFILE || '~');
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(process.env.HOME || process.env.USERPROFILE || '~'));
 	});
 
 	test('A hardcoded path works', async function ({ app, settings }) {
@@ -56,21 +54,21 @@ test.describe('Notebook Working Directory Configuration', {
 		await settings.set({
 			'notebook.workingDirectory': tempDir
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, tempDir);
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'notebook-test');
 	});
 
 	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '/does/not/exist'
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('Bad variables result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${asdasd}'
 		});
-		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, NOTEBOOK_PARENT_DIR);
+		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #7988. Adds a `notebook.workingDirectory` setting and hides the `jupyter.notebookFileRoot` setting, which doesn't work in Positron.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added `notebook.workingDirectory` setting, which can be used to set the default working directory for notebooks (#7988)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:notebooks @:vscode-settings @:console @:extensions @:interpreter @:win

I added some unit tests and e2e tests!

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
Some things to try:
- The `jupyter.notebookFileRoot` setting should no longer exist
- Open a workspace, and a new notebook in a subdirectory of that workspace, with a cell containing `%pwd`, and see its value for different values of the new setting (note you need to close/open the notebook for the change to take effect):
  - (unset)
  - `${workspaceFolder}`
  - `${fileDirname}`
  - `${userHome}`
  - `/some/path/that/exists`
  - `/some/path/that/doesnt/exist`
  - whatever else you want to try (variables are defined [here](https://github.com/posit-dev/positron/blob/adcc385b17e3246c5439ea23c01eaf551b57403d/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts#L77))
- The Console and Terminal working directories shouldn't change
- Filename completions should correspond to the correct working directory
- This should work for R (`getwd()`) or Python (`os.getcwd()`) notebooks, and for VSC or Positron notebooks