### PR TITLE
Add code formatting helper script and advice so Claude Code can properly format JS/TS files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,41 @@ npm run watch
 npm test
 ```
 
+### Code Formatting
+
+**🚨 CRITICAL: DO NOT USE PRETTIER**
+
+Positron uses VSCode's built-in TypeScript formatter, not Prettier. Using Prettier will create formatting conflicts that are very difficult to resolve.
+
+**Correct way to format files:**
+```bash
+# Format specific TypeScript/JavaScript files using the project's formatter script
+node scripts/format.js <file1> [file2] [file3] ...
+
+# Examples:
+node scripts/format.js src/vs/workbench/contrib/positronDataExplorer/browser/positronDataExplorer.tsx
+node scripts/format.js src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+
+# Format multiple files at once:
+node scripts/format.js file1.ts file2.tsx file3.js
+```
+
+**This script uses TypeScript's built-in formatter - the exact same formatter used by the pre-commit hook.**
+
+**Project formatting rules:**
+- Uses **tabs** (not spaces)  
+- Uses **single quotes**
+- Inserts final newlines
+- VSCode's TypeScript formatter handles all formatting
+- ESLint with `@stylistic/eslint-plugin-ts` provides additional style rules
+
+**Never use:**
+- `prettier` or `npx prettier` commands
+- `npm run eslint` (runs on entire codebase, too broad)
+- Any other third-party formatters
+
+When editing files, format them with `npx eslint --fix <file_path>` to match the project's formatting standards exactly.
+
 ### Testing
 ```bash
 # Run specific e2e test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ node scripts/format.js file1.ts file2.tsx file3.js
 - `npm run eslint` (runs on entire codebase, too broad)
 - Any other third-party formatters
 
-When editing files, format them with `npx eslint --fix <file_path>` to match the project's formatting standards exactly.
+When editing files, format them with `node scripts/format.js <file_path>` to match the project's formatting standards exactly.
 
 ### Testing
 ```bash

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const fs = require('fs');
+const path = require('path');
+
+// Import the formatter from the build directory
+const formatter = require('../build/lib/formatter');
+
+function formatFile(filePath) {
+	try {
+		// Resolve the file path relative to project root
+		const resolvedPath = path.resolve(filePath);
+		
+		// Check if file exists
+		if (!fs.existsSync(resolvedPath)) {
+			console.error(`Error: File not found: ${filePath}`);
+			return false;
+		}
+
+		// Read the file content
+		const content = fs.readFileSync(resolvedPath, 'utf8');
+		
+		// Format the content using TypeScript's formatter
+		const formatted = formatter.format(resolvedPath, content);
+		
+		// Write the formatted content back to the file
+		fs.writeFileSync(resolvedPath, formatted);
+		
+		console.log(`Formatted: ${filePath}`);
+		return true;
+	} catch (error) {
+		console.error(`Error formatting ${filePath}:`, error.message);
+		return false;
+	}
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	
+	if (args.length === 0) {
+		console.log('Usage: node scripts/format.js <file1> [file2] [file3] ...');
+		console.log('');
+		console.log('Format TypeScript/JavaScript files using the project\'s TypeScript formatter.');
+		console.log('This is the same formatter used by the pre-commit hook.');
+		console.log('');
+		console.log('Examples:');
+		console.log('  node scripts/format.js src/vs/workbench/browser/workbench.ts');
+		console.log('  node scripts/format.js src/**/*.ts src/**/*.js');
+		process.exit(1);
+	}
+
+	let allSuccessful = true;
+	
+	for (const filePath of args) {
+		const success = formatFile(filePath);
+		if (!success) {
+			allSuccessful = false;
+		}
+	}
+	
+	if (!allSuccessful) {
+		process.exit(1);
+	}
+}
+
+if (require.main === module) {
+	main();
+}


### PR DESCRIPTION
The VSCode Codebase uses its own built-in TypeScript formatter which seems to require some effort to invoke from the command line. Without these instructions, Claude will invoke prettier if you ask it to format files which creates a big mess. 