### PR TITLE
e2e: fix flake in notebook working dir tests

### DIFF
--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -17,6 +17,8 @@ test.describe('Notebook Working Directory Configuration', {
 	tag: [tags.WIN, tags.WEB, tags.NOTEBOOKS]
 }, () => {
 
+	test.beforeAll(async function ({ python }) { });
+
 	test.afterEach(async function ({ app }) {
 		await app.workbench.notebooks.closeNotebookWithoutSaving();
 	});

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -67,6 +67,7 @@ test.describe('Notebook Working Directory Configuration', {
 
 async function verifyWorkingDirectoryEndsWith(notebooks: Notebooks, expectedEnd: string) {
 	await notebooks.openNotebook('working-directory.ipynb');
+	await notebooks.selectInterpreter('Python');
 	await notebooks.runAllCells();
 	await notebooks.assertCellOutput(new RegExp(`^'.*${expectedEnd}'$`));
 }


### PR DESCRIPTION
This should fix the flaky notebook working directory e2e web tests we've been seeing. Now we wait to select the interpreter before running the cells.

Addresses #8828.

@:notebooks @:win @:web