### PR TITLE
Remove loading of 1Password secrets in E2E workflows for Ubuntu and Windows

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -128,14 +128,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Load secret
-        uses: 1password/load-secrets-action@v3
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ANTHROPIC: "op://Positron/Anthropic/credential"
+      # - name: Load secret
+      #   uses: 1password/load-secrets-action@v3
+      #   with:
+      #     # Export loaded secrets as environment variables
+      #     export-env: true
+      #   env:
+      #     OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      #     ANTHROPIC: "op://Positron/Anthropic/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -82,14 +82,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Load secret
-        uses: 1password/load-secrets-action@v3
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ANTHROPIC: "op://Positron/Anthropic/credential"
+      # - name: Load secret
+      #   uses: 1password/load-secrets-action@v3
+      #   with:
+      #     # Export loaded secrets as environment variables
+      #     export-env: true
+      #   env:
+      #     OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      #     ANTHROPIC: "op://Positron/Anthropic/credential"
 
       - name: Set screen resolution
         shell: pwsh


### PR DESCRIPTION
Due to https://github.com/1Password/load-secrets-action/issues/116  

Disabling for now

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
