### PR TITLE
Claude Code: Better instructions for stopping build daemons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ timeout /t 10 /nobreak >nul && tasklist | findstr /i "positron electron"
 
 # Run tests
 npm test
+
+# Shutdown build daemons
+# On macOS/Linux:
+pkill -f "gulp watch-client" && pkill -f "gulp watch-extensions" && pkill -f "deemon" && pkill -f "npm run watch"
+# On Windows:
+taskkill /F /IM node.exe /FI "WINDOWTITLE eq *watch*"
 ```
 
 ### Code Formatting & Linting


### PR DESCRIPTION
Without these instructions, CC guesses wrong the first time when asked to shut down the build daemons. 