### PR TITLE
e2e - remove over-sanitization for adding code to notebook cell

### DIFF
--- a/product.json
+++ b/product.json
@@ -258,7 +258,7 @@
 		},
 		{
 			"name": "posit.air-vscode",
-			"version": "0.14.0",
+			"version": "0.16.0",
 			"repo": "https://github.com/posit-dev/air",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -123,7 +123,6 @@ export class Notebooks {
 		await test.step('Add code to first cell', async () => {
 			await this.selectCellAtIndex(cellIndex);
 			await this.typeInEditor(code, delay);
-			await this.waitForActiveCellEditorContents(code);
 		});
 	}
 
@@ -194,8 +193,6 @@ export class Notebooks {
 			delay
 				? await this.code.driver.page.locator(textarea).pressSequentially(text, { delay })
 				: await this.code.driver.page.locator(textarea).fill(text);
-
-			await this._waitForActiveCellEditorContents(c => c.indexOf(text) > -1);
 		});
 	}
 


### PR DESCRIPTION
Removed calls to `waitForActiveCellEditorContents` and `_waitForActiveCellEditorContents` after typing code in the cell, streamlining the cell editing steps in `notebooks.ts`.

### QA Notes

@:web @:win @:critical @:notebooks