### PR TITLE
assistant: tool call refinement to reduce token usage

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -406,7 +406,8 @@
         "canBeReferencedInPrompt": false,
         "tags": [
           "positron-assistant",
-          "requires-workspace"
+          "requires-workspace",
+          "high-token-usage"
         ],
         "inputSchema": {
           "type": "object",

--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -58,7 +58,7 @@ You prefer to use knowledge you are already provided with to infer details when 
 Tools with tag `high-token-usage` may result in high token usage, so redirect the USER to provide you with the information you need to answer their question without using these tools whenever possible. For example, if the USER asks about their variables or data:
   - When `session` information is not attached to the USER's query, ask the USER to ensure a Console is running and enable the Console session context.
   - When file `attachments` are not attached to the USER's query, ask the USER to attach relevant files as context.
-  - DO NOT try to search for text or retrieve file contents using the tools, unless the USER specifically asks you to do so.
+  - DO NOT construct the project tree, search for text or retrieve file contents using the tools, unless the USER specifically asks you to do so.
 </tools>
 
 <chat-participants>

--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -54,6 +54,11 @@ We will provide you with a collection of tools to interact with the current Posi
 The USER can see when you invoke a tool, so you do not need to tell the user or mention the name of tools when you use them.
 
 You prefer to use knowledge you are already provided with to infer details when assisting the USER with their request. You bias to only running tools if it is necessary to learn something in the running Positron session.
+
+Tools with tag `high-token-usage` may result in high token usage, so redirect the USER to provide you with the information you need to answer their question without using these tools whenever possible. For example:
+- If the USER asks about their variables or data, but the `attachments` or `session` are not attached to the USER’s query, ask the USER to:
+  - Ensure a Console is running and enable the Console session context
+  - Attach relevant files as context
 </tools>
 
 <chat-participants>

--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -55,10 +55,10 @@ The USER can see when you invoke a tool, so you do not need to tell the user or 
 
 You prefer to use knowledge you are already provided with to infer details when assisting the USER with their request. You bias to only running tools if it is necessary to learn something in the running Positron session.
 
-Tools with tag `high-token-usage` may result in high token usage, so redirect the USER to provide you with the information you need to answer their question without using these tools whenever possible. For example:
-- If the USER asks about their variables or data, but the `attachments` or `session` are not attached to the USER’s query, ask the USER to:
-  - Ensure a Console is running and enable the Console session context
-  - Attach relevant files as context
+Tools with tag `high-token-usage` may result in high token usage, so redirect the USER to provide you with the information you need to answer their question without using these tools whenever possible. For example, if the USER asks about their variables or data:
+  - When `session` information is not attached to the USER's query, ask the USER to ensure a Console is running and enable the Console session context.
+  - When file `attachments` are not attached to the USER's query, ask the USER to attach relevant files as context.
+  - DO NOT try to search for text or retrieve file contents using the tools, unless the USER specifically asks you to do so.
 </tools>
 
 <chat-participants>

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -746,7 +746,21 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
 		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
 		const languages = await this.getActiveSessionInstructions();
-		return defaultSystem + '\n\n' + filepaths + '\n\n' + languages;
+		const prompts = [defaultSystem, filepaths, languages];
+		return prompts.join('\n\n');
+	}
+}
+
+/** The participant used in the chat pane in Edit mode. */
+class PositronAssistantEditParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
+	id = ParticipantID.Edit;
+
+	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string> {
+		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
+		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
+		const languages = await this.getActiveSessionInstructions();
+		const prompts = [defaultSystem, filepaths, languages];
+		return prompts.join('\n\n');
 	}
 }
 
@@ -756,9 +770,11 @@ export class PositronAssistantAgentParticipant extends PositronAssistantParticip
 
 	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string> {
 		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
+		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
 		const agent = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'agent.md'), 'utf8');
 		const languages = await this.getActiveSessionInstructions();
-		return defaultSystem + '\n\n' + agent + '\n\n' + languages;
+		const prompts = [defaultSystem, filepaths, agent, languages];
+		return prompts.join('\n\n');
 	}
 }
 
@@ -845,17 +861,6 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 class PositronAssistantNotebookParticipant extends PositronAssistantEditorParticipant implements IPositronAssistantParticipant {
 	id = ParticipantID.Notebook;
 	// For now, the Notebook Participant inherits everything from the Editor Participant.
-}
-
-/** The participant used in the chat pane in Edit mode. */
-class PositronAssistantEditParticipant extends PositronAssistantParticipant implements IPositronAssistantParticipant {
-	id = ParticipantID.Edit;
-
-	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string> {
-		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
-		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
-		return defaultSystem + '\n\n' + filepaths;
-	}
 }
 
 export function registerParticipants(context: vscode.ExtensionContext) {

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -37,7 +37,7 @@ export const FileContentsToolData: IToolData = {
 		properties: {
 			filePath: {
 				type: 'string',
-				description: 'The file path to get the contents of. The file path must be a path to a file in the workspace or a file that is currently open in the editor. The file path can be either absolute or relative to the workspace root.',
+				description: 'The absolute file path to get the contents of. The file path must be a path to a file in the workspace or a file that is currently open in the editor.',
 			},
 		},
 		required: ['filePath']

--- a/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/fileContentsTool.ts
@@ -16,8 +16,6 @@ import { getUriForFileOpenOrInsideWorkspace } from './utils.js';
 
 const getFileContentsModelDescription = `
 This tool returns the contents of the specified file in the project.
-The provided file path must be a path to a file in the workspace or a file that is currently open in the editor.
-The file path can be either absolute or relative to the workspace root.
 The tool will return the contents of the file as a string, along with its size and encoding.
 `;
 
@@ -28,14 +26,18 @@ export const FileContentsToolData: IToolData = {
 	displayName: localize('chat.tools.getFileContents', "Get File Contents"),
 	source: ToolDataSource.Internal,
 	modelDescription: getFileContentsModelDescription,
-	tags: ['positron-assistant', 'requires-workspace'],
+	tags: [
+		'positron-assistant',
+		'requires-workspace',
+		'high-token-usage',
+	],
 	canBeReferencedInPrompt: false,
 	inputSchema: {
 		type: 'object',
 		properties: {
 			filePath: {
 				type: 'string',
-				description: 'The file path to get the contents of.',
+				description: 'The file path to get the contents of. The file path must be a path to a file in the workspace or a file that is currently open in the editor. The file path can be either absolute or relative to the workspace root.',
 			},
 		},
 		required: ['filePath']

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -119,7 +119,7 @@ export class TextSearchTool implements IToolImpl {
 		const query = this._queryBuilder.text(searchParams, workspaceUris, queryOptions);
 
 		// Search for the text
-		const { results, messages } = await this._searchService.textSearch(query, _token);
+		const { results, messages, limitHit } = await this._searchService.textSearch(query, _token);
 
 		// If we have a chat context, include references for each result
 		if (invocation.context) {
@@ -153,13 +153,18 @@ export class TextSearchTool implements IToolImpl {
 			}
 		}
 
+		const response: any = {
+			results,
+			messages,
+		};
+		if (limitHit) {
+			response.hitMaxResults = `Hit the maximum number of results: ${maxResults}.`;
+		}
+
 		return {
 			content: [{
 				kind: 'text',
-				value: JSON.stringify({
-					results,
-					messages,
-				}),
+				value: JSON.stringify(response),
 			}],
 		};
 	}

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -17,9 +17,8 @@ import { IChatService } from '../../common/chatService.js';
 const findTextInProjectModelDescription = `
 This tool searches for the specified text inside files in the project and returns a set of files and their corresponding lines where the text is found,
 as well as messages about the search results.
-Do not use this tool to find files or directories in the workspace, as it is specifically designed for searching text within files.
+DO NOT use this tool to find files or directories in the workspace, as it is specifically designed for searching text within files.
 The search is performed across all files in the project, excluding files and directories that are ignored by the workspace settings.
-The provided pattern is interpreted as text unless indicated to be a regular expression.
 Other search options such as case sensitivity, whole word matching, and multiline matching can be specified.
 `;
 
@@ -30,14 +29,18 @@ export const TextSearchToolData: IToolData = {
 	displayName: localize('chat.tools.findTextInProject', "Find Text In Project"),
 	source: ToolDataSource.Internal,
 	modelDescription: findTextInProjectModelDescription,
-	tags: ['positron-assistant', 'requires-workspace'],
+	tags: [
+		'positron-assistant',
+		'requires-workspace',
+		'high-token-usage',
+	],
 	canBeReferencedInPrompt: false,
 	inputSchema: {
 		type: 'object',
 		properties: {
 			pattern: {
 				type: 'string',
-				description: 'The text pattern to search for in the project.',
+				description: 'The text pattern to search for in the project. This pattern is interpreted as text unless isRegExp is set to true.',
 			},
 			isRegExp: {
 				type: 'boolean',


### PR DESCRIPTION
### Summary

- addresses
    - #8556
    - #8645

#### Approach

- add `high-token-usage` tag to tools: project tree, text search, file contents
- add instructions for `high-token-usage` tools to default prompt
   - avoid using these tools to retrieve information that the user should provide as context
- limit the maximum results for the text search tool
   - I set it to 50 results...is this too little?
- require absolute file path for file contents tool (seems to resolve the file path errors!)

### Release Notes

#### New Features

- Assistant: refine tool calls to reduce token usage (#8556)

#### Bug Fixes

- Assistant: fix file path bug when using file contents tool (#8645)

### QA Notes

@:assistant

#### Desired Outcomes
- project tree, text search and file contents tools are called much less readily
- when asked about session variables without files nor the console session attached as context, Assistant should ask the user to attach more information like the session, instead of running a bunch of high token usage tools
   - if the user insists that Assistant help find the variables, then Assistant will at this point run these other tools
- when the text search tool is run with a lot of potential matches, we no longer / much less frequently overflow the token output limit