### PR TITLE
Resolve keybinding conflict for code cells in `.R` files

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -485,7 +485,7 @@
         "command": "r.sourceCurrentFile",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorLangId == r && !isRPackage"
+        "when": "editorLangId == r && !isRPackage && !positron.hasCodeCells"
       },
       {
         "command": "r.insertSection",


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8637


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Resolve keyboard shortcut conflict for code cells in `.R` files (https://github.com/posit-dev/positron/issues/8637)


### QA Notes

If you have R code like this in a regular `.R` file, with your cursor in one of the code cells:

```r
# %%
plot(1:10)

# %%
sample(1:100, 10)

# %%
plot(pressure)
```

the keyboard shortcut <kbd>Cmd/Ctrl+Shift+Enter</kbd> should run the current code cell, and should _not_ `source()` the current file. You can still `source()` the current file from the editor action bar, the context menu, the command palette, etc.
