### PR TITLE
Reticulate: Reload settings on Web tests

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -21,7 +21,7 @@ test.describe('Reticulate', {
 		try {
 			await settings.set({
 				'positron.reticulate.enabled': true
-			});
+			}, { 'reload': 'web' });
 
 		} catch (e) {
 			await app.code.driver.takeScreenshot('reticulateSetup');

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -21,7 +21,7 @@ test.describe('Reticulate', {
 		try {
 			await settings.set({
 				'positron.reticulate.enabled': true
-			});
+			}, { 'reload': 'web' });
 
 		} catch (e) {
 			await app.code.driver.takeScreenshot('reticulateSetup');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

CI failed with: 


![](https://d38p2avprg8il3.cloudfront.net/playwright-report-16806052508-9344/data/8568a245645d0eda14c5e1df8cc4e0327021e3be.png)

It looks like the reticulate integration wasn't yet enabled when real_python() was executed. This PR tries to fix it.

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:web @:reticulate