### PR TITLE
Port Bedrock improvements from 2025.08

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -4150,17 +4150,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",

--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -14,7 +14,7 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@ai-sdk/amazon-bedrock": "^1.1.6",
+        "@ai-sdk/amazon-bedrock": "2.2.12",
         "@ai-sdk/anthropic": "^1.0.5",
         "@ai-sdk/azure": "^1.1.9",
         "@ai-sdk/google": "^1.1.17",
@@ -44,21 +44,54 @@
       }
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-1.1.6.tgz",
-      "integrity": "sha512-h6SJWpku+i8OsSz0A4RT2g2uD+3E0SUgWHsWRIpxmPNgM1DnH6lgSby5sxqAZDY5xJyJtRFW5vB9G3GEBjHy/g==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.12.tgz",
+      "integrity": "sha512-m8gARnh45pr1s08Uu4J/Pm8913mwJPejPOm59b+kUqMsP9ilhUtH/bp8432Ra/v+vHuMoBrglG2ZvXtctAaH2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.7",
-        "@ai-sdk/provider-utils": "2.1.6",
-        "@aws-sdk/client-bedrock-runtime": "^3.663.0"
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@smithy/eventstream-codec": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "aws4fetch": "^1.0.20"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -540,408 +573,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.755.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.755.0.tgz",
-      "integrity": "sha512-g5Adp2haJn3d1M7he4KSBUO/QAJuDNhnCNSZ4Ud30F0WvX07C7nZUDzKOi8cYa8xeXK6gpSlk6DdgcJflXdfXA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-node": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/eventstream-serde-browser": "^4.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-        "@smithy/eventstream-serde-node": "^4.0.1",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.1.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.750.0.tgz",
-      "integrity": "sha512-y0Rx6pTQXw0E61CaptpZF65qNggjqOgymq/RYZU5vWba5DGQ+iqGt8Yq8s+jfBoBBNXshxq8l8Dl5Uq/JTY1wg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.750.0.tgz",
-      "integrity": "sha512-In6bsG0p/P31HcH4DBRKBbcDS/3SHvEPjfXV8ODPWZO/l3/p7IRoYBdQ07C9R+VMZU2D0+/Sc/DWK/TUNDk1+Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.750.0.tgz",
-      "integrity": "sha512-wFB9qqfa20AB0dElsQz5ZlZT5o+a+XzpEpmg0erylmGYqEOvh8NQWfDUVpRmQuGq9VbvW/8cIbxPoNqEbPtuWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.750.0.tgz",
-      "integrity": "sha512-2YIZmyEr5RUd3uxXpxOLD9G67Bibm4I/65M6vKFP17jVMUT+R1nL7mKqmhEVO2p+BoeV+bwMyJ/jpTYG368PCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.750.0.tgz",
-      "integrity": "sha512-THWHHAceLwsOiowPEmKyhWVDlEUxH07GHSw5AQFDvNQtGKOQl0HSIFO1mKObT2Q2Vqzji9Bq8H58SO5BFtNPRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-ini": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.750.0.tgz",
-      "integrity": "sha512-Q78SCH1n0m7tpu36sJwfrUSxI8l611OyysjQeMiIOliVfZICEoHcLHLcLkiR+tnIpZ3rk7d2EQ6R1jwlXnalMQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.750.0.tgz",
-      "integrity": "sha512-FGYrDjXN/FOQVi/t8fHSv8zCk+NEvtFnuc4cZUj5OIbM4vrfFc5VaPyn41Uza3iv6Qq9rZg0QOwWnqK8lNrqUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.750.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/token-providers": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.750.0.tgz",
-      "integrity": "sha512-Nz8zs3YJ+GOTSrq+LyzbbC1Ffpt7pK38gcOyNZv76pP5MswKTUKNYBJehqwa+i7FcFQHsCk3TdhR8MT1ZR23uA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.750.0.tgz",
-      "integrity": "sha512-YYcslDsP5+2NZoN3UwuhZGkhAHPSli7HlJHBafBrvjGV/I9f8FuOO1d1ebxGdEP4HyRXUGyh+7Ur4q+Psk0ryw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.750.0.tgz",
-      "integrity": "sha512-OH68BRF0rt9nDloq4zsfeHI0G21lj11a66qosaljtEP66PWm7tQ06feKbFkXHT5E1K3QhJW3nVyK8v2fEBY5fg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.750.0.tgz",
-      "integrity": "sha512-X/KzqZw41iWolwNdc8e3RMcNSMR364viHv78u6AefXOO5eRM40c4/LuST1jDzq35/LpnqRhL7/MuixOetw+sFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.743.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-      "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-endpoints": "^3.0.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.750.0.tgz",
-      "integrity": "sha512-84HJj9G9zbrHX2opLk9eHfDceB+UIHVrmflMzWHpsmo9fDuro/flIBqaVDlE021Osj6qIM0SJJcnL6s23j7JEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
@@ -1928,74 +1559,15 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
-      "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+      "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
-      "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
-      "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-      "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
-      "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2303,9 +1875,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2628,13 +2200,6 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3048,6 +2613,13 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3504,11 +3076,13 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/extend": {
@@ -4576,6 +4150,17 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5217,7 +4802,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -202,6 +202,19 @@
             "type": "boolean",
             "default": false,
             "description": "%configuration.showTokenUsage.description%"
+          },
+          "positron.assistant.maxOutputTokens": {
+            "type": "object",
+            "default": {},
+            "description": "%configuration.maxOutputTokens.description%",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "positron.assistant.followups.enable": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.followups.enable.description%"
           }
         }
       }
@@ -504,7 +517,7 @@
     "postinstall": "ts-node scripts/post-install.ts"
   },
   "devDependencies": {
-    "@ai-sdk/amazon-bedrock": "^1.1.6",
+    "@ai-sdk/amazon-bedrock": "2.2.12",
     "@ai-sdk/anthropic": "^1.0.5",
     "@ai-sdk/azure": "^1.1.9",
     "@ai-sdk/google": "^1.1.17",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -208,7 +208,8 @@
             "default": {},
             "description": "%configuration.maxOutputTokens.description%",
             "additionalProperties": {
-              "type": "number"
+              "type": "number",
+              "minimum": 512
             }
           },
           "positron.assistant.followups.enable": {

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -23,5 +23,7 @@
 	"configuration.inlineCompletionExcludes.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from inline completions.",
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
 	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
-	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage."
+	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
+	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units.",
+	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses."
 }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -24,6 +24,6 @@
 	"configuration.gitIntegration.description": "Enable Positron Assistant git integration.",
 	"configuration.getTableSummary.description": "Enable Positron Assistant get table summary tool.",
 	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
-	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model, in 1K token units.",
+	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model.",
 	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses."
 }

--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -100,6 +100,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 
 		// Log request information - the request ID is only available upon connection.
 		stream.on('connect', () => {
+			log.info(`[anthropic] Start request ${stream.request_id} to ${this._config.model}: ${anthropicMessages.length} messages`);
 			if (log.logLevel <= vscode.LogLevel.Trace) {
 				log.trace(`[anthropic] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
 			} else {
@@ -136,6 +137,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			await stream.done();
 		} catch (error) {
 			if (error instanceof Anthropic.APIError) {
+				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
 				let data: any;
 				try {
 					data = JSON.parse(error.message);
@@ -146,6 +148,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 					throw new Error(`Anthropic's API is temporarily overloaded.`);
 				}
 			} else if (error instanceof Anthropic.AnthropicError) {
+				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
 				// This can happen if the API key was not persisted correctly.
 				if (error.message.startsWith('Could not resolve authentication method')) {
 					throw new Error('Something went wrong when storing the Anthropic API key. ' +
@@ -161,9 +164,8 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			log.trace(`[anthropic] RECV messages.stream [${stream.request_id}]: ${JSON.stringify(message, null, 2)}`);
 		} else {
 			log.debug(
-				`[anthropic] RECV messages.stream [${stream.request_id}]: ` +
-				`usage: ${JSON.stringify(message.usage)}`
-			);
+				`[anthropic] RECV messages.stream [${stream.request_id}]`);
+			log.info(`[anthropic] Finished request ${stream.request_id}; usage: ${JSON.stringify(message.usage)}`);
 		}
 
 		// Record token usage

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -511,7 +511,7 @@ class OpenRouterCompletion extends FimPromptCompletion {
 }
 
 class AWSCompletion extends FimPromptCompletion {
-	protected model;
+	protected model: ai.LanguageModelV1;
 
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Completion,
@@ -529,11 +529,10 @@ class AWSCompletion extends FimPromptCompletion {
 	constructor(_config: ModelConfig) {
 		super(_config);
 
+		// Cast to ai.LanguageModelV1 to satisfy base class type
 		this.model = createAmazonBedrock({
-			bedrockOptions: {
-				credentials: fromNodeProviderChain(),
-			}
-		})(this._config.model);
+			credentialProvider: fromNodeProviderChain(),
+		})(this._config.model) as unknown as ai.LanguageModelV1;
 	}
 }
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -422,7 +422,6 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		const outputCount = usage.completionTokens;
 		const inputCount = usage.promptTokens;
 		const requestId = (options.modelOptions as any)?.requestId;
-		log.debug(`[${this._config.name}]: ${inputCount} input tokens, ${outputCount} output tokens`);
 
 		if (requestId) {
 			recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
@@ -436,7 +435,19 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 
 		// Log Bedrock usage if available
 		if (other && other.bedrock && other.bedrock.usage) {
+			// Get the Bedrock usage object; it typically contains
+			// `cacheReadInputTokens` and `cacheWriteInputTokens`
+			const usage = other.bedrock.usage as Record<string, any>;
+
+			// Add the input and output tokens to the usage object
+			usage.inputTokens = inputCount;
+			usage.outputTokens = outputCount;
+
+			// Log the Bedrock usage
 			log.debug(`[${this._config.name}]: Bedrock usage: ${JSON.stringify(other.bedrock.usage, null, 2)}`);
+		} else {
+			// For all other models, log the input and output tokens alone
+			log.debug(`[${this._config.name}]: Usage: ${inputCount} input tokens, ${outputCount} output tokens`);
 		}
 	}
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -217,7 +217,15 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		// Override maxOutputTokens if specified in the configuration
 		for (const [key, value] of Object.entries(maxOutputTokens)) {
 			if (_config.model.indexOf(key) !== -1 && value) {
-				const maxOutputTokens = value * 1024; // Convert from 1K tokens to actual tokens
+				let maxOutputTokens = value;
+				if (typeof maxOutputTokens !== 'number') {
+					log.warn(`Invalid maxOutputTokens '${maxOutputTokens}' for ${key} (${_config.model}); ignoring`);
+					continue;
+				}
+				if (maxOutputTokens < 512) {
+					log.warn(`Specified maxOutputTokens '${maxOutputTokens}' for ${key} (${_config.model}) is too low; using 512 instead`);
+					maxOutputTokens = 512;
+				}
 				log.debug(`Setting maxOutputTokens for ${key} (${_config.model}) to ${maxOutputTokens}`);
 				this.maxOutputTokens = maxOutputTokens;
 				break;


### PR DESCRIPTION
Addresses #8913. 

Brings forward these improvements:

- configurable max output tokens per provider (applies to all providers)
- ability to toggle followup generation on/off (applies to all providers)
- lower max output tokens for Bedrock Claude models
- cache breakpoints for Bedrock Claude

I've also made two additional logging improvements not included in 2025.08:

- all Anthropic usage stats logged in one entry after each request finishes (suggestion from @wch)
- we now log at the `[info]` level more often (at least twice every time you ask Assistant something). Formerly, it was very possible to see literally nothing in the Assistant logs at the default `[info]` level, which was disconcerting.

I would like to refactor the Bedrock bits, so there are fewer model-specific switches in the general Vercel handling. That can be tracked in #8776. 

### QA Notes

- Be sure to set the log level to Trace to see all the new logging.
- Turning on followup generation requires an IDE restart.
- If you want to test these changes in Desktop, you'll need the following guide: https://connect.posit.it/positron-wiki/positron-assistant.html#aws-bedrock-in-positron-desktop