### PR TITLE
python: rename uv envs

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -201,7 +201,7 @@ async function resolveSimpleEnv(env: BasicEnvInfo): Promise<PythonEnvInfo> {
         const uvDirs = await getUvDirs();
         for (const uvDir of uvDirs) {
             if (isParentPath(location, uvDir)) {
-                envInfo.name = 'managed';
+                envInfo.name = '';
             }
         }
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/resolverUtils.ts
@@ -32,7 +32,9 @@ import { traceError, traceWarn } from '../../../../logging';
 import { isVirtualEnvironment } from '../../../common/environmentManagers/simplevirtualenvs';
 import { getWorkspaceFolderPaths } from '../../../../common/vscodeApis/workspaceApis';
 import { ActiveState } from '../../../common/environmentManagers/activestate';
+// --- Start Positron ---
 import { getUvDirs } from '../../../common/environmentManagers/uv';
+// --- End Positron ---
 
 function getResolvers(): Map<PythonEnvKind, (env: BasicEnvInfo) => Promise<PythonEnvInfo>> {
     const resolvers = new Map<PythonEnvKind, (_: BasicEnvInfo) => Promise<PythonEnvInfo>>();

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -206,7 +206,7 @@ async function getName(nativeEnv: NativeEnvInfo, kind: PythonEnvKind, condaEnvDi
         const uvDirs = await getUvDirs();
         for (const uvDir of uvDirs) {
             if (isParentPath(nativeEnv.prefix, uvDir)) {
-                return 'managed';
+                return '';
             }
         }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -192,7 +192,10 @@ function foundOnPath(fsPath: string): boolean {
     return paths.some((p) => normalized.includes(p));
 }
 
+// --- Start Positron ---
+// added async
 async function getName(nativeEnv: NativeEnvInfo, kind: PythonEnvKind, condaEnvDirs: string[]): Promise<string> {
+    // --- End Positron ---
     if (nativeEnv.name) {
         return nativeEnv.name;
     }
@@ -237,14 +240,20 @@ async function getName(nativeEnv: NativeEnvInfo, kind: PythonEnvKind, condaEnvDi
     return '';
 }
 
+// --- Start Positron ---
+// added async
 async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[]): Promise<PythonEnvInfo | undefined> {
+    // --- End Positron ---
     if (!validEnv(nativeEnv)) {
         return undefined;
     }
     const kind = categoryToKind(nativeEnv.kind);
     const arch = toArch(nativeEnv.arch);
     const version: PythonVersion = parseVersion(nativeEnv.version ?? '');
+    // --- Start Positron ---
+    // added await
     const name = await getName(nativeEnv, kind, condaEnvDirs);
+    // --- End Positron ---
     const displayName = nativeEnv.version
         ? getDisplayName(version, kind, arch, name)
         : nativeEnv.displayName ?? 'Python';
@@ -519,12 +528,10 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     }
 
     // --- Start Positron ---
-    // added async
+    // added async/await
     private async addEnv(native: NativeEnvInfo, searchLocation?: Uri): Promise<PythonEnvInfo | undefined> {
-        // --- End Positron ---
         const info = await toPythonEnvInfo(native, this._condaEnvDirs);
         if (info) {
-            // --- Start Positron ---
             if (info.executable.filename && (await isUvEnvironment(info.executable.filename))) {
                 traceInfo(`Found uv environment: ${info.executable.filename}`);
                 info.kind = PythonEnvKind.Uv;

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -76,7 +76,7 @@ export async function verifyVenvEnvStarts(app: Application) {
 
 export async function verifyUvEnvStarts(app: Application) {
 	await test.step('Verify uv environment starts', async () => {
-		await app.workbench.console.waitForConsoleContents('(Uv: .venv) started.');
+		await app.workbench.console.waitForConsoleContents(/(Uv: .+) started./);
 	});
 }
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -61,5 +61,5 @@ async function verifyNotebookAndConsolePythonVersion(app: Application) {
 	// Only look within an 'a' tag with class 'kernel-label' to avoid false positives
 	const kernelLabel = app.code.driver.page.locator('a.kernel-label');
 	await expect(kernelLabel).toContainText(`Python ${pythonVersion}`);
-	await expect(kernelLabel).toContainText('.venv');
+	await expect(kernelLabel).toContainText('python-notebook-runtime');
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #8316. Renames uv envs so they look like this:
<img width="1196" height="288" alt="Screenshot 2025-07-30 at 15 40 12" src="https://github.com/user-attachments/assets/92ee16cb-7a5d-42b4-825c-725248afc047" />



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:interpreter

Make sure the names look okay.