### PR TITLE
Data Explorer: Implement searchSchema API for DuckDB backend

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1399,11 +1399,12 @@ END`;
 								other_count: 0
 							};
 							break;
-						case ColumnProfileType.SummaryStats:
+						case ColumnProfileType.SummaryStats: {
 							// Create null summary stats appropriate for the column type
 							const columnSchema = this.fullSchema[request.column_index];
 							result.summary_stats = this.createEmptySummaryStats(columnSchema);
 							break;
+						}
 					}
 				}
 				return result;
@@ -1791,8 +1792,9 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 				return table.setRowFilters(rpc.params as SetRowFiltersParams);
 			case DataExplorerBackendRequest.SetSortColumns:
 				return table.setSortColumns(rpc.params as SetSortColumnsParams);
-			case DataExplorerBackendRequest.SetColumnFilters:
 			case DataExplorerBackendRequest.SearchSchema:
+				return table.searchSchema(rpc.params as SearchSchemaParams);
+			case DataExplorerBackendRequest.SetColumnFilters:
 				return `${rpc.method} not yet implemented`;
 			default:
 				return `unrecognized data explorer method: ${rpc.method} `;

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -816,7 +816,7 @@ export class DuckDBTableView {
 					column_name: entry.column_name,
 					column_index: index,
 					type_name: entry.column_type,
-					type_display,
+					type_display
 				};
 			}),
 		};

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1117,7 +1117,7 @@ END`;
 					return columnValues;
 				} else {
 					// Set of values indices, just get the lower and upper extent
-					return spec.indices.map((i) => adapter(field, i));
+					return spec.indices.map(i => adapter(field, i));
 				}
 			};
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -8,6 +8,7 @@ import {
 	BackendState,
 	ColumnDisplayType,
 	ColumnFilter,
+	ColumnFilterType,
 	ColumnFrequencyTable,
 	ColumnFrequencyTableParams,
 	ColumnHistogram,
@@ -35,6 +36,7 @@ import {
 	FilterBetween,
 	FilterComparison,
 	FilterComparisonOp,
+	FilterMatchDataTypes,
 	FilterResult,
 	FilterSetMembership,
 	FilterTextSearch,
@@ -47,6 +49,9 @@ import {
 	ReturnColumnProfilesEvent,
 	RowFilter,
 	RowFilterType,
+	SearchSchemaParams,
+	SearchSchemaResult,
+	SearchSchemaSortOrder,
 	SetRowFiltersParams,
 	SetSortColumnsParams,
 	SupportStatus,
@@ -811,9 +816,122 @@ export class DuckDBTableView {
 					column_name: entry.column_name,
 					column_index: index,
 					type_name: entry.column_type,
-					type_display
+					type_display,
 				};
-			})
+			}),
+		};
+	}
+
+	async searchSchema(
+		params: SearchSchemaParams,
+	): RpcResponse<SearchSchemaResult> {
+		// Get all column indices
+		const allIndices: number[] = [];
+		for (let i = 0; i < this.fullSchema.length; i++) {
+			allIndices.push(i);
+		}
+
+		// Apply filters if any
+		let filteredIndices = allIndices;
+		if (params.filters && params.filters.length > 0) {
+			filteredIndices = allIndices.filter((index) => {
+				const entry = this.fullSchema[index];
+				const columnName = entry.column_name;
+				const columnType = entry.column_type;
+
+				// Get display type for this column
+				let displayType = SCHEMA_TYPE_MAPPING.get(columnType);
+				if (displayType === undefined) {
+					displayType = ColumnDisplayType.Unknown;
+				}
+				if (columnType.startsWith('DECIMAL')) {
+					displayType = ColumnDisplayType.Number;
+				}
+
+				// Apply each filter
+				return params.filters.every((filter) => {
+					switch (filter.filter_type) {
+						case ColumnFilterType.TextSearch: {
+							const textFilter =
+								filter.params as FilterTextSearch;
+							const searchTerm = textFilter.case_sensitive
+								? textFilter.term
+								: textFilter.term.toLowerCase();
+							const columnNameToMatch = textFilter.case_sensitive
+								? columnName
+								: columnName.toLowerCase();
+
+							switch (textFilter.search_type) {
+								case TextSearchType.Contains:
+									return columnNameToMatch.includes(
+										searchTerm,
+									);
+								case TextSearchType.NotContains:
+									return !columnNameToMatch.includes(
+										searchTerm,
+									);
+								case TextSearchType.StartsWith:
+									return columnNameToMatch.startsWith(
+										searchTerm,
+									);
+								case TextSearchType.EndsWith:
+									return columnNameToMatch.endsWith(
+										searchTerm,
+									);
+								case TextSearchType.RegexMatch:
+									try {
+										const regex = new RegExp(
+											textFilter.term,
+											textFilter.case_sensitive
+												? ''
+												: 'i',
+										);
+										return regex.test(columnName);
+									} catch {
+										return false;
+									}
+								default:
+									return false;
+							}
+						}
+						case ColumnFilterType.MatchDataTypes: {
+							const typeFilter =
+								filter.params as FilterMatchDataTypes;
+							return typeFilter.display_types.includes(
+								displayType,
+							);
+						}
+						default:
+							return false;
+					}
+				});
+			});
+		}
+
+		// Sort the filtered indices
+		switch (params.sort_order) {
+			case SearchSchemaSortOrder.Ascending:
+				filteredIndices.sort((a, b) => {
+					const nameA = this.fullSchema[a].column_name.toLowerCase();
+					const nameB = this.fullSchema[b].column_name.toLowerCase();
+					return nameA.localeCompare(nameB);
+				});
+				break;
+			case SearchSchemaSortOrder.Descending:
+				filteredIndices.sort((a, b) => {
+					const nameA = this.fullSchema[a].column_name.toLowerCase();
+					const nameB = this.fullSchema[b].column_name.toLowerCase();
+					return nameB.localeCompare(nameA);
+				});
+				break;
+			case SearchSchemaSortOrder.Original:
+			default:
+				// Keep original order
+				break;
+		}
+
+		return {
+			matches: filteredIndices,
 		};
 	}
 
@@ -999,7 +1117,7 @@ END`;
 					return columnValues;
 				} else {
 					// Set of values indices, just get the lower and upper extent
-					return spec.indices.map(i => adapter(field, i));
+					return spec.indices.map((i) => adapter(field, i));
 				}
 			};
 
@@ -1117,8 +1235,17 @@ END`;
 					]
 				},
 				search_schema: {
-					support_status: SupportStatus.Unsupported,
-					supported_types: []
+					support_status: SupportStatus.Supported,
+					supported_types: [
+						{
+							column_filter_type: ColumnFilterType.TextSearch,
+							support_status: SupportStatus.Supported,
+						},
+						{
+							column_filter_type: ColumnFilterType.MatchDataTypes,
+							support_status: SupportStatus.Supported,
+						}
+					],
 				},
 				set_column_filters: {
 					support_status: SupportStatus.Unsupported,

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -16,6 +16,7 @@ export interface DataExplorerRpc {
 	uri?: string;
 	params: OpenDatasetParams |
 	GetSchemaParams |
+	SearchSchemaParams |
 	GetDataValuesParams |
 	GetRowLabelsParams |
 	GetColumnProfilesParams |
@@ -73,14 +74,10 @@ export interface OpenDatasetResult {
  */
 export interface SearchSchemaResult {
 	/**
-	 * A schema containing matching columns up to the max_results limit
+	 * The column indices of the matching column indices in the indicated
+	 * sort order
 	 */
-	matches: TableSchema;
-
-	/**
-	 * The total number of columns matching the filter
-	 */
-	total_num_matches: number;
+	matches: Array<number>;
 
 }
 
@@ -97,6 +94,28 @@ export interface ExportedData {
 	 * The exported data format
 	 */
 	format: ExportFormat;
+
+}
+
+/**
+ * Code snippet for the data view
+ */
+export interface ConvertedCode {
+	/**
+	 * Lines of code that implement filters and sort keys
+	 */
+	converted_code: Array<string>;
+
+}
+
+/**
+ * Syntax to use for code conversion
+ */
+export interface CodeSyntaxName {
+	/**
+	 * The name of the code syntax, eg, pandas, polars, dplyr, etc.
+	 */
+	code_syntax_name: string;
 
 }
 
@@ -815,7 +834,7 @@ export interface ColumnFrequencyTable {
 	/**
 	 * The formatted top values
 	 */
-	values: Array<string>;
+	values: Array<ColumnValue>;
 
 	/**
 	 * Counts of top values
@@ -1006,21 +1025,19 @@ export interface SetSortColumnsFeatures {
 }
 
 /**
- * Feature flags for 'convert_to_code' RPC
+ * Feature flags for convert to code RPC
  */
 export interface ConvertToCodeFeatures {
 	/**
 	 * The support status for this RPC method
-	 * */
-	support_status: SupportStatus;
-	/**
-	 * The supported code syntax names
 	 */
-	supported_code_syntaxes?: Array<CodeSyntaxName>;
-}
+	support_status: SupportStatus;
 
-export interface CodeSyntaxName {
-	code_syntax_name: string;
+	/**
+	 * The syntaxes for converted code
+	 */
+	code_syntaxes?: Array<CodeSyntaxName>;
+
 }
 
 /**
@@ -1142,6 +1159,15 @@ export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataS
 
 /// Union of selection specifications for array_selection
 export type ArraySelection = DataSelectionRange | DataSelectionIndices;
+
+/**
+ * Possible values for SortOrder in SearchSchema
+ */
+export enum SearchSchemaSortOrder {
+	Original = 'original',
+	Ascending = 'ascending',
+	Descending = 'descending'
+}
 
 /**
  * Possible values for ColumnDisplayType
@@ -1294,20 +1320,15 @@ export interface GetSchemaParams {
  */
 export interface SearchSchemaParams {
 	/**
-	 * Column filters to apply when searching
+	 * Column filters to apply when searching, can be empty
 	 */
 	filters: Array<ColumnFilter>;
 
 	/**
-	 * Index (starting from zero) of first result to fetch (for paging)
+	 * How to sort results: original in-schema order, alphabetical ascending
+	 * or descending
 	 */
-	start_index: number;
-
-	/**
-	 * Maximum number of resulting column schemas to fetch from the start
-	 * index
-	 */
-	max_results: number;
+	sort_order: SearchSchemaSortOrder;
 }
 
 /**
@@ -1353,6 +1374,31 @@ export interface ExportDataSelectionParams {
 	 * Result string format
 	 */
 	format: ExportFormat;
+}
+
+/**
+ * Parameters for the ConvertToCode method.
+ */
+export interface ConvertToCodeParams {
+	/**
+	 * Zero or more column filters to apply
+	 */
+	column_filters: Array<ColumnFilter>;
+
+	/**
+	 * Zero or more row filters to apply
+	 */
+	row_filters: Array<RowFilter>;
+
+	/**
+	 * Zero or more sort keys to apply
+	 */
+	sort_keys: Array<ColumnSortKey>;
+
+	/**
+	 * The code syntax to use for conversion
+	 */
+	code_syntax_name: CodeSyntaxName;
 }
 
 /**
@@ -1471,6 +1517,8 @@ export enum DataExplorerBackendRequest {
 	GetDataValues = 'get_data_values',
 	GetRowLabels = 'get_row_labels',
 	ExportDataSelection = 'export_data_selection',
+	ConvertToCode = 'convert_to_code',
+	SuggestCodeSyntax = 'suggest_code_syntax',
 	SetColumnFilters = 'set_column_filters',
 	SetRowFilters = 'set_row_filters',
 	SetSortColumns = 'set_sort_columns',

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -9,6 +9,8 @@ import * as vscode from 'vscode';
 import {
 	BackendState,
 	ColumnDisplayType,
+	ColumnFilter,
+	ColumnFilterType,
 	ColumnProfileType,
 	ColumnSchema,
 	ColumnSortKey,
@@ -18,6 +20,8 @@ import {
 	DataExplorerRpc,
 	ExportFormat,
 	FilterComparisonOp,
+	FilterMatchDataTypes,
+	FilterTextSearch,
 	FormatOptions,
 	GetDataValuesParams,
 	GetSchemaParams,
@@ -25,6 +29,9 @@ import {
 	RowFilterCondition,
 	RowFilterParams,
 	RowFilterType,
+	SearchSchemaParams,
+	SearchSchemaResult,
+	SearchSchemaSortOrder,
 	Selection,
 	SetRowFiltersParams,
 	SupportStatus,
@@ -215,8 +222,17 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			sort_keys: [],
 			supported_features: {
 				search_schema: {
-					support_status: SupportStatus.Unsupported,
-					supported_types: []
+					support_status: SupportStatus.Supported,
+					supported_types: [
+						{
+							column_filter_type: ColumnFilterType.TextSearch,
+							support_status: SupportStatus.Supported
+						},
+						{
+							column_filter_type: ColumnFilterType.MatchDataTypes,
+							support_status: SupportStatus.Supported
+						}
+					]
 				},
 				set_column_filters: {
 					support_status: SupportStatus.Unsupported,
@@ -1745,6 +1761,224 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		assert.strictEqual(numberStats.mean, '0', 'Mean should be 0 for all null column');
 		assert.strictEqual(numberStats.median, '0', 'Median should be 0 for all null column');
 		assert.strictEqual(numberStats.stdev, '0', 'Stdev should be 0 for all null column');
+	});
+
+	test('searchSchema functionality', async () => {
+		// Create a test table with various column types
+		const tableName = makeTempTableName();
+		await createTempTable(tableName, [
+			{
+				name: 'id',
+				type: 'INTEGER',
+				display_type: ColumnDisplayType.Number,
+				values: ['1', '2', '3'],
+			},
+			{
+				name: 'name',
+				type: 'VARCHAR',
+				display_type: ColumnDisplayType.String,
+				values: ["'Alice'", "'Bob'", "'Charlie'"],
+			},
+			{
+				name: 'age',
+				type: 'INTEGER',
+				display_type: ColumnDisplayType.Number,
+				values: ['25', '30', '35'],
+			},
+			{
+				name: 'created_at',
+				type: 'TIMESTAMP',
+				display_type: ColumnDisplayType.Datetime,
+				values: [
+					"'2024-01-01 00:00:00'",
+					"'2024-01-02 00:00:00'",
+					"'2024-01-03 00:00:00'",
+				],
+			},
+			{
+				name: 'is_active',
+				type: 'BOOLEAN',
+				display_type: ColumnDisplayType.Boolean,
+				values: ['true', 'false', 'true'],
+			},
+			{
+				name: 'birth_date',
+				type: 'DATE',
+				display_type: ColumnDisplayType.Date,
+				values: ["'1999-01-01'", "'1994-01-01'", "'1989-01-01'"],
+			},
+		]);
+
+		const uri = vscode.Uri.from({ scheme: 'duckdb', path: tableName });
+
+		// Helper function to test searchSchema
+		const testSearchSchema = async (
+			filters: ColumnFilter[],
+			sortOrder: SearchSchemaSortOrder,
+			expectedIndices: number[],
+			description: string,
+		) => {
+			const result = (await dxExec({
+				method: DataExplorerBackendRequest.SearchSchema,
+				uri: uri.toString(),
+				params: {
+					filters,
+					sort_order: sortOrder,
+				} satisfies SearchSchemaParams,
+			})) as SearchSchemaResult;
+
+			assert.deepStrictEqual(
+				result.matches,
+				expectedIndices,
+				description,
+			);
+		};
+
+		// Helper to create text search filter
+		const textFilter = (
+			searchType: TextSearchType,
+			term: string,
+			caseSensitive = false,
+		): ColumnFilter => ({
+			filter_type: ColumnFilterType.TextSearch,
+			params: {
+				search_type: searchType,
+				term,
+				case_sensitive: caseSensitive,
+			} satisfies FilterTextSearch,
+		});
+
+		// Helper to create data type filter
+		const typeFilter = (
+			...displayTypes: ColumnDisplayType[]
+		): ColumnFilter => ({
+			filter_type: ColumnFilterType.MatchDataTypes,
+			params: {
+				display_types: displayTypes,
+			} satisfies FilterMatchDataTypes,
+		});
+
+		// Test cases defined as data
+		const testCases: Array<{
+			filters: ColumnFilter[];
+			sortOrder: SearchSchemaSortOrder;
+			expected: number[];
+			description: string;
+		}> = [
+				// Basic tests
+				{
+					filters: [],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [0, 1, 2, 3, 4, 5],
+					description: 'No filters, original order',
+				},
+
+				// Text search tests
+				{
+					filters: [textFilter(TextSearchType.Contains, 'date')],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [5],
+					description: 'Contains "date"',
+				},
+				{
+					filters: [textFilter(TextSearchType.StartsWith, 'is')],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [4],
+					description: 'Starts with "is"',
+				},
+				{
+					filters: [textFilter(TextSearchType.EndsWith, 'e')],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [1, 2, 4, 5],
+					description: 'Ends with "e"',
+				},
+				{
+					filters: [textFilter(TextSearchType.NotContains, '_')],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [0, 1, 2],
+					description: 'Not contains "_"',
+				},
+				{
+					filters: [textFilter(TextSearchType.RegexMatch, '^[a-z]+$')],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [0, 1, 2],
+					description: 'Regex match ^[a-z]+$',
+				},
+
+				// Type filter tests
+				{
+					filters: [typeFilter(ColumnDisplayType.Number)],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [0, 2],
+					description: 'Number columns',
+				},
+				{
+					filters: [
+						typeFilter(
+							ColumnDisplayType.Date,
+							ColumnDisplayType.Datetime,
+						),
+					],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [3, 5],
+					description: 'Date/Datetime columns',
+				},
+
+				// Multiple filters (AND logic)
+				{
+					filters: [
+						textFilter(TextSearchType.Contains, 'a'),
+						typeFilter(ColumnDisplayType.Number),
+					],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [2],
+					description: 'Contains "a" AND type is Number',
+				},
+
+				// Sort order tests
+				{
+					filters: [],
+					sortOrder: SearchSchemaSortOrder.Ascending,
+					expected: [2, 5, 3, 0, 4, 1],
+					description: 'Ascending alphabetical order',
+				},
+				{
+					filters: [],
+					sortOrder: SearchSchemaSortOrder.Descending,
+					expected: [1, 4, 0, 3, 5, 2],
+					description: 'Descending alphabetical order',
+				},
+				{
+					filters: [textFilter(TextSearchType.Contains, 'a')],
+					sortOrder: SearchSchemaSortOrder.Ascending,
+					expected: [2, 5, 3, 4, 1],
+					description: 'Filtered with ascending sort',
+				},
+
+				// Case sensitivity tests
+				{
+					filters: [textFilter(TextSearchType.Contains, 'AGE', true)],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [],
+					description: 'Case-sensitive, wrong case',
+				},
+				{
+					filters: [textFilter(TextSearchType.Contains, 'age', true)],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [2],
+					description: 'Case-sensitive, correct case',
+				},
+			];
+
+		// Run all test cases
+		for (const testCase of testCases) {
+			await testSearchSchema(
+				testCase.filters,
+				testCase.sortOrder,
+				testCase.expected,
+				testCase.description,
+			);
+		}
 	});
 
 	test('ColumnProfileEvaluator.computeSummaryStats - Edge case: single value', async () => {


### PR DESCRIPTION
This brings the DuckDB backend up to feature parity with Python and R. I can add sorting-by-data-type to the three backends in follow up PRs

@:data-explorer