### PR TITLE
Fix for Data Explorer scroll bars snapping back to 0 on Safari

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridScrollbar.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridScrollbar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,6 +11,7 @@ import React, { CSSProperties, MouseEvent, useLayoutEffect, useState } from 'rea
 
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
+import { isSafari } from '../../../../base/common/platform.js';
 import { pinToRange } from '../../../../base/common/positronUtilities.js';
 
 /**
@@ -250,8 +251,12 @@ export const DataGridScrollbar = (props: DataGridScrollbarProps) => {
 			target.removeEventListener('pointermove', pointerMoveHandler);
 			target.removeEventListener('lostpointercapture', lostPointerCaptureHandler);
 
-			// Adjust the slider.
-			updateSliderPosition(e);
+			// Adjust the slider for the final pointer event. Do not do this on Safari because the
+			// clientX and clientY will be 0 which causes the scrollbar to snap back to the top
+			// or the left. See https://github.com/posit-dev/positron/issues/8930.
+			if (!isSafari) {
+				updateSliderPosition(e);
+			}
 		};
 
 		/**


### PR DESCRIPTION
### Description

This PR addresses #8930. This fix was tested on Chromium-based browsers, Firefox, and Safari.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #8930 Fix for Data Explorer scrollbars snapping back to 0 on Safari.

### QA Notes

To test this, open Positron on Safari, open a (medium to large) data frame into Data Explorer, and verify that the thumb of vertical and horizontal scroll bars can be dragged to any position without "snapping back" to 0.