### PR TITLE
python: make PET default locator

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -433,6 +433,13 @@ jobs:
         run: npm run test:functional
         if: matrix.test-suite == 'functional'
 
+      - name: Install pet binary for smoke tests
+        working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR }}
+        run: npm run install-pet
+        env:
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
+        if: matrix.test-suite == 'smoke'
+
       - name: Run smoke tests
         env:
           POSITRON_GITHUB_RO_PAT: ${{ github.token }}

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -244,7 +244,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.x']
         test-suite:
-          [ts-unit, venv, single-workspace, debugger, functional, smoke]
+          [ts-unit, venv, single-workspace, debugger, functional]
         # TODO: Add integration tests on windows and ubuntu. This requires updating
         # src/test/positron/testElectron.ts to support installing Positron on these platforms.
         exclude:
@@ -254,16 +254,12 @@ jobs:
             test-suite: debugger
           - os: windows-latest
             test-suite: single-workspace
-          - os: windows-latest
-            test-suite: smoke
           - os: ubuntu-latest
             test-suite: venv
           - os: ubuntu-latest
             test-suite: debugger
           - os: ubuntu-latest
             test-suite: single-workspace
-          - os: ubuntu-latest
-            test-suite: smoke
 
     steps:
       - name: Checkout
@@ -376,10 +372,6 @@ jobs:
           & $condaPythonPath ./build/ci/addEnvPath.py ${{ env.PYTHON_VIRTUAL_ENVS_LOCATION }} condaPath
           & $condaExecPath init --all
 
-      - name: Prepare VSIX for smoke tests
-        run: npm run package --allow-star-activation
-        if: matrix.test-suite == 'smoke'
-
       - name: Set CI_PYTHON_PATH and CI_DISABLE_AUTO_SELECTION
         run: |
           echo "CI_PYTHON_PATH=$(which python)" >> $GITHUB_ENV
@@ -433,16 +425,3 @@ jobs:
         run: npm run test:functional
         if: matrix.test-suite == 'functional'
 
-      - name: Install pet binary for smoke tests
-        working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR }}
-        run: npm run install-pet
-        env:
-          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
-        if: matrix.test-suite == 'smoke'
-
-      - name: Run smoke tests
-        env:
-          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
-        run: |
-          npx tsc && node ./out/test/smokeTest.js
-        if: matrix.test-suite == 'smoke'

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -806,14 +806,10 @@
                 },
                 "python.locator": {
                     "default": "native",
-                    "description": "%python.locator.description%",
+                    "markdownDescription": "%python.locator.description%",
                     "enum": [
                         "js",
                         "native"
-                    ],
-                    "tags": [
-                        "onExP",
-                        "preview"
                     ],
                     "scope": "machine-overridable",
                     "type": "string"

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -805,7 +805,7 @@
                     "type": "string"
                 },
                 "python.locator": {
-                    "default": "js",
+                    "default": "native",
                     "description": "%python.locator.description%",
                     "enum": [
                         "js",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -86,7 +86,7 @@
     "python.logging.level.description": "The logging level the extension logs at, defaults to 'error'",
     "python.logging.level.deprecation": "This setting is deprecated. Please use command `Developer: Set Log Level...` to set logging level.",
     "python.missingPackage.severity.description": "Set severity of missing packages in requirements.txt or pyproject.toml",
-    "python.locator.description": "[Experimental] Select implementation of environment locators. This is an experimental setting while we test native environment location.",
+    "python.locator.description": "Choose how to discover Python interpreters. Native uses [Python Environment Tools](https://github.com/microsoft/python-environment-tools) a faster, Rust-based locator, while JS uses a JavaScript implementation.",
     "python.pipenvPath.description": "Path to the pipenv executable to use for activation.",
     "python.poetryPath.description": "Path to the poetry executable.",
     "python.quietMode.description": "Start Positron's IPython shell in quiet mode, to suppress initial version and help messages (restart Positron to apply).",
@@ -129,7 +129,7 @@
     "walkthrough.positron.step.migrateFromVSCode.panes.description": "Find your way around the panes and layout of Positron\n[Customize your layout](command:workbench.action.customizeLayout)",
     "walkthrough.pythonWelcome.title": "Get Started with Python Development",
     "walkthrough.pythonWelcome.description": "Your first steps to set up a Python project with all the powerful tools and features that the Python extension has to offer!",
-     "walkthrough.step.python.createPythonFile.title": "Create a Python file",
+    "walkthrough.step.python.createPythonFile.title": "Create a Python file",
     "walkthrough.step.python.createPythonFolder.title": "Open a Python project folder",
     "walkthrough.step.python.createPythonFile.description": {
         "message": "[Open](command:toSide:workbench.action.files.openFile) or [create](command:toSide:workbench.action.files.newUntitledFile?%7B%22languageId%22%3A%22python%22%7D) a Python file - make sure to save it as \".py\".\n[Create Python File](command:toSide:workbench.action.files.newUntitledFile?%7B%22languageId%22%3A%22python%22%7D)",
@@ -141,7 +141,7 @@
     },
     "walkthrough.step.python.createPythonFolder.description": {
         "message": "[Open](command:workbench.action.files.openFolder) or create a project folder.\n[Open Project Folder](command:workbench.action.files.openFolder)",
-        "comment":  [
+        "comment": [
             "{Locked='](command:workbench.action.files.openFolder'}",
             "Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
             "Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
@@ -171,7 +171,7 @@
     "walkthrough.step.python.createEnvironment.title": "Select or create a Python environment",
     "walkthrough.step.python.createEnvironment.description": {
         "message": "Create an environment for your Python project or use [Select Python Interpreter](command:python.setInterpreter) to select an existing one.\n[Create Environment](command:python.createEnvironment)\n**Tip**: Run the ``Python: Create Environment`` command in the [Command Palette](command:workbench.action.showCommands).",
-        "comment":  [
+        "comment": [
             "{Locked='](command:python.createEnvironment'}",
             "{Locked='](command:workbench.action.showCommands'}",
             "{Locked='](command:python.setInterpreter'}",
@@ -183,8 +183,8 @@
     "walkthrough.step.python.runAndDebug.description": "Open your Python file  and click on the play button on the top right of the editor, or press F5 when on the file and select \"Python File\" to run with the debugger. \n  \n[Learn more](https://code.visualstudio.com/docs/python/python-tutorial#_run-hello-world)",
     "walkthrough.step.python.learnMoreWithDS.title": "Keep exploring!",
     "walkthrough.step.python.learnMoreWithDS.description": {
-        "message":"🎨 Explore all the features the Python extension has to offer by looking for \"Python\" in the [Command Palette](command:workbench.action.showCommands). \n 📈 Learn more about getting started with [data science](command:workbench.action.openWalkthrough?%7B%22category%22%3A%22ms-python.python%23pythonDataScienceWelcome%22%2C%22step%22%3A%22ms-python.python%23python.createNewNotebook%22%7D) in Python. \n ✨ Take a look at our [Release Notes](https://aka.ms/AA8dxtb) to learn more about the latest features. \n \n[Follow along with the Python Tutorial](https://aka.ms/AA8dqti)",
-        "comment":[
+        "message": "🎨 Explore all the features the Python extension has to offer by looking for \"Python\" in the [Command Palette](command:workbench.action.showCommands). \n 📈 Learn more about getting started with [data science](command:workbench.action.openWalkthrough?%7B%22category%22%3A%22ms-python.python%23pythonDataScienceWelcome%22%2C%22step%22%3A%22ms-python.python%23python.createNewNotebook%22%7D) in Python. \n ✨ Take a look at our [Release Notes](https://aka.ms/AA8dxtb) to learn more about the latest features. \n \n[Follow along with the Python Tutorial](https://aka.ms/AA8dqti)",
+        "comment": [
             "{Locked='](command:workbench.action.showCommands'}",
             "{Locked='](command:workbench.action.openWalkthrough?%7B%22category%22%3A%22ms-python.python%23pythonDataScienceWelcome%22%2C%22step%22%3A%22ms-python.python%23python.createNewNotebook%22%7D'}",
             "Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.locator": "native",
     "interpreters.startupBehavior": "manual",
     "positron.r.kernel.logLevel": "trace",
     "python.languageServerLogLevel": "debug",


### PR DESCRIPTION
Changes from "js" locator to the PET. 🎉 

This PR also removes CI runs for upstream smoke tests. This was brought on due to the fact that smoke tests do not run from the expected `positron/extensions/positron-python` directory, so the `pet` binary would need to be redownloaded and inserted into the temporary testing path. We have disabled all behavior that is being tested in the smoke tests besides: checking if the LSP is on, running a Python file in the terminal, and checking if Smart Send is on. These are all features that are covered in Positron's own e2e tests. Since the smoke tests are not adding additional coverage or information to our testing suite, we decided to remove them completely.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #6582 Use Rust-based Python Environment Tools locator as default.

#### Bug Fixes

- N/A


### QA Notes

passes CI and if you poke around in different workspaces, Python should be discovered. I don't think we need to add "native" to the e2e settings anymore.