### PR TITLE
Fix null percentage calculation and display logic

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -216,23 +216,60 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	 * @returns The rendered component.
 	 */
 	const ColumnNullPercent = () => {
-		// Set the null percent and graph null percent.
-		let nullPercent = props.instance.getColumnProfileNullPercent(props.columnIndex);
+		// Get the null percent value for this column
+		const nullPercent = props.instance.getColumnProfileNullPercent(props.columnIndex);
+
+		/**
+		 * The graph null percent value is used to determine how much of the
+		 * "progress bar" for missing values is filled in the UI. This value is
+		 * not always the same as the null percent value.
+		 *
+		 * The null percent value is the percentage of null values in the column.
+		 * The graph null percent value may be higher or lower than the null percent
+		 * value to ensure the "progress bar" is visually readable by the user.
+		 * This is relevant when the percentage of null values is very small or very large.
+		 *
+		 * In the very small case, we want to ensure that the bar does not look empty.
+		 * In the very large case, we want to ensure that the bar does not look completely full.
+		 */
 		let graphNullPercent = nullPercent;
+
 		if (nullPercent !== undefined) {
 			if (nullPercent <= 0) {
-				nullPercent = graphNullPercent = 0;
+				graphNullPercent = 0;
 			} else if (nullPercent >= 100) {
-				nullPercent = graphNullPercent = 100;
+				graphNullPercent = 100;
 			} else {
-				// Pin the graph null percent such that anything above 0% and below 5% reads as 5% and
-				// anything below 100% above 95% reads as 95%.
+				// Pin the graph null percent such that anything above 0% and below 5% reads as 5%
+				// and anything below 100% above 95% reads as 95%. This ensures that the missing values
+				// "progress bar" is visually readable by the user and does not appear incorrectly empty
+				// or full. This is especially important for columns with very few rows.
 				graphNullPercent = Math.min(Math.max(nullPercent, 5), 95);
 			}
 		}
 
 		// Create a reference to the container div
 		const containerRef = useRef<HTMLDivElement>(null);
+
+		// Helper function to format the null percentage we display in the UI.
+		const getDisplayNullPercent = () => {
+			if (nullPercent === undefined) {
+				return undefined;
+			} else if (nullPercent <= 0) {
+				return '0%';
+			} else if (nullPercent >= 100) {
+				return '100%';
+			} else if (nullPercent > 0 && nullPercent < 1) {
+				return '<1%';
+			} else {
+				/**
+				 * We round the percentage to the nearest integer
+				 * when displaying it in the UI to avoid cluttering
+				 * the UI with too many decimal places.
+				 */
+				return `${Math.floor(nullPercent)}%`;
+			}
+		};
 
 		// Create tooltip text based on nullPercent
 		const getTooltipText = () => {
@@ -255,10 +292,11 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					'Missing Values\nAll values are missing ({0} values)', nullCount.toLocaleString()
 				);
 			} else {
+				// Format percentage for tooltip
 				return nls.localize(
 					'positron.missingValues.some',
-					'Missing Values\n{0}% of values are missing ({1} values)',
-					nullPercent,
+					'Missing Values\n{0} of values are missing ({1} values)',
+					getDisplayNullPercent(),
 					nullCount.toLocaleString()
 				);
 			}
@@ -296,7 +334,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			>
 				{nullPercent !== undefined &&
 					<div className={positronClassNames('text-percent', { 'zero': nullPercent === 0 })}>
-						{nullPercent}%
+						{getDisplayNullPercent()}
 					</div>
 				}
 				<div className='graph-percent'>

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -340,7 +340,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		}
 
 		// Calculate and return the column null percent.
-		return Math.floor(nullCount * 100 / rows);
+		return (nullCount * 100) / rows;
 	}
 
 	/**


### PR DESCRIPTION
Addresses #8515

This PR fixes the user reported issue of small missing values not correctly displaying the correct percentage value in the UI. The percentage value, progress bar, and missing value tooltip were not handling the <1% missing data scenario correctly.

We now explicitly display "<1%" as the percent value when there is less than 1% of missing data in the summary panel.

The issue causing this bug was twofold:
1. We were prematurely rounding the null percent value
2. Conflating display logic with calculation logic

The original code used `Math.floor()` to round down the null percentage in `getColumnProfileNullPercent()`, which caused precise percentages like 0.99% to be truncated to 0%. This meant that any column with less than 1% missing values would be calculated as having 0% missing values. The tooltip logic then used this rounded value to determine if it should show a "no missing values" message.

The original code was also conflating the actual null percentage value with the adjusted percentage value we used to graphically represent the amount of missing data in the "progress bar". This meant that after the visual adjustment percentage logic ran (which pins values between 5-95% for better visual readability in the progress bar), the original null percentage value was lost. The tooltip then used this visually-adjusted percentage instead of the true percentage, causing tooltips to show incorrect information like "5% of values are missing" when only 0.99% were actually missing.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix accuracy of null percentage value in tooltip for small percentages in Data Explorer (#8515)

### Screenshots
**Before - flights dataset**

<img width="357" height="902" alt="Screenshot 2025-08-08 at 2 24 41 PM" src="https://github.com/user-attachments/assets/749a65b3-3fbb-4960-ab6e-ab02c8b4e459" />

**After - flights dataset**

<img width="433" height="902" alt="Screenshot 2025-08-08 at 2 30 23 PM" src="https://github.com/user-attachments/assets/c6b533e4-94f9-48b2-9d65-7a8ea17e664c" />

**After - <1% missing**

<img width="577" height="902" alt="Screenshot 2025-08-08 at 2 28 14 PM" src="https://github.com/user-attachments/assets/475b0121-2125-4250-a6f5-f259a98d7357" />

**After - >99% missing**

<img width="521" height="902" alt="Screenshot 2025-08-08 at 2 47 00 PM" src="https://github.com/user-attachments/assets/aab6f466-890c-449f-8b4d-691a4b61ba74" />


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:data-explorer
