### PR TITLE
Update button labels for session actions in the console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -57,9 +57,8 @@ const positronInterruptExecution = localize('positronInterruptExecution', "Inter
 const positronToggleTrace = localize('positronToggleTrace', "Toggle Trace");
 const positronToggleWordWrap = localize('positronToggleWordWrap', "Toggle Word Wrap");
 const positronClearConsole = localize('positronClearConsole', "Clear Console");
-const positronRestartConsole = localize('positronRestartConsole', "Restart Console");
-const positronDeleteConsole = localize('positronDeleteConsole', "Delete Console");
 const positronOpenInEditor = localize('positronOpenInEditor', "Open in Editor");
+const positronDeleteSession = localize('positronDeleteSession', "Delete Session");
 
 /**
  * Provides a localized label for the given runtime state. Only the transient
@@ -126,6 +125,9 @@ export const ActionBar = (props: ActionBarProps) => {
 
 	const [stateLabel, setStateLabel] = useState('');
 	const [directoryLabel, setDirectoryLabel] = useState('');
+
+	// Localized strings with placeholders
+	const positronRestartSession = localize('positronRestartSession', "Restart {0}", activePositronConsoleInstance?.runtimeMetadata.languageName ?? localize('positronSession', "Session"));
 
 	// Main useEffect hook.
 	useEffect(() => {
@@ -407,17 +409,18 @@ export const ActionBar = (props: ActionBarProps) => {
 		component: (
 			<ActionBarButton
 				align='right'
-				ariaLabel={positronRestartConsole}
+				ariaLabel={positronRestartSession}
+				dataTestId='restart-session'
 				disabled={!canShutdown || restarting}
 				icon={ThemeIcon.fromId('positron-restart-runtime-thin')}
-				tooltip={positronRestartConsole}
+				tooltip={(positronRestartSession)}
 				onPressed={restartConsoleHandler}
 			/>
 		),
 		overflowContextMenuItem: {
 			commandId: 'positron.restartRuntime',
 			icon: 'positron-restart-runtime-thin',
-			label: positronRestartConsole,
+			label: positronRestartSession,
 			onSelected: restartConsoleHandler
 		}
 	});
@@ -430,18 +433,18 @@ export const ActionBar = (props: ActionBarProps) => {
 			component: (
 				<ActionBarButton
 					align='right'
-					ariaLabel={positronDeleteConsole}
+					ariaLabel={positronDeleteSession}
 					dataTestId='trash-session'
 					disabled={!(canShutdown || canStart)}
 					icon={ThemeIcon.fromId('trash')}
-					tooltip={positronDeleteConsole}
+					tooltip={positronDeleteSession}
 					onPressed={deleteSessionHandler}
 				/>
 			),
 			overflowContextMenuItem: {
 				commandId: 'positron.trashSession',
 				icon: 'trash',
-				label: positronDeleteConsole,
+				label: positronDeleteSession,
 				onSelected: deleteSessionHandler
 			}
 		});

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -42,7 +42,7 @@ export class Console {
 
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private hotKeys: HotKeys) {
 		// Standard Console Button Locators
-		this.restartButton = this.code.driver.page.getByLabel('Restart console');
+		this.restartButton = this.code.driver.page.getByTestId('restart-session');
 		this.clearButton = this.code.driver.page.getByLabel('Clear console');
 		this.trashButton = this.code.driver.page.getByTestId('trash-session');
 


### PR DESCRIPTION
Addresses #8677 

Updated the label for the restart button to now say "Restart {language}" instead of "Restart Console".

**Python**
<img width="992" height="232" alt="Screenshot 2025-07-25 at 4 09 39 PM" src="https://github.com/user-attachments/assets/33fdc033-d918-4abc-a97b-659a05c33c2d" />

**R**
<img width="986" height="227" alt="image" src="https://github.com/user-attachments/assets/fad2c24f-3a37-42c3-886b-203fd320266c" />

While I was in here, I also went ahead and updated the label for the delete button to say "Delete Session" instead of "Delete Console".

**Delete Label**
<img width="986" height="227" alt="image" src="https://github.com/user-attachments/assets/2908e160-6d4b-440f-9cbc-284b2b0ff280" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Update label for restart session button in console (#8677)


### QA Notes

@:console @:sessions @:win @:web