### PR TITLE
Fix save-as making it easy to save without extension for positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -20,7 +20,6 @@ import { ExtUri, joinPath } from '../../../../base/common/resources.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { INotificationService } from '../../../../platform/notification/common/notification.js';
 
 /**
  * Mostly empty options object. Based on the same one in `vs/workbench/contrib/notebook/browser/notebookEditorInput.ts`
@@ -42,11 +41,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	static count = 0;
 
-	/**
-	 * Supported file extensions for Positron notebooks.
-	 * Currently only .ipynb, but designed for easy expansion when other formats are supported.
-	 */
-	public static readonly SUPPORTED_EXTENSIONS = ['.ipynb'];
 
 	/**
 	 * Unique identifier for this specific input instance
@@ -113,7 +107,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 		@ILogService private readonly _logService: ILogService,
 		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
-		@INotificationService private readonly _notificationService: INotificationService,
 	) {
 		// Call the base class's constructor.
 		super();
@@ -257,23 +250,18 @@ export class PositronNotebookEditorInput extends EditorInput {
 			return undefined; // save cancelled
 		}
 
-		// Validate and potentially fix the target path
-		// NOTE: In normal usage, this validation is rarely triggered because showSaveDialog
-		// with filters automatically appends .ipynb extensions. However, this method serves
-		// as a safety net for cases where the user bypasses the filter and types a different extension.
-		const validatedTarget = this._validateAndFixFileExtension(target);
 
 		// Transfer the runtime session when saving an untitled notebook
 		try {
-			this._logService.debug(`Reassigning notebook session URI: ${this.resource.toString()} → ${validatedTarget.toString()}`);
+			this._logService.debug(`Reassigning notebook session URI: ${this.resource.toString()} → ${target.toString()}`);
 
 			// Call updateNotebookSessionUri on the runtime service
 			// This updates internal mappings and emits events that other components listen for
-			const sessionId = this._runtimeSessionService.updateNotebookSessionUri(this.resource, validatedTarget);
+			const sessionId = this._runtimeSessionService.updateNotebookSessionUri(this.resource, target);
 
 			if (sessionId) {
 				// Log success to aid debugging session transfer issues
-				this._logService.debug(`Successfully reassigned session ${sessionId} to URI: ${validatedTarget.toString()}`);
+				this._logService.debug(`Successfully reassigned session ${sessionId} to URI: ${target.toString()}`);
 			} else {
 				// This is an expected case for notebooks without executed cells (no session yet)
 				this._logService.debug(`No session found to reassign for URI: ${this.resource.toString()}`);
@@ -287,7 +275,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 		}
 
 		// Use the model's saveAs method which handles the actual file saving
-		const result = await this._editorModelReference.object.saveAs(validatedTarget);
+		const result = await this._editorModelReference.object.saveAs(target);
 
 		if (result) {
 			// After 'saveAs', the original untitled working copy is left in a dirty state.
@@ -308,7 +296,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 			// Update the instance map to handle the URI change from untitled to saved file
 			// This ensures the same notebook instance continues to be used after save
-			PositronNotebookInstance.updateInstanceUri(this.resource, validatedTarget);
+			PositronNotebookInstance.updateInstanceUri(this.resource, target);
 		}
 
 		return result;
@@ -339,65 +327,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 		return joinPath(await this._fileDialogService.defaultFilePath(), suggestedFilename);
 	}
 
-	/**
-	 * Validates and potentially fixes file extensions for notebook saving.
-	 *
-	 * NOTE: In normal usage, this validation is rarely triggered because showSaveDialog
-	 * with filters automatically appends .ipynb extensions. However, this method serves
-	 * as a safety net for several edge cases:
-	 *
-	 * 1. "All Files" filter selection - Users can bypass .ipynb filter and type any extension
-	 * 2. Platform differences - File dialog behavior varies across Windows/Mac/Linux
-	 * 3. Programmatic usage - Other code calling saveAs() with pre-constructed URIs
-	 * 4. VS Code dialog bugs - Known issues with extension preservation in showSaveDialog
-	 *
-	 * This defensive approach ensures consistent behavior regardless of how the URI is obtained.
-	 */
-	private _validateAndFixFileExtension(target: URI): URI {
-		const extUri = new ExtUri(() => false);
-		const filename = extUri.basename(target);
-
-		// Check if filename has no extension (no dot at all)
-		if (filename.indexOf('.') === -1) {
-			// Auto-append extension when filename has no extension at all
-			// This happens when:
-			// - User selects "All Files" filter and types extension-less filename
-			// - Platform-specific dialog behavior doesn't auto-append
-			// - Programmatic calls with extension-less URIs
-			//
-			// Currently defaults to .ipynb since we only support one notebook type
-			// Future enhancement: When multiple extensions are supported, could:
-			// 1. Use this.viewType to determine appropriate extension
-			// 2. Show user a quick pick to choose extension
-			// 3. Use workspace/user preferences for default
-			const defaultExtension = PositronNotebookEditorInput.SUPPORTED_EXTENSIONS[0];
-			const newFilename = `${filename}${defaultExtension}`;
-
-			// Note: No notification needed here since this is rare edge case behavior
-			// and the file dialog already shows users the expected extension
-
-			return URI.joinPath(extUri.dirname(target), newFilename);
-		}
-
-		// User provided an extension - validate it (don't auto-append)
-		// This catches cases like:
-		// - "myfile.py" when user selected "All Files" filter
-		// - Platform bugs where wrong extension wasn't caught by dialog
-		// - Programmatic usage with invalid extensions
-		const hasValidExtension = PositronNotebookEditorInput.SUPPORTED_EXTENSIONS.some(ext =>
-			filename.toLowerCase().endsWith(ext)
-		);
-
-		if (!hasValidExtension) {
-			const supportedExts = PositronNotebookEditorInput.SUPPORTED_EXTENSIONS.join(', ');
-			this._notificationService.error(
-				`File extension "${filename.substring(filename.lastIndexOf('.'))}" is not supported. Please use one of: ${supportedExts}`
-			);
-			throw new Error('Invalid file extension'); // Still throw for control flow
-		}
-
-		return target;
-	}
 
 	override async resolve(_options?: IEditorOptions): Promise<IResolvedNotebookEditorModel | null> {
 		this._logService.info(this._identifier, 'resolve');

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -41,7 +41,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	static count = 0;
 
-
 	/**
 	 * Unique identifier for this specific input instance
 	 */
@@ -75,7 +74,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * @param viewType The view type for the notebook. Aka `'jupyter-notebook;`.
 	 * @param options Options for the notebook editor input.
 	 */
-	static getOrCreate(instantiationService: IInstantiationService, resource: URI, _preferredResource: URI | undefined, viewType: string, options: PositronNotebookEditorInputOptions = {}) {
+	static getOrCreate(instantiationService: IInstantiationService, resource: URI, preferredResource: URI | undefined, viewType: string, options: PositronNotebookEditorInputOptions = {}) {
 
 		// In the vscode-notebooks there is some caching work done here for looking for editors that
 		// exist etc. We may need that eventually but not now.
@@ -252,7 +251,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 			return undefined; // save cancelled
 		}
 
-
 		// Transfer the runtime session when saving an untitled notebook
 		try {
 			this._logService.debug(`Reassigning notebook session URI: ${this.resource.toString()} → ${target.toString()}`);
@@ -328,7 +326,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 		return joinPath(await this._fileDialogService.defaultFilePath(), suggestedFilename);
 	}
-
 
 	override async resolve(_options?: IEditorOptions): Promise<IResolvedNotebookEditorModel | null> {
 		this._logService.info(this._identifier, 'resolve');

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -173,7 +173,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	override getName(): string {
 		const extUri = new ExtUri(() => false);
-		return extUri.basename(this.resource) ?? localize('positronNotebookInputName', "Positron Notebook");
+		return extUri.basename(this.resource) ?? localize('positron.notebook.inputName', "Positron Notebook");
 	}
 
 	/**
@@ -240,9 +240,11 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 		// Ask the user where to save the file with proper filters
 		const target = await this._fileDialogService.showSaveDialog({
+			title: localize('positron.notebook.saveAs', "Save Notebook As"),
 			defaultUri: pathCandidate,
 			filters: [
-				{ name: 'Jupyter Notebook', extensions: ['ipynb'] }
+				// This will ensure that the saved file has the .ipynb extension.
+				{ name: localize('positron.notebook.fileType', 'Jupyter Notebook'), extensions: ['ipynb'] }
 			],
 			availableFileSystems: options?.availableFileSystems
 		});

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -102,7 +102,7 @@ test.describe('Positron notebook opening and saving', {
 		await quickInput.type(path.join(app.workspacePathOrFolder, baseFileName));
 		await quickInput.clickOkButton();
 
-		// Verify the file was saved with .ipynb extension automatically added
+		// Verify the file was saved and the .ipynb extension was automatically added
 		const expectedFileName = `${baseFileName}.ipynb`;
 		await editors.waitForActiveTab(expectedFileName, false);
 		await notebooksPositron.expectToBeVisible();

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -92,18 +92,22 @@ test.describe('Positron notebook opening and saving', {
 		// New notebooks should automatically be named "Untitled-1.ipynb" by default
 		await editors.waitForActiveTab('Untitled-1.ipynb', false);
 
-		// Save the notebook with a specific name
+		// Test save dialog functionality - save with a name that doesn't include .ipynb extension
+		// The enhanced save dialog should automatically handle extension enforcement
 		await runCommand('workbench.action.files.saveAs', { keepOpen: true });
 		await quickInput.waitForQuickInputOpened();
-		const newFileName = `saved-positron-notebook-${Math.random().toString(36).substring(7)}.ipynb`;
-		await quickInput.type(path.join(app.workspacePathOrFolder, newFileName));
+
+		// Type filename without extension to test automatic extension handling
+		const baseFileName = `saved-positron-notebook-${Math.random().toString(36).substring(7)}`;
+		await quickInput.type(path.join(app.workspacePathOrFolder, baseFileName));
 		await quickInput.clickOkButton();
 
-		// Verify the editor tab now shows the new filename instead of "Untitled" and it is a positron notebook
-		await editors.waitForActiveTab(newFileName, false);
+		// Verify the file was saved with .ipynb extension automatically added
+		const expectedFileName = `${baseFileName}.ipynb`;
+		await editors.waitForActiveTab(expectedFileName, false);
 		await notebooksPositron.expectToBeVisible();
 
 		// Keep the test workspace clean for subsequent test runs
-		await cleanup.removeTestFiles([newFileName]);
+		await cleanup.removeTestFiles([expectedFileName]);
 	});
 });


### PR DESCRIPTION
Addresses #8857.

@:notebooks

Adds proper file dialog configuration to `PositronNotebookEditorInput` to prevent users from
saving notebooks without `.ipynb` extensions. Uses VS Code's `showSaveDialog` with filters, title,
and localized labels to provide a native save experience that automatically handles extension
enforcement. The dialog's built-in extension enforcement ensures users cannot accidentally save
notebooks un-extensioned files that causes the file to display as raw json.

### Release Notes

#### New Features

#### Bug Fixes
- Properly configured the save as dialog for positron notebooks to prevent mangled file names

### QA Notes

Updated the positron notebook save e2e test to make sure this behavior is working. At least for the case of saving without a file extension. 

Test the enhanced save dialog by creating a new untitled notebook and saving it. The dialog
should provide a native experience with proper labeling and automatic extension handling.

1. Create a new untitled notebook
2. Add some content (e.g., a code cell with `print("test")`)
3. Use "Save As" and observe:
   - Dialog shows "Save Notebook As" title
   - Type `mynotebook` (should automatically become `mynotebook.ipynb`)

Expected behavior: The save dialog automatically enforces`.ipynb` extensions, preventing users from accidentally saving raw JSON notebook content.