### PR TITLE
Set Assistant action bar as nested

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
+++ b/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
@@ -82,7 +82,7 @@ export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 
 	return (
 		<div className='chat-action-bar'>
-			<PositronActionBar>
+			<PositronActionBar nestedActionBar={true}>
 				{renderCurrentProvider()}
 			</PositronActionBar>
 		</div>


### PR DESCRIPTION
Address #8574

The action bar had some theme changes that affects how it looks for the chat provider switcher. Setting `nestedActionBar=true` on the component makes the component background transparent. This now matches the rest of the view in light, dark, and high contrast themes.

Light
<img width="366" height="79" alt="image" src="https://github.com/user-attachments/assets/a12b6109-8b4c-4b90-a9d4-4b1694271060" />

Dark
<img width="354" height="80" alt="image" src="https://github.com/user-attachments/assets/37f078db-7e62-4ec9-acdf-cea09eb6a3e4" />

Light High Contrast
<img width="362" height="77" alt="image" src="https://github.com/user-attachments/assets/0acd44fb-2994-4dd4-b7ce-072a6ce03460" />

Dark High Contrast
<img width="359" height="82" alt="image" src="https://github.com/user-attachments/assets/2a10ce4d-b720-4703-94e6-ec15bd4b31b2" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Assistant provider switcher theme


### QA Notes
The option also affects a keydown handler. Using the keyboard still works to open the switcher.