### PR TITLE
Bump Ark to 0.1.201

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -981,7 +981,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.200"
+      "ark": "0.1.201"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:

- https://github.com/posit-dev/ark/pull/886
  Addresses https://github.com/posit-dev/positron/issues/8630

- https://github.com/posit-dev/ark/pull/887
  Addresses https://github.com/posit-dev/positron/issues/8374

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- "Go to Definition" now gives priority to definitions in the current file (https://github.com/posit-dev/positron/issues/8630).

- The regression in the "Navigate to File" RStudio API handler has been fixed (https://github.com/posit-dev/positron/issues/8374). This solves issues with functions like `usethis::use_test()`.


### QA Notes

See linked Ark PRs.
