### PR TITLE
Fix leaked disposable warnings

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -810,9 +810,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		// This fixes https://github.com/posit-dev/positron/issues/2281 by stopping mouse down
 		// events from propagating to the ConsoleInstance, which has its own context menu that was
 		// showing instead of the CodeEditorWidget's context menu.
-		codeEditorWidget.onMouseDown(e => {
+		disposableStore.add(codeEditorWidget.onMouseDown(e => {
 			e.event.stopPropagation();
-		});
+		}));
 
 		// Add the code editor widget to the disposables store.
 		disposableStore.add(codeEditorWidget);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -64,6 +64,9 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 				}
 			})
 		);
+
+		// Return cleanup function to dispose of the store when effect cleans up.
+		return () => disposableStore.dispose();
 	}, [services.runtimeSessionService, positronConsoleInstance.sessionId])
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -84,10 +84,11 @@ class DataExplorerRuntime extends Disposable {
 				const dataExplorerClientInstance = new DataExplorerClientInstance(commInstance);
 				this._register(dataExplorerClientInstance);
 
-				// Add the onDidClose event handler on the DataExplorerClientInstance,
-				dataExplorerClientInstance.onDidClose(() => {
+				// Register the onDidClose event handler on the DataExplorerClientInstance
+				// so that we can clean up the instance when it is closed.
+				this._register(dataExplorerClientInstance.onDidClose(() => {
 					this._onDidCloseDataExplorerClientEmitter.fire(dataExplorerClientInstance);
-				});
+				}));
 
 				// Raise the onDidOpenDataExplorerClient event.
 				this._onDidOpenDataExplorerClientEmitter.fire(dataExplorerClientInstance);


### PR DESCRIPTION
I noticed a few leaky disposable warnings and that we needed to resolve. The warnings I noticed were in the following areas: `PositronDataExplorerService`, `ConsoleInput`, and `ConsoleTabList`.

<img width="1536" height="156" alt="Screenshot 2025-08-12 at 2 28 47 PM" src="https://github.com/user-attachments/assets/946753eb-fa8a-45a3-8b76-382d3490614e" />

<img width="1536" height="293" alt="Screenshot 2025-08-12 at 2 28 26 PM" src="https://github.com/user-attachments/assets/d27cedc4-68f4-48a2-a4c0-41e7f8cdb7b8" />

The `ConsoleTabList` component was missing the call to `dispose` during cleanup of the `useEffect`. The missing cleanup logic has been added.

The `dataExplorerClientInstance.onDidClose` event in `PositronDataExplorerService`  and `codeEditorWidget.onMouseDown` event in `ConsoleInput` were not being disposed of properly. Registering these events with the disposable seemed to resolve the issue (looks like we do that in a few other places).

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
