### PR TITLE
Add `Alt+Enter` keybinding

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -133,12 +133,6 @@
         "icon": "$(play)"
       },
       {
-        "command": "workbench.action.positronConsole.executeCode",
-        "category": "R",
-        "title": "%r.command.executeSelectionInConsole.title%",
-        "icon": "$(play)"
-      },
-      {
         "command": "r.rmarkdownRender",
         "category": "R",
         "title": "%r.command.rmarkdownRender.title%",
@@ -518,13 +512,6 @@
         },
         {
           "category": "R",
-          "command": "workbench.action.positronConsole.executeCode",
-          "icon": "$(play)",
-          "title": "%r.command.executeSelectionInConsole.title%",
-          "when": "editorLangId == r"
-        },
-        {
-          "category": "R",
           "command": "r.rmarkdownRender",
           "icon": "$(play)",
           "title": "%r.command.rmarkdownRender.title%",
@@ -603,7 +590,6 @@
         {
           "command": "workbench.action.positronConsole.executeCode",
           "group": "R",
-          "title": "%r.command.executeSelectionInConsole.title%",
           "when": "editorLangId == r"
         },
         {
@@ -631,7 +617,6 @@
         {
           "command": "workbench.action.positronConsole.executeCode",
           "icon": "$(play)",
-          "title": "%r.command.executeSelectionInConsole.title%",
           "when": "resourceLangId == r && !isInDiffEditor"
         },
         {

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -4,7 +4,6 @@
 	"r.capabilities.untrustedWorkspaces.description": "R cannot be started in untrusted folders.",
 	"r.command.sourceCurrentFile.title": "Source R File",
 	"r.command.sourceCurrentFileWithEcho.title": "Source R File with Echo",
-	"r.command.executeSelectionInConsole.title": "Run Selection in Console",
 	"r.command.createNewFile.title": "New R File",
 	"r.command.packageLoad.title": "Load R Package",
 	"r.command.insertPipe.title": "Insert the pipe operator",

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -40,6 +40,7 @@ const enum PositronConsoleCommandId {
 	ClearConsole = 'workbench.action.positronConsole.clearConsole',
 	ClearInputHistory = 'workbench.action.positronConsole.clearInputHistory',
 	ExecuteCode = 'workbench.action.positronConsole.executeCode',
+	ExecuteCodeWithoutAdvancing = 'workbench.action.positronConsole.executeCodeWithoutAdvancing',
 	FocusConsole = 'workbench.action.positronConsole.focusConsole',
 	NavigateInputHistoryDown = 'workbench.action.positronConsole.navigateInputHistoryDown',
 	NavigateInputHistoryUp = 'workbench.action.positronConsole.navigateInputHistoryUp',
@@ -574,13 +575,13 @@ export function registerPositronConsoleActions() {
 	registerAction2(class extends Action2 {
 		constructor() {
 			super({
-				id: 'workbench.action.positronConsole.executeCodeWithoutMotion',
+				id: PositronConsoleCommandId.ExecuteCodeWithoutAdvancing,
 				title: {
-					value: localize('workbench.action.positronConsole.executeCodeWithoutMotion', 'Execute Code Without Moving)'),
-					original: 'Execute Code Without Moving'
+					value: localize('workbench.action.positronConsole.executeCodeWithoutAdvancing', 'Execute Code Without Advancing)'),
+					original: 'Execute Code Without Advancing'
 				},
 				f1: false,
-				category: POSITRON_CONSOLE_ACTION_CATEGORY,
+				category,
 				precondition: ContextKeyExpr.and(
 					EditorContextKeys.editorTextFocus,
 					NOTEBOOK_EDITOR_FOCUSED.toNegated()

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -597,8 +597,8 @@ export function registerPositronConsoleActions() {
 			// Forward user options to `executeCode` with hard-coded `advance`
 			opts = {
 				...opts,
-				 advance: false
-			}
+				advance: false
+			};
 			const commandService = accessor.get(ICommandService);
 			return commandService.executeCommand('workbench.action.positronConsole.executeCode', opts);
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -31,6 +31,7 @@ import { IPositronModalDialogsService } from '../../../services/positronModalDia
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IExecutionHistoryService } from '../../../services/positronHistory/common/executionHistoryService.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 /**
  * Positron console command ID's.
@@ -563,6 +564,42 @@ export function registerPositronConsoleActions() {
 				text: '\n'
 			};
 			model.pushEditOperations([], [editOperation], () => []);
+		}
+	});
+
+	/**
+	 * Register the "Execute without advancing" action. This action executes the
+	 * current statement in the editor without advancing the cursor.
+	 */
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.positronConsole.executeCodeWithoutMotion',
+				title: {
+					value: localize('workbench.action.positronConsole.executeCodeWithoutMotion', 'Execute Code Without Moving)'),
+					original: 'Execute Code Without Moving'
+				},
+				f1: false,
+				category: POSITRON_CONSOLE_ACTION_CATEGORY,
+				precondition: ContextKeyExpr.and(
+					EditorContextKeys.editorTextFocus,
+					NOTEBOOK_EDITOR_FOCUSED.toNegated()
+				),
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.Alt | KeyCode.Enter
+				}
+			});
+		}
+
+		async run(accessor: ServicesAccessor, opts: {}) {
+			// Forward user options to `executeCode` with hard-coded `advance`
+			opts = {
+				...opts,
+				 advance: false
+			}
+			const commandService = accessor.get(ICommandService);
+			return commandService.executeCommand('workbench.action.positronConsole.executeCode', opts);
 		}
 	});
 

--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -152,20 +152,6 @@ class PositronKeybindingsContribution extends Disposable {
 			primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyK
 		}));
 
-		// Execute without advancing
-		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
-			id: 'workbench.action.positronConsole.executeCode',
-			weight: KeybindingWeight.BuiltinExtension,
-			when: ContextKeyExpr.and(
-				EditorContextKeys.editorTextFocus,
-				ContextKeyExpr.not('notebookEditorFocused')
-			),
-			primary: KeyMod.Alt | KeyCode.Enter,
-			args: {
-				advance: false,
-			}
-		}));
-
 		// Insert code cell
 		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
 			id: 'quarto.insertCodeCell',

--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -152,6 +152,20 @@ class PositronKeybindingsContribution extends Disposable {
 			primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyK
 		}));
 
+		// Execute without advancing
+		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
+			id: 'workbench.action.positronConsole.executeCode',
+			weight: KeybindingWeight.BuiltinExtension,
+			when: ContextKeyExpr.and(
+				EditorContextKeys.editorTextFocus,
+				ContextKeyExpr.not('notebookEditorFocused')
+			),
+			primary: KeyMod.Alt | KeyCode.Enter,
+			args: {
+				advance: false,
+			}
+		}));
+
 		// Insert code cell
 		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
 			id: 'quarto.insertCodeCell',


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2778

This executes without advancing, using the argument added in https://github.com/posit-dev/positron/pull/3334.

The main potential conflicts are Find all matches when the Find widget is visible, and the Quarto keybindings, but these have precedence over that new RStudio keybinding and still work fine.

Actually I wonder if we should add this as a default keybinding? It's a generally useful keybinding and doesn't seem to conflict with existing keybindings.

Edit: Now a default keybinding

<img width="834" height="588" alt="Screenshot 2025-07-24 at 12 09 50" src="https://github.com/user-attachments/assets/05833891-10a2-41e7-bca1-6b0d8c00a908" />



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Bound Alt+Enter to _Execute statement without advancing_ (https://github.com/posit-dev/positron/issues/2778).

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
