### PR TITLE
Assistant: disable tools in invalid contexts

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -357,7 +357,8 @@
         "modelDescription": "View the current active plot if one exists. Don't invoke this tool if there are no plots in the session.",
         "canBeReferencedInPrompt": false,
         "tags": [
-          "positron-assistant"
+          "positron-assistant",
+          "requires-session"
         ]
       },
       {
@@ -390,7 +391,8 @@
           ]
         },
         "tags": [
-          "positron-assistant"
+          "positron-assistant",
+          "requires-session"
         ]
       },
       {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -193,6 +193,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		// See IChatRuntimeSessionContext for the structure of the active
 		// session context objects
 		const activeSessions: Set<string> = new Set();
+		let hasVariables = false;
 		let hasConsoleSessions = false;
 		for (const reference of request.references) {
 			const value = reference.value as any;
@@ -201,6 +202,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				if (value.activeSession.mode === positron.LanguageRuntimeSessionMode.Console) {
 					hasConsoleSessions = true;
 				}
+			}
+			if (value.variables && value.variables.length > 0) {
+				hasVariables = true;
 			}
 		}
 
@@ -279,8 +283,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return activeSessions.has('python');
 					case PositronAssistantToolName.GetPlot:
 						return positronContext.plots?.hasPlots === true;
-					// case PositronAssistantToolName.InspectVariables:
-					// TODO: only allow this tool when there are variables to inspect
+					case PositronAssistantToolName.InspectVariables:
+						return hasVariables;
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -277,6 +277,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						// TODO: Remove this restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
 						// The logic above with TOOL_TAG_REQUIRES_ACTIVE_SESSION will handle checking for active sessions once this is removed.
 						return activeSessions.has('python');
+					case PositronAssistantToolName.GetPlot:
+						return positronContext.plots?.hasPlots === true;
+					// case PositronAssistantToolName.InspectVariables:
+					// TODO: only allow this tool when there are variables to inspect
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.
 					// Allow all tools in Agent mode.
 					default:

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -280,9 +280,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						return inChatPane && (isEditMode || isAgentMode);
 					// Only include the getTableSummary tool for Python sessions until supported in R
 					case PositronAssistantToolName.GetTableSummary:
-						// TODO: Remove this restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
+						// TODO: Remove the python-specific restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
 						// The logic above with TOOL_TAG_REQUIRES_ACTIVE_SESSION will handle checking for active sessions once this is removed.
-						return activeSessions.has('python');
+						// We'll still want to check that variables are defined.
+						return activeSessions.has('python') && hasVariables;
 					// Only include the getPlot tool if there is a plot available.
 					case PositronAssistantToolName.GetPlot:
 						return positronContext.plots?.hasPlots === true;

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -188,8 +188,6 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const positronContext = await positron.ai.getPositronChatContext(request);
 		log.debug(`[context] Positron context for request ${request.id}:\n${JSON.stringify(positronContext, null, 2)}`);
 
-		// Build a list of languages for which we have active sessions.
-		//
 		// See IChatRuntimeSessionContext for the structure of the active
 		// session context objects
 		const activeSessions: Set<string> = new Set();
@@ -197,12 +195,16 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		let hasConsoleSessions = false;
 		for (const reference of request.references) {
 			const value = reference.value as any;
+
+			// Build a list of languages for which we have active sessions.
 			if (value.activeSession) {
 				activeSessions.add(value.activeSession.languageId);
 				if (value.activeSession.mode === positron.LanguageRuntimeSessionMode.Console) {
 					hasConsoleSessions = true;
 				}
 			}
+
+			// Check if there are variables defined in the session.
 			if (value.variables && value.variables.length > 0) {
 				hasVariables = true;
 			}
@@ -281,8 +283,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						// TODO: Remove this restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
 						// The logic above with TOOL_TAG_REQUIRES_ACTIVE_SESSION will handle checking for active sessions once this is removed.
 						return activeSessions.has('python');
+					// Only include the getPlot tool if there is a plot available.
 					case PositronAssistantToolName.GetPlot:
 						return positronContext.plots?.hasPlots === true;
+					// Only include the inspectVariables tool if there are variables defined.
 					case PositronAssistantToolName.InspectVariables:
 						return hasVariables;
 					// Otherwise, include the tool if it is tagged for use with Positron Assistant.


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8078
- inspectVariables: now filtered out when no variables in session
- getPlot: now filtered out if no session or no current plot
- getTableSummary: now filtered out if no session and no variables in session
- projectTreeTool: filtering already covered in https://github.com/posit-dev/positron/pull/8264

### Release Notes

#### New Features

- Assistant: tools are now disabled if the context doesn't include the info needed for the tool (#8078)

### QA Notes

@:assistant

#### test cases

| tool | enabled when | disabled when |
|--------|--------|--------|
| inspectVariables | session(s) exist and at least 1 variable is defined | no sessions; or sessions exist but no variables defined |
| getPlot | session(s) exist and there is a plot currently visible | no sessions; or sessions exist but no plot visible |
| getTableSummary | for now, only when Python session(s) exist (this tool is not yet implemented for R https://github.com/posit-dev/positron/issues/8343) and at least 1 variable is defined | for now, if no sessions or if only R sessions exist; or Python sessions exist but no variables defined | 

#### how to check

- try to invoke the disabled tool via chat and notice that the tool cannot be called; or
- check the Output pane for Assistant with log level Debug or Trace for the message with `[tools] Available tools for participant`
    - if the tool is not in the list, it is disabled/filtered out