### PR TITLE
Use ai-sdk for token usage

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -175,7 +175,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			// Also record token usage by request ID if available
 			const requestId = (options.modelOptions as any)?.requestId;
 			if (requestId) {
-				recordRequestTokenUsage(requestId, inputTokens, outputTokens);
+				recordRequestTokenUsage(requestId, this.provider, inputTokens, outputTokens);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -629,7 +629,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		// --- Start Positron ---
 		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
-		if (isResponseVM(element) && element.tokenUsage && element.isComplete && showTokens) {
+		const experimentalTokenUsage = this.configService.getValue<Array<string>>('positron.assistant.approximateTokenCount');
+		if (isResponseVM(element) && element.tokenUsage && element.isComplete && showTokens && experimentalTokenUsage.includes(element.tokenUsage.provider)) {
 			templateData.value.appendChild(dom.$('.token-usage', undefined, localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens)));
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -340,6 +340,7 @@ export interface IResponse {
 
 // --- Start Positron ---
 export interface IChatTokenUsage {
+	readonly provider: string;
 	readonly inputTokens: number;
 	readonly outputTokens: number;
 }
@@ -1978,10 +1979,3 @@ export interface IChatAgentEditedFileEvent {
 	readonly uri: URI;
 	readonly eventKind: ChatRequestEditedFileEventKind;
 }
-
-// --- Start Positron ---
-export interface IChatTokenUsage {
-	readonly inputTokens: number;
-	readonly outputTokens: number;
-}
-// --- End Positron ---

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -153,6 +153,7 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 		await app.workbench.assistant.clickCloseButton();
 
 		await settings.set({ 'positron.assistant.showTokenUsage.enable': true });
+		await settings.set({ 'positron.assistant.approximateTokenCount': ['echo'] });
 	});
 
 	test.beforeEach('Clear chat', async function ({ app }) {
@@ -172,6 +173,13 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 
 	test('Token usage is not displayed when setting is disabled', async function ({ app, settings }) {
 		await settings.set({ 'positron.assistant.showTokenUsage.enable': false });
+		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
+
+		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
+	});
+
+	test('Token usage is not displayed for non-supported providers', async function ({ app, settings }) {
+		await settings.set({ 'positron.assistant.approximateTokenCount': [] });
 		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());


### PR DESCRIPTION
Switches token usage for ai-sdk providers to use what is returned in the response. The hidden setting is tied to the token usage in the chat history. The chat history data won't contain the token usage at all if the provider is not enabled.

The provider id was added to the token usage. This allows checking if the token usage should be shown if available. This also opens up in the future displaying the provider for each response since we don't clear the chat when the provider changes.

### Release Notes

#### New Features

- Add experimental token usage to Assistant chat for non-Anthropic providers

#### Bug Fixes

- N/A


### QA Notes
A new e2e test has been added to check that the token usage is not show when `positron.assistant.approximateTokenCount` does not enable the provider.