### PR TITLE
Data Explorer: Implement histogram as a single SVG path to avoid 1-pixel gaps depending on zoom level

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
@@ -68,6 +68,7 @@ const FrequencyCount = React.memo(({
 		<foreignObject
 			key={`count-${countIndex}`}
 			className='tooltip-container'
+			data-height={countHeight.toFixed(1)}
 			height={graphHeight}
 			width={countWidth}
 			x={xPosition}
@@ -138,6 +139,7 @@ const OtherCount = React.memo(({
 	return (
 		<foreignObject
 			className='tooltip-container'
+			data-height={countHeight.toFixed(1)}
 			height={graphHeight}
 			width={graphWidth - xPosition}
 			x={xPosition}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -65,11 +65,11 @@ const BinItem = React.memo(({
 	return (
 		<foreignObject
 			className='tooltip-container'
+			data-height={binCountHeight}
 			height={graphHeight}
 			width={binWidth}
 			x={binStart}
 			y={0}
-			data-height={binCountHeight}
 		>
 			<div
 				ref={containerRef}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -65,7 +65,7 @@ const BinItem = React.memo(({
 	return (
 		<foreignObject
 			className='tooltip-container'
-			data-height={binCountHeight}
+			data-height={binCountHeight.toFixed(1)}
 			height={graphHeight}
 			width={binWidth}
 			x={binStart}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -25,7 +25,7 @@ interface VectorHistogramProps {
 }
 
 /**
- * BinItem component to render a single histogram bin with tooltip
+ * BinItem component to provide hover and tooltip functionality for a histogram bin
  */
 const BinItem = React.memo(({
 	binCount,
@@ -37,7 +37,6 @@ const BinItem = React.memo(({
 	binWidth,
 	graphHeight,
 	hoverManager,
-	isHoverOnly = false,
 	xAxisHeight
 }: {
 	binCount: number;
@@ -49,7 +48,6 @@ const BinItem = React.memo(({
 	binWidth: number;
 	graphHeight: number;
 	hoverManager: IHoverManager;
-	isHoverOnly?: boolean;
 	xAxisHeight: number;
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -95,18 +93,9 @@ const BinItem = React.memo(({
 				}}
 			>
 				<svg height='100%' width='100%'>
-					{isHoverOnly && isHovered && (
+					{isHovered && (
 						<rect
 							className='bin-count-hover'
-							height={binCountHeight}
-							width={binWidth}
-							x={0}
-							y={graphHeight - xAxisHeight - binCountHeight}
-						/>
-					)}
-					{!isHoverOnly && (
-						<rect
-							className={isHovered ? 'bin-count-hover' : 'bin-count'}
 							height={binCountHeight}
 							width={binWidth}
 							x={0}
@@ -226,7 +215,6 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 							binWidth={width}
 							graphHeight={props.graphHeight}
 							hoverManager={props.hoverManager}
-							isHoverOnly={true}
 							xAxisHeight={props.xAxisHeight}
 						/>
 					);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -29,26 +29,28 @@ interface VectorHistogramProps {
  */
 const BinItem = React.memo(({
 	binCount,
-	binCountIndex,
-	binMin,
-	binMax,
-	binWidth,
 	binCountHeight,
-	graphHeight,
-	xAxisHeight,
 	binCountPercent,
-	hoverManager
+	binMax,
+	binMin,
+	binStart,
+	binWidth,
+	graphHeight,
+	hoverManager,
+	isHoverOnly = false,
+	xAxisHeight
 }: {
 	binCount: number;
-	binCountIndex: number;
-	binMin: string;
-	binMax: string;
-	binWidth: number;
 	binCountHeight: number;
-	graphHeight: number;
-	xAxisHeight: number;
 	binCountPercent: string;
+	binMax: string;
+	binMin: string;
+	binStart: number;
+	binWidth: number;
+	graphHeight: number;
 	hoverManager: IHoverManager;
+	isHoverOnly?: boolean;
+	xAxisHeight: number;
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isHovered, setIsHovered] = useState(false);
@@ -62,19 +64,12 @@ const BinItem = React.memo(({
 	const formattedMin = formatValue(binMin);
 	const formattedMax = formatValue(binMax);
 
-	// Calculate exact bin position and width to avoid 1-pixel gaps between bins
-	const binPosition = Math.round(binCountIndex * binWidth);
-
-	// Make sure bin width is at least 1
-	binWidth = Math.max(1, Math.round((binCountIndex + 1) * binWidth) - binPosition);
-
 	return (
 		<foreignObject
-			key={`bin-count-container-${binCountIndex}`}
 			className='tooltip-container'
 			height={graphHeight}
 			width={binWidth}
-			x={binPosition}
+			x={binStart}
 			y={0}
 		>
 			<div
@@ -100,12 +95,32 @@ const BinItem = React.memo(({
 				}}
 			>
 				<svg height='100%' width='100%'>
+					{isHoverOnly && isHovered && (
+						<rect
+							className='bin-count-hover'
+							height={binCountHeight}
+							width={binWidth}
+							x={0}
+							y={graphHeight - xAxisHeight - binCountHeight}
+						/>
+					)}
+					{!isHoverOnly && (
+						<rect
+							className={isHovered ? 'bin-count-hover' : 'bin-count'}
+							height={binCountHeight}
+							width={binWidth}
+							x={0}
+							y={graphHeight - xAxisHeight - binCountHeight}
+						/>
+					)}
+					{/* Invisible rect for hover detection */}
 					<rect
-						className={isHovered ? 'bin-count-hover' : 'bin-count'}
-						height={binCountHeight}
+						fill='transparent'
+						height={graphHeight}
+						pointerEvents='all'
 						width={binWidth}
 						x={0}
-						y={graphHeight - xAxisHeight - binCountHeight}
+						y={0}
 					/>
 				</svg>
 			</div>
@@ -120,18 +135,6 @@ const BinItem = React.memo(({
  */
 export const VectorHistogram = (props: VectorHistogramProps) => {
 	// State hooks.
-	const [binWidth] = useState(() => {
-		// Get the number of bin counts that will be rendered.
-		const binCounts = props.columnHistogram.bin_counts.length;
-
-		// If the number of bin counts that will be rendered is 0, return 0.
-		if (!binCounts) {
-			return 0;
-		}
-
-		// Calculate and return the bin width.
-		return props.graphWidth / binCounts;
-	});
 	const [maxBinCount] = useState(() => {
 		// Find the max bin count.
 		let maxBinCount = 0;
@@ -151,6 +154,36 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 		return props.columnHistogram.bin_counts.reduce((sum, count) => sum + count, 0);
 	}, [props.columnHistogram.bin_counts]);
 
+	// Build a single path for all bins to avoid gaps
+	const buildHistogramPath = () => {
+		let path = '';
+		const binCounts = props.columnHistogram.bin_counts;
+		const numBins = binCounts.length;
+
+		for (let i = 0; i < numBins; i++) {
+			const binHeight = (binCounts[i] / maxBinCount) * props.graphHeight;
+			const x = (i / numBins) * props.graphWidth;
+			const nextX = ((i + 1) / numBins) * props.graphWidth;
+			const y = props.graphHeight - props.xAxisHeight - binHeight;
+
+			// Move to bottom left of bin
+			if (i === 0) {
+				path += `M ${x} ${props.graphHeight - props.xAxisHeight} `;
+			}
+
+			// Line to top left
+			path += `L ${x} ${y} `;
+			// Line to top right
+			path += `L ${nextX} ${y} `;
+			// Line to bottom right
+			path += `L ${nextX} ${props.graphHeight - props.xAxisHeight} `;
+		}
+
+		// Close the path
+		path += 'Z';
+		return path;
+	};
+
 	// Render.
 	return (
 		<svg
@@ -165,6 +198,11 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 					x={0}
 					y={props.graphHeight - props.xAxisHeight}
 				/>
+				<path
+					className='bin-count'
+					d={buildHistogramPath()}
+					fill='var(--vscode-positronDataExplorer-sparklineFill)'
+				/>
 				{props.columnHistogram.bin_counts.map((binCount, binCountIndex) => {
 					const binCountHeight = (binCount / maxBinCount) * props.graphHeight;
 					const binMin = props.columnHistogram.bin_edges[binCountIndex];
@@ -172,18 +210,23 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 					// Calculate percentage of the total
 					const binCountPercent = totalBinCount > 0 ? ((binCount / totalBinCount) * 100).toFixed(1) : '0.0';
 
+					// Calculate positions for hover areas
+					const x = (binCountIndex / props.columnHistogram.bin_counts.length) * props.graphWidth;
+					const width = props.graphWidth / props.columnHistogram.bin_counts.length;
+
 					return (
 						<BinItem
 							key={`bin-item-${binCountIndex}`}
 							binCount={binCount}
 							binCountHeight={binCountHeight}
-							binCountIndex={binCountIndex}
 							binCountPercent={binCountPercent}
 							binMax={binMax}
 							binMin={binMin}
-							binWidth={binWidth}
+							binStart={x}
+							binWidth={width}
 							graphHeight={props.graphHeight}
 							hoverManager={props.hoverManager}
+							isHoverOnly={true}
 							xAxisHeight={props.xAxisHeight}
 						/>
 					);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -69,6 +69,7 @@ const BinItem = React.memo(({
 			width={binWidth}
 			x={binStart}
 			y={0}
+			data-height={binCountHeight}
 		>
 			<div
 				ref={containerRef}

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -245,7 +245,7 @@ export class DataExplorer {
 		}
 
 		// Extract heights from tooltip containers which now have data-height attributes
-		const containers = await this.code.driver.page.locator('.column-profile-sparkline .tooltip-container').all();
+		const containers = await this.code.driver.page.locator('.column-profile-sparkline svg foreignObject.tooltip-container').all();
 		const profileSparklineHeights: string[] = [];
 		for (let i = 0; i < containers.length; i++) {
 			const height = await containers[i].getAttribute('data-height');
@@ -370,7 +370,7 @@ export class DataExplorer {
 
 	async verifySparklineHoverDialog(verificationText: string[]): Promise<void> {
 		await test.step(`Verify sparkline tooltip: ${verificationText}`, async () => {
-			const firstSparkline = this.code.driver.page.locator('.column-profile-sparkline .tooltip-container').nth(0);
+			const firstSparkline = this.code.driver.page.locator('.column-profile-sparkline svg foreignObject.tooltip-container').nth(0);
 			await firstSparkline.hover();
 			const hoverTooltip = this.code.driver.page.locator('.hover-contents');
 			await expect(hoverTooltip).toBeVisible();

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -244,11 +244,11 @@ export class DataExplorer {
 			}
 		}
 
-		// some rects have 'count' class, some have 'bin-count' class, some have 'count other' class
-		const rects = await this.code.driver.page.locator('.column-profile-sparkline').locator('[class*="count"]').all();
+		// Extract heights from tooltip containers which now have data-height attributes
+		const containers = await this.code.driver.page.locator('.column-profile-sparkline .tooltip-container').all();
 		const profileSparklineHeights: string[] = [];
-		for (let i = 0; i < rects.length; i++) {
-			const height = await rects[i].getAttribute('height');
+		for (let i = 0; i < containers.length; i++) {
+			const height = await containers[i].getAttribute('data-height');
 			if (height !== null) {
 				const rounded = parseFloat(height).toFixed(1); // Round to one decimal place
 				profileSparklineHeights.push(rounded);
@@ -370,7 +370,7 @@ export class DataExplorer {
 
 	async verifySparklineHoverDialog(verificationText: string[]): Promise<void> {
 		await test.step(`Verify sparkline tooltip: ${verificationText}`, async () => {
-			const firstSparkline = this.code.driver.page.locator('.column-sparkline .tooltip-container').nth(0);
+			const firstSparkline = this.code.driver.page.locator('.column-profile-sparkline .tooltip-container').nth(0);
 			await firstSparkline.hover();
 			const hoverTooltip = this.code.driver.page.locator('.hover-contents');
 			await expect(hoverTooltip).toBeVisible();

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -372,7 +372,10 @@ export class DataExplorer {
 
 	async verifySparklineHoverDialog(verificationText: string[]): Promise<void> {
 		await test.step(`Verify sparkline tooltip: ${verificationText}`, async () => {
-			const firstSparkline = this.code.driver.page.locator('.column-profile-sparkline svg foreignObject.tooltip-container').nth(0);
+			// Try the proper selector first, then fallback to direct vector components
+			// This handles both expanded profiles (with .column-profile-sparkline wrapper)
+			// and collapsed headers (direct vector components)
+			const firstSparkline = this.code.driver.page.locator('.column-profile-sparkline foreignObject.tooltip-container, .vector-histogram foreignObject.tooltip-container, .vector-frequency-table foreignObject.tooltip-container').nth(0);
 			await firstSparkline.hover();
 			const hoverTooltip = this.code.driver.page.locator('.hover-contents');
 			await expect(hoverTooltip).toBeVisible();

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -245,7 +245,9 @@ export class DataExplorer {
 		}
 
 		// Extract heights from tooltip containers which now have data-height attributes
-		const containers = await this.code.driver.page.locator('.column-profile-sparkline svg foreignObject.tooltip-container').all();
+		// Find sparkline containers within the expanded profile area for this specific row
+		const profileAreaSelector = `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-profile-sparkline`;
+		const containers = await this.code.driver.page.locator(`${profileAreaSelector} foreignObject.tooltip-container`).all();
 		const profileSparklineHeights: string[] = [];
 		for (let i = 0; i < containers.length; i++) {
 			const height = await containers[i].getAttribute('data-height');


### PR DESCRIPTION
Addresses #8273. I had to seek Claude Code's help on this one as I am not an expert in SVG rendering. By rendering the histogram as a single SVG path, the UI scale level will not accidentally introduce 1-pixel gaps as seen in #8273. The only extra complexity is that we need to overlay transparent SVG rects for the histogram bar orange highlighting to continue working. 

| Before | After |
  |--------|-------|
  | <img width="400" alt="image" src="https://github.com/user-attachments/assets/a3e3d8f8-9339-4adf-8032-e31a0172b70e" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/4e3dca13-e9e7-4a15-bab0-868526cf01aa" /> |
  | 1-pixel gaps visible between histogram bars when zooming | No gaps - seamless histogram rendering at all zoom levels |

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- 1-pixel gaps that sometimes occur in the data explorer summary panel histograms have been fixed. 

### QA Notes

Open the Flights dataset and watch the summary histograms while increasing and decreasing the Zoom level (Cmd/Ctrl-+/-) several times. 

@:data-explorer