### PR TITLE
Update rstudio.rstudio-workbench to 1.5.67 for 2025.08.1 patch

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,14 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "build/secrets/.secrets.baseline"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1653,6 +1645,15 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/api/node/loopbackServer.ts": [
+      {
+        "type": "AWS Access Key",
+        "filename": "src/vs/workbench/api/node/loopbackServer.ts",
+        "hashed_secret": "094ab4147707513f945937285ac0a6ef8472a356",
+        "is_verified": false,
+        "line_number": 184
+      }
+    ],
     "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1721,6 +1722,15 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 96
+      }
+    ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
@@ -1770,5 +1780,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-06T17:26:02Z"
+  "generated_at": "2025-08-06T19:15:53Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -95,6 +95,10 @@
       "filename": "build/secrets/.secrets.baseline"
     },
     {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1165,7 +1169,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "26ed1bbc63a0b36978ff0acd9c35193146bf0327",
+        "hashed_secret": "b62fa8cef25f84ac3cbe965001c576001a09d049",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1649,16 +1653,6 @@
         "is_secret": false
       }
     ],
-    "src/vs/workbench/api/node/loopbackServer.ts": [
-      {
-        "type": "AWS Access Key",
-        "filename": "src/vs/workbench/api/node/loopbackServer.ts",
-        "hashed_secret": "094ab4147707513f945937285ac0a6ef8472a356",
-        "is_verified": false,
-        "line_number": 184,
-        "is_secret": false
-      }
-    ],
     "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1727,16 +1721,6 @@
         "is_secret": false
       }
     ],
-    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
-      {
-        "type": "IBM Cloud IAM Key",
-        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
-        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
-        "is_verified": false,
-        "line_number": 96,
-        "is_secret": false
-      }
-    ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
@@ -1786,5 +1770,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-01T19:57:57Z"
+  "generated_at": "2025-08-06T17:26:02Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.66",
+			"version": "1.5.67",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "6bf65a445572cf18ef9bc832e9c56e5313674fedb0e5260db2e203e03f147ba7",
+			"sha256": "f716664a9579469ef98534b85df429c3f72097344333d993188d7ff0ec527c48",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Update Workbench Ext to 1.5.67 with sha256 hash f716664a9579469ef98534b85df429c3f72097344333d993188d7ff0ec527c48

Also update secrets baseline with detect secrets audit.

