### PR TITLE
Enable `getTableSummary` tool for R

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -27,8 +27,7 @@ results, generate the code and return it directly without trying to execute it.
 When the user asks questions that require detailed information about tabular
 data objects (DataFrames, arrays, matrices, etc.), use the `getTableSummary`
 tool to retrieve structured information such as data summaries and statistics.
-Currently, this tool is only available for Python so in R sessions you will need
-to execute code to query in-memory data.
+This tool is available in Python and R sessions.
 
 To use the tool effectively:
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -337,10 +337,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 							return available(inChatPane && (isEditMode || isAgentMode));
 						// Only include the getTableSummary tool for Python sessions until supported in R
 						case PositronAssistantToolName.GetTableSummary:
-							// TODO: Remove the python-specific restriction when the tool is supported in R https://github.com/posit-dev/positron/issues/8343
-							// The logic above with TOOL_TAG_REQUIRES_ACTIVE_SESSION will handle checking for active sessions once this is removed.
-							// We'll still want to check that variables are defined.
-							return available(activeSessions.has('python') && hasVariables);
+							return available(hasVariables);
 						// Only include the getPlot tool if there is a plot available.
 						case PositronAssistantToolName.GetPlot:
 							return available(positronContext.plots?.hasPlots === true);

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -315,7 +315,6 @@ export function registerAssistantTools(
 				]);
 			}
 
-			// temporarily only enable for Python sessions
 			let session: positron.LanguageRuntimeSession | undefined;
 			const sessions = await positron.runtime.getActiveSessions();
 			if (sessions && sessions.length > 0) {
@@ -329,7 +328,8 @@ export function registerAssistantTools(
 				]);
 			}
 
-			if (session.runtimeMetadata.languageId !== 'python') {
+			// Enable only for R and Python sessions
+			if (session.runtimeMetadata.languageId !== 'python' && session.runtimeMetadata.languageId !== 'r') {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart('[[]]')
 				]);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8343

Requires https://github.com/posit-dev/ark/pull/904

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron Assistant can now use the data summary tool for R objects (#8343).

#### Bug Fixes

- N/A


### QA Notes

With the flights data:

<img width="407" height="979" alt="Screenshot 2025-08-21 at 11 14 36" src="https://github.com/user-attachments/assets/2db203cb-f948-47e3-ab98-9525845bb22d" />


I've checked in the Assistant logs that the summaries returned by the tool are equivalent to those in Python.
