### PR TITLE
Fix ghost notebook editor on restart

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -62,6 +62,9 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou
 import { NotebookRendererMessagingService } from './services/notebookRendererMessagingServiceImpl.js';
 import { INotebookRendererMessagingService } from '../common/notebookRendererMessagingService.js';
 import { INotebookCellOutlineDataSourceFactory, NotebookCellOutlineDataSourceFactory } from './viewModel/notebookOutlineDataSourceFactory.js';
+// --- Start Positron ---
+import { checkPositronNotebookEnabled } from '../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
+// --- End Positron ---
 
 // Editor Controller
 import './controller/coreActions.js';
@@ -835,6 +838,9 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 		@IWorkingCopyEditorService private readonly _workingCopyEditorService: IWorkingCopyEditorService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@INotebookService private readonly _notebookService: INotebookService,
+		// --- Start Positron ---
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		// --- End Positron ---
 	) {
 		super();
 
@@ -842,6 +848,14 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 	}
 
 	async handles(workingCopy: IWorkingCopyIdentifier): Promise<boolean> {
+		// --- Start Positron ---
+		// If this is a .ipynb file and Positron notebooks are enabled,
+		// let the Positron handler take care of it
+		if (workingCopy.resource.path.endsWith('.ipynb') &&
+			checkPositronNotebookEnabled(this._configurationService)) {
+			return false;
+		}
+		// --- End Positron ---
 		const viewType = this.handlesSync(workingCopy);
 		if (!viewType) {
 			return false;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -16,17 +16,26 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ExtUri, joinPath } from '../../../../base/common/resources.js';
+import { ExtUri, joinPath, isEqual } from '../../../../base/common/resources.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
 
 /**
- * Mostly empty options object. Based on the same one in `vs/workbench/contrib/notebook/browser/notebookEditorInput.ts`
- * May be filled out later.
+ * Options for Positron notebook editor input, including backup support.
+ * Based on the same interface in `vs/workbench/contrib/notebook/browser/notebookEditorInput.ts`
  */
 export interface PositronNotebookEditorInputOptions {
 	startDirty?: boolean;
+	/**
+	 * backupId for webview - used to restore webview state on reload
+	 */
+	_backupId?: string;
+	/**
+	 * Working copy identifier - used for backup/restore of dirty notebooks
+	 */
+	_workingCopy?: IWorkingCopyIdentifier;
 }
 
 
@@ -181,8 +190,13 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * @returns true if the other input matches this input; otherwise, false.
 	 */
 	override matches(otherInput: EditorInput | IUntypedEditorInput): boolean {
-		return otherInput instanceof PositronNotebookEditorInput &&
-			otherInput.resource.toString() === this.resource.toString();
+		if (super.matches(otherInput)) {
+			return true;
+		}
+		if (otherInput instanceof PositronNotebookEditorInput) {
+			return this.viewType === otherInput.viewType && isEqual(this.resource, otherInput.resource);
+		}
+		return false;
 	}
 
 	/**
@@ -327,6 +341,15 @@ export class PositronNotebookEditorInput extends EditorInput {
 		return joinPath(await this._fileDialogService.defaultFilePath(), suggestedFilename);
 	}
 
+	override toUntyped(): IUntypedEditorInput {
+		return {
+			resource: this.resource,
+			options: {
+				override: PositronNotebookEditorInput.EditorID
+			}
+		};
+	}
+
 	override async resolve(_options?: IEditorOptions): Promise<IResolvedNotebookEditorModel | null> {
 		this._logService.info(this._identifier, 'resolve');
 
@@ -375,10 +398,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 			this._editorModelReference.object.load();
 		}
 
-		// In the vscode-notebooks there is a logic branch here to handle
-		// cases with a _backupId. Not sure what it does or when it's needed but
-		// am leaving this here as a reminder we skipped something.
-		// if (this.options._backupId) {}
 
 		return this._editorModelReference.object;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -83,11 +83,21 @@ class PositronNotebookContribution extends Disposable {
 					// Determine notebook type from file content or metadata
 					const viewType = await this.detectNotebookViewType(resource);
 
+					// Type guard for backup working copy options
+					interface BackupWorkingCopyOptions {
+						_backupId?: string;
+						_workingCopy?: IWorkingCopyIdentifier;
+					}
+					function hasBackupWorkingCopyOptions(obj: unknown): obj is BackupWorkingCopyOptions {
+						return typeof obj === 'object' && obj !== null &&
+							('_backupId' in obj || '_workingCopy' in obj);
+					}
+
 					// Preserve backup options if they exist
 					const positronOptions: PositronNotebookEditorInputOptions = {
 						startDirty: false,
-						_backupId: (options as any)?._backupId,
-						_workingCopy: (options as any)?._workingCopy
+						_backupId: hasBackupWorkingCopyOptions(options) ? options._backupId : undefined,
+						_workingCopy: hasBackupWorkingCopyOptions(options) ? options._workingCopy : undefined
 					};
 
 					const editorInput = PositronNotebookEditorInput.getOrCreate(

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -110,4 +110,49 @@ test.describe('Positron notebook opening and saving', {
 		// Keep the test workspace clean for subsequent test runs
 		await cleanup.removeTestFiles([expectedFileName]);
 	});
+
+	test('Ghost editor issue: Positron notebook does not create duplicate VS Code notebook on reload with dirty notebook', async function ({ app, settings, hotKeys }) {
+		const { notebooks, notebooksPositron, editors } = app.workbench;
+
+		// Configure Positron as the default notebook editor
+		await setNotebookEditor(settings, 'positron');
+
+		// Create a new notebook (which starts dirty)
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify only the expected tab is open (new notebooks are named Untitled-N.ipynb)
+		await editors.waitForTab('Untitled-1.ipynb', true); // true = isDirty
+
+		// Count tabs before reload (checkinnng for multiple tabs with same file is the ghost editor symptom)
+		const tabsBefore = await app.code.driver.page.locator('.tabs-container div.tab').count();
+		test.expect(tabsBefore).toBe(1);
+
+		// Reload the window to simulate restart
+		await hotKeys.reloadWindow();
+		// Wait for the reload to complete
+		await app.code.driver.page.waitForTimeout(3000);
+		await app.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
+
+		// After reload, check for the ghost editor issue
+		// The bug would cause both a Positron notebook AND a VS Code notebook to be visible
+
+		// Check tab count - should still be 1, not 2
+		const tabsAfter = await app.code.driver.page.locator('.tabs-container div.tab').count();
+		test.expect(tabsAfter).toBe(1);
+
+		// Verify that the Positron notebook is visible
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify that the VS Code notebook is NOT visible (this is the ghost editor we're trying to prevent)
+		const vscodeNotebookElements = await app.code.driver.page.locator('.notebook-editor').count();
+		const positronNotebookElements = await app.code.driver.page.locator('.positron-notebook').count();
+
+		// Should have only one notebook editor, and it should be the Positron one
+		test.expect(positronNotebookElements).toBe(1);
+		test.expect(vscodeNotebookElements).toBe(0);
+
+		// Additional verification: ensure the active tab is still the restored untitled notebook
+		await editors.waitForActiveTab('Untitled-1.ipynb', true); // true = isDirty
+	});
 });

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -124,7 +124,7 @@ test.describe('Positron notebook opening and saving', {
 		// Verify only the expected tab is open (new notebooks are named Untitled-N.ipynb)
 		await editors.waitForTab('Untitled-1.ipynb', true); // true = isDirty
 
-		// Count tabs before reload (checkinnng for multiple tabs with same file is the ghost editor symptom)
+		// Count tabs before reload (checking for multiple tabs with same file is the ghost editor symptom)
 		const tabsBefore = await app.code.driver.page.locator('.tabs-container div.tab').count();
 		test.expect(tabsBefore).toBe(1);
 


### PR DESCRIPTION
Addresses #9037.

This PR fixes the ghost VSCode notebook editor that appears when restarting Positron with dirty (unsaved) notebook files. The issue occurred because VS Code's backup restoration system was creating duplicate editors - one VS Code notebook and one Positron notebook - for the same file during restoration.

This fix:
- Added a simple check in VS Code's `SimpleNotebookWorkingCopyEditorHandler` to defer to Positron when Positron notebooks are enabled
- Created a new `PositronNotebookWorkingCopyEditorHandler` that properly handles backup restoration for Positron notebooks
- Both handlers now work cooperatively without conflicts or race conditions

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed ghost VS Code notebook editor appearing on restart with dirty Positron notebooks (#9037)

### QA Notes

@:notebooks @:critical

1. Enable Positron notebooks in settings:
   ```json
   {
     "positron.notebook.enabled": true
   }
   ```
2. Create a new notebook (File → New Notebook) - it will start dirty by default
3. Add some content to a cell but don't save
4. Reload the window (Developer: Reload Window or Cmd+R)
5. After reload, verify:
   - Only one notebook tab is visible (not two)
   - The notebook content is preserved
   - The tab shows as dirty (dot indicator)
   - No VS Code notebook editor appears behind the Positron notebook

Also test with Positron notebooks disabled to ensure VS Code notebooks still work normally:
1. Set `"positron.notebook.enabled": false`
2. Repeat steps 2-5 above
3. Verify the standard VS Code notebook editor works correctly
