### PR TITLE
Assistant: Optimize token usage for Bedrock

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -14,7 +14,7 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@ai-sdk/amazon-bedrock": "^1.1.6",
+        "@ai-sdk/amazon-bedrock": "2.2.12",
         "@ai-sdk/anthropic": "^1.0.5",
         "@ai-sdk/azure": "^1.1.9",
         "@ai-sdk/google": "^1.1.17",
@@ -44,21 +44,54 @@
       }
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-1.1.6.tgz",
-      "integrity": "sha512-h6SJWpku+i8OsSz0A4RT2g2uD+3E0SUgWHsWRIpxmPNgM1DnH6lgSby5sxqAZDY5xJyJtRFW5vB9G3GEBjHy/g==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.12.tgz",
+      "integrity": "sha512-m8gARnh45pr1s08Uu4J/Pm8913mwJPejPOm59b+kUqMsP9ilhUtH/bp8432Ra/v+vHuMoBrglG2ZvXtctAaH2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.7",
-        "@ai-sdk/provider-utils": "2.1.6",
-        "@aws-sdk/client-bedrock-runtime": "^3.663.0"
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@smithy/eventstream-codec": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "aws4fetch": "^1.0.20"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -540,408 +573,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.755.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.755.0.tgz",
-      "integrity": "sha512-g5Adp2haJn3d1M7he4KSBUO/QAJuDNhnCNSZ4Ud30F0WvX07C7nZUDzKOi8cYa8xeXK6gpSlk6DdgcJflXdfXA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-node": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/eventstream-serde-browser": "^4.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-        "@smithy/eventstream-serde-node": "^4.0.1",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.1.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.750.0.tgz",
-      "integrity": "sha512-y0Rx6pTQXw0E61CaptpZF65qNggjqOgymq/RYZU5vWba5DGQ+iqGt8Yq8s+jfBoBBNXshxq8l8Dl5Uq/JTY1wg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.750.0.tgz",
-      "integrity": "sha512-In6bsG0p/P31HcH4DBRKBbcDS/3SHvEPjfXV8ODPWZO/l3/p7IRoYBdQ07C9R+VMZU2D0+/Sc/DWK/TUNDk1+Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.750.0.tgz",
-      "integrity": "sha512-wFB9qqfa20AB0dElsQz5ZlZT5o+a+XzpEpmg0erylmGYqEOvh8NQWfDUVpRmQuGq9VbvW/8cIbxPoNqEbPtuWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.750.0.tgz",
-      "integrity": "sha512-2YIZmyEr5RUd3uxXpxOLD9G67Bibm4I/65M6vKFP17jVMUT+R1nL7mKqmhEVO2p+BoeV+bwMyJ/jpTYG368PCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.750.0.tgz",
-      "integrity": "sha512-THWHHAceLwsOiowPEmKyhWVDlEUxH07GHSw5AQFDvNQtGKOQl0HSIFO1mKObT2Q2Vqzji9Bq8H58SO5BFtNPRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-ini": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.750.0.tgz",
-      "integrity": "sha512-Q78SCH1n0m7tpu36sJwfrUSxI8l611OyysjQeMiIOliVfZICEoHcLHLcLkiR+tnIpZ3rk7d2EQ6R1jwlXnalMQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.750.0.tgz",
-      "integrity": "sha512-FGYrDjXN/FOQVi/t8fHSv8zCk+NEvtFnuc4cZUj5OIbM4vrfFc5VaPyn41Uza3iv6Qq9rZg0QOwWnqK8lNrqUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.750.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/token-providers": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.750.0.tgz",
-      "integrity": "sha512-Nz8zs3YJ+GOTSrq+LyzbbC1Ffpt7pK38gcOyNZv76pP5MswKTUKNYBJehqwa+i7FcFQHsCk3TdhR8MT1ZR23uA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.750.0.tgz",
-      "integrity": "sha512-YYcslDsP5+2NZoN3UwuhZGkhAHPSli7HlJHBafBrvjGV/I9f8FuOO1d1ebxGdEP4HyRXUGyh+7Ur4q+Psk0ryw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.750.0.tgz",
-      "integrity": "sha512-OH68BRF0rt9nDloq4zsfeHI0G21lj11a66qosaljtEP66PWm7tQ06feKbFkXHT5E1K3QhJW3nVyK8v2fEBY5fg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.750.0.tgz",
-      "integrity": "sha512-X/KzqZw41iWolwNdc8e3RMcNSMR364viHv78u6AefXOO5eRM40c4/LuST1jDzq35/LpnqRhL7/MuixOetw+sFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.743.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-      "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-endpoints": "^3.0.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.750.0.tgz",
-      "integrity": "sha512-84HJj9G9zbrHX2opLk9eHfDceB+UIHVrmflMzWHpsmo9fDuro/flIBqaVDlE021Osj6qIM0SJJcnL6s23j7JEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
@@ -1928,74 +1559,15 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
-      "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+      "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
-      "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
-      "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-      "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
-      "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2303,9 +1875,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2628,13 +2200,6 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3048,6 +2613,13 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3504,11 +3076,13 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/extend": {
@@ -4576,6 +4150,17 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5217,7 +4802,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -517,7 +517,7 @@
     "postinstall": "ts-node scripts/post-install.ts"
   },
   "devDependencies": {
-    "@ai-sdk/amazon-bedrock": "^1.1.6",
+    "@ai-sdk/amazon-bedrock": "2.2.12",
     "@ai-sdk/anthropic": "^1.0.5",
     "@ai-sdk/azure": "^1.1.9",
     "@ai-sdk/google": "^1.1.17",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -202,6 +202,14 @@
             "type": "boolean",
             "default": false,
             "description": "%configuration.showTokenUsage.description%"
+          },
+          "positron.assistant.maxOutputTokens": {
+            "type": "object",
+            "default": {},
+            "description": "%configuration.maxOutputTokens.description%",
+            "additionalProperties": {
+              "type": "number"
+            }
           }
         }
       }

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -210,6 +210,11 @@
             "additionalProperties": {
               "type": "number"
             }
+          },
+          "positron.assistant.followups.enable": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.followups.enable.description%"
           }
         }
       }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -24,5 +24,6 @@
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
 	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
 	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
-	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units."
+	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units.",
+	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses."
 }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -23,5 +23,6 @@
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
 	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
-	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage."
+	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
+	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units."
 }

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -511,7 +511,7 @@ class OpenRouterCompletion extends FimPromptCompletion {
 }
 
 class AWSCompletion extends FimPromptCompletion {
-	protected model;
+	protected model: ai.LanguageModelV1;
 
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Completion,
@@ -529,11 +529,10 @@ class AWSCompletion extends FimPromptCompletion {
 	constructor(_config: ModelConfig) {
 		super(_config);
 
+		// Cast to ai.LanguageModelV1 to satisfy base class type
 		this.model = createAmazonBedrock({
-			bedrockOptions: {
-				credentials: fromNodeProviderChain(),
-			}
-		})(this._config.model);
+			credentialProvider: fromNodeProviderChain(),
+		})(this._config.model) as unknown as ai.LanguageModelV1;
 	}
 }
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -359,7 +359,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		const outputCount = usage.completionTokens;
 		const inputCount = usage.promptTokens;
 		const requestId = (options.modelOptions as any)?.requestId;
-		log.debug(`[${this._config.name}]: input=${inputCount}, output=${outputCount}`);
+		log.debug(`[${this._config.name}]: ${inputCount} input tokens, ${outputCount} output tokens`);
 
 		if (requestId) {
 			recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
@@ -370,8 +370,10 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		}
 
 		const other = await result.providerMetadata;
-		if (other) {
-			log.debug(`[${this._config.name}]: providerMetadata=${JSON.stringify(other)}`);
+
+		// Log Bedrock usage if available
+		if (other && other.bedrock && other.bedrock.usage) {
+			log.debug(`[${this._config.name}]: Bedrock usage: ${JSON.stringify(other.bedrock.usage, null, 2)}`);
 		}
 	}
 
@@ -618,12 +620,10 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 		super(_config, _context);
 
 		this.model = createAmazonBedrock({
-			bedrockOptions: {
-				// AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN, and AWS_SECRET_ACCESS_KEY must be set
-				// sets the AWS region where the models are available
-				region: process.env.AWS_REGION ?? 'us-east-1',
-				credentials: fromNodeProviderChain(),
-			}
+			// AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN, and AWS_SECRET_ACCESS_KEY must be set
+			// sets the AWS region where the models are available
+			region: process.env.AWS_REGION ?? 'us-east-1',
+			credentialProvider: fromNodeProviderChain(),
 		})(this._config.model);
 	}
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -286,12 +286,22 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			}, {});
 		}
 
+		const modelTools = this._config.toolCalls ? tools : undefined;
+
+		log.debug(`[${this._config.name}] SEND ${aiMessages.length} messages, ${modelTools ? Object.keys(modelTools).length : 0} tools`);
+		if (modelTools) {
+			log.trace(`tools: ${modelTools ? Object.keys(modelTools).join(', ') : '(none)'}`);
+		}
+		if (modelOptions.system) {
+			log.trace(`system: ${modelOptions.system.length > 100 ? `${modelOptions.system.substring(0, 100)}...` : modelOptions.system} (${modelOptions.system.length} chars)`);
+		}
+		log.trace(`messages: ${JSON.stringify(aiMessages)}`);
 		const result = ai.streamText({
 			model: this.model,
 			system: modelOptions.system ?? undefined,
 			messages: aiMessages,
 			maxSteps: modelOptions.maxSteps ?? 50,
-			tools: this._config.toolCalls ? tools : undefined,
+			tools: modelTools,
 			abortSignal: signal,
 			maxTokens: modelOptions.maxTokens ?? this.maxOutputTokens,
 		});
@@ -339,7 +349,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		result.warnings.then((warnings) => {
 			if (warnings) {
 				for (const warning of warnings) {
-					log.warn(`${this.model} (${this.identifier}): ${warning}`);
+					log.warn(`[${this.model}] (${this.identifier}): ${warning}`);
 				}
 			}
 		});

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -344,19 +344,24 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			}
 		});
 
+		// ai-sdk provides token usage in the result but it's not clear how it is calculated
+		const usage = await result.usage;
+		const outputCount = usage.completionTokens;
+		const inputCount = usage.promptTokens;
+		const requestId = (options.modelOptions as any)?.requestId;
+		log.debug(`[${this._config.name}]: input=${inputCount}, output=${outputCount}`);
+
+		if (requestId) {
+			recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
+		}
+
 		if (this._context) {
-			// ai-sdk provides token usage in the result but it's not clear how it is calculated
-			const usage = await result.usage;
-			const outputCount = usage.completionTokens;
-			const inputCount = usage.promptTokens;
-			const requestId = (options.modelOptions as any)?.requestId;
-
 			recordTokenUsage(this._context, this.provider, inputCount, outputCount);
+		}
 
-			if (requestId) {
-				recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
-			}
-
+		const other = await result.providerMetadata;
+		if (other) {
+			log.debug(`[${this._config.name}]: providerMetadata=${JSON.stringify(other)}`);
 		}
 	}
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -272,7 +272,8 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		const processedMessages = processMessages(messages);
 		// Only Anthropic currently supports experimental_content in tool
 		// results.
-		const toolResultExperimentalContent = this.provider === 'anthropic';
+		const toolResultExperimentalContent = this.provider === 'anthropic' ||
+			this.model.modelId.startsWith('us.anthropic');
 
 		// Only select Bedrock models support cache breakpoints; specifically,
 		// the Claude 3.5 Sonnet models don't support them.

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -335,6 +335,15 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			}
 		}
 
+		// Log all the warnings from the response
+		result.warnings.then((warnings) => {
+			if (warnings) {
+				for (const warning of warnings) {
+					log.warn(`${this.model} (${this.identifier}): ${warning}`);
+				}
+			}
+		});
+
 		if (this._context) {
 			// ai-sdk provides token usage in the result but it's not clear how it is calculated
 			const usage = await result.usage;

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -624,7 +624,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 			// sets the AWS region where the models are available
 			region: process.env.AWS_REGION ?? 'us-east-1',
 			credentialProvider: fromNodeProviderChain(),
-		})(this._config.model);
+		})(this._config.model) as ai.LanguageModelV1;
 	}
 
 	get providerName(): string {

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -737,17 +737,17 @@ export const availableModels = new Map<string, { name: string; identifier: strin
 			{
 				name: 'Claude 4 Sonnet Bedrock',
 				identifier: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
-				maxOutputTokens: 64_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
+				maxOutputTokens: 8_192, // use more conservative value for Bedrock (up to 64K tokens available)
 			},
 			{
 				name: 'Claude 4 Opus Bedrock',
 				identifier: 'us.anthropic.claude-opus-4-20250514-v1:0',
-				maxOutputTokens: 32_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
+				maxOutputTokens: 8_192, // use more conservative value for Bedrock (up to 32K tokens available)
 			},
 			{
 				name: 'Claude 3.7 Sonnet v1 Bedrock',
 				identifier: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
-				maxOutputTokens: 64_000, // reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
+				maxOutputTokens: 8_192, // use more conservative value for Bedrock (up to 64K tokens available)
 			},
 			{
 				name: 'Claude 3.5 Sonnet v2 Bedrock',

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -12,10 +12,15 @@ import { log } from './extension.js';
 
 /**
  * Convert messages from VSCode Language Model format to Vercel AI format.
+ *
+ * @param messages The messages to convert.
+ * @param toolResultExperimentalContent Whether to use experimental content for tool results.
+ * @param bedrockCacheBreakpoint Whether to use Bedrock cache breakpoints.
  */
 export function toAIMessage(
 	messages: vscode.LanguageModelChatMessage2[],
-	toolResultExperimentalContent: boolean = false
+	toolResultExperimentalContent: boolean = false,
+	bedrockCacheBreakpoint: boolean = false
 ): ai.CoreMessage[] {
 	// Gather all tool call references
 	const toolCalls = messages.reduce<Record<string, vscode.LanguageModelToolCallPart>>((acc, message) => {
@@ -58,7 +63,7 @@ export function toAIMessage(
 
 				// If this is a cache breakpoint, note it in the message
 				// content. This is only used by the Bedrock provider.
-				if (cacheBreakpoint) {
+				if (cacheBreakpoint && bedrockCacheBreakpoint) {
 					messageContent.providerOptions = {
 						bedrock: {
 							cachePoint: {


### PR DESCRIPTION
This PR contains several changes intended to reduce Assistant's token usage on Bedrock. Specifically:

Add an option to override the max output tokens per model: 

<img width="461" height="182" alt="image" src="https://github.com/user-attachments/assets/486a6c59-79c7-484b-a0de-c44cb30d61c4" />

Reduce the default max output tokens for all Bedrock models to 8K.

Provide an option to turn off followup generation as this hits the LLM a second time after every query, consuming a lot of additional tokens and increasing load. Followup generation is enabled by default.

<img width="449" height="68" alt="image" src="https://github.com/user-attachments/assets/218e2f0d-154d-443c-af78-5c677fd89775" />

Add I/O trace logging to Vercel-based AI interactions, similar to what we have with Anthropic. Add some Bedrock-specific usage logging:

<img width="652" height="114" alt="image" src="https://github.com/user-attachments/assets/e5e29dab-9c75-445c-ad63-3b4b995aa819" />

For Claude 3.7+ based models, mark some user messages with cache breakpoints. This is the single most important change for token conservation. Note that this required an update of the Bedrock package for AI-SDK. 

These changes were all made with the intent of performing the minimally invasive/risky change needed for implementation given that the change is targeted for 2025.08.1. I don't love that there are now (even more) hardcoded "if this model, do this" switches in the code; a better approach would be to make some of these attributes more declarative in the model config, make Bedrock more of a first-class model provider like Anthropic, provide overloads for `toAiMessage` so we wouldn't have model-specific logic in there, etc.