### PR TITLE
Connections Pane support for native duckdb connections

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -4186,3 +4186,8 @@ Apache Spark and its logo are trademarks of The Apache Software Foundation.
 https://spark.apache.org/trademarks.html
 ---------------------------------------------------------
 
+---------------------------------------------------------
+The DuckDB trademarks, service marks, and graphics marks are held by the Dutch Stichting DuckDB Foundation (“hereinafter: the DuckDB Foundation”).
+
+https://duckdb.org/trademark_guidelines.html
+---------------------------------------------------------

--- a/extensions/positron-connections/media/logo/duckdb.svg
+++ b/extensions/positron-connections/media/logo/duckdb.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<svg width="344.4" height="344.4" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 1209.5 344.4" version="1.1" xml:space="preserve">
+ <style type="text/css">.st0{fill:#fff100}</style>
+ <g class="layer" display="inline">
+  <title>Layer 1</title>
+  <path d="m172.2,339.4l0,0c-92.5,0 -167.2,-74.7 -167.2,-167.2l0,0c0,-92.5 74.7,-167.2 167.2,-167.2l0,0c92.5,0 167.2,74.7 167.2,167.2l0,0c0,92.5 -74.7,167.2 -167.2,167.2z" id="svg_2"/>
+  <path class="st0" d="m261.6,147.4l-32.8,0l0,49.5l32.8,0c13.6,0 24.9,-11.3 24.9,-24.9c0,-13.7 -11.3,-24.6 -24.9,-24.6" id="svg_3"/>
+  <path class="st0" d="m68.1,172.2c0,38.2 31.1,69.3 69.3,69.3s69.3,-31.1 69.3,-69.3s-31.1,-69.3 -69.3,-69.3s-69.3,31.1 -69.3,69.3l0,0" id="svg_4"/>
+ </g>
+</svg>

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -853,18 +853,19 @@ class DuckDBConnection(Connection):
         if len(path) != 3:
             raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
 
-        schema, table, catalog = path
+        catalog, schema, table = path
         if (
             schema.kind != "schema"
             or table.kind not in ["table", "view"]
             or catalog.kind != "catalog"
         ):
             raise ValueError(
-                "Path must include a schema and a table/view in this order.", f"Path: {path}"
+                "Path must include a catalog, a schema and a table/view in this order.",
+                f"Path: {path}",
             )
 
         # Use DuckDB's native pandas integration via .df() method
-        query = f'SELECT * FROM "{catalog.name}.{schema.name}"."{table.name}" LIMIT 1000'
+        query = f'SELECT * FROM "{catalog.name}"."{schema.name}"."{table.name}" LIMIT 1000'
         return self.conn.execute(query).df()
 
     def list_object_types(self):

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -815,7 +815,7 @@ class DuckDBConnection(Connection):
 
         # DuckDB doesn't have deeper hierarchies. If we get to this point
         # it means the path is invalid.
-        raise ValueError(f"Path length must be at most 1, but got {len(path)}. Path: {path}")
+        raise ValueError(f"Path length must be at most 2, but got {len(path)}. Path: {path}")
 
     def list_fields(self, path: list[ObjectSchema]):
         if len(path) != 3:

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -295,6 +295,8 @@ class ConnectionsService:
             return SQLite3Connection(obj)
         elif safe_isinstance(obj, "sqlalchemy", "Engine"):
             return SQLAlchemyConnection(obj)
+        elif safe_isinstance(obj, "duckdb", "DuckDBPyConnection"):
+            return DuckDBConnection(obj)
         else:
             type_name = type(obj).__name__
             raise UnsupportedConnectionError(f"Unsupported connection type {type(obj)}")
@@ -302,10 +304,12 @@ class ConnectionsService:
     def object_is_supported(self, obj: Any) -> bool:
         """Checks if an object is supported by the connections pane."""
         try:
-            # This block might fail if for some reason 'Connection' or 'Engine' are
+            # This block might fail if for some reason 'Connection', 'Engine', or 'DuckDBPyConnection' are
             # not available in their modules.
-            return safe_isinstance(obj, "sqlite3", "Connection") or safe_isinstance(
-                obj, "sqlalchemy", "Engine"
+            return (
+                safe_isinstance(obj, "sqlite3", "Connection")
+                or safe_isinstance(obj, "sqlalchemy", "Engine")
+                or safe_isinstance(obj, "duckdb", "DuckDBPyConnection")
             )
         except Exception as err:
             logger.error(f"Error checking supported {err}")
@@ -727,3 +731,148 @@ class SQLAlchemyConnection(Connection):
                 "Invalid path. Expected path to contain a schema and a table/view.",
                 f"But got schema.kind={schema.kind} and table.kind={table.kind}",
             )
+
+
+class DuckDBConnection(Connection):
+    """Support for DuckDB connections to databases."""
+
+    def __init__(self, conn: Any):
+        self.conn = conn
+
+        db_list = conn.execute("PRAGMA database_list;").fetchall()
+        databases = ", ".join([row[1] for row in db_list])
+
+        self.host = db_list[0][2]  # pragma database_list returns (seq, name, file)
+        if self.host == "" or self.host is None:
+            self.host = ":memory:"
+
+        self.display_name = f"DuckDB ({databases})"
+        self.type = "DuckDB"
+
+        # DuckDB allows attaching other databases, thus we can't really get to the exact same
+        # state. But we can at least show how to connect to the initial database.
+        self.code = (
+            "import duckdb\n"
+            f"conn = duckdb.connect(database={self.host!r})\n"
+            "%connection_show conn\n"
+        )
+
+    def list_objects(self, path: list[ObjectSchema]):
+        if len(path) == 0:
+            # we are at the root of the connection. DuckDB allows a connection to attach to multiple
+            # databases. so we return a list of 'catalogs'.
+            res = self.conn.execute(
+                "SELECT DISTINCT catalog_name FROM information_schema.schemata WHERE catalog_name NOT IN ('system', 'temp');"
+            )
+
+            return [
+                ConnectionObject({"name": name, "kind": "catalog"}) for (name,) in res.fetchall()
+            ]
+
+        if len(path) == 1:
+            # We must have a catalog on the path, and we return the list of schemas in that catalog.
+            catalog = path[0]
+            if catalog.kind != "catalog":
+                raise ValueError(
+                    f"Invalid path. Expected it to include a catalog, but got '{catalog.kind}'",
+                    f"Path: {path}",
+                )
+
+            res = self.conn.execute(
+                """
+                SELECT DISTINCT schema_name FROM information_schema.schemata
+                WHERE catalog_name = ?;
+                """,
+                (catalog.name,),
+            )
+
+            return [
+                ConnectionObject({"name": name, "kind": "schema"}) for (name,) in res.fetchall()
+            ]
+
+        if len(path) == 2:
+            # Query for tables and views in the catalog/ schema
+            catalog, schema = path
+            if catalog.kind != "catalog" or schema.kind != "schema":
+                raise ValueError(
+                    "Path must include a catalog and a schema in this order.", f"Path: {path}"
+                )
+
+            res = self.conn.execute(
+                """
+                SELECT table_name, table_type
+                FROM information_schema.tables
+                WHERE table_schema = ? AND table_catalog = ?
+                """,
+                (schema.name, catalog.name),
+            )
+
+            tables: list[ConnectionObject] = []
+            for name, table_type in res.fetchall():
+                # Convert DuckDB table types to our standard types
+                kind = "view" if table_type == "VIEW" else "table"
+                tables.append(ConnectionObject({"name": name, "kind": kind}))
+
+            return tables
+
+        # DuckDB doesn't have deeper hierarchies. If we get to this point
+        # it means the path is invalid.
+        raise ValueError(f"Path length must be at most 1, but got {len(path)}. Path: {path}")
+
+    def list_fields(self, path: list[ObjectSchema]):
+        if len(path) != 3:
+            raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
+
+        catalog, schema, table = path
+        if (
+            schema.kind != "schema"
+            or table.kind not in ["table", "view"]
+            or catalog.kind != "catalog"
+        ):
+            raise ValueError(
+                "Path must include a catalog, a schema and a table/view in this order.",
+                f"Path: {path}",
+            )
+
+        # Query for column information
+        res = self.conn.execute(
+            """
+            SELECT column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema = ? AND table_name = ? AND table_catalog = ?
+            ORDER BY ordinal_position;
+            """,
+            (schema.name, table.name, catalog.name),
+        )
+
+        return [
+            ConnectionObjectFields({"name": name, "dtype": dtype}) for name, dtype in res.fetchall()
+        ]
+
+    def preview_object(self, path: list[ObjectSchema]):
+        if len(path) != 3:
+            raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
+
+        schema, table, catalog = path
+        if (
+            schema.kind != "schema"
+            or table.kind not in ["table", "view"]
+            or catalog.kind != "catalog"
+        ):
+            raise ValueError(
+                "Path must include a schema and a table/view in this order.", f"Path: {path}"
+            )
+
+        # Use DuckDB's native pandas integration via .df() method
+        query = f'SELECT * FROM "{catalog.name}.{schema.name}"."{table.name}" LIMIT 1000'
+        return self.conn.execute(query).df()
+
+    def list_object_types(self):
+        return {
+            "table": ConnectionObjectInfo({"contains": "data", "icon": None}),
+            "view": ConnectionObjectInfo({"contains": "data", "icon": None}),
+            "schema": ConnectionObjectInfo({"contains": None, "icon": None}),
+        }
+
+    def disconnect(self):
+        self.conn.close()  # type: ignore

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -752,9 +752,7 @@ class DuckDBConnection(Connection):
         # DuckDB allows attaching other databases, thus we can't really get to the exact same
         # state. But we can at least show how to connect to the initial database.
         self.code = (
-            "import duckdb\n"
-            f"conn = duckdb.connect(database={self.host!r})\n"
-            "%connection_show conn\n"
+            f"import duckdb\nconn = duckdb.connect(database={self.host!r})\n%connection_show conn\n"
         )
 
     def list_objects(self, path: list[ObjectSchema]):

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1151,6 +1151,18 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
         return True
 
 
+class DuckDBConnectionInspector(BaseConnectionInspector):
+    CLASS_QNAME = ("duckdb.duckdb.DuckDBPyConnection",)
+
+    def _is_active(self, value) -> bool:
+        try:
+            # a connection is active if you can acquire a cursor from it
+            value.cursor()
+        except Exception:
+            return False
+        return True
+
+
 class IbisExprInspector(PositronInspector["ibis.Expr"]):
     def has_children(self) -> bool:
         return False
@@ -1188,6 +1200,7 @@ INSPECTOR_CLASSES: dict[str, type[PositronInspector]] = {
     DatetimeInspector.CLASS_QNAME: DatetimeInspector,
     **dict.fromkeys(SQLiteConnectionInspector.CLASS_QNAME, SQLiteConnectionInspector),
     **dict.fromkeys(SQLAlchemyEngineInspector.CLASS_QNAME, SQLAlchemyEngineInspector),
+    **dict.fromkeys(DuckDBConnectionInspector.CLASS_QNAME, DuckDBConnectionInspector),
     "ibis.Expr": IbisExprInspector,
     "boolean": BooleanInspector,
     "bytes": BytesInspector,

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1153,7 +1153,7 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
 
 
 class DuckDBConnectionInspector(BaseConnectionInspector):
-    CLASS_QNAME = ("duckdb.duckdb.DuckDBPyConnection",)
+    CLASS_QNAME = ("duckdb.DuckDBPyConnection",)
 
     def _is_active(self, value) -> bool:
         try:

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -104,6 +104,7 @@ SIMPLER_NAMES = {
     "pandas.core.indexes.multi.MultiIndex": "pandas.MultiIndex",
     # Just display Int64Index as pandas.Index, since the former is deprecated since pandas v1.4.0.
     "pandas.core.indexes.numeric.Int64Index": "pandas.Index",
+    "duckdb.duckdb.DuckDBPyConnection": "duckdb.DuckDBPyConnection",
 }
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
@@ -9,6 +9,13 @@ from typing import Tuple
 import pytest
 import sqlalchemy
 
+try:
+    import duckdb
+
+    HAS_DUCKDB = True
+except ImportError:
+    HAS_DUCKDB = False
+
 from positron.access_keys import encode_access_key
 from positron.connections import ConnectionsService
 
@@ -34,6 +41,14 @@ def get_sqlalchemy_sqlite_connection():
 def get_sqlite3_sqlite_connection():
     con = sqlite3.connect(":memory:")
     add_default_data(lambda sql: con.cursor().execute(sql))
+    return con
+
+
+def get_duckdb_connection():
+    if not HAS_DUCKDB:
+        pytest.skip("DuckDB not available")
+    con = duckdb.connect(":memory:")
+    add_default_data(lambda sql: con.execute(sql))
     return con
 
 
@@ -142,6 +157,127 @@ class TestSQLiteConnectionsService:
         assert result is None
 
 
+@pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not available")
+class TestDuckDBConnectionsService:
+    def test_register_connection(self, connections_service: ConnectionsService):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+        assert comm_id in connections_service.comms
+
+    @pytest.mark.parametrize("path", [[], [{"kind": "schema", "name": "main"}]])
+    def test_contains_data(self, connections_service: ConnectionsService, path):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="contains_data", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert result is False
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ([], ""),
+            ([{"kind": "schema", "name": "main"}], ""),
+        ],
+    )
+    def test_get_icon(self, connections_service: ConnectionsService, path, expected):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="get_icon", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        ("path", "expected_contains"),
+        [
+            ([], "memory"),  # DuckDB has been connected to memory
+            ([{"kind": "catalog", "name": "memory"}], "main"),
+            (
+                [{"kind": "catalog", "name": "memory"}, {"kind": "schema", "name": "main"}],
+                "movie",
+            ),  # Should contain our test table
+        ],
+    )
+    def test_list_objects(self, connections_service: ConnectionsService, path, expected_contains):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="list_objects", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+
+        # Check that expected item is in the results
+        names = [item["name"] for item in result]
+        assert expected_contains in names
+
+    def test_list_fields(self, connections_service: ConnectionsService):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(
+            params={
+                "path": [
+                    {"kind": "catalog", "name": "memory"},
+                    {"kind": "schema", "name": "main"},
+                    {"kind": "table", "name": "movie"},
+                ]
+            },
+            method="list_fields",
+            comm_id=comm_id,
+        )
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert len(result) == 3
+        # DuckDB uses different type names than SQLite
+        assert result[0]["name"] == "title"
+        assert result[1]["name"] == "year"
+        assert result[2]["name"] == "score"
+
+    def test_preview_object(self, connections_service: ConnectionsService):
+        con = get_duckdb_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(
+            params={
+                "path": [
+                    {"kind": "catalog", "name": "memory"},
+                    {"kind": "schema", "name": "main"},
+                    {"kind": "table", "name": "movie"},
+                ]
+            },
+            method="preview_object",
+            comm_id=comm_id,
+        )
+        dummy_comm.handle_msg(msg)
+        # cleanup the data_explorer state, so we don't break its own tests
+        connections_service._kernel.data_explorer_service.shutdown()  # noqa: SLF001
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert result is None
+
+
 class TestVariablePaneIntegration:
     @pytest.mark.parametrize("con", get_sqlite_connections())
     def test_open_then_delete(
@@ -207,6 +343,24 @@ class TestVariablePaneIntegration:
         connections_service.comms[comm_id].comm.handle_close({})
 
         assert connections_service.comms.get(comm_id) is None
+        assert connections_service.path_to_comm_ids.get(path) is None
+
+    @pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not available")
+    def test_duckdb_integration(
+        self,
+        shell: PositronShell,
+        connections_service: ConnectionsService,
+        variables_comm: DummyComm,
+    ):
+        con = get_duckdb_connection()
+        self._assign_variables(shell, variables_comm, duck_con=con)
+        path = self._view_in_connections_pane(variables_comm, ["duck_con"])
+
+        assert connections_service.path_to_comm_ids[path] is not None
+        assert connections_service.variable_has_active_connection("duck_con")
+
+        # Test deleting DuckDB connection
+        self._delete_variables(shell, variables_comm, ["duck_con"])
         assert connections_service.path_to_comm_ids.get(path) is None
 
     # TODO: reuse code from test_data_explorer.py


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


Adresses #8484 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added support for inspecting native DuckDB connections in the Connections Pane (#8484).

#### Bug Fixes

- N/A


### QA Notes

1. `pip install duckdb`
2. Use the modal to create a new duckdb connection with all the defaults
3. press `Connect` button in Connections modal
4. in the console, run

```python
conn.execute("""
    CREATE TABLE employees (
        id INTEGER,
        name VARCHAR,
        department VARCHAR,
        salary INTEGER
    )
""")

# Insert sample data
conn.execute("""
    INSERT INTO employees VALUES 
    (1, 'Alice', 'Engineering', 75000),
    (2, 'Bob', 'Marketing', 65000),
    (3, 'Charlie', 'Engineering', 80000),
    (4, 'Diana', 'Sales', 70000)
""")
```
5. See tables populated as you click through the Connections pane