### PR TITLE
Jonv-nightly-only-windows

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -42,7 +42,7 @@ on:
         required: false
         description: "Comma-separated list of tags to skip."
         type: string
-        default: "@:nightly-only"
+        default: ""
 
   workflow_dispatch:
     inputs:
@@ -61,7 +61,7 @@ on:
         description: "Comma-separated list of tags to skip."
         type: string
         default: "@:nightly-only"
-        
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -56,7 +56,12 @@ on:
         description: "Run each test N times, defaults to one."
         default: 1
         type: number
-
+      skip_tags:
+        required: false
+        description: "Comma-separated list of tags to skip."
+        type: string
+        default: "@:nightly-only"
+        
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -42,7 +42,7 @@ on:
         required: false
         description: "Comma-separated list of tags to skip."
         type: string
-        default: ""
+        default: "@:nightly-only"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -38,6 +38,12 @@ on:
         type: boolean
         default: false
 
+      skip_tags:
+        required: false
+        description: "Comma-separated list of tags to skip."
+        type: string
+        default: ""
+
   workflow_dispatch:
     inputs:
       grep:
@@ -208,9 +214,40 @@ jobs:
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID }}
         run: |
+          echo "Processing skip_tags input: '${{ inputs.skip_tags }}'"
+
+          # Convert comma-separated skip_tags input into a pipe-separated string
+          SKIP_TAGS_PATTERN=$(echo "${{ inputs.skip_tags }}" | sed 's/,/|/g')
+
+          # Build a single lookahead regex pattern
+          if [ -n "$SKIP_TAGS_PATTERN" ]; then
+            SKIP_TAGS_REGEX="(?=.*($SKIP_TAGS_PATTERN|@:web-only))"
+          else
+            SKIP_TAGS_REGEX="(?=.*(@:web-only))"
+          fi
+
+          # Build the --grep-invert argument if needed
+          GREP_INVERT_ARG=""
+          if [ -n "$SKIP_TAGS_REGEX" ]; then
+            GREP_INVERT_ARG="--grep-invert \"$SKIP_TAGS_REGEX\""
+          fi
+
+          # Build the --grep argument only if PW_TAGS is non-empty
+          if [ -z "${PW_TAGS}" ]; then
+            GREP_ARG=""
+          else
+            GREP_ARG="--grep \"${PW_TAGS}\""
+          fi
+
+          # Log the arguments
+          echo "Final --grep argument: $GREP_ARG"
+          echo "Final --grep-invert argument: $GREP_INVERT_ARG"
+
           export SKIP_BOOTSTRAP=true
           export SKIP_CLONE=true
-          npx playwright test --project "e2e-windows" --grep "${PW_TAGS}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
+          # Run the Playwright test command directly using eval
+          echo "Running: npx playwright test --project \"e2e-windows\" --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10"
+          eval npx playwright test --project \"e2e-windows\" --workers 2 $GREP_ARG $GREP_INVERT_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -30,6 +30,7 @@ jobs:
       display_name: "electron (windows)"
       currents_tags: "merge,electron/windows"
       report_testrail: false
+      skip_tags: "@:nightly-only"
       upload_logs: false
     secrets: inherit
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -56,6 +56,7 @@ jobs:
       currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       report_currents: false
+      skip_tags: "@:nightly-only"
       upload_logs: false
     secrets: inherit
 

--- a/test/e2e/tests/positron-assistant/inspect-ai.test.ts
+++ b/test/e2e/tests/positron-assistant/inspect-ai.test.ts
@@ -17,7 +17,7 @@ test.use({
  * the dataset for use in the inspect-ai tests. It also does some basic validation that there are valid responses
  * from the assistant.
  */
-test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY, tags.ASSISTANT] }, () => {
+test.describe.skip('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
 		await app.workbench.assistant.selectModelProvider('Anthropic');

--- a/test/e2e/tests/positron-assistant/inspect-ai.test.ts
+++ b/test/e2e/tests/positron-assistant/inspect-ai.test.ts
@@ -17,7 +17,7 @@ test.use({
  * the dataset for use in the inspect-ai tests. It also does some basic validation that there are valid responses
  * from the assistant.
  */
-test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
+test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY, tags.ASSISTANT] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
 		await app.workbench.assistant.selectModelProvider('Anthropic');

--- a/test/e2e/tests/positron-assistant/inspect-ai.test.ts
+++ b/test/e2e/tests/positron-assistant/inspect-ai.test.ts
@@ -17,7 +17,7 @@ test.use({
  * the dataset for use in the inspect-ai tests. It also does some basic validation that there are valid responses
  * from the assistant.
  */
-test.describe.skip('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
+test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
 		await app.workbench.assistant.selectModelProvider('Anthropic');


### PR DESCRIPTION
Adds skipping nightly-only tests on windows


### QA Notes
See example run https://github.com/posit-dev/positron/actions/runs/16711731113

I unskipped the inspect-ai test for the above run and it didn't execute

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
