### PR TITLE
fix bug with notebook.workingDirectory setting on web

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -436,6 +436,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			NotebookSetting.workingDirectory, { resource: notebookUri }
 		);
 		if (!configValue || configValue.trim() === '') {
+			this._logService.info(`${NotebookSetting.workingDirectory}: Setting is unset. Using default: '${defaultValue}'`);
 			return defaultValue;
 		}
 		const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(notebookUri);
@@ -447,12 +448,13 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				workspaceFolder || undefined, configValue
 			);
 		} catch (error) {
-			this._logService.warn(`${NotebookSetting.workingDirectory}: Failed to resolve variables in '${configValue}':`, error);
+			this._logService.warn(`${NotebookSetting.workingDirectory}: Failed to resolve variables in '${configValue}'. Using default: '${defaultValue}'`, error);
 			return defaultValue;
 		}
 
 		// Check if the result is a directory that exists
 		if (await this.isValidDirectory(notebookUri.with({ path: resolvedValue }))) {
+			this._logService.info(`${NotebookSetting.workingDirectory}: Resolved '${configValue}' to '${resolvedValue}'`);
 			return resolvedValue;
 		} else {
 			return defaultValue;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -396,22 +396,22 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	/**
-	 * Validates that a path is an existing directory.
+	 * Validates that a URI is an existing directory.
 	 *
-	 * @param path The path to validate
-	 * @returns A promise that resolves to true if the path is a directory and exists,
+	 * @param uri The URI to validate
+	 * @returns A promise that resolves to true if the URI is a directory and exists,
 	 * false otherwise.
 	 */
-	private async isValidDirectory(path: string): Promise<boolean> {
+	private async isValidDirectory(uri: URI): Promise<boolean> {
 		try {
-			const stat = await this._fileService.stat(URI.file(path));
+			const stat = await this._fileService.stat(uri);
 			if (!stat.isDirectory) {
-				this._logService.warn(`${NotebookSetting.workingDirectory}: Path '${path}' exists but is not a directory`);
+				this._logService.warn(`${NotebookSetting.workingDirectory}: Path '${uri.fsPath}' exists but is not a directory`);
 				return false;
 			}
 			return true;
 		} catch (error) {
-			this._logService.warn(`${NotebookSetting.workingDirectory}: Path '${path}' does not exist or is not accessible:`, error);
+			this._logService.warn(`${NotebookSetting.workingDirectory}: Path '${uri.fsPath}' does not exist or is not accessible:`, error);
 			return false;
 		}
 	}
@@ -428,7 +428,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// The default value is the notebook's parent directory, if it exists.
 		let defaultValue: string | undefined;
 		const notebookParent = dirname(notebookUri.fsPath);
-		if (await this.isValidDirectory(notebookParent)) {
+		if (await this.isValidDirectory(notebookUri.with({ path: notebookParent }))) {
 			defaultValue = notebookParent;
 		}
 
@@ -452,7 +452,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		}
 
 		// Check if the result is a directory that exists
-		if (await this.isValidDirectory(resolvedValue)) {
+		if (await this.isValidDirectory(notebookUri.with({ path: resolvedValue }))) {
 			return resolvedValue;
 		} else {
 			return defaultValue;

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -13,9 +13,8 @@ test.use({
 	suiteId: __filename
 });
 
-// Untagged for WEB due to https://github.com/posit-dev/positron/issues/8828
 test.describe('Notebook Working Directory Configuration', {
-	tag: [tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.WIN, tags.WEB, tags.NOTEBOOKS]
 }, () => {
 
 	test.afterEach(async function ({ app }) {

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -29,14 +29,14 @@ test.describe('Notebook Working Directory Configuration', {
 	test('workspaceFolder works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${workspaceFolder}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'qa-example-content');
 	});
 
 	test('fileDirname works', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${fileDirname}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
@@ -46,21 +46,21 @@ test.describe('Notebook Working Directory Configuration', {
 
 		await settings.set({
 			'notebook.workingDirectory': tempDir
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, path.basename(tempDir));
 	});
 
 	test('Paths that do not exist result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '/does/not/exist'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 
 	test('Bad variables result in the default notebook parent', async function ({ app, settings }) {
 		await settings.set({
 			'notebook.workingDirectory': '${asdasd}'
-		});
+		}, { reload: 'web' });
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #8828.

Previously there was an assumption that the filepaths passed around as strings had the `file://` scheme, which isn't true on Web (it's `vscode-remote://` or something like that). Changing the method to use URIs instead of strings fixes the bug where the setting wasn't working on Web.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed `notebook.workingDirectory` setting on web https://github.com/posit-dev/positron/issues/8828


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
Added the WEB tag back to the e2e test.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:web @:win @:notebooks