### PR TITLE
data explorer: use localized pytz timezones for iso8601-like values

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -2101,7 +2101,7 @@ def _parse_iso8601_like(x, tz=None):
             if tz is not None:
                 if isinstance(tz, str):
                     tz = pytz.timezone(tz)
-                result = result.replace(tzinfo=tz)
+                result = tz.localize(result)
 
             return result
         except ValueError:  # noqa: PERF203


### PR DESCRIPTION
Localizing the timezones as directed by `pytz`:

> if you want to create local wallclock times you need to use the localize() method 

This does mean we will not correctly filter for LMT timezones and optimize for wallclock times instead, so there is updated behavior in the tests. This seems like the right move, though. Added a test for `pd.Timestamp` as well to make sure we have the desired behavior for that type as well.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8760 Correctly filter YYYY-MM-DD values for pandas data frames.


### QA Notes

1. create pandas dataframe

```python
import pandas as pd
test_df = pd.DataFrame(
        {
            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
        }
    )
%view test_df
```

2. add filters for "greater than" -> 2000-01-03
3. see that only 2000-01-04 and 2000-01-05 are shown
