### PR TITLE
Data Explorer: Add tooltip for top-left reset-scroll-position button

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
@@ -13,6 +13,7 @@ import { IDataColumn } from '../interfaces/dataColumn.js';
 import { IColumnSortKey } from '../interfaces/columnSortKey.js';
 import { AnchorPoint } from '../../positronComponents/positronModalPopup/positronModalPopup.js';
 import { ILayoutEntry, LayoutManager } from '../../../services/positronDataExplorer/common/layoutManager.js';
+import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 
 /**
  * ColumnHeaderOptions type.
@@ -990,6 +991,14 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	get selection() {
 		return this._selection;
+	}
+
+	/**
+	 * Gets the hover manager for displaying tooltips, if available.
+	 * @returns The hover manager, or undefined if not available.
+	 */
+	get hoverManager(): PositronActionBarHoverManager | undefined {
+		return undefined;
 	}
 
 	//#endregion Public Properties - Settings

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
@@ -7,9 +7,10 @@
 import './dataGridCornerTopLeft.css';
 
 // React.
-import React from 'react';
+import React, { useRef } from 'react';
 
 // Other dependencies.
+import * as nls from '../../../../nls.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
 import { VerticalSplitter } from '../../../../base/browser/ui/positronComponents/splitters/verticalSplitter.js';
 
@@ -29,9 +30,28 @@ export const DataGridCornerTopLeft = (props: DataGridCornerTopLeftProps) => {
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
+	// Ref for hover tooltip.
+	const containerRef = useRef<HTMLDivElement>(undefined!);
+
+	// Get hover manager from the instance.
+	const hoverManager = context.instance.hoverManager;
+
+	// Localized tooltip text.
+	const tooltipText = nls.localize(
+		'positronDataGrid.resetScrollPosition',
+		'Reset scroll position to top-left'
+	);
+
 	// Render.
 	return (
-		<div className='data-grid-corner-top-left' onClick={props.onClick}>
+		<div
+			ref={containerRef}
+			className='data-grid-corner-top-left'
+			title={!hoverManager ? tooltipText : undefined}
+			onClick={props.onClick}
+			onMouseLeave={hoverManager ? () => hoverManager.hideHover() : undefined}
+			onMouseOver={hoverManager ? () => hoverManager.showHover(containerRef.current, tooltipText) : undefined}
+		>
 			<div className='border-overlay' />
 			<VerticalSplitter
 				onBeginResize={() => ({

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
@@ -38,8 +38,8 @@ export const DataGridCornerTopLeft = (props: DataGridCornerTopLeftProps) => {
 
 	// Localized tooltip text.
 	const tooltipText = nls.localize(
-		'positronDataGrid.resetScrollPosition',
-		'Reset scroll position to top-left'
+		'positronDataGrid.scrollToTopLeft',
+		'Scroll to top-left'
 	);
 
 	// Render.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridScrollbarCorner.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridScrollbarCorner.tsx
@@ -7,9 +7,10 @@
 import './dataGridScrollbarCorner.css';
 
 // React.
-import React from 'react';
+import React, { useRef } from 'react';
 
 // Other dependencies.
+import * as nls from '../../../../nls.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
 
 /**
@@ -28,15 +29,31 @@ export const DataGridScrollbarCorner = (props: DataGridScrollbarCornerProps) => 
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
+	// Ref for hover tooltip.
+	const containerRef = useRef<HTMLDivElement>(undefined!);
+
+	// Get hover manager from the instance.
+	const hoverManager = context.instance.hoverManager;
+
+	// Localized tooltip text.
+	const tooltipText = nls.localize(
+		'positronDataGrid.scrollToBottomRight',
+		'Scroll to bottom-right'
+	);
+
 	// Render.
 	return (
 		<div
+			ref={containerRef}
 			className='data-grid-scrollbar-corner'
 			style={{
 				width: context.instance.scrollbarThickness,
 				height: context.instance.scrollbarThickness
 			}}
+			title={!hoverManager ? tooltipText : undefined}
 			onClick={props.onClick}
+			onMouseLeave={hoverManager ? () => hoverManager.hideHover() : undefined}
+			onMouseOver={hoverManager ? () => hoverManager.showHover(containerRef.current, tooltipText) : undefined}
 		/>
 	);
 };

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -48,9 +48,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	private readonly _onAddFilterEmitter = this._register(new Emitter<ColumnSchema>);
 
 	/**
-	 * The cell hover manager with longer delay for data cell tooltips.
+	 * The hover manager for data cell tooltips and corner reset button.
 	 */
-	private readonly _cellHoverManager: PositronActionBarHoverManager;
+	private readonly _hoverManager: PositronActionBarHoverManager;
 
 	//#endregion Private Properties
 
@@ -90,8 +90,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			cursorOffset: 0.5,
 		});
 
-		this._cellHoverManager = this._register(new PositronActionBarHoverManager(false, this._services.configurationService, this._services.hoverService));
-		this._cellHoverManager.setCustomHoverDelay(500);
+		this._hoverManager = this._register(new PositronActionBarHoverManager(false, this._services.configurationService, this._services.hoverService));
+		this._hoverManager.setCustomHoverDelay(500);
 
 		/**
 		 * Updates the layout entries.
@@ -301,11 +301,10 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @returns The cell value.
 	 */
 	/**
-	 * Gets the cell hover manager.
-	 * @returns The cell hover manager.
+	 * Override base class to provide hover manager.
 	 */
-	get cellHoverManager(): PositronActionBarHoverManager {
-		return this._cellHoverManager;
+	override get hoverManager(): PositronActionBarHoverManager {
+		return this._hoverManager;
 	}
 
 	/**
@@ -332,7 +331,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			<TableDataCell
 				column={column}
 				dataCell={dataCell}
-				hoverManager={this._cellHoverManager}
+				hoverManager={this._hoverManager}
 			/>
 		);
 	}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -304,7 +304,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	/**
 	 * Gets the hover manager.
 	 */
-	get hoverManager() {
+	override get hoverManager() {
 		return this._hoverManager;
 	}
 


### PR DESCRIPTION
Related to #8935, this adds a tooltip for the top-left corner square that explains that clicking it resets the scroll position to the beginning / top-left. Otherwise it just shows a pointer without being clear what the function is (and if you click it when the scroll position is already (0, 0), it appears to do nothing)

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add tooltips to Data Explorer top-left and bottom-right corner square buttons to clarify these quick-scrolling behaviors.

#### Bug Fixes

- N/A

@:data-explorer