### PR TITLE
e2e: add polars convert to code

### DIFF
--- a/test/e2e/tests/data-explorer/convert-to-code.test.ts
+++ b/test/e2e/tests/data-explorer/convert-to-code.test.ts
@@ -122,7 +122,7 @@ test.describe('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPL
 			await dataExplorer.convertToCodeModal.expectToBeVisible();
 
 			// verify the generated code is correct and has syntax highlights
-			// Use normalized code for UI text comparison (spaces instead of newlines)
+			// Use normalized code for UI text comparison (no newlines)
 			await expect(dataExplorer.convertToCodeModal.codeBox).toContainText(normalizeCodeForDisplay(expectedGeneratedCode));
 			await dataExplorer.convertToCodeModal.expectSyntaxHighlighting();
 

--- a/test/e2e/tests/data-explorer/helpers/convert-to-code-data.ts
+++ b/test/e2e/tests/data-explorer/helpers/convert-to-code-data.ts
@@ -46,8 +46,8 @@ df = pl.DataFrame({
 "state": ["Texas", "Texas", "Texas", "Texas"],
 "is_student": [True, False, False, True],
 "enrollment_date": pl.date_range(
-low="2021-07-15",
-high="2023-01-01",
+start=pl.date(2021, 7, 15),
+end=pl.date(2023, 7, 15),
 interval="1y",
 eager=True
 ).to_list() + [None],  # Add NA manually to match Bob


### PR DESCRIPTION
added e2e for polars. 

Reading the text from the modal has no newlines, whereas the clipboard does have newlines. I wrote a little helper to manage this for the test, but I'm not sure why that is even happening 😅 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer