### PR TITLE
Assistant: enable positron assistant git integration by default

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -221,11 +221,8 @@
           },
           "positron.assistant.gitIntegration.enable": {
             "type": "boolean",
-            "default": false,
-            "description": "%configuration.gitIntegration.description%",
-            "tags": [
-              "experimental"
-            ]
+            "default": true,
+            "description": "%configuration.gitIntegration.description%"
           },
           "positron.assistant.showTokenUsage.enable": {
             "type": "boolean",

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -28,6 +28,10 @@ import { ScmHistoryItemResolver } from '../../multiDiffEditor/browser/scmMultiDi
 import { ISCMHistoryItem } from '../common/history.js';
 import { ISCMProvider, ISCMService, ISCMViewService } from '../common/scm.js';
 
+// --- Start Positron ---
+import { isWeb } from '../../../../base/common/platform.js';
+// --- End Positron ---
+
 export interface SCMHistoryItemTransferData {
 	readonly name: string;
 	readonly resource: UriComponents;
@@ -95,7 +99,14 @@ class SCMHistoryItemContext implements IChatContextPickerItem {
 
 	isEnabled(_widget: IChatWidget): Promise<boolean> | boolean {
 		const activeRepository = this._scmViewService.activeRepository.get();
+		// --- Start Positron ---
+		// Disable SCM History Chat Context in Positron Web due to path error
+		// See https://github.com/posit-dev/positron/issues/9181
+		return activeRepository?.provider.historyProvider.get() !== undefined && !isWeb;
+		/*
 		return activeRepository?.provider.historyProvider.get() !== undefined;
+		*/
+		// --- End Positron ---
 	}
 
 	asPicker(_widget: IChatWidget) {

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -30,6 +30,7 @@ import { ISCMProvider, ISCMService, ISCMViewService } from '../common/scm.js';
 
 // --- Start Positron ---
 import { isWeb } from '../../../../base/common/platform.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 // --- End Positron ---
 
 export interface SCMHistoryItemTransferData {
@@ -94,6 +95,9 @@ class SCMHistoryItemContext implements IChatContextPickerItem {
 	}
 
 	constructor(
+		// --- Start Positron ---
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		// --- End Positron ---
 		@ISCMViewService private readonly _scmViewService: ISCMViewService
 	) { }
 
@@ -102,7 +106,10 @@ class SCMHistoryItemContext implements IChatContextPickerItem {
 		// --- Start Positron ---
 		// Disable SCM History Chat Context in Positron Web due to path error
 		// See https://github.com/posit-dev/positron/issues/9181
-		return activeRepository?.provider.historyProvider.get() !== undefined && !isWeb;
+		const schContextEnabled = this._configurationService.getValue<boolean>('positron.assistant.sourceControlHistoryContext.enable');
+		// if schContextEnabled is configured, follow the config to enable/disable scm history context
+		// if schContextEnabled is undefined, enable scm history context on desktop, but disable on web
+		return activeRepository?.provider.historyProvider.get() !== undefined && (schContextEnabled ?? !isWeb);
 		/*
 		return activeRepository?.provider.historyProvider.get() !== undefined;
 		*/


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/9066
- sets the default for `positron.assistant.gitIntegration.enable` to true and removes the experimental tag, but keeps the flag for now
- disables the `Source Control...` context item on Web due to https://github.com/posit-dev/positron/issues/9181

### Release Notes

#### New Features

- Assistant: git integration Assistant tools available by default (#9066)

### QA Notes

See this PR for usage: https://github.com/posit-dev/positron/pull/8257

#### Git features enabled by default!

- `positron.assistant.gitIntegration.enable` setting still available in the settings UI but is now enabled by default

#### `Source Control...` context option disabled by default for Web/Workbench

- On Web / Workbench, the `Source Control...` context option should be missing:

    <img width="672" height="211" alt="image" src="https://github.com/user-attachments/assets/b3d9202c-0e55-4ea4-906c-71b327d7367a" />

- On Desktop, it should be available (some extra options because of my clipboard and editor state):

    <img width="607" height="279" alt="image" src="https://github.com/user-attachments/assets/2103b951-14f0-4c31-9eae-ddc1caeda48f" />

#### `positron.assistant.gitIntegration.enable` setting can be used to make `Source Control...` context option available on Web/Workbench

- Add `"positron.assistant.sourceControlHistoryContext.enable": true` to the settings JSON in a web build to enable the `Source Control...` context option (helpful for debugging)