### PR TITLE
Feat/notebook cell execution info

### DIFF
--- a/src/vs/workbench/browser/positronComponents/popover/popover.css
+++ b/src/vs/workbench/browser/positronComponents/popover/popover.css
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-popover {
+	position: fixed;
+	z-index: 1000;
+}

--- a/src/vs/workbench/browser/positronComponents/popover/popover.tsx
+++ b/src/vs/workbench/browser/positronComponents/popover/popover.tsx
@@ -28,14 +28,14 @@ interface PopoverProps {
  * Fixed-position popover that positions itself relative to an anchor element.
  * Automatically repositions to stay within viewport. Closes on click outside,
  * Escape key, or mouse leave.
- * 
+ *
  * **Note:** This is a pure React component that renders within the React tree,
  * so it's constrained by CSS overflow and z-index of parent containers. For
  * popovers that need to escape container boundaries, use modal dialogs instead.
- * 
+ *
  * @example
  * ```tsx
- * <Popover 
+ * <Popover
  *   anchorElement={buttonRef.current}
  *   onClose={() => setIsOpen(false)}
  * >
@@ -47,7 +47,7 @@ export function Popover({
 	anchorElement,
 	onClose,
 	autoCloseOnMouseLeave = true,
-	autoCloseDelay = 250,
+	autoCloseDelay = 100,
 	className = '',
 	offset = 4,
 	viewportMargin = 8,

--- a/src/vs/workbench/browser/positronComponents/popover/popover.tsx
+++ b/src/vs/workbench/browser/positronComponents/popover/popover.tsx
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../base/browser/dom.js';
+import React, { useEffect, useRef, useState, useCallback, PropsWithChildren } from 'react';
+import './popover.css';
+
+interface PopoverProps {
+	/** Element to position the popover relative to */
+	anchorElement: HTMLElement;
+	/** Called when popover should close (click outside, Escape key, mouse leave) */
+	onClose: () => void;
+	/** Auto-close on mouse leave @default true */
+	autoCloseOnMouseLeave?: boolean;
+	/** Mouse leave delay in ms @default 250 */
+	autoCloseDelay?: number;
+	/** Additional CSS classes @default '' */
+	className?: string;
+	/** Spacing from anchor element in px @default 4 */
+	offset?: number;
+	/** Viewport edge margin in px @default 8 */
+	viewportMargin?: number;
+}
+
+/**
+ * Fixed-position popover that positions itself relative to an anchor element.
+ * Automatically repositions to stay within viewport. Closes on click outside,
+ * Escape key, or mouse leave.
+ * 
+ * **Note:** This is a pure React component that renders within the React tree,
+ * so it's constrained by CSS overflow and z-index of parent containers. For
+ * popovers that need to escape container boundaries, use modal dialogs instead.
+ * 
+ * @example
+ * ```tsx
+ * <Popover 
+ *   anchorElement={buttonRef.current}
+ *   onClose={() => setIsOpen(false)}
+ * >
+ *   Content
+ * </Popover>
+ * ```
+ */
+export function Popover({
+	anchorElement,
+	onClose,
+	autoCloseOnMouseLeave = true,
+	autoCloseDelay = 250,
+	className = '',
+	offset = 4,
+	viewportMargin = 8,
+	children
+}: PropsWithChildren<PopoverProps>) {
+	const popoverRef = useRef<HTMLDivElement>(null);
+	const [position, setPosition] = useState({ top: 0, left: 0 });
+	const closeTimeoutRef = useRef<number | null>(null);
+
+	// Calculate position relative to anchor
+	useEffect(() => {
+		if (!popoverRef.current) {
+			return;
+		}
+
+		const targetWindow = DOM.getWindow(popoverRef.current);
+		const rect = anchorElement.getBoundingClientRect();
+		const popoverRect = popoverRef.current.getBoundingClientRect();
+		const windowWidth = targetWindow.innerWidth;
+		const windowHeight = targetWindow.innerHeight;
+
+		let top = rect.bottom + offset;
+		let left = rect.left;
+
+		// Adjust if popover would go off screen
+		if (left + popoverRect.width > windowWidth) {
+			left = windowWidth - popoverRect.width - viewportMargin;
+		}
+		if (top + popoverRect.height > windowHeight) {
+			top = rect.top - popoverRect.height - offset;
+		}
+
+		setPosition({ top, left });
+	}, [anchorElement, offset, viewportMargin]);
+
+	// Handle auto-close on mouse leave
+	const handleMouseEnter = useCallback(() => {
+		if (closeTimeoutRef.current !== null) {
+			const targetWindow = DOM.getWindow(anchorElement);
+			targetWindow.clearTimeout(closeTimeoutRef.current);
+			closeTimeoutRef.current = null;
+		}
+	}, [anchorElement]);
+
+	const handleMouseLeave = useCallback(() => {
+		if (autoCloseOnMouseLeave) {
+			const targetWindow = DOM.getWindow(anchorElement);
+			closeTimeoutRef.current = targetWindow.setTimeout(onClose, autoCloseDelay);
+		}
+	}, [autoCloseOnMouseLeave, autoCloseDelay, onClose, anchorElement]);
+
+	// Monitor anchor element for mouse leave events
+	useEffect(() => {
+		if (!autoCloseOnMouseLeave) {
+			return;
+		}
+
+		const handleAnchorMouseEnter = () => {
+			if (closeTimeoutRef.current !== null) {
+				const targetWindow = DOM.getWindow(anchorElement);
+				targetWindow.clearTimeout(closeTimeoutRef.current);
+				closeTimeoutRef.current = null;
+			}
+		};
+
+		const handleAnchorMouseLeave = () => {
+			const targetWindow = DOM.getWindow(anchorElement);
+			closeTimeoutRef.current = targetWindow.setTimeout(onClose, autoCloseDelay);
+		};
+
+		anchorElement.addEventListener('mouseenter', handleAnchorMouseEnter);
+		anchorElement.addEventListener('mouseleave', handleAnchorMouseLeave);
+
+		return () => {
+			anchorElement.removeEventListener('mouseenter', handleAnchorMouseEnter);
+			anchorElement.removeEventListener('mouseleave', handleAnchorMouseLeave);
+		};
+	}, [anchorElement, autoCloseOnMouseLeave, autoCloseDelay, onClose]);
+
+	// Clean up on unmount
+	useEffect(() => {
+		return () => {
+			if (closeTimeoutRef.current !== null) {
+				const targetWindow = DOM.getWindow(anchorElement);
+				targetWindow.clearTimeout(closeTimeoutRef.current);
+			}
+		};
+	}, [anchorElement]);
+
+	// Close on escape key
+	useEffect(() => {
+		const targetWindow = DOM.getWindow(anchorElement);
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				onClose();
+			}
+		};
+
+		targetWindow.addEventListener('keydown', handleKeyDown);
+		return () => targetWindow.removeEventListener('keydown', handleKeyDown);
+	}, [onClose, anchorElement]);
+
+	// Close on click outside
+	useEffect(() => {
+		const targetWindow = DOM.getWindow(anchorElement);
+		const handleClickOutside = (e: MouseEvent) => {
+			if (popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
+				!anchorElement.contains(e.target as Node)) {
+				onClose();
+			}
+		};
+
+		// Delay to avoid immediate close on open
+		const timer = targetWindow.setTimeout(() => {
+			targetWindow.document.addEventListener('mousedown', handleClickOutside);
+		}, 0);
+
+		return () => {
+			targetWindow.clearTimeout(timer);
+			targetWindow.document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [anchorElement, onClose]);
+
+	return (
+		<div
+			ref={popoverRef}
+			className={`positron-popover ${className}`}
+			style={{
+				top: `${position.top}px`,
+				left: `${position.left}px`
+			}}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+		>
+			{children}
+		</div>
+	);
+}

--- a/src/vs/workbench/browser/positronComponents/popover/popover.tsx
+++ b/src/vs/workbench/browser/positronComponents/popover/popover.tsx
@@ -54,7 +54,7 @@ export function Popover({
 	children
 }: PropsWithChildren<PopoverProps>) {
 	const popoverRef = useRef<HTMLDivElement>(null);
-	const [position, setPosition] = useState({ top: 0, left: 0 });
+	const [position, setPosition] = useState<{ top: number; left: number } | undefined>(undefined);
 	const closeTimeoutRef = useRef<number | null>(null);
 
 	// Calculate position relative to anchor
@@ -175,10 +175,17 @@ export function Popover({
 		<div
 			ref={popoverRef}
 			className={`positron-popover ${className}`}
-			style={{
-				top: `${position.top}px`,
-				left: `${position.left}px`
-			}}
+			style={
+				position ? {
+					top: `${position.top}px`,
+					left: `${position.left}px`,
+					visibility: 'visible'
+				} : {
+					top: 0,
+					left: 0,
+					visibility: 'hidden'
+				}
+			}
 			onMouseEnter={handleMouseEnter}
 			onMouseLeave={handleMouseLeave}
 		>

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
@@ -27,7 +27,7 @@ export function KernelStatusBadge() {
 		className='positron-notebook-kernel-status-badge'
 		onPressed={() => services.commandService.executeCommand(SELECT_KERNEL_ID_POSITRON, { forceDropdown: true })}
 	>
-		<div>
+		<div aria-label='Notebook kernel status'>
 			Kernel
 			<span className={`kernel-status ${kernelStatus}`}>{' ' + kernelStatus}</span>
 		</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -14,20 +14,34 @@ import { IPositronNotebookCodeCell, NotebookCellOutputs } from '../../../../serv
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { pickPreferredOutputItem } from './notebookOutputUtils.js';
 import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
+import { INotebookExecutionStateService, NotebookExecutionType } from '../../../notebook/common/notebookExecutionStateService.js';
 
 export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implements IPositronNotebookCodeCell {
 	override kind: CellKind.Code = CellKind.Code;
 	outputs: ISettableObservable<NotebookCellOutputs[]>;
+
+	// Execution timing observables
+	lastExecutionDuration: ISettableObservable<number | undefined>;
+	lastExecutionOrder: ISettableObservable<number | undefined>;
+	lastRunSuccess: ISettableObservable<boolean | undefined>;
+	lastRunEndTime: ISettableObservable<number | undefined>;
 
 	constructor(
 		cellModel: NotebookCellTextModel,
 		private instance: PositronNotebookInstance,
 		@ITextModelService _textModelResolverService: ITextModelService,
 		@IPositronWebviewPreloadService private _webviewPreloadService: IPositronWebviewPreloadService,
+		@INotebookExecutionStateService private _executionStateService: INotebookExecutionStateService
 	) {
 		super(cellModel, instance, _textModelResolverService);
 
 		this.outputs = observableValue<NotebookCellOutputs[], void>('cellOutputs', this.parseCellOutputs());
+
+		// Initialize execution timing observables
+		this.lastExecutionDuration = observableValue<number | undefined, void>('positronNotebookCodeCell.lastExecutionDuration', this.calculateExecutionDuration());
+		this.lastExecutionOrder = observableValue<number | undefined, void>('positronNotebookCodeCell.lastExecutionOrder', cellModel.internalMetadata.executionOrder);
+		this.lastRunSuccess = observableValue<boolean | undefined, void>('positronNotebookCodeCell.lastRunSuccess', cellModel.internalMetadata.lastRunSuccess ?? undefined);
+		this.lastRunEndTime = observableValue<number | undefined, void>('positronNotebookCodeCell.lastRunEndTime', cellModel.internalMetadata.runEndTime ?? undefined);
 
 		// Listen for changes to the cell outputs and update the observable
 		this._register(
@@ -35,6 +49,38 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 				this.outputs.set(this.parseCellOutputs(), undefined);
 			})
 		);
+
+		// Listen for changes to the internal metadata to update execution timing
+		this._register(
+			this.cellModel.onDidChangeInternalMetadata(() => {
+				this.updateExecutionInfo();
+			})
+		);
+
+		// Listen for execution state changes
+		this._register(
+			this._executionStateService.onDidChangeExecution(e => {
+				if (e.type === NotebookExecutionType.cell && e.affectsCell(this.cellModel.uri)) {
+					this.updateExecutionInfo();
+				}
+			})
+		);
+	}
+
+	private calculateExecutionDuration(): number | undefined {
+		const { runStartTime, runEndTime } = this.cellModel.internalMetadata;
+		if (typeof runStartTime === 'number' && typeof runEndTime === 'number') {
+			return Math.max(0, runEndTime - runStartTime);
+		}
+		return undefined;
+	}
+
+	private updateExecutionInfo(): void {
+		const metadata = this.cellModel.internalMetadata;
+		this.lastExecutionDuration.set(this.calculateExecutionDuration(), undefined);
+		this.lastExecutionOrder.set(metadata.executionOrder ?? undefined, undefined);
+		this.lastRunSuccess.set(metadata.lastRunSuccess ?? undefined, undefined);
+		this.lastRunEndTime.set(metadata.runEndTime ?? undefined, undefined);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.css
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.cell-execution-info-icon {
+	position: absolute;
+	top: 6px;
+	left: -20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 10px;
+	height: 12px;
+	font-size: 7px;
+	border-inline: 1px solid color-mix(in srgb, var(--vscode-widget-border) 60%, transparent);
+	background-color: transparent;
+	padding: 1px 2px;
+	user-select: none;
+	transition: border-color 0.15s ease;
+	z-index: 10;
+	pointer-events: auto;
+}
+
+.cell-execution-info-icon span.execution-order-badge {
+	cursor: default;
+}
+.cell-execution-info-icon:hover {
+	border-color: color-mix(in srgb, var(--vscode-widget-border) 80%, transparent);
+}
+
+/* Status-specific styling */
+.cell-execution-info-icon-running {
+	color: var(--vscode-debugIcon-startForeground);
+	border: none;
+	background: transparent;
+	animation: none;
+}
+
+.cell-execution-info-icon-success {
+	border-color: color-mix(in srgb, var(--vscode-testing-iconPassed) 70%, transparent);
+}
+
+.cell-execution-info-icon-failed {
+	border-color: color-mix(in srgb, var(--vscode-testing-iconFailed) 70%, transparent);
+}
+
+.cell-execution-info-icon-failed .execution-order-badge {
+	color: var(--vscode-testing-iconFailed);
+}
+
+.cell-execution-info-icon-neutral {
+	border-color: var(--vscode-textLink-foreground);
+}
+
+.cell-execution-info-icon-pending {
+	color: color-mix(in srgb, var(--vscode-widget-border) 70%, transparent);
+	border: 1px dashed color-mix(in srgb, var(--vscode-widget-border) 50%, transparent);
+}
+
+.cell-execution-info-icon-queued {
+	border-color: color-mix(in srgb, var(--vscode-widget-border) 60%, transparent);
+}
+
+/* Execution order badge styling */
+.execution-order-badge {
+	font-weight: 500;
+	font-size: 10px;
+	line-height: 1;
+	color: inherit;
+	font-family: var(--monaco-monospace-font);
+}
+
+/* Icon styling */
+.execution-icon {
+	font-size: 9px;
+	line-height: 1;
+}
+
+/* Animation for running state */
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.codicon-modifier-spin {
+	animation: spin 1s linear infinite;
+}
+
+/* Dark theme adjustments */
+.vscode-dark .cell-execution-info-icon,
+.vscode-high-contrast .cell-execution-info-icon {
+	background-color: transparent;
+}
+
+.vscode-dark .cell-execution-info-icon:hover,
+.vscode-high-contrast .cell-execution-info-icon:hover {
+	border-color: color-mix(in srgb, var(--vscode-widget-border) 80%, transparent);
+}
+
+
+/* Ensure the icon doesn't interfere with cell selection */
+.cell-execution-info-icon {
+	pointer-events: auto;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './CellExecutionInfoIcon.css';
+
+// React.
+import React, { useRef, useState, useCallback } from 'react';
+
+// Other dependencies.
+import * as DOM from '../../../../../base/browser/dom.js';
+import { useObservedValue } from '../useObservedValue.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { CellExecutionInfoPopup } from './CellExecutionInfoPopup.js';
+import { Popover } from '../../../../browser/positronComponents/popover/popover.js';
+
+interface CellExecutionInfoIconProps {
+	cell: PositronNotebookCodeCell;
+}
+
+const POPUP_DELAY = 250;
+
+export function CellExecutionInfoIcon({ cell }: CellExecutionInfoIconProps) {
+	// Reference hooks.
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// State hooks.
+	const [showPopup, setShowPopup] = useState(false);
+	const [hoverTimeoutId, setHoverTimeoutId] = useState<number | null>(null);
+
+	// Observed values for icon display (popup will observe its own values)
+	const executionOrder = useObservedValue(cell.lastExecutionOrder);
+	const lastRunSuccess = useObservedValue(cell.lastRunSuccess);
+	const executionStatus = useObservedValue(cell.executionStatus);
+
+	// Icon hover handlers
+	const handleMouseEnter = useCallback(() => {
+		if (!showPopup && containerRef.current) {
+			const targetWindow = DOM.getWindow(containerRef.current);
+			const timeoutId = targetWindow.setTimeout(() => {
+				setShowPopup(true);
+			}, POPUP_DELAY);
+
+			setHoverTimeoutId(timeoutId);
+		}
+	}, [showPopup]);
+
+	const handleMouseLeave = useCallback(() => {
+		// Clear the hover timeout if we leave before the popup shows
+		if (hoverTimeoutId !== null && containerRef.current) {
+			const targetWindow = DOM.getWindow(containerRef.current);
+			targetWindow.clearTimeout(hoverTimeoutId);
+			setHoverTimeoutId(null);
+		}
+		// Note: The popup will handle its own auto-close behavior
+	}, [hoverTimeoutId]);
+
+	// Show pending state if the cell has never been executed
+	const showPending = executionOrder === undefined;
+
+	// Determine the status class for styling
+	let statusClass = 'cell-execution-info-icon';
+	if (showPending) {
+		statusClass += ' cell-execution-info-icon-pending';
+	} else if (executionStatus === 'running') {
+		statusClass += ' cell-execution-info-icon-running';
+	} else if (lastRunSuccess === false) {
+		statusClass += ' cell-execution-info-icon-failed';
+	} else if (lastRunSuccess === true) {
+		statusClass += ' cell-execution-info-icon-success';
+	}
+
+	// Determine status for test attribute
+	let dataExecutionStatus = 'idle';
+	if (showPending) {
+		dataExecutionStatus = 'pending';
+	} else if (executionStatus === 'running') {
+		dataExecutionStatus = 'running';
+	} else if (lastRunSuccess === false) {
+		dataExecutionStatus = 'failed';
+	} else if (lastRunSuccess === true) {
+		dataExecutionStatus = 'success';
+	}
+
+	return (
+		<>
+			<div
+				ref={containerRef}
+				aria-busy={executionStatus === 'running'}
+				aria-label='Cell execution info'
+				className={statusClass}
+				data-execution-order={executionOrder}
+				data-execution-status={dataExecutionStatus}
+				role='status'
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				{showPending ? (
+					<span className='execution-order-badge'>-</span>
+				) : executionStatus === 'running' ? (
+					<span
+						aria-label='Cell is executing'
+						className='execution-icon codicon codicon-sync codicon-modifier-spin'
+						role='img'
+					></span>
+				) : (
+					<span className='execution-order-badge'>
+						{String(executionOrder)}
+					</span>
+				)}
+			</div>
+			{showPopup && containerRef.current && (
+				<Popover
+					anchorElement={containerRef.current}
+					autoCloseDelay={POPUP_DELAY}
+					autoCloseOnMouseLeave={true}
+					onClose={() => setShowPopup(false)}
+				>
+					<CellExecutionInfoPopup cell={cell} />
+				</Popover>
+			)}
+		</>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
@@ -20,7 +20,7 @@ interface CellExecutionInfoIconProps {
 	cell: PositronNotebookCodeCell;
 }
 
-const POPUP_DELAY = 250;
+const POPUP_DELAY = 100;
 
 export function CellExecutionInfoIcon({ cell }: CellExecutionInfoIconProps) {
 	// Reference hooks.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoIcon.tsx
@@ -25,10 +25,10 @@ const POPUP_DELAY = 100;
 export function CellExecutionInfoIcon({ cell }: CellExecutionInfoIconProps) {
 	// Reference hooks.
 	const containerRef = useRef<HTMLDivElement>(null);
+	const hoverTimeoutIdRef = useRef<number | null>(null);
 
 	// State hooks.
 	const [showPopup, setShowPopup] = useState(false);
-	const [hoverTimeoutId, setHoverTimeoutId] = useState<number | null>(null);
 
 	// Observed values for icon display (popup will observe its own values)
 	const executionOrder = useObservedValue(cell.lastExecutionOrder);
@@ -43,19 +43,19 @@ export function CellExecutionInfoIcon({ cell }: CellExecutionInfoIconProps) {
 				setShowPopup(true);
 			}, POPUP_DELAY);
 
-			setHoverTimeoutId(timeoutId);
+			hoverTimeoutIdRef.current = timeoutId;
 		}
 	}, [showPopup]);
 
 	const handleMouseLeave = useCallback(() => {
 		// Clear the hover timeout if we leave before the popup shows
-		if (hoverTimeoutId !== null && containerRef.current) {
+		if (hoverTimeoutIdRef.current !== null && containerRef.current) {
 			const targetWindow = DOM.getWindow(containerRef.current);
-			targetWindow.clearTimeout(hoverTimeoutId);
-			setHoverTimeoutId(null);
+			targetWindow.clearTimeout(hoverTimeoutIdRef.current);
+			hoverTimeoutIdRef.current = null;
 		}
 		// Note: The popup will handle its own auto-close behavior
-	}, [hoverTimeoutId]);
+	}, []);
 
 	// Show pending state if the cell has never been executed
 	const showPending = executionOrder === undefined;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.css
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.cell-execution-info-popup {
+	padding: 12px;
+	background: var(--vscode-editorHoverWidget-background);
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	font-size: 12px;
+	color: var(--vscode-editorHoverWidget-foreground);
+	min-width: 80px;
+	max-width: 300px;
+}
+
+.popup-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+	line-height: 1.4;
+}
+
+.popup-row:last-child {
+	margin-bottom: 0;
+}
+
+.popup-row-secondary {
+	margin-top: -2px;
+	margin-bottom: 6px;
+}
+
+.popup-icon {
+	font-size: 14px;
+	min-width: 16px;
+	text-align: center;
+	color: var(--vscode-symbolIcon-colorForeground);
+}
+
+.popup-icon.codicon-play {
+	color: var(--vscode-textLink-foreground);
+}
+
+.popup-icon.codicon-clock {
+	color: var(--vscode-descriptionForeground);
+}
+
+.popup-icon.codicon-calendar {
+	color: var(--vscode-descriptionForeground);
+}
+
+.popup-icon.codicon-pass {
+	color: var(--vscode-testing-iconPassed);
+}
+
+.popup-icon.codicon-error {
+	color: var(--vscode-testing-iconFailed);
+}
+
+.popup-icon.codicon-sync {
+	color: var(--vscode-debugIcon-startForeground);
+}
+
+.popup-label {
+	flex: 1;
+	white-space: nowrap;
+	color: var(--vscode-editorHoverWidget-foreground);
+}
+
+.popup-label-text {
+	color: var(--vscode-descriptionForeground);
+	flex: 0 0 auto;
+	margin-right: 3px;
+}
+
+.popup-value-text {
+	color: var(--vscode-foreground);
+	font-weight: 500;
+	flex: 0 0 auto;
+}
+
+.popup-separator {
+	height: 1px;
+	background-color: var(--vscode-descriptionForeground);
+	opacity: 0.2;
+	margin: 8px 0;
+}
+
+.popup-label-secondary {
+	font-style: italic;
+	opacity: 0.8;
+	color: var(--vscode-descriptionForeground);
+}
+
+.popup-label-success {
+	color: var(--vscode-testing-iconPassed);
+	font-weight: 500;
+}
+
+.popup-label-failed {
+	color: var(--vscode-testing-iconFailed);
+	font-weight: 500;
+}
+
+/* Dark theme adjustments */
+.vscode-dark .cell-execution-info-popup {
+	background: var(--vscode-editorHoverWidget-background);
+	border-color: var(--vscode-editorHoverWidget-border);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+/* High contrast theme adjustments */
+.vscode-high-contrast .cell-execution-info-popup {
+	background: var(--vscode-editorHoverWidget-background);
+	border: 2px solid var(--vscode-editorHoverWidget-border);
+}
+
+/* Ensure proper spacing and alignment */
+.cell-execution-info-popup .popup-row:first-child {
+	margin-top: 0;
+}
+
+/* Animation for spinning icon */
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.codicon-modifier-spin {
+	animation: spin 1s linear infinite;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './CellExecutionInfoPopup.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { useObservedValue } from '../useObservedValue.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+
+interface CellExecutionInfoPopupProps {
+	cell: PositronNotebookCodeCell;
+}
+
+/**
+ * Format cell duration for display
+ * @param duration Duration in milliseconds
+ * @returns Formatted duration string
+ */
+function formatCellDuration(duration: number): string {
+	if (duration < 1000) {
+		return `${duration}ms`;
+	}
+
+	const minutes = Math.floor(duration / 1000 / 60);
+	const seconds = Math.floor(duration / 1000) % 60;
+	const tenths = Math.floor((duration % 1000) / 100);
+
+	if (minutes > 0) {
+		return `${minutes}m ${seconds}.${tenths}s`;
+	} else {
+		return `${seconds}.${tenths}s`;
+	}
+}
+
+/**
+ * Format timestamp for display
+ * @param timestamp Unix timestamp in milliseconds
+ * @returns Formatted time string
+ */
+function formatTimestamp(timestamp: number): string {
+	const date = new Date(timestamp);
+	return date.toLocaleTimeString();
+}
+
+/**
+ * Check if timestamp was more than 1 hour ago
+ * @param timestamp Unix timestamp in milliseconds
+ * @returns True if more than 1 hour ago
+ */
+function isMoreThanOneHourAgo(timestamp: number): boolean {
+	const now = Date.now();
+	const diff = now - timestamp;
+	const hours = diff / (1000 * 60 * 60);
+	return hours >= 1;
+}
+
+/**
+ * Get relative time string (e.g., '2 minutes ago')
+ * @param timestamp Unix timestamp in milliseconds
+ * @returns Relative time string
+ */
+function getRelativeTime(timestamp: number): string {
+	const now = Date.now();
+	const diff = now - timestamp;
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 0) {
+		return localize('cellExecution.daysAgo', '{0} days ago', days);
+	} else if (hours > 0) {
+		return localize('cellExecution.hoursAgo', '{0} hours ago', hours);
+	} else if (minutes > 0) {
+		return localize('cellExecution.minutesAgo', '{0} minutes ago', minutes);
+	} else if (seconds > 0) {
+		return localize('cellExecution.secondsAgo', '{0} seconds ago', seconds);
+	} else {
+		return localize('cellExecution.justNow', 'Just now');
+	}
+}
+
+export function CellExecutionInfoPopup({ cell }: CellExecutionInfoPopupProps) {
+	// Use reactive hooks to observe cell state changes
+	const executionOrder = useObservedValue(cell.lastExecutionOrder);
+	const duration = useObservedValue(cell.lastExecutionDuration);
+	const lastRunEndTime = useObservedValue(cell.lastRunEndTime);
+	const lastRunSuccess = useObservedValue(cell.lastRunSuccess);
+	const executionStatus = useObservedValue(cell.executionStatus);
+	// Determine the data availability for various sections
+	const hasExecutionOrder = executionOrder !== undefined;
+	const hasExecutionResult = lastRunSuccess !== undefined;
+	const isCurrentlyRunning = executionStatus === 'running';
+	const hasDuration = duration !== undefined;
+	const hasCompletionTime = lastRunEndTime !== undefined;
+	const hasTimingInfo = hasDuration || hasCompletionTime;
+	const completedMoreThanAnHourAgo =
+		lastRunEndTime !== undefined && isMoreThanOneHourAgo(lastRunEndTime);
+
+	// Check if cell has never been run
+	const hasNeverBeenRun =
+		!hasExecutionOrder && !hasExecutionResult && !isCurrentlyRunning;
+
+	// If cell has never been run, show a simple message
+	if (hasNeverBeenRun) {
+		return (
+			<div
+				aria-label='Cell execution details'
+				className='cell-execution-info-popup'
+				role='tooltip'
+			>
+				<div className='popup-row'>
+					<span className='popup-label'>
+						{localize('cellExecution.notYetRun', 'Cell not yet run')}
+					</span>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			aria-label='Cell execution details'
+			className='cell-execution-info-popup'
+			role='tooltip'
+		>
+			{/* Popup body: lists high-level status then timing metadata */}
+			{/* Status Section */}
+			{hasExecutionOrder && (
+				<div aria-label='Execution order' className='popup-row'>
+					{/* Execution order row: shows the cell's execution sequence number when available */}
+					<span className='popup-icon codicon codicon-play'></span>
+					<span className='popup-label-text'>
+						{localize('cellExecution.order.label', 'Execution order:')}
+					</span>
+					<span className='popup-value-text'>{executionOrder}</span>
+				</div>
+			)}
+			{hasExecutionResult && (
+				<div aria-label='Execution status' className='popup-row'>
+					{/* Execution result row: success/failure indicator with icon and label */}
+					<span
+						aria-label={
+							lastRunSuccess ? 'Execution succeeded' : 'Execution failed'
+						}
+						className={`popup-icon codicon ${lastRunSuccess ? 'codicon-pass' : 'codicon-error'
+							}`}
+						role='img'
+					></span>
+					<span className='popup-label-text'>
+						{localize('cellExecution.status.label', 'Status:')}
+					</span>
+					<span
+						aria-label={
+							lastRunSuccess ? 'Execution succeeded' : 'Execution failed'
+						}
+						className={`popup-value-text ${lastRunSuccess ? 'popup-label-success' : 'popup-label-failed'
+							}`}
+					>
+						{lastRunSuccess
+							? localize('cellExecution.success', 'Success')
+							: localize('cellExecution.failed', 'Failed')}
+					</span>
+				</div>
+			)}
+			{isCurrentlyRunning && (
+				<div className='popup-row'>
+					{/* Running row: spinner and text shown only while a cell is currently executing */}
+					<span
+						aria-label='Cell is executing'
+						className='popup-icon codicon codicon-sync codicon-modifier-spin'
+						role='img'
+					></span>
+					<span className='popup-label'>
+						{localize('cellExecution.running', 'Currently running...')}
+					</span>
+				</div>
+			)}
+
+			{/* Separator between status and timing information */}
+			{hasTimingInfo && (
+				<div className='popup-separator'>
+					{/* Visual divider separating status rows from timing rows */}
+				</div>
+			)}
+
+			{/* Timing Section */}
+			{hasDuration && (
+				<div aria-label='Execution duration' className='popup-row'>
+					{/* Duration row: displays formatted run time (e.g., 2.3s or 850ms) */}
+					<span className='popup-icon codicon codicon-clock'></span>
+					<span className='popup-label-text'>
+						{localize('cellExecution.duration.label', 'Duration:')}
+					</span>
+					<span className='popup-value-text'>
+						{duration !== undefined ? formatCellDuration(duration) : ''}
+					</span>
+				</div>
+			)}
+			{hasCompletionTime && (
+				<div className='popup-row'>
+					{/* Completion time row: shows relative time; if >1 hour ago, also shows absolute local time */}
+					<span className='popup-icon codicon codicon-calendar'></span>
+					<span className='popup-label-text'>
+						{localize('cellExecution.endTime.label', 'Completed:')}
+					</span>
+					<span className='popup-value-text'>
+						{lastRunEndTime !== undefined // for type narrowing
+							? completedMoreThanAnHourAgo
+								? `${getRelativeTime(lastRunEndTime)} (${formatTimestamp(lastRunEndTime)})`
+								: `${getRelativeTime(lastRunEndTime)}`
+							: ''}
+					</span>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
@@ -75,13 +75,21 @@ function getRelativeTime(timestamp: number): string {
 	const days = Math.floor(hours / 24);
 
 	if (days > 0) {
-		return localize('cellExecution.daysAgo', '{0} days ago', days);
+		return days === 1
+			? localize('cellExecution.dayAgo', '1 day ago')
+			: localize('cellExecution.daysAgo', '{0} days ago', days);
 	} else if (hours > 0) {
-		return localize('cellExecution.hoursAgo', '{0} hours ago', hours);
+		return hours === 1
+			? localize('cellExecution.hourAgo', '1 hour ago')
+			: localize('cellExecution.hoursAgo', '{0} hours ago', hours);
 	} else if (minutes > 0) {
-		return localize('cellExecution.minutesAgo', '{0} minutes ago', minutes);
+		return minutes === 1
+			? localize('cellExecution.minuteAgo', '1 minute ago')
+			: localize('cellExecution.minutesAgo', '{0} minutes ago', minutes);
 	} else if (seconds > 0) {
-		return localize('cellExecution.secondsAgo', '{0} seconds ago', seconds);
+		return seconds === 1
+			? localize('cellExecution.secondAgo', '1 second ago')
+			: localize('cellExecution.secondsAgo', '{0} seconds ago', seconds);
 	} else {
 		return localize('cellExecution.justNow', 'Just now');
 	}
@@ -94,6 +102,7 @@ export function CellExecutionInfoPopup({ cell }: CellExecutionInfoPopupProps) {
 	const lastRunEndTime = useObservedValue(cell.lastRunEndTime);
 	const lastRunSuccess = useObservedValue(cell.lastRunSuccess);
 	const executionStatus = useObservedValue(cell.executionStatus);
+
 	// Determine the data availability for various sections
 	const hasExecutionOrder = executionOrder !== undefined;
 	const hasExecutionResult = lastRunSuccess !== undefined;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
@@ -1,10 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-cell {
 	position: relative;
+	margin-left: 12px;
 
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 
@@ -44,17 +45,14 @@
 
 @keyframes running-cell-pulse {
 	0% {
-		outline-width: 1px;
-		outline-offset: 0px;
+		outline-color: var(--vscode-focusBorder);
 	}
 
 	50% {
-		outline-width: 3px;
-		outline-offset: 1.5px;
+		outline-color: color-mix(in srgb, var(--vscode-focusBorder) 70%, white 30%);
 	}
 
 	100% {
-		outline-width: 1px;
-		outline-offset: 0px;
+		outline-color: var(--vscode-focusBorder);
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -34,6 +34,7 @@ export function NotebookCellWrapper({ cell, children }: { cell: IPositronNoteboo
 		ref={cellRef}
 		className={`positron-notebook-cell positron-notebook-${cell.kind === CellKind.Code ? 'code' : 'markdown'}-cell ${selectionStatus}`}
 		data-is-running={executionStatus === 'running'}
+		data-testid='notebook-cell'
 		tabIndex={0}
 		onClick={(e) => {
 			const clickTarget = e.nativeEvent.target as HTMLElement;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -21,6 +21,7 @@ import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
+import { CellExecutionInfoIcon } from './CellExecutionInfoIcon.js';
 
 interface CellExecutionControlsProps {
 	isRunning: boolean;
@@ -44,7 +45,7 @@ interface CellOutputsSectionProps {
 
 function CellOutputsSection({ outputs = [] }: CellOutputsSectionProps) {
 	return (
-		<div className='positron-notebook-code-cell-outputs'>
+		<div className='positron-notebook-code-cell-outputs' data-testid='cell-output'>
 			{outputs?.map((output) => (
 				<CellOutput key={output.outputId} {...output} />
 			))}
@@ -66,6 +67,7 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 				<CellEditorMonacoWidget cell={cell} />
 				<CellOutputsSection outputs={outputContents} />
 			</div>
+			<CellExecutionInfoIcon cell={cell} />
 		</NotebookCellWrapper>
 	);
 }

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
@@ -1,11 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
+import { ISettableObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { NotebookPreloadOutputResults } from '../../positronWebviewPreloads/browser/positronWebviewPreloadService.js';
@@ -129,6 +129,26 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	 * Current cell outputs as an observable
 	 */
 	outputs: ISettableObservable<NotebookCellOutputs[], void>;
+
+	/**
+	 * Duration of the last execution in milliseconds
+	 */
+	lastExecutionDuration: ISettableObservable<number | undefined>;
+
+	/**
+	 * Execution order number for the last execution
+	 */
+	lastExecutionOrder: ISettableObservable<number | undefined>;
+
+	/**
+	 * Whether the last execution was successful
+	 */
+	lastRunSuccess: ISettableObservable<boolean | undefined>;
+
+	/**
+	 * Timestamp when the last execution ended
+	 */
+	lastRunEndTime: ISettableObservable<number | undefined>;
 }
 
 
@@ -205,7 +225,7 @@ export interface NotebookCellOutputs {
 /**
  * Lightweight copy of the vscode `NotebookCellTextModel` interface.
  */
-interface PositronNotebookCellTextModel {
+export interface PositronNotebookCellTextModel {
 	readonly uri: URI;
 	handle: number;
 	language: string;

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
+import { ISettableObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, IPositronNotebookCell } from './IPositronNotebookCell.js';
 import { SelectionStateMachine } from './selectionMachine.js';

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -10,6 +10,7 @@ import { QuickAccess } from './quickaccess';
 import test, { expect, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
 
+const DEFAULT_TIMEOUT = 10000;
 /**
  * Notebooks functionality exclusive to Positron notebooks.
  */
@@ -35,16 +36,312 @@ export class PositronNotebooks extends Notebooks {
 		await this.expectToBeVisible();
 	}
 
+	/**
+	 * Override selectCellAtIndex to use Positron-specific selectors
+	 */
+	async selectCellAtIndex(cellIndex: number): Promise<void> {
+		await test.step(`Select cell at index: ${cellIndex}`, async () => {
+			// Use semantic selector
+			await this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex).click();
+		});
+	}
+
+	/**
+	 * Get the current number of cells in the notebook
+	 */
+	private async getCellCount(): Promise<number> {
+		return await this.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+	}
+
+	/**
+	 * Create a new code cell at the specified index
+	 */
+	private async createNewCodeCell(index: number): Promise<void> {
+		await test.step(`Create new code cell at index ${index}`, async () => {
+			// Find all "New Code Cell" buttons - they appear between cells
+			const addCellButtons = this.code.driver.page.getByLabel('New Code Cell');
+			const buttonCount = await addCellButtons.count();
+
+			if (buttonCount === 0) {
+				throw new Error('No "New Code Cell" buttons found');
+			}
+
+			// Click the last button (which adds a cell at the end)
+			// Note: This assumes we're always adding at the end, which matches the validation in addCodeToCellAtIndex
+			await addCellButtons.last().click();
+
+			// Wait for the new cell to appear
+			await expect(this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(index)).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Override addCodeToCellAtIndex to use Positron-specific selectors and Monaco editor
+	 */
+	async addCodeToCellAtIndex(code: string, cellIndex = 0, delay = 0): Promise<void> {
+		await test.step('Add code to Positron cell', async () => {
+			// Check if the cell exists
+			const currentCellCount = await this.getCellCount();
+
+			if (cellIndex >= currentCellCount) {
+				// Cell doesn't exist, need to create it
+				// Verify we're only adding one cell at the end
+				if (cellIndex > currentCellCount) {
+					throw new Error(`Cannot create cell at index ${cellIndex}. Current cell count is ${currentCellCount}. Can only add cells sequentially.`);
+				}
+
+				// Create the new cell
+				await this.createNewCodeCell(cellIndex);
+			}
+
+			// Now select and fill the cell (existing logic)
+			await this.selectCellAtIndex(cellIndex);
+
+			// Find the Monaco editor within the Positron cell
+			const editorSelector = '.positron-cell-editor-monaco-widget textarea';
+
+			// Get the specific cell's editor
+			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+			const editor = cell.locator(editorSelector);
+
+			// Ensure editor is focused and type/fill the code
+			await editor.focus();
+			if (delay) {
+				await editor.pressSequentially(code, { delay });
+			} else {
+				await editor.fill(code);
+			}
+		});
+	}
+
+	/**
+	 * Execute code in the current cell by clicking the run button
+	 */
+	async executeCodeInCell(cellIndex = 0): Promise<void> {
+		await test.step('Execute code in Positron notebook cell', async () => {
+			// Select the cell first
+			await this.selectCellAtIndex(cellIndex);
+
+			// Find and click the run button for this specific cell
+			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+			const runButton = cell.getByLabel('Run cell');
+
+			await runButton.click();
+
+			// Wait for execution to complete by checking the execution spinner is gone
+			const spinner = cell.getByLabel('Cell is executing');
+
+			// Wait for spinner to appear (cell is executing)
+			await expect(spinner).toBeVisible({ timeout: DEFAULT_TIMEOUT }).catch(() => {
+				// Spinner might not appear for very fast executions, that's okay
+			});
+
+			// Wait for spinner to disappear (execution complete)
+			await expect(spinner).toHaveCount(0, { timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Start executing code in the current cell by clicking the run button without waiting for completion
+	 */
+	async startExecutingCodeInCell(cellIndex = 0): Promise<void> {
+		await test.step('Start executing code in Positron notebook cell', async () => {
+			// Select the cell first
+			await this.selectCellAtIndex(cellIndex);
+
+			// Find and click the run button for this specific cell
+			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+			const runButton = cell.getByLabel('Run cell');
+
+			await runButton.click();
+		});
+	}
+
+	/**
+	 * Add code to a cell and run it - combined operation for efficiency.
+	 * This avoids repeatedly finding the same cell and provides better performance.
+	 * Returns the cell locator for further operations.
+	 */
+	async addCodeToCellAndRun(code: string, cellIndex = 0, delay = 0): Promise<Locator> {
+		return await test.step(`Add code and run cell ${cellIndex}`, async () => {
+			// Check if the cell exists
+			const currentCellCount = await this.getCellCount();
+
+			if (cellIndex >= currentCellCount) {
+				// Cell doesn't exist, need to create it
+				// Verify we're only adding one cell at the end
+				if (cellIndex > currentCellCount) {
+					throw new Error(`Cannot create cell at index ${cellIndex}. Current cell count is ${currentCellCount}. Can only add cells sequentially.`);
+				}
+
+				// Create the new cell
+				await this.createNewCodeCell(cellIndex);
+			}
+
+			// Get the cell once and reuse the reference
+			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+
+			// Select the cell
+			await cell.click();
+
+			// Find and fill the Monaco editor
+			const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
+			await editor.focus();
+
+			if (delay) {
+				await editor.pressSequentially(code, { delay });
+			} else {
+				await editor.fill(code);
+			}
+
+			// Find and click the run button
+			const runButton = cell.getByLabel('Run cell');
+			await runButton.click();
+
+			// // Wait for execution to complete
+			// const spinner = cell.getByLabel('Cell is executing');
+
+			// // Wait for spinner to appear (cell is executing)
+			// await expect(spinner).toBeVisible({ timeout: DEFAULT_TIMEOUT }).catch(() => {
+			// 	// Spinner might not appear for very fast executions, that's okay
+			// });
+
+			// // Wait for spinner to disappear (execution complete)
+			// await expect(spinner).toHaveCount(0, { timeout: DEFAULT_TIMEOUT });
+			return cell;
+		});
+	}
+
+	/**
+	 * Get execution info icon for a specific cell
+	 */
+	getExecutionInfoIcon(cellIndex = 0): Locator {
+		const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+		return cell.getByLabel('Cell execution info');
+	}
+
+
+	/**
+	 * Get the execution status for a specific cell
+	 */
+	async getExecutionStatus(cellIndex = 0): Promise<string | null> {
+		const icon = this.getExecutionInfoIcon(cellIndex);
+		return await icon.getAttribute('data-execution-status');
+	}
+
+	/**
+	 * Wait for execution info icon to be visible after cell execution
+	 */
+	async waitForExecutionInfoIcon(cellIndex = 0, timeout = DEFAULT_TIMEOUT): Promise<void> {
+		await test.step(`Wait for execution info icon in cell ${cellIndex}`, async () => {
+			const icon = this.getExecutionInfoIcon(cellIndex);
+			await expect(icon).toBeVisible({ timeout });
+		});
+	}
+
+	/**
+	 * Select interpreter and wait for the kernel to be ready.
+	 * This combines selecting the interpreter with waiting for kernel connection to prevent flakiness.
+	 * Directly implements Positron-specific logic without unnecessary notebook type detection.
+	 */
+	async selectAndWaitForKernel(
+		kernelGroup: 'Python' | 'R',
+		desiredKernel = kernelGroup === 'Python'
+			? process.env.POSITRON_PY_VER_SEL!
+			: process.env.POSITRON_R_VER_SEL!
+	): Promise<void> {
+		await test.step(`Select kernel and wait for ready: ${desiredKernel}`, async () => {
+			// Ensure notebook is visible
+			await this.expectToBeVisible();
+
+			// Wait for kernel detection to complete
+			await expect(this.code.driver.page.locator('.cell-status-item-has-runnable .codicon-sync')).not.toBeVisible({ timeout: 30000 });
+			await expect(this.code.driver.page.locator('text="Detecting Kernels"')).not.toBeVisible({ timeout: 30000 });
+
+			// Get the kernel status badge using aria-label
+			const kernelStatusBadge = this.code.driver.page.getByLabel(/notebook kernel status/i);
+			await expect(kernelStatusBadge).toBeVisible({ timeout: 5000 });
+
+			try {
+				// Check if the desired kernel is already selected
+				const currentKernelText = await kernelStatusBadge.textContent();
+				if (currentKernelText && currentKernelText.includes(desiredKernel) && currentKernelText.includes('Connected')) {
+					this.code.logger.log(`Kernel already selected and connected: ${desiredKernel}`);
+					return;
+				}
+			} catch (e) {
+				this.code.logger.log('Could not check current kernel status');
+			}
+
+			// Need to select the kernel
+			try {
+				// Click on kernel status badge to open selection
+				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
+				await kernelStatusBadge.click();
+
+				// Wait for kernel selection UI to appear
+				await this.quickinput.waitForQuickInputOpened();
+
+				// Select the desired kernel
+				await this.quickinput.selectQuickInputElementContaining(desiredKernel);
+				await this.quickinput.waitForQuickInputClosed();
+
+				this.code.logger.log(`Selected kernel: ${desiredKernel}`);
+			} catch (e) {
+				this.code.logger.log(`Failed to select kernel: ${e}`);
+				throw e;
+			}
+
+			// Wait for the kernel status to show "Connected"
+			await expect(kernelStatusBadge).toContainText('Connected', { timeout: 30000 });
+			this.code.logger.log('Kernel is connected and ready');
+		});
+	}
+
 	// -- Verifications --
 
 	/**
 	 * Verify: a Positron notebook is visible on the page.
 	 */
-	async expectToBeVisible(timeout = 5000): Promise<void> {
+	async expectToBeVisible(timeout = DEFAULT_TIMEOUT): Promise<void> {
 		await test.step('Verify Positron notebook is visible', async () => {
 			await expect(this.positronNotebook).toBeVisible({ timeout });
 		});
 	}
 
 
+	/**
+	 * Helper function to set notebook editor associations
+	 * @param settings - The settings fixture
+	 * @param editor - 'positron' to use Positron notebook editor, 'default' to clear associations
+	 * @param waitMs - The number of milliseconds to wait for the settings to be applied
+	 */
+	async setNotebookEditor(
+		settings: {
+			set: (settings: Record<string, unknown>, options?: { reload?: boolean | 'web'; waitMs?: number; waitForReady?: boolean; keepOpen?: boolean }) => Promise<void>;
+		},
+		editor: 'positron' | 'default',
+		waitMs = 800
+	) {
+		await settings.set({
+			'positron.notebook.enabled': true,
+			'workbench.editorAssociations': editor === 'positron'
+				? { '*.ipynb': 'workbench.editor.positronNotebook' }
+				: {}
+		}, { waitMs });
+	}
+
+	/**
+	 * Helper function to enable Positron notebooks with reload
+	 * @param settings - The settings fixture
+	 */
+	async enablePositronNotebooks(
+		settings: {
+			set: (settings: Record<string, unknown>, options?: { reload?: boolean | 'web'; waitMs?: number; waitForReady?: boolean; keepOpen?: boolean }) => Promise<void>;
+		}
+	) {
+		await settings.set({
+			'positron.notebook.enabled': true,
+		}, { reload: true });
+	}
 }

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra/index.js';
+import { test, tags } from '../_test.setup';
+import { expect, Locator } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * Helper function to execute code in a cell and wait for the execution info icon to appear
+ */
+async function executeCodeAndWaitForIcon(app: Application, code: string, cellIndex: number = 0) {
+	const cell = await app.workbench.notebooksPositron.addCodeToCellAndRun(code, cellIndex);
+	const icon = cell.getByLabel('Cell execution info');
+	return icon;
+}
+
+async function activateInfoPopup({ app, icon }: { app: Application; icon: Locator }): Promise<Locator> {
+	await icon.hover({ force: true });
+	const popup = app.code.driver.page.getByRole('tooltip', { name: 'Cell execution details' });
+	await expect(popup).toBeVisible();
+	return popup;
+}
+
+test.describe('Cell Execution Info Popup', {
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+		// Configure Positron as the notebook editor
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+	});
+
+	test('Comprehensive cell execution info test - all scenarios in one notebook', async function ({ app }) {
+		// Setup: Create notebook and select kernel once
+		await app.workbench.notebooks.createNewNotebook();
+		await app.workbench.notebooksPositron.selectAndWaitForKernel('Python');
+
+		// ========================================
+		// Cell 0: Basic popup display with successful execution
+		// ========================================
+		const icon0 = await executeCodeAndWaitForIcon(app, 'print("hello world")', 0);
+		const popup0 = await activateInfoPopup({ app, icon: icon0 });
+
+		// Verify popup content shows execution info
+		await expect(popup0.getByLabel('Execution order')).toBeVisible();
+		await expect(popup0.getByLabel('Execution order')).toContainText('1');
+		await expect(popup0.getByLabel('Execution duration')).toBeVisible();
+		await expect(popup0.getByLabel('Execution status')).toContainText('Success');
+
+		// Verify auto-close behavior
+		await app.code.driver.page.mouse.move(0, 0); // Move mouse away
+		await expect(popup0).toBeHidden();
+
+		// ========================================
+		// Cell 1: Failed execution state display
+		// ========================================
+		// Create and execute a new cell with failing code
+		const icon1 = await executeCodeAndWaitForIcon(app, 'raise Exception("test error")', 1);
+		await expect(icon1).toBeVisible();
+
+		// Verify failed execution status
+		await expect(icon1).toHaveAttribute('data-execution-status', 'failed');
+
+		// Verify popup shows failed status
+		const popup1 = await activateInfoPopup({ app, icon: icon1 });
+		await expect(popup1).toContainText(/Failed/i);
+
+		// Move mouse away to close popup
+		await app.code.driver.page.mouse.move(0, 0);
+		await expect(popup1).toBeHidden();
+
+		// ========================================
+		// Cell 2: Running execution state display
+		// ========================================
+		// Add a code cell that will run for a reasonable time
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('import time; time.sleep(3)', 2);
+
+		// Start executing the cell without waiting for completion
+		await app.workbench.notebooksPositron.startExecutingCodeInCell(2);
+
+		// Wait for execution to start - spinner should appear in button area
+		const cell2 = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(2);
+		const spinner = cell2.getByLabel('Cell is executing');
+		await expect(spinner).toBeVisible({ timeout: 5000 });
+
+		// Wait for execution info icon to appear during execution and verify running state
+		const icon2 = app.workbench.notebooksPositron.getExecutionInfoIcon(2);
+		await expect(icon2).toBeVisible({ timeout: 3000 });
+		await expect(icon2).toHaveAttribute('data-execution-status', 'running');
+
+		// Verify spinning icon is present in the execution info icon
+		const popup2 = await activateInfoPopup({ app, icon: icon2 });
+
+		// Verify popup shows running status
+		await expect(popup2).toContainText('Currently running...');
+
+		// Move mouse away and wait for execution to complete
+		await app.code.driver.page.mouse.move(0, 0);
+		await expect(spinner).toHaveCount(0, { timeout: 10000 });
+
+		// ========================================
+		// Cell 3: Relative time display
+		// ========================================
+		// Execute code in a new cell and get the execution info icon
+		const icon3 = await executeCodeAndWaitForIcon(app, 'print("relative time test")', 3);
+		const popup3 = await activateInfoPopup({ app, icon: icon3 });
+
+		// Verify relative time is displayed (should show recent execution)
+		// Some renderers may insert non-breaking spaces between words. Use \s to match any whitespace.
+		// Some renderers may insert non-breaking spaces between words. Check for either phrase.
+		const popupText = await popup3.textContent();
+		expect(
+			popupText?.toLowerCase().includes('seconds ago') ||
+			popupText?.toLowerCase().includes('just now')
+		).toBeTruthy();
+
+		// Move mouse away to close popup
+		await app.code.driver.page.mouse.move(0, 0);
+		await expect(popup3).toBeHidden();
+
+		// ========================================
+		// Cell 4: Hover timing and interaction
+		// ========================================
+		// Execute code in a new cell and get the execution info icon
+		const icon4 = await executeCodeAndWaitForIcon(app, 'print("hover test")', 4);
+		const popup4 = await activateInfoPopup({ app, icon: icon4 });
+
+		// Test popup closes when mouse moves away
+		await app.code.driver.page.mouse.move(0, 0);
+		await expect(popup4).toBeHidden();
+
+		// Test that hovering again after closing still works
+		await icon4.hover();
+		await expect(popup4).toBeVisible();
+
+		// ========================================
+		// Cleanup
+		// ========================================
+		// Move mouse away to ensure tooltip is hidden before closing
+		await app.code.driver.page.mouse.move(0, 0);
+		await expect(app.code.driver.page.getByRole('tooltip', { name: 'Cell execution details' })).toBeHidden();
+
+		// Close the notebook without saving
+		await app.workbench.notebooks.closeNotebookWithoutSaving();
+	});
+});


### PR DESCRIPTION
Addresses #5495.

@:notebooks

Adds execution information display for notebook cells, showing execution order, duration, and status through a hover popup. The feature includes an execution order badge or status icon in the cell gutter that triggers a detailed popup on hover, providing users with visibility into when cells were executed, how long they took, and their success status. Includes e2e tests covering popup interactions, status changes, and accessibility features.

<img width="620" height="481" alt="image" src="https://github.com/user-attachments/assets/31ac4b3f-515a-45e8-baa3-5f67d27151aa" />


### Release Notes


#### Bug Fixes
- N/A

### QA Notes

The e2e tests in `test/e2e/tests/notebook/cell-execution-info.test.ts` verify all interaction patterns

#### Manual Testing

Create a new Python notebook and execute cells to verify the execution info appears correctly.

```python
import time
print("Quick execution")
```

```python  
import time
time.sleep(2)
print("Slow execution")
```

After running these cells, you should see:
1. Execution order badges (1, 2) appear in the cell gutters
2. Hover over the badges to see popup with execution duration and timestamp
3. Status icons during execution (spinning icon while running)
4. Different styling for successful vs failed executions
5. Popup auto-closes when mouse leaves the area

