### PR TITLE
Data Explorer: Override numpy.histogram bin edges when all the values are constant to return lower edge == upper edge

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -2032,6 +2032,16 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
 
     if need_recompute:
         bin_counts, bin_edges = np.histogram(data, **hist_params)
+
+    # Special case: if we have a single bin, check if all values are the same
+    # If so, override the bin edges to be the same value instead of value +/- 0.5
+    if len(bin_counts) == 1 and len(data) > 0:
+        # Check if all non-null values are the same
+        unique_values = np.unique(data)
+        if len(unique_values) == 1:
+            # All values are the same, set bin edges to [value, value]
+            bin_edges = np.array([unique_values[0], unique_values[0]])
+
     return bin_counts, bin_edges
 
 


### PR DESCRIPTION
This addresses the Python side of #8095.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- In the Data Explorer in Python, if a column contains constant values, the histogram will show a single bin with the lower and upper edge equal, matching the DuckDB behavior when opening a file from the file explorer pane.

### QA Notes

@:data-explorer

Open a data frame like

```
df = pd.DataFrame({'a': [1] * 100})
```

The histogram in the summary pane should show a range where the lower and upper extent are equal.