### PR TITLE
Basic inline completions in notebooks

### DIFF
--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -190,7 +190,7 @@ class OpenAILegacyCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -386,7 +386,7 @@ abstract class FimPromptCompletion extends CompletionModel {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 
@@ -648,7 +648,7 @@ export class CopilotCompletion implements vscode.InlineCompletionItemProvider {
 		token: vscode.CancellationToken
 	): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined> {
 		// Check if the file should be excluded from AI features
-		if (await positron.ai.areCompletionsEnabled(document.uri)) {
+		if (!await positron.ai.areCompletionsEnabled(document.uri)) {
 			return [];
 		}
 		return await this._copilotService.inlineCompletion(document, position, context, token);

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2152,10 +2152,10 @@ declare module 'positron' {
 		}
 
 		/**
-		 * Checks the file for exclusion from AI completion.
-		 * @param file The file to check for exclusion.
-		 * @returns A Thenable that resolves to true if the file should be excluded, false otherwise.
+		 * Checks if completions are enabled for the given file.
+		 * @param uri The file URI to check if completions are enabled.
+		 * @returns A Thenable that resolves to true if completions should be enabled for the file, false otherwise.
 		 */
-		export function areCompletionsEnabled(file: vscode.Uri): Thenable<boolean>;
+		export function areCompletionsEnabled(uri: vscode.Uri): Thenable<boolean>;
 	}
 }

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -116,7 +116,7 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	}
 
 	/**
-	 * Check if a file should be excluded from AI completions based on configuration settings.
+	 * Check if a file should be enabled for AI completions based on configuration settings.
 	 */
 	async $areCompletionsEnabled(file: UriComponents): Promise<boolean> {
 		const uri = URI.revive(file);

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -106,17 +106,17 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 		const globPattern = this._configurationService.getValue<string[]>('positron.assistant.inlineCompletionExcludes');
 
 		if (!globPattern || globPattern.length === 0) {
-			return false; // No glob patterns configured, so no files are excluded
+			return true; // No glob patterns configured, so completions are enabled
 		}
 
-		// Check all of the glob patterns and return true if any match
+		// Check all of the glob patterns and return false if any match
 		for (const pattern of globPattern) {
 			if (glob.match(pattern, uri.path)) {
-				return true; // File matches an exclusion pattern
+				return false; // File matches an exclusion pattern, so it is excluded from completions
 			}
 		}
 
-		return false; // No patterns matched, so the file is not excluded
+		return true; // No patterns matched, so completions are enabled
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -124,9 +124,9 @@ export interface IPositronAssistantService {
 	removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 
 	/**
-	 * Check if a file should be excluded from AI completions.
-	 * @param uri The URI of the file to check.
-	 * @returns True if the file should be excluded from the Positron Assistant, false otherwise.
+	 * Checks if completions are enabled for the given file.
+	 * @param uri The file URI to check if completions are enabled.
+	 * @returns true if completions should be enabled for the file, false otherwise.
 	 */
 	areCompletionsEnabled(uri: URI): boolean;
 


### PR DESCRIPTION
This PR continues @sharon-wang's work in https://github.com/posit-dev/positron/pull/8498 to add basic inline completions in notebooks (https://github.com/posit-dev/positron/issues/8061), which also works by default in Positron notebooks (#8734).

The Copilot language server advertises that it supports notebooks (in the initialize result) which causes vscode-languageclient to send notebookDocument/did* notifications instead of textDocument/did* notifications. Servers are expected to create the text documents referenced in the notebook document, however, the Copilot server
doesn't seem to do that, causing "document not found" errors.

This PR adds language client middleware that intercepts notebookDocument/did* notifications and sends textDocument/did* notifications for each affected cell.

The current implementation treats each cell independently, so the server will be aware of all cells in a notebook, but not
their structure, kind, outputs, etc.

### Release Notes

#### New Features

- Assistant: Copilot inline completions are now available in Jupyter notebooks

#### Bug Fixes

- N/A


### QA Notes

via @sharon-wang:

@:assistant

* inline completions should be available for ipynb files when authenticated with GitHub Copilot
* the `positron.assistant.inlineCompletionExcludes` setting should continue to work