### PR TITLE
Reticulate commands

### DIFF
--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -27,7 +27,7 @@
       "title": "%configurationTitle%",
       "properties": {
         "positron.reticulate.enabled": {
-          "type": "boolean",
+          "type": ["boolean"],
           "default": false,
           "description": "%enabledDescription%"
         }

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -28,14 +28,14 @@
       "properties": {
         "positron.reticulate.enabled": {
           "type": "string",
-        "enum": ["auto", "never", "always"],
-        "enumDescriptions": [
-          "%autoDescription%",
-          "%neverDescription%",
-          "%alwaysDescription%"
-        ],
-        "default": "auto",
-        "description": "%enabledDescription%"
+          "enum": ["auto", "never", "always"],
+          "enumDescriptions": [
+            "%autoDescription%",
+            "%neverDescription%",
+            "%alwaysDescription%"
+          ],
+          "default": "auto",
+          "description": "%enabledDescription%"
         }
       }
     }

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -27,9 +27,15 @@
       "title": "%configurationTitle%",
       "properties": {
         "positron.reticulate.enabled": {
-          "type": ["boolean"],
-          "default": false,
-          "description": "%enabledDescription%"
+          "type": "string",
+        "enum": ["auto", "never", "always"],
+        "enumDescriptions": [
+          "%autoDescription%",
+          "%neverDescription%",
+          "%alwaysDescription%"
+        ],
+        "default": "auto",
+        "description": "%enabledDescription%"
         }
       }
     }

--- a/extensions/positron-reticulate/package.nls.json
+++ b/extensions/positron-reticulate/package.nls.json
@@ -2,5 +2,8 @@
 	"displayName": "Positron Reticulate",
 	"description": "Provides reticulate support for positron",
 	"configurationTitle": "Reticulate",
-	"enabledDescription": "Enables reticulate console sessions"
+	"enabledDescription": "Enables reticulate console sessions",
+	"autoDescription": "Enables when reticulate has been loaded in the current project at least once",
+	"neverDescription": "Never use reticulate console sessions",
+	"alwaysDescription": "Always enable reticulate console sessions"
 }

--- a/extensions/positron-reticulate/package.nls.json
+++ b/extensions/positron-reticulate/package.nls.json
@@ -3,7 +3,7 @@
 	"description": "Provides reticulate support for positron",
 	"configurationTitle": "Reticulate",
 	"enabledDescription": "Enables reticulate console sessions",
-	"autoDescription": "Enables when reticulate has been loaded in the current project at least once",
+	 "autoDescription": "Enable when the reticulate R package has been loaded in the current workspace",
 	"neverDescription": "Never use reticulate console sessions",
 	"alwaysDescription": "Always enable reticulate console sessions"
 }

--- a/extensions/positron-reticulate/package.nls.json
+++ b/extensions/positron-reticulate/package.nls.json
@@ -3,7 +3,7 @@
 	"description": "Provides reticulate support for positron",
 	"configurationTitle": "Reticulate",
 	"enabledDescription": "Enables reticulate console sessions",
-	 "autoDescription": "Enable when the reticulate R package has been loaded in the current workspace",
+	"autoDescription": "Enable when the reticulate R package has been loaded in the current workspace",
 	"neverDescription": "Never use reticulate console sessions",
 	"alwaysDescription": "Always enable reticulate console sessions"
 }

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -58,7 +58,13 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 	featureEnabled(): boolean | undefined {
 		// If it's disabled, don't do any registration
 		const config = vscode.workspace.getConfiguration('positron.reticulate');
-		const option = config.get<'auto' | 'never' | 'always'>('enabled');
+		const option = config.get<('auto' | 'never' | 'always') | boolean>('enabled');
+
+		if (typeof option === 'boolean') {
+			// Keep supporting the old option which was a boolean.
+			return option; // If it's a boolean, return it directly
+		}
+
 		switch (option) {
 			case 'auto':
 				const val = CONTEXT.workspaceState.get(autoEnabledStorageKey, false);

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -330,6 +330,11 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		return session;
 	}
 
+	/**
+	 * Validates whether the Reticulate session with the given session ID is active and usable.
+	 * @param sessionId The ID of the session to validate.
+	 * @returns A promise that resolves to true if the session is valid, false otherwise.
+	 */
 	async validateSession(sessionId: string): Promise<boolean> {
 		LOGGER.info(`Validating Reticulate session. sessionId: ${sessionId}`);
 		return Promise.resolve(true);

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -1030,6 +1030,39 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	);
 
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.reticulate.isEnabledExplicitlySet', async () => {
+			// This command is used to check if the reticulate runtime is explicitly enabled.
+			const config = vscode.workspace.getConfiguration('positron.reticulate');
+			const inspection = config.inspect<boolean>('enabled');
+
+			if (!inspection) {
+				// Should not happen, the config always exists
+				return false;
+			}
+
+			if (
+				inspection.globalValue !== undefined ||
+				inspection.workspaceValue !== undefined ||
+				inspection.workspaceFolderValue !== undefined
+			) {
+				// User set a value for one of the profiles
+				return true;
+			} else {
+				// user never set a value
+				return false;
+			}
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.reticulate.toggleEnabled', async () => {
+			const config = vscode.workspace.getConfiguration('positron.reticulate');
+			const currentValue = config.get<boolean>('enabled');
+			await config.update('enabled', !currentValue, vscode.ConfigurationTarget.Global);
+		})
+	);
+
 	context.subscriptions.push(reticulateProvider);
 
 	return reticulateProvider;


### PR DESCRIPTION
This is another way of addressing https://github.com/posit-dev/positron/issues/8563 instead of https://github.com/posit-dev/positron/pull/8564

We now expose two commands `positron.reticulate.isEnabledExplicitlySet` and `positron.reticulate.toggleEnabled`.
Reticulate will use a `.onAttach` hook that does the following:

```
opt <- .ps.ui.evaluateWhenClause("config.positron.reticulate.enabled")
if (!opt && !ps.ui.executeCommand('positron.reticulate.isEnabledExplicitlySet')) {
  .ps.ui.executeCommand('positron.reticulate.toggleEnabled')
  cli::cli_inform('Reticulate has been eanbled, to disable set {.url positron://settings/positron.reticulate.enabled} to {.val false}')
}
```

Adding to Reticulate's .onAttach hook means that the feature is enabled whenever `library(reticulate)` is called in an R session. If a package just imports reticulate, eg, tidymodels packages, etc. That won't force the feature to be enabled.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Reticulate integration will now be automatically enabled in workspaces where the package has been loaded. (#8769)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:reticulate
