### PR TITLE
Fix connections pane buttons sizes and padding

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -6,7 +6,7 @@
 .connections-new-connection-create-connection {
 	display: grid;
 	gap: 10px;
-	grid-template-rows: 36px 2fr 15px 2fr 28px;
+	grid-template-rows: 36px 2fr 15px 2fr 32px;
 	grid-template-columns: 1fr 90px;
 	grid-template-areas:
 		"title-1  title-1"

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
@@ -6,7 +6,7 @@
 .connections-new-connection-list-drivers {
 	display: grid;
 	gap: 10px;
-	grid-template-rows: 36px 24px 1fr 28px;
+	grid-template-rows: 36px 24px 1fr 32px;
 	height: 100%;
 }
 

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModelDialog.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModelDialog.css
@@ -4,5 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-modal-dialog-box > .connections-new-connection-modal > .content-area {
-	bottom: 0px;
+	bottom: 10px;
+}
+
+.positron-modal-dialog-box .connections-new-connection-modal .action-bar-button {
+	height: 32px;
 }

--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.css
@@ -4,14 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 .connections-resume-connection-modal .positron-modal-dialog-box .content-area {
-	bottom: 0px;
+	bottom: 10px;
+}
+
+.connections-resume-connection-modal .positron-modal-dialog-box .content-area .action-bar-button {
+	height: 32px;
 }
 
 .connections-resume-connection-modal .content {
 	height: 100%;
 	display: grid;
 	gap: 10px;
-	grid-template-rows: 18px auto 28px;
+	grid-template-rows: 18px auto 32px;
 	grid-template-columns: auto 90px;
 	grid-template-areas:
 		"title  title"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Addresses #8964 

I don't know for sure what change could have caused this, but this should make the buttons with a fixed height and also adds bottom padding to the modal content area.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes padding in Connections Pande modals. (#8964)

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
