### PR TITLE
e2e: support menuitemcheckbox in context menu

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -7,6 +7,7 @@ import { Code } from './code';
 import { Modals } from '../pages/dialog-modals';
 import { Toasts } from '../pages/dialog-toasts';
 import { Popups } from '../pages/dialog-popups.js';
+import { ContextMenu } from '../pages/dialog-contextMenu.js';
 import { Console } from '../pages/console';
 import { Variables } from '../pages/variables';
 import { DataExplorer } from '../pages/dataExplorer';
@@ -54,6 +55,7 @@ export class Workbench {
 	readonly modals: Modals;
 	readonly toasts: Toasts;
 	readonly popups: Popups;
+	readonly contextMenu: ContextMenu;
 	readonly console: Console;
 	readonly variables: Variables;
 	readonly dataExplorer: DataExplorer;
@@ -96,10 +98,11 @@ export class Workbench {
 		this.hotKeys = new HotKeys(code);
 		this.toasts = new Toasts(code);
 		this.popups = new Popups(code);
+		this.contextMenu = new ContextMenu(code);
 		this.variables = new Variables(code, this.hotKeys);
 		this.dataExplorer = new DataExplorer(code, this);
 		this.sideBar = new SideBar(code);
-		this.plots = new Plots(code);
+		this.plots = new Plots(code, this.contextMenu);
 		this.explorer = new Explorer(code);
 		this.help = new Help(code);
 		this.topActionBar = new TopActionBar(code);
@@ -110,7 +113,7 @@ export class Workbench {
 		this.connections = new Connections(code, this.quickaccess);
 		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess);
 		this.output = new Output(code, this.quickaccess, this.quickInput);
-		this.console = new Console(code, this.quickInput, this.quickaccess, this.hotKeys);
+		this.console = new Console(code, this.quickInput, this.quickaccess, this.hotKeys, this.contextMenu);
 		this.modals = new Modals(code, this.toasts, this.console);
 		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess, this.hotKeys);

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -265,7 +265,7 @@ export class Console {
 		await this.code.driver.page.locator(MAXIMIZE_CONSOLE).click();
 	}
 
-	async pasteCodeToConsole(code: string, sendEnterKey = false, waitForExecution = true) {
+	async pasteCodeToConsole(code: string, sendEnterKey = false) {
 		await test.step(`Paste code to console: ${code}`, async () => {
 			const consoleInput = this.activeConsole.locator(CONSOLE_INPUT);
 			await this.pasteInMonaco(consoleInput!, code);
@@ -273,10 +273,6 @@ export class Console {
 			if (sendEnterKey) {
 				await expect(this.code.driver.page.getByLabel('Interrupt execution')).not.toBeVisible();
 				await this.sendEnterKey();
-			}
-
-			if (waitForExecution) {
-				await this.waitForConsoleExecution({ timeout: 30000 });
 			}
 		});
 	}

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -265,7 +265,7 @@ export class Console {
 		await this.code.driver.page.locator(MAXIMIZE_CONSOLE).click();
 	}
 
-	async pasteCodeToConsole(code: string, sendEnterKey = false) {
+	async pasteCodeToConsole(code: string, sendEnterKey = false, waitForExecution = true) {
 		await test.step(`Paste code to console: ${code}`, async () => {
 			const consoleInput = this.activeConsole.locator(CONSOLE_INPUT);
 			await this.pasteInMonaco(consoleInput!, code);
@@ -273,6 +273,10 @@ export class Console {
 			if (sendEnterKey) {
 				await expect(this.code.driver.page.getByLabel('Interrupt execution')).not.toBeVisible();
 				await this.sendEnterKey();
+			}
+
+			if (waitForExecution) {
+				await this.waitForConsoleExecution({ timeout: 30000 });
 			}
 		});
 	}

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -40,7 +40,7 @@ export class Console {
 		return this.code.driver.page.locator(EMPTY_CONSOLE).getByText('There is no interpreter running');
 	}
 
-	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private hotKeys: HotKeys) {
+	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private hotKeys: HotKeys, private contextMenu: ContextMenu) {
 		// Standard Console Button Locators
 		this.restartButton = this.code.driver.page.getByTestId('restart-session');
 		this.clearButton = this.code.driver.page.getByLabel('Clear console');
@@ -63,10 +63,10 @@ export class Console {
 	 * @param contextMenu
 	 * @param runtime provided when option is 'Start New' to specify the runtime for the new session.
 	 */
-	async clickStartAnotherSessionButton(contextMenu: ContextMenu, runtime: SessionRuntimes) {
+	async clickStartAnotherSessionButton(runtime: SessionRuntimes) {
 		await test.step(`Expand \`+\` session button to start new session: ${runtime}`, async () => {
 
-			await contextMenu.triggerAndClick({
+			await this.contextMenu.triggerAndClick({
 				menuTrigger: this.addSessionExpandMenuButton,
 				menuItemLabel: 'Start Another...'
 			});
@@ -93,9 +93,9 @@ export class Console {
 	 * @param contextMenu the context menu instance to use for interaction
 	 * @param runtimes the runtime names to expect in the context menu
 	 */
-	async expectSessionContextMenuToContain(contextMenu: ContextMenu, runtimes: string[]) {
+	async expectSessionContextMenuToContain(runtimes: string[]) {
 		await test.step('Verify `+` menu contains runtime(s)', async () => {
-			const menuItems = await contextMenu.getMenuItems(this.addSessionExpandMenuButton);
+			const menuItems = await this.contextMenu.getMenuItems(this.addSessionExpandMenuButton);
 			const filteredMenuItems = menuItems.filter(item => item !== 'Start Another...');
 
 			// Check if expected runtimes are present

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -12,6 +12,7 @@ export class ContextMenu {
 	private contextMenu: Locator = this.page.locator('.monaco-menu');
 	private contextMenuItems: Locator = this.contextMenu.getByRole('menuitem');
 	private getContextMenuItem: (label: string) => Locator = (label: string) => this.contextMenu.getByRole('menuitem', { name: label });
+	private getContextMenuCheckboxItem: (label: string) => Locator = (label: string) => this.contextMenu.getByRole('menuitemcheckbox', { name: label, exact: true });
 
 	constructor(
 		private code: Code,
@@ -27,8 +28,9 @@ export class ContextMenu {
 	 *
 	 * @param menuTrigger The locator that will trigger the context menu when clicked
 	 * @param menuItemLabel The label of the menu item to click
+	 * @param menuItemType The type of the menu item, either 'menuitemcheckbox' or 'menuitem'
 	 */
-	async triggerAndClick({ menuTrigger, menuItemLabel }: ContextMenuClick): Promise<void> {
+	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem' }: ContextMenuClick): Promise<void> {
 		await test.step(`Trigger context menu and click '${menuItemLabel}'`, async () => {
 			if (this.isNativeMenu) {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel });
@@ -36,7 +38,9 @@ export class ContextMenu {
 				await menuTrigger.click();
 
 				// Hover over the menu item
-				const menuItem = this.getContextMenuItem(menuItemLabel);
+				const menuItem = menuItemType === 'menuitemcheckbox'
+					? this.getContextMenuCheckboxItem(menuItemLabel)
+					: this.getContextMenuItem(menuItemLabel);
 				await menuItem.hover();
 				await this.page.waitForTimeout(500);
 
@@ -155,7 +159,7 @@ export class ContextMenu {
 	 * @param menuTrigger The locator that will trigger the context menu when clicked
 	 * @param menuItemLabel The label of the menu item to click
 	 */
-	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel }: ContextMenuClick): Promise<void> {
+	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel }: Omit<ContextMenuClick, 'menuItemType'>): Promise<void> {
 		// Show the context menu by clicking on the trigger element
 		const menuItems = await this.showContextMenu(() => menuTrigger.click());
 
@@ -177,4 +181,5 @@ export class ContextMenu {
 interface ContextMenuClick {
 	menuTrigger: Locator;
 	menuItemLabel: string;
+	menuItemType?: 'menuitemcheckbox' | 'menuitem';
 }

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -14,12 +14,10 @@ export class ContextMenu {
 	private getContextMenuItem: (label: string | RegExp) => Locator = (label: string | RegExp) => this.contextMenu.getByRole('menuitem', { name: label });
 	private getContextMenuCheckboxItem: (label: string | RegExp) => Locator = (label: string | RegExp) => this.contextMenu.getByRole('menuitemcheckbox', { name: label });
 
-	constructor(
-		private code: Code,
-		private projectName: string,
-		private platform: string,
-	) {
-		this.isNativeMenu = this.platform === 'darwin' && !this.projectName.includes('browser');
+	constructor(private code: Code) {
+		// Check if we're on macOS AND we have an Electron app instance
+		// Only macOS + Electron combination uses native context menus
+		this.isNativeMenu = process.platform === 'darwin' && !!this.code.electronApp;
 	}
 
 	/**
@@ -114,7 +112,7 @@ export class ContextMenu {
 	private async showContextMenu(trigger: () => Promise<void>): Promise<{ menuId: number; items: string[] } | undefined> {
 		try {
 			if (!this.code.electronApp) {
-				throw new Error(`Electron app is not available. Platform: ${this.platform}, Project: ${this.projectName}`);
+				throw new Error(`Electron app is not available. Platform: ${process.platform}`);
 			}
 
 			const shownPromise: Promise<[number, string[]]> | undefined = this.code.electronApp.evaluate(({ app }) => {

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -162,7 +162,7 @@ export class Plots {
 
 
 	async setThePlotZoom(zoomLevel: ZoomLevels) {
-		await test.step(`Set plot zoom to ${zoomLevel}`, async () => {
+		await test.step(`Set plot zoom to: ${zoomLevel}`, async () => {
 			await this.contextMenu.triggerAndClick({
 				menuTrigger: this.code.driver.page.getByRole('button', { name: /Fit|%/ }),
 				menuItemLabel: zoomLevel
@@ -176,7 +176,7 @@ export class Plots {
 			'new window': /Open in new window$/,
 			'editor tab to the side': /Open in editor tab to the Side$/
 		};
-		await test.step(`Open plot in ${plotLocation}`, async () => {
+		await test.step(`Open plot in: ${plotLocation}`, async () => {
 			await this.contextMenu.triggerAndClick({
 				menuTrigger: this.code.driver.page.getByRole('button', { name: 'Select where to open plot' }),
 				menuItemLabel: menuItemRegex[plotLocation],

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { Application, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, ApplicationOptions, Quality, MultiLogger, VscodeSettings, ContextMenu, getRandomUserDataDir, copyFixtureFile } from '../infra';
+import { Application, createLogger, createApp, TestTags, Sessions, HotKeys, TestTeardown, ApplicationOptions, Quality, MultiLogger, VscodeSettings, getRandomUserDataDir, copyFixtureFile } from '../infra';
 import { PackageManager } from '../pages/utils/packageManager';
 
 // Constants
@@ -179,13 +179,6 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleDevTools');
 		await use();
 	}, { scope: 'test' }],
-
-	// This fixture provides a way interact with context menu items for both Electron and web apps. :tada:
-	contextMenu: [async ({ app }, use, testInfo) => {
-		const contextMenu = new ContextMenu(app.code, testInfo.project.name, process.platform);
-		await use(contextMenu);
-	},
-	{ scope: 'test' }],
 
 	// ex: await openFile('workspaces/basic-rmd-file/basicRmd.rmd');
 	openFile: async ({ app }, use) => {
@@ -483,7 +476,6 @@ interface TestFixtures {
 	packages: PackageManager;
 	autoTestFixture: any;
 	devTools: void;
-	contextMenu: ContextMenu;
 	openFile: (filePath: string, waitForFocus?: boolean) => Promise<void>;
 	openDataFile: (filePath: string) => Promise<void>;
 	openFolder: (folderPath: string) => Promise<void>;

--- a/test/e2e/tests/console/console-add.test.ts
+++ b/test/e2e/tests/console/console-add.test.ts
@@ -28,12 +28,12 @@ test.describe('Console: Add +', {
 
 	test('Validate can start a different runtime via Console + button', {
 		tag: [tags.ARK]
-	}, async function ({ app, page, contextMenu }) {
+	}, async function ({ app, page }) {
 		const { sessions, console } = app.workbench;
 		await sessions.start(['r', 'r']);
 
 		// Click the `+ v` button in the console to Start Another session
-		await console.clickStartAnotherSessionButton(contextMenu, 'python');
+		await console.clickStartAnotherSessionButton('python');
 		await expect(page.getByTestId(/console-tab-r-*/)).toHaveCount(2);
 		await expect(page.getByTestId(/console-tab-python-*/)).toHaveCount(1);
 		await sessions.expectAllSessionsToBeReady();
@@ -41,12 +41,12 @@ test.describe('Console: Add +', {
 
 	test('Validate Console + button menu shows both active and disconnected sessions', {
 		tag: [tags.ARK]
-	}, async function ({ app, contextMenu }) {
+	}, async function ({ app }) {
 		const { sessions, console } = app.workbench;
 		const [pythonSession, rSession] = await sessions.start(['python', 'r', 'r', 'r', 'r', 'r', 'r',]);
 
 		// Verify the Python and R sessions are listed in the console `+` menu
-		await console.expectSessionContextMenuToContain(contextMenu, [rSession.name, pythonSession.name]);
+		await console.expectSessionContextMenuToContain([rSession.name, pythonSession.name]);
 
 		// Disconnect the R session
 		await sessions.select(rSession.id);
@@ -59,6 +59,6 @@ test.describe('Console: Add +', {
 		await sessions.expectStatusToBe(pythonSession.id, 'disconnected');
 
 		// Verify the disconnected sessions are still in the console `+` menu
-		await console.expectSessionContextMenuToContain(contextMenu, [rSession.name, pythonSession.name]);
+		await console.expectSessionContextMenuToContain([rSession.name, pythonSession.name]);
 	});
 });

--- a/test/e2e/tests/example.test.ts
+++ b/test/e2e/tests/example.test.ts
@@ -77,10 +77,10 @@ test.describe('Examples of Concepts', () => {
 
 
 test.describe('Example Context Menu Tests', { tag: [tags.WEB] }, () => {
-	test("Context Menu Open Bash", async function ({ app, page, contextMenu }) {
+	test("Context Menu Open Bash", async function ({ app, page }) {
 		await app.workbench.terminal.clickTerminalTab();
 
-		await contextMenu.triggerAndClick({
+		await app.workbench.contextMenu.triggerAndClick({
 			menuTrigger: page.getByLabel('Launch Profile...'),
 			menuItemLabel: 'bash'
 		});
@@ -89,10 +89,10 @@ test.describe('Example Context Menu Tests', { tag: [tags.WEB] }, () => {
 	});
 
 
-	test("Context Menu Fail Open Bash", async function ({ app, page, contextMenu }) {
+	test("Context Menu Fail Open Bash", async function ({ app, page }) {
 		await app.workbench.terminal.clickTerminalTab();
 
-		await contextMenu.triggerAndClick({
+		await app.workbench.contextMenu.triggerAndClick({
 			menuTrigger: page.getByLabel('Launch Profile...'),
 			menuItemLabel: 'zsh'
 		});

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -65,7 +65,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			}
 
 			await test.step('Verify plot can be opened in editor', async () => {
-				await app.workbench.plots.openPlotInEditor();
+				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
@@ -95,7 +95,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			});
 
 			await test.step('Verify plot can be opened in editor', async () => {
-				await app.workbench.plots.openPlotInEditor();
+				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
@@ -163,7 +163,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			});
 
 			await test.step('Open plot in editor', async () => {
-				await app.workbench.plots.openPlotInEditor();
+				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
 			});
 
@@ -283,7 +283,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('Python - Verify Plot Zoom works (Fit vs. 200%)', { tag: [tags.WEB] },
-			async function ({ app, contextMenu, openFile, python, page }, testInfo) {
+			async function ({ app, openFile, python, page }, testInfo) {
 				await openFile(path.join('workspaces', 'python-plots', 'matplotlib-zoom-example.py'));
 
 				await test.step('Run Python File in Console', async () => {
@@ -292,17 +292,11 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 				});
 				const imgLocator = page.getByRole('img', { name: /%run/ });
 
-				await contextMenu.triggerAndClick({
-					menuTrigger: page.getByRole('button', { name: 'Fit' }),
-					menuItemLabel: 'Fit'
-				});
-				await page.waitForTimeout(300);
+				await app.workbench.plots.setThePlotZoom('Fit');
+				await page.waitForTimeout(2000);
 				await dismissPlotZoomTooltip(page);
 				const bufferFit1 = await imgLocator.screenshot();
-				await contextMenu.triggerAndClick({
-					menuTrigger: page.getByRole('button', { name: 'Fit' }),
-					menuItemLabel: '200%'
-				});
+				await app.workbench.plots.setThePlotZoom('200%');
 
 				await page.waitForTimeout(2000);
 				await dismissPlotZoomTooltip(page);
@@ -315,10 +309,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 				});
 				expect(resultZoom.rawMisMatchPercentage).toBeGreaterThan(1.5); // should be large diff
 
-				await contextMenu.triggerAndClick({
-					menuTrigger: page.getByRole('button', { name: '200%' }),
-					menuItemLabel: 'Fit'
-				});
+				await app.workbench.plots.setThePlotZoom('Fit');
 				await page.waitForTimeout(2000);
 				await dismissPlotZoomTooltip(page);
 				const bufferFit2 = await imgLocator.screenshot();
@@ -378,7 +369,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			}
 
 			await test.step('Verify plot can be opened in editor', async () => {
-				await app.workbench.plots.openPlotInEditor();
+				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
@@ -406,7 +397,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			});
 
 			await test.step('Open plot in editor', async () => {
-				await app.workbench.plots.openPlotInEditor();
+				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
 			});
 


### PR DESCRIPTION
### Summary
This PR includes several improvements to the `ContextMenu` POM:
* Added support for `checkboxmenuitem` in context menus (as need by `Open In New Window`, etc), expanding beyond the previously supported `menuitem` type.
* Updated menu item selection to support regular expressions, reducing ambiguity when multiple items have similar labels.
* Refactored to remove the need for test-specific info, making the implementation more self-contained and streamlined.

Updates to the `Plots` POM include:
* Added `setThePlotZoom()` method
* Added `openPlotIn()` method

### QA Notes

@:plots @:console @:win @:web

Note: the session-state failure on web is a flake and it's unrelated to these chagnes. It's on my todo list. 😅 