### PR TITLE
E2E test: flake fixes

### DIFF
--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -50,7 +50,7 @@ test.describe('Positron notebook opening and saving', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Switching between VS Code and Positron notebook editors works correctly', async function ({ app, hotKeys, settings }) {
+	test('Switching between VS Code and Positron notebook editors works correctly', async function ({ app, python, hotKeys, settings }) {
 		const { notebooks, notebooksVscode, notebooksPositron } = app.workbench;
 
 		// Verify default behavior - VS Code notebook editor should be used when no association is set

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -82,13 +82,13 @@ test.describe('Sessions: State', {
 		// Verify Python session transitions to active when executing code
 		await sessions.select(pySession.name);
 		await console.executeCode('Python', 'import time');
-		await console.executeCode('Python', 'time.sleep(10)', { waitForReady: false, maximizeConsole: false });
+		await console.pasteCodeToConsole('time.sleep(10)', true);
 		await sessions.expectStatusToBe(pySession.name, 'active');
 
 		// Verify R session transitions to active when executing code
 		// Verify Python session continues to run and transitions to idle when finished
 		await sessions.select(rSession.name);
-		await console.executeCode('R', 'Sys.sleep(10)', { waitForReady: false, maximizeConsole: false });
+		await console.pasteCodeToConsole('Sys.sleep(2)', true);
 		await sessions.expectStatusToBe(rSession.name, 'active');
 		await sessions.expectStatusToBe(rSession.name, 'idle');
 		await sessions.expectStatusToBe(pySession.name, 'active');

--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -88,7 +88,7 @@ test.describe('Sessions: State', {
 		// Verify R session transitions to active when executing code
 		// Verify Python session continues to run and transitions to idle when finished
 		await sessions.select(rSession.name);
-		await console.executeCode('R', 'Sys.sleep(2)', { waitForReady: false, maximizeConsole: false });
+		await console.executeCode('R', 'Sys.sleep(10)', { waitForReady: false, maximizeConsole: false });
 		await sessions.expectStatusToBe(rSession.name, 'active');
 		await sessions.expectStatusToBe(rSession.name, 'idle');
 		await sessions.expectStatusToBe(pySession.name, 'active');

--- a/test/e2e/tests/shiny/shiny.test.ts
+++ b/test/e2e/tests/shiny/shiny.test.ts
@@ -12,6 +12,8 @@ test.use({
 
 test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tags.WEB] }, () => {
 
+	// No longer need to install Shiny extension
+
 	test.afterEach(async function ({ app }) {
 		await app.workbench.terminal.sendKeysToTerminal('Control+C');
 		await app.workbench.viewer.refreshViewer();

--- a/test/e2e/tests/shiny/shiny.test.ts
+++ b/test/e2e/tests/shiny/shiny.test.ts
@@ -11,15 +11,6 @@ test.use({
 });
 
 test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tags.WEB] }, () => {
-	test.beforeAll(async function ({ app }) {
-		try {
-			await app.workbench.extensions.installExtension('posit.shiny', true);
-			await app.workbench.extensions.closeExtension('Shiny');
-		} catch (e) {
-			await app.code.driver.takeScreenshot('shinySetup');
-			throw e;
-		}
-	});
 
 	test.afterEach(async function ({ app }) {
 		await app.workbench.terminal.sendKeysToTerminal('Control+C');


### PR DESCRIPTION
* Timing fix for session test
* Stop installing shiny extension
* wait longer for startup for notebook test that toggles between MS and Positron notebooks

### QA Notes

@:apps @:sessions @:web @:notebooks
