### PR TITLE
Use table icon for non plaintext files in data explorer editor

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -512,7 +512,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	//#endregion Private Methods
 }
 
-export const PLAINTEXT_EXTS = [
+const PLAINTEXT_EXTS = [
 	'.csv',
 	'.tsv'
 ]

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -512,7 +512,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	//#endregion Private Methods
 }
 
-const PLAINTEXT_EXTS = [
+export const PLAINTEXT_EXTS = [
 	'.csv',
 	'.tsv'
 ]

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
@@ -9,7 +9,6 @@ import { EditorInput } from '../../../common/editor/editorInput.js';
 import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { PLAINTEXT_EXTS } from './positronDataExplorerEditor.js';
 
 /**
  * PositronDataExplorerEditorInput class.
@@ -96,22 +95,10 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	}
 
 	/**
-	 * Override getIcon to return different icons for data frames vs text files
+	 * Gets the icon to display in the editor tab.
+	 * @returns The icon to display in the editor tab.
 	 */
 	override getIcon(): ThemeIcon | undefined {
-		const identifier = PositronDataExplorerUri.parse(this.resource);
-
-		// If this is a file-based data explorer, check the extension
-		if (identifier && identifier.startsWith('duckdb:')) {
-			// Get the backing URI and check if it's a plaintext file
-			const backingUri = PositronDataExplorerUri.backingUri(this.resource);
-			if (backingUri && PLAINTEXT_EXTS.some(ext => backingUri.path.endsWith(ext))) {
-				// Use the default text file icon if it is a plaintext file
-				return undefined;
-			}
-		}
-
-		// In all other cases, use the table icon for data frames
 		return ThemeIcon.fromId('table');
 	}
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
@@ -8,6 +8,8 @@ import { IUntypedEditorInput } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { PLAINTEXT_EXTS } from './positronDataExplorerEditor.js';
 
 /**
  * PositronDataExplorerEditorInput class.
@@ -91,6 +93,26 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	setName(name: string) {
 		this._name = name;
 		this._onDidChangeLabel.fire();
+	}
+
+	/**
+	 * Override getIcon to return different icons for data frames vs text files
+	 */
+	override getIcon(): ThemeIcon | undefined {
+		const identifier = PositronDataExplorerUri.parse(this.resource);
+
+		// If this is a file-based data explorer, check the extension
+		if (identifier && identifier.startsWith('duckdb:')) {
+			// Get the backing URI and check if it's a plaintext file
+			const backingUri = PositronDataExplorerUri.backingUri(this.resource);
+			if (backingUri && PLAINTEXT_EXTS.some(ext => backingUri.path.endsWith(ext))) {
+				// Use the default text file icon if it is a plaintext file
+				return undefined;
+			}
+		}
+
+		// In all other cases, use the table icon for data frames
+		return ThemeIcon.fromId('table');
 	}
 
 	/**


### PR DESCRIPTION
Addresses #8164

The data explorer editor did not provide any custom icons for the tab to use, which meant that the default text file icon was used.  We now show the `table` icon if the editor tab is a data explorer input instance. This is the same icon that we use in the variables pane for dataframe objects.

The only open question as far as behavior is if we want to show a different icon for data explorer editors backed by a plaintext resource. Prior to this change, ".csv" files always displayed a custom csv icon in the editor tab regardless if the file was viewed via the data explorer or as a plaintext file. I am not sure if this was intentional and if we want all editors backed by a csv resource to show the green csv icon.

The current behavior is such that every data explorer instance shows the table icon. If a plaintext file is viewed in plaintext mode, the icon will change to the text file icon (or the csv icon in the case of csv files).


https://github.com/user-attachments/assets/83375d47-aa03-445f-be89-cb6d131afd1f


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Data Explorer editor tabs now use the `table` icon (#8164)

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer @:layouts @:viewer @:editor @:variables @:web @:win
