### PR TITLE
Data Explorer: Add option to VerticalSplitter to always show the collapse button in the data explorer

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
@@ -44,10 +44,12 @@ type VerticalSplitterCollapseProps = | {
 	readonly collapsible?: false;
 	readonly isCollapsed?: never;
 	readonly onCollapsedChanged?: never;
+	readonly alwaysShowExpandCollapseButton?: never;
 } | {
 	readonly collapsible: true;
 	readonly isCollapsed: boolean;
 	readonly onCollapsedChanged: (collapsed: boolean) => void;
+	readonly alwaysShowExpandCollapseButton?: boolean;
 };
 
 /**
@@ -79,6 +81,7 @@ const getSashSize = (configurationService: IConfigurationService) =>
  */
 const getHoverDelay = (configurationService: IConfigurationService) =>
 	configurationService.getValue<number>('workbench.sash.hoverDelay');
+
 
 /**
  * Determines whether a point is inside an element.
@@ -136,6 +139,7 @@ export const VerticalSplitter = ({
 	showSash,
 	collapsible,
 	isCollapsed,
+	alwaysShowExpandCollapseButton,
 	onCollapsedChanged,
 	onBeginResize,
 	onResize,
@@ -412,7 +416,7 @@ export const VerticalSplitter = ({
 					/>
 				}
 			</div>
-			{collapsible && (hovering || resizing || collapsed) &&
+			{collapsible && (alwaysShowExpandCollapseButton || hovering || resizing || collapsed) &&
 				<Button
 					ref={expandCollapseButtonRef}
 					className='expand-collapse-button'

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -360,6 +360,7 @@ export const DataExplorer = () => {
 			}
 			<div ref={splitterRef} className='splitter'>
 				<VerticalSplitter
+					alwaysShowExpandCollapseButton={true}
 					collapsible={true}
 					invert={layout === PositronDataExplorerLayout.SummaryOnRight}
 					isCollapsed={columnsCollapsed}


### PR DESCRIPTION
Addresses #6509. We could make this always-showing option configurable in the Settings UI, but having it always visible does not seem too bad. 

<img width="946" height="631" alt="image" src="https://github.com/user-attachments/assets/3a243a05-25d4-450e-81dd-ddd24c2d0707" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
