### PR TITLE
Add sorting to summary panel

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -26,11 +26,11 @@ export interface SummaryRowActionBarProps {
 export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	const filterRef = useRef<ActionBarFilterHandle>(null);
 	// State to hold the search text typed by the user
-	const [searchText, setSearchText] = useState('');
+	const [searchText, setSearchText] = useState(instance.searchText || '');
 	// State to hold the debounced search text that we use to filter data.
 	const [debouncedSearchText, setDebouncedSearchText] = useState('');
 	// State to hold the current sort option
-	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(SearchSchemaSortOrder.Original);
+	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(instance.sortOption || SearchSchemaSortOrder.Original);
 
 	/**
 	 * Update the debounced search text after a delay.
@@ -56,13 +56,22 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	}, [debouncedSearchText, instance]);
 
 	/**
+	 * Whenever the sort option changes, we request the summary data grid instance to
+	 * re-fetch the data with the new sort option.
+	 */
+	useEffect(() => {
+		const updateSortOption = async () => {
+			await instance.setSortOption(sortOption);
+		};
+		updateSortOption();
+	}, [sortOption, instance]);
+
+	/**
 	 * Update the sort option when the user selects a new sort option from the dropdown.
 	 * @param newSortOption The new sort option selected by the user.
 	 */
 	const handleSortChanged = (newSortOption: SearchSchemaSortOrder) => {
 		setSortOption(newSortOption);
-		// TODO: Implement sorting logic in the TableSummaryDataGridInstance
-		// instance.setSortOption(newSortOption);
 	};
 
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -13,7 +13,7 @@ import { PositronActionBar } from '../../../../../../../platform/positronActionB
 import { PositronActionBarContextProvider } from '../../../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { ActionBarRegion } from '../../../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../../../platform/positronActionBar/browser/components/actionBarFilter.js';
-import { SummaryRowSortOption } from '../../../../../../services/positronDataExplorer/common/tableSummaryCache.js';
+import { SearchSchemaSortOrder } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 
 // This is the debounce time for the search input in milliseconds.
 // It allows the user to type without triggering a search on every keystroke.
@@ -30,7 +30,7 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	// State to hold the debounced search text that we use to filter data.
 	const [debouncedSearchText, setDebouncedSearchText] = useState('');
 	// State to hold the current sort option
-	const [sortOption, setSortOption] = useState<SummaryRowSortOption>(SummaryRowSortOption.Original);
+	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(SearchSchemaSortOrder.Original);
 
 	/**
 	 * Update the debounced search text after a delay.
@@ -59,7 +59,7 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	 * Update the sort option when the user selects a new sort option from the dropdown.
 	 * @param newSortOption The new sort option selected by the user.
 	 */
-	const handleSortChanged = (newSortOption: SummaryRowSortOption) => {
+	const handleSortChanged = (newSortOption: SearchSchemaSortOrder) => {
 		setSortOption(newSortOption);
 		// TODO: Implement sorting logic in the TableSummaryDataGridInstance
 		// instance.setSortOption(newSortOption);

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -13,6 +13,7 @@ import { PositronActionBar } from '../../../../../../../platform/positronActionB
 import { PositronActionBarContextProvider } from '../../../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { ActionBarRegion } from '../../../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../../../platform/positronActionBar/browser/components/actionBarFilter.js';
+import { SummaryRowSortOption } from '../../../../../../services/positronDataExplorer/common/tableSummaryCache.js';
 
 // This is the debounce time for the search input in milliseconds.
 // It allows the user to type without triggering a search on every keystroke.
@@ -28,6 +29,8 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	const [searchText, setSearchText] = useState('');
 	// State to hold the debounced search text that we use to filter data.
 	const [debouncedSearchText, setDebouncedSearchText] = useState('');
+	// State to hold the current sort option
+	const [sortOption, setSortOption] = useState<SummaryRowSortOption>(SummaryRowSortOption.Original);
 
 	/**
 	 * Update the debounced search text after a delay.
@@ -52,18 +55,31 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 		search();
 	}, [debouncedSearchText, instance]);
 
+	/**
+	 * Update the sort option when the user selects a new sort option from the dropdown.
+	 * @param newSortOption The new sort option selected by the user.
+	 */
+	const handleSortChanged = (newSortOption: SummaryRowSortOption) => {
+		setSortOption(newSortOption);
+		// TODO: Implement sorting logic in the TableSummaryDataGridInstance
+		// instance.setSortOption(newSortOption);
+	};
+
 
 	return (
 		<div className='summary-row-filter-bar'>
 			<PositronActionBarContextProvider>
-				<PositronActionBar>
+				<PositronActionBar paddingLeft={8} paddingRight={14}>
 					<ActionBarRegion location='left'>
-						<SummaryRowSortDropdown />
+						<SummaryRowSortDropdown
+							currentSort={sortOption}
+							onSortChanged={handleSortChanged}
+						/>
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarFilter
 							ref={filterRef}
-							width={150}
+							width={140}
 							onFilterTextChanged={filterText => setSearchText(filterText)} />
 					</ActionBarRegion>
 				</PositronActionBar>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.css
@@ -2,7 +2,3 @@
  *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-
-.summary-row-sort-dropdown-container {
-	margin-left: 8px
-}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
@@ -3,14 +3,88 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React from 'react';
-
 import './summaryRowSortDropdown.css';
 
-export const SummaryRowSortDropdown = () => {
+import React from 'react';
+
+import { ActionBarMenuButton } from '../../../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
+import { localize } from '../../../../../../../nls.js';
+import { SummaryRowSortOption } from '../../../../../../services/positronDataExplorer/common/tableSummaryCache.js';
+
+/**
+ * Localized strings.
+ */
+const positronDataExplorerSummarySort = localize('positron.dataExplorer.sort', "Sort summary row data");
+const positronSortByOriginal = localize('positron.dataExplorer.sortByOriginal', "Sort by Original");
+const positronSortByNameAsc = localize('positron.dataExplorer.sortByNameAsc', "Sort by Name, Ascending");
+const positronSortByNameDesc = localize('positron.dataExplorer.sortByNameDesc', "Sort by Name, Descending");
+const positronSortByTypeAsc = localize('positron.dataExplorer.sortByTypeAsc', "Sort by Type, Ascending");
+const positronSortByTypeDesc = localize('positron.dataExplorer.sortByTypeDesc', "Sort by Type, Descending");
+
+const sortOptions = [
+	{
+		id: SummaryRowSortOption.Original,
+		label: positronSortByOriginal,
+		option: SummaryRowSortOption.Original
+	},
+	{
+		id: SummaryRowSortOption.NameAscending,
+		label: positronSortByNameAsc,
+		option: SummaryRowSortOption.NameAscending
+	},
+	{
+		id: SummaryRowSortOption.NameDescending,
+		label: positronSortByNameDesc,
+		option: SummaryRowSortOption.NameDescending
+	},
+	{
+		id: SummaryRowSortOption.TypeAscending,
+		label: positronSortByTypeAsc,
+		option: SummaryRowSortOption.TypeAscending
+	},
+	{
+		id: SummaryRowSortOption.TypeDescending,
+		label: positronSortByTypeDesc,
+		option: SummaryRowSortOption.TypeDescending
+	}
+];
+
+// create a map of sort id to sort label for the dropdown
+const sortLabelMap = new Map(
+	sortOptions.map(option => [option.id, option.label])
+);
+
+/**
+ * SummaryRowSortDropdownProps interface.
+ */
+export interface SummaryRowSortDropdownProps {
+	currentSort: SummaryRowSortOption; // TODO: replace with backend supported option or map to backend supported options
+	onSortChanged: (sortOption: SummaryRowSortOption) => void;
+}
+
+export const SummaryRowSortDropdown = ({ currentSort, onSortChanged }: SummaryRowSortDropdownProps) => {
+	// Get the label for the current sort option
+	const currentSortLabel = sortLabelMap.get(currentSort) || positronSortByOriginal;
+
+	// Builds the actions.
+	const actions = () => {
+		return sortOptions.map(sortOption => ({
+			class: undefined,
+			id: sortOption.id,
+			label: sortOption.label,
+			tooltip: sortOption.label,
+			enabled: true,
+			checked: currentSort === sortOption.option,
+			run: () => { onSortChanged(sortOption.option) }
+		}));
+	};
+
 	return (
-		<div className='summary-row-sort-dropdown-container'>
-			<span>Sort by original</span>
-		</div>
+		<ActionBarMenuButton
+			actions={actions}
+			ariaLabel={positronDataExplorerSummarySort}
+			label={currentSortLabel}
+			tooltip={positronDataExplorerSummarySort}
+		/>
 	);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
@@ -9,8 +9,7 @@ import React from 'react';
 
 import { ActionBarMenuButton } from '../../../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { localize } from '../../../../../../../nls.js';
-import { SummaryRowSortOption } from '../../../../../../services/positronDataExplorer/common/tableSummaryCache.js';
-
+import { SearchSchemaSortOrder } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 /**
  * Localized strings.
  */
@@ -23,30 +22,30 @@ const positronSortByTypeDesc = localize('positron.dataExplorer.sortByTypeDesc', 
 
 const sortOptions = [
 	{
-		id: SummaryRowSortOption.Original,
+		id: SearchSchemaSortOrder.Original,
 		label: positronSortByOriginal,
-		option: SummaryRowSortOption.Original
+		option: SearchSchemaSortOrder.Original
 	},
 	{
-		id: SummaryRowSortOption.NameAscending,
+		id: SearchSchemaSortOrder.AscendingName,
 		label: positronSortByNameAsc,
-		option: SummaryRowSortOption.NameAscending
+		option: SearchSchemaSortOrder.AscendingName
 	},
 	{
-		id: SummaryRowSortOption.NameDescending,
+		id: SearchSchemaSortOrder.DescendingName,
 		label: positronSortByNameDesc,
-		option: SummaryRowSortOption.NameDescending
+		option: SearchSchemaSortOrder.DescendingName
 	},
 	{
-		id: SummaryRowSortOption.TypeAscending,
+		id: SearchSchemaSortOrder.AscendingType,
 		label: positronSortByTypeAsc,
-		option: SummaryRowSortOption.TypeAscending
+		option: SearchSchemaSortOrder.AscendingType
 	},
 	{
-		id: SummaryRowSortOption.TypeDescending,
+		id: SearchSchemaSortOrder.DescendingType,
 		label: positronSortByTypeDesc,
-		option: SummaryRowSortOption.TypeDescending
-	}
+		option: SearchSchemaSortOrder.DescendingType
+	},
 ];
 
 // create a map of sort id to sort label for the dropdown
@@ -58,8 +57,8 @@ const sortLabelMap = new Map(
  * SummaryRowSortDropdownProps interface.
  */
 export interface SummaryRowSortDropdownProps {
-	currentSort: SummaryRowSortOption; // TODO: replace with backend supported option or map to backend supported options
-	onSortChanged: (sortOption: SummaryRowSortOption) => void;
+	currentSort: SearchSchemaSortOrder;
+	onSortChanged: (sortOption: SearchSchemaSortOrder) => void;
 }
 
 export const SummaryRowSortDropdown = ({ currentSort, onSortChanged }: SummaryRowSortDropdownProps) => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -9,7 +9,7 @@ import React, { JSX } from 'react';
 // Other dependencies.
 import { Emitter } from '../../../../base/common/event.js';
 import { DataGridInstance } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
-import { TableSummaryCache } from '../common/tableSummaryCache.js';
+import { SummaryRowSortOption, TableSummaryCache } from '../common/tableSummaryCache.js';
 import { ColumnSummaryCell } from './components/columnSummaryCell.js';
 import { BackendState, ColumnDisplayType } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { DataExplorerClientInstance } from '../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
@@ -43,6 +43,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * The current column name search filter text.
 	 */
 	private _searchText?: string;
+
+	/**
+	 * The current sort option for the summary rows
+	 */
+	private _sortOption?: SummaryRowSortOption // TODO: replace with backend supported sort options type
 
 	/**
 	 * The onDidSelectColumn event emitter.
@@ -207,6 +212,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			await this._tableSummaryCache.update({
 				invalidateCache: !!invalidateCache,
 				searchText: this._searchText,
+				sortOption: this._sortOption,
 				firstColumnIndex: rowDescriptor.rowIndex,
 				screenColumns: this.screenRows
 			});
@@ -396,6 +402,15 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		this._searchText = searchText || undefined;
 		// Invalidate the cache when the search text is cleared
 		await this.fetchData(!this._searchText);
+	}
+
+	/**
+	 * Sets the sort option for the summary rows.
+	 * @param sortOption The sort option used to order the rows.
+	 */
+	async setSortOption(sortOption: SummaryRowSortOption): Promise<void> {
+		this._sortOption = sortOption;
+		await this.fetchData();
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -9,9 +9,9 @@ import React, { JSX } from 'react';
 // Other dependencies.
 import { Emitter } from '../../../../base/common/event.js';
 import { DataGridInstance } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
-import { SummaryRowSortOption, TableSummaryCache } from '../common/tableSummaryCache.js';
+import { TableSummaryCache } from '../common/tableSummaryCache.js';
 import { ColumnSummaryCell } from './components/columnSummaryCell.js';
-import { BackendState, ColumnDisplayType } from '../../languageRuntime/common/positronDataExplorerComm.js';
+import { BackendState, ColumnDisplayType, SearchSchemaSortOrder } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { DataExplorerClientInstance } from '../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { COLUMN_PROFILE_DATE_LINE_COUNT } from './components/columnProfileDate.js';
 import { COLUMN_PROFILE_NUMBER_LINE_COUNT } from './components/columnProfileNumber.js';
@@ -46,8 +46,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 	/**
 	 * The current sort option for the summary rows
+	 *
+	 * If no sort option is set, the summary rows
+	 * are displayed in their original order.
 	 */
-	private _sortOption?: SummaryRowSortOption // TODO: replace with backend supported sort options type
+	private _sortOption?: SearchSchemaSortOrder;
 
 	/**
 	 * The onDidSelectColumn event emitter.
@@ -408,7 +411,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * Sets the sort option for the summary rows.
 	 * @param sortOption The sort option used to order the rows.
 	 */
-	async setSortOption(sortOption: SummaryRowSortOption): Promise<void> {
+	async setSortOption(sortOption: SearchSchemaSortOrder): Promise<void> {
 		this._sortOption = sortOption;
 		await this.fetchData();
 	}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -184,6 +184,20 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Gets the search text.
+	 */
+	get searchText() {
+		return this._searchText;
+	}
+
+	/**
+	 * Gets the sort option.
+	 */
+	get sortOption() {
+		return this._sortOption;
+	}
+
+	/**
 	 * Gets the scroll width.
 	 */
 	override get scrollWidth() {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -21,6 +21,7 @@ import { COLUMN_PROFILE_BOOLEAN_LINE_COUNT } from './components/columnProfileBoo
 import { COLUMN_PROFILE_DATE_TIME_LINE_COUNT } from './components/columnProfileDatetime.js';
 import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 import { PositronReactServices } from '../../../../base/browser/positronReactServices.js';
+import { summaryPanelEnhancementsFeatureEnabled } from '../common/positronDataExplorerSummaryEnhancementsFeatureFlag.js';
 
 /**
  * Constants.
@@ -225,14 +226,21 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 */
 	override async fetchData(invalidateCache?: boolean) {
 		const rowDescriptor = this.firstRow;
+		const showSummaryPanelEnhancements = summaryPanelEnhancementsFeatureEnabled(this._services.configurationService);
 		if (rowDescriptor) {
-			await this._tableSummaryCache.update({
-				invalidateCache: !!invalidateCache,
-				searchText: this._searchText,
-				sortOption: this._sortOption,
-				firstColumnIndex: rowDescriptor.rowIndex,
-				screenColumns: this.screenRows
-			});
+			showSummaryPanelEnhancements
+				? await this._tableSummaryCache.update2({
+					invalidateCache: !!invalidateCache,
+					searchText: this._searchText,
+					sortOption: this._sortOption,
+					firstColumnIndex: rowDescriptor.rowIndex,
+					screenColumns: this.screenRows
+				})
+				: await this._tableSummaryCache.update({
+					invalidateCache: !!invalidateCache,
+					firstColumnIndex: rowDescriptor.rowIndex,
+					screenColumns: this.screenRows
+				});
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -32,6 +32,9 @@ import {
 	ReturnColumnProfilesEvent,
 	RowFilter,
 	SchemaUpdateEvent,
+	SearchSchemaParams,
+	SearchSchemaResult,
+	SearchSchemaSortOrder,
 	SetColumnFiltersParams,
 	SetRowFiltersParams,
 	SetSortColumnsParams,
@@ -57,6 +60,7 @@ export interface DataExplorerRpc {
 	uri?: string;
 	params: OpenDatasetParams |
 	GetSchemaParams |
+	SearchSchemaParams |
 	GetDataValuesParams |
 	GetRowLabelsParams |
 	GetColumnProfilesParams |
@@ -173,6 +177,17 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 			method: DataExplorerBackendRequest.GetSchema,
 			uri: this.uri.toString(),
 			params: { column_indices: columnIndices } satisfies GetSchemaParams
+		});
+	}
+
+	async searchSchema(filters: Array<ColumnFilter>, sortOrder: SearchSchemaSortOrder): Promise<SearchSchemaResult> {
+		return this._execRpc<SearchSchemaResult>({
+			method: DataExplorerBackendRequest.SearchSchema,
+			uri: this.uri.toString(),
+			params: {
+				filters: filters,
+				sort_order: sortOrder
+			} satisfies SearchSchemaParams
 		});
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -416,27 +416,24 @@ export class TableSummaryCache extends Disposable {
 			);
 			const viewableColumns = searchResult.matches.slice(viewableStartIndex, viewableEndIndex + 1);
 
-			// If the cache is invalidated we will need to load all the columns in view into the cache again
-			// otherwise, we just need the missing columns should be in view.
+			// If the cache is invalidated we will need to load all the columns in view into
+			// the cache again otherwise, we just need the missing columns should be in view.
 			// The cache will be updated with the data for the columns in `columnIndices`
 			columnIndices = invalidateCache
-				? viewableColumns.filter(columnIndex => !this._columnSchemaCache.has(columnIndex))
-				: viewableColumns;
+				? viewableColumns
+				: viewableColumns.filter(columnIndex => !this._columnSchemaCache.has(columnIndex));
 		} else if (!searchResult || searchResult.matches.length === 0) {
 			// No search results, which means we have nothing to cache
 			columnIndices = [];
 		} else {
+			const viewableColumns = arrayFromIndexRange(startColumnIndex, endColumnIndex);
 			if (invalidateCache) {
 				// No search/sort, so we need indices of all columns in viewable range
 				// since we're clearing and replacing the caches
-				columnIndices = arrayFromIndexRange(startColumnIndex, endColumnIndex);
+				columnIndices = viewableColumns;
 			} else {
 				// No search/sort, get all column indices in viewable range that aren't already cached
-				for (let columnIndex = startColumnIndex; columnIndex <= endColumnIndex; columnIndex++) {
-					if (!this._columnSchemaCache.has(columnIndex)) {
-						columnIndices.push(columnIndex);
-					}
-				}
+				columnIndices = viewableColumns.filter(columnIndex => !this._columnSchemaCache.has(columnIndex));
 			}
 		}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -22,11 +22,34 @@ const SMALL_FREQUENCY_TABLE_LIMIT = 8;
 const LARGE_FREQUENCY_TABLE_LIMIT = 16;
 
 /**
+ * TODO: replace with backend supported sort options type
+ *
+ * Enum options for sorting the summary row.
+ *
+ * These options are used to determine how the summary row data should be sorted.
+ *
+ * Each option corresponds to a specific sorting criterion:
+ * - Original: No sorting, uses the original order of the data
+ * - NameAscending: Sort by name in ascending order
+ * - NameDescending: Sort by name in descending order
+ * - TypeAscending: Sort by the data type of the column field in ascending order, e.g. boolean, number, string
+ * - TypeDescending: Sort by the data type of the column field in descending order, e.g. string, number, boolean
+ */
+export enum SummaryRowSortOption {
+	Original = 'original',
+	NameAscending = 'name-asc',
+	NameDescending = 'name-desc',
+	TypeAscending = 'type-asc',
+	TypeDescending = 'type-desc'
+}
+
+/**
  * UpdateDescriptor interface.
  */
 interface UpdateDescriptor {
 	invalidateCache: boolean;
 	searchText?: string;
+	sortOption?: SummaryRowSortOption;
 	firstColumnIndex: number;
 	screenColumns: number;
 }
@@ -58,6 +81,11 @@ export class TableSummaryCache extends Disposable {
 	 * to avoid unnecessary cache updates when the search text has not changed.
 	 */
 	private _searchText?: string;
+
+	/**
+	 * The sort option used to order the summary rows.
+	 */
+	private _sortOption?: SummaryRowSortOption;
 
 	/**
 	 * Gets or sets the columns.
@@ -216,10 +244,12 @@ export class TableSummaryCache extends Disposable {
 		const {
 			invalidateCache,
 			searchText,
+			sortOption,
 			firstColumnIndex,
 			screenColumns
 		} = updateDescriptor;
 
+		this._sortOption = sortOption;
 		const searchTextChanged = searchText !== this._searchText;
 		this._searchText = searchText;
 
@@ -261,6 +291,7 @@ export class TableSummaryCache extends Disposable {
 		const tableSchema = this._searchText
 			? await this._dataExplorerClientInstance.searchSchema({
 				searchText: this._searchText,
+				//sortOption: this._sortOption ?? SummaryRowSortOption.Original,
 				startIndex: columnIndices[0],
 				numColumns: columnIndices[columnIndices.length - 1] - columnIndices[0] + 1
 			})

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -461,9 +461,8 @@ export class TableSummaryCache extends Disposable {
 					}
 
 					// Cache the column schema
-					for (let i = 0; i < tableSchema.columns.length; i++) {
-						const columnIndex = columnIndices[i];
-						this._columnSchemaCache.set(columnIndex, tableSchema.columns[i]);
+					for (const columnSchema of tableSchema.columns) {
+						this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
 					}
 				}
 
@@ -488,9 +487,9 @@ export class TableSummaryCache extends Disposable {
 					this._columnProfileCache.clear();
 				}
 
-				// Cache the column schema that was returned
-				for (let i = 0; i < tableSchema.columns.length; i++) {
-					this._columnSchemaCache.set(columnIndices[i], tableSchema.columns[i]);
+				// Cache the column schema
+				for (const columnSchema of tableSchema.columns) {
+					this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
 				}
 			}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -9,7 +9,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { arrayFromIndexRange } from './utils.js';
 import { DataExplorerClientInstance } from '../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { dataExplorerExperimentalFeatureEnabled } from './positronDataExplorerExperimentalConfig.js';
-import { ColumnDisplayType, ColumnHistogramParamsMethod, ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema } from '../../languageRuntime/common/positronDataExplorerComm.js';
+import { ColumnDisplayType, ColumnHistogramParamsMethod, ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema, SearchSchemaSortOrder } from '../../languageRuntime/common/positronDataExplorerComm.js';
 
 /**
  * Constants.
@@ -22,34 +22,12 @@ const SMALL_FREQUENCY_TABLE_LIMIT = 8;
 const LARGE_FREQUENCY_TABLE_LIMIT = 16;
 
 /**
- * TODO: replace with backend supported sort options type
- *
- * Enum options for sorting the summary row.
- *
- * These options are used to determine how the summary row data should be sorted.
- *
- * Each option corresponds to a specific sorting criterion:
- * - Original: No sorting, uses the original order of the data
- * - NameAscending: Sort by name in ascending order
- * - NameDescending: Sort by name in descending order
- * - TypeAscending: Sort by the data type of the column field in ascending order, e.g. boolean, number, string
- * - TypeDescending: Sort by the data type of the column field in descending order, e.g. string, number, boolean
- */
-export enum SummaryRowSortOption {
-	Original = 'original',
-	NameAscending = 'name-asc',
-	NameDescending = 'name-desc',
-	TypeAscending = 'type-asc',
-	TypeDescending = 'type-desc'
-}
-
-/**
  * UpdateDescriptor interface.
  */
 interface UpdateDescriptor {
 	invalidateCache: boolean;
 	searchText?: string;
-	sortOption?: SummaryRowSortOption;
+	sortOption?: SearchSchemaSortOrder;
 	firstColumnIndex: number;
 	screenColumns: number;
 }
@@ -85,7 +63,7 @@ export class TableSummaryCache extends Disposable {
 	/**
 	 * The sort option used to order the summary rows.
 	 */
-	private _sortOption?: SummaryRowSortOption;
+	private _sortOption?: SearchSchemaSortOrder;
 
 	/**
 	 * Gets or sets the columns.
@@ -291,7 +269,7 @@ export class TableSummaryCache extends Disposable {
 		const tableSchema = this._searchText
 			? await this._dataExplorerClientInstance.searchSchema({
 				searchText: this._searchText,
-				//sortOption: this._sortOption ?? SummaryRowSortOption.Original,
+				//sortOption: this._sortOption,
 				startIndex: columnIndices[0],
 				numColumns: columnIndices[columnIndices.length - 1] - columnIndices[0] + 1
 			})


### PR DESCRIPTION
Addresses #8533 #8534 #8806

To view these changes, set `"dataExplorer.summaryPanelEnhancements": true` in your settings.json file.

This PR adds the dropdown for sorting the summary panel rows and switches the summary panel to use the search/sort backend implementation when the feature flag is on. Searching and sorting the summary panel rows should be _mostly_ functional. The UI will still have some bugs (expanding/collapsing a specific column, and scrollbar management) but these changes can be resolved after we have the changes for pinning columns in the layout manager.

This PR also adds additional safety checks to make sure that changes behind the feature flag do not effect the behavior of the data explorer when the feature flag is off since much of the foundational logic will be changing. We will be maintaining two code paths until this feature is complete.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:data-explorer @:web @:win @:duck-db