### PR TITLE
Send pre-renderings with plot updates

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/plot_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/plot_comm.py
@@ -209,6 +209,16 @@ class PlotFrontendEvent(str, enum.Enum):
     Show = "show"
 
 
+class UpdateParams(BaseModel):
+    """
+    Notification that a plot has been updated on the backend.
+    """
+
+    pre_render: Optional[PlotResult] = Field(
+        description="Optional pre-rendering data for immediate display",
+    )
+
+
 IntrinsicSize.update_forward_refs()
 
 PlotResult.update_forward_refs()
@@ -222,3 +232,5 @@ GetIntrinsicSizeRequest.update_forward_refs()
 RenderParams.update_forward_refs()
 
 RenderRequest.update_forward_refs()
+
+UpdateParams.update_forward_refs()

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -966,7 +966,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.202"
+      "ark": "0.1.203"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/positron/comms/plot-frontend-openrpc.json
+++ b/positron/comms/plot-frontend-openrpc.json
@@ -8,7 +8,16 @@
 		{
 			"name": "update",
 			"summary": "Notification that a plot has been updated on the backend.",
-			"params": []
+			"params": [
+				{
+					"name": "pre_render",
+					"description": "Optional pre-rendering data for immediate display",
+					"required": false,
+					"schema": {
+						"$ref": "plot-backend-openrpc.json#/components/schemas/plot_result"
+					}
+				}
+			]
 		},
 		{
 			"name": "show",

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -6,7 +6,7 @@
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IPositronPlotClient, IZoomablePlotClient, ZoomLevel } from '../../positronPlots/common/positronPlots.js';
-import { IntrinsicSize, PlotResult, PlotRenderFormat } from './positronPlotComm.js';
+import { IntrinsicSize, PlotResult, PlotRenderFormat, PlotSize } from './positronPlotComm.js';
 import { IPlotSize, IPositronPlotSizingPolicy } from '../../positronPlots/common/sizingPolicy.js';
 import { PositronPlotCommProxy } from './positronPlotCommProxy.js';
 import { PlotSizingPolicyCustom } from '../../positronPlots/common/sizingPolicyCustom.js';
@@ -241,10 +241,54 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			this._state = state;
 		}));
 
+		let needsSelect = true;
+
 		// Listen for plot updates
-		this._register(this._commProxy.onDidRenderUpdate(async () => {
+		this._register(this._commProxy.onDidRenderUpdate(async (evt) => {
+			const preRender = evt.pre_render;
+
+			// If there's a pre-rendering, check if we can use it for immediate display
+			if (preRender && preRender.settings) {
+				const uri = `data:${preRender.mime_type};base64,${preRender.data}`;
+				const preRenderPlot: IRenderedPlot = {
+					uri,
+					size: preRender.settings.size,
+					pixel_ratio: preRender.settings.pixel_ratio,
+					renderTimeMs: 0,
+				};
+
+				// Store the pre-rendering as the last render
+				this._lastRender = preRenderPlot;
+
+				// Fire the complete render event to actually update the plot instance
+				this._completeRenderEmitter.fire(preRenderPlot);
+
+				// Fire the render update event to select the updated plot in the UI
+				this._renderUpdateEmitter.fire(preRenderPlot);
+
+				// Check if the current render settings match
+				const currentRenderRequest = this._currentRender?.renderRequest ?? this._lastRender;
+
+				if (currentRenderRequest && this.settingsEqual(
+					preRender.settings,
+					currentRenderRequest
+				)) {
+					// The settings match, return without queueing a render request
+					return;
+				}
+
+				// Otherwise fallthrough. But don't select plot again to avoid
+				// unexpected jerkiness.
+				needsSelect = false;
+			}
+
+			// No pre-rendering or settings mismatch: Queue a render request
 			const rendered = await this.queuePlotUpdateRequest();
-			this._renderUpdateEmitter.fire(rendered);
+
+			// Fire the update event to select it in the UI
+			if (needsSelect) {
+				this._renderUpdateEmitter.fire(rendered);
+			}
 		}));
 
 		// Listn for plot show events
@@ -290,6 +334,26 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 * @param preview If true, the plot will be rendered but not stored and no events are emitted.
 	 * @returns A promise that resolves to a rendered image, or rejects with an error.
 	 */
+
+	/**
+	 * Check if the render settings match
+	 */
+	private settingsEqual(
+		left: { size?: PlotSize; pixel_ratio: number; format?: PlotRenderFormat },
+		right: { size?: PlotSize; pixel_ratio: number; format?: PlotRenderFormat },
+	): boolean {
+		if (left.size?.height !== right.size?.height) {
+			return false;
+		}
+		if (left.size?.width !== right.size?.width) {
+			return false;
+		}
+		if (left.pixel_ratio !== right.pixel_ratio) {
+			return false;
+		}
+		return true;
+	}
+
 	public render(size: IPlotSize | undefined, pixel_ratio: number, format = PlotRenderFormat.Png, preview = false): Promise<IRenderedPlot> {
 		// Deal with whole pixels only
 		const sizeInt = size && {
@@ -300,10 +364,10 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		// Compare against the last render request. It is normal for the same
 		// render request to be made multiple times, e.g. when the UI component
 		// is redrawn without changing the plot size.
-		if (this._lastRender &&
-			this._lastRender.size?.height === sizeInt?.height &&
-			this._lastRender.size?.width === sizeInt?.width &&
-			this._lastRender.pixel_ratio === pixel_ratio) {
+		if (sizeInt && this._lastRender?.size && this._lastRender && this.settingsEqual(
+			{ size: sizeInt, pixel_ratio, format },
+			this._lastRender
+		)) {
 			// The last render request was the same size; return the last render
 			// result without performing another render.
 			return Promise.resolve(this._lastRender);

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -136,9 +136,24 @@ export interface RenderParams {
 }
 
 /**
+ * Parameters for the Update method.
+ */
+export interface UpdateParams {
+	/**
+	 * Optional pre-rendering data for immediate display
+	 */
+	pre_render?: PlotResult;
+}
+
+/**
  * Event: Notification that a plot has been updated on the backend.
  */
 export interface UpdateEvent {
+	/**
+	 * Optional pre-rendering data for immediate display
+	 */
+	pre_render?: PlotResult;
+
 }
 
 /**
@@ -163,7 +178,7 @@ export class PositronPlotComm extends PositronBaseComm {
 		options?: PositronCommOptions<PlotBackendRequest>,
 	) {
 		super(instance, options);
-		this.onDidUpdate = super.createEventEmitter('update', []);
+		this.onDidUpdate = super.createEventEmitter('update', ['pre_render']);
 		this.onDidShow = super.createEventEmitter('show', []);
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotCommProxy.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotCommProxy.ts
@@ -6,7 +6,7 @@
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IRuntimeClientInstance, RuntimeClientState } from './languageRuntimeClientInstance.js';
-import { IntrinsicSize, PositronPlotComm } from './positronPlotComm.js';
+import { IntrinsicSize, PositronPlotComm, UpdateEvent } from './positronPlotComm.js';
 import { DeferredRender, PositronPlotRenderQueue } from './positronPlotRenderQueue.js';
 
 
@@ -46,10 +46,10 @@ export class PositronPlotCommProxy extends Disposable {
 	/**
 	 * Event that fires when the plot has been updated by the runtime and
 	 * re-rendered. Notifies clients so they can request a render update with their own
-	 * render parameters.
+	 * render parameters. May include a pre-rendering for immediate display.
 	 */
-	onDidRenderUpdate: Event<void>;
-	private readonly _renderUpdateEmitter = new Emitter<void>();
+	onDidRenderUpdate: Event<UpdateEvent>;
+	private readonly _renderUpdateEmitter = new Emitter<UpdateEvent>();
 
 	/**
 	 * Event that fires when the plot wants to display itself.
@@ -105,8 +105,8 @@ export class PositronPlotCommProxy extends Disposable {
 			this._didShowPlotEmitter.fire();
 		}));
 
-		this._register(this._comm.onDidUpdate((_evt) => {
-			this._renderUpdateEmitter.fire();
+		this._register(this._comm.onDidUpdate((evt) => {
+			this._renderUpdateEmitter.fire(evt);
 		}));
 
 		this._register(this._comm);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7679
Addresses https://github.com/posit-dev/positron/issues/8941

Since https://github.com/posit-dev/positron/pull/7247 we send pre-renderings of plots in the `comm_open` notification that opens the plot, so that it can be immediately displayed in the plot pane. This isn't the case for plot _updates_ which currently require the frontend to request the rendering, resulting in delays and missing updates. To fix this, the `update` notification gains an optional `pre_render` parameter that the frontend can use to display the update immediately. If the rendering settings are outdated and do not match, we still request a rerender as before.

In addition, this PR fixes an issue in the comm generation where importing from the backend in the frontend of a comm (or vice versa) resulted in a redundant import.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Plots created in steps with prompts in between (e.g. `demo(graphics)` are now immediately displayed in full (#7679).
- Plots created in steps are now consistently rendered with expected rendering settings (#8941).


### QA Notes

Run an expression that creates a plot in two steps:

```r
dat <- mtcars
pr <- princomp(dat)
biplot(pr)
```

With release Positron there is a delay between the two steps:

https://github.com/user-attachments/assets/65fb5ea4-659c-45a0-b054-e07db260731c

With the fix, it's much snappier:

https://github.com/user-attachments/assets/ea5dc4f2-3600-4f46-86bc-69f5b4c8beb7

If you create the plot a second time, with release Positron the second plot uses incorrect rendering settings:

https://github.com/user-attachments/assets/16dd9652-b521-4257-8474-61fa48c1b7c4

With the fix, the second plot is rerendered with the right settings immediately:

https://github.com/user-attachments/assets/3ec3abf3-2921-497c-9303-099f342acb5c

More important fix: With an expression that prompts the user for inputs between multi-step plots:

```r
demo(graphics)
```

With release Positron, you only get updates after the whole command returns

https://github.com/user-attachments/assets/c593e948-cba9-4d6c-8966-fc8d918f3698

With the fix, the plot is fully rendered immediately:

https://github.com/user-attachments/assets/ea96eab4-f2ef-4a99-93a1-3d1b03c8d50b
