### PR TITLE
Assistant: add context and system prompt to the assistant exported log

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -12,7 +12,7 @@ import * as xml from './xml.js';
 import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_ACTIVE_SESSION, TOOL_TAG_REQUIRES_WORKSPACE } from './constants';
 import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString } from './utils';
 import { EXPORT_QUARTO_COMMAND, quartoHandler } from './commands/quarto';
-import { PositronAssistantToolName } from './types.js';
+import { ContextInfo, PositronAssistantToolName } from './types.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
 import { ReplaceSelectionProcessor } from './replaceSelectionProcessor.js';
@@ -320,9 +320,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		// not cached. Since the context message is transiently added to each request, caching it
 		// will write a prompt prefix to the cache that will never be read. We will want to keep
 		// an eye on whether the order of user prompt and context message affects model responses.
-		const contextMessage = await this.getContextMessage(request, context, response, positronContext);
-		if (contextMessage) {
-			messages.push(contextMessage);
+		const contextInfo = await this.getContextInfo(request, context, response, positronContext);
+		if (contextInfo) {
+			messages.push(contextInfo.message);
 		}
 
 		// Send the request to the language model.
@@ -333,19 +333,25 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				// Attach the model ID as metadata so that we can use the same model in the followup provider.
 				modelId: request.model.id,
 				// Include token usage if available
-				tokenUsage: tokenUsage
+				tokenUsage: tokenUsage,
+				// Include the tools available for this request
+				availableTools: tools.length > 0 ? tools.map(t => t.name) : undefined,
+				// Include the context message if available
+				positronContext: contextInfo ? { prompts: contextInfo.prompts, attachedDataTypes: contextInfo.attachedDataTypes } : undefined,
+				// Include the system prompt used for this request
+				systemPrompt: system,
 			},
 		};
 	}
 
 	protected abstract getSystemPrompt(request: vscode.ChatRequest): Promise<string>;
 
-	private async getContextMessage(
+	private async getContextInfo(
 		request: vscode.ChatRequest,
 		context: vscode.ChatContext,
 		response: vscode.ChatResponseStream,
 		positronContext: positron.ai.ChatContext,
-	): Promise<vscode.LanguageModelChatMessage2 | undefined> {
+	): Promise<ContextInfo | undefined> {
 		// This function returns a single user message containing all context
 		// relevant to a request, including:
 		// 1. A text prompt.
@@ -563,7 +569,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		parts.push(...userDataParts);
 
 		if (parts.length > 0) {
-			return vscode.LanguageModelChatMessage2.User(parts);
+			return {
+				message: vscode.LanguageModelChatMessage2.User(parts),
+				prompts,
+				attachedDataTypes: userDataParts.map(part => part.mimeType),
+			};
 		}
 
 		return undefined;

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
+
 export enum PositronAssistantToolName {
 	DocumentEdit = 'documentEdit',
 	EditFile = 'positron_editFile_internal',
@@ -52,3 +54,15 @@ export interface LanguageModelCacheBreakpoint {
 	 */
 	type: LanguageModelCacheBreakpointType;
 }
+
+/**
+ * Represents the context information that is sent as part of the request to the model.
+ */
+export type ContextInfo = {
+	/** The constructed language model message */
+	message: vscode.LanguageModelChatMessage2;
+	/** The prompts that are part of the message */
+	prompts: string[];
+	/** The mimeTypes for attached data included in the message */
+	attachedDataTypes?: string[];
+};


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8429

### Release Notes

#### New Features

- Assistant: exported chat log now contains prompt and positron **context** info (#8429)

### QA Notes

The exported chat log via the `Positron Assistant: export the current chat` commands now contain the following info per request:

- positronContext
    - prompts: text prompts included in positron context
    - attachedDataTypes: data attachment mimeTypes (e.g. if an image was attached)
- systemPrompt: the default prompt used for each request
- availableTools: which tools were available for the request

This new content is in requests > result > metadata, alongside where we already have `tokenUsage`