### PR TITLE
Exclude .claude directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ product.overrides.json
 .vscode-test
 
 # --- Start Positron ---
+.claude
 .Rproj.user
 /playwright-report/
 /blob-report/


### PR DESCRIPTION
If you use Claude Code to work on any part of Positron, it will leave behind a .claude local session data directory that should never be committed to git, so this excludes these from showing up in `git status`.