### PR TITLE
e2e Testing: Help flake fix

### DIFF
--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -19,13 +19,14 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 
 	test('Python - Verify halp landing page', { tag: [tags.WIN] }, async function ({ app }) {
 
+		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
 		await app.workbench.help.openHelpPanel();
 
 		const helpFrame = await app.workbench.help.getHelpWelcomePageFrame();
 		const docLink = helpFrame.getByRole('link', { name: 'Positron Documentation' });
 		await expect(docLink).toBeVisible();
 		await expect(docLink).toHaveAttribute('href', 'https://positron.posit.co/');
-
+		await app.workbench.layouts.enterLayout('stacked');
 	});
 
 	test('Python - Verify basic help functionality', { tag: [tags.WIN] }, async function ({ app, python }) {

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -17,7 +17,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		await settings.set({ 'workbench.reduceMotion': 'on' }, { reload: 'web' });
 	});
 
-	test('Python - Verify halp landing page', { tag: [tags.WIN] }, async function ({ app }) {
+	test('Python - Verify Help landing page', { tag: [tags.WIN] }, async function ({ app }) {
 
 		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
 		await app.workbench.help.openHelpPanel();


### PR DESCRIPTION
MacOS release started to have issue after fixing a screen resolution isse.  This is a somewhat speculative fix.

Make Aux bar full sized to find help.

### QA Notes
@:help @:web @:win
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
