### PR TITLE
Data Explorer: Implement native Polars histogram 

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
@@ -303,8 +303,7 @@ def _get_histogram_polars(
         # Ensure the last edge exactly matches max_val to avoid floating point issues
         bin_edges[-1] = max_val
 
-    # Compute bin indices for each value using efficient vectorized operations
-    # This is O(N) instead of O(N * K)
+    # Compute bin indices for each value using efficient vectorized operations and group_by
 
     # Handle edge case: if only one bin edge (degenerate case)
     if len(bin_edges) <= 1:

--- a/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
@@ -1,0 +1,364 @@
+"""
+Internal utilities for the Data Explorer.
+
+This module provides implementations of data analysis functions for both
+NumPy and Polars to handle cases where one or the other may not be available.
+"""
+
+import math
+from typing import Tuple, Union, Optional, Any
+import warnings
+
+# Constants
+_EMPTY_HISTOGRAM = ([], [0.0, 1.0])
+
+
+def _is_polars_integer_type(dtype) -> bool:
+    """Check if a Polars dtype is an integer type."""
+    import polars as pl
+
+    return dtype in [
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+    ]
+
+
+def _calculate_sqrt_fallback_binwidth(data_range: float, n: int) -> float:
+    """Calculate fallback bin width using sqrt method."""
+    return data_range / math.sqrt(n) if n > 0 else data_range
+
+
+def _calculate_fd_binwidth(data, data_range: float, n: int) -> float:
+    """Calculate Freedman-Diaconis bin width with sqrt fallback."""
+    q75 = data.quantile(0.75)
+    q25 = data.quantile(0.25)
+    iqr = q75 - q25
+    if iqr > 0:
+        return 2.0 * iqr * (n ** (-1.0 / 3.0))
+    else:
+        return _calculate_sqrt_fallback_binwidth(data_range, n)
+
+
+def _get_histogram_method(method):
+    """Convert histogram method enum to string."""
+    from .data_explorer_comm import ColumnHistogramParamsMethod
+
+    return {
+        ColumnHistogramParamsMethod.Fixed: "fixed",
+        ColumnHistogramParamsMethod.Sturges: "sturges",
+        ColumnHistogramParamsMethod.FreedmanDiaconis: "fd",
+        ColumnHistogramParamsMethod.Scott: "scott",
+    }[method]
+
+
+def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
+    """
+    Compute histogram using NumPy.
+
+    This is the original implementation that requires NumPy to be installed.
+    """
+    try:
+        import numpy as np
+    except ModuleNotFoundError as e:
+        # If NumPy is not installed, we cannot compute histograms
+        warnings.warn(
+            "Numpy not installed, histogram computation will not work. "
+            "Please install NumPy to enable this feature.",
+            stacklevel=1,
+        )
+        raise e
+
+    if to_numpy:
+        data = data.to_numpy()
+
+    assert num_bins is not None
+    hist_params = {"bins": num_bins} if method == "fixed" else {"bins": method}
+
+    if data.dtype == object:
+        # For decimals, we convert to float which is lossy but works for now
+        return _get_histogram_numpy(data.astype(float), num_bins, method=method)
+
+    # We optimistically compute the histogram once, and then do extra
+    # work in the special cases where the binning method produces a
+    # finer-grained histogram than the maximum number of bins that we
+    # want to render, as indicated by the num_bins argument
+    try:
+        bin_counts, bin_edges = np.histogram(data, **hist_params)
+    except ValueError:
+        if issubclass(data.dtype.type, np.integer):
+            # Issue #5176. There is a class of error for integers where np.histogram
+            # will fail on Windows (platform int issue), e.g. this array fails with Numpy 2.1.1
+            # array([ -428566661,  1901704889,   957355142,  -401364305, -1978594834,
+            #         519144975,  1384373326,  1974689646,   194821408, -1564699930],
+            #         dtype=int32)
+            # So we try again with the data converted to floating point as a fallback
+            return _get_histogram_numpy(data.astype(np.float64), num_bins, method=method)
+
+        # If there are inf/-inf values in the dataset, ValueError is
+        # raised. We catch it and try again to avoid paying the
+        # filtering cost every time
+        data = data[np.isfinite(data)]
+        bin_counts, bin_edges = np.histogram(data, **hist_params)
+
+    need_recompute = False
+
+    # If the method returns more bins than what the front-end requested,
+    # we re-define the bin edges.
+    if len(bin_edges) > num_bins:
+        hist_params = {"bins": num_bins}
+        need_recompute = True
+
+    # For integers, we want to make sure the number of bins is smaller
+    # then than `data.max() - data.min()`, so we don't endup with more bins
+    # then there's data to display.
+    # hist_params = {"bins": bin_edges.tolist()}
+    if issubclass(data.dtype.type, np.integer):
+        # Avoid overflows with smaller integers
+        width = (data.max().astype(np.int64) - data.min().astype(np.int64)).item()
+        if len(bin_edges) > width and width > 0:
+            hist_params = {"bins": width + 1}
+            need_recompute = True
+
+    if need_recompute:
+        bin_counts, bin_edges = np.histogram(data, **hist_params)
+
+    # Special case: if we have a single bin, check if all values are the same
+    # If so, override the bin edges to be the same value instead of value +/- 0.5
+    if len(bin_counts) == 1 and len(data) > 0:
+        # Check if all non-null values are the same
+        unique_values = np.unique(data)
+        if len(unique_values) == 1:
+            # All values are the same, set bin edges to [value, value]
+            bin_edges = np.array([unique_values[0], unique_values[0]])
+
+    return bin_counts, bin_edges
+
+
+def _get_histogram_polars(
+    data: "pl.Series", num_bins: int, method: str = "fd"
+) -> Tuple[list, list]:
+    """
+    Compute histogram using Polars operations instead of NumPy.
+
+    This function provides consistent behavior with NumPy's histogram function
+    but uses Polars for computation when NumPy is not available.
+
+    Parameters
+    ----------
+    data : pl.Series
+        Input data as a Polars Series
+    num_bins : int
+        Maximum number of bins to use
+    method : str
+        Binning method: 'fixed', 'fd', 'sturges', 'auto', 'scott', 'rice', 'sqrt', 'doane'
+
+    Returns
+    -------
+    bin_counts : list
+        The counts for each bin
+    bin_edges : list
+        The edges of the bins (length = len(bin_counts) + 1)
+    """
+    import polars as pl
+
+    # Convert to Polars Series if needed
+    if not isinstance(data, pl.Series):
+        data = pl.Series(data)
+
+    # Handle object dtype (like Decimals) by converting to float
+    if data.dtype == pl.Object:
+        # For decimals and other objects, convert to float which is lossy but works for now
+        try:
+
+            def safe_float_convert(val):
+                if val is None:
+                    return None
+                try:
+                    return float(val)
+                except (ValueError, TypeError):
+                    return None
+
+            data = data.map_elements(safe_float_convert, return_dtype=pl.Float64)
+        except Exception:
+            # If conversion fails, return empty histogram
+            return _EMPTY_HISTOGRAM
+
+    # Remove null values
+    data = data.drop_nulls()
+
+    if len(data) == 0:
+        # Return empty histogram for empty data
+        return _EMPTY_HISTOGRAM
+
+    # Filter out infinite values
+    if data.dtype in [pl.Float32, pl.Float64]:
+        data = data.filter(data.is_finite())
+        if len(data) == 0:
+            return _EMPTY_HISTOGRAM
+
+    # Get data statistics
+    min_val = data.min()
+    max_val = data.max()
+
+    # Handle single value case
+    if min_val == max_val:
+        # All values are the same
+        return [len(data)], [min_val, min_val]
+
+    # Calculate optimal number of bins based on method
+    n = len(data)
+    data_range = max_val - min_val
+
+    if method == "fixed":
+        n_bins = num_bins
+    else:
+        # Calculate bin width based on method
+        if method == "fd":  # Freedman-Diaconis
+            bin_width = _calculate_fd_binwidth(data, data_range, n)
+        elif method == "sturges":
+            n_bins_sturges = math.ceil(math.log2(n)) + 1
+            bin_width = data_range / n_bins_sturges
+        elif method == "scott":
+            std_dev = data.std()
+            if std_dev > 0:
+                bin_width = 3.5 * std_dev * (n ** (-1.0 / 3.0))
+            else:
+                bin_width = _calculate_sqrt_fallback_binwidth(data_range, n)
+        elif method == "rice":
+            n_bins_rice = math.ceil(2 * (n ** (1.0 / 3.0)))
+            bin_width = data_range / n_bins_rice
+        elif method == "sqrt":
+            n_bins_sqrt = math.ceil(math.sqrt(n))
+            bin_width = data_range / n_bins_sqrt
+        elif method == "doane":
+            # Doane's method accounts for skewness
+            # g1 = skewness
+            mean_val = data.mean()
+            std_dev = data.std()
+            if std_dev > 0:
+                # Calculate skewness manually
+                centered = (data - mean_val) / std_dev
+                g1 = (centered**3).mean()
+                # Standard error of skewness
+                sg1 = math.sqrt(6.0 * (n - 2) / ((n + 1) * (n + 3)))
+                if sg1 > 0:
+                    k = 1 + math.log2(n) + math.log2(1 + abs(g1) / sg1)
+                else:
+                    k = 1 + math.log2(n)
+            else:
+                k = 1 + math.log2(n)
+            n_bins_doane = math.ceil(k)
+            bin_width = data_range / n_bins_doane
+        elif method == "auto":
+            # Use minimum of FD and Sturges (with sqrt correction for FD)
+            # FD with correction
+            fd_bw = _calculate_fd_binwidth(data, data_range, n)
+            sqrt_bw = _calculate_sqrt_fallback_binwidth(data_range, n)
+            fd_bw_corrected = max(fd_bw, sqrt_bw / 2)
+
+            # Sturges
+            n_bins_sturges = math.ceil(math.log2(n)) + 1
+            sturges_bw = data_range / n_bins_sturges
+
+            bin_width = min(fd_bw_corrected, sturges_bw)
+        else:
+            raise ValueError(f"Unknown binning method: {method}")
+
+        # Calculate number of bins from bin width
+        if bin_width > 0:
+            n_bins = math.ceil(data_range / bin_width)
+        else:
+            n_bins = 1
+
+    # Limit to maximum number of bins
+    n_bins = min(n_bins, num_bins)
+
+    # For integer data, ensure bins don't exceed the integer range
+    if _is_polars_integer_type(data.dtype):
+        # Ensure we don't have more bins than the integer range
+        int_range = int(max_val - min_val)
+        if int_range > 0 and n_bins > int_range:
+            n_bins = min(n_bins, int_range + 1)
+
+    # Ensure at least 1 bin
+    n_bins = max(1, n_bins)
+
+    # Create bin edges
+    if n_bins == 1:
+        # Single bin case
+        if min_val == max_val:
+            bin_edges = [min_val, min_val]
+        else:
+            bin_edges = [min_val, max_val]
+    else:
+        # Create evenly spaced bins
+        bin_width = (max_val - min_val) / n_bins
+        bin_edges = [min_val + i * bin_width for i in range(n_bins + 1)]
+        # Ensure the last edge exactly matches max_val to avoid floating point issues
+        bin_edges[-1] = max_val
+
+    # Compute bin indices for each value using efficient vectorized operations
+    # This is O(N) instead of O(N * K)
+
+    # Handle edge case: if only one bin edge (degenerate case)
+    if len(bin_edges) <= 1:
+        bin_counts = []
+    elif len(bin_edges) == 2:
+        # Single bin case
+        bin_counts = [len(data)]
+    else:
+        # Compute bin width for uniform bins
+        bin_width = (bin_edges[-1] - bin_edges[0]) / (len(bin_edges) - 1)
+
+        # Create a DataFrame to work with expressions and compute bin indices in one step
+        max_bin_idx = len(bin_edges) - 2  # Last valid bin index
+
+        df_for_groupby = pl.DataFrame({"value": data}).with_columns(
+            [
+                # Compute bin indices: (value - min_edge) / bin_width, then handle edge cases
+                pl.when(pl.col("value") >= bin_edges[-1])
+                .then(pl.lit(max_bin_idx))  # Values at max edge go in last bin
+                .otherwise(
+                    ((pl.col("value") - bin_edges[0]) / bin_width)
+                    .floor()
+                    .cast(pl.Int32)
+                    .clip(0, max_bin_idx)  # Clip out-of-bounds indices
+                )
+                .alias("bin_idx")
+            ]
+        )
+
+        # Use groupby to count efficiently - O(N log N) or better
+        bin_counts_df = (
+            df_for_groupby.group_by("bin_idx")
+            .agg(pl.col("value").count().alias("count"))
+            .sort("bin_idx")
+        )
+
+        # Convert to the final bin_counts list, filling in zeros for missing bins
+        observed_bins = bin_counts_df["bin_idx"].to_list()
+        observed_counts = bin_counts_df["count"].to_list()
+
+        # Create the final bin_counts array with zeros for unobserved bins
+        bin_counts = [0] * (len(bin_edges) - 1)
+        for bin_idx, count in zip(observed_bins, observed_counts):
+            if 0 <= bin_idx < len(bin_counts):  # Safety check
+                bin_counts[bin_idx] = count
+
+    # Special case: if we have a single bin, check if all values are the same
+    # If so, override the bin edges to be the same value instead of value +/- 0.5
+    if len(bin_counts) == 1 and len(data) > 0:
+        # Check if all non-null values are the same
+        unique_count = data.n_unique()
+        if unique_count == 1:
+            # All values are the same, set bin edges to [value, value]
+            unique_value = data[0]  # Get the single unique value
+            bin_edges = [unique_value, unique_value]
+
+    return bin_counts, bin_edges

--- a/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
@@ -281,7 +281,6 @@ def _get_histogram_polars(
 
             # Use integer division with careful rounding
             range_int = max_int - min_int
-            bin_width_exact = range_int / n_bins  # This gives exact division
 
             # Create bin edges using integer arithmetic where possible
             bin_edges = []

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -25,6 +25,11 @@ import comm
 
 from .access_keys import decode_access_key
 from .convert import PandasConverter, PolarsConverter
+from ._data_explorer_internal import (
+    _get_histogram_numpy,
+    _get_histogram_polars,
+    _get_histogram_method,
+)
 from .data_explorer_comm import (
     ArraySelection,
     BackendState,
@@ -2009,95 +2014,6 @@ COMPARE_OPS = {
 }
 
 
-def _get_histogram_method(method: ColumnHistogramParamsMethod):
-    return {
-        ColumnHistogramParamsMethod.Fixed: "fixed",
-        ColumnHistogramParamsMethod.Sturges: "sturges",
-        ColumnHistogramParamsMethod.FreedmanDiaconis: "fd",
-        ColumnHistogramParamsMethod.Scott: "scott",
-    }[method]
-
-
-def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
-    try:
-        import numpy as np
-    except ModuleNotFoundError as e:
-        # If NumPy is not installed, we cannot compute histograms
-        # intentionally printing since errors will not show up in the console
-        warnings.warn(
-            "Numpy not installed, histogram computation will not work. "
-            "Please install NumPy to enable this feature.",
-            category=DataExplorerWarning,
-            stacklevel=1,
-        )
-        raise e
-
-    if to_numpy:
-        data = data.to_numpy()
-
-    assert num_bins is not None
-    hist_params = {"bins": num_bins} if method == "fixed" else {"bins": method}
-
-    if data.dtype == object:
-        # For decimals, we convert to float which is lossy but works for now
-        return _get_histogram_numpy(data.astype(float), num_bins, method=method)
-
-    # We optimistically compute the histogram once, and then do extra
-    # work in the special cases where the binning method produces a
-    # finer-grained histogram than the maximum number of bins that we
-    # want to render, as indicated by the num_bins argument
-    try:
-        bin_counts, bin_edges = np.histogram(data, **hist_params)
-    except ValueError:
-        if issubclass(data.dtype.type, np.integer):
-            # Issue #5176. There is a class of error for integers where np.histogram
-            # will fail on Windows (platform int issue), e.g. this array fails with Numpy 2.1.1
-            # array([ -428566661,  1901704889,   957355142,  -401364305, -1978594834,
-            #         519144975,  1384373326,  1974689646,   194821408, -1564699930],
-            #         dtype=int32)
-            # So we try again with the data converted to floating point as a fallback
-            return _get_histogram_numpy(data.astype(np.float64), num_bins, method=method)
-
-        # If there are inf/-inf values in the dataset, ValueError is
-        # raised. We catch it and try again to avoid paying the
-        # filtering cost every time
-        data = data[np.isfinite(data)]
-        bin_counts, bin_edges = np.histogram(data, **hist_params)
-
-    need_recompute = False
-
-    # If the method returns more bins than what the front-end requested,
-    # we re-define the bin edges.
-    if len(bin_edges) > num_bins:
-        hist_params = {"bins": num_bins}
-        need_recompute = True
-
-    # For integers, we want to make sure the number of bins is smaller
-    # then than `data.max() - data.min()`, so we don't endup with more bins
-    # then there's data to display.
-    # hist_params = {"bins": bin_edges.tolist()}
-    if issubclass(data.dtype.type, np.integer):
-        # Avoid overflows with smaller integers
-        width = (data.max().astype(np.int64) - data.min().astype(np.int64)).item()
-        if len(bin_edges) > width and width > 0:
-            hist_params = {"bins": width + 1}
-            need_recompute = True
-
-    if need_recompute:
-        bin_counts, bin_edges = np.histogram(data, **hist_params)
-
-    # Special case: if we have a single bin, check if all values are the same
-    # If so, override the bin edges to be the same value instead of value +/- 0.5
-    if len(bin_counts) == 1 and len(data) > 0:
-        # Check if all non-null values are the same
-        unique_values = np.unique(data)
-        if len(unique_values) == 1:
-            # All values are the same, set bin edges to [value, value]
-            bin_edges = np.array([unique_values[0], unique_values[0]])
-
-    return bin_counts, bin_edges
-
-
 def _date_median(x):
     """
     Computes the median of a date or datetime series.
@@ -2824,9 +2740,8 @@ class PolarsView(DataExplorerTableView):
 
         method = _get_histogram_method(params.method)
 
-        bin_counts, bin_edges = _get_histogram_numpy(
-            data, params.num_bins, method=method, to_numpy=True
-        )
+        # Always use the Polars implementation for PolarsView
+        bin_counts, bin_edges = _get_histogram_polars(data, params.num_bins, method=method)
         bin_edges = pl.Series(bin_edges)
 
         if cast_bin_edges:

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 import math
 import operator
-import warnings
 from datetime import datetime
 from decimal import Decimal
 from types import MappingProxyType
@@ -23,13 +22,13 @@ from typing import (
 
 import comm
 
-from .access_keys import decode_access_key
-from .convert import PandasConverter, PolarsConverter
 from ._data_explorer_internal import (
+    _get_histogram_method,
     _get_histogram_numpy,
     _get_histogram_polars,
-    _get_histogram_method,
 )
+from .access_keys import decode_access_key
+from .convert import PandasConverter, PolarsConverter
 from .data_explorer_comm import (
     ArraySelection,
     BackendState,
@@ -42,7 +41,6 @@ from .data_explorer_comm import (
     ColumnFrequencyTableParams,
     ColumnHistogram,
     ColumnHistogramParams,
-    ColumnHistogramParamsMethod,
     ColumnProfileResult,
     ColumnProfileSpec,
     ColumnProfileType,

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for _data_explorer_internal.py
+
+Tests the Polars-based histogram implementation and verifies consistency
+with NumPy implementation across various data types and edge cases.
+"""
+
+import math
+import pytest
+import polars as pl
+from positron._data_explorer_internal import (
+    _get_histogram_polars,
+    _get_histogram_numpy,
+    _get_histogram_method,
+)
+
+
+def _assert_histogram_valid(data, bin_counts, bin_edges):
+    """Helper function to validate basic histogram properties."""
+    assert len(bin_edges) == len(bin_counts) + 1
+    assert sum(bin_counts) == len(data)
+
+    # Check bins are ordered
+    for i in range(len(bin_edges) - 1):
+        assert bin_edges[i] <= bin_edges[i + 1]
+
+
+def _get_test_histogram(data_values, num_bins=10, method="fixed", dtype=None):
+    """Helper function to create test data and get histogram."""
+    data = pl.Series(data_values, dtype=dtype) if dtype else pl.Series(data_values)
+    return _get_histogram_polars(data, num_bins=num_bins, method=method)
+
+
+def test_histogram_polars_basic():
+    """Test basic histogram functionality with Polars."""
+    # Simple integer data
+    data_values = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
+    bin_counts, bin_edges = _get_test_histogram(data_values, num_bins=4)
+
+    assert len(bin_counts) == 4
+    assert len(bin_edges) == 5
+    assert sum(bin_counts) == len(data_values)
+    assert bin_edges[0] == 1
+    assert bin_edges[-1] == 4
+
+
+def test_histogram_polars_empty_data():
+    """Test histogram with empty data."""
+    bin_counts, bin_edges = _get_test_histogram([], dtype=pl.Float64)
+
+    assert len(bin_counts) == 0
+    assert bin_edges == [0.0, 1.0]
+
+
+def test_histogram_polars_single_value():
+    """Test histogram with all identical values."""
+    bin_counts, bin_edges = _get_test_histogram([5.0] * 100)
+
+    assert len(bin_counts) == 1
+    assert bin_counts[0] == 100
+    assert bin_edges == [5.0, 5.0]
+
+
+def test_histogram_polars_single_bin_special_case():
+    """Test the single-bin special case where all values are the same."""
+    test_cases = [
+        ([42] * 10, 42),  # Integer
+        ([3.14] * 5, 3.14),  # Float
+        ([0] * 3, 0),  # Zero
+        ([-1.5] * 7, -1.5),  # Negative
+    ]
+
+    for values, expected_value in test_cases:
+        bin_counts, bin_edges = _get_test_histogram(values)
+
+        assert len(bin_counts) == 1, f"Expected 1 bin, got {len(bin_counts)} for {values}"
+        assert bin_counts[0] == len(values), f"Expected count {len(values)}, got {bin_counts[0]}"
+        assert bin_edges == [expected_value, expected_value], (
+            f"Expected edges [{expected_value}, {expected_value}], got {bin_edges}"
+        )
+
+
+def test_histogram_polars_with_nulls():
+    """Test histogram with null values."""
+    bin_counts, bin_edges = _get_test_histogram([1, 2, None, 3, None, 4, 5], num_bins=5)
+
+    # Nulls should be excluded
+    assert sum(bin_counts) == 5
+    assert bin_edges[0] == 1
+    assert bin_edges[-1] == 5
+
+
+def test_histogram_polars_with_inf():
+    """Test histogram with infinite values."""
+    data_with_inf = [1.0, 2.0, float("inf"), 3.0, float("-inf"), 4.0, 5.0]
+    bin_counts, bin_edges = _get_test_histogram(data_with_inf, num_bins=5)
+
+    # Infinities should be excluded
+    assert sum(bin_counts) == 5
+    assert bin_edges[0] == 1.0
+    assert bin_edges[-1] == 5.0
+
+
+def test_histogram_polars_integer_data():
+    """Test histogram with integer data."""
+    # Small integer range
+    data_values = [1, 1, 2, 2, 2, 3, 3, 3, 3]
+    bin_counts, bin_edges = _get_test_histogram(data_values, dtype=pl.Int32)
+
+    # Should not create more bins than the integer range
+    assert len(bin_counts) <= 3
+    assert sum(bin_counts) == 9
+
+
+def test_histogram_polars_methods():
+    """Test different binning methods."""
+    import numpy as np
+
+    # Generate some normally distributed data
+    np.random.seed(42)
+    data_values = np.random.randn(1000).tolist()
+
+    methods = ["fixed", "fd", "sturges", "scott", "rice", "sqrt", "doane", "auto"]
+
+    for method in methods:
+        bin_counts, bin_edges = _get_test_histogram(data_values, num_bins=50, method=method)
+        _assert_histogram_valid(data_values, bin_counts, bin_edges)
+
+        # Additional checks for method-specific behavior
+        data_series = pl.Series(data_values)
+        assert bin_edges[0] <= data_series.min()
+        assert bin_edges[-1] >= data_series.max()
+
+
+def test_histogram_consistency_with_numpy():
+    """Test that Polars and NumPy implementations produce similar results."""
+    import numpy as np
+
+    # Skip if NumPy is not available
+    pytest.importorskip("numpy")
+
+    # Test various data distributions
+    np.random.seed(42)
+    test_distributions = [
+        np.random.uniform(0, 10, 1000),  # Uniform distribution
+        np.random.randn(1000),  # Normal distribution
+        np.random.randint(0, 100, 500),  # Integer data
+        np.random.exponential(2, 800),  # Skewed data
+    ]
+
+    for values in test_distributions:
+        # Test with fixed bins
+        counts_pl, edges_pl = _get_test_histogram(values.tolist(), num_bins=20)
+        counts_np, edges_np = _get_histogram_numpy(values, num_bins=20, method="fixed")
+
+        # Check that results are very close
+        assert len(counts_pl) == len(counts_np)
+        assert len(edges_pl) == len(edges_np)
+
+        # Edge values should be very close
+        for i in range(len(edges_pl)):
+            assert abs(edges_pl[i] - edges_np[i]) < 1e-10
+
+        # Counts should match exactly for fixed bins
+        for i in range(len(counts_pl)):
+            assert counts_pl[i] == counts_np[i]
+
+
+def test_histogram_edge_cases():
+    """Test various edge cases."""
+    edge_cases = [
+        # Very small range
+        ([1.0, 1.0001, 1.0002], 3, None),
+        # Large integer values
+        ([1000000, 1000001, 1000002], 3, pl.Int64),
+        # Negative values
+        ([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], 11, None),
+    ]
+
+    for data_values, expected_count, dtype in edge_cases:
+        bin_counts, bin_edges = _get_test_histogram(
+            data_values, num_bins=len(data_values), dtype=dtype
+        )
+        assert sum(bin_counts) == expected_count
+
+    # Test specific edge boundaries
+    bin_counts, bin_edges = _get_test_histogram([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5])
+    assert bin_edges[0] == -5
+    assert bin_edges[-1] == 5
+
+
+def test_histogram_datetime_data():
+    """Test histogram with datetime data after casting."""
+    from datetime import datetime, timedelta
+
+    # Create datetime series
+    base = datetime(2024, 1, 1)
+    dates = [base + timedelta(days=i) for i in range(100)]
+    data = pl.Series(dates)
+
+    # Cast to int64 as done in PolarsView
+    data_int = data.cast(pl.Int64)
+    bin_counts, bin_edges = _get_histogram_polars(data_int, num_bins=10, method="fixed")
+
+    assert sum(bin_counts) == 100
+    assert len(bin_edges) == 11
+
+
+def test_histogram_categorical_error():
+    """Test that categorical data raises appropriate error or is handled."""
+    data = pl.Series(["A", "B", "C", "A", "B"], dtype=pl.Categorical)
+
+    # The histogram should not work with categorical data
+    from polars.exceptions import ComputeError
+
+    with pytest.raises((ValueError, TypeError, ComputeError)):
+        _get_histogram_polars(data, num_bins=5, method="fixed")
+
+
+def test_histogram_method_parameter():
+    """Test the _get_histogram_method helper function."""
+    from positron.data_explorer_comm import ColumnHistogramParamsMethod
+
+    method_mappings = [
+        (ColumnHistogramParamsMethod.Fixed, "fixed"),
+        (ColumnHistogramParamsMethod.Sturges, "sturges"),
+        (ColumnHistogramParamsMethod.FreedmanDiaconis, "fd"),
+        (ColumnHistogramParamsMethod.Scott, "scott"),
+    ]
+
+    for enum_value, expected_string in method_mappings:
+        assert _get_histogram_method(enum_value) == expected_string
+
+
+def test_histogram_polars_decimal_data():
+    """Test histogram with decimal/high precision data."""
+    from decimal import Decimal
+
+    # Polars handles Decimal as Float64
+    decimal_values = [Decimal("1.1"), Decimal("2.2"), Decimal("3.3")]
+    data = pl.Series(decimal_values).cast(pl.Float64)  # Cast as would be done in practice
+
+    bin_counts, bin_edges = _get_histogram_polars(data, num_bins=3, method="fixed")
+    assert sum(bin_counts) == 3
+
+
+def test_histogram_polars_performance():
+    """Test that Polars histogram performs well with large datasets."""
+    import time
+
+    # Large dataset
+    large_data = list(range(1000000))
+
+    start = time.time()
+    bin_counts, bin_edges = _get_test_histogram(large_data, num_bins=100)
+    elapsed = time.time() - start
+
+    # Should complete in reasonable time (< 1 second for 1M values)
+    assert elapsed < 1.0
+    assert sum(bin_counts) == 1000000
+
+
+def test_histogram_sparse_bins():
+    """Test histogram with data that doesn't fill all bins (zero-filling test)."""
+    # Data that will leave gaps in the histogram
+    sparse_data = [1, 1, 1, 9, 9, 9]  # Only uses first and last bins
+    bin_counts, bin_edges = _get_test_histogram(sparse_data, num_bins=5)
+
+    # Should have 5 bins with zeros in the middle
+    assert len(bin_counts) == 5
+    assert sum(bin_counts) == 6  # Total data points
+    assert bin_counts[0] > 0  # First bin has data
+    assert bin_counts[-1] > 0  # Last bin has data
+
+    # Middle bins should be zero (this tests the zero-filling logic)
+    middle_bins_sum = sum(bin_counts[1:-1])
+    assert middle_bins_sum == 0, f"Expected middle bins to be zero, got {bin_counts}"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
@@ -1,5 +1,5 @@
 """
-Unit tests for _data_explorer_internal.py
+Unit tests for _data_explorer_internal.py.
 
 Tests the Polars-based histogram implementation and verifies consistency
 with NumPy implementation across various data types and edge cases.
@@ -117,8 +117,8 @@ def test_histogram_polars_methods():
     import numpy as np
 
     # Generate some normally distributed data
-    np.random.seed(42)
-    data_values = np.random.randn(1000).tolist()
+    np.random.seed(42)  # noqa: NPY002
+    data_values = np.random.randn(1000).tolist()  # noqa: NPY002
 
     methods = ["fixed", "fd", "sturges", "scott"]
 
@@ -140,12 +140,12 @@ def test_histogram_consistency_with_numpy():
     pytest.importorskip("numpy")
 
     # Test various data distributions
-    np.random.seed(42)
+    np.random.seed(42)  # noqa: NPY002
     test_distributions = [
-        np.random.uniform(0, 10, 1000),  # Uniform distribution
-        np.random.randn(1000),  # Normal distribution
-        np.random.randint(0, 100, 500),  # Integer data
-        np.random.exponential(2, 800),  # Skewed data
+        np.random.uniform(0, 10, 1000),  # Uniform distribution  # noqa: NPY002
+        np.random.randn(1000),  # Normal distribution  # noqa: NPY002
+        np.random.randint(0, 100, 500),  # Integer data  # noqa: NPY002
+        np.random.exponential(2, 800),  # Skewed data  # noqa: NPY002
     ]
 
     for values in test_distributions:
@@ -194,7 +194,7 @@ def test_histogram_datetime_data():
     from datetime import datetime, timedelta
 
     # Create datetime series
-    base = datetime(2024, 1, 1)
+    base = datetime(2024, 1, 1)  # noqa: DTZ001
     dates = [base + timedelta(days=i) for i in range(100)]
     data = pl.Series(dates)
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
@@ -5,13 +5,13 @@ Tests the Polars-based histogram implementation and verifies consistency
 with NumPy implementation across various data types and edge cases.
 """
 
-import math
-import pytest
 import polars as pl
+import pytest
+
 from positron._data_explorer_internal import (
-    _get_histogram_polars,
-    _get_histogram_numpy,
     _get_histogram_method,
+    _get_histogram_numpy,
+    _get_histogram_polars,
 )
 
 
@@ -277,8 +277,6 @@ def test_histogram_sparse_bins():
 
 def test_histogram_large_integer_overflow():
     """Test histogram with very large integers that could cause overflow."""
-    import sys
-
     # Test with large 64-bit integers near the limits
     max_int64 = 2**63 - 1
     large_values = [

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer_internal.py
@@ -120,7 +120,7 @@ def test_histogram_polars_methods():
     np.random.seed(42)
     data_values = np.random.randn(1000).tolist()
 
-    methods = ["fixed", "fd", "sturges", "scott", "rice", "sqrt", "doane", "auto"]
+    methods = ["fixed", "fd", "sturges", "scott"]
 
     for method in methods:
         bin_counts, bin_edges = _get_test_histogram(data_values, num_bins=50, method=method)


### PR DESCRIPTION
Addresses #8446 — currently we don't support histograms for Polars if NumPy is not installed. I had Claude Code bootstrap an implementation using native Polars operations and looking at the NumPy source code, using the existing unit tests as a guide. The initial implementation had some performance issues but I was able to refine it and iterate towards something that at least locally outperforms the current NumPy implementation.  

#### New Features

- Data Explorer histograms for Polars are supported in environments where NumPy is not installed.

#### Bug Fixes

- N/A


### QA Notes

Try looking at a data frame in an environment where Polars is installed but NumPy is not. 

@:data-explorer