### PR TITLE
Make it possible to override the Package Manager URL

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -349,6 +349,11 @@
             ],
             "default": "auto",
             "markdownDescription": "%r.configuration.defaultRepositories.description%"
+          },
+          "positron.r.packageManagerRepository": {
+            "scope": "window",
+            "type": "string",
+            "markdownDescription": "%r.configuration.packageManagerRepository.description%"
           }
         }
       }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -70,6 +70,7 @@
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",
 	"r.configuration.defaultRepositories.posit-ppm.description": "Use the Posit public package manager (packagemanager.posit.co)",
 	"r.configuration.defaultRepositories.none.description": "Do not set a default repository or change the value of the 'repos' option",
+	"r.configuration.packageManagerRepository.description": "The Posit Package Manager repository URL to use for R package installation, rather than the default https://packagemanager.posit.co/cran/latest.\n\nOnly takes effect when `#positron.r.defaultRepositories#` is `auto` (restart Positron to apply).",
 	"r.walkthrough.migrateFromRStudio.title": "Migrating from RStudio to Positron",
 	"r.walkthrough.migrateFromRStudio.description": "Learn how to get started with R in Positron as an RStudio user!",
 	"r.walkthrough.migrateFromRStudio.panesAndUI.title": "Get to know the Positron UI",


### PR DESCRIPTION
This commit introduces a new `positron.r.packageManagerRepository` setting that allows users to override the Posit Package Manager URL used to install R packages (in some scenarios).

The new setting allows users of self-hosted Package Manager installations to configure Positron to use them. They also benefit from our existing logic for determining the appropriate Linux binaries automatically.

It also opens the door to users pointing at a specific CRAN snapshot on Public Package Manager rather than `latest`.

Under the hood this works by passing a new flag down to Ark. Companion PR: https://github.com/posit-dev/ark/pull/906.

### Release Notes


#### New Features

- A new `positron.r.packageManagerRepository` setting allows overriding the Posit Package Manager URL used to install R packages when `positron.r.defaultRepositories` is set to `auto`.

#### Bug Fixes

- N/A

### QA Notes

Please advise.
