### PR TITLE
python: add UVInstaller class

### DIFF
--- a/extensions/positron-python/src/client/common/installer/productInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/productInstaller.ts
@@ -293,10 +293,17 @@ export class DataScienceInstaller extends BaseInstaller {
 
         // If this is a non-conda environment & pip isn't installed, we need to install pip.
         // The prompt would have been disabled prior to this point, so we can assume that.
+        // --- Start Positron ---
+        // uv doesn't need pip either
+        const uvIsAvailable = channels.some((channel) => channel.type === ModuleInstallerType.Uv);
+        // --- End Positron ---
         if (
             flags &&
             flags & ModuleInstallFlags.installPipIfRequired &&
             interpreter.envType !== EnvironmentType.Conda &&
+            // --- Start Positron ---
+            !uvIsAvailable &&
+            // --- End Positron ---
             !channels.some((channel) => channel.type === ModuleInstallerType.Pip)
         ) {
             const installers = this.serviceContainer.getAll<IModuleInstaller>(IModuleInstaller);
@@ -347,6 +354,10 @@ export class DataScienceInstaller extends BaseInstaller {
         let requiredInstaller = ModuleInstallerType.Unknown;
         if (interpreter.envType === EnvironmentType.Conda && isAvailableThroughConda) {
             requiredInstaller = ModuleInstallerType.Conda;
+            // --- Start Positron ---
+        } else if (uvIsAvailable) {
+            requiredInstaller = ModuleInstallerType.Uv;
+            // --- End Positron ---
         } else if (interpreter.envType === EnvironmentType.Conda && !isAvailableThroughConda) {
             // This case is temporary and can be removed when https://github.com/microsoft/vscode-jupyter/issues/5034 is unblocked
             traceInfo(

--- a/extensions/positron-python/src/client/common/installer/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/common/installer/serviceRegistry.ts
@@ -10,11 +10,17 @@ import { PipEnvInstaller } from './pipEnvInstaller';
 import { PipInstaller } from './pipInstaller';
 import { PixiInstaller } from './pixiInstaller';
 import { PoetryInstaller } from './poetryInstaller';
+// --- Start Positron ---
+import { UVInstaller } from './uvInstaller';
+// --- End Positron ---
 import { DataScienceProductPathService, TestFrameworkProductPathService } from './productPath';
 import { ProductService } from './productService';
 import { IInstallationChannelManager, IModuleInstaller, IProductPathService, IProductService } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
+    // --- Start Positron ---
+    serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, UVInstaller);
+    // --- End Positron ---
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PixiInstaller);
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, CondaInstaller);
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PipInstaller);

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -57,7 +57,7 @@ export class UVInstaller extends ModuleInstaller {
         // TODO: should we use uv add if a pyproject.toml exists?
         const args = ['pip', 'install', '--upgrade'];
 
-        // Get the path to the python interpreter (same as ModuleInstaller install code)
+        // Get the path to the python interpreter (similar to a part in ModuleInstaller.installModule())
         const configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
         const settings = configService.getSettings(isResource(resource) ? resource : undefined);
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -53,8 +53,8 @@ export class UVInstaller extends ModuleInstaller {
         const pythonPath = isResource(resource)
             ? this.configurationService.getSettings(resource).pythonPath
             : resource
-                ? getEnvPath(resource.path, resource.envPath).path ?? ''
-                : '';
+            ? getEnvPath(resource.path, resource.envPath).path ?? ''
+            : '';
 
         // If the resource isSupported, then the uv binary exists
         const execPath = 'uv';

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -9,18 +9,16 @@ import { inject, injectable } from 'inversify';
 import { ModuleInstallerType } from '../../pythonEnvironments/info';
 import { ExecutionInfo, IConfigurationService } from '../types';
 import { ModuleInstaller } from './moduleInstaller';
-import { InterpreterUri } from './types';
+import { InterpreterUri, ModuleInstallFlags } from './types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { IServiceContainer } from '../../ioc/types';
 import { isResource } from '../utils/misc';
-import { getEnvPath } from '../../pythonEnvironments/base/info/env';
+import { IWorkspaceService } from '../application/types';
+import { IInterpreterService } from '../../interpreter/contracts';
 
 @injectable()
 export class UVInstaller extends ModuleInstaller {
-    constructor(
-        @inject(IServiceContainer) serviceContainer: IServiceContainer,
-        @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
-    ) {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super(serviceContainer);
     }
 
@@ -49,20 +47,42 @@ export class UVInstaller extends ModuleInstaller {
         }
     }
 
-    protected async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
-        const pythonPath = isResource(resource)
-            ? this.configurationService.getSettings(resource).pythonPath
-            : resource
-            ? getEnvPath(resource.path, resource.envPath).path ?? ''
-            : '';
-
+    protected async getExecutionInfo(
+        moduleName: string,
+        resource?: InterpreterUri,
+        flags: ModuleInstallFlags = 0,
+    ): Promise<ExecutionInfo> {
         // If the resource isSupported, then the uv binary exists
         const execPath = 'uv';
-        const args = ['pip', 'install', '--python', pythonPath, moduleName];
         // TODO: should we use uv add if a pyproject.toml exists?
+        const args = ['pip', 'install', '--upgrade'];
+
+        // Get the path to the python interpreter (same as ModuleInstaller install code)
+        const configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const settings = configService.getSettings(isResource(resource) ? resource : undefined);
+        const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
+        const interpreter = isResource(resource) ? await interpreterService.getActiveInterpreter(resource) : resource;
+        const interpreterPath = interpreter?.path ?? settings.pythonPath;
+        const pythonPath = isResource(resource) ? interpreterPath : resource.path;
+        args.push('--python', pythonPath);
+
+        const workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        const proxy = workspaceService.getConfiguration('http').get('proxy', '');
+        if (proxy.length > 0) {
+            args.push('--proxy', proxy);
+        }
+
+        if (flags & ModuleInstallFlags.reInstall) {
+            args.push('--force-reinstall');
+        }
+
+        // Support the --break-system-packages flag to temporarily work around PEP 668.
+        if (flags & ModuleInstallFlags.breakSystemPackages) {
+            args.push('--break-system-packages');
+        }
 
         return {
-            args,
+            args: [...args, moduleName],
             execPath,
         };
     }

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable class-methods-use-this */
+
+import { inject, injectable } from 'inversify';
+import { ModuleInstallerType } from '../../pythonEnvironments/info';
+import { ExecutionInfo, IConfigurationService } from '../types';
+import { ModuleInstaller } from './moduleInstaller';
+import { InterpreterUri } from './types';
+import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
+import { IServiceContainer } from '../../ioc/types';
+import { isResource } from '../utils/misc';
+import { getEnvPath } from '../../pythonEnvironments/base/info/env';
+
+@injectable()
+export class UVInstaller extends ModuleInstaller {
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
+    ) {
+        super(serviceContainer);
+    }
+
+    public get name(): string {
+        return 'Uv';
+    }
+
+    public get displayName(): string {
+        return 'uv';
+    }
+
+    public get type(): ModuleInstallerType {
+        return ModuleInstallerType.Uv;
+    }
+
+    public get priority(): number {
+        return 30;
+    }
+
+    public async isSupported(_resource?: InterpreterUri): Promise<boolean> {
+        // uv can be used in any environment type
+        try {
+            return await isUvInstalled();
+        } catch {
+            return false;
+        }
+    }
+
+    protected async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
+        const pythonPath = isResource(resource)
+            ? this.configurationService.getSettings(resource).pythonPath
+            : resource
+                ? getEnvPath(resource.path, resource.envPath).path ?? ''
+                : '';
+
+        // If the resource isSupported, then the uv binary exists
+        const execPath = 'uv';
+        const args = ['pip', 'install', '--python', pythonPath, moduleName];
+        // TODO: should we use uv add if a pyproject.toml exists?
+
+        return {
+            args,
+            execPath,
+        };
+    }
+}

--- a/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
@@ -62,6 +62,9 @@ export enum ModuleInstallerType {
     Poetry = 'Poetry',
     Pipenv = 'Pipenv',
     Pixi = 'Pixi',
+    // --- Start Positron ---
+    Uv = 'Uv',
+    // --- End Positron ---
 }
 
 /**

--- a/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
@@ -230,6 +230,41 @@ suite('DataScienceInstaller install', async () => {
         expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
     });
 
+    test('Will invoke uv', async () => {
+        const testEnvironment: PythonEnvironment = {
+            envType: EnvironmentType.Uv,
+            envName: 'test',
+            envPath: interpreterPath,
+            path: interpreterPath,
+            architecture: Architecture.x64,
+            sysPrefix: '',
+        };
+        const testInstaller = TypeMoq.Mock.ofType<IModuleInstaller>();
+
+        testInstaller.setup((c) => c.type).returns(() => ModuleInstallerType.Uv);
+        testInstaller
+            .setup((c) =>
+                c.installModule(
+                    TypeMoq.It.isValue(Product.ipykernel),
+                    TypeMoq.It.isValue(testEnvironment),
+                    TypeMoq.It.isAny(),
+                    TypeMoq.It.isAny(),
+                    // --- Start Positron ---
+                    // We added the `options` param in https://github.com/posit-dev/positron-python/pull/66.
+                    TypeMoq.It.isAny(),
+                    // --- End Positron ---
+                ),
+            )
+            .returns(() => Promise.resolve());
+
+        installationChannelManager
+            .setup((c) => c.getInstallationChannels(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve([testInstaller.object]));
+
+        const result = await dataScienceInstaller.install(Product.ipykernel, testEnvironment);
+        expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
+    });
+
     // --- Start Positron ---
     test('Will install pip if necessary', async () => {
         const testEnvironment: PythonEnvironment = {

--- a/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
@@ -250,10 +250,8 @@ suite('DataScienceInstaller install', async () => {
                     TypeMoq.It.isValue(testEnvironment),
                     TypeMoq.It.isAny(),
                     TypeMoq.It.isAny(),
-                    // --- Start Positron ---
                     // We added the `options` param in https://github.com/posit-dev/positron-python/pull/66.
                     TypeMoq.It.isAny(),
-                    // --- End Positron ---
                 ),
             )
             .returns(() => Promise.resolve());

--- a/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/productInstaller.unit.test.ts
@@ -230,6 +230,7 @@ suite('DataScienceInstaller install', async () => {
         expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
     });
 
+    // --- Start Positron ---
     test('Will invoke uv', async () => {
         const testEnvironment: PythonEnvironment = {
             envType: EnvironmentType.Uv,
@@ -265,7 +266,6 @@ suite('DataScienceInstaller install', async () => {
         expect(result).to.equal(InstallerResponse.Installed, 'Should be Installed');
     });
 
-    // --- Start Positron ---
     test('Will install pip if necessary', async () => {
         const testEnvironment: PythonEnvironment = {
             envType: EnvironmentType.VirtualEnv,

--- a/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
@@ -18,234 +18,234 @@ import * as envUtils from '../../../client/pythonEnvironments/base/info/env';
 
 // Test class to expose protected methods
 class UVInstallerTest extends UVInstaller {
-	public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
-		return super.getExecutionInfo(moduleName, resource);
-	}
+    public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
+        return super.getExecutionInfo(moduleName, resource);
+    }
 }
 
 suite('UV Installer Tests', () => {
-	let uvInstaller: UVInstallerTest;
-	let serviceContainer: IServiceContainer;
-	let configurationService: IConfigurationService;
-	let isUvInstalledStub: sinon.SinonStub;
-	let getEnvPathStub: sinon.SinonStub;
+    let uvInstaller: UVInstallerTest;
+    let serviceContainer: IServiceContainer;
+    let configurationService: IConfigurationService;
+    let isUvInstalledStub: sinon.SinonStub;
+    let getEnvPathStub: sinon.SinonStub;
 
-	setup(() => {
-		// Create mocks
-		serviceContainer = {} as IServiceContainer;
-		configurationService = {
-			getSettings: sinon.stub(),
-		} as any;
+    setup(() => {
+        // Create mocks
+        serviceContainer = {} as IServiceContainer;
+        configurationService = {
+            getSettings: sinon.stub(),
+        } as any;
 
-		// Create stubs for external dependencies
-		isUvInstalledStub = sinon.stub(uvUtils, 'isUvInstalled');
-		getEnvPathStub = sinon.stub(envUtils, 'getEnvPath');
+        // Create stubs for external dependencies
+        isUvInstalledStub = sinon.stub(uvUtils, 'isUvInstalled');
+        getEnvPathStub = sinon.stub(envUtils, 'getEnvPath');
 
-		// Create installer instance
-		uvInstaller = new UVInstallerTest(serviceContainer, configurationService);
-	});
+        // Create installer instance
+        uvInstaller = new UVInstallerTest(serviceContainer, configurationService);
+    });
 
-	teardown(() => {
-		sinon.restore();
-	});
+    teardown(() => {
+        sinon.restore();
+    });
 
-	suite('Basic Properties', () => {
-		test('Should have correct name', () => {
-			expect(uvInstaller.name).to.equal('Uv');
-		});
+    suite('Basic Properties', () => {
+        test('Should have correct name', () => {
+            expect(uvInstaller.name).to.equal('Uv');
+        });
 
-		test('Should have correct display name', () => {
-			expect(uvInstaller.displayName).to.equal('uv');
-		});
+        test('Should have correct display name', () => {
+            expect(uvInstaller.displayName).to.equal('uv');
+        });
 
-		test('Should have correct type', () => {
-			expect(uvInstaller.type).to.equal(ModuleInstallerType.Uv);
-		});
+        test('Should have correct type', () => {
+            expect(uvInstaller.type).to.equal(ModuleInstallerType.Uv);
+        });
 
-		test('Should have correct priority', () => {
-			expect(uvInstaller.priority).to.equal(30);
-		});
-	});
+        test('Should have correct priority', () => {
+            expect(uvInstaller.priority).to.equal(30);
+        });
+    });
 
-	suite('isSupported Method', () => {
-		test('Should return true when uv is installed', async () => {
-			isUvInstalledStub.resolves(true);
+    suite('isSupported Method', () => {
+        test('Should return true when uv is installed', async () => {
+            isUvInstalledStub.resolves(true);
 
-			const result = await uvInstaller.isSupported();
+            const result = await uvInstaller.isSupported();
 
-			expect(result).to.be.true;
-			expect(isUvInstalledStub.calledOnce).to.be.true;
-		});
+            expect(result).to.be.true;
+            expect(isUvInstalledStub.calledOnce).to.be.true;
+        });
 
-		test('Should return false when uv is not installed', async () => {
-			isUvInstalledStub.resolves(false);
+        test('Should return false when uv is not installed', async () => {
+            isUvInstalledStub.resolves(false);
 
-			const result = await uvInstaller.isSupported();
+            const result = await uvInstaller.isSupported();
 
-			expect(result).to.be.false;
-			expect(isUvInstalledStub.calledOnce).to.be.true;
-		});
+            expect(result).to.be.false;
+            expect(isUvInstalledStub.calledOnce).to.be.true;
+        });
 
-		test('Should return false when uv check throws error', async () => {
-			isUvInstalledStub.rejects(new Error('Command not found'));
+        test('Should return false when uv check throws error', async () => {
+            isUvInstalledStub.rejects(new Error('Command not found'));
 
-			const result = await uvInstaller.isSupported();
+            const result = await uvInstaller.isSupported();
 
-			expect(result).to.be.false;
-			expect(isUvInstalledStub.calledOnce).to.be.true;
-		});
+            expect(result).to.be.false;
+            expect(isUvInstalledStub.calledOnce).to.be.true;
+        });
 
-		test('Should work with resource parameter', async () => {
-			const resource = Uri.file('/test/path');
-			isUvInstalledStub.resolves(true);
+        test('Should work with resource parameter', async () => {
+            const resource = Uri.file('/test/path');
+            isUvInstalledStub.resolves(true);
 
-			const result = await uvInstaller.isSupported(resource);
+            const result = await uvInstaller.isSupported(resource);
 
-			expect(result).to.be.true;
-			expect(isUvInstalledStub.calledOnce).to.be.true;
-		});
+            expect(result).to.be.true;
+            expect(isUvInstalledStub.calledOnce).to.be.true;
+        });
 
-		test('Should work with PythonEnvironment parameter', async () => {
-			const pythonEnv: PythonEnvironment = {
-				path: '/path/to/python',
-				envPath: '/path/to/env',
-			} as PythonEnvironment;
-			isUvInstalledStub.resolves(true);
+        test('Should work with PythonEnvironment parameter', async () => {
+            const pythonEnv: PythonEnvironment = {
+                path: '/path/to/python',
+                envPath: '/path/to/env',
+            } as PythonEnvironment;
+            isUvInstalledStub.resolves(true);
 
-			const result = await uvInstaller.isSupported(pythonEnv);
+            const result = await uvInstaller.isSupported(pythonEnv);
 
-			expect(result).to.be.true;
-			expect(isUvInstalledStub.calledOnce).to.be.true;
-		});
-	});
+            expect(result).to.be.true;
+            expect(isUvInstalledStub.calledOnce).to.be.true;
+        });
+    });
 
-	suite('getExecutionInfo Method', () => {
-		test('Should return correct execution info for resource', async () => {
-			const resource = Uri.file('/test/path');
-			const pythonPath = '/path/to/python';
-			const moduleName = 'numpy';
+    suite('getExecutionInfo Method', () => {
+        test('Should return correct execution info for resource', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+            const moduleName = 'numpy';
 
-			const settings: IPythonSettings = {
-				pythonPath,
-			} as IPythonSettings;
+            const settings: IPythonSettings = {
+                pythonPath,
+            } as IPythonSettings;
 
-			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+            (configurationService.getSettings as sinon.SinonStub).returns(settings);
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+            const result = await uvInstaller.getExecutionInfo(moduleName, resource);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', pythonPath, moduleName],
-				execPath: 'uv',
-			});
-			expect((configurationService.getSettings as sinon.SinonStub).calledWith(resource)).to.be.true;
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', pythonPath, moduleName],
+                execPath: 'uv',
+            });
+            expect((configurationService.getSettings as sinon.SinonStub).calledWith(resource)).to.be.true;
+        });
 
-		test('Should return correct execution info for PythonEnvironment', async () => {
-			const pythonEnv: PythonEnvironment = {
-				path: '/path/to/python',
-				envPath: '/path/to/env',
-			} as PythonEnvironment;
-			const moduleName = 'pandas';
-			const expectedPythonPath = '/resolved/path/to/python';
+        test('Should return correct execution info for PythonEnvironment', async () => {
+            const pythonEnv: PythonEnvironment = {
+                path: '/path/to/python',
+                envPath: '/path/to/env',
+            } as PythonEnvironment;
+            const moduleName = 'pandas';
+            const expectedPythonPath = '/resolved/path/to/python';
 
-			getEnvPathStub.returns({ path: expectedPythonPath });
+            getEnvPathStub.returns({ path: expectedPythonPath });
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+            const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', expectedPythonPath, moduleName],
-				execPath: 'uv',
-			});
-			expect(getEnvPathStub.calledWith(pythonEnv.path, pythonEnv.envPath)).to.be.true;
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', expectedPythonPath, moduleName],
+                execPath: 'uv',
+            });
+            expect(getEnvPathStub.calledWith(pythonEnv.path, pythonEnv.envPath)).to.be.true;
+        });
 
-		test('Should handle empty python path from getEnvPath', async () => {
-			const pythonEnv: PythonEnvironment = {
-				path: '/path/to/python',
-				envPath: '/path/to/env',
-			} as PythonEnvironment;
-			const moduleName = 'requests';
+        test('Should handle empty python path from getEnvPath', async () => {
+            const pythonEnv: PythonEnvironment = {
+                path: '/path/to/python',
+                envPath: '/path/to/env',
+            } as PythonEnvironment;
+            const moduleName = 'requests';
 
-			getEnvPathStub.returns({ path: null });
+            getEnvPathStub.returns({ path: null });
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+            const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', '', moduleName],
-				execPath: 'uv',
-			});
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', '', moduleName],
+                execPath: 'uv',
+            });
+        });
 
-		test('Should handle undefined getEnvPath result', async () => {
-			const pythonEnv: PythonEnvironment = {
-				path: '/path/to/python',
-				envPath: '/path/to/env',
-			} as PythonEnvironment;
-			const moduleName = 'matplotlib';
+        test('Should handle undefined getEnvPath result', async () => {
+            const pythonEnv: PythonEnvironment = {
+                path: '/path/to/python',
+                envPath: '/path/to/env',
+            } as PythonEnvironment;
+            const moduleName = 'matplotlib';
 
-			getEnvPathStub.returns({});
+            getEnvPathStub.returns({});
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+            const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', '', moduleName],
-				execPath: 'uv',
-			});
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', '', moduleName],
+                execPath: 'uv',
+            });
+        });
 
-		test('Should handle empty settings python path', async () => {
-			const resource = Uri.file('/test/path');
-			const moduleName = 'scipy';
+        test('Should handle empty settings python path', async () => {
+            const resource = Uri.file('/test/path');
+            const moduleName = 'scipy';
 
-			const settings: IPythonSettings = {
-				pythonPath: '',
-			} as IPythonSettings;
+            const settings: IPythonSettings = {
+                pythonPath: '',
+            } as IPythonSettings;
 
-			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+            (configurationService.getSettings as sinon.SinonStub).returns(settings);
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+            const result = await uvInstaller.getExecutionInfo(moduleName, resource);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', '', moduleName],
-				execPath: 'uv',
-			});
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', '', moduleName],
+                execPath: 'uv',
+            });
+        });
 
-		test('Should work without resource parameter', async () => {
-			const moduleName = 'pytest';
+        test('Should work without resource parameter', async () => {
+            const moduleName = 'pytest';
 
-			// When no resource is provided, isResource returns true and calls getSettings with undefined
-			const settings: IPythonSettings = {
-				pythonPath: '',
-			} as IPythonSettings;
+            // When no resource is provided, isResource returns true and calls getSettings with undefined
+            const settings: IPythonSettings = {
+                pythonPath: '',
+            } as IPythonSettings;
 
-			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+            (configurationService.getSettings as sinon.SinonStub).returns(settings);
 
-			const result = await uvInstaller.getExecutionInfo(moduleName);
+            const result = await uvInstaller.getExecutionInfo(moduleName);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', '', moduleName],
-				execPath: 'uv',
-			});
-		});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', '', moduleName],
+                execPath: 'uv',
+            });
+        });
 
-		test('Should handle module names with special characters', async () => {
-			const resource = Uri.file('/test/path');
-			const pythonPath = '/path/to/python';
-			const moduleName = 'package-with-dashes>=1.0.0';
+        test('Should handle module names with special characters', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+            const moduleName = 'package-with-dashes>=1.0.0';
 
-			const settings: IPythonSettings = {
-				pythonPath,
-			} as IPythonSettings;
+            const settings: IPythonSettings = {
+                pythonPath,
+            } as IPythonSettings;
 
-			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+            (configurationService.getSettings as sinon.SinonStub).returns(settings);
 
-			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+            const result = await uvInstaller.getExecutionInfo(moduleName, resource);
 
-			expect(result).to.deep.equal({
-				args: ['pip', 'install', '--python', pythonPath, moduleName],
-				execPath: 'uv',
-			});
-		});
-	});
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--python', pythonPath, moduleName],
+                execPath: 'uv',
+            });
+        });
+    });
 });

--- a/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
@@ -1,0 +1,251 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Uri } from 'vscode';
+import { UVInstaller } from '../../../client/common/installer/uvInstaller';
+import { ExecutionInfo, IConfigurationService, IPythonSettings } from '../../../client/common/types';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { ModuleInstallerType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
+import { InterpreterUri } from '../../../client/common/installer/types';
+import * as uvUtils from '../../../client/pythonEnvironments/common/environmentManagers/uv';
+import * as envUtils from '../../../client/pythonEnvironments/base/info/env';
+
+// Test class to expose protected methods
+class UVInstallerTest extends UVInstaller {
+	public async getExecutionInfo(moduleName: string, resource?: InterpreterUri): Promise<ExecutionInfo> {
+		return super.getExecutionInfo(moduleName, resource);
+	}
+}
+
+suite('UV Installer Tests', () => {
+	let uvInstaller: UVInstallerTest;
+	let serviceContainer: IServiceContainer;
+	let configurationService: IConfigurationService;
+	let isUvInstalledStub: sinon.SinonStub;
+	let getEnvPathStub: sinon.SinonStub;
+
+	setup(() => {
+		// Create mocks
+		serviceContainer = {} as IServiceContainer;
+		configurationService = {
+			getSettings: sinon.stub(),
+		} as any;
+
+		// Create stubs for external dependencies
+		isUvInstalledStub = sinon.stub(uvUtils, 'isUvInstalled');
+		getEnvPathStub = sinon.stub(envUtils, 'getEnvPath');
+
+		// Create installer instance
+		uvInstaller = new UVInstallerTest(serviceContainer, configurationService);
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	suite('Basic Properties', () => {
+		test('Should have correct name', () => {
+			expect(uvInstaller.name).to.equal('Uv');
+		});
+
+		test('Should have correct display name', () => {
+			expect(uvInstaller.displayName).to.equal('uv');
+		});
+
+		test('Should have correct type', () => {
+			expect(uvInstaller.type).to.equal(ModuleInstallerType.Uv);
+		});
+
+		test('Should have correct priority', () => {
+			expect(uvInstaller.priority).to.equal(30);
+		});
+	});
+
+	suite('isSupported Method', () => {
+		test('Should return true when uv is installed', async () => {
+			isUvInstalledStub.resolves(true);
+
+			const result = await uvInstaller.isSupported();
+
+			expect(result).to.be.true;
+			expect(isUvInstalledStub.calledOnce).to.be.true;
+		});
+
+		test('Should return false when uv is not installed', async () => {
+			isUvInstalledStub.resolves(false);
+
+			const result = await uvInstaller.isSupported();
+
+			expect(result).to.be.false;
+			expect(isUvInstalledStub.calledOnce).to.be.true;
+		});
+
+		test('Should return false when uv check throws error', async () => {
+			isUvInstalledStub.rejects(new Error('Command not found'));
+
+			const result = await uvInstaller.isSupported();
+
+			expect(result).to.be.false;
+			expect(isUvInstalledStub.calledOnce).to.be.true;
+		});
+
+		test('Should work with resource parameter', async () => {
+			const resource = Uri.file('/test/path');
+			isUvInstalledStub.resolves(true);
+
+			const result = await uvInstaller.isSupported(resource);
+
+			expect(result).to.be.true;
+			expect(isUvInstalledStub.calledOnce).to.be.true;
+		});
+
+		test('Should work with PythonEnvironment parameter', async () => {
+			const pythonEnv: PythonEnvironment = {
+				path: '/path/to/python',
+				envPath: '/path/to/env',
+			} as PythonEnvironment;
+			isUvInstalledStub.resolves(true);
+
+			const result = await uvInstaller.isSupported(pythonEnv);
+
+			expect(result).to.be.true;
+			expect(isUvInstalledStub.calledOnce).to.be.true;
+		});
+	});
+
+	suite('getExecutionInfo Method', () => {
+		test('Should return correct execution info for resource', async () => {
+			const resource = Uri.file('/test/path');
+			const pythonPath = '/path/to/python';
+			const moduleName = 'numpy';
+
+			const settings: IPythonSettings = {
+				pythonPath,
+			} as IPythonSettings;
+
+			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', pythonPath, moduleName],
+				execPath: 'uv',
+			});
+			expect((configurationService.getSettings as sinon.SinonStub).calledWith(resource)).to.be.true;
+		});
+
+		test('Should return correct execution info for PythonEnvironment', async () => {
+			const pythonEnv: PythonEnvironment = {
+				path: '/path/to/python',
+				envPath: '/path/to/env',
+			} as PythonEnvironment;
+			const moduleName = 'pandas';
+			const expectedPythonPath = '/resolved/path/to/python';
+
+			getEnvPathStub.returns({ path: expectedPythonPath });
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', expectedPythonPath, moduleName],
+				execPath: 'uv',
+			});
+			expect(getEnvPathStub.calledWith(pythonEnv.path, pythonEnv.envPath)).to.be.true;
+		});
+
+		test('Should handle empty python path from getEnvPath', async () => {
+			const pythonEnv: PythonEnvironment = {
+				path: '/path/to/python',
+				envPath: '/path/to/env',
+			} as PythonEnvironment;
+			const moduleName = 'requests';
+
+			getEnvPathStub.returns({ path: null });
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', '', moduleName],
+				execPath: 'uv',
+			});
+		});
+
+		test('Should handle undefined getEnvPath result', async () => {
+			const pythonEnv: PythonEnvironment = {
+				path: '/path/to/python',
+				envPath: '/path/to/env',
+			} as PythonEnvironment;
+			const moduleName = 'matplotlib';
+
+			getEnvPathStub.returns({});
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, pythonEnv);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', '', moduleName],
+				execPath: 'uv',
+			});
+		});
+
+		test('Should handle empty settings python path', async () => {
+			const resource = Uri.file('/test/path');
+			const moduleName = 'scipy';
+
+			const settings: IPythonSettings = {
+				pythonPath: '',
+			} as IPythonSettings;
+
+			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', '', moduleName],
+				execPath: 'uv',
+			});
+		});
+
+		test('Should work without resource parameter', async () => {
+			const moduleName = 'pytest';
+
+			// When no resource is provided, isResource returns true and calls getSettings with undefined
+			const settings: IPythonSettings = {
+				pythonPath: '',
+			} as IPythonSettings;
+
+			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+
+			const result = await uvInstaller.getExecutionInfo(moduleName);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', '', moduleName],
+				execPath: 'uv',
+			});
+		});
+
+		test('Should handle module names with special characters', async () => {
+			const resource = Uri.file('/test/path');
+			const pythonPath = '/path/to/python';
+			const moduleName = 'package-with-dashes>=1.0.0';
+
+			const settings: IPythonSettings = {
+				pythonPath,
+			} as IPythonSettings;
+
+			(configurationService.getSettings as sinon.SinonStub).returns(settings);
+
+			const result = await uvInstaller.getExecutionInfo(moduleName, resource);
+
+			expect(result).to.deep.equal({
+				args: ['pip', 'install', '--python', pythonPath, moduleName],
+				execPath: 'uv',
+			});
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/6477 and https://github.com/posit-dev/databot/issues/11. Adds a `UVInstaller` class that uses `uv pip install` whenever Positron tries to install something pythony, assuming uv is installed.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Positron (and Assistant) can now automatically install packages into uv environments without pip https://github.com/posit-dev/positron/issues/6477


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:interpreter


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
1. Set up a uv env without pip
```
cd ~
uv init proj
cd proj
uv venv
```
2. Open `proj` in a workspace
3. `import pandas` in the console should result in ModuleNotFoundError
4. Ask Assistant to "install pandas" and give permission to run the tool. It should work.
5. `import pandas` in the console should work

I'd also try doing this in different env types (pyenv, conda). It should use uv and it should work.

Also try the `install ipykernel?` popup when ipykernel bundling is disabled.