### PR TITLE
e2e: fix plots flake of tooltip blocking context menu click

### DIFF
--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -37,9 +37,8 @@ export class ContextMenu {
 				await menuTrigger.click();
 				await this.page.mouse.move(0, 0);
 				await this.getContextMenuItem(menuItemLabel).hover();
-				await this.page.waitForTimeout(500);
+				await this.page.waitForTimeout(250);
 				await this.getContextMenuItem(menuItemLabel).click();
-				await this.page.mouse.move(0, 0);
 			}
 		});
 	}

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -35,9 +35,11 @@ export class ContextMenu {
 			}
 			else {
 				await menuTrigger.click();
+				await this.page.mouse.move(0, 0);
 				await this.getContextMenuItem(menuItemLabel).hover();
 				await this.page.waitForTimeout(500);
 				await this.getContextMenuItem(menuItemLabel).click();
+				await this.page.mouse.move(0, 0);
 			}
 		});
 	}

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -290,32 +290,16 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			});
 			const imgLocator = page.getByRole('img', { name: /%run/ });
 
-			await expect(async () => {
-				try {
-					await contextMenu.triggerAndClick({
-						menuTrigger: page.getByLabel('Fit'),
-						menuItemLabel: 'Fit'
-					});
-				} catch (e) {
-					await page.keyboard.press('Escape');
-					throw e;
-				}
-			}).toPass({ timeout: 60000 });
-
+			await contextMenu.triggerAndClick({
+				menuTrigger: page.getByLabel('Fit'),
+				menuItemLabel: 'Fit'
+			});
 			await page.waitForTimeout(300);
 			const bufferFit1 = await imgLocator.screenshot();
-
-			await expect(async () => {
-				try {
-					await contextMenu.triggerAndClick({
-						menuTrigger: page.getByLabel('Fit'),
-						menuItemLabel: '200%'
-					});
-				} catch (e) {
-					await page.keyboard.press('Escape');
-					throw e;
-				}
-			}).toPass({ timeout: 60000 });
+			await contextMenu.triggerAndClick({
+				menuTrigger: page.getByLabel('Fit'),
+				menuItemLabel: '200%'
+			});
 
 			await page.waitForTimeout(2000);
 			const bufferZoom = await imgLocator.screenshot();
@@ -327,18 +311,10 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			});
 			expect(resultZoom.rawMisMatchPercentage).toBeGreaterThan(2); // should be large diff
 
-			await expect(async () => {
-				try {
-					await contextMenu.triggerAndClick({
-						menuTrigger: page.getByLabel('200%'),
-						menuItemLabel: 'Fit'
-					});
-				} catch (e) {
-					await page.keyboard.press('Escape');
-					throw e;
-				}
-			}).toPass({ timeout: 60000 });
-
+			await contextMenu.triggerAndClick({
+				menuTrigger: page.getByLabel('200%'),
+				menuItemLabel: 'Fit'
+			});
 			await page.waitForTimeout(2000);
 			const bufferFit2 = await imgLocator.screenshot();
 			// Compare: Fit vs Fit again


### PR DESCRIPTION
### Summary
I noticed that plots test was flaking when trying to click on context menu because tooltip was in the way. Adjusting `triggerAndClick()` to move mouse out of way after key interactions.

### QA Notes
n/a

@:plots