### PR TITLE
Assistant: Fix adding a specific git commit as context item

### DIFF
--- a/extensions/positron-assistant/src/git.ts
+++ b/extensions/positron-assistant/src/git.ts
@@ -37,16 +37,15 @@ function getAPI(): GitAPI {
 	if (!gitExtension) {
 		throw new Error('Git extension not found');
 	}
-	const git = gitExtension.getAPI(1);
-	if (git.repositories.length === 0) {
-		throw new Error('No Git repositories found');
-	}
-	return git;
+	return gitExtension.getAPI(1);
 }
 
 /** Get the list of active repositories */
 function currentGitRepositories(): Repository[] {
 	const git = getAPI();
+	if (git.repositories.length === 0) {
+		throw new Error('No Git repositories found');
+	}
 	return git.repositories;
 }
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -494,6 +494,11 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					// The user attached a specific git commit
 					const details = JSON.parse(value.query) as { historyItemId: string; historyItemParentId: string };
 					const diff = await getCommitChanges(value, details.historyItemId, details.historyItemParentId);
+
+					// Add as a reference to the response.
+					response.reference(value);
+
+					// Attach the git commit details.
 					const attachmentNode = xml.node('attachment', diff, {
 						historyItemId: details.historyItemId,
 						historyItemParentId: details.historyItemParentId,

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -17,6 +17,7 @@ import { StreamingTagLexer } from './streamingTagLexer.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
 import { ReplaceSelectionProcessor } from './replaceSelectionProcessor.js';
 import { log, getRequestTokenUsage } from './extension.js';
+import { getCommitChanges } from './git.js';
 
 export enum ParticipantID {
 	/** The participant used in the chat pane in Ask mode. */
@@ -444,7 +445,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 					attachmentPrompts.push(rangeAttachmentNode, documentAttachmentNode);
 					log.debug(`[context] adding file range attachment context: ${rangeAttachmentNode.length} characters`);
 					log.debug(`[context] adding file attachment context: ${documentAttachmentNode.length} characters`);
-				} else if (value instanceof vscode.Uri) {
+				} else if (value instanceof vscode.Uri && value.scheme === 'file') {
 					const fileStat = await vscode.workspace.fs.stat(value);
 					if (fileStat.type === vscode.FileType.Directory) {
 						// The user attached a directory - usually a manually attached directory in the workspace.
@@ -489,6 +490,17 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 						attachmentPrompts.push(attachmentNode);
 						log.debug(`[context] adding file attachment context: ${attachmentNode.length} characters`);
 					}
+				} else if (value instanceof vscode.Uri && value.scheme === 'scm-history-item') {
+					// The user attached a specific git commit
+					const details = JSON.parse(value.query) as { historyItemId: string; historyItemParentId: string };
+					const diff = await getCommitChanges(value, details.historyItemId, details.historyItemParentId);
+					const attachmentNode = xml.node('attachment', diff, {
+						historyItemId: details.historyItemId,
+						historyItemParentId: details.historyItemParentId,
+						description: 'Git commit details',
+					});
+					attachmentPrompts.push(attachmentNode);
+					log.debug(`[context] adding git commit details context: ${attachmentNode.length} characters`);
 				} else if (value instanceof vscode.ChatReferenceBinaryData) {
 					if (isChatImageMimeType(value.mimeType)) {
 						// The user attached an image - usually a pasted image or screenshot of the IDE.


### PR DESCRIPTION
* Completes the second half of the work requested by @jennybc in #8207, so that specific commit IDs can be added as context.

* This should probably be merged and tested before enabling git integration by default, in #9073.

### QA Notes

To test this integration:

0) Enable git integrations in user settings: `"positron.assistant.gitIntegration.enable": true`.

1) Load a project with an existing git repo and history into Positron.

2) Open a fresh chat window. Click "Add Context", "Source Control" and then select a specific commit from the quick pick menu.

3) Ensure the commit has been added as context:
<img width="404" height="142" alt="Screenshot 2025-08-18 at 11 01 36" src="https://github.com/user-attachments/assets/38de2de3-877e-4950-8406-8e2f5d4cb75a" />

4) Ask assistant about the commit. Confirm assistant can see the changes.

<img width="656" height="572" alt="Screenshot 2025-08-18 at 11 02 56" src="https://github.com/user-attachments/assets/30a237f3-a890-4f3d-8f32-389cd124d95a" />
