### PR TITLE
Update 1Password action to v3

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -201,7 +201,6 @@ jobs:
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/ubuntu' }}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
-          ANTHROPIC_API_KEY: ${{ steps.load_from_1password.outputs.ANTHROPIC_API_KEY }}
         run: |
           echo "Processing skip_tags input: '${{ inputs.skip_tags }}'"
 

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@v3
         with:
           # Export loaded secrets as environment variables
           export-env: true
@@ -201,6 +201,7 @@ jobs:
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/ubuntu' }}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.report_currents }}
           CURRENTS_PROJECT_ID: ${{ vars.CURRENTS_PROJECT_ID}}
+          ANTHROPIC_API_KEY: ${{ steps.load_from_1password.outputs.ANTHROPIC_API_KEY }}
         run: |
           echo "Processing skip_tags input: '${{ inputs.skip_tags }}'"
 

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -82,6 +82,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Load secret
+        uses: 1password/load-secrets-action@v3
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_API_KEY: "op://Positron/Anthropic/credential"
+
       - name: Set screen resolution
         shell: pwsh
         run: |

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -671,6 +675,16 @@
         "is_secret": false
       }
     ],
+    ".github/workflows/test-e2e-windows.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/test-e2e-windows.yml",
+        "hashed_secret": "74d50d4e7dbf232033bcb82f4c4ad6223a354c8e",
+        "is_verified": false,
+        "line_number": 92,
+        "is_secret": false
+      }
+    ],
     ".github/workflows/test-full-suite.yml": [
       {
         "type": "Secret Keyword",
@@ -1163,7 +1177,8 @@
         "filename": "product.json",
         "hashed_secret": "cc79c1d278e908dda36350d2b88f9b78f35d4be8",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 114,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1781,5 +1796,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-14T17:51:29Z"
+  "generated_at": "2025-08-15T15:41:28Z"
 }

--- a/test/e2e/tests/positron-assistant/inspect-ai.test.ts
+++ b/test/e2e/tests/positron-assistant/inspect-ai.test.ts
@@ -17,7 +17,7 @@ test.use({
  * the dataset for use in the inspect-ai tests. It also does some basic validation that there are valid responses
  * from the assistant.
  */
-test.describe.skip('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
+test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
 		await app.workbench.assistant.selectModelProvider('Anthropic');

--- a/test/e2e/tests/positron-assistant/inspect-ai.test.ts
+++ b/test/e2e/tests/positron-assistant/inspect-ai.test.ts
@@ -17,7 +17,7 @@ test.use({
  * the dataset for use in the inspect-ai tests. It also does some basic validation that there are valid responses
  * from the assistant.
  */
-test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB] }, () => {
+test.describe.skip('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI, tags.WIN, tags.WEB, tags.NIGHTLY_ONLY] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
 		await app.workbench.assistant.selectModelProvider('Anthropic');


### PR DESCRIPTION
The 1Password GH Action now supports windows as well.

Currently this just sets an anthropic key for assistant testsing, but can now be utilized for any secret.

The assistant test that uses it is skipped for now, but this is needed when it's enabled soon.

### QA Notes
In testing, I unskipped the test and ran it in CI. You can see it passed in https://github.com/posit-dev/positron/actions/runs/16993754640/job/48179307637

It's marked failed due to the S3 upload of playwright log failure.