### PR TITLE
Add instructions about using eslint to fix issues when using Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,26 +46,11 @@ timeout /t 10 /nobreak >nul && tasklist | findstr /i "positron electron"
 npm test
 ```
 
-### Code Formatting
+### Code Formatting & Linting
 
 **🚨 CRITICAL: DO NOT USE PRETTIER**
 
 Positron uses VSCode's built-in TypeScript formatter, not Prettier. Using Prettier will create formatting conflicts that are very difficult to resolve.
-
-**Correct way to format files:**
-```bash
-# Format specific TypeScript/JavaScript files using the project's formatter script
-node scripts/format.js <file1> [file2] [file3] ...
-
-# Examples:
-node scripts/format.js src/vs/workbench/contrib/positronDataExplorer/browser/positronDataExplorer.tsx
-node scripts/format.js src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
-
-# Format multiple files at once:
-node scripts/format.js file1.ts file2.tsx file3.js
-```
-
-**This script uses TypeScript's built-in formatter - the exact same formatter used by the pre-commit hook.**
 
 **Project formatting rules:**
 - Uses **tabs** (not spaces)  
@@ -74,12 +59,30 @@ node scripts/format.js file1.ts file2.tsx file3.js
 - VSCode's TypeScript formatter handles all formatting
 - ESLint with `@stylistic/eslint-plugin-ts` provides additional style rules
 
+**CRITICAL: After making any code changes, you MUST run both commands:**
+```bash
+# 1. Fix ESLint errors (JSX prop sorting, style issues, etc.)
+npx eslint --fix <file_path>
+
+# 2. Format with project's TypeScript formatter (matches pre-commit hook)
+node scripts/format.js <file_path>
+
+# 3. Verify compilation succeeds in build daemon
+```
+
+**Examples:**
+```bash
+npx eslint --fix src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+node scripts/format.js src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+
+# Format multiple files at once:
+node scripts/format.js file1.ts file2.tsx file3.js
+```
+
 **Never use:**
 - `prettier` or `npx prettier` commands
 - `npm run eslint` (runs on entire codebase, too broad)
 - Any other third-party formatters
-
-When editing files, format them with `node scripts/format.js <file_path>` to match the project's formatting standards exactly.
 
 ### Testing
 ```bash


### PR DESCRIPTION
Claude Code will sometimes introduce eslint warnings that will fail the project's pre-commit hooks. This adds the extra instruction to fix issues with eslint as part of formatting files.