### PR TITLE
pin uv to 0.7.22 in the GitHub Action

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -18,6 +18,7 @@ runs:
       with:
         python-version: '3.12.6'
 
+    # Pinning UV due to https://github.com/rstudio/reticulate/issues/1811
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -20,6 +20,8 @@ runs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
+      with:
+        version: "0.7.22"
 
     - name: Install Python dependencies
       shell: bash


### PR DESCRIPTION
Due to https://github.com/rstudio/reticulate/issues/1811 we need to pin uv to a 0.7 version until reticulate is fixed


### QA Notes
@:reticulate
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
