### PR TITLE
Backport to 2025.08.1: Fixes diff in Settings import (#8868)

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/helpers.ts
@@ -18,7 +18,7 @@ import { untildify } from '../../../../base/common/labels.js';
 
 const WAS_PROMPTED_KEY = 'positron.welcome.promptedImport';
 
-export const POSITRON_IMPORT_SETTINGS_COMMAND_ID = 'positron.workbench.action.importSettings'
+export const POSITRON_IMPORT_SETTINGS_COMMAND_ID = 'positron.workbench.action.importSettings';
 
 export async function getImportWasPrompted(
 	storageService: IStorageService,
@@ -144,7 +144,7 @@ export async function mergeSettingsJson(
 	// Read the contents of the existing and incoming settings files
 	let existingContents;
 	if (await fileService.exists(existing)) {
-		const fileContent = await fileService.readFile(incoming);
+		const fileContent = await fileService.readFile(existing);
 		existingContents = fileContent.value.toString();
 	} else {
 		existingContents = '{}';

--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -65,5 +65,9 @@
     {
         "key": "cmd+b c",
         "command": "workbench.action.closeSidebar" // View: Close Primary Side Bar
+    },
+    {
+       "key": "cmd+j p",
+       "command": "workbench.action.minimizePanel" // View: Minimize Bottom Panel
     }
 ]

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -150,6 +150,10 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+B C', 'Close primary sidebar');
 	}
 
+	public async minimizeBottomPanel() {
+		await this.pressHotKeys('Cmd+J P', 'Minimize bottom panel');
+	}
+
 	// ----------------------
 	// --- Workspace Actions ---
 	// ----------------------

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -84,6 +84,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 
 			// import settings and verify diff displays
 			await hotKeys.importSettings();
+			await hotKeys.minimizeBottomPanel();
 			await expectDiffToBeVisible(page);
 
 			// reject the changes
@@ -98,6 +99,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 
 			// import settings and verify diff displays
 			await hotKeys.importSettings();
+			await hotKeys.minimizeBottomPanel();
 			await expectDiffToBeVisible(page);
 
 			// accept changes
@@ -135,8 +137,12 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 async function expectDiffToBeVisible(page: Page, visible = true) {
 	if (visible) {
 		await expect(page.getByRole('tab', { name: 'settings.json' })).toBeVisible();
+		expect(await page.getByText('<<<<<<< Existing').count()).toBeGreaterThan(0);
+		expect(await page.getByText('>>>>>>> Incoming').count()).toBeGreaterThan(0);
 	} else {
 		await page.waitForTimeout(3000); // waiting to avoid false positive
 		await expect(page.getByRole('tab', { name: 'settings.json' })).not.toBeVisible();
+		await expect(page.getByText('<<<<<<< Existing')).not.toBeVisible();
+		await expect(page.getByText('>>>>>>> Incoming')).not.toBeVisible();
 	}
 }


### PR DESCRIPTION

Diff now displays during settings import when conflicting settings exist
in Positron and VSCode

Addresses https://github.com/posit-dev/positron/issues/8867

---------

Co-authored-by: Marie Idleman <marie.idleman@posit.co>