### PR TITLE
Fix error loading webview service worker on Chrome

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -6,7 +6,7 @@
 
 	<!-- Start PWB: serve same origin -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-/qgqbHEZCrIqUOyxf4kxCym0Svcu9WOma3qHTPUldD4=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-b44KuKuk9GsPR+7co1E0GpMp7DYwzzR7wODAXGtCin4=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 	<!-- End PWB: serve same origin -->
 
 	<!-- Disable pinch zooming -->
@@ -240,7 +240,7 @@
 			}
 
 			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
-			navigator.serviceWorker.register(swPath, { type: 'module' })
+			navigator.serviceWorker.register(swPath)
 				.then(async registration => {
 					/**
 					 * @param {MessageEvent} event


### PR DESCRIPTION
This change fixes an issue loading webviews in Positron Server in Chrome on Posit Workbench.

In upstream commit https://github.com/microsoft/vscode/commit/2b3fe79f88285e7539717a5b94f52a94938ab608, Microsoft made the service worker script a (fake) module to address some type leakage (irrelevant to us). However, it turns out that specifying `{ type: "module" }` as one of the [service worker registration options](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register) has the side effect of making Chrome make the HTTP request for the service worker _without any cookies_ (possibly using a "more secure" code path). 

This, in turn, makes the request for the service worker return a 302, redirecting to the login page since no cookies are present on the request. Chrome won't load service workers from a redirect, and throws an error instead of registering the worker.

The fix is to just revert the minimal part of the upstream change that caused the issue.

Addresses https://github.com/rstudio/rstudio-pro/issues/8713.
