### PR TITLE
Data Explorer: Streamline missing values tooltip

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -279,24 +279,24 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			if (nullPercent === undefined || nullCount === undefined) {
 				return nls.localize(
 					'positron.missingValues.calculating',
-					'Missing Values\nCalculating...'
+					'Calculating...'
 				);
 			} else if (nullPercent === 0) {
 				return nls.localize(
 					'positron.missingValues.none',
-					'Missing Values\nNo missing values'
+					'No missing values'
 				);
 			} else if (nullPercent === 100) {
 				return nls.localize(
 					'positron.missingValues.all',
-					'Missing Values\nAll values are missing ({0} values)', nullCount.toLocaleString()
+					'All values are missing ({0} values)', nullCount.toLocaleString()
 				);
 			} else {
 				// Format percentage for tooltip
 				return nls.localize(
 					'positron.missingValues.some',
-					'Missing Values\n{0} of values are missing ({1} values)',
-					getDisplayNullPercent(),
+					'{0}% of values are missing ({1} values)',
+					nullPercent,
 					nullCount.toLocaleString()
 				);
 			}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -295,8 +295,8 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				// Format percentage for tooltip
 				return nls.localize(
 					'positron.missingValues.some',
-					'{0}% of values are missing ({1} values)',
-					nullPercent,
+					'{0} of values are missing ({1} values)',
+					getDisplayNullPercent(),
 					nullCount.toLocaleString()
 				);
 			}

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -403,7 +403,8 @@ export class DataExplorer {
 			await firstNullPercent.hover();
 			const hoverTooltip = this.code.driver.page.locator('.hover-contents');
 			await expect(hoverTooltip).toBeVisible();
-			await expect(hoverTooltip).toContainText('Missing Values');
+			// After streamlining, tooltip shows either "No missing values" or "X% of values are missing"
+			await expect(hoverTooltip).toContainText(/No missing values|of values are missing/);
 		});
 	}
 


### PR DESCRIPTION
Proposed improvement for #8936. I agree that reducing redundancy in the tooltip would be better.

@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The missing values tooltip in the Data Explorer has been streamlined for clarity.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
