### PR TITLE
Fix Viewer serving non-HTML content in web mode via positron proxy

### DIFF
--- a/extensions/positron-proxy/src/htmlProxy.ts
+++ b/extensions/positron-proxy/src/htmlProxy.ts
@@ -93,16 +93,22 @@ export class HtmlProxyServer implements Disposable {
 			this._app.use(`/${serverPath}`, async (req, res, next) => {
 				const filePath = path.join(targetPath, req.path);
 				if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
-					let content = fs.readFileSync(filePath, 'utf8');
 					const fileExt = path.extname(filePath).toLowerCase();
 					const isHtmlFile = ['.html', '.htm'].includes(fileExt);
 
-					// If the file is an HTML file and we have an HTML configuration, inject the
-					// preview resources into the HTML content.
-					if (isHtmlFile && htmlConfig) {
-						content = injectPreviewResources(content, htmlConfig);
+					if (isHtmlFile) {
+						// For HTML files, read as text and potentially inject resources
+						let content = fs.readFileSync(filePath, 'utf8');
+						if (htmlConfig) {
+							content = injectPreviewResources(content, htmlConfig);
+						}
+						res.send(content);
+					} else {
+						// For non-HTML files, use sendFile with root option for security and proper Content-Type.
+						// The root option prevents path traversal attacks by restricting file access to within
+						// targetPath.
+						res.sendFile(req.path, { root: targetPath });
 					}
-					res.send(content);
 				} else {
 					next();
 				}


### PR DESCRIPTION
Addresses #8785

### Before this fix, when running in web mode, the HtmlProxyServer was:
 
- Reading ALL files (HTML, CSS, JS, images, etc.) as UTF-8 text
- Using `res.send(content)` for all files, which doesn't set proper `Content-Type` headers
- This caused CSS files to be served as `text/html` instead of `text/css`, JS files as `text/html` instead of `application/javascript`, etc.

### Now the code:

- For HTML files: Continues to read them as text and inject HTML resources if needed (preserving the existing functionality)
- For non-HTML files: Uses `res.sendFile()` with the `root` option, which automatically sets the correct `Content-Type` headers based on file extensions

### Why res.sendFile() with root option:

- Built-in MIME type detection that properly maps file extensions to `Content-Type` headers
- Built-in path traversal protection via the `root` option
- Only HTML files need special processing (resource injection), so other files can use the standard secure file serving
- Simpler and more secure than manual path validation or dynamic `express.static()` calls
- This preserves the existing HTML processing while fixing the Content-Type issue for all other file types.

This should resolve the issue where the proxy was sending back the wrong `Content-Type` header for non-HTML content like .js or .css files, which is important if the client is strictly enforcing the MIME type (such as when `nosniff` was enforced, which is the case in Workbench Positron Pro sessions).

## New Features

N/A

## Bug Fixes

- Fixed an issue with non-HTML content being served through Positron Proxy for the Viewer Pane in web mode.


## QA Notes

Need to verify interactive plots in the Viewer function in Positron Pro in Workbench

@:web @:critical