### PR TITLE
Data Explorer: Upgrade positron-duckdb to duckdb-wasm 1.29.1-dev132.0 to pull in upstream DuckDB bug fixes

### DIFF
--- a/extensions/positron-duckdb/package-lock.json
+++ b/extensions/positron-duckdb/package-lock.json
@@ -8,7 +8,7 @@
       "name": "positron-duckdb",
       "version": "0.0.1",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "1.29.0",
+        "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
         "apache-arrow": "^16.0.0",
         "web-worker": "^1.3.0"
       },
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.0.tgz",
-      "integrity": "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q==",
+      "version": "1.29.1-dev132.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.1-dev132.0.tgz",
+      "integrity": "sha512-OUkJuH9564GQ/OgggdgJ/Yxmlk5PYnWiJe0rrNkEs0Sfsi00nK6WZgJmWGGAtCK6le2KJxFWZ4Z2MjUKGBzLuQ==",
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^17.0.0"

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -32,7 +32,7 @@
     "@vscode/vsce": "^3.3.2"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.29.0",
+    "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
     "apache-arrow": "^16.0.0",
     "web-worker": "^1.3.0"
   },


### PR DESCRIPTION
This addresses the failure with a troublesome Parquet file in #8808.

@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix issues opening certain atypical Parquet files via the File Explorer pane in the Data Explorer.

### QA Notes

You can check that the file created by the R example code in #8808 can be opened successfully.
