### PR TITLE
Assistant: always display `Working...` indicator at bottom of response while in progress

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -77,7 +77,14 @@ export class ChatEditor extends EditorPane {
 							return true;
 						},
 						referencesExpandedWhenEmptyResponse: false,
+						// --- Start Positron ---
+						/*
 						progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask,
+						*/
+						// Always show progress message at bottom of response to make it more apparent
+						// in all modes.
+						progressMessageAtBottomOfResponse: true,
+						// --- End Positron ---
 					},
 					enableImplicitContext: true,
 					enableWorkingSet: 'explicit',

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -973,6 +973,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			!lastPart ||
 			lastPart.kind === 'references' ||
 			(lastPart.kind === 'toolInvocation' && (lastPart.isComplete || lastPart.presentation === 'hidden')) ||
+			// --- Start Positron ---
+			// Show working progress if the last part is markdown content and the response is in progress
+			// This is especially helpful when running in Agent mode, when the executeCode code block is still being constructed
+			// This causes the in progress indicator to show in any mode, while markdown text is being rendered and the response is not complete
+			(lastPart.kind === 'markdownContent' && element.model.isInProgress.get()) ||
+			// --- End Positron ---
 			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !part.isComplete)) ||
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||
 			lastPart.kind === 'prepareToolInvocation'

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -366,8 +366,20 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 		this.hoverHidden(requestHover);
 		const user = dom.append(header, $('.user'));
+		// --- Start Positron ---
+		// Contain the avatar and username in a row, so that the detailContainer can be shown on
+		// a separate row. See src/vs/workbench/contrib/chat/browser/media/chat.css for the styles.
+		// https://github.com/posit-dev/positron/issues/7740
+		const userProfileRow = dom.append(user, $('.user-profile-row'));
+		/*
 		const avatarContainer = dom.append(user, $('.avatar-container'));
+		*/
+		const avatarContainer = dom.append(userProfileRow, $('.avatar-container'));
+		/*
 		const username = dom.append(user, $('h3.username'));
+		*/
+		const username = dom.append(userProfileRow, $('h3.username'));
+		// --- End Positron ---
 		username.tabIndex = 0;
 		const detailContainer = dom.append(detailContainerParent ?? user, $('span.detail-container'));
 		const detail = dom.append(detailContainer, $('span.detail'));

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -977,7 +977,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			// Show working progress if the last part is markdown content and the response is in progress
 			// This is especially helpful when running in Agent mode, when the executeCode code block is still being constructed
 			// This causes the in progress indicator to show in any mode, while markdown text is being rendered and the response is not complete
-			(lastPart.kind === 'markdownContent' && element.model.isInProgress.get()) ||
+			(lastPart.kind === 'markdownContent' && element.isComplete) ||
 			// --- End Positron ---
 			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !part.isComplete)) ||
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -366,20 +366,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 		this.hoverHidden(requestHover);
 		const user = dom.append(header, $('.user'));
-		// --- Start Positron ---
-		// Contain the avatar and username in a row, so that the detailContainer can be shown on
-		// a separate row. See src/vs/workbench/contrib/chat/browser/media/chat.css for the styles.
-		// https://github.com/posit-dev/positron/issues/7740
-		const userProfileRow = dom.append(user, $('.user-profile-row'));
-		/*
 		const avatarContainer = dom.append(user, $('.avatar-container'));
-		*/
-		const avatarContainer = dom.append(userProfileRow, $('.avatar-container'));
-		/*
 		const username = dom.append(user, $('h3.username'));
-		*/
-		const username = dom.append(userProfileRow, $('h3.username'));
-		// --- End Positron ---
 		username.tabIndex = 0;
 		const detailContainer = dom.append(detailContainerParent ?? user, $('span.detail-container'));
 		const detail = dom.append(detailContainer, $('span.detail'));

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -200,7 +200,14 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 							return true;
 						},
 						referencesExpandedWhenEmptyResponse: false,
+						// --- Start Positron ---
+						/*
 						progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask,
+						*/
+						// Always show progress message at bottom of response to make it more apparent
+						// in all modes.
+						progressMessageAtBottomOfResponse: true,
+						// --- End Positron ---
 					},
 					editorOverflowWidgetsDomNode: editorOverflowNode,
 					enableImplicitContext: this.chatOptions.location === ChatAgentLocation.Panel,

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -41,8 +41,16 @@
 
 .interactive-item-container .header .user {
 	display: flex;
-	align-items: center;
 	/* --- Start Positron --- */
+	/*
+	 * Adjust the flex item alignment and direction to position the detail-container
+	 * below the user profile row, so that the in progress state is more visually
+	 * apparent. See src/vs/workbench/contrib/chat/browser/chatListRenderer.ts for
+	 * the changes that pair with this.
+	 * https://github.com/posit-dev/positron/issues/7740
+	 */
+	align-items: flex-start;
+	flex-direction: column;
 	gap: 4px;
 	/* --- End Positron --- */
 
@@ -52,6 +60,25 @@
 	padding: 2px;
 	margin: -2px;
 }
+
+/* --- Start Positron --- */
+/*
+ * Pairs with the changes above and in src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+ * https://github.com/posit-dev/positron/issues/7740
+ */
+.interactive-item-container .header .user .user-profile-row {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 4px;
+	width: 100%;
+}
+
+.interactive-item-container .header .user .detail-container {
+	width: 100%;
+	margin: 2px;
+}
+/* --- End Positron --- */
 
 .interactive-item-container .header .username {
 	margin: 0;

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -41,16 +41,8 @@
 
 .interactive-item-container .header .user {
 	display: flex;
+	align-items: center;
 	/* --- Start Positron --- */
-	/*
-	 * Adjust the flex item alignment and direction to position the detail-container
-	 * below the user profile row, so that the in progress state is more visually
-	 * apparent. See src/vs/workbench/contrib/chat/browser/chatListRenderer.ts for
-	 * the changes that pair with this.
-	 * https://github.com/posit-dev/positron/issues/7740
-	 */
-	align-items: flex-start;
-	flex-direction: column;
 	gap: 4px;
 	/* --- End Positron --- */
 
@@ -60,25 +52,6 @@
 	padding: 2px;
 	margin: -2px;
 }
-
-/* --- Start Positron --- */
-/*
- * Pairs with the changes above and in src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
- * https://github.com/posit-dev/positron/issues/7740
- */
-.interactive-item-container .header .user .user-profile-row {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: 4px;
-	width: 100%;
-}
-
-.interactive-item-container .header .user .detail-container {
-	width: 100%;
-	margin: 2px;
-}
-/* --- End Positron --- */
 
 .interactive-item-container .header .username {
 	margin: 0;


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/7740

Before
- Ask Mode: `Working...` chat progress indicator was displayed inline in the chat avatar row
- Edit/Agent mode: `Working...` chat progress indicator was displayed below the chat avatar row
- When markdown content is being streamed, the `Working...` chat progress indicator is NOT shown if the response is still in progress

After
- Ask/Edit/Agent modes: `Working...` chat progress indicator was displayed at the bottom of the response as long as the response is still in progress
- Note that this makes the chat look a bit more jumpy/in motion, so we may want to create a new element like the chat total token count, but we may not be able to access the individual chat item state as easily in that part of the code

#### Demo

https://github.com/user-attachments/assets/56319b54-8414-4248-a42f-30284b58623d

### Release Notes

#### New Features

- Assistant: display `Working...` indicator at bottom of response while response is in progress (#7740)

### QA Notes

@:assistant

Although the indicator is more apparent now, I was able to confirm that the indicator disappears before the assistant response is done streaming in the UI.

To be extra sure that the response is done, it'd be best to wait for the element matching the selector `.chat-most-recent-response.chat-response-loading` to not be visible. The most recent response has the `chat-response-loading` class applied while the chat is still in progress. The `Working...` indicator and send/stop button both switch slightly earlier than the `chat-response-loading` class.