### PR TITLE
Add Claude Code hook to auto-format TS/JS code and fix eslint issues

### DIFF
--- a/.claude/hooks/format-hook.sh
+++ b/.claude/hooks/format-hook.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Claude Code hook script for auto-formatting Positron code
+# This script runs after file edits to ensure consistent formatting
+
+set -e
+
+# Read JSON data from stdin
+HOOK_DATA=$(cat)
+
+# Get the file path from Claude's JSON input
+FILE_PATH=$(echo "$HOOK_DATA" | jq -r '.tool_input.file_path // empty')
+
+# Exit if no file path provided
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Check if file is a TypeScript/JavaScript file
+if [[ ! "$FILE_PATH" =~ \.(ts|tsx|js|jsx|mjs|cjs)$ ]]; then
+    exit 0
+fi
+
+# Change to project directory
+cd "$CLAUDE_PROJECT_DIR"
+
+# Check if file exists
+if [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+echo "🔧 Auto-formatting: $FILE_PATH"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Step 1: Run ESLint with auto-fix
+echo "📋 Running ESLint..."
+if npx eslint --fix "$FILE_PATH" 2>&1; then
+    echo "✓ ESLint completed"
+else
+    echo "⚠️  ESLint reported issues (may have auto-fixed some)"
+fi
+
+# Step 2: Run TypeScript formatter
+echo ""
+echo "📐 Running TypeScript formatter..."
+if node scripts/format.js "$FILE_PATH" 2>&1; then
+    echo "✓ TypeScript formatter completed"
+else
+    echo "⚠️  TypeScript formatter encountered issues"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Formatting complete for: $(basename "$FILE_PATH")"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Edit|MultiEdit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format-hook.sh"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ product.overrides.json
 # Ignore Claude local/personal files but keep commands
 .claude/*
 !.claude/commands/
+!.claude/hooks/
+!.claude/settings.json
+
 .Rproj.user
 /playwright-report/
 /blob-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,26 +46,11 @@ timeout /t 10 /nobreak >nul && tasklist | findstr /i "positron electron"
 npm test
 ```
 
-### Code Formatting
+### Code Formatting & Linting
 
 **🚨 CRITICAL: DO NOT USE PRETTIER**
 
 Positron uses VSCode's built-in TypeScript formatter, not Prettier. Using Prettier will create formatting conflicts that are very difficult to resolve.
-
-**Correct way to format files:**
-```bash
-# Format specific TypeScript/JavaScript files using the project's formatter script
-node scripts/format.js <file1> [file2] [file3] ...
-
-# Examples:
-node scripts/format.js src/vs/workbench/contrib/positronDataExplorer/browser/positronDataExplorer.tsx
-node scripts/format.js src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
-
-# Format multiple files at once:
-node scripts/format.js file1.ts file2.tsx file3.js
-```
-
-**This script uses TypeScript's built-in formatter - the exact same formatter used by the pre-commit hook.**
 
 **Project formatting rules:**
 - Uses **tabs** (not spaces)  
@@ -74,12 +59,30 @@ node scripts/format.js file1.ts file2.tsx file3.js
 - VSCode's TypeScript formatter handles all formatting
 - ESLint with `@stylistic/eslint-plugin-ts` provides additional style rules
 
+**CRITICAL: After making any code changes, you MUST run both commands:**
+```bash
+# 1. Fix ESLint errors (JSX prop sorting, style issues, etc.)
+npx eslint --fix <file_path>
+
+# 2. Format with project's TypeScript formatter (matches pre-commit hook)
+node scripts/format.js <file_path>
+
+# 3. Verify compilation succeeds in build daemon
+```
+
+**Examples:**
+```bash
+npx eslint --fix src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+node scripts/format.js src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+
+# Format multiple files at once:
+node scripts/format.js file1.ts file2.tsx file3.js
+```
+
 **Never use:**
 - `prettier` or `npx prettier` commands
 - `npm run eslint` (runs on entire codebase, too broad)
 - Any other third-party formatters
-
-When editing files, format them with `node scripts/format.js <file_path>` to match the project's formatting standards exactly.
 
 ### Testing
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Positron is a next-generation data science IDE built on VS Code, designed for Py
 To work effectively on specific areas of Positron, ask Claude to include relevant context files:
 
 - **E2E Testing**: `Please read .claude/e2e-testing.md` - For working with Playwright end-to-end tests
-- **Extensions**: `Please read .claude/extensions.md` - For Positron-specific extensions development  
+- **Extensions**: `Please read .claude/extensions.md` - For Positron-specific extensions development
 - **Data Explorer**: `Please read .claude/data-explorer.md` - For data viewing and exploration features
 - **DuckDB Extension**: `Please read .claude/positron-duckdb.md` - For positron-duckdb extension development
 - **Console/REPL**: `Please read .claude/console.md` - For console and REPL functionality
@@ -48,41 +48,14 @@ npm test
 
 ### Code Formatting & Linting
 
-**🚨 CRITICAL: DO NOT USE PRETTIER**
+**AUTOMATIC FORMATTING ENABLED**
 
-Positron uses VSCode's built-in TypeScript formatter, not Prettier. Using Prettier will create formatting conflicts that are very difficult to resolve.
+This project has a Claude Code hook configured that automatically handles most code formatting after every file edit.
 
 **Project formatting rules:**
-- Uses **tabs** (not spaces)  
+- Uses **tabs** (not spaces)
 - Uses **single quotes**
 - Inserts final newlines
-- VSCode's TypeScript formatter handles all formatting
-- ESLint with `@stylistic/eslint-plugin-ts` provides additional style rules
-
-**CRITICAL: After making any code changes, you MUST run both commands:**
-```bash
-# 1. Fix ESLint errors (JSX prop sorting, style issues, etc.)
-npx eslint --fix <file_path>
-
-# 2. Format with project's TypeScript formatter (matches pre-commit hook)
-node scripts/format.js <file_path>
-
-# 3. Verify compilation succeeds in build daemon
-```
-
-**Examples:**
-```bash
-npx eslint --fix src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
-node scripts/format.js src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
-
-# Format multiple files at once:
-node scripts/format.js file1.ts file2.tsx file3.js
-```
-
-**Never use:**
-- `prettier` or `npx prettier` commands
-- `npm run eslint` (runs on entire codebase, too broad)
-- Any other third-party formatters
 
 ### Testing
 ```bash
@@ -140,7 +113,7 @@ When you must modify upstream VSCode files:
 
 #### Extensions
 - **Prefix:** Always start with `positron-`
-- **Style:** kebab-case after prefix  
+- **Style:** kebab-case after prefix
 - **Examples:** `positron-python`, `positron-connections`, `positron-run-app`
 
 #### Files and Components


### PR DESCRIPTION
Adds a Claude Code hook that automatically formats code after file edits to prevent formatting violations that commonly cause pre-commit failures.

### Summary

This PR implements an automatic code formatting hook that runs after every file edit in Claude Code. The hook applies the project's formatting standards (tabs, single quotes, final newlines) to prevent common formatting issues that cause pre-commit hook failures.

Paired with #9108 which adds documentation about manual eslint usage.