### PR TITLE
Summary panel data now hidden when collapsed

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -343,7 +343,7 @@ export const DataExplorer = () => {
 
 			<div ref={leftColumnRef} className='left-column'>
 				{layout === PositronDataExplorerLayout.SummaryOnLeft &&
-					showSummaryPanelEnhancements && !columnsCollapsed &&
+					showSummaryPanelEnhancements &&
 					<SummaryRowActionBar
 						instance={context.instance.tableSchemaDataGridInstance}
 					/>
@@ -381,7 +381,7 @@ export const DataExplorer = () => {
 			}
 			<div ref={rightColumnRef} className='right-column'>
 				{layout !== PositronDataExplorerLayout.SummaryOnLeft &&
-					showSummaryPanelEnhancements && !columnsCollapsed &&
+					showSummaryPanelEnhancements &&
 					<SummaryRowActionBar
 						instance={context.instance.tableSchemaDataGridInstance}
 					/>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -343,7 +343,7 @@ export const DataExplorer = () => {
 
 			<div ref={leftColumnRef} className='left-column'>
 				{layout === PositronDataExplorerLayout.SummaryOnLeft &&
-					showSummaryPanelEnhancements &&
+					showSummaryPanelEnhancements && !columnsCollapsed &&
 					<SummaryRowActionBar
 						instance={context.instance.tableSchemaDataGridInstance}
 					/>
@@ -381,7 +381,7 @@ export const DataExplorer = () => {
 			}
 			<div ref={rightColumnRef} className='right-column'>
 				{layout !== PositronDataExplorerLayout.SummaryOnLeft &&
-					showSummaryPanelEnhancements &&
+					showSummaryPanelEnhancements && !columnsCollapsed &&
 					<SummaryRowActionBar
 						instance={context.instance.tableSchemaDataGridInstance}
 					/>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
@@ -5,6 +5,9 @@
 
 .summary-row-filter-bar {
 	height: 36px;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -54,19 +54,20 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 
 
 	return (
-		<PositronActionBarContextProvider>
-			<PositronActionBar>
-				<ActionBarRegion location='left'>
-					<SummaryRowSortDropdown />
-				</ActionBarRegion>
-				<ActionBarRegion location='right'>
-					<ActionBarFilter
-						ref={filterRef}
-						width={150}
-						onFilterTextChanged={filterText => setSearchText(filterText)} />
-				</ActionBarRegion>
-			</PositronActionBar>
-		</PositronActionBarContextProvider>
-
+		<div className='summary-row-filter-bar'>
+			<PositronActionBarContextProvider>
+				<PositronActionBar>
+					<ActionBarRegion location='left'>
+						<SummaryRowSortDropdown />
+					</ActionBarRegion>
+					<ActionBarRegion location='right'>
+						<ActionBarFilter
+							ref={filterRef}
+							width={150}
+							onFilterTextChanged={filterText => setSearchText(filterText)} />
+					</ActionBarRegion>
+				</PositronActionBar>
+			</PositronActionBarContextProvider>
+		</div>
 	);
 }


### PR DESCRIPTION
Addresses #8989

This PR resolves the content overflow bug that caused the summary panel data to be shown when the summary panel was collapsed.

The `SummaryRowActionBar` and `PositronDataGrid` were using different approaches to be hidden when the summary panel was collapsed. The `PositronDataGrid` is always rendered in the DOM, and hidden via CSS width styling `width: 0` and `overflow: hidden` to prevent content from spilling out when the container width is 0. 

Rather than conditionally showing/hiding the `SummaryRowActionBar` when the summary panel is collapsed, we are now using CSS to hide the content like the `PositronDataGrid`. The `SummaryRowActionBar`. This change prevents the component from un-mounting when the summary panel is collapsed which means the user's last used state is now preserved until the Data Explorer is closed.

Both components now use the same CSS visibility solution.

### Release Notes 

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer
