### PR TITLE
python: remove link handler for native repl

### DIFF
--- a/extensions/positron-python/src/client/extensionActivation.ts
+++ b/extensions/positron-python/src/client/extensionActivation.ts
@@ -55,7 +55,10 @@ import { registerReplCommands, registerReplExecuteOnEnter, registerStartNativeRe
 import { registerTriggerForTerminalREPL } from './terminals/codeExecution/terminalReplWatcher';
 import { registerPythonStartup } from './terminals/pythonStartup';
 import { registerPixiFeatures } from './pythonEnvironments/common/environmentManagers/pixi';
-import { registerCustomTerminalLinkProvider } from './terminals/pythonStartupLinkProvider';
+// --- Start Positron ---
+// This hyperlinks the terminal to the native REPL, which we don't use.
+// import { registerCustomTerminalLinkProvider } from './terminals/pythonStartupLinkProvider';
+// --- End Positron ---
 import { registerEnvExtFeatures } from './envExt/api.internal';
 
 // --- Start Positron ---
@@ -142,7 +145,10 @@ export async function activateFeatures(ext: ExtensionState, _components: Compone
     registerStartNativeReplCommand(ext.disposables, interpreterService);
     registerReplCommands(ext.disposables, interpreterService, executionHelper, commandManager);
     registerReplExecuteOnEnter(ext.disposables, interpreterService, commandManager);
-    registerCustomTerminalLinkProvider(ext.disposables);
+    // --- Start Positron ---
+    // This hyperlinks the terminal to the native REPL, which we don't use.
+    // registerCustomTerminalLinkProvider(ext.disposables);
+    // --- End Positron ---
 }
 
 /// //////////////////////////

--- a/extensions/positron-python/src/test/terminals/shellIntegration/pythonStartup.test.ts
+++ b/extensions/positron-python/src/test/terminals/shellIntegration/pythonStartup.test.ts
@@ -134,8 +134,10 @@ suite('Terminal - Shell Integration with PYTHONSTARTUP', () => {
 
         globalEnvironmentVariableCollection.verify((c) => c.delete('PYTHONSTARTUP'), TypeMoq.Times.once());
     });
-
-    test('Ensure registering terminal link calls registerTerminalLinkProvider', async () => {
+    // --- Start Positron ---
+    // We don't use the terminal link provider for the native repl, so we skip this test.
+    test.skip('Ensure registering terminal link calls registerTerminalLinkProvider', async () => {
+        // --- End Positron ---
         const registerTerminalLinkProviderStub = sinon.stub(
             pythonStartupLinkProvider,
             'registerCustomTerminalLinkProvider',


### PR DESCRIPTION
I can't seem to consistently reproduce the appearance of this message; it was definitely caused by some combination of settings but unfortunately I have cleared all my state 😩. Regardless, disabling the link handler won't hurt anything. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8507 Remove VSCode specific "Native REPL" language from Python console startup message.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
