### PR TITLE
Remvoed WIN tag

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -21,8 +21,9 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await settings.set({ 'interpreters.startupBehavior': 'auto' }, { waitMs: 5000 });
 	});
 
+	// Removing WIN tag until we get uv into windows CI as this expects uv to be the interpreter
 	test('Jupyter Folder Defaults', {
-		tag: [tags.CRITICAL, tags.WIN]
+		tag: [tags.CRITICAL, tags.INTERPRETER]
 	}, async function ({ app, settings }) {
 		const folderName = addRandomNumSuffix('python-notebook-runtime');
 


### PR DESCRIPTION
The notebook new folder flow tests assumes the `uv` is used for the interpreter  and looks for it to contain `python-notebook-runtime`.  However, windows CI doesn't currently have `uv` installed.

* Removes the WIN tag
* Adds INTERPRETER tag

### QA Notes
@:win
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
