### PR TITLE
assistant: ensure variables are included in context and tool calls

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -329,7 +329,7 @@
       {
         "name": "inspectVariables",
         "displayName": "Inspect Variables",
-        "modelDescription": "List the children of an array of variables in a session. For example, the columns in a dataframe, items in a column or array, or elements of a list. If `accessKeys` is empty, lists all root-level variables in the session.\n\nIf the user references a variable by name, first determine the `access_key` from the user context or a previous inspect variables result.\n\nDo not call when:\n  - the variables do not appear in the user context\n  - there is no session (the session identifier is empty or not defined)",
+        "modelDescription": "List the children of an array of variables in a session. For example, the columns in a dataframe, items in a column or array, or elements of a list. If `accessKeys` is empty, lists all root-level variables in the session.\n\nIf the user references a variable by name, first determine the `access_key` from the user context or a previous inspect variables result.",
         "canBeReferencedInPrompt": false,
         "inputSchema": {
           "type": "object",
@@ -350,7 +350,11 @@
                 }
               }
             }
-          }
+          },
+          "required": [
+            "sessionIdentifier",
+            "accessKeys"
+          ]
         },
         "tags": [
           "positron-assistant",

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -388,8 +388,14 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				if (value.activeSession) {
 					// The user attached a runtime session - usually the active session in the IDE.
 					const sessionSummary = JSON.stringify(value.activeSession, null, 2);
-					sessionPrompts.push(xml.node('session', sessionSummary));
-					log.debug(`[context] adding session context for session ${value.activeSession.identifier}: ${sessionSummary.length} characters`);
+					let sessionContent = sessionSummary;
+					if (value.variables) {
+						// Include the session variables in the session content.
+						const variablesSummary = JSON.stringify(value.variables, null, 2);
+						sessionContent += '\n' + xml.node('variables', variablesSummary);
+					}
+					sessionPrompts.push(xml.node('session', sessionContent));
+					log.debug(`[context] adding session context for session ${value.activeSession.identifier}: ${sessionContent.length} characters`);
 				} else if (value instanceof vscode.Location) {
 					// The user attached a range of a file -
 					// usually the automatically attached visible region of the active file.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1589,7 +1589,8 @@ export class MainThreadLanguageRuntime
 		if (!client) {
 			throw new Error(`No variables provider available for session ${instance.session.sessionId}`);
 		}
-		if (accessKeys) {
+		const accessKeysProvided = !!accessKeys && accessKeys.length > 0 && accessKeys.some(key => key.length !== 0);
+		if (accessKeysProvided) {
 			const result = [];
 			for (const accessKey of accessKeys) {
 				result.push((await client.comm.inspect(accessKey)).children);


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8642, https://github.com/posit-dev/positron/issues/8641
- if the access keys are not specified, are empty, or only contain empty arrays, ensure we fall into the all vars list; otherwise inspect the vars indicated by the access keys
- ensure we are adding variables info into the session context

### Release Notes

#### Bug Fixes

- Assistant: ensure variables are included in context and tool calls (#8641, #8642)

### QA Notes

@:assistant

See #8641 and #8642 -- thanks for the repro steps!