### PR TITLE
Mark internal positron extensions as private

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-code-cells/package.json
+++ b/extensions/positron-code-cells/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "publisher": "positron",
   "version": "0.0.1",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-ipywidgets/package.json
+++ b/extensions/positron-ipywidgets/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/extensions/positron-javascript/package.json
+++ b/extensions/positron-javascript/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-notebooks/package.json
+++ b/extensions/positron-notebooks/package.json
@@ -4,6 +4,7 @@
   "description": "Positron Notebook Helpers",
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-proxy/package.json
+++ b/extensions/positron-proxy/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.2",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-run-app/package.json
+++ b/extensions/positron-run-app/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-runtime-debugger/package.json
+++ b/extensions/positron-runtime-debugger/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "publisher": "positron",
   "version": "0.0.1",
+  "private": true,
   "engines": {
     "vscode": "^1.61.0"
   },

--- a/extensions/positron-viewer/package.json
+++ b/extensions/positron-viewer/package.json
@@ -7,6 +7,7 @@
   ],
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.70.0"
   },


### PR DESCRIPTION
The following positron built-in extensions aren't published to NPM as standalone extensions and are under the licensing terms of the repository. This marker does not stop them from being bundled into the product, but does control how they are handled by third-party dependency licensing scanning tools. Their dependencies will still be tracked, but they themselves will not be listed as independent components in their own right.
