### PR TITLE
Plots: base64 render URIs now properly padded

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -12,6 +12,7 @@ import { PositronPlotCommProxy } from './positronPlotCommProxy.js';
 import { PlotSizingPolicyCustom } from '../../positronPlots/common/sizingPolicyCustom.js';
 import { DeferredRender, IRenderedPlot, RenderRequest } from './positronPlotRenderQueue.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { padBase64 } from './utils.js';
 
 export const FreezeSlowPlotsConfigKey = 'positron.plots.freezeSlowPlots';
 
@@ -195,7 +196,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			// The policy should normally be defined in a pre-render result but we
 			// check just in case
 			if (preRender.settings) {
-				const uri = `data:${preRender.mime_type};base64,${preRender.data}`;
+				const uri = `data:${preRender.mime_type};base64,${padBase64(preRender.data)}`;
 				this._lastRender = {
 					uri,
 					size: preRender.settings.size,

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
@@ -10,6 +10,7 @@ import { IPlotSize } from '../../positronPlots/common/sizingPolicy.js';
 import { ILanguageRuntimeSession } from '../../runtimeSession/common/runtimeSessionService.js';
 import { RuntimeState } from './languageRuntimeService.js';
 import { PlotRenderFormat, PositronPlotComm, IntrinsicSize } from './positronPlotComm.js';
+import { padBase64 } from './utils.js';
 
 /**
  * The type of operation being queued.
@@ -388,7 +389,7 @@ export class PositronPlotRenderQueue extends Disposable {
 					const renderTimeMs = finishedTime - startedTime;
 
 					// The server returned a rendered plot image; save it and resolve the promise
-					const uri = `data:${response.mime_type};base64,${this.padBase64(response.data)}`;
+					const uri = `data:${response.mime_type};base64,${padBase64(response.data)}`;
 					const renderResult: IRenderedPlot = {
 						size: operationRequest.size,
 						pixel_ratio: operationRequest.pixel_ratio!,
@@ -420,15 +421,6 @@ export class PositronPlotRenderQueue extends Disposable {
 			queuedOperation.operation.error(new Error(`Unknown operation type: ${operationRequest.type}`));
 			this._isProcessing = false;
 			this.processQueue();
-		}
-	}
-
-	private padBase64(base64: string): string {
-		const remainder = base64.length % 4;
-		if (remainder === 0) {
-			return base64; // No padding needed
-		} else {
-			return `${base64}${'='.repeat(4 - remainder)}`;
 		}
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/utils.ts
+++ b/src/vs/workbench/services/languageRuntime/common/utils.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pads a base64 string with the necessary padding characters.
+ * @param base64 The base64 string to pad.
+ * @returns The padded base64 string.
+ */
+export function padBase64(base64: string): string {
+	const remainder = base64.length % 4;
+	if (remainder === 0) {
+		return base64; // No padding needed
+	} else {
+		return `${base64}${'='.repeat(4 - remainder)}`;
+	}
+}


### PR DESCRIPTION
Certain circumstances (custom plot size seems to be a factor) caused Assistant to error out when referencing a plot. This was due to improperly padded base64 URIs being provided.

Plots logic was updated to pad these URIs in an additional spot. This seems to be the only other location that the URI is set.

Confirmed Assistant now handles custom-sized plots properly.

<img width="3120" height="1779" alt="Screenshot 2025-08-20 at 1 10 43 PM" src="https://github.com/user-attachments/assets/a98411ef-feff-4e40-9c78-b4de03788f4d" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #8755


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:assistant @:plots