### PR TITLE
Enable TypeScript strict mode in a few extensions

### DIFF
--- a/extensions/positron-code-cells/tsconfig.json
+++ b/extensions/positron-code-cells/tsconfig.json
@@ -6,6 +6,7 @@
 		"typeRoots": [
 			"./node_modules/@types"
 		],
+		"strict": true,
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/positron-ipywidgets/renderer/tsconfig.json
+++ b/extensions/positron-ipywidgets/renderer/tsconfig.json
@@ -9,6 +9,7 @@
 			"es2018",
 			"DOM",
 			"DOM.Iterable"
-		]
+		],
+		"strict": true,
 	}
 }

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -20,7 +20,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _debugApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
-	private readonly _appServers = new Map<string, { terminalPid: number; proxyUri: vscode.Uri }>();
+	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
 
 	constructor(
 		private readonly _globalState: vscode.Memento,
@@ -376,7 +376,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				vscode.l10n.t(
 					"Failed to get '{0}' interpreter information. Error: {1}",
 					languageId,
-					error.message
+					JSON.stringify(error)
 				),
 			);
 		}
@@ -508,7 +508,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		return true;
 	}
 
-	private addAppServer(appUrl: string, terminalPid: number, proxyUri: vscode.Uri): void {
+	private addAppServer(appUrl: string, terminalPid: number | undefined, proxyUri: vscode.Uri): void {
 		const url = appUrl.endsWith('/')
 			? appUrl.slice(0, -1) // Remove trailing slash if present
 			: appUrl; // Otherwise, use the URL as is
@@ -517,7 +517,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		log.trace(`Known app servers: ${JSON.stringify(Array.from(this._appServers.entries()))}`);
 	}
 
-	private removeAppServer(terminalPid: number): void {
+	private removeAppServer(terminalPid: number | undefined): void {
 		log.trace(`Removing app server for terminal process ID: ${terminalPid}`);
 		const serversToRemove: string[] = [];
 		this._appServers.forEach((value, key) => {

--- a/extensions/positron-run-app/src/types.ts
+++ b/extensions/positron-run-app/src/types.ts
@@ -18,7 +18,7 @@ export type PositronProxyInfo = {
 };
 
 export type AppPreviewOptions = {
-	terminalPid: number;
+	terminalPid: number | undefined;
 	proxyInfo?: PositronProxyInfo;
 	urlPath?: string;
 	appReadyMessage?: string;

--- a/extensions/positron-run-app/tsconfig.json
+++ b/extensions/positron-run-app/tsconfig.json
@@ -6,6 +6,7 @@
 		"lib": ["ES2020"],
 		"sourceMap": true,
 		"rootDir": "src",
+		"strict": true,
 		"typeRoots": ["./node_modules/@types"],
 		"paths": {
 			"*": ["./node_modules/*"],


### PR DESCRIPTION
I noticed that a few extensions I'd created didn't have strict compilation mode enabled.

Thankfully there were no errors except in the run app extension where a terminal's process could be undefined. I updated the types to more accurately reflect what's really going on.

We should probably keep the original types and improve how we handle the undefined cases.