### PR TITLE
e2e Tests: Session state flake

### DIFF
--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -82,7 +82,7 @@ test.describe('Sessions: State', {
 		// Verify Python session transitions to active when executing code
 		await sessions.select(pySession.name);
 		await console.executeCode('Python', 'import time');
-		await console.executeCode('Python', 'time.sleep(7)', { waitForReady: false, maximizeConsole: false });
+		await console.executeCode('Python', 'time.sleep(10)', { waitForReady: false, maximizeConsole: false });
 		await sessions.expectStatusToBe(pySession.name, 'active');
 
 		// Verify R session transitions to active when executing code


### PR DESCRIPTION
It appears the python sleep finishes before the test checks that it's still running, so I just bumped the sleep time up a bit.


### QA Notes
@:sessions @:web 
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
