### PR TITLE
Add React Unit Tests for ColumnSummaryCell Component

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -12,7 +12,6 @@ import React, { useRef, useEffect } from 'react';
 // Other dependencies.
 import * as nls from '../../../../../nls.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
-import { usePositronDataGridContext } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
 import { VectorHistogram } from './vectorHistogram.js';
 import { ColumnProfileDate } from './columnProfileDate.js';
 import { ColumnProfileNumber } from './columnProfileNumber.js';
@@ -49,9 +48,6 @@ interface ColumnSummaryCellProps {
  * @returns The rendered component.
  */
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
-	// Context hooks.
-	const context = usePositronDataGridContext();
-
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
 
@@ -531,7 +527,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				className={positronClassNames(
 					'cursor-indicator',
 					{ 'cursor': cursor },
-					{ 'focused': cursor && context.instance.focused }
+					{ 'focused': cursor && props.instance.focused }
 				)}
 			/>
 			<div className='basic-info'>

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -5,15 +5,90 @@
 
 import React from 'react';
 import assert from 'assert';
-import sinon from 'sinon';
+import sinon, { SinonStubbedInstance } from 'sinon';
 import { createRoot, Root } from 'react-dom/client';
 import { mainWindow } from '../../../../../base/browser/window.js';
 
 import { ColumnSummaryCell } from '../../browser/components/columnSummaryCell.js';
 import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
-import { ColumnDisplayType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { PositronDataGridContextProvider } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
+import { ColumnDisplayType, SupportStatus, ColumnProfileType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
+
+export function createMockTableSummaryDataGridInstance(overrides = {}): SinonStubbedInstance<TableSummaryDataGridInstance> {
+	// Mock the hover manager
+	const mockHoverManager = {
+		showHover: sinon.stub(),
+		hideHover: sinon.stub()
+	};
+
+	// Mock the configuration service
+	const mockConfigurationService = {};
+
+	// Mock supported features - this needs to match the expected structure
+	const mockSupportedFeatures = {
+		get_column_profiles: {
+			support_status: SupportStatus.Supported,
+			supported_types: [
+				{
+					profile_type: ColumnProfileType.SummaryStats,
+					support_status: SupportStatus.Supported
+				},
+				{
+					profile_type: ColumnProfileType.NullCount,
+					support_status: SupportStatus.Supported
+				}
+			]
+		},
+		search_schema: {
+			support_status: SupportStatus.Supported,
+			supported_types: []
+		},
+		set_column_filters: {
+			support_status: SupportStatus.Supported,
+			supported_types: []
+		},
+		set_row_filters: {
+			support_status: SupportStatus.Supported,
+			supported_types: []
+		},
+		set_sort_columns: {
+			support_status: SupportStatus.Supported
+		},
+		export_data_selection: {
+			support_status: SupportStatus.Supported,
+			supported_formats: []
+		},
+		convert_to_code: {
+			support_status: SupportStatus.Supported
+		}
+	};
+
+	const mockInstance = {
+		// Mock properties from DataGridInstance base class
+		cursorRowIndex: 0,
+		focused: false,
+		// Mock methods from DataGridInstance base class
+		scrollToRow: sinon.stub().resolves(),
+		setCursorRow: sinon.stub(),
+		// Mock properties from TableSummaryDataGridInstance
+		hoverManager: mockHoverManager,
+		configurationService: mockConfigurationService,
+		// Mock methods from TableSummaryDataGridInstance
+		getSupportedFeatures: sinon.stub().returns(mockSupportedFeatures),
+		isColumnExpanded: sinon.stub().returns(false),
+		toggleExpandColumn: sinon.stub().resolves(),
+		getColumnProfileNullCount: sinon.stub().returns(undefined),
+		getColumnProfileNullPercent: sinon.stub().returns(undefined),
+		getColumnProfileSummaryStats: sinon.stub().returns(undefined),
+		getColumnProfileSmallHistogram: sinon.stub().returns(undefined),
+		getColumnProfileLargeHistogram: sinon.stub().returns(undefined),
+		getColumnProfileSmallFrequencyTable: sinon.stub().returns(undefined),
+		getColumnProfileLargeFrequencyTable: sinon.stub().returns(undefined),
+		...overrides
+	};
+
+	return mockInstance
+}
 
 suite('ColumnSummaryCell', () => {
 	let root: Root;
@@ -38,23 +113,23 @@ suite('ColumnSummaryCell', () => {
 		sinon.restore();
 	});
 
-	test('displays null percentage correctly based on getColumnProfileNullPercent return value', async () => {
+	test('displays 0%  correctly when getColumnProfileNullPercent return 0', async () => {
 		// Mock out <ColumnSummaryCell> props
 		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
-		const mockTableSummaryDataGridInstance = sinon.createStubInstance(TableSummaryDataGridInstance);
-		mockTableSummaryDataGridInstance.getColumnProfileNullPercent.resolves(0);
-		mockTableSummaryDataGridInstance.getColumnProfileNullCount.resolves(0);
+
+		const mockTableSummaryDataGridInstance = createMockTableSummaryDataGridInstance({
+			getColumnProfileNullPercent: sinon.stub().returns(0),
+			getColumnProfileNullCount: sinon.stub().returns(0),
+		});
 
 		// Test case 1: 0% null values
 		root.render(
-			<PositronDataGridContextProvider instance={mockTableSummaryDataGridInstance}>
-				<ColumnSummaryCell
-					columnIndex={0}
-					columnSchema={columnSchema}
-					instance={mockTableSummaryDataGridInstance}
-					onDoubleClick={() => { }}
-				/>
-			</PositronDataGridContextProvider>
+			<ColumnSummaryCell
+				columnIndex={0}
+				columnSchema={columnSchema}
+				instance={mockTableSummaryDataGridInstance}
+				onDoubleClick={() => { }}
+			/>
 		);
 
 		// Wait for initial render
@@ -65,15 +140,12 @@ suite('ColumnSummaryCell', () => {
 		assert.strictEqual(nullPercentElement.textContent, '0%', 'Expected to find 0% for 0% input');
 	});
 
-	test('displays 25% when getColumnProfileNullPercent returns 25.7', async () => {
-
+	test.skip('displays 25% when getColumnProfileNullPercent returns 25.7', async () => {
 	});
 
-	test('displays <1% when getColumnProfileNullPercent returns 0.5', async () => {
-
+	test.skip('displays <1% when getColumnProfileNullPercent returns 0.5', async () => {
 	});
 
-	test('displays 100% when getColumnProfileNullPercent returns 100', async () => {
-
+	test.skip('displays 100% when getColumnProfileNullPercent returns 100', async () => {
 	});
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -13,6 +13,7 @@ import { ColumnSummaryCell } from '../../browser/components/columnSummaryCell.js
 import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
 import { ColumnDisplayType, SupportStatus, ColumnProfileType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 export function createMockTableSummaryDataGridInstance(overrides = {}): TableSummaryDataGridInstance {
 	// Mock the hover manager
@@ -160,4 +161,7 @@ suite('ColumnSummaryCell', () => {
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '<1%', 'Expected to find <1% for 0.5% input');
 	});
+
+	// Ensure that all disposables are cleaned up.
+	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -6,61 +6,24 @@
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
-import { createRoot } from 'react-dom/client';
+import { createRoot, Root } from 'react-dom/client';
 import { mainWindow } from '../../../../../base/browser/window.js';
 
 import { ColumnSummaryCell } from '../../browser/components/columnSummaryCell.js';
-import { mockObject } from '../../../../../base/test/common/mock.js';
 import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
-import { ColumnDisplayType, ColumnProfileType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
+import { ColumnDisplayType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataGridContextProvider } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
+import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
 
 suite('ColumnSummaryCell', () => {
-	let mockInstance: any;
-	let mockConfigurationService: any;
-	let mockHoverManager: any;
+	let root: Root;
 	let container: HTMLElement;
-	let root: any;
 
 	setup(() => {
 		// Create a container element for React to render into
 		container = mainWindow.document.createElement('div');
 		mainWindow.document.body.appendChild(container);
 		root = createRoot(container);
-
-		// Create minimal mocks for the required services
-		mockConfigurationService = mockObject()();
-		mockHoverManager = mockObject()({
-			showHover: sinon.stub(),
-			hideHover: sinon.stub(),
-			setCustomHoverDelay: sinon.stub()
-		});
-
-		// Create a comprehensive mock for TableSummaryDataGridInstance
-		mockInstance = mockObject<TableSummaryDataGridInstance>()({
-			// Essential properties the component needs
-			cursorRowIndex: 0,
-			focused: false,
-			configurationService: mockConfigurationService,
-			hoverManager: mockHoverManager,
-
-			// Mock the methods the component calls
-			getSupportedFeatures: sinon.stub().returns({
-				get_column_profiles: {
-					supported_types: [{
-						profile_type: ColumnProfileType.SummaryStats,
-						support_status: 'supported'
-					}]
-				}
-			}),
-			isColumnExpanded: sinon.stub().returns(false),
-			toggleExpandColumn: sinon.stub().resolves(),
-			getColumnProfileNullPercent: sinon.stub().returns(0),
-			getColumnProfileNullCount: sinon.stub().returns(0),
-			scrollToRow: sinon.stub(),
-			setCursorRow: sinon.stub()
-		});
 	});
 
 	teardown(() => {
@@ -76,115 +39,41 @@ suite('ColumnSummaryCell', () => {
 	});
 
 	test('displays null percentage correctly based on getColumnProfileNullPercent return value', async () => {
+		// Mock out <ColumnSummaryCell> props
 		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
+		const mockTableSummaryDataGridInstance = sinon.createStubInstance(TableSummaryDataGridInstance);
+		mockTableSummaryDataGridInstance.getColumnProfileNullPercent.resolves(0);
+		mockTableSummaryDataGridInstance.getColumnProfileNullCount.resolves(0);
 
 		// Test case 1: 0% null values
-		mockInstance.getColumnProfileNullPercent.returns(0);
-		mockInstance.getColumnProfileNullCount.returns(0);
-
-		const component = React.createElement(
-			PositronDataGridContextProvider,
-			{ instance: mockInstance },
-			React.createElement(ColumnSummaryCell, {
-				columnIndex: 0,
-				columnSchema: columnSchema,
-				instance: mockInstance,
-				onDoubleClick: () => { }
-			})
+		root.render(
+			<PositronDataGridContextProvider instance={mockTableSummaryDataGridInstance}>
+				<ColumnSummaryCell
+					columnIndex={0}
+					columnSchema={columnSchema}
+					instance={mockTableSummaryDataGridInstance}
+					onDoubleClick={() => { }}
+				/>
+			</PositronDataGridContextProvider>
 		);
 
 		// Wait for initial render
-		await new Promise<void>((resolve) => {
-			root.render(component);
-			setTimeout(resolve, 10);
-		});
+		await new Promise(resolve => setTimeout(resolve, 0));
 
 		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
-		assert.strictEqual(nullPercentElement!.textContent, '0%', 'Expected to find 0% for 0% input');
+		assert.strictEqual(nullPercentElement.textContent, '0%', 'Expected to find 0% for 0% input');
 	});
 
 	test('displays 25% when getColumnProfileNullPercent returns 25.7', async () => {
-		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
 
-		// Test case: 25.7% null values should display as 25%
-		mockInstance.getColumnProfileNullPercent.returns(25.7);
-		mockInstance.getColumnProfileNullCount.returns(257);
-
-		const component = React.createElement(
-			PositronDataGridContextProvider,
-			{ instance: mockInstance },
-			React.createElement(ColumnSummaryCell, {
-				columnIndex: 0,
-				columnSchema: columnSchema,
-				instance: mockInstance,
-				onDoubleClick: () => { }
-			})
-		);
-
-		await new Promise<void>((resolve) => {
-			root.render(component);
-			setTimeout(resolve, 10);
-		});
-
-		const nullPercentElement = container.querySelector('.text-percent');
-		assert.ok(nullPercentElement, 'Expected to find null percent element');
-		assert.strictEqual(nullPercentElement!.textContent, '25%', 'Expected to find 25% for 25.7% input');
 	});
 
 	test('displays <1% when getColumnProfileNullPercent returns 0.5', async () => {
-		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
 
-		// Test case: 0.5% null values should display as <1%
-		mockInstance.getColumnProfileNullPercent.returns(0.5);
-		mockInstance.getColumnProfileNullCount.returns(5);
-
-		const component = React.createElement(
-			PositronDataGridContextProvider,
-			{ instance: mockInstance },
-			React.createElement(ColumnSummaryCell, {
-				columnIndex: 0,
-				columnSchema: columnSchema,
-				instance: mockInstance,
-				onDoubleClick: () => { }
-			})
-		);
-
-		await new Promise<void>((resolve) => {
-			root.render(component);
-			setTimeout(resolve, 10);
-		});
-
-		const nullPercentElement = container.querySelector('.text-percent');
-		assert.ok(nullPercentElement, 'Expected to find null percent element');
-		assert.strictEqual(nullPercentElement!.textContent, '<1%', 'Expected to find <1% for 0.5% input');
 	});
 
 	test('displays 100% when getColumnProfileNullPercent returns 100', async () => {
-		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
 
-		// Test case: 100% null values
-		mockInstance.getColumnProfileNullPercent.returns(100);
-		mockInstance.getColumnProfileNullCount.returns(1000);
-
-		const component = React.createElement(
-			PositronDataGridContextProvider,
-			{ instance: mockInstance },
-			React.createElement(ColumnSummaryCell, {
-				columnIndex: 0,
-				columnSchema: columnSchema,
-				instance: mockInstance,
-				onDoubleClick: () => { }
-			})
-		);
-
-		await new Promise<void>((resolve) => {
-			root.render(component);
-			setTimeout(resolve, 10);
-		});
-
-		const nullPercentElement = container.querySelector('.text-percent');
-		assert.ok(nullPercentElement, 'Expected to find null percent element');
-		assert.strictEqual(nullPercentElement!.textContent, '100%', 'Expected to find 100% for 100% input');
 	});
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import { createRoot } from 'react-dom/client';
+import { mainWindow } from '../../../../../base/browser/window.js';
+
+import { ColumnSummaryCell } from '../../browser/components/columnSummaryCell.js';
+import { mockObject } from '../../../../../base/test/common/mock.js';
+import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
+import { ColumnDisplayType, ColumnProfileType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
+import { PositronDataGridContextProvider } from '../../../../browser/positronDataGrid/positronDataGridContext.js';
+
+suite('ColumnSummaryCell', () => {
+	let mockInstance: any;
+	let mockConfigurationService: any;
+	let mockHoverManager: any;
+	let container: HTMLElement;
+	let root: any;
+
+	setup(() => {
+		// Create a container element for React to render into
+		container = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+		root = createRoot(container);
+
+		// Create minimal mocks for the required services
+		mockConfigurationService = mockObject()();
+		mockHoverManager = mockObject()({
+			showHover: sinon.stub(),
+			hideHover: sinon.stub(),
+			setCustomHoverDelay: sinon.stub()
+		});
+
+		// Create a comprehensive mock for TableSummaryDataGridInstance
+		mockInstance = mockObject<TableSummaryDataGridInstance>()({
+			// Essential properties the component needs
+			cursorRowIndex: 0,
+			focused: false,
+			configurationService: mockConfigurationService,
+			hoverManager: mockHoverManager,
+
+			// Mock the methods the component calls
+			getSupportedFeatures: sinon.stub().returns({
+				get_column_profiles: {
+					supported_types: [{
+						profile_type: ColumnProfileType.SummaryStats,
+						support_status: 'supported'
+					}]
+				}
+			}),
+			isColumnExpanded: sinon.stub().returns(false),
+			toggleExpandColumn: sinon.stub().resolves(),
+			getColumnProfileNullPercent: sinon.stub().returns(0),
+			getColumnProfileNullCount: sinon.stub().returns(0),
+			scrollToRow: sinon.stub(),
+			setCursorRow: sinon.stub()
+		});
+	});
+
+	teardown(() => {
+		// Clean up the React root and container
+		if (root) {
+			root.unmount();
+		}
+		if (container && container.parentNode) {
+			container.parentNode.removeChild(container);
+		}
+		// Restore spies and stubs
+		sinon.restore();
+	});
+
+	test('displays null percentage correctly based on getColumnProfileNullPercent return value', async () => {
+		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
+
+		// Test case 1: 0% null values
+		mockInstance.getColumnProfileNullPercent.returns(0);
+		mockInstance.getColumnProfileNullCount.returns(0);
+
+		const component = React.createElement(
+			PositronDataGridContextProvider,
+			{ instance: mockInstance },
+			React.createElement(ColumnSummaryCell, {
+				columnIndex: 0,
+				columnSchema: columnSchema,
+				instance: mockInstance,
+				onDoubleClick: () => { }
+			})
+		);
+
+		// Wait for initial render
+		await new Promise<void>((resolve) => {
+			root.render(component);
+			setTimeout(resolve, 10);
+		});
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement!.textContent, '0%', 'Expected to find 0% for 0% input');
+	});
+
+	test('displays 25% when getColumnProfileNullPercent returns 25.7', async () => {
+		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
+
+		// Test case: 25.7% null values should display as 25%
+		mockInstance.getColumnProfileNullPercent.returns(25.7);
+		mockInstance.getColumnProfileNullCount.returns(257);
+
+		const component = React.createElement(
+			PositronDataGridContextProvider,
+			{ instance: mockInstance },
+			React.createElement(ColumnSummaryCell, {
+				columnIndex: 0,
+				columnSchema: columnSchema,
+				instance: mockInstance,
+				onDoubleClick: () => { }
+			})
+		);
+
+		await new Promise<void>((resolve) => {
+			root.render(component);
+			setTimeout(resolve, 10);
+		});
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement!.textContent, '25%', 'Expected to find 25% for 25.7% input');
+	});
+
+	test('displays <1% when getColumnProfileNullPercent returns 0.5', async () => {
+		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
+
+		// Test case: 0.5% null values should display as <1%
+		mockInstance.getColumnProfileNullPercent.returns(0.5);
+		mockInstance.getColumnProfileNullCount.returns(5);
+
+		const component = React.createElement(
+			PositronDataGridContextProvider,
+			{ instance: mockInstance },
+			React.createElement(ColumnSummaryCell, {
+				columnIndex: 0,
+				columnSchema: columnSchema,
+				instance: mockInstance,
+				onDoubleClick: () => { }
+			})
+		);
+
+		await new Promise<void>((resolve) => {
+			root.render(component);
+			setTimeout(resolve, 10);
+		});
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement!.textContent, '<1%', 'Expected to find <1% for 0.5% input');
+	});
+
+	test('displays 100% when getColumnProfileNullPercent returns 100', async () => {
+		const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
+
+		// Test case: 100% null values
+		mockInstance.getColumnProfileNullPercent.returns(100);
+		mockInstance.getColumnProfileNullCount.returns(1000);
+
+		const component = React.createElement(
+			PositronDataGridContextProvider,
+			{ instance: mockInstance },
+			React.createElement(ColumnSummaryCell, {
+				columnIndex: 0,
+				columnSchema: columnSchema,
+				instance: mockInstance,
+				onDoubleClick: () => { }
+			})
+		);
+
+		await new Promise<void>((resolve) => {
+			root.render(component);
+			setTimeout(resolve, 10);
+		});
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement!.textContent, '100%', 'Expected to find 100% for 100% input');
+	});
+});

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -162,6 +162,52 @@ suite('ColumnSummaryCell', () => {
 		assert.strictEqual(nullPercentElement.textContent, '<1%', 'Expected to find <1% for 0.5% input');
 	});
 
+	test('displays 99% when getColumnProfileNullPercent returns 99.9', async () => {
+		const mockTableSummaryDataGridInstance = createMockTableSummaryDataGridInstance({
+			getColumnProfileNullPercent: sinon.stub().returns(99.9),
+			getColumnProfileNullCount: sinon.stub().returns(999),
+		});
+
+		root.render(
+			<ColumnSummaryCell
+				columnIndex={0}
+				columnSchema={columnSchema}
+				instance={mockTableSummaryDataGridInstance}
+				onDoubleClick={() => { }}
+			/>
+		);
+
+		// Wait for initial render
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement.textContent, '99%', 'Expected to find 99% for 99.9% input');
+	});
+
+	test('displays 100% when getColumnProfileNullPercent returns 100', async () => {
+		const mockTableSummaryDataGridInstance = createMockTableSummaryDataGridInstance({
+			getColumnProfileNullPercent: sinon.stub().returns(100),
+			getColumnProfileNullCount: sinon.stub().returns(1000),
+		});
+
+		root.render(
+			<ColumnSummaryCell
+				columnIndex={0}
+				columnSchema={columnSchema}
+				instance={mockTableSummaryDataGridInstance}
+				onDoubleClick={() => { }}
+			/>
+		);
+
+		// Wait for initial render
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		const nullPercentElement = container.querySelector('.text-percent');
+		assert.ok(nullPercentElement, 'Expected to find null percent element');
+		assert.strictEqual(nullPercentElement.textContent, '100%', 'Expected to find 100% for 100% input');
+	});
+
 	// Ensure that all disposables are cleaned up.
 	ensureNoDisposablesAreLeakedInTestSuite();
 });


### PR DESCRIPTION
This PR adds a React unit test for the bug from #8515

The unit test is for the `ColumnSummaryCell` component, that verifies the null percentage display value from the Data Explorer Summary panel matches the expectations in the UI.

The test checks 4 specific null percentage formatting edge cases:
* 0%
* <1% - Values between 0% and 1%
* 99% - Values between 99% and 99.9%
* 100%

You can run the unit test in several different ways:
```
// run test by providing a glob based search for the file name
./scripts/test.sh --glob **/columnSummaryCell.*

// run test by providing the full path for the compiled file
./scripts/test.sh --run vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.js

// run test based off the test suite name
./scripts/test.sh --grep "ColumnSummaryCell"
```

The react unit test setup uses Mocha + assert + Sinon.js + React instead of the now common place react-testing-library. This is to reduce introducing any additional dependencies since the number of component unit tests will be added on an as-needed basis.

* We setup/teardown of DOM containers and React roots. 
* We render the component with `ReactDOM.createRoot()`
* We query the DOM using native DOM APIs (e.g., `container.querySelector`)
4. Use `assert` and `sinon` for test logic (vs RTL querying and jest mocking)

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:data-explorer
@:web
@:win

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
