### PR TITLE
assistant: update chat text/confirmations to use "Assistant"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -262,8 +262,14 @@ export async function discardAllEditsWithConfirmation(accessor: ServicesAccessor
 		const confirmation = await dialogService.confirm({
 			title: localize('chat.editing.discardAll.confirmation.title', "Undo all edits?"),
 			message: entries.length === 1
+				// --- Start Positron ---
+				/*
 				? localize('chat.editing.discardAll.confirmation.oneFile', "This will undo changes made by {0} in {1}. Do you want to proceed?", 'Copilot Edits', basename(entries[0].modifiedURI))
 				: localize('chat.editing.discardAll.confirmation.manyFiles', "This will undo changes made by {0} in {1} files. Do you want to proceed?", 'Copilot Edits', entries.length),
+				*/
+				? localize('chat.editing.discardAll.confirmation.oneFile', "This will undo changes made by {0} in {1}. Do you want to proceed?", 'Assistant Edits', basename(entries[0].modifiedURI))
+				: localize('chat.editing.discardAll.confirmation.manyFiles', "This will undo changes made by {0} in {1} files. Do you want to proceed?", 'Assistant Edits', entries.length),
+			// --- End Positron ---
 			primaryButton: localize('chat.editing.discardAll.confirmation.primaryButton', "Yes"),
 			type: 'info'
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -794,7 +794,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			);
 
 			let welcomeContent: IChatViewWelcomeContent;
+			// --- Start Positron ---
+			/*
 			if ((startupExpValue === StartupExperimentGroup.MaximizedChat
+			*/
+			// Don't use the experimental view for Positron Assistant
+			const useExpView = false;
+			if (useExpView && (startupExpValue === StartupExperimentGroup.MaximizedChat
+				// --- End Positron ---
 				|| startupExpValue === StartupExperimentGroup.SplitEmptyEditorChat
 				|| startupExpValue === StartupExperimentGroup.SplitWelcomeChat
 				|| expIsActive) && this.contextKeyService.contextMatchesRules(chatSetupTriggerContext)) {

--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -333,7 +333,12 @@ export class BuiltinChatMode implements IChatMode {
 }
 
 export namespace ChatMode {
+	// --- Start Positron ---
+	/*
 	export const Ask = new BuiltinChatMode(ChatModeKind.Ask, 'Ask', localize('chatDescription', "Ask Copilot"));
+	*/
+	export const Ask = new BuiltinChatMode(ChatModeKind.Ask, 'Ask', localize('chatDescription', "Ask Assistant"));
+	// --- End Positron ---
 	export const Edit = new BuiltinChatMode(ChatModeKind.Edit, 'Edit', localize('editsDescription', "Edit files in your workspace"));
 	export const Agent = new BuiltinChatMode(ChatModeKind.Agent, 'Agent', localize('agentDescription', "Edit files in your workspace in agent mode"));
 }


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8650

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### Bug Fixes

- Assistant: fix incorrect Assistant text in various chat UI (#8650)

### QA Notes

See https://github.com/posit-dev/positron/issues/8650 for some screenshots of places to check!

- sidebar chat in Edit mode
    - ask for some edits to code
    - in the sidebar chat, click the **Undo** option
- sidebar chat in Ask mode
- chat in editor in Ask mode
    - open sidebar chat, then run command `Chat: Open Chat in Editor`
- chat in new window in Ask mode
    - open sidebar chat, then run command `Chat: Open Chat in New Window`
- quick chat -- command `Chat: Open Quick Chat`
- <kbd>Cmd+I</kbd> in Editor
- <kbd>Cmd+I</kbd> in Notebook Editor
- <kbd>Cmd+I</kbd> in Terminal

