### PR TITLE
Restore default log level to INFO

### DIFF
--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -38,11 +38,7 @@ export enum LogLevel {
 	Error
 }
 
-// --- Start Positron ---
-// TODO(seem): Temporarily set the default log level to debug during beta. This should be reverted
-//             to LogLevel.Info after beta.
-export const DEFAULT_LOG_LEVEL: LogLevel = LogLevel.Debug;
-// --- End Positron ---
+export const DEFAULT_LOG_LEVEL: LogLevel = LogLevel.Info;
 
 export interface ILogger extends IDisposable {
 	onDidChangeLogLevel: Event<LogLevel>;


### PR DESCRIPTION
Restores the log level to INFO; addresses #8539.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The default log level has been returned to Info (was Debug) to reduce log noise. Please consider using the Set Log Level command to restore Debug-level logging when reporting bugs. (#8539)

#### Bug Fixes

- N/A


### QA Notes

You can check the log level by using the _Developer > Set Log Level_ command.