### PR TITLE
e2e: unskip convert to code test

### DIFF
--- a/test/e2e/tests/data-explorer/convert-to-code.test.ts
+++ b/test/e2e/tests/data-explorer/convert-to-code.test.ts
@@ -33,7 +33,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
+test.describe('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
 
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
@@ -73,14 +73,14 @@ test.describe.skip('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA
 			await dataExplorer.clickConvertToCodeButton();
 			await modals.expectButtonToBeVisible(expectedCodeStyle.toLowerCase());
 			await modals.expectToContainText(
-				'filter_mask = (df[\'status\'] == active) & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)'
+				'filter_mask = (df[\'status\'] == \'active\') & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)'
 			);
 
 			const expectedGeneratedCode = {
-				'Pandas': 'filter_mask = (df[\'status\'] == active) & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)',
-				'Polars': 'tbd',
-				'Tidyverse': 'tbd',
-				'data.table': 'tbd'
+				'Pandas': 'filter_mask = (df[\'status\'] == \'active\') & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)',
+				// 'Polars': 'tbd',
+				// 'Tidyverse': 'tbd',
+				// 'data.table': 'tbd'
 			}[expectedCodeStyle] || '';
 			await modals.expectToContainText(expectedGeneratedCode);
 		});


### PR DESCRIPTION
Flipping the switch for the e2e pandas conversion test!

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Run e2e test for converting pandas data explorer filters to code.

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer should be green 💯 