### PR TITLE
Tolerate less normalized paths when generating proxy URLs

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -656,7 +656,7 @@ function readCookie(name: string): string | undefined {
 					resolvedUri = resolvedUri.with({
 						scheme: resolvedScheme,
 						authority: mainWindow.location.host,
-						path: [mainWindow.location.pathname, renderedTemplate, resolvedUri.path].join('/'),
+						path: posix.join(mainWindow.location.pathname, renderedTemplate, resolvedUri.path),
 					});
 				} else {
 					throw new Error(`Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.`);


### PR DESCRIPTION
Continued work from https://github.com/posit-dev/positron/pull/9086.

Testing has revealed that, while the simple approach of joining the path elements with `/` works in many cases, it does not work in  _all_ cases. In particular, a lot of Python applications produce path elements that are not normalized, and adding `/` produces URLs with a lot of `/` and `.` elements that don't always resolve correctly. 

This updated fix uses a join method from the VS Code base utility set that performs path normalization in addition to joining.

https://github.com/posit-dev/positron/blob/39095fec916918b17bfd6514a4222d5233cf5500/src/vs/base/common/path.ts#L1221-L1240


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
