### PR TITLE
Data Explorer: Request profiles one at a time for larger tables

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/utils.py
@@ -9,6 +9,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 import re
 import sys
 import threading
@@ -149,7 +150,9 @@ class BackgroundJobQueue:
 
     def __init__(self, max_workers=None):
         # Initialize the ThreadPoolExecutor with the specified number
-        # of workers
+        # of workers. Default to the number of CPU cores for optimal performance.
+        if max_workers is None:
+            max_workers = os.cpu_count() or 4
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
         self.pending_futures = set()
         self.lock = threading.Lock()


### PR DESCRIPTION
These are some changes to make profile rendering a little smoother. Before we were batching 4 profiles at a time, but this changes to 1-at-a-time for over 1 million rows (below that they the in-window profiles are requested in a single big batch):

I also noticed that the background task queue in Python was using 5 x # CPUs by default and for compute heavy profile computation this can result in inefficient context switching when computing many profiles. Now the number of workers is equal to the number of logical CPU cores.

Before:

https://github.com/user-attachments/assets/33fd3466-fbef-43c3-8ad4-2dc39c1d9360

After:

https://github.com/user-attachments/assets/99c68463-2e86-459b-8eee-0c30dffeeff3

### Release Notes

#### New Features

- Column profiles in the data explorer render more smoothly and incrementally for tables with many rows.

#### Bug Fixes

- N/A


### QA Notes

Check data frames with at least 10 million rows to observe the sparkline pop-in performance.

@:data-explorer