### PR TITLE
Fix for 8622

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -629,7 +629,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		// --- Start Positron ---
 		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
-		const experimentalTokenUsage = ['anthropic', ...this.configService.getValue<Array<string>>('positron.assistant.approximateTokenCount')];
+		let experimentalTokenUsage = ['anthropic'];
+		const approximateTokenCount = this.configService.getValue<Array<string>>('positron.assistant.approximateTokenCount');
+		if (approximateTokenCount && approximateTokenCount.length > 0) {
+			experimentalTokenUsage = experimentalTokenUsage.concat(approximateTokenCount);
+		}
 
 		if (element.tokenUsage && element.isComplete && showTokens && experimentalTokenUsage.includes(element.tokenUsage.provider)) {
 			const tokenUsageElements = templateData.value.getElementsByClassName('token-usage');

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -631,7 +631,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const showTokens = this.configService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
 		let experimentalTokenUsage = ['anthropic'];
 		const approximateTokenCount = this.configService.getValue<Array<string>>('positron.assistant.approximateTokenCount');
-		if (approximateTokenCount && approximateTokenCount.length > 0) {
+		if (approximateTokenCount?.length > 0) {
 			experimentalTokenUsage = experimentalTokenUsage.concat(approximateTokenCount);
 		}
 


### PR DESCRIPTION
## Description

This PR addresses #8622 by fixing an exception that was being thrown by:

`['anthropic', ...this.configService.getValue<Array<string>>('positron.assistant.approximateTokenCount')]`

When `positron.assistant.approximateTokenCount` was undefined.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #8622 Fix exception that was causing Assistant chat UI to overlap.

### QA Notes

