### PR TITLE
e2e: fix new folder flow conda test

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -87,10 +87,8 @@ runs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-        # installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
         auto-activate-base: false
-        channels: conda-forge #,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
-        conda-remove-defaults: "true"
+        channels: conda-forge
         channel-priority: strict
 
     - name: Create Conda Environment with Python 3.12 in ~/scratch
@@ -105,7 +103,8 @@ runs:
 
         # Define environment path
         CONDA_ENV_DIR="$HOME/scratch/python-env"
-        # NOTE: now that we're using Miniforge, conda-forge is the default and override is no longer strictly necessary,
+
+        # NOTE: When using Minforge conda-forge is the default and override is no longer strictly necessary,
         # but we keep it to prevent any unintentional fallback if configs change.
         conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -97,12 +97,13 @@ runs:
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       shell: bash
       run: |
-        set -e # Exit immediately if any command fails
+        set -e  # Exit immediately if any command fails
         echo "Setting up Conda environment with Python 3.12..."
 
         # Ensure Conda is available
         source "$CONDA/etc/profile.d/conda.sh"
 
+        # Define environment path
         CONDA_ENV_DIR="$HOME/scratch/python-env"
         # NOTE: now that we're using Miniforge, conda-forge is the default and override is no longer strictly necessary,
         # but we keep it to prevent any unintentional fallback if configs change.

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -83,6 +83,7 @@ runs:
         python --version
 
     - name: Setup Conda Python 3.12 env in scratch
+      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
@@ -96,6 +97,10 @@ runs:
     - name: Verify Conda Python Installation
       shell: bash -el {0}
       run: |
+        conda config --set channels conda-forge
+        conda config --set conda-remove-defaults true
+        conda config --set channel_priority strict
+
         conda info
         conda list
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -82,13 +82,14 @@ runs:
         # Verify that Python is reset
         python --version
 
-    - name: Install Conda (Miniconda from Anaconda)
-      # Miniforge avoids Anaconda ToS and defaults to conda-forge
+    # Miniforge avoids Anaconda ToS and defaults to conda-forge
+    - name: Setup Conda (Miniforge3)
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
         auto-activate-base: false
-        channels: conda-forge
+        channels: conda-forge,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
+        conda-remove-defaults: "true"
         channel-priority: strict
 
     - name: Create Conda Environment with Python 3.12 in ~/scratch
@@ -96,6 +97,7 @@ runs:
       shell: bash
       run: |
         set -e  # Exit immediately if any command fails
+
         echo "Setting up Conda environment with Python 3.12..."
 
         # Ensure Conda is available
@@ -112,4 +114,4 @@ runs:
         "$CONDA_ENV_DIR/bin/python" --version
         "$CONDA_ENV_DIR/bin/python" -c "import sys; print(f'Python {sys.version} is working!')"
 
-        echo "Miniconda-based Python 3.12 setup complete!"
+        echo "Miniforge-based Python 3.12 setup complete!"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -82,46 +82,63 @@ runs:
         # Verify that Python is reset
         python --version
 
-    - name: Create Conda Environment with Python 3.12 in ~/scratch
-      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
-      shell: bash
+    - name: Setup Conda Python 3.12 env in scratch
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Miniforge3
+        python-version: 3.12.10
+        activate-environment: ~/scratch/python-env
+        auto-activate-base: false
+        conda-remove-defaults: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Verify Conda Python Installation
+      shell: bash -el {0}
       run: |
-        set -e  # Exit immediately if any command fails
+        conda info
+        conda list
 
-        echo "Setting up Conda environment with Python 3.12..."
+    # - name: Create Conda Environment with Python 3.12 in ~/scratch
+    #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}
+    #   shell: bash
+    #   run: |
+    #     set -e  # Exit immediately if any command fails
 
-        # Ensure Conda is available
-        source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    #     echo "Setting up Conda environment with Python 3.12..."
 
-        # Clean up all channel config and enforce conda-forge only
-        conda config --remove-key channels || true
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda config --set conda-remove-defaults true
+    #     # Ensure Conda from setup-miniconda is available
+    #     source "$CONDA/etc/profile.d/conda.sh"
 
-        # Define environment path
-        CONDA_ENV_DIR="$HOME/scratch/python-env"
+    #     # Clean up all channel config and enforce conda-forge only
+    #     conda config --remove-key channels || true
+    #     conda config --add channels conda-forge
+    #     conda config --set channel_priority strict
+    #     conda config --set conda-remove-defaults true
 
-        # Create a new Conda environment with Python 3.12
-        conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
+    #     # Define environment path
+    #     CONDA_ENV_DIR="$HOME/scratch/python-env"
 
-        # Verify Python installation
-        PYTHON_BIN="$CONDA_ENV_DIR/bin/python"
+    #     # Create a new Conda environment with Python 3.12
+    #     conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 
-        if [[ -x "$PYTHON_BIN" ]]; then
-            echo "Python successfully installed in Conda environment at $PYTHON_BIN"
-            $PYTHON_BIN --version
-        else
-            echo "Error: Python binary not found in Conda environment!"
-            exit 1
-        fi
+    #     # Verify Python installation
+    #     PYTHON_BIN="$CONDA_ENV_DIR/bin/python"
 
-        # Verify Python modules are working
-        echo "Checking if Python modules work..."
-        $PYTHON_BIN -c "import venv, sys; print(f'Python {sys.version} modules are working!')"
+    #     if [[ -x "$PYTHON_BIN" ]]; then
+    #         echo "Python successfully installed in Conda environment at $PYTHON_BIN"
+    #         $PYTHON_BIN --version
+    #     else
+    #         echo "Error: Python binary not found in Conda environment!"
+    #         exit 1
+    #     fi
 
-        # Final verification
-        echo "Final Python check..."
-        $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
+    #     # Verify Python modules are working
+    #     echo "Checking if Python modules work..."
+    #     $PYTHON_BIN -c "import venv, sys; print(f'Python {sys.version} modules are working!')"
 
-        echo "Miniconda-based Python 3.12 setup complete!"
+    #     # Final verification
+    #     echo "Final Python check..."
+    #     $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
+
+    #     echo "Miniconda-based Python 3.12 setup complete!"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -89,7 +89,7 @@ runs:
         # miniforge-version: latest
         installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
         auto-activate-base: false
-        channels: conda-forge
+        channels: conda-forge,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
         conda-remove-defaults: "true"
         channel-priority: strict
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -83,18 +83,15 @@ runs:
         python --version
 
     - name: Install Conda (Miniconda from Anaconda)
+      # Miniforge avoids Anaconda ToS and defaults to conda-forge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        installer-url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        # miniforge-version: latest
+        installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
         auto-activate-base: false
-        channels: conda-forge,defaults
+        channels: conda-forge
+        conda-remove-defaults: "true"
         channel-priority: strict
-
-    - name: Accept Anaconda ToS for defaults
-      shell: bash
-      run: |
-        conda tos accept --channel https://repo.anaconda.com/pkgs/main
-        conda tos accept --channel https://repo.anaconda.com/pkgs/r
 
     - name: Create Conda Environment with Python 3.12 in ~/scratch
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
@@ -106,6 +103,8 @@ runs:
         source "$CONDA/etc/profile.d/conda.sh"
 
         CONDA_ENV_DIR="$HOME/scratch/python-env"
+        # NOTE: now that we're using Miniforge, conda-forge is the default and override is no longer strictly necessary,
+        # but we keep it to prevent any unintentional fallback if configs change.
         conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 
         echo "Verifying Python in Conda environment..."

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -97,18 +97,11 @@ runs:
       if: ${{ inputs.install_undetectable_interpreters != 'true' }}
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Miniforge3
+        miniforge-variant: Miniconda3
         miniforge-version: latest
         auto-activate-base: false
         channels: conda-forge,defaults
         channel-priority: strict
-
-    # Conda 25.x removed the conda tos command.
-    - name: Downgrade Conda to 24.x to support tos acceptance
-      shell: bash
-      run: |
-        conda install -y -n base -c conda-forge conda=24.3
-        conda --version
 
     # Accept Anaconda Terms of Service for the defaults channel.
     # This is required in CI when running Chromium-based tests that trigger `create_conda.py`.

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -97,9 +97,10 @@ runs:
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       shell: bash
       run: |
-        set -e
+        set -e # Exit immediately if any command fails
         echo "Setting up Conda environment with Python 3.12..."
 
+        # Ensure Conda is available
         source "$CONDA/etc/profile.d/conda.sh"
 
         CONDA_ENV_DIR="$HOME/scratch/python-env"
@@ -110,3 +111,5 @@ runs:
         echo "Verifying Python in Conda environment..."
         "$CONDA_ENV_DIR/bin/python" --version
         "$CONDA_ENV_DIR/bin/python" -c "import sys; print(f'Python {sys.version} is working!')"
+
+        echo "Miniconda-based Python 3.12 setup complete!"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -86,10 +86,10 @@ runs:
       # Miniforge avoids Anaconda ToS and defaults to conda-forge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        # miniforge-version: latest
-        installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        miniforge-version: latest
+        # installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
         auto-activate-base: false
-        channels: conda-forge,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
+        channels: conda-forge #,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
         conda-remove-defaults: "true"
         channel-priority: strict
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -91,7 +91,7 @@ runs:
         echo "Setting up Conda environment with Python 3.12..."
 
         # Ensure Conda is available
-        source "${CONDA}/etc/profile.d/conda.sh"
+        source "$HOME/miniforge3/etc/profile.d/conda.sh"
 
         # Clean up all channel config and enforce conda-forge only
         conda config --remove-key channels || true

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -93,6 +93,12 @@ runs:
         # Ensure Conda is available
         source "${CONDA}/etc/profile.d/conda.sh"
 
+        # Clean up all channel config and enforce conda-forge only
+        conda config --remove-key channels || true
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+        conda config --set conda-remove-defaults true
+
         # Define environment path
         CONDA_ENV_DIR="$HOME/scratch/python-env"
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -103,7 +103,7 @@ runs:
         CONDA_ENV_DIR="$HOME/scratch/python-env"
 
         # Create a new Conda environment with Python 3.12
-        conda create -y -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
+        conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 
         # Verify Python installation
         PYTHON_BIN="$CONDA_ENV_DIR/bin/python"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -83,7 +83,7 @@ runs:
         python --version
 
     - name: Setup Conda Python 3.12 env in scratch
-      # if: ${{ inputs.install_undetectable_interpreters == 'true' }}
+      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
@@ -93,6 +93,17 @@ runs:
         conda-remove-defaults: true
         channels: conda-forge
         channel-priority: strict
+
+    - name: Install Conda (Miniforge) (always)
+      if: ${{ inputs.install_undetectable_interpreters != 'true' }}
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Miniforge3
+        auto-activate-base: false
+        conda-remove-defaults: true
+        channels: conda-forge
+        channel-priority: strict
+
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch
     #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -104,6 +104,15 @@ runs:
         channels: conda-forge
         channel-priority: strict
 
+    - name: Patch Conda config to avoid defaults
+      shell: bash
+      run: |
+        conda config --remove-key channels || true
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+        conda config --set conda-remove-defaults true
+
+        conda config --show | grep conda-remove-defaults
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch
     #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -82,16 +82,6 @@ runs:
         # Verify that Python is reset
         python --version
 
-    # Miniforge avoids Anaconda ToS and defaults to conda-forge
-    - name: Setup Conda (Miniforge3)
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        auto-activate-base: false
-        channels: conda-forge,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
-        conda-remove-defaults: "true"
-        channel-priority: strict
-
     - name: Create Conda Environment with Python 3.12 in ~/scratch
       if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -90,7 +90,6 @@ runs:
         python-version: 3.12.10
         activate-environment: ~/scratch/python-env
         auto-activate-base: false
-        conda-remove-defaults: true
         channels: conda-forge
         channel-priority: strict
 
@@ -111,7 +110,6 @@ runs:
         conda config --remove-key channels || true
         conda config --add channels conda-forge
         conda config --set channel_priority strict
-        conda config --set conda-remove-defaults true
         conda config --show
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -82,17 +82,6 @@ runs:
         # Verify that Python is reset
         python --version
 
-    - name: Setup Conda Python 3.12 env in scratch
-      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Miniforge3
-        python-version: 3.12.10
-        activate-environment: ~/scratch/python-env
-        auto-activate-base: false
-        channels: conda-forge
-        channel-priority: strict
-
     - name: Install Conda (Miniconda from Anaconda)
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -100,65 +89,25 @@ runs:
         auto-activate-base: false
         channels: conda-forge,defaults
         channel-priority: strict
-    # Accept Anaconda Terms of Service for the defaults channel.
-    # This is required in CI when running Chromium-based tests that trigger `create_conda.py`.
-    # That script creates a new Conda environment without overriding channels, which causes Conda
-    # to pull from Anaconda-hosted defaults packages. Without this step, Conda will raise a
-    # CondaToSNonInteractiveError and fail to create the environment.
+
     - name: Accept Anaconda ToS for defaults
       shell: bash
       run: |
         conda tos accept --channel https://repo.anaconda.com/pkgs/main
         conda tos accept --channel https://repo.anaconda.com/pkgs/r
 
-    # - name: Patch conda config to disable defaults
-    #   shell: bash
-    #   run: |
-    #     conda config --remove-key channels || true
-    #     conda config --add channels conda-forge
-    #     conda config --set channel_priority strict
-    #     conda config --show
+    - name: Create Conda Environment with Python 3.12 in ~/scratch
+      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
+      shell: bash
+      run: |
+        set -e
+        echo "Setting up Conda environment with Python 3.12..."
 
-    # - name: Create Conda Environment with Python 3.12 in ~/scratch
-    #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}
-    #   shell: bash
-    #   run: |
-    #     set -e  # Exit immediately if any command fails
+        source "$CONDA/etc/profile.d/conda.sh"
 
-    #     echo "Setting up Conda environment with Python 3.12..."
+        CONDA_ENV_DIR="$HOME/scratch/python-env"
+        conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
 
-    #     # Ensure Conda from setup-miniconda is available
-    #     source "$CONDA/etc/profile.d/conda.sh"
-
-    #     # Clean up all channel config and enforce conda-forge only
-    #     conda config --remove-key channels || true
-    #     conda config --add channels conda-forge
-    #     conda config --set channel_priority strict
-    #     conda config --set conda-remove-defaults true
-
-    #     # Define environment path
-    #     CONDA_ENV_DIR="$HOME/scratch/python-env"
-
-    #     # Create a new Conda environment with Python 3.12
-    #     conda create -y --override-channels -c conda-forge -p "$CONDA_ENV_DIR" python=3.12.10 pip setuptools
-
-    #     # Verify Python installation
-    #     PYTHON_BIN="$CONDA_ENV_DIR/bin/python"
-
-    #     if [[ -x "$PYTHON_BIN" ]]; then
-    #         echo "Python successfully installed in Conda environment at $PYTHON_BIN"
-    #         $PYTHON_BIN --version
-    #     else
-    #         echo "Error: Python binary not found in Conda environment!"
-    #         exit 1
-    #     fi
-
-    #     # Verify Python modules are working
-    #     echo "Checking if Python modules work..."
-    #     $PYTHON_BIN -c "import venv, sys; print(f'Python {sys.version} modules are working!')"
-
-    #     # Final verification
-    #     echo "Final Python check..."
-    #     $PYTHON_BIN -c "import sys; print(f'Python {sys.version} is working!')"
-
-    #     echo "Miniconda-based Python 3.12 setup complete!"
+        echo "Verifying Python in Conda environment..."
+        "$CONDA_ENV_DIR/bin/python" --version
+        "$CONDA_ENV_DIR/bin/python" -c "import sys; print(f'Python {sys.version} is working!')"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -103,10 +103,11 @@ runs:
         channels: conda-forge,defaults
         channel-priority: strict
 
-    - name: Upgrade Conda to support tos acceptance
+    # Conda 25.x removed the conda tos command.
+    - name: Downgrade Conda to 24.x to support tos acceptance
       shell: bash
       run: |
-        conda install -y -n base -c conda-forge conda
+        conda install -y -n base -c conda-forge conda=24.3
         conda --version
 
     # Accept Anaconda Terms of Service for the defaults channel.

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -99,20 +99,16 @@ runs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
+        miniforge-version: latest
         auto-activate-base: false
         conda-remove-defaults: true
         channels: conda-forge
         channel-priority: strict
 
-    - name: Patch Conda config to avoid defaults
+    - name: Patch conda config to disable defaults
       shell: bash
-      run: |
-        conda config --remove-key channels || true
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda config --set conda-remove-defaults true
-
-        conda config --show | grep conda-remove-defaults
+      run:
+        conda config --show
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch
     #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -100,17 +100,16 @@ runs:
         miniforge-variant: Miniforge3
         miniforge-version: latest
         auto-activate-base: false
-        # conda-remove-defaults: true
-        channels: conda-forge
+        channels: conda-forge,defaults
         channel-priority: strict
 
-    - name: Patch conda config to disable defaults
-      shell: bash
-      run: |
-        conda config --remove-key channels || true
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda config --show
+    # - name: Patch conda config to disable defaults
+    #   shell: bash
+    #   run: |
+    #     conda config --remove-key channels || true
+    #     conda config --add channels conda-forge
+    #     conda config --set channel_priority strict
+    #     conda config --show
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch
     #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -96,7 +96,7 @@ runs:
     - name: Install Conda (Miniconda from Anaconda)
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniconda-installer-url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        installer-url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
         auto-activate-base: false
         channels: conda-forge,defaults
         channel-priority: strict

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -94,16 +94,6 @@ runs:
         channels: conda-forge
         channel-priority: strict
 
-    - name: Verify Conda Python Installation
-      shell: bash -el {0}
-      run: |
-        conda config --set channels conda-forge
-        conda config --set conda-remove-defaults true
-        conda config --set channel_priority strict
-
-        conda info
-        conda list
-
     # - name: Create Conda Environment with Python 3.12 in ~/scratch
     #   if: ${{ inputs.install_undetectable_interpreters == 'true' }}
     #   shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -103,6 +103,17 @@ runs:
         channels: conda-forge,defaults
         channel-priority: strict
 
+    - name: Upgrade Conda to support tos acceptance
+      shell: bash
+      run: |
+        conda install -y -n base -c conda-forge conda
+        conda --version
+
+    # Accept Anaconda Terms of Service for the defaults channel.
+    # This is required in CI when running Chromium-based tests that trigger `create_conda.py`.
+    # That script creates a new Conda environment without overriding channels, which causes Conda
+    # to pull from Anaconda-hosted defaults packages. Without this step, Conda will raise a
+    # CondaToSNonInteractiveError and fail to create the environment.
     - name: Accept Anaconda ToS for defaults
       shell: bash
       run: |

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -101,13 +101,17 @@ runs:
         miniforge-variant: Miniforge3
         miniforge-version: latest
         auto-activate-base: false
-        conda-remove-defaults: true
+        # conda-remove-defaults: true
         channels: conda-forge
         channel-priority: strict
 
     - name: Patch conda config to disable defaults
       shell: bash
-      run:
+      run: |
+        conda config --remove-key channels || true
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+        conda config --set conda-remove-defaults true
         conda config --show
 
     # - name: Create Conda Environment with Python 3.12 in ~/scratch

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -83,7 +83,7 @@ runs:
         python --version
 
     - name: Setup Conda Python 3.12 env in scratch
-      if: ${{ inputs.install_undetectable_interpreters == 'true' }}
+      # if: ${{ inputs.install_undetectable_interpreters == 'true' }}
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -93,16 +93,13 @@ runs:
         channels: conda-forge
         channel-priority: strict
 
-    - name: Install Conda (Miniforge) (always)
-      if: ${{ inputs.install_undetectable_interpreters != 'true' }}
+    - name: Install Conda (Miniconda from Anaconda)
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Miniconda3
-        miniforge-version: latest
+        miniconda-installer-url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
         auto-activate-base: false
         channels: conda-forge,defaults
         channel-priority: strict
-
     # Accept Anaconda Terms of Service for the defaults channel.
     # This is required in CI when running Chromium-based tests that trigger `create_conda.py`.
     # That script creates a new Conda environment without overriding channels, which causes Conda

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -103,6 +103,12 @@ runs:
         channels: conda-forge,defaults
         channel-priority: strict
 
+    - name: Accept Anaconda ToS for defaults
+      shell: bash
+      run: |
+        conda tos accept --channel https://repo.anaconda.com/pkgs/main
+        conda tos accept --channel https://repo.anaconda.com/pkgs/r
+
     # - name: Patch conda config to disable defaults
     #   shell: bash
     #   run: |

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -35,13 +35,6 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
       with:
         tinytex: true
-    # - name: Patch Conda config to avoid defaults
-    #   shell: bash
-    #   run: |
-    #     conda config --remove-key channels || true
-    #     conda config --add channels conda-forge
-    #     conda config --set channel_priority strict
-    #     conda config --set conda-remove-defaults true
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -36,13 +36,14 @@ runs:
       with:
         tinytex: true
 
-    - name: Setup Conda (Miniforge3)
+    - name: Install Miniforge (always)
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
-        miniforge-version: latest
         auto-activate-base: false
-        conda-prefix: ~/miniforge3
+        conda-remove-defaults: true
+        channels: conda-forge
+        channel-priority: strict
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -42,6 +42,7 @@ runs:
         miniforge-variant: Miniforge3
         miniforge-version: latest
         auto-activate-base: false
+        conda-prefix: ~/miniforge3
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -36,6 +36,16 @@ runs:
       with:
         tinytex: true
 
+    # Miniforge avoids Anaconda ToS and defaults to conda-forge
+    - name: Setup Conda (Miniforge3)
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-version: latest
+        auto-activate-base: false
+        channels: conda-forge,defaults  # Defaults included only to suppress warnings; all packages are still resolved from conda-forge
+        conda-remove-defaults: "true"
+        channel-priority: strict
+
     - name: Setup Python
       uses: ./.github/actions/install-python
       with:

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -35,16 +35,6 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
       with:
         tinytex: true
-
-    # - name: Install Miniforge (always)
-    #   uses: conda-incubator/setup-miniconda@v3
-    #   with:
-    #     miniforge-variant: Miniforge3
-    #     auto-activate-base: false
-    #     conda-remove-defaults: true
-    #     channels: conda-forge
-    #     channel-priority: strict
-
     # - name: Patch Conda config to avoid defaults
     #   shell: bash
     #   run: |

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -36,14 +36,22 @@ runs:
       with:
         tinytex: true
 
-    - name: Install Miniforge (always)
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Miniforge3
-        auto-activate-base: false
-        conda-remove-defaults: true
-        channels: conda-forge
-        channel-priority: strict
+    # - name: Install Miniforge (always)
+    #   uses: conda-incubator/setup-miniconda@v3
+    #   with:
+    #     miniforge-variant: Miniforge3
+    #     auto-activate-base: false
+    #     conda-remove-defaults: true
+    #     channels: conda-forge
+    #     channel-priority: strict
+
+    # - name: Patch Conda config to avoid defaults
+    #   shell: bash
+    #   run: |
+    #     conda config --remove-key channels || true
+    #     conda config --add channels conda-forge
+    #     conda config --set channel_priority strict
+    #     conda config --set conda-remove-defaults true
 
     - name: Setup Python
       uses: ./.github/actions/install-python

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -183,6 +183,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           install_undetectable_interpreters: ${{ inputs.install_undetectable_interpreters }}
 
+      - name: Verify Conda Python Installation
+        shell: bash -el {0}
+        run: |
+          conda config --set channels conda-forge
+          conda config --set conda-remove-defaults true
+          conda config --set channel_priority strict
+
+          conda info
+          conda list
+
       # Preloading ensures the Node.js binary is fully built and ready before
       # any parallel processes start, preventing runtime conflicts
       - name: Preload Node.js Binary

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -183,16 +183,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           install_undetectable_interpreters: ${{ inputs.install_undetectable_interpreters }}
 
-      - name: Verify Conda Python Installation
-        shell: bash -el {0}
-        run: |
-          conda config --set channels conda-forge
-          conda config --set conda-remove-defaults true
-          conda config --set channel_priority strict
-
-          conda info
-          conda list
-
       # Preloading ensures the Node.js binary is fully built and ready before
       # any parallel processes start, preventing runtime conflicts
       - name: Preload Node.js Binary

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -105,6 +105,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         print(f"EXISTING_CONDA_ENV:{env_path}")
     else:
         # --- Start Positron ---
+        # Special case for Playwright CI: force conda-forge to avoid ToS prompt from defaults
         is_playwright_test = os.environ.get("PW_TEST") == "1"
 
         cmd = [
@@ -119,7 +120,9 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
 
         if is_playwright_test:
-            print("PW_TEST environment variable detected: Configuring conda to use conda-forge channel only")
+            print(
+                "PW_TEST env var detected: Configuring conda to use conda-forge channel only"
+            )
             cmd.extend(["--override-channels", "-c", "conda-forge"])
 
         run_process(

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -113,7 +113,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         print(f"EXISTING_CONDA_ENV:{env_path}")
     else:
         # --- Start Positron ---
-        use_conda_forge = os.environ.get("PW_TEST") == "1"
+        is_playwright_test = os.environ.get("PW_TEST") == "1"
 
         cmd = [
             sys.executable,
@@ -126,12 +126,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             f"python={args.python}",
         ]
 
-        if use_conda_forge:
+        if is_playwright_test:
             print("MARIE Using conda-forge only due to PW_TEST=1")
             cmd.extend(["--override-channels", "-c", "conda-forge"])
         else:
             print("MARIE Using default conda channels")
-            print("MARIE", os.environ.get("PW_TEST"))
+            print(f"MARIE PW_TEST env var: {os.environ.get('PW_TEST')}")
             print("MARIE", os.environ.get("PW_TEST") == "1")
 
         run_process(

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -127,8 +127,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
 
         if use_conda_forge:
-            print("Using conda-forge only due to PW_TEST=1")
+            print("MARIE Using conda-forge only due to PW_TEST=1")
             cmd.extend(["--override-channels", "-c", "conda-forge"])
+        else:
+            print("MARIE Using default conda channels")
+            print("MARIE", os.environ.get("PW_TEST"))
+            print("MARIE", os.environ.get("PW_TEST") == "1")
 
         run_process(
             cmd,

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -44,14 +44,6 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         metavar="NAME",
         action="store",
     )
-    # --- Start Positron ----
-    parser.add_argument(
-        "--override-conda-forge",
-        action="store_true",
-        default=False,
-        help="Use conda-forge only as the channel source.",
-    )
-    # --- End Positron ----
     return parser.parse_args(argv)
 
 

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -113,9 +113,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         print(f"EXISTING_CONDA_ENV:{env_path}")
     else:
         # --- Start Positron ---
-        use_conda_forge = os.environ.get("E2E") == "true"
-        if use_conda_forge:
-            print("Using conda-forge only due to E2E=true")
+        use_conda_forge = os.environ.get("PW_TEST") == "1"
 
         cmd = [
             sys.executable,
@@ -129,6 +127,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
 
         if use_conda_forge:
+            print("Using conda-forge only due to PW_TEST=1")
             cmd.extend(["--override-channels", "-c", "conda-forge"])
 
         run_process(

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -120,9 +120,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
 
         if is_playwright_test:
-            print(
-                "PW_TEST env var detected: Configuring conda to use conda-forge channel only"
-            )
+            print("PW_TEST env var detected: Configuring conda to use conda-forge channel only")
             cmd.extend(["--override-channels", "-c", "conda-forge"])
 
         run_process(

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -123,7 +123,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
         # If the --override-conda-forge flag is passed, we force Conda to use only the conda-forge channel.
         # This is especially helpful in CI where ToS issues with the defaults channel can break setup.
-        if args.override_conda_forge:
+        if args.override_conda_forge or os.environ.get("CI") == "true":
+            print("Using conda-forge only due to --override-conda-forge or CI=true")
             cmd += ["--override-channels", "-c", "conda-forge"]
 
         run_process(

--- a/extensions/positron-python/python_files/create_conda.py
+++ b/extensions/positron-python/python_files/create_conda.py
@@ -119,12 +119,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ]
 
         if is_playwright_test:
-            print("MARIE Using conda-forge only due to PW_TEST=1")
+            print("PW_TEST environment variable detected: Configuring conda to use conda-forge channel only")
             cmd.extend(["--override-channels", "-c", "conda-forge"])
-        else:
-            print("MARIE Using default conda channels")
-            print(f"MARIE PW_TEST env var: {os.environ.get('PW_TEST')}")
-            print("MARIE", os.environ.get("PW_TEST") == "1")
 
         run_process(
             cmd,

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -98,6 +98,7 @@ async function createCondaEnv(
         cwd: workspace.uri.fsPath,
         env: {
             PATH: pathEnv,
+            PW_TEST: process.env.PW_TEST,
         },
     });
 

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -98,7 +98,9 @@ async function createCondaEnv(
         cwd: workspace.uri.fsPath,
         env: {
             PATH: pathEnv,
+            // --- Start Positron ---
             PW_TEST: process.env.PW_TEST,
+            // --- End Positron ---
         },
     });
 

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -156,7 +156,7 @@ export class HotKeys {
 
 	public async closeWorkspace() {
 		await this.pressHotKeys('Cmd+J W');
-		await expect(this.code.driver.page.locator('.explorer-folders-view')).toBeVisible();
+		await expect(this.code.driver.page.locator('.explorer-folders-view')).not.toBeVisible();
 	}
 
 	public async importSettings() {

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -59,7 +59,7 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 		await verifyPyprojectTomlCreated(app);
 	});
 
-	test.skip('New env: Conda environment', async function ({ app }) {
+	test('New env: Conda environment', async function ({ app }) {
 		const folderName = addRandomNumSuffix('conda-installed');
 		await createNewFolder(app, {
 			folderTemplate,

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -94,11 +94,8 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 	});
 
 	test.describe('No Workspace', () => {
-		test.beforeAll(async function ({ hotKeys }) {
-			await hotKeys.closeWorkspace();
-		});
-
 		test.beforeEach(async function ({ hotKeys, sessions }) {
+			await hotKeys.closeWorkspace();
 			await sessions.expectSessionPickerToBe('Start Session');
 			await sessions.expectNoStartUpMessaging();
 			await hotKeys.openWelcomeWalkthrough();


### PR DESCRIPTION
### Summary

This PR resolves a flake in the new folder flow test related to Conda environment creation. The test would occasionally fail because the `create-conda.py` script fell back to the defaults channel, despite CI being configured to use `conda-forge` via Miniforge.

We could use either Miniforge or Miniconda, but for now we prefer Miniforge due to recent changes to Miniconda that require Terms of Service acceptance when using the defaults channel and this also aligns with the container work done by @testlabauto.

### QA Notes

@:new-folder-flow @:web
