### PR TITLE
Address ResizeObserver not working in secondary windows by polling for size changes in the DataGridWaffle

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.css
@@ -15,6 +15,7 @@
 
 .column-selector .column-selector-search {
 	height: 34px;
+	box-sizing: border-box;
 	grid-row: column-selector-search / column-selector-data-grid;
 	border-bottom: 1px solid var(--vscode-positronDataExplorer-border);
 }

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -94,8 +94,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 		// ResizeObserver does not work well on elements inside secondary Electron windows. This causes issues
 		// with the data grid's automatic layout feature, which relies on knowing when the size of the data grid
-		// waffle changes. See https://github.com/posit-dev/positron/issues/8695. This workaround ensures that the
-		// initial data grid waffle's size is updated when the component is mounted.
+		// waffle changes. See https://github.com/posit-dev/positron/issues/8695. Using `requestAnimationFrame`
+		// ensures that the initial size of the data grid waffle is set when the component is mounted.
 		DOM.getWindow(dataGridWaffleRef.current).requestAnimationFrame(async () =>
 			await setSize(dataGridWaffleRef.current.offsetWidth, dataGridWaffleRef.current.offsetHeight)
 		);


### PR DESCRIPTION
### Description

This PR addresses #8695. The root cause of this issue is that ResizeObserver does not work well on elements inside secondary Electron windows. This causes issues with the Data Grid's automatic layout feature, which relies on knowing when the size of the Data Grid waffle changes. In a secondary Electron window, the workaround is to poll for changes in the Data Grid waffle’s size.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #8695 Fix for ResizeObserver not working well in secondary Electron windows.

### QA Notes
