### PR TITLE
Fix Assistant welcome message links

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -831,6 +831,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				ChatViewWelcomePart,
 				welcomeContent,
 				{
+					// --- Start Positron ---
+					firstLinkToButton: !this.languageModelsService.currentProvider,
+					// --- End Positron ---
 					location: this.location,
 					isWidgetAgentWelcomeViewContent: this.input?.currentModeKind === ChatModeKind.Agent
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -888,7 +888,7 @@ Type \`/\` to use predefined commands such as \`/help\`.`,
 		}
 		return {
 			title: welcomeTitle,
-			message: new MarkdownString(welcomeText),
+			message: new MarkdownString(welcomeText, { supportThemeIcons: true, isTrusted: true }),
 			icon: Codicon.positronAssistant,
 			tips,
 			additionalMessage,


### PR DESCRIPTION
### Release Notes
Address #8722

The options were accidentally left out during the 1.102 merge. This would have affected the configure provider and Assistant guide links.

<img width="344" height="256" alt="image" src="https://github.com/user-attachments/assets/e285e2cd-730a-4238-9481-c82f23e10287" />

#### New Features

- N/A

#### Bug Fixes

- Fix Assistant links in welcome message


### QA Notes