### PR TITLE
Assistant code block toolbar snaps to bottom when scrolled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
@@ -27,6 +27,11 @@
 	overflow: hidden;
 }
 
+.interactive-result-code-block .interactive-result-code-block-toolbar.bottom > .monaco-toolbar {
+	bottom: 15px;
+	top: unset;
+}
+
 .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar {
 	left: 0px
 }

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
@@ -26,11 +26,13 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
-
+/* --- Start Positron --- */
+/* Ensures that the toolbar is positioned correctly at the bottom */
 .interactive-result-code-block .interactive-result-code-block-toolbar.bottom > .monaco-toolbar {
 	bottom: 15px;
 	top: unset;
 }
+/* --- End Positron --- */
 
 .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar {
 	left: 0px

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -150,6 +150,9 @@ export interface ICodeBlockRenderOptions {
 }
 
 const defaultCodeblockPadding = 10;
+// --- Start Positron ---
+const codeBlockScrollDelta = 13; // how far above the top of the container a code block needs to be scrolled to show the toolbar at the bottom
+// --- End Positron ---
 export class CodeBlockPart extends Disposable {
 	protected readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
@@ -291,19 +294,21 @@ export class CodeBlockPart extends Disposable {
 		if (delegate.onDidScroll) {
 			this._register(delegate.onDidScroll(e => {
 				this.clearWidgets();
+				// --- Start Positron ---
 				const delegateTop = delegate.container.getBoundingClientRect().top;
 				const toolbarTop = toolbarElement.getElementsByClassName('monaco-toolbar')[0]?.getBoundingClientRect().top || 0;
 				const parentTop = toolbarElement.parentElement?.getBoundingClientRect().top || 0;
 
 				if (toolbarTop !== 0) {
-					if (!toolbarElement.classList.contains('bottom') && parentTop < (delegateTop - 13)) {
+					if (!toolbarElement.classList.contains('bottom') && parentTop < (delegateTop - codeBlockScrollDelta)) {
 						// Toolbar is above the delegate
 						toolbarElement.classList.add('bottom');
-					} else if (toolbarElement.classList.contains('bottom') && parentTop >= (delegateTop - 13)) {
+					} else if (toolbarElement.classList.contains('bottom') && parentTop >= (delegateTop - codeBlockScrollDelta)) {
 						// Toolbar is below the delegate
 						toolbarElement.classList.remove('bottom');
 					}
 				}
+				// --- End Positron ---
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -291,6 +291,19 @@ export class CodeBlockPart extends Disposable {
 		if (delegate.onDidScroll) {
 			this._register(delegate.onDidScroll(e => {
 				this.clearWidgets();
+				const delegateTop = delegate.container.getBoundingClientRect().top;
+				const toolbarTop = toolbarElement.getElementsByClassName('monaco-toolbar')[0]?.getBoundingClientRect().top || 0;
+				const parentTop = toolbarElement.parentElement?.getBoundingClientRect().top || 0;
+
+				if (toolbarTop !== 0) {
+					if (!toolbarElement.classList.contains('bottom') && parentTop < (delegateTop - 13)) {
+						// Toolbar is above the delegate
+						toolbarElement.classList.add('bottom');
+					} else if (toolbarElement.classList.contains('bottom') && parentTop >= (delegateTop - 13)) {
+						// Toolbar is below the delegate
+						toolbarElement.classList.remove('bottom');
+					}
+				}
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -365,12 +365,13 @@
 	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
 		top: 6px;
 	}
-
+	/* --- Start Positron --- */
+	/* Ensures that the toolbar is positioned correctly at the bottom */
 	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar.bottom > .monaco-toolbar {
 		top: unset;
 		bottom: 15px;
 	}
-
+	/* --- End Positron --- */
 }
 
 .interactive-item-container .value.inline-progress {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -365,6 +365,12 @@
 	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
 		top: 6px;
 	}
+
+	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar.bottom > .monaco-toolbar {
+		top: unset;
+		bottom: 15px;
+	}
+
 }
 
 .interactive-item-container .value.inline-progress {


### PR DESCRIPTION
When scrolling Assistant chat, code block toolbars now snap to the bottom of the code block when the top is scrolled out of view.


https://github.com/user-attachments/assets/132f0b07-392a-4343-9cad-38b2ed434b95



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #7038

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:console