### PR TITLE
Assistant: Put getTableSummary tool behind an experimental feature flag

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -198,6 +198,12 @@
             "description": "%configuration.gitIntegration.description%",
             "tags": ["experimental"]
           },
+          "positron.assistant.getTableSummary.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.getTableSummary.description%",
+            "tags": ["experimental"]
+          },
           "positron.assistant.showTokenUsage.enable": {
             "type": "boolean",
             "default": false,
@@ -393,7 +399,8 @@
         "tags": [
           "positron-assistant",
           "requires-session"
-        ]
+        ],
+        "when": "config.positron.assistant.getTableSummary.enable"
       },
       {
         "name": "getProjectTree",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -22,5 +22,6 @@
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
+	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
 	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for each message and response including prompts. Check with your provider for detailed usage."
 }


### PR DESCRIPTION
Due to bugs with tool invocation by the models as described in #7114, putting this behind an experimental feature flag until we can improve the tool and make it more robust across LLMs. 

@:assistant