### PR TITLE
data explorer: add row filtering context key

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -18,7 +18,7 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 import { IPositronDataExplorerEditor } from './positronDataExplorerEditor.js';
 import { IPositronDataExplorerService, PositronDataExplorerLayout } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
-import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR, POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING, POSITRON_DATA_EXPLORER_IS_CONVERT_TO_CODE_ENABLED, POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE, POSITRON_DATA_EXPLORER_IS_PLAINTEXT, POSITRON_DATA_EXPLORER_LAYOUT } from './positronDataExplorerContextKeys.js';
+import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR, POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING, POSITRON_DATA_EXPLORER_IS_CONVERT_TO_CODE_ENABLED, POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE, POSITRON_DATA_EXPLORER_IS_ROW_FILTERING, POSITRON_DATA_EXPLORER_IS_PLAINTEXT, POSITRON_DATA_EXPLORER_LAYOUT } from './positronDataExplorerContextKeys.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
 import { EditorOpenSource } from '../../../../platform/editor/common/editor.js';
@@ -803,7 +803,10 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 			f1: true,
 			precondition: ContextKeyExpr.and(
 				POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
-				POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE
+				POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE,
+				ContextKeyExpr.or(
+					POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING,
+					POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 			),
 			icon: Codicon.code,
 			menu: [

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerContextKeys.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerContextKeys.ts
@@ -38,3 +38,7 @@ export const POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE = new RawContextKey<
 	'positronDataExplorerCodeSyntaxesAvailable',
 	false
 );
+export const POSITRON_DATA_EXPLORER_IS_ROW_FILTERING = new RawContextKey<boolean>(
+	'positronDataExplorerIsRowFiltering',
+	false
+);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -364,9 +364,10 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 					}
 					// set context keys for convert to code and code syntaxes availability
 					const convertToCode = backendState.supported_features.convert_to_code;
-					if (backendState.supported_features.convert_to_code.support_status === SupportStatus.Unsupported) {
-						this._isConvertToCodeEnabledContextKey.set(false);
-					}
+
+					this._isConvertToCodeEnabledContextKey.set((
+						convertToCode.support_status === SupportStatus.Supported) && checkDataExplorerConvertToCodeEnabled(this._configurationService)
+					);
 					this._codeSyntaxesAvailableContextKey.set(
 						!!(convertToCode.code_syntaxes && convertToCode.code_syntaxes.length > 0)
 					);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -258,12 +258,6 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 			this._group.scopedContextKeyService
 		);
 
-		// Set the convert to code context key based on the configuration value.
-		this._isConvertToCodeEnabledContextKey.set(
-			checkDataExplorerConvertToCodeEnabled(this._configurationService)
-		);
-
-
 		// Listen for configuration changes to the convert to code setting and update the context key accordingly.
 		this._register(this._configurationService.onDidChangeConfiguration(event => {
 			if (event.affectsConfiguration(DATA_EXPLORER_CONVERT_TO_CODE)) {


### PR DESCRIPTION
Adding a context key, similar to the `isColumnSorting`, but instead we'll track if there's filtering. I'm just using the backend state to see if any filters are present, since it syncs as filters get applied/removed.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #8719 Adds a context key that tracks if row filters are applied.

#### Bug Fixes

- N/A


### QA Notes

The `Convert to Code` button should only be available in `pandas` DataFrames when either filtering or sorting is applied. Here's a simple df to copy/paste for convenience!


```python
import pandas as pd

x = pd.DataFrame({'x':[1,2,3,4,5]})
%view x
```