### PR TITLE
Open new windows in native tabs if option is set

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1557,7 +1557,12 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			mark('code/didCreateCodeWindow');
 
 			// Add as window tab if configured (macOS only)
-			if (options.forceNewTabbedWindow) {
+			// --- Start Positron ---
+			// Force opening in tabbed windows if `window.nativeTabs` is set to `true`.
+			// https://github.com/microsoft/vscode/issues/250042
+			const forceNewTabbedWindow = this.configurationService.getValue<boolean>('window.nativeTabs');
+			if (forceNewTabbedWindow || options.forceNewTabbedWindow) {
+				// --- End Positron ---
 				const activeWindow = this.getLastActiveWindow();
 				activeWindow?.addTabbedWindow(createdWindow);
 			}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8731


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- macOS: When the `window.nativeTabs` is set to `true`, new windows will now always open in native tabs (#8731). Previously they would only do so if the global macOS setting to always prefer opening in native tabs was also set.

#### Bug Fixes

- N/A


### QA Notes

When `window.nativeTabs` is set on macOS, every action that opens a new window should consistently open a native tab.

This should be the case even when the following macOS setting is set to "never":

<img width="520" height="184" alt="Screenshot 2025-08-25 at 17 19 19" src="https://github.com/user-attachments/assets/641a76aa-d166-4df8-98ff-215e6082e932" />
