### PR TITLE
Assistant: use raw integer value for max output token setting

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -208,7 +208,8 @@
             "default": {},
             "description": "%configuration.maxOutputTokens.description%",
             "additionalProperties": {
-              "type": "number"
+              "type": "number",
+              "minimum": 512
             }
           },
           "positron.assistant.followups.enable": {

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -24,6 +24,6 @@
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
 	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
 	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
-	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units.",
+	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model.",
 	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses."
 }

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -217,7 +217,15 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		// Override maxOutputTokens if specified in the configuration
 		for (const [key, value] of Object.entries(maxOutputTokens)) {
 			if (_config.model.indexOf(key) !== -1 && value) {
-				const maxOutputTokens = value * 1024; // Convert from 1K tokens to actual tokens
+				let maxOutputTokens = value;
+				if (typeof maxOutputTokens !== 'number') {
+					log.warn(`Invalid maxOutputTokens '${maxOutputTokens}' for ${key} (${_config.model}); ignoring`);
+					continue;
+				}
+				if (maxOutputTokens < 512) {
+					log.warn(`Specified maxOutputTokens '${maxOutputTokens}' for ${key} (${_config.model}) is too low; using 512 instead`);
+					maxOutputTokens = 512;
+				}
 				log.debug(`Setting maxOutputTokens for ${key} (${_config.model}) to ${maxOutputTokens}`);
 				this.maxOutputTokens = maxOutputTokens;
 				break;


### PR DESCRIPTION
Small improvement to #8891 that makes the `maxOutputTokens` setting a raw integer value instead of 1K token units. 

Very small max output token values usually result in poor UX, so a minimum of 512 is enforced. 