### PR TITLE
data explorer: `polars` convert to code backend

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -5,7 +5,7 @@
 
 # ruff: noqa: PIE790
 import abc
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from .data_explorer_comm import (
     ColumnDisplayType,
@@ -440,8 +440,8 @@ class PolarsFilterHandler(FilterHandler):
 class CodeConverter:
     """Base class for generating dataframe code strings."""
 
-    filter_handler_class: Optional[FilterHandler] = None
-    sort_handler_class: Optional[SortHandler] = None
+    filter_handler_class: Optional[Type[FilterHandler]] = None
+    sort_handler_class: Optional[Type[SortHandler]] = None
 
     def __init__(
         self,
@@ -488,7 +488,7 @@ class CodeConverter:
         method_chain_parts = []
         filters = self.params.row_filters
 
-        if not filters:
+        if not self.filter_handler_class or not filters:
             return method_chain_setup, method_chain_parts
 
         comparisons = []
@@ -527,7 +527,7 @@ class CodeConverter:
         tuple[List[StrictStr], List[StrictStr]]
             Tuple of (method_chain_setup, method_chain_parts).
         """
-        if not self.params.sort_keys:
+        if not self.params.sort_keys or not self.sort_handler_class:
             return [], []
 
         handler = self.sort_handler_class(

--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -623,7 +623,7 @@ class PolarsFilterHandler(FilterHandler):
         elif search_type == TextSearchType.NotContains:
             return f"~{self.col_expr}.str.contains({value!r})"
         elif search_type == TextSearchType.RegexMatch:
-            return f"{self.col_expr}.str.contains({value!r})"
+            return f"{self.col_expr}.str.contains({value!r}, literal=False)"
         elif search_type == TextSearchType.StartsWith:
             return f"{self.col_expr}.str.starts_with({value!r})"
         elif search_type == TextSearchType.EndsWith:
@@ -635,7 +635,7 @@ class PolarsFilterHandler(FilterHandler):
         return f"{self.col_expr}.str.len_chars() == 0"
 
     def _convert_not_empty_filter(self) -> str:
-        return f"{self.col_expr}.str.len_chars() != 0"
+        return f"{self.col_expr}.str.len_chars() > 0"
 
     def _convert_is_null_filter(self) -> str:
         return f"{self.col_expr}.is_null()"

--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from .data_explorer_comm import (
     ColumnDisplayType,
@@ -628,11 +628,7 @@ class PolarsFilterHandler(FilterHandler):
             ColumnDisplayType.Datetime,
             ColumnDisplayType.Date,
         ]:
-            # For Polars use pl.datetime() or pl.date()
-            if self.filter_key.column_schema.type_display == ColumnDisplayType.Datetime:
-                value = f"pl.datetime({repr(value)})"
-            else:
-                value = f"pl.date({repr(value)})"
+            value = f"pl.lit({value!r}).str.to_datetime()"
 
         return f"{self.col_expr} {op} {value}"
 

--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -170,6 +170,38 @@ class CodeConverter:
 
         return method_chain_setup, method_chain_parts
 
+    def _format_single_filter(self, comparison: str) -> tuple[List[StrictStr], List[StrictStr]]:
+        """Format a single filter comparison into method chain parts.
+
+        Parameters
+        ----------
+        comparison : str
+            The comparison string to format.
+
+        Returns
+        -------
+        tuple[List[StrictStr], List[StrictStr]]
+            Tuple of setup and method chain parts.
+        """
+        raise NotImplementedError("Subclasses must implement _format_single_filter method")
+
+    def _format_multi_filter(
+        self, comparisons: List[str]
+    ) -> tuple[List[StrictStr], List[StrictStr]]:
+        """Format multiple filter comparisons into method chain parts.
+
+        Parameters
+        ----------
+        comparisons : List[str]
+            List of comparison strings to format.
+
+        Returns
+        -------
+        tuple[List[StrictStr], List[StrictStr]]
+            Tuple of setup and method chain parts.
+        """
+        raise NotImplementedError("Subclasses must implement _format_multi_filter method")
+
 
 class PandasConverter(CodeConverter):
     def __init__(

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1401,7 +1401,7 @@ class PandasView(DataExplorerTableView):
         converter = PandasConverter(
             self.table, self.state.name, request, was_series=self.was_series
         )
-        converted_code = converter.convert()
+        converted_code = converter.build_code()
         return ConvertedCode(converted_code=converted_code).dict()
 
     @classmethod
@@ -2372,7 +2372,7 @@ class PolarsView(DataExplorerTableView):
     def convert_to_code(self, request: ConvertToCodeParams):
         """Translates the current data view, including filters and sorts, into a code snippet."""
         converter = PolarsConverter(self.table, self.state.name, request)
-        converted_code = converter.convert()
+        converted_code = converter.build_code()
         return ConvertedCode(converted_code=converted_code).dict()
 
     def _get_single_column_schema(self, column_index: int):
@@ -2417,6 +2417,7 @@ class PolarsView(DataExplorerTableView):
             column_index=column_index,
             type_name=type_name,
             type_display=ColumnDisplayType(type_display),
+            timezone=getattr(column.dtype, "time_zone", None),
         )
 
     TYPE_DISPLAY_MAPPING = MappingProxyType(
@@ -2864,7 +2865,10 @@ class PolarsView(DataExplorerTableView):
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
         convert_to_code=ConvertToCodeFeatures(
             support_status=SupportStatus.Supported,
-            code_syntaxes=[CodeSyntaxName(code_syntax_name="polars")],
+            code_syntaxes=[
+                CodeSyntaxName(code_syntax_name="polars"),
+                CodeSyntaxName(code_syntax_name="pandas"),
+            ],
         ),
     )
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -24,7 +24,7 @@ from typing import (
 import comm
 
 from .access_keys import decode_access_key
-from .convert import PandasConverter
+from .convert import PandasConverter, PolarsConverter
 from .data_explorer_comm import (
     ArraySelection,
     BackendState,
@@ -2371,7 +2371,9 @@ class PolarsView(DataExplorerTableView):
 
     def convert_to_code(self, request: ConvertToCodeParams):
         """Translates the current data view, including filters and sorts, into a code snippet."""
-        raise NotImplementedError("Convert to code is not implemented for Polars DataFrames.")
+        converter = PolarsConverter(self.table, self.state.name, request)
+        converted_code = converter.convert()
+        return ConvertedCode(converted_code=converted_code).dict()
 
     def _get_single_column_schema(self, column_index: int):
         if self.state.schema_cache:
@@ -2861,7 +2863,7 @@ class PolarsView(DataExplorerTableView):
         ),
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
         convert_to_code=ConvertToCodeFeatures(
-            support_status=SupportStatus.Unsupported,
+            support_status=SupportStatus.Supported,
             code_syntaxes=[CodeSyntaxName(code_syntax_name="polars")],
         ),
     )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -54,7 +54,7 @@ class DataExplorerConvertFixture(DataExplorerFixture):
         column_filters=None,
         row_filters=None,
         sort_keys=None,
-        code_syntax_name="pandas",
+        code_syntax_name=None,
     ):
         table_id = var_guid()
         ex_id = var_guid()
@@ -65,7 +65,7 @@ class DataExplorerConvertFixture(DataExplorerFixture):
             table_id, column_filters, row_filters, sort_keys, code_syntax_name
         )
         assert response["converted_code"] is not None
-
+        # get new code as a list of lines
         new_df_code = response["converted_code"]
 
         # added to ensure the new table is created in the shell's user namespace
@@ -75,9 +75,15 @@ class DataExplorerConvertFixture(DataExplorerFixture):
         new_df_code = "\n".join(new_df_code)
         self.shell.user_ns[table_id] = table
 
+        # run the code in the shell, simulating the user executing it
         self.shell.run_cell(new_df_code).raise_error()
 
-        new_df = pd.DataFrame(self.shell.user_ns[new_table_id])
+        if code_syntax_name == "pandas":
+            new_df = pd.DataFrame(self.shell.user_ns[new_table_id])
+        elif code_syntax_name == "polars":
+            new_df = pl.DataFrame(self.shell.user_ns[new_table_id])
+        else:
+            raise ValueError(f"Unsupported code syntax: {code_syntax_name}")
         self.register_table(new_table_id, new_df)
         self.compare_tables(new_table_id, ex_id, table.shape)
 
@@ -91,10 +97,11 @@ def dxf(
     return DataExplorerConvertFixture(shell, de_service, variables_comm)
 
 
-@pytest.mark.parametrize(
-    ("test_df", "syntax_name"), [(SIMPLE_PANDAS_DF, "pandas"), (SIMPLE_POLARS_DF, "polars")]
-)
-def test_convert_filter_is_null_true(test_df, syntax_name, dxf: DataExplorerConvertFixture):
+# --- Pandas tests ---
+
+
+def test_convert_filter_is_null_true_pandas(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_PANDAS_DF
     schema = dxf.get_schema_for(test_df)
     b_is_null = _filter("is_null", schema[1])
     b_not_null = _filter("not_null", schema[1])
@@ -127,18 +134,16 @@ def test_convert_filter_is_null_true(test_df, syntax_name, dxf: DataExplorerConv
 
     for filter_set, expected_df in cases:
         dxf.check_conversion_case(
-            test_df, expected_df, row_filters=filter_set, code_syntax_name=syntax_name
+            test_df, expected_df, row_filters=filter_set, code_syntax_name="pandas"
         )
 
 
-@pytest.mark.parametrize(("test_df", "syntax_name"), [(pd.Series, "pandas"), (pl.Series, "polars")])
-def test_convert_filter_empty(test_df, syntax_name, dxf: DataExplorerConvertFixture):
-    test_df = test_df(
-        {
-            "a": ["foo1", "foo2", "", "2FOO", "FOO3", "bar1", "2BAR"],
-            "b": [1, 11, 31, 22, 24, 62, 89],
-        }
-    )
+def test_convert_filter_empty_pandas(dxf: DataExplorerConvertFixture):
+    data = {
+        "a": ["foo1", "foo2", "", "2FOO", "FOO3", "bar1", "2BAR"],
+        "b": [1, 11, 31, 22, 24, 62, 89],
+    }
+    test_df = pd.DataFrame(data)
 
     dxf.register_table("test_df", test_df)
     schema = dxf.get_schema("test_df")
@@ -155,25 +160,24 @@ def test_convert_filter_empty(test_df, syntax_name, dxf: DataExplorerConvertFixt
             test_df[test_df["a"].str.len() > 0],
         ],
     ]
+
     for filter_set, expected_df in cases:
         dxf.check_conversion_case(
-            test_df, expected_df, row_filters=filter_set, code_syntax_name=syntax_name
+            test_df, expected_df, row_filters=filter_set, code_syntax_name="pandas"
         )
 
 
-@pytest.mark.parametrize(("test_df", "syntax_name"), [(pd.Series, "pandas"), (pl.Series, "polars")])
-def test_convert_filter_search(test_df, syntax_name, dxf: DataExplorerConvertFixture):
-    test_df = test_df(
-        {
-            "a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"],
-            "b": [1, 11, 31, 22, 24, 62, 89],
-        }
-    )
+def test_convert_filter_search_pandas(dxf: DataExplorerConvertFixture):
+    data = {
+        "a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"],
+        "b": [1, 11, 31, 22, 24, 62, 89],
+    }
+    test_df = pd.DataFrame(data)
 
     dxf.register_table("test_df", test_df)
     schema = dxf.get_schema("test_df")
 
-    # (search_type, column_schema, term, case_sensitive, boolean mask)
+    # (search_type, column_schema, term, case_sensitive)
     # TODO (iz): make this more DRY since we have another test for search filters
     cases = [
         (
@@ -242,7 +246,7 @@ def test_convert_filter_search(test_df, syntax_name, dxf: DataExplorerConvertFix
         ),
     ]
 
-    for search_type, column_schema, term, cs, mask in cases:
+    for search_type, column_schema, term, cs, expected_df in cases:
         search_filter = _search_filter(
             column_schema,
             term,
@@ -250,19 +254,18 @@ def test_convert_filter_search(test_df, syntax_name, dxf: DataExplorerConvertFix
             search_type=search_type,
         )
 
-        expected_df = test_df[mask.astype(bool)]
+        # For pandas, convert the boolean mask to a filtered dataframe
+        expected_df = test_df[expected_df.astype(bool)]
         dxf.check_conversion_case(
             test_df,
             expected_df,
             row_filters=[search_filter],
-            code_syntax_name=syntax_name,
+            code_syntax_name="pandas",
         )
 
 
-@pytest.mark.parametrize(
-    ("test_df", "syntax_name"), [(SIMPLE_PANDAS_DF, "pandas"), (SIMPLE_POLARS_DF, "polars")]
-)
-def test_convert_filter_between(test_df, syntax_name, dxf: DataExplorerConvertFixture):
+def test_convert_filter_between_pandas(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_PANDAS_DF
     schema = dxf.get_schema("simple")
 
     cases = [
@@ -272,7 +275,6 @@ def test_convert_filter_between(test_df, syntax_name, dxf: DataExplorerConvertFi
 
     for column_schema, left_value, right_value in cases:
         col = test_df.iloc[:, column_schema["column_index"]]
-
         ex_between = test_df[(col >= left_value) & (col <= right_value)]
         ex_not_between = test_df[(col < left_value) | (col > right_value)]
 
@@ -280,22 +282,19 @@ def test_convert_filter_between(test_df, syntax_name, dxf: DataExplorerConvertFi
             test_df,
             ex_between,
             row_filters=[_between_filter(column_schema, str(left_value), str(right_value))],
-            code_syntax_name=syntax_name,
+            code_syntax_name="pandas",
         )
         dxf.check_conversion_case(
             test_df,
             ex_not_between,
             row_filters=[_not_between_filter(column_schema, str(left_value), str(right_value))],
-            code_syntax_name=syntax_name,
+            code_syntax_name="pandas",
         )
 
 
-@pytest.mark.parametrize(
-    ("test_df", "syntax_name"), [(SIMPLE_PANDAS_DF, "pandas"), (SIMPLE_POLARS_DF, "polars")]
-)
-def test_convert_filter_compare(test_df, syntax_name, dxf: DataExplorerConvertFixture):
-    # Just use the 'a' column to smoke test comparison filters on
-    # integers
+def test_convert_filter_compare_pandas(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_PANDAS_DF
+    # Just use the 'a' column to smoke test comparison filters on integers
     column = "a"
     schema = dxf.get_schema("simple")
 
@@ -303,32 +302,16 @@ def test_convert_filter_compare(test_df, syntax_name, dxf: DataExplorerConvertFi
         filt = _compare_filter(schema[0], op, 3)
         expected_df = test_df[op_func(test_df[column], 3)]
         dxf.check_conversion_case(
-            test_df, expected_df, row_filters=[filt], code_syntax_name=syntax_name
+            test_df, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
 
 
-@pytest.mark.parametrize(
-    ("test_df", "syntax_name"),
-    [
-        (
-            pd.DataFrame(
-                {
-                    "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
-                }
-            ),
-            "pandas",
-        ),
-        (
-            pl.DataFrame(
-                {
-                    "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
-                }
-            ),
-            "polars",
-        ),
-    ],
-)
-def test_convert_filter_datetimetz(test_df, syntax_name, dxf: DataExplorerConvertFixture):
+def test_convert_filter_datetimetz_pandas(dxf: DataExplorerConvertFixture):
+    test_df = pd.DataFrame(
+        {
+            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
+        }
+    )
     tz = pytz.timezone("US/Eastern")
 
     dxf.register_table("dtz", test_df)
@@ -340,14 +323,12 @@ def test_convert_filter_datetimetz(test_df, syntax_name, dxf: DataExplorerConver
         filt = _compare_filter(schema[0], op, "2000-01-03")
         expected_df = test_df[op_func(test_df["date"], val)]
         dxf.check_conversion_case(
-            test_df, expected_df, row_filters=[filt], code_syntax_name=syntax_name
+            test_df, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
 
 
-@pytest.mark.parametrize(
-    ("test_df", "syntax_name"), [(SIMPLE_PANDAS_DF, "pandas"), (SIMPLE_POLARS_DF, "polars")]
-)
-def test_convert_sort_and_filter(test_df, syntax_name, dxf: DataExplorerConvertFixture):
+def test_convert_sort_and_filter_pandas(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_PANDAS_DF
     # Test that we can convert a sort and filter operation
     schema = dxf.get_schema("simple")
     filt = [_compare_filter(schema[2], FilterComparisonOp.Eq, "foo")]
@@ -361,15 +342,14 @@ def test_convert_sort_and_filter(test_df, syntax_name, dxf: DataExplorerConvertF
         expected_df,
         row_filters=filt,
         sort_keys=sort_keys,
-        code_syntax_name=syntax_name,
+        code_syntax_name="pandas",
     )
 
 
-@pytest.mark.parametrize(("test_df", "syntax_name"), [(pd.Series, "pandas"), (pl.Series, "polars")])
-def test_convert_series_filter_and_sort(test_df, syntax_name, dxf: DataExplorerConvertFixture):
+def test_convert_series_filter_and_sort_pandas(dxf: DataExplorerConvertFixture):
     # Test filtering and sorting on pandas Series
     series_data = [5, 2, 8, 1, 9, 3, 7, 4, 6]
-    test_series = test_df(series_data, name="values")
+    test_series = pd.Series(series_data, name="values")
 
     dxf.register_table("test_series", test_series)
     schema = dxf.get_schema("test_series")
@@ -387,9 +367,9 @@ def test_convert_series_filter_and_sort(test_df, syntax_name, dxf: DataExplorerC
     for op, value, expected_series in comparison_cases:
         filt = _compare_filter(schema[0], op, value)
         # check as df to confirm columns
-        expected_df = test_df({"values": expected_series})
+        expected_df = pd.DataFrame({"values": expected_series})
         dxf.check_conversion_case(
-            test_series, expected_df, row_filters=[filt], code_syntax_name=syntax_name
+            test_series, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
 
     # Test between filters
@@ -400,18 +380,19 @@ def test_convert_series_filter_and_sort(test_df, syntax_name, dxf: DataExplorerC
 
     for left_val, right_val, expected_series in between_cases:
         filt = _between_filter(schema[0], str(left_val), str(right_val))
-        expected_df = test_df({"values": expected_series})
+        expected_df = pd.DataFrame({"values": expected_series})
         dxf.check_conversion_case(
-            test_series, expected_df, row_filters=[filt], code_syntax_name=syntax_name
+            test_series, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
 
         # Test not_between
         not_between_series = test_series[(test_series < left_val) | (test_series > right_val)]
+        expected_df = pd.DataFrame({"values": not_between_series})
         filt = _not_between_filter(schema[0], str(left_val), str(right_val))
-        expected_df = test_df({"values": not_between_series})
         dxf.check_conversion_case(
-            test_series, expected_df, row_filters=[filt], code_syntax_name=syntax_name
+            test_series, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
+
     # Test sorting on Series
     sort_cases = [
         (True, test_series.sort_values(ascending=True)),
@@ -420,15 +401,15 @@ def test_convert_series_filter_and_sort(test_df, syntax_name, dxf: DataExplorerC
 
     for ascending, expected_series in sort_cases:
         sort_keys = [{"column_index": 0, "ascending": ascending}]
-        expected_df = test_df({"values": expected_series})
+        expected_df = pd.DataFrame({"values": expected_series})
         dxf.check_conversion_case(
-            test_series, expected_df, sort_keys=sort_keys, code_syntax_name=syntax_name
+            test_series, expected_df, sort_keys=sort_keys, code_syntax_name="pandas"
         )
 
     # Test combined filter and sort
     filtered_series = test_series.sort_values(ascending=True)
     filtered_series = filtered_series[filtered_series > 3]
-    expected_df = test_df({"values": filtered_series})
+    expected_df = pd.DataFrame({"values": filtered_series})
 
     filt = _compare_filter(schema[0], ">", 3)
     sort_keys = [{"column_index": 0, "ascending": True}]
@@ -437,5 +418,256 @@ def test_convert_series_filter_and_sort(test_df, syntax_name, dxf: DataExplorerC
         expected_df,
         sort_keys=sort_keys,
         row_filters=[filt],
-        code_syntax_name=syntax_name,
+        code_syntax_name="pandas",
+    )
+
+
+# --- Polars tests ---
+
+
+def test_convert_filter_is_null_true_polars(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_POLARS_DF
+    schema = dxf.get_schema_for(test_df)
+    b_is_null = _filter("is_null", schema[1])
+    b_not_null = _filter("not_null", schema[1])
+    b_is_true = _filter("is_true", schema[1])
+    b_is_false = _filter("is_false", schema[1])
+    c_not_null = _filter("not_null", schema[2])
+
+    cases = [
+        [
+            [b_is_null],
+            test_df.filter(pl.col("b").is_null()),
+        ],
+        [
+            [b_not_null],
+            test_df.filter(pl.col("b").is_not_null()),
+        ],
+        [
+            [b_is_true],
+            test_df.filter(pl.col("b") == True),
+        ],
+        [
+            [b_is_false],
+            test_df.filter(pl.col("b") == False),
+        ],
+        [
+            [b_not_null, c_not_null],
+            test_df.filter(pl.col("b").is_not_null() & pl.col("c").is_not_null()),
+        ],
+    ]
+
+    for filter_set, expected_df in cases:
+        dxf.check_conversion_case(
+            test_df, expected_df, row_filters=filter_set, code_syntax_name="polars"
+        )
+
+
+def test_convert_filter_empty_polars(dxf: DataExplorerConvertFixture):
+    data = {
+        "a": ["foo1", "foo2", "", "2FOO", "FOO3", "bar1", "2BAR"],
+        "b": [1, 11, 31, 22, 24, 62, 89],
+    }
+    test_df = pl.DataFrame(data)
+
+    dxf.register_table("test_df", test_df)
+    schema = dxf.get_schema("test_df")
+    a_is_empty = _filter("is_empty", schema[0])
+    a_is_not_empty = _filter("not_empty", schema[0])
+
+    cases = [
+        [
+            [a_is_empty],
+            test_df.filter(pl.col("a").str.len_chars() == 0),
+        ],
+        [
+            [a_is_not_empty],
+            test_df.filter(pl.col("a").str.len_chars() > 0),
+        ],
+    ]
+
+    for filter_set, expected_df in cases:
+        dxf.check_conversion_case(
+            test_df, expected_df, row_filters=filter_set, code_syntax_name="polars"
+        )
+
+
+def test_convert_filter_search_polars(dxf: DataExplorerConvertFixture):
+    data = {
+        "a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"],
+        "b": [1, 11, 31, 22, 24, 62, 89],
+    }
+    test_df = pl.DataFrame(data)
+
+    dxf.register_table("test_df", test_df)
+    schema = dxf.get_schema("test_df")
+
+    cases = [
+        (
+            "contains",
+            schema[0],
+            "foo",
+            False,
+            test_df.filter(pl.col("a").str.contains("(?i)foo")),
+        ),
+        ("contains", schema[0], "foo", True, test_df.filter(pl.col("a").str.contains("foo"))),
+        (
+            "not_contains",
+            schema[0],
+            "foo",
+            False,
+            test_df.filter(~pl.col("a").str.contains("(?i)foo")),
+        ),
+        (
+            "not_contains",
+            schema[0],
+            "foo",
+            True,
+            test_df.filter(~pl.col("a").str.contains("foo")),
+        ),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            False,
+            test_df.filter(pl.col("a").str.starts_with("(?i)foo")),
+        ),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            True,
+            test_df.filter(pl.col("a").str.starts_with("foo")),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            False,
+            test_df.filter(pl.col("a").str.ends_with("(?i)foo")),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            True,
+            test_df.filter(pl.col("a").str.ends_with("foo")),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+",
+            False,
+            test_df.filter(pl.col("a").str.contains("(?i)f[o]+", literal=False)),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+[^o]*",
+            True,
+            test_df.filter(pl.col("a").str.contains("f[o]+[^o]*", literal=False)),
+        ),
+    ]
+
+    for search_type, column_schema, term, cs, expected_df in cases:
+        search_filter = _search_filter(
+            column_schema,
+            term,
+            case_sensitive=cs,
+            search_type=search_type,
+        )
+
+        # Convert to pandas for comparison
+        expected_df = expected_df
+        dxf.check_conversion_case(
+            test_df,
+            expected_df,
+            row_filters=[search_filter],
+            code_syntax_name="polars",
+        )
+
+
+def test_convert_filter_between_polars(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_POLARS_DF
+    schema = dxf.get_schema("simple")
+
+    cases = [
+        (schema[0], 2, 4),  # a column
+        (schema[0], 0, 2),  # d column
+    ]
+
+    for column_schema, left_value, right_value in cases:
+        col_name = test_df.columns[column_schema["column_index"]]
+        ex_between = test_df.filter(
+            (pl.col(col_name) >= left_value) & (pl.col(col_name) <= right_value)
+        )
+        ex_not_between = test_df.filter(
+            (pl.col(col_name) < left_value) | (pl.col(col_name) > right_value)
+        )
+
+        dxf.check_conversion_case(
+            test_df,
+            ex_between,
+            row_filters=[_between_filter(column_schema, str(left_value), str(right_value))],
+            code_syntax_name="polars",
+        )
+        dxf.check_conversion_case(
+            test_df,
+            ex_not_between,
+            row_filters=[_not_between_filter(column_schema, str(left_value), str(right_value))],
+            code_syntax_name="polars",
+        )
+
+
+def test_convert_filter_compare_polars(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_POLARS_DF
+    # Just use the 'a' column to smoke test comparison filters on integers
+    column = "a"
+    schema = dxf.get_schema("simple")
+
+    for op, op_func in COMPARE_OPS.items():
+        filt = _compare_filter(schema[0], op, 3)
+        expected_df = test_df.filter(op_func(pl.col(column), 3))
+        dxf.check_conversion_case(
+            test_df, expected_df, row_filters=[filt], code_syntax_name="polars"
+        )
+
+
+def test_convert_filter_datetimetz_polars(dxf: DataExplorerConvertFixture):
+    test_df = pl.DataFrame(
+        {
+            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
+        }
+    )
+    tz = pytz.timezone("US/Eastern")
+
+    dxf.register_table("dtz", test_df)
+    schema = dxf.get_schema("dtz")
+
+    val = tz.localize(datetime.datetime(2000, 1, 3))  # noqa: DTZ001
+
+    for op, op_func in COMPARE_OPS.items():
+        filt = _compare_filter(schema[0], op, "2000-01-03")
+        expected_df = test_df.filter(op_func(pl.col("date"), pl.lit(val)))
+        dxf.check_conversion_case(
+            test_df, expected_df, row_filters=[filt], code_syntax_name="polars"
+        )
+
+
+def test_convert_sort_and_filter_polars(dxf: DataExplorerConvertFixture):
+    test_df = SIMPLE_POLARS_DF
+    # Test that we can convert a sort and filter operation
+    schema = dxf.get_schema("simple")
+    filt = [_compare_filter(schema[2], FilterComparisonOp.Eq, "foo")]
+
+    sort_keys = [{"column_index": 0, "ascending": True}]
+
+    expected_df = test_df.filter(pl.col("c") == "foo").sort("a")
+
+    dxf.check_conversion_case(
+        test_df,
+        expected_df,
+        row_filters=filt,
+        sort_keys=sort_keys,
+        code_syntax_name="polars",
     )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -161,7 +161,6 @@ def test_convert_pandas_filter_empty(dxf: DataExplorerConvertFixture):
             test_df[test_df["a"].str.len() > 0],
         ],
     ]
-
     for filter_set, expected_df in cases:
         dxf.check_conversion_case(
             test_df, expected_df, row_filters=filter_set, code_syntax_name="pandas"
@@ -256,7 +255,6 @@ def test_convert_pandas_filter_search(dxf: DataExplorerConvertFixture):
             search_type=search_type,
         )
 
-        # For pandas, convert the boolean mask to a filtered dataframe
         expected_df = test_df[mask.astype(bool)]
         dxf.check_conversion_case(
             test_df,
@@ -396,7 +394,6 @@ def test_convert_pandas_series_filter_and_sort(dxf: DataExplorerConvertFixture):
         dxf.check_conversion_case(
             test_series, expected_df, row_filters=[filt], code_syntax_name="pandas"
         )
-
     # Test sorting on Series
     sort_cases = [
         (True, test_series.sort_values(ascending=True)),
@@ -674,4 +671,19 @@ def test_convert_polars_sort_and_filter(dxf: DataExplorerConvertFixture):
         row_filters=filt,
         sort_keys=sort_keys,
         code_syntax_name="polars",
+    )
+
+
+def test_convert_polars_sort_to_pandas(dxf: DataExplorerConvertFixture):
+    # Test that we can convert a sort operation to pandas
+    test_df = SIMPLE_POLARS_DF
+    sort_keys = [{"column_index": 0, "ascending": True}]
+
+    expected_df = test_df.sort("a").to_pandas()
+
+    dxf.check_conversion_case(
+        test_df,
+        expected_df,
+        sort_keys=sort_keys,
+        code_syntax_name="pandas",
     )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -51,10 +51,10 @@ class DataExplorerConvertFixture(DataExplorerFixture):
         self,
         table,
         expected_table,
+        code_syntax_name,
         column_filters=None,
         row_filters=None,
         sort_keys=None,
-        code_syntax_name=None,
     ):
         table_id = var_guid()
         ex_id = var_guid()

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -3251,50 +3251,37 @@ def test_histogram_single_value_special_case():
 
 
 POLARS_TYPE_EXAMPLES = [
-    (pl.Null, [None, None, None, None], "Null", "unknown"),
-    (pl.Boolean, [False, None, True, False], "Boolean", "boolean"),
-    (pl.Int8, [-1, 2, 3, None], "Int8", "number"),
-    (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number"),
-    (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number"),
-    (
-        pl.Int64,
-        [-10000000000, 20000000000, 30000000000, None],
-        "Int64",
-        "number",
-    ),
-    (pl.UInt8, [0, 2, 3, None], "UInt8", "number"),
-    (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number"),
-    (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number"),
-    (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number"),
-    (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number"),
-    (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number"),
-    (
-        pl.Binary,
-        [b"testing", b"some", b"strings", None],
-        "Binary",
-        "string",
-    ),
-    (pl.String, ["tésting", "söme", "strîngs", None], "String", "string"),
-    (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time"),
+    (pl.Null, [None, None, None, None], "Null", "unknown", None),
+    (pl.Boolean, [False, None, True, False], "Boolean", "boolean", None),
+    (pl.Int8, [-1, 2, 3, None], "Int8", "number", None),
+    (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number", None),
+    (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number", None),
+    (pl.Int64, [-10000000000, 20000000000, 30000000000, None], "Int64", "number", None),
+    (pl.UInt8, [0, 2, 3, None], "UInt8", "number", None),
+    (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number", None),
+    (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number", None),
+    (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number", None),
+    (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number", None),
+    (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number", None),
+    (pl.Binary, [b"testing", b"some", b"strings", None], "Binary", "string", None),
+    (pl.String, ["tésting", "söme", "strîngs", None], "String", "string", None),
+    (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time", None),
     (
         pl.Datetime("ms"),
         [1704394167126, 946730085000, 0, None],
         "Datetime(time_unit='ms', time_zone=None)",
         "datetime",
+        None,
     ),
     (
         pl.Datetime("us", "America/New_York"),
         [1704394167126123, 946730085000123, 0, None],
         "Datetime(time_unit='us', time_zone='America/New_York')",
         "datetime",
+        "America/New_York",
     ),
-    (pl.Date, [130120, 0, -1, None], "Date", "date"),
-    (
-        pl.Duration("ms"),
-        [0, 1000, 2000, None],
-        "Duration(time_unit='ms')",
-        "interval",
-    ),
+    (pl.Date, [130120, 0, -1, None], "Date", "date", None),
+    (pl.Duration("ms"), [0, 1000, 2000, None], "Duration(time_unit='ms')", "interval", None),
     (
         pl.Decimal(12, 4),
         [
@@ -3305,8 +3292,9 @@ POLARS_TYPE_EXAMPLES = [
         ],
         "Decimal(precision=12, scale=4)",
         "number",
+        None,
     ),
-    (pl.List(pl.Int32), [[], [1, None, 3], [0], None], "List(Int32)", "array"),
+    (pl.List(pl.Int32), [[], [1, None, 3], [0], None], "List(Int32)", "array", None),
     (
         pl.Struct({"a": pl.Int64, "b": pl.List(pl.String)}),
         [
@@ -3317,16 +3305,17 @@ POLARS_TYPE_EXAMPLES = [
         ],
         "Struct({'a': Int64, 'b': List(String)})",
         "struct",
+        None,
     ),
-    (pl.Categorical, ["a", "b", "a", None], "Categorical", "string"),
-    (pl.Object, ["Hello", True, None, 5], "Object", "object"),
+    (pl.Categorical, ["a", "b", "a", None], "Categorical", "string", None),
+    (pl.Object, ["Hello", True, None, 5], "Object", "object", None),
 ]
 
 
 def example_polars_df():
     full_schema = []
     full_data = []
-    for i, (dtype, data, type_name, type_display) in enumerate(POLARS_TYPE_EXAMPLES):
+    for i, (dtype, data, type_name, type_display, timezone) in enumerate(POLARS_TYPE_EXAMPLES):
         name = f"f{i}"
         s = pl.Series(name=name, values=data, dtype=dtype)
         full_data.append(s)
@@ -3343,6 +3332,7 @@ def example_polars_df():
                 "column_index": i,
                 "type_name": type_name,
                 "type_display": type_display,
+                "timezone": timezone,
             }
         )
 


### PR DESCRIPTION
Added new base classes `FilterHandler` and `SortHandler` with subclasses for polars and pandas.

Implemented and tested similarly to the `pandas` backend #8716

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #8753 Add **Convert to Code** support for `polars` data frames.

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer

I've added a handful of unit tests here to check that the dataframe generated from the "convert to code" is equivalent to an expected output. I've also updated the e2e test to check polars dataframes as well.

You can do a quick overview by using the flights data in qa-example-content. Unit tests cover all the operations, although not for all types.
