### PR TITLE
Data Explorer: Add "click to compute profile" feature for large tables

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -120,33 +120,48 @@
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute {
 	pointer-events: auto;
 	cursor: pointer;
+	transition: opacity 0.15s ease;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover {
-	opacity: 0.8;
+	opacity: 1;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline .click-to-compute-sparkline .placeholder-bg {
-	fill: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundFill);
-	stroke: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke);
-	stroke-dasharray: 2,2;
-	opacity: 0.6;
+	fill: var(--vscode-input-background);
+	stroke: var(--vscode-input-border);
+	stroke-width: 1.5;
+	stroke-dasharray: 3, 2;
+	opacity: 0.8;
+	transition: all 0.15s ease;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline .click-to-compute-sparkline .click-to-compute-text {
-	fill: var(--vscode-foreground);
-	opacity: 0.7;
-	font-size: 10px;
+	fill: var(--vscode-input-foreground);
+	opacity: 1;
+	font-size: 9px;
 	font-weight: 500;
+	font-family: var(--vscode-font-family);
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	transition: opacity 0.15s ease;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover .click-to-compute-sparkline .placeholder-bg {
+	fill: var(--vscode-editor-selectionBackground);
+	stroke: var(--vscode-focusBorder);
 	stroke-dasharray: none;
-	opacity: 0.8;
+	opacity: 0.3;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover .click-to-compute-sparkline .click-to-compute-text {
-	opacity: 1;
+	fill: var(--vscode-foreground);
+	opacity: 0.9;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:active .click-to-compute-sparkline .placeholder-bg {
+	fill: var(--vscode-editor-selectionBackground);
+	opacity: 0.5;
 }
 
 /* column-null-percent */

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -131,7 +131,7 @@
 	fill: var(--vscode-input-background);
 	stroke: var(--vscode-input-border);
 	stroke-width: 1.5;
-	stroke-dasharray: 3, 2;
+	stroke-dasharray: none;
 	opacity: 0.8;
 	transition: all 0.15s ease;
 }
@@ -141,7 +141,6 @@
 	opacity: 1;
 	font-size: 9px;
 	font-weight: 500;
-	font-family: var(--vscode-font-family);
 	letter-spacing: 0.5px;
 	text-transform: uppercase;
 	transition: opacity 0.15s ease;

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -115,6 +115,40 @@
 	100% { opacity: 0.2; }
 }
 
+/* Click-to-compute sparkline styles */
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute {
+	pointer-events: auto;
+	cursor: pointer;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover {
+	opacity: 0.8;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline .click-to-compute-sparkline .placeholder-bg {
+	fill: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundFill);
+	stroke: var(--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke);
+	stroke-dasharray: 2,2;
+	opacity: 0.6;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline .click-to-compute-sparkline .click-to-compute-text {
+	fill: var(--vscode-foreground);
+	opacity: 0.7;
+	font-size: 10px;
+	font-weight: 500;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover .click-to-compute-sparkline .placeholder-bg {
+	stroke-dasharray: none;
+	opacity: 0.8;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .column-sparkline.click-to-compute:hover .click-to-compute-sparkline .click-to-compute-text {
+	opacity: 1;
+}
+
 /* column-null-percent */
 
 .data-grid-row-cell .content .column-summary .basic-info .column-null-percent {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -49,8 +49,6 @@ interface ColumnSummaryCellProps {
  * @returns The rendered component.
  */
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
-	console.log(`[ColumnSummaryCell] Rendering column ${props.columnIndex}`);
-
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
@@ -64,7 +62,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		const disposable = props.instance.tableSummaryCache.onDidUpdate(() => {
 			const newState = props.instance.isSparklineRequested(props.columnIndex);
 			if (newState !== sparklineRequested) {
-				console.log(`[Column ${props.columnIndex}] Parent state update: ${sparklineRequested} -> ${newState}`);
 				setSparklineRequested(newState);
 			}
 		});
@@ -106,12 +103,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		const isLargeDataset = props.instance.isLargeDataset();
 
 		// Use parent's state
-		console.log(`[Column ${props.columnIndex}] Render - sparklineRequested (from parent state):`, sparklineRequested);
-
-		// Also check what data is available
-		const columnHistogram = props.instance.getColumnProfileSmallHistogram(props.columnIndex);
-		const columnFrequencyTable = props.instance.getColumnProfileSmallFrequencyTable(props.columnIndex);
-		console.log(`[Column ${props.columnIndex}] Data available - histogram:`, !!columnHistogram, 'frequencyTable:', !!columnFrequencyTable);
 
 		// Determines whether a sparkline is expected for this column type
 		const shouldShowSparkline = () => {
@@ -119,19 +110,15 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				case ColumnDisplayType.Number:
 				case ColumnDisplayType.Boolean:
 				case ColumnDisplayType.String:
-					console.log(`[Column ${props.columnIndex}] shouldShowSparkline: true for type ${props.columnSchema.type_display}`);
 					return true;
 				default:
-					console.log(`[Column ${props.columnIndex}] shouldShowSparkline: false for type ${props.columnSchema.type_display}`);
 					return false;
 			}
 		};
 
 		// Check if sparkline computation should be skipped for large datasets
 		const shouldSkipSparklineForLargeDataset = () => {
-			const result = isLargeDataset && !sparklineRequested;
-			console.log(`[Column ${props.columnIndex}] shouldSkipSparklineForLargeDataset: isLargeDataset=${isLargeDataset}, sparklineRequested=${sparklineRequested}, result=${result}`);
-			return result;
+			return isLargeDataset && !sparklineRequested;
 		};
 
 		/**
@@ -186,24 +173,12 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				e.stopPropagation();
 				e.preventDefault();
 
-				console.log(`[Column ${props.columnIndex}] Button clicked! Before request - sparklineRequested (state):`, sparklineRequested);
-				console.log(`[Column ${props.columnIndex}] Before request - isRequested (cache):`, props.instance.isSparklineRequested(props.columnIndex));
-				console.log(`[Column ${props.columnIndex}] Before request - data available:`, {
-					histogram: !!props.instance.getColumnProfileSmallHistogram(props.columnIndex),
-					frequencyTable: !!props.instance.getColumnProfileSmallFrequencyTable(props.columnIndex)
-				});
-
 				// Immediately update parent state
 				setSparklineRequested(true);
 
 				try {
 					// Request the sparkline for this column
 					await props.instance.requestSparkline(props.columnIndex);
-					console.log(`[Column ${props.columnIndex}] After request - isRequested (cache):`, props.instance.isSparklineRequested(props.columnIndex));
-					console.log(`[Column ${props.columnIndex}] After request - data available:`, {
-						histogram: !!props.instance.getColumnProfileSmallHistogram(props.columnIndex),
-						frequencyTable: !!props.instance.getColumnProfileSmallFrequencyTable(props.columnIndex)
-					});
 					// Note: Parent component will re-render when cache updates
 				} catch (err) {
 					console.error('Failed to request sparkline:', err);
@@ -630,7 +605,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 	// Get the expanded state of the column.
 	const expanded = props.instance.isColumnExpanded(props.columnIndex);
-	console.log(`[Column ${props.columnIndex}] expanded=${expanded}`);
 
 	// Set the summary stats supported flag.
 	let summaryStatsSupported;

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -196,8 +196,8 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 						height: SPARKLINE_HEIGHT + SPARKLINE_X_AXIS_HEIGHT,
 						cursor: 'pointer'
 					}}
-					onMouseDown={handleClick}
 					onClick={(e) => e.stopPropagation()}
+					onMouseDown={handleClick}
 					onMouseLeave={() => props.instance.hoverManager.hideHover()}
 					onMouseOver={() =>
 						props.instance.hoverManager.showHover(
@@ -209,8 +209,8 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					<svg
 						className='vector-histogram click-to-compute-sparkline'
 						shapeRendering='crispEdges'
-						viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT + SPARKLINE_X_AXIS_HEIGHT}`}
 						style={{ pointerEvents: 'none' }}
+						viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT + SPARKLINE_X_AXIS_HEIGHT}`}
 					>
 						<g>
 							<rect className='x-axis'
@@ -221,18 +221,18 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							/>
 							<rect className='placeholder-bg'
 								height={SPARKLINE_HEIGHT}
+								rx={2}
 								width={SPARKLINE_WIDTH}
 								x={0}
 								y={0}
-								rx={2}
 							/>
 							<text
 								className='click-to-compute-text'
-								x={SPARKLINE_WIDTH / 2}
-								y={SPARKLINE_HEIGHT / 2}
-								textAnchor='middle'
 								dominantBaseline='central'
 								fontSize={9}
+								textAnchor='middle'
+								x={SPARKLINE_WIDTH / 2}
+								y={SPARKLINE_HEIGHT / 2}
 							>
 								Compute
 							</text>

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -420,6 +420,31 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Checks if the current dataset is considered large (> 10M rows).
+	 * @returns True if the dataset has more than 10 million rows, false otherwise.
+	 */
+	isLargeDataset(): boolean {
+		return this._tableSummaryCache.isLargeDataset();
+	}
+
+	/**
+	 * Checks if a sparkline has been manually requested for the given column.
+	 * @param columnIndex The column index.
+	 * @returns True if the sparkline has been requested, false otherwise.
+	 */
+	isSparklineRequested(columnIndex: number): boolean {
+		return this._tableSummaryCache.isSparklineRequested(columnIndex);
+	}
+
+	/**
+	 * Requests a sparkline for the given column.
+	 * @param columnIndex The column index.
+	 */
+	async requestSparkline(columnIndex: number): Promise<void> {
+		await this._tableSummaryCache.requestSparkline(columnIndex);
+	}
+
+	/**
 	 * Sets the column name search filter.
 	 * @param searchText The search text used to filter column names (case insensitive).
 	 */

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -445,6 +445,14 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Gets the table summary cache for subscribing to events.
+	 * @returns The table summary cache.
+	 */
+	get tableSummaryCache(): TableSummaryCache {
+		return this._tableSummaryCache;
+	}
+
+	/**
 	 * Sets the column name search filter.
 	 * @param searchText The search text used to filter column names (case insensitive).
 	 */


### PR DESCRIPTION
As partly addressing #8869, this adds a feature where we can disable auto-computing the sparkline / profile plots when the data is over a certain size (the null percentages are still computed but that's a much less expensive computation. The threshold is currently set at 10M rows but we probably want to make that a little higher since 10M is still pretty snappy to compute. 

See in action on a 50M row data frame:

https://github.com/user-attachments/assets/175fd2dd-68b8-4a0d-a6b2-8a2a1aee22f0

This PR was implemented with Claude Code's help so this is simply a basic proposal to solicit feedback for now — I'm happy to take critical feedback about the approach and do another pass with CC. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:data-explorer