### PR TITLE
[backport] Automation PR: Update rstudio.rstudio-workbench to 1.5.63

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1165,7 +1165,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "f357ef66c1709d15238e87e1ba368b3aed500844",
+        "hashed_secret": "86ecf0a4b4852133b57b0ea059b28750e1f275e7",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1711,7 +1711,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/vs/workbench/contrib/webview/browser/pre/index.html",
-        "hashed_secret": "8f848d45aabb6a8b8da85a44943af7f622b9ade3",
+        "hashed_secret": "8e7109befbc4b291b584a623b3f203fb3a7c7fea",
         "is_verified": false,
         "line_number": 9,
         "is_secret": false
@@ -1786,5 +1786,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-30T21:02:03Z"
+  "generated_at": "2025-07-31T21:28:30Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.62",
+			"version": "1.5.63",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "f8f7c6aebfca72b6c7c4714cbbc500d2dcf237d0617bf8700e00b8dd0268022e",
+			"sha256": "7069a528594fd2843b71ee800e941a1d7e76942a4f467b61e5acfcab8b4d7193",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Backport automation PR https://github.com/posit-dev/positron/pull/8777 to the `prerelease/2025.08` branch.