### PR TITLE
data explorer: sync backend state when a sort is added

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -229,6 +229,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			ascending: columnSort.ascending
 		})));
 
+		// Synchronize the backend state.
+		await this._dataExplorerClientInstance.updateBackendState();
+
 		// Get the first column layout entry and the first row layout entry. If they were found,
 		// update the cache.
 		const columnDescriptor = this.firstColumn;


### PR DESCRIPTION
Backend state is not updated when a column sort is applied, which causes the state to be wrong until a filter is added or the sorts are cleared. I added this fix, following the precedent from row filters in the same file:

https://github.com/posit-dev/positron/blob/9f9dfd594d04403daf0f0401e14df7153876f141/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx#L680-L685



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8844 Synchronize data explorer backend state when a column is sorted.


### QA Notes

It's worth it to check that adding and clearing filters still act normally, but this does not really have any surface area to interact with directly. CI should be green ✅ 