### PR TITLE
Add csh support to supervisor

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -168,7 +168,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.51"
+      "kallichore": "0.1.52"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
This is a small change that makes it possible for the supervisor to run kernels under `csh` / `tcsh`. As these shells don't support `-l -c` together, we use `-d` instead to emulate a login shell (it loads the same directory stack as a login shell). A more involved change could enable us to use a _real_ csh login shell, but I don't think it's worth the complexity given that even a non-login csh runs enough startup scripts (including user/system scripts) for most practical purposes.

Most of this change is on the supervisor side; this just brings in the new supervisor version. See https://github.com/posit-dev/kallichore/pull/45.

Addresses https://github.com/posit-dev/positron/issues/9020.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue starting R and Python sessions when 'Run in Login Shell' is enabled and the user's `SHELL` is `csh` (https://github.com/posit-dev/positron/issues/9020)


### QA Notes

If you don't want to mess with your default shell, you can set the SHELL just for Positron in `Environment Variables > Set`:

<img width="447" height="207" alt="image" src="https://github.com/user-attachments/assets/43aa254a-c36b-458e-9347-7a2a6e8b8873" />

Also note that the way we pass through `DYLD_LIBRARY_PATH` is not compatible with csh right now, so you may experience trouble starting R on macOS if you use csh. This change is intended for Linux users, so if you can, test there.
