### PR TITLE
Data Explorer: Implement sorting columns by data type for Python and DuckDB, improve search_schema RPC documentation

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -910,18 +910,32 @@ export class DuckDBTableView {
 
 		// Sort the filtered indices
 		switch (params.sort_order) {
-			case SearchSchemaSortOrder.Ascending:
+			case SearchSchemaSortOrder.AscendingName:
 				filteredIndices.sort((a, b) => {
 					const nameA = this.fullSchema[a].column_name.toLowerCase();
 					const nameB = this.fullSchema[b].column_name.toLowerCase();
 					return nameA.localeCompare(nameB);
 				});
 				break;
-			case SearchSchemaSortOrder.Descending:
+			case SearchSchemaSortOrder.DescendingName:
 				filteredIndices.sort((a, b) => {
 					const nameA = this.fullSchema[a].column_name.toLowerCase();
 					const nameB = this.fullSchema[b].column_name.toLowerCase();
 					return nameB.localeCompare(nameA);
+				});
+				break;
+			case SearchSchemaSortOrder.AscendingType:
+				filteredIndices.sort((a, b) => {
+					const typeA = this.fullSchema[a].column_type.toLowerCase();
+					const typeB = this.fullSchema[b].column_type.toLowerCase();
+					return typeA.localeCompare(typeB);
+				});
+				break;
+			case SearchSchemaSortOrder.DescendingType:
+				filteredIndices.sort((a, b) => {
+					const typeA = this.fullSchema[a].column_type.toLowerCase();
+					const typeB = this.fullSchema[b].column_type.toLowerCase();
+					return typeB.localeCompare(typeA);
 				});
 				break;
 			case SearchSchemaSortOrder.Original:

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -1165,8 +1165,10 @@ export type ArraySelection = DataSelectionRange | DataSelectionIndices;
  */
 export enum SearchSchemaSortOrder {
 	Original = 'original',
-	Ascending = 'ascending',
-	Descending = 'descending'
+	AscendingName = 'ascending_name',
+	DescendingName = 'descending_name',
+	AscendingType = 'ascending_type',
+	DescendingType = 'descending_type'
 }
 
 /**

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -308,12 +308,26 @@ class DataExplorerTableView:
             self._search_schema_last_result = (filters, matches)
 
         # Apply sorting based on sort_order
-        if sort_order == SearchSchemaSortOrder.Ascending:
+        if sort_order == SearchSchemaSortOrder.AscendingName:
             # Sort by column name ascending
-            matches = sorted(matches, key=lambda idx: self._get_column_name(idx))
-        elif sort_order == SearchSchemaSortOrder.Descending:
+            matches = sorted(matches, key=lambda idx: self._get_column_name(idx).lower())
+        elif sort_order == SearchSchemaSortOrder.DescendingName:
             # Sort by column name descending
-            matches = sorted(matches, key=lambda idx: self._get_column_name(idx), reverse=True)
+            matches = sorted(
+                matches, key=lambda idx: self._get_column_name(idx).lower(), reverse=True
+            )
+        elif sort_order == SearchSchemaSortOrder.AscendingType:
+            # Sort by column type ascending (using lowercase type name)
+            matches = sorted(
+                matches, key=lambda idx: str(self._get_column_type_display(idx)).lower()
+            )
+        elif sort_order == SearchSchemaSortOrder.DescendingType:
+            # Sort by column type descending (using lowercase type name)
+            matches = sorted(
+                matches,
+                key=lambda idx: str(self._get_column_type_display(idx)).lower(),
+                reverse=True,
+            )
         # For SearchSchemaSortOrder.Original, keep original order (no sorting needed)
 
         return SearchSchemaResult(matches=matches)

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -26,9 +26,13 @@ class SearchSchemaSortOrder(str, enum.Enum):
 
     Original = "original"
 
-    Ascending = "ascending"
+    AscendingName = "ascending_name"
 
-    Descending = "descending"
+    DescendingName = "descending_name"
+
+    AscendingType = "ascending_type"
+
+    DescendingType = "descending_type"
 
 
 @enum.unique
@@ -243,7 +247,7 @@ class SearchSchemaResult(BaseModel):
     """
 
     matches: List[StrictInt] = Field(
-        description="The column indices of the matching column indices in the indicated sort order",
+        description="The column indices that match the search parameters in the indicated sort order.",
     )
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -1033,7 +1033,9 @@ def test_search_schema_sort_by_type(dxf: DataExplorerFixture):
         "age": [25, 30, 35],
         "created_at": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
         "is_active": [True, False, True],
-        "birth_date": pd.to_datetime(["1999-01-01", "1994-01-01", "1989-01-01"]).date,
+        "birth_date": pd.to_datetime(["1999-01-01", "1994-01-01", "1989-01-01"])
+        .to_series()
+        .dt.date,
         "salary": [50000.0, 60000.0, 70000.0],
     }
 
@@ -1042,11 +1044,13 @@ def test_search_schema_sort_by_type(dxf: DataExplorerFixture):
 
     # Test ascending type sort
     result = dxf.search_schema("type_sort_test_df", [], "ascending_type")
+    # is_active(6), birth_date(7), created_at(5), id(0), user_id(1), age(4), salary(8), name(2), full_name(3)
     expected_ascending_type = [6, 7, 5, 0, 1, 4, 8, 2, 3]  # boolean, date, datetime, number, string
     assert result["matches"] == expected_ascending_type
 
     # Test descending type sort
     result = dxf.search_schema("type_sort_test_df", [], "descending_type")
+    # name(2), full_name(3), id(0), user_id(1), age(4), salary(8), created_at(5), birth_date(7), is_active(6)
     expected_descending_type = [
         2,
         3,

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -79,8 +79,10 @@
 						"type": "string",
 						"enum": [
 							"original",
-							"ascending",
-							"descending"
+							"ascending_name",
+							"descending_name",
+							"ascending_type",
+							"descending_type"
 						]
 					}
 				}
@@ -94,7 +96,7 @@
 					],
 					"properties": {
 						"matches": {
-							"description": "The column indices of the matching column indices in the indicated sort order",
+							"description": "The column indices that match the search parameters in the indicated sort order.",
 							"type": "array",
 							"items": {
 								"type": "integer"

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -27,8 +27,8 @@ export interface OpenDatasetResult {
  */
 export interface SearchSchemaResult {
 	/**
-	 * The column indices of the matching column indices in the indicated
-	 * sort order
+	 * The column indices that match the search parameters in the indicated
+	 * sort order.
 	 */
 	matches: Array<number>;
 
@@ -1118,8 +1118,10 @@ export type ArraySelection = DataSelectionRange | DataSelectionIndices;
  */
 export enum SearchSchemaSortOrder {
 	Original = 'original',
-	Ascending = 'ascending',
-	Descending = 'descending'
+	AscendingName = 'ascending_name',
+	DescendingName = 'descending_name',
+	AscendingType = 'ascending_type',
+	DescendingType = 'descending_type'
 }
 
 /**


### PR DESCRIPTION
This adds the missing "sort columns by data type" mode, and renames the ascending/descending sort to AscendingName or DescendingName for clarity.

@:data-explorer