### PR TITLE
e2e: fix r-debug test flake

### DIFF
--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -79,7 +79,7 @@ test.describe('R Debugging', {
 		await debug.selectCallStackAtIndex(2);
 		await editors.expectEditorToContain('outer(5)');
 
-		await console.focus();
+		await console.clearButton.click();
 		await page.keyboard.press('Q');
 		await page.keyboard.press('Enter');
 		await console.waitForReady('>');


### PR DESCRIPTION
### Summary
The `r-debug.test.ts` was attempting to interact with (and exit) the debugger, but the console was scrolled out of view, causing keystrokes to silently fail. The test has been updated to first clear the console, which brings it into view and ensures it has focus before sending any input.

### QA Notes

n/a, the test is already tagged as critical.
