### PR TITLE
Address issue showing R HTML widgets (etc) on Workbench

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -26,8 +26,6 @@ import { create } from '../../../workbench/workbench.web.main.internal.js';
 // --- Start PWB: proxy port url ---
 import { extractLocalHostUriMetaDataForPortMapping, TunnelOptions, TunnelCreationOptions } from '../../../platform/tunnel/common/tunnel.js';
 import { transformPort } from './urlPorts.js';
-// eslint-disable-next-line no-duplicate-imports
-import { join } from '../../../base/common/path.js';
 // --- End PWB ---
 
 interface ISecretStorageCrypto {
@@ -658,7 +656,7 @@ function readCookie(name: string): string | undefined {
 					resolvedUri = resolvedUri.with({
 						scheme: resolvedScheme,
 						authority: mainWindow.location.host,
-						path: join(mainWindow.location.pathname, renderedTemplate, resolvedUri.path),
+						path: [mainWindow.location.pathname, renderedTemplate, resolvedUri.path].join('/'),
 					});
 				} else {
 					throw new Error(`Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.`);


### PR DESCRIPTION
This change addresses an issue causing R HTML widgets (and many other URLs, such as Shiny applications) to fail to load in Positron when accessed via a browser running on Windows.

The problem is in the code that transforms URLs into the Workbench proxy URL format. This code invokes `path.join`, which uses platform-specific separators, generating URLs that look like this:

```
https://dev1.rstudio.internal/\s\d5de86ae9dc1b05047743\p\b73015df\
```

Or, if URL encoded:

```
https://dev1.rstudio.internal/%5Cs%5Cd5de86ae9dc1b05047743%5Cp%5Cb73015df%5C
```

The fix is to join these components with `/` instead of using `path.join`. 

Addresses : https://github.com/posit-dev/positron/issues/9027.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

This URL resolution step affects almost every place we load URL content into Positron that gets proxied through Workbench. In addition to looking at HTML widgets, check local development server scenarios, such as Shiny apps, Python web apps (dash, streamlit, etc.), and Quarto preview servers.