### PR TITLE
python CI: use github token in lint step

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -32,6 +32,10 @@ env:
   special-working-directory: './path with spaces'
   special-working-directory-relative: 'path with spaces'
 
+# Scope the github.token's permissions for safety
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -58,6 +62,8 @@ jobs:
 
       - name: Install Node dependencies
         run: npm ci --fetch-timeout 120000
+        env:
+          POSITRON_GITHUB_PAT: ${{ github.token }}
 
       - name: Run `gulp prePublishNonBundle`
         run: npm run prePublish
@@ -279,9 +285,9 @@ jobs:
           cache: 'pip'
 
       - name: Install Node dependencies
-        run: |
-          git config credential.https://api.github.com.token ${{ secrets.POSITRON_GITHUB_PAT }}
-          npm ci --fetch-timeout 120000
+        run: npm ci --fetch-timeout 120000
+        env:
+          POSITRON_GITHUB_PAT: ${{ github.token }}
 
       - name: Run `gulp prePublishNonBundle`
         run: npm run prePublish
@@ -429,7 +435,7 @@ jobs:
 
       - name: Run smoke tests
         env:
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ github.token }}
         run: |
           npx tsc && node ./out/test/smokeTest.js
         if: matrix.test-suite == 'smoke'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Fixes https://github.com/posit-dev/positron/issues/8655. (No verification needed if CI passes.)

Adds the runner-provided github token to the python lint step, so there's less rate limiting.

Also cleans up how we use the token in the rest of the file so it's standardized.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

CI should be green.
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
