### PR TITLE
Bump Ark to 0.1.200

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -981,7 +981,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.199"
+      "ark": "0.1.200"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/product.json
+++ b/product.json
@@ -230,7 +230,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.18.0",
+			"version": "1.18.1",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",

--- a/test/e2e/tests/diagnostics/diagnostics.test.ts
+++ b/test/e2e/tests/diagnostics/diagnostics.test.ts
@@ -61,29 +61,28 @@ test.describe('Diagnostics', {
 	}, async function ({ app, runCommand, sessions }) {
 		const { problems, editor, console } = app.workbench;
 
-		// Start R Session and install 'circlize'
+		// Start R Session and define variable
 		const rSession = await sessions.start('r');
-		await console.executeCode('R', "install.packages('circlize')", { maximizeConsole: false });
-		await console.executeCode('R', 'library(circlize)', { maximizeConsole: false });
+		await console.executeCode('R', 'unlikelyvariablename <- 1', { maximizeConsole: false });
 
-		// Open new R file and use 'circlize'
+		// Open new R file and use variable
 		await runCommand('R: New File');
-		await editor.type('library(circlize)\ncircos.points()\n');
+		await editor.type('unlikelyvariablename');
 
 		// Session 1 - verify no problems
 		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
 		await problems.expectSquigglyCountToBe('warning', 0);
 
-		// Start R Session 2 - verify warning since circlize is not installed
+		// Start R Session 2 - verify warning since variable is not defined
 		const rSessionAlt = await sessions.start('rAlt');
 		await problems.expectSquigglyCountToBe('warning', 1);
 		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 1, errorCount: 0 });
-		await problems.expectWarningText('No symbol named \'circos.');
+		await problems.expectWarningText('No symbol named \'unlikelyvariablename');
 
 		// Introduce a syntax error
 		await editor.selectTabAndType('Untitled-1', 'x <-');
 
-		// Session 2 - verify both problems (circos and syntax) are present
+		// Session 2 - verify both problems (variable and syntax) are present
 		await sessions.select(rSessionAlt.id);
 		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
@@ -93,11 +92,10 @@ test.describe('Diagnostics', {
 		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 
-		// Session 1 - restart session and verify both problems (circos and syntax) are present
-		// Diagnostics engine is not aware of the circlize package, this is expected
+		// Session 1 - restart session and verify both problems (variable and syntax) are present
+		// Diagnostics engine is not aware of the defined variable, this is expected
 		await sessions.restart(rSession.id);
 		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
 		await problems.expectSquigglyCountToBe('error', 1);
 	});
 });
-

--- a/test/e2e/tests/diagnostics/diagnostics.test.ts
+++ b/test/e2e/tests/diagnostics/diagnostics.test.ts
@@ -67,7 +67,7 @@ test.describe('Diagnostics', {
 
 		// Open new R file and use variable
 		await runCommand('R: New File');
-		await editor.type('unlikelyvariablename');
+		await editor.type('unlikelyvariablename\n');
 
 		// Session 1 - verify no problems
 		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });


### PR DESCRIPTION
Ark update that fixes squiggles in fresh sessions:

- https://github.com/posit-dev/ark/pull/870
  Addresses posit-dev/positron#1325

- https://github.com/posit-dev/ark/pull/872
  Addresses posit-dev/positron#2252
  Addresses posit-dev/positron#8549
  Addresses posit-dev/positron#8550
  Addresses posit-dev/positron#3685

- https://github.com/posit-dev/ark/pull/881
  Addresses posit-dev/positron#8668

- https://github.com/posit-dev/ark/pull/883
  Addresses posit-dev/positron#8708

Other updates:

- https://github.com/posit-dev/ark/pull/884 from @isabelizimm
  Addresses posit-dev/positron#8095


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->


#### New Features

- The diagnostics engine is vastly improved in fresh sessions. You no longer have to attach packages in the console session to silence "unknown symbol" diagnostics in scripts (https://github.com/posit-dev/positron/issues/1325 and https://github.com/posit-dev/positron/issues/8708). The issue has also been resolved in packages where a `load_all()` is no longer necessary to silence symbol diagnostics (https://github.com/posit-dev/positron/issues/2252).

#### Bug Fixes

- Fixed a race condition between the workspace indexer and diagnostics that caused spurious diagnotics on startup (https://github.com/posit-dev/positron/issues/8549).

- Fixed a diagnostics issue where objects defined in other files were not properly detected (https://github.com/posit-dev/positron/issues/8550).

- Workspace symbols no longer get duplicates when a file is renamed (https://github.com/posit-dev/positron/issues/8668).


### QA Notes

See linked Ark PRs.

I had to update E2E tests and adapt the unknown variable check to be resolved by evaluating an assignment instead of a `library()` call.

@:ark