### PR TITLE
Bump Ark to 0.1.199

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -189,6 +189,16 @@
             "type": "boolean",
             "default": true,
             "description": "%r.configuration.diagnostics.enable.description%"
+          },
+          "positron.r.symbols.includeAssignmentsInBlocks": {
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.symbols.includeAssignmentsInBlocks.description%"
+          },
+          "positron.r.workspaceSymbols.includeCommentSections": {
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.workspaceSymbols.includeCommentSections.description%"
           }
         }
       },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -971,7 +971,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.198"
+      "ark": "0.1.199"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -971,7 +971,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.197"
+      "ark": "0.1.198"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -64,6 +64,8 @@
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
+	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
+	"r.configuration.workspaceSymbols.includeCommentSections.description": "Controls whether comment sections like `# My section ---` are included as workspace symbols.",
 	"r.configuration.defaultRepositories.description": "The default repositories to use for R package installation, if no repository is otherwise specified in R startup scripts (restart Positron to apply).\n\nThe default repositories will be set as the `repos` option in R.",
 	"r.configuration.defaultRepositories.auto.description": "Automatically choose a default repository, or use a repos.conf file if it exists.",
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",
@@ -81,4 +83,3 @@
 	"r.walkthrough.migrateFromRStudio.formatting.description": "  \n[Configure Air to format on save](command:r.walkthrough.formatOnSave)"
 
 }
-

--- a/test/e2e/pages/outline.ts
+++ b/test/e2e/pages/outline.ts
@@ -53,11 +53,15 @@ export class Outline {
 		const outllineElements = await this.code.driver.page.locator(OUTLINE_ELEMENT).all();
 
 		const outlineData: string[] = [];
-		for (let i = 0; i < outllineElements.length; i++) {
-			const element = outllineElements[i];
-			const text = await element.textContent();
-			if (text !== null) {
-				outlineData.push(text);
+		for (const element of outllineElements) {
+			// Extract only the symbol name from `.label-name`. We use to extract
+			// metadata associated to the symbol, but this is too fragile and
+			// dependent on upstream changes. For instance the number of
+			// diagnostics/problems may be included there, and other details generated
+			// by the LSP backend.
+			const labelName = await element.locator('.label-name').textContent();
+			if (labelName !== null) {
+				outlineData.push(labelName.trim());
 			}
 		}
 

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -142,11 +142,11 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 		test('Python - Verify Outline Contents', async function ({ app, python, openFile }) {
 			await openFile(join('workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 			await app.workbench.outline.expectOutlineToContain([
-				'data_file_pathdata_file_path = os.path.join(os.getcwd(), \'data-files\', \'chinook\', \'chinook.db\')',
-				'connconn = sqlite3.connect(data_file_path)',
-				'curcur = conn.cursor()',
-				'rowsrows = cur.fetchall()',
-				'dfdf = pd.DataFrame(rows)'
+				'data_file_path',
+				'conn',
+				'cur',
+				'rows',
+				'df'
 			]);
 		});
 

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -171,8 +171,7 @@ async function verifyPythonOutline(outline: Outline) {
 }
 
 async function verifyROutline(outline: Outline) {
-	await outline.expectOutlineElementCountToBe(3); // ensure no dupes from multisessions
+	await outline.expectOutlineElementCountToBe(2); // ensure no dupes from multisessions
 	await outline.expectOutlineElementToBeVisible('demonstrate_scope');
 	await outline.expectOutlineElementToBeVisible('global_variable');
-	await outline.expectOutlineElementToBeVisible('local_variable');
 }


### PR DESCRIPTION
Big Ark update related to treatment of document and workspace symbols:

- https://github.com/posit-dev/ark/pull/855
  Closes https://github.com/posit-dev/ark/issues/846
  Addresses https://github.com/posit-dev/positron/issues/6137

- https://github.com/posit-dev/ark/pull/856
  Addresses https://github.com/posit-dev/positron/issues/1428

- https://github.com/posit-dev/ark/pull/858 and https://github.com/posit-dev/ark/pull/860
  Addresses https://github.com/posit-dev/positron/issues/6546
  Addresses https://github.com/posit-dev/positron/issues/6107
  Addresses https://github.com/posit-dev/positron/issues/5241

- https://github.com/posit-dev/ark/pull/859
  Addresses https://github.com/posit-dev/positron/issues/8330

- https://github.com/posit-dev/ark/pull/861
  Addresses https://github.com/posit-dev/positron/issues/6549

- https://github.com/posit-dev/ark/pull/866
  Addresses https://github.com/posit-dev/positron/issues/4886

- https://github.com/posit-dev/ark/pull/867
  Addresses https://github.com/posit-dev/positron/issues/8402

Fix from @jennybc:

- https://github.com/posit-dev/ark/pull/877
  Addresses https://github.com/posit-dev/positron/issues/5486

Other updates:

- https://github.com/posit-dev/ark/pull/865
- https://github.com/posit-dev/ark/pull/873  (@isabelizimm)


### Release Notes

#### New Features

- `test_that()` blocks now appear in the outline and breadcrumbs, and also support sticky scroll functionality (https://github.com/posit-dev/positron/issues/1428).

- All functions passed as named arguments also gain outline, breadcrumbs, and sticky scroll support. This improves the UX for R6 methods in particular (https://github.com/posit-dev/positron/issues/6546).

- Added support for comment sections (like `# Title ----`) in function calls. This is especially useful for users of the `targets` package where it is common to have very large targets calls that can now be sectioned in the outline, with breadcrumbs and sticky scroll support (https://github.com/posit-dev/positron/issues/8402).

- R6 methods are now exported as workspace symbols. You now search for them with `Ctrl/Cmd + t` (https://github.com/posit-dev/positron/issues/6549).

- New `positron.r.symbols.includeAssignmentsInBlocks` setting to control whether local variables in functions and nested `{}` blocks (e.g. in `test_that()` calls) appear in the outline. It's turned off by default to keep the outline focused on the overall structure of the file (https://github.com/posit-dev/positron/issues/8330).

- New `positron.r.workspaceSymbols.includeCommentSections` setting to control whether comment sections (like `# Title ----`) are exported as workspace symbols. When enabled, you can search for the sections with `Ctrl/Cmd + t`. This is disabled by default to keep symbol search focused on actual symbols (https://github.com/posit-dev/positron/issues/4886).

- `browseURL()` in R now delegates to the operating system's default opener for inputs that are not recognized as a web URL or an HTML file (https://github.com/posit-dev/positron/issues/5486).

#### Bug Fixes

- The breadcrumbs and sticky scroll features now behave properly in the presence of comment sections like `# Title ----` (https://github.com/posit-dev/positron/issues/6137).

- Section comments nested in `{ }` blocks now appear in the outline https://github.com/posit-dev/positron/issues/6107.

- When a comment section (like `# Title ----`) is emitted as workspace symbol, and it clashes with another top-level definition (such as `Title <- function() {}`), the "Go to definition" feature now always prioritizes the definition of regular functions and variables (https://github.com/posit-dev/positron/issues/4886).


### QA Notes

See linked Ark PRs.

I had to update E2E tests to:

- Avoid making assumptions about whether local variables are included in the outline. This is now a user setting and we're still discussing the default. Even if we don't turn it off by default (which was the initial assumption), better not have E2E tests depend on that.

- Outline elements no longer retrieve metadata, only the symbol name. The metadata seems too brittle to changes in backends, for instance the variables now include a summary of related problems, and this was included in the element string, causing a test failure.

@:ark
@:outline
