### PR TITLE
Claude Code: Be a little more prescriptive about always checking that the build daemons are running

### DIFF
--- a/.claude/build-system.md
+++ b/.claude/build-system.md
@@ -1,6 +1,43 @@
 # Positron Build System & Development Workflows
 
-This prompt provides context for running Positron development workflows directly with Claude Code, bypassing the need for VSCode.
+## 🚨 CRITICAL: Always Check Build Daemons First!
+
+**NEVER launch Positron without ensuring build daemons are running!** 
+
+### Required Startup Sequence Every Time:
+
+1. **Check if daemons are already running:**
+```bash
+ps aux | grep -E "npm.*watch-(client|extensions|e2e)d" | grep -v grep
+```
+
+2. **If NOT running, start them (and wait for compilation):**
+```bash
+# Start required daemons
+npm run watch-clientd &      # Core compilation
+npm run watch-extensionsd &  # Extensions compilation
+
+# Wait for initial compilation (30-60 seconds)
+sleep 30
+
+# Look for "Finished compilation" messages before proceeding
+```
+
+3. **Only after daemons are confirmed running, launch Positron:**
+```bash
+./scripts/code.sh &
+```
+
+4. **Verify Positron launched successfully:**
+```bash
+sleep 10 && ps aux | grep -i "positron\|code" | grep -v grep
+```
+
+### Why This Matters:
+- Positron WILL crash if daemons aren't running
+- Extensions won't load without `watch-extensionsd`
+- Changes won't be reflected without active daemons
+- Initial compilation takes 30-60 seconds
 
 ## Core Development Workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ This is the main coordination file for Claude Code when working on Positron. Bas
 
 Positron is a next-generation data science IDE built on VS Code, designed for Python and R development with enhanced data science workflows.
 
+## 🚨 CRITICAL: Development Startup
+
+**ALWAYS read `.claude/build-system.md` before launching Positron!**
+This file contains critical instructions for ensuring build daemons are running. Never skip this step.
+
 ## Using Modular Prompts
 
 To work effectively on specific areas of Positron, ask Claude to include relevant context files:
@@ -25,24 +30,30 @@ To work effectively on specific areas of Positron, ask Claude to include relevan
 
 ### Development
 ```bash
-# Start build daemons for development (CRITICAL: Wait for completion before launching!)
-npm run watch-clientd     # Core compilation daemon
-npm run watch-extensionsd # Extensions compilation daemon
-npm run watch-e2ed        # E2E tests compilation daemon (if doing E2E testing)
+# STEP 1: Check if daemons are already running
+ps aux | grep -E "npm.*watch-(client|extensions|e2e)d" | grep -v grep
 
-# Launch Positron (only after build daemons complete)
+# STEP 2: If NOT running, start build daemons (CRITICAL: Wait for completion!)
+npm run watch-clientd &     # Core compilation daemon
+npm run watch-extensionsd & # Extensions compilation daemon
+# Optional: npm run watch-e2ed & # E2E tests daemon (only if doing E2E testing)
+
+# STEP 3: Wait for initial compilation (30-60 seconds)
+sleep 30
+
+# STEP 4: Launch Positron (ONLY after daemons are confirmed running)
 # On macOS/Linux:
 ./scripts/code.sh &
 # On Windows:
 start ./scripts/code.bat
 
-# Check after 5-10 seconds that Positron launched successfully
+# STEP 5: Verify Positron launched successfully
 # On macOS/Linux:
 sleep 10 && ps aux | grep -i "positron\|code" | grep -v grep
 # On Windows:
 timeout /t 10 /nobreak >nul && tasklist | findstr /i "positron electron"
 
-# Run tests
+# Run tests (after Positron is running)
 npm test
 ```
 


### PR DESCRIPTION
I ran into a scenario where I asked "launch Positron" and it ran the `code.sh` script without checking that the build daemons are running. This makes it less likely (though perhaps not impossible) that it will make this mistake. 