### PR TITLE
Add `ctrl` options for Mac, for Quarto shortcuts with RStudio keybindings

### DIFF
--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -173,6 +173,10 @@ class PositronKeybindingsContribution extends Disposable {
 				ContextKeyExpr.not('findInputFocussed'),
 				ContextKeyExpr.not('replaceInputFocussed')
 			),
+			mac: {
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+				secondary: [KeyMod.WinCtrl | KeyCode.Enter]
+			},
 			primary: KeyMod.CtrlCmd | KeyCode.Enter
 		}));
 
@@ -186,6 +190,10 @@ class PositronKeybindingsContribution extends Disposable {
 				ContextKeyExpr.not('findInputFocussed'),
 				ContextKeyExpr.not('replaceInputFocussed')
 			),
+			mac: {
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter,
+				secondary: [KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Enter]
+			},
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
 		}));
 


### PR DESCRIPTION
Addresses #8661

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Restored keyboard shortcuts for Quarto run commands <kbd>Ctrl+Enter</kbd> and <kbd>Ctrl+Shift+Enter</kbd> on Mac, in addition to <kbd>Cmd</kbd> versions.


### QA Notes

If you have the RStudio keybindings enabled, you can send a single line from a Quarto cell to the console via <kbd>Ctrl</kbd>+<kbd>Enter</kbd> and an entire cell to the console via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd>. This is in addition to the <kbd>Cmd</kbd> keybindings for these.
