### PR TITLE
E2E test: notify slack nightly if extensions are out of date in product.json

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -29,6 +29,7 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0 # CI skips building releases
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -1,0 +1,72 @@
+name: 'Nightly: Bootstrap Extensions Check'
+
+# Run builds daily at 2am UTC (10p EST) on weekdays for now, or manually
+on:
+  schedule:
+    - cron: "0 2 * * 1-5"
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  extensions-linux:
+    name: 'extensions-linux'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest-8x
+    container:
+      image: ghcr.io/posit-dev/positron-ubuntu24-amd64:27
+      options: --user 0:0
+      # Static PAT is needed because the bot can't pass a token to the job for security reasons
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Attempt 1 - Setup Build and Compile
+        id: attempt1
+        uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 2 - Setup Build and Compile
+        if: ${{ steps.attempt1.outcome == 'failure' }}
+        id: attempt2
+        uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 3 - Setup Build and Compile
+        id: attempt3
+        if: ${{ steps.attempt2.outcome == 'failure' }}
+        uses: ./.github/actions/setup-build-env
+
+      - name: Fail if Retries Exhausted
+        if: ${{ steps.attempt3.outcome == 'failure' }}
+        run: exit 1
+
+      - name: Setup Xvfb
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Send Results to GH Summary
+        uses: ./.github/actions/gen-report-dir
+
+      - name: Run Playwright Tests (Electron)
+        shell: bash
+        env:
+          POSITRON_PY_VER_SEL: "3.10.12"
+          POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_PY_ALT_VER_SEL: "3.13.0"
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+          EXTENSIONS_FAIL_ON_MISMATCH: true
+        run: |
+          echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: "0 2 * * 1-5"
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   extensions-linux:
     name: 'extensions-linux'
-    timeout-minutes: 15
+    timeout-minutes: 60
     runs-on: ubuntu-latest-8x
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24-amd64:27

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -103,8 +103,9 @@ async function waitForExtensions(extensions: { fullName: string; shortName: stri
 		console.log(' 2. If SHA is needed, download package and follow instructions here: https://connect.posit.it/positron-wiki/updating-extensions.html#updating-extensions');
 		console.log(' 3. Update the `product.json` file with the correct version and (as needed) SHA');
 
-		// rely on logging for now
-		// throw new Error('Some extensions were installed with mismatched versions. Please check the logs above.');
+		if (process.env.EXTENSIONS_FAIL_ON_MISMATCH === 'true') {
+			throw new Error('Some extensions were installed with mismatched versions. Please check the logs above.');
+		}
 	}
 
 	console.log('\n🎉 All extensions installed with correct versions.');


### PR DESCRIPTION
During most runs, this test doesn't fail but simply logs. We need it to fail at least nightly to keep product.json up to date.

### QA Notes

