### PR TITLE
e2e: add more assertions to `convert-to-code.test.ts`

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -48,7 +48,7 @@ export class DataExplorer {
 	selectFilterModalValue: (value: string) => Locator;
 	filteringMenu: Locator;
 	menuItemClearFilters: Locator;
-	codeBox: Locator;
+	private _convertToCodeModal: ConvertToCodeModal;
 
 	constructor(private code: Code, private workbench: Workbench) {
 		this.clearSortingButton = this.code.driver.page.locator(CLEAR_SORTING_BUTTON);
@@ -60,7 +60,7 @@ export class DataExplorer {
 		this.applyFilterButton = this.code.driver.page.getByRole('button', { name: 'Apply Filter' });
 		this.filteringMenu = this.code.driver.page.getByRole('button', { name: 'Filtering' });
 		this.menuItemClearFilters = this.code.driver.page.getByRole('button', { name: 'Clear Filters' });
-		this.codeBox = this.code.driver.page.locator('.positron-modal-dialog-box .convert-to-code-editor');
+		this._convertToCodeModal = new ConvertToCodeModal(code, workbench);
 	}
 
 	async clearAllFilters() {
@@ -432,7 +432,19 @@ export class DataExplorer {
 		await this.workbench.editorActionBar.clickButton('Convert to Code');
 	}
 
-	async expectConvertToCodeModalToBeVisible() {
+	get convertToCodeModal(): ConvertToCodeModal {
+		return this._convertToCodeModal;
+	}
+}
+
+export class ConvertToCodeModal {
+	codeBox: Locator;
+
+	constructor(private code: Code, private workbench: Workbench) {
+		this.codeBox = this.code.driver.page.locator('.positron-modal-dialog-box .convert-to-code-editor');
+	}
+
+	async expectToBeVisible() {
 		await test.step('Verify convert to code modal is visible', async () => {
 			await expect(this.codeBox).toBeVisible();
 			await this.workbench.modals.expectButtonToBeVisible('Copy Code');
@@ -442,7 +454,6 @@ export class DataExplorer {
 
 	async expectSyntaxHighlighting() {
 		await test.step('Verify syntax highlighting', async () => {
-
 			// Verify code highlighting - more than one style means highlighting is active
 			const mtkLocator = this.code.driver.page.locator('[class*="mtk"]');
 			const tokenClasses = await mtkLocator.evaluateAll(spans =>
@@ -457,5 +468,13 @@ export class DataExplorer {
 			const bracketHighlightingCount = await this.code.driver.page.locator('[class*="bracket-highlighting-"]').count();
 			expect(bracketHighlightingCount).toBeGreaterThan(0);
 		});
+	}
+
+	async clickOK() {
+		await this.workbench.modals.clickButton('Copy Code');
+	}
+
+	async clickCancel() {
+		await this.workbench.modals.clickButton('Cancel');
 	}
 }

--- a/test/e2e/tests/data-explorer/convert-to-code.test.ts
+++ b/test/e2e/tests/data-explorer/convert-to-code.test.ts
@@ -9,31 +9,67 @@ Summary:
 - Ensures basic filters (e.g. "is not null", "contains") are applied correctly across supported data frame types.
 - Confirms the filtered result is exported in the correct syntax for each language/library combination.
 
- * |Type              |Language |Construct                         |Expected Code Style     |
- * |------------------|---------|----------------------------------|------------------------|
- * |pandas.DataFrame  |Python   |pd.DataFrame(...)                 |Pandas                  |
- * |polars.DataFrame  |Python   |pl.DataFrame(...)                 |Polars                  |
- * |data.frame        |R        |data.frame(...)                   |Tidyverse (or Base R)   |
- * |tibble            |R        |tibble::tibble(...)               |Tidyverse               |
- * |data.table        |R        |data.table::data.table(...)       |data.table              |
+ * |Type              |Language |Variable                                   |Expected Code Style     |
+ * |------------------|---------|-------------------------------------------|------------------------|
+ * |pandas.DataFrame  |Python   |<class 'pandas.core.frame.DataFrame'>      |Pandas                  |
+ * |polars.DataFrame  |Python   |<class 'polars.dataframe.frame.DataFrame'> |Polars                  |
+ * |data.frame        |R        |<data.frame>                               |Tidyverse (or Base R)   |
+ * |tibble            |R        |<tbl_df>                                   |Tidyverse               |
+ * |data.table        |R        |<data.table>                               |data.table              |
  */
 
 import { test, tags } from '../_test.setup';
 import { pandasDataFrameScript } from './helpers/convert-to-code-data.js';
 
-const testCases: { language: 'Python' | 'R'; dataScript: string; expectedCodeStyle: string; dataFrameType: string }[] = [
-	{ language: 'Python', dataScript: pandasDataFrameScript, expectedCodeStyle: 'Pandas', dataFrameType: 'pandas.DataFrame' },
-	// { language: 'Python', dataScript: polarsDataFrameScript, expectedCodeStyle: 'Polars', dataFrameType: 'polars.DataFrame' },
-	// { language: 'R', dataScript: rDataFrameScript, expectedCodeStyle: 'Tidyverse', dataFrameType: 'data.frame' },
-	// { language: 'R', dataScript: tibbleScript, expectedCodeStyle: 'Tidyverse', dataFrameType: 'tibble' },
-	// { language: 'R', dataScript: dataTableScript, expectedCodeStyle: 'data.table', dataFrameType: 'data.table' },
-];
+const testCases: {
+	language: 'Python' | 'R';
+	dataScript: string;
+	expectedCodeStyle: string;
+	dataFrameType: string;
+	expectedGeneratedCode: string;
+}[] = [
+		{
+			language: 'Python',
+			dataScript: pandasDataFrameScript,
+			expectedCodeStyle: 'Pandas',
+			dataFrameType: 'pandas.DataFrame',
+			expectedGeneratedCode: 'filter_mask = (df[\'status\'] == \'active\') & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)'
+		},
+		// {
+		//   language: 'Python',
+		//   dataScript: polarsDataFrameScript,
+		//   expectedCodeStyle: 'Polars',
+		//   dataFrameType: 'polars.DataFrame',
+		//   expectedGeneratedCode: 'tbd'
+		// },
+		// {
+		//   language: 'R',
+		//   dataScript: rDataFrameScript,
+		//   expectedCodeStyle: 'Tidyverse',
+		//   dataFrameType: 'data.frame',
+		//   expectedGeneratedCode: 'tbd'
+		// },
+		// {
+		//   language: 'R',
+		//   dataScript: tibbleScript,
+		//   expectedCodeStyle: 'Tidyverse',
+		//   dataFrameType: 'tibble',
+		//   expectedGeneratedCode: 'tbd'
+		// },
+		// {
+		//   language: 'R',
+		//   dataScript: dataTableScript,
+		//   expectedCodeStyle: 'data.table',
+		//   dataFrameType: 'data.table',
+		//   expectedGeneratedCode: 'tbd'
+		// },
+	];
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
+test.describe('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
 
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
@@ -45,10 +81,10 @@ test.describe.skip('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA
 		await hotKeys.closeAllEditors();
 	});
 
-	testCases.forEach(({ language, dataScript, expectedCodeStyle, dataFrameType }) => {
+	testCases.forEach(({ language, dataScript, expectedCodeStyle, dataFrameType, expectedGeneratedCode }) => {
 
 		test(`${language} - ${expectedCodeStyle} (${dataFrameType}) - Verify copy code behavior with basic filters`, async function ({ app, sessions, hotKeys }) {
-			const { dataExplorer, variables, modals, console } = app.workbench;
+			const { dataExplorer, variables, modals, console, clipboard, toasts } = app.workbench;
 			await sessions.start(language === 'Python' ? 'python' : 'r');
 
 			// execute code to create a data construct
@@ -72,31 +108,31 @@ test.describe.skip('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA
 			// copy code and verify result is accurate
 			await dataExplorer.clickConvertToCodeButton();
 			await modals.expectButtonToBeVisible(expectedCodeStyle.toLowerCase());
-			await modals.expectToContainText(
-				'filter_mask = (df[\'status\'] == active) & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)'
-			);
+			await dataExplorer.expectConvertToCodeModalToBeVisible();
 
-			const expectedGeneratedCode = {
-				'Pandas': 'filter_mask = (df[\'status\'] == active) & (df[\'score\'] >= 85) & (df[\'is_student\'] == False)',
-				'Polars': 'tbd',
-				'Tidyverse': 'tbd',
-				'data.table': 'tbd'
-			}[expectedCodeStyle] || '';
+			// verify the generated code is correct and has syntax highlights
 			await modals.expectToContainText(expectedGeneratedCode);
+			await dataExplorer.expectSyntaxHighlighting();
+
+			// verify copy to clipboard behavior
+			await modals.clickButton('Copy');
+			await clipboard.expectClipboardTextToBe(expectedGeneratedCode + '\ndf[filter_mask]');
+			await toasts.expectToBeVisible('Copied to clipboard');
 		});
-	});
+	})
+	// `filter_mask = (df['status'] == 'active') & (df['score'] >= 85) & (df['is_student'] == False) df[filter_mask]`
+	// "filter_mask = (df['status'] == 'active') & (df['score'] >= 85) & (df['is_student'] == False)"
+
+	// test('Python - Verify copy code with many filters', async function ({ app, r, openDataFile }) {
+	// });
+
+	// test('R - Verify copy code with many filters', async function ({ app, r, openDataFile }) {
+	// });
+
+	// test('R - Verify copy code with changed default', async function ({ app, r, openDataFile }) {
+	// });
+
 });
-
-
-// test('Python - Verify copy code with many filters', async function ({ app, r, openDataFile }) {
-// });
-
-// test('R - Verify copy code with many filters', async function ({ app, r, openDataFile }) {
-// });
-
-// test('R - Verify copy code with changed default', async function ({ app, r, openDataFile }) {
-// });
-
 
 
 

--- a/test/e2e/tests/data-explorer/convert-to-code.test.ts
+++ b/test/e2e/tests/data-explorer/convert-to-code.test.ts
@@ -108,20 +108,18 @@ test.describe('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPL
 			// copy code and verify result is accurate
 			await dataExplorer.clickConvertToCodeButton();
 			await modals.expectButtonToBeVisible(expectedCodeStyle.toLowerCase());
-			await dataExplorer.expectConvertToCodeModalToBeVisible();
+			await dataExplorer.convertToCodeModal.expectToBeVisible();
 
 			// verify the generated code is correct and has syntax highlights
 			await modals.expectToContainText(expectedGeneratedCode);
-			await dataExplorer.expectSyntaxHighlighting();
+			await dataExplorer.convertToCodeModal.expectSyntaxHighlighting();
 
 			// verify copy to clipboard behavior
-			await modals.clickButton('Copy');
+			await dataExplorer.convertToCodeModal.clickOK();
 			await clipboard.expectClipboardTextToBe(expectedGeneratedCode + '\ndf[filter_mask]');
 			await toasts.expectToBeVisible('Copied to clipboard');
 		});
 	})
-	// `filter_mask = (df['status'] == 'active') & (df['score'] >= 85) & (df['is_student'] == False) df[filter_mask]`
-	// "filter_mask = (df['status'] == 'active') & (df['score'] >= 85) & (df['is_student'] == False)"
 
 	// test('Python - Verify copy code with many filters', async function ({ app, r, openDataFile }) {
 	// });


### PR DESCRIPTION
### Summary
Updated the data explorerer `convert-to-code.test.ts` to assert:
* syntax highlighting exists in code dialog
* code copies to clipboard
* toast notification for clipboard copy
* and cleaned up test cases


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


@:data-explorer @:win
