### PR TITLE
Update rstudio.rstudio-workbench to 1.5.72 (#9038)

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1163,7 +1167,8 @@
         "filename": "product.json",
         "hashed_secret": "cc79c1d278e908dda36350d2b88f9b78f35d4be8",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 114,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1650,7 +1655,8 @@
         "filename": "src/vs/workbench/api/node/loopbackServer.ts",
         "hashed_secret": "094ab4147707513f945937285ac0a6ef8472a356",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 184,
+        "is_secret": false
       }
     ],
     "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
@@ -1727,7 +1733,8 @@
         "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
         "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 96,
+        "is_secret": false
       }
     ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
@@ -1779,5 +1786,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-14T17:51:29Z"
+  "generated_at": "2025-08-14T18:55:44Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1161,10 +1161,9 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "b62fa8cef25f84ac3cbe965001c576001a09d049",
+        "hashed_secret": "cc79c1d278e908dda36350d2b88f9b78f35d4be8",
         "is_verified": false,
-        "line_number": 114,
-        "is_secret": false
+        "line_number": 114
       },
       {
         "type": "Hex High Entropy String",
@@ -1780,5 +1779,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-06T19:15:53Z"
+  "generated_at": "2025-08-14T17:51:29Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.67",
+			"version": "1.5.72",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "f716664a9579469ef98534b85df429c3f72097344333d993188d7ff0ec527c48",
+			"sha256": "59e50a76fe856c2686867a1af5906a92c0ce6e4681a61ceb2218cf2c2c573210",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Cherry-picked from `main`. This updates the workbench extension to `1.5.72`.