### PR TITLE
Disable web for notebook-workspace tests

### DIFF
--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -29,14 +29,14 @@ test.describe('Notebook Working Directory Configuration', {
 	test('workspaceFolder works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${workspaceFolder}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'qa-example-content');
 	});
 
 	test('fileDirname works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${fileDirname}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
@@ -46,21 +46,21 @@ test.describe('Notebook Working Directory Configuration', {
 
 		await settings.set({
 			'notebook.workingDirectory': tempDir
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(tempDir));
 	});
 
 	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '/does/not/exist'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('Bad variables result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${asdasd}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 });

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -13,8 +13,9 @@ test.use({
 	suiteId: __filename
 });
 
+// Untagged for WEB due to https://github.com/posit-dev/positron/issues/8828
 test.describe('Notebook Working Directory Configuration', {
-	tag: [tags.WIN, tags.WEB, tags.NOTEBOOKS]
+	tag: [tags.WIN, tags.NOTEBOOKS]
 }, () => {
 
 	test.afterEach(async function ({ app }) {
@@ -29,14 +30,14 @@ test.describe('Notebook Working Directory Configuration', {
 	test('workspaceFolder works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${workspaceFolder}'
-		}, { reload: 'web' });
+		});
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'qa-example-content');
 	});
 
 	test('fileDirname works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${fileDirname}'
-		}, { reload: 'web' });
+		});
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
@@ -46,21 +47,21 @@ test.describe('Notebook Working Directory Configuration', {
 
 		await settings.set({
 			'notebook.workingDirectory': tempDir
-		}, { reload: 'web' });
+		});
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(tempDir));
 	});
 
 	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '/does/not/exist'
-		}, { reload: 'web' });
+		});
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('Bad variables result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${asdasd}'
-		}, { reload: 'web' });
+		});
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 });


### PR DESCRIPTION
Due to https://github.com/posit-dev/positron/issues/8828 removed the WEB tag.


### QA Notes
@:notebooks @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
