### PR TITLE
Remove prereleases update channel

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -52,10 +52,9 @@ configurationRegistry.registerConfiguration({
 		'update.positron.channel': {
 			type: 'string',
 			default: 'releases',
-			enum: ['dailies', 'prereleases', 'releases'],
+			enum: ['dailies', 'releases'],
 			enumDescriptions: [
 				localize('dailies', "The latest daily build. This is the most up-to-date version of Positron."),
-				localize('prereleases', "Receive pre-release updates."),
 				localize('releases', "Receive stable releases only."),
 			],
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -86,7 +86,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	*/
 	protected async initialize(): Promise<void> {
 		// --- Start Positron ---
-		const updateChannel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
+		const updateChannel = this.getUpdateChannel();
 		if (process.env.POSITRON_UPDATE_CHANNEL) {
 			this.logService.info('update#ctor - using update channel from environment variable', process.env.POSITRON_UPDATE_CHANNEL);
 		}
@@ -154,6 +154,18 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	}
 
 	// --- Start Positron ---
+	private getUpdateChannel(): string {
+		let persistedUpdateChannel = this.configurationService.getValue<string>('update.positron.channel');
+
+		// settings migration from prereleases to releases
+		if (persistedUpdateChannel && persistedUpdateChannel === 'prereleases') {
+			this.configurationService.updateValue('update.positron.channel', 'releases');
+			persistedUpdateChannel = 'releases'
+		}
+
+		return process.env.POSITRON_UPDATE_CHANNEL ?? persistedUpdateChannel;
+	}
+
 	// This is essentially the update 'channel' (aka insiders, stable, etc.). VS Code sets it through the
 	// product.json. Positron will have it configurable for now.
 	// @ts-ignore


### PR DESCRIPTION
Address #8382 

Removes the `prereleases` option and add a migration of the setting when the update services initializes. The migration code can be removed at a future time.

### Release Notes

#### New Features

- Removed `prereleases` as an update channel option

#### Bug Fixes

- N/A


### QA Notes