### PR TITLE
Positron notebook contributable cell actions

### DIFF
--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -84,7 +84,7 @@
 }
 
 .custom-context-menu-item .shortcut {
-	padding: 10px;
+	padding-inline: 10px; /* Vertical padding can cause overflow and supurious scrollbars. */
 	white-space: nowrap;
 	grid-column: shortcut / end;
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -37,6 +37,7 @@ export interface CustomContextMenuProps {
 	readonly width?: number | 'auto';
 	readonly minWidth?: number | 'auto';
 	readonly entries: CustomContextMenuEntry[];
+	readonly onClose?: () => void;
 }
 
 /**
@@ -48,20 +49,23 @@ export interface CustomContextMenuProps {
  * @param width The width.
  * @param minWidth The minimum width.
  * @param entries The context menu entries.
+ * @param onClose The callback to call when the context menu is closed/disposed.
  */
-export const showCustomContextMenu = async ({
+export const showCustomContextMenu = ({
 	anchorElement,
 	anchorPoint,
 	popupPosition,
 	popupAlignment,
 	width,
 	minWidth,
-	entries
+	entries,
+	onClose,
 }: CustomContextMenuProps) => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
 		container: PositronReactServices.services.workbenchLayoutService.getContainer(DOM.getWindow(anchorElement)),
-		parent: anchorElement
+		parent: anchorElement,
+		onDisposed: onClose
 	});
 
 	// Supply the default width.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { ISettableObservable } from '../../../../../base/common/observableInternal/base.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
@@ -14,7 +13,7 @@ import { ExecutionStatus, IPositronNotebookCodeCell, IPositronNotebookCell, IPos
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
-import { observableValue } from '../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 
 export abstract class PositronNotebookCellGeneral extends Disposable implements IPositronNotebookCell {
 	kind!: CellKind;
@@ -114,6 +113,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	insertCodeCellBelow(): void {
 		this._instance.insertCodeCellAndFocusContainer('below', this);
 	}
+
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -106,6 +106,14 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	deselect(): void {
 		this._instance.selectionStateMachine.deselectCell(this);
 	}
+
+	insertCodeCellAbove(): void {
+		this._instance.insertCodeCellAndFocusContainer('above', this);
+	}
+
+	insertCodeCellBelow(): void {
+		this._instance.insertCodeCellAndFocusContainer('below', this);
+	}
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -14,7 +14,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IActiveNotebookEditorDelegate, IBaseCellEditorOptions, INotebookEditorCreationOptions, INotebookEditorViewState } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
-import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionStateType, ICellReplaceEdit, NotebookCellExecutionState } from '../../notebook/common/notebookCommon.js';
+import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionStateType, ICellReplaceEdit, NotebookCellExecutionState, ICellDto2 } from '../../notebook/common/notebookCommon.js';
 import { INotebookExecutionService } from '../../notebook/common/notebookExecutionService.js';
 import { INotebookExecutionStateService } from '../../notebook/common/notebookExecutionStateService.js';
 import { createNotebookCell } from './PositronNotebookCells/createNotebookCell.js';
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
-import { CellSelectionType, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType, SelectionStateMachine, SelectionState } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
@@ -378,6 +378,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		@ILogService private readonly _logService: ILogService,
 		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
 		@IPositronWebviewPreloadService private readonly _webviewPreloadService: IPositronWebviewPreloadService,
+		@IClipboardService private readonly _clipboardService: IClipboardService,
 	) {
 		super();
 
@@ -512,21 +513,38 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._onDidChangeContent.fire();
 	}
 
-	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below'): void {
-		const indexOfSelectedCell = this.selectionStateMachine.getIndexOfSelectedCell();
-		if (indexOfSelectedCell === null) {
+	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+		let index: number | null;
+
+		this._assertTextModel();
+
+		if (referenceCell) {
+			const cellIndex = this.textModel.cells.indexOf(referenceCell.cellModel as NotebookCellTextModel);
+			index = cellIndex >= 0 ? cellIndex : null;
+		} else {
+			index = this.selectionStateMachine.getIndexOfSelectedCell();
+		}
+
+		if (index === null) {
 			return;
 		}
 
-		this.addCell(CellKind.Code, indexOfSelectedCell + (aboveOrBelow === 'above' ? 0 : 1));
+		this.addCell(CellKind.Code, index + (aboveOrBelow === 'above' ? 0 : 1));
 	}
 
 	deleteCell(cellToDelete?: IPositronNotebookCell): void {
-		this._assertTextModel();
-
 		const cell = cellToDelete ?? this.selectionStateMachine.getSelectedCell();
 
 		if (!cell) {
+			return;
+		}
+		this.deleteCells([cell]);
+	}
+
+	deleteCells(cellsToDelete: IPositronNotebookCell[]): void {
+		this._assertTextModel();
+
+		if (cellsToDelete.length === 0) {
 			return;
 		}
 
@@ -534,19 +552,51 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		// TODO: Hook up readOnly to the notebook actual value
 		const readOnly = false;
 		const computeUndoRedo = !readOnly || textModel.viewType === 'interactive';
-		const cellIndex = textModel.cells.indexOf(cell.cellModel as NotebookCellTextModel);
 
-		const edits: ICellReplaceEdit = {
-			editType: CellEditType.Replace, index: cellIndex, count: 1, cells: []
-		};
+		// Get indices and sort in descending order to avoid index shifting
+		const cellIndices = cellsToDelete
+			.map(cell => textModel.cells.indexOf(cell.cellModel as NotebookCellTextModel))
+			.filter(index => index >= 0)
+			.sort((a, b) => b - a);
 
-		const nextCellAfterContainingSelection = textModel.cells[cellIndex + 1] ?? undefined;
+		if (cellIndices.length === 0) {
+			return;
+		}
+
+		// Calculate where focus should go after deletion
+		const lowestDeletedIndex = Math.min(...cellIndices);
+		const totalCellsToDelete = cellIndices.length;
+		const originalCellCount = textModel.cells.length;
+		const newCellCount = originalCellCount - totalCellsToDelete;
+
+		// Determine the index of the cell that should receive focus after deletion
+		let targetFocusIndex: number | null = null;
+		if (newCellCount > 0) {
+			if (lowestDeletedIndex < newCellCount) {
+				// Focus on the cell that takes the place of the first deleted cell
+				targetFocusIndex = lowestDeletedIndex;
+			} else {
+				// We deleted from the end, focus on the last remaining cell
+				targetFocusIndex = newCellCount - 1;
+			}
+		}
+
+		// Create delete edits for each cell
+		const edits: ICellReplaceEdit[] = cellIndices.map(index => ({
+			editType: CellEditType.Replace,
+			index,
+			count: 1,
+			cells: []
+		}));
+
+		// Find the cell that will be at the position of the first (lowest index) deleted cell
+		const nextCellAfterContainingSelection = textModel.cells[lowestDeletedIndex + cellIndices.length] ?? undefined;
 		const focusRange = {
-			start: cellIndex,
-			end: cellIndex + 1
+			start: lowestDeletedIndex,
+			end: lowestDeletedIndex + 1
 		};
 
-		textModel.applyEdits([edits], true, { kind: SelectionStateType.Index, focus: focusRange, selections: [focusRange] }, () => {
+		textModel.applyEdits(edits, true, { kind: SelectionStateType.Index, focus: focusRange, selections: [focusRange] }, () => {
 			if (nextCellAfterContainingSelection) {
 				const cellIndex = textModel.cells.findIndex(cell => cell.handle === nextCellAfterContainingSelection.handle);
 				return { kind: SelectionStateType.Index, focus: { start: cellIndex, end: cellIndex + 1 }, selections: [{ start: cellIndex, end: cellIndex + 1 }] };
@@ -562,6 +612,20 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}, undefined, computeUndoRedo);
 
 		this._onDidChangeContent.fire();
+
+		// After the content change fires and cells are synced, explicitly set the selection
+		// to maintain focus on the appropriate cell after deletion
+		if (targetFocusIndex !== null) {
+			this._register(disposableTimeout(() => {
+				if (targetFocusIndex !== null && targetFocusIndex < this._cells.length) {
+					const cellToFocus = this._cells[targetFocusIndex];
+					if (cellToFocus) {
+						this.selectionStateMachine.selectCell(cellToFocus, CellSelectionType.Normal);
+						cellToFocus.focus();
+					}
+				}
+			}, 0));
+		}
 	}
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -14,7 +14,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IActiveNotebookEditorDelegate, IBaseCellEditorOptions, INotebookEditorCreationOptions, INotebookEditorViewState } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
-import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionStateType, ICellReplaceEdit, NotebookCellExecutionState, ICellDto2 } from '../../notebook/common/notebookCommon.js';
+import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionStateType, ICellReplaceEdit, NotebookCellExecutionState } from '../../notebook/common/notebookCommon.js';
 import { INotebookExecutionService } from '../../notebook/common/notebookExecutionService.js';
 import { INotebookExecutionStateService } from '../../notebook/common/notebookExecutionStateService.js';
 import { createNotebookCell } from './PositronNotebookCells/createNotebookCell.js';
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
-import { CellSelectionType, SelectionStateMachine, SelectionState } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
@@ -378,7 +378,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		@ILogService private readonly _logService: ILogService,
 		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
 		@IPositronWebviewPreloadService private readonly _webviewPreloadService: IPositronWebviewPreloadService,
-		@IClipboardService private readonly _clipboardService: IClipboardService,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -15,6 +15,14 @@
 	display: flex;
 	gap: 0.25rem;
 
+	&.visible {
+		visibility: visible;
+	}
+
+	&.hidden {
+		visibility: hidden;
+	}
+
 	.action-button {
 		aspect-ratio: 1;
 		display: grid;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -76,7 +76,7 @@ export function NotebookCellActionBar({ cell, children, isHovered }: NotebookCel
 		{mainActions.map(action => (
 			<ActionButton
 				key={action.commandId}
-				ariaLabel={action.commandId} // TODO: Use CommandCenter.title when available
+				ariaLabel={String(action.label ?? action.commandId)}
 				onPressed={() => handleActionClick(action)}
 			>
 				<div className={`button-icon codicon ${action.icon}`} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -7,23 +7,87 @@
 import './NotebookCellActionBar.css';
 
 // React.
-import React from 'react';
+import React, { useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { IPositronNotebookCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 import { ActionButton } from '../utilityComponents/ActionButton.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { useSelectionStatus } from './useSelectionStatus.js';
+import { NotebookCellMoreActionsMenu } from './actionBar/NotebookCellMoreActionsMenu.js';
+import { useActionBarVisibility } from './actionBar/useActionBarVisibility.js';
+import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBar/actionBarRegistry.js';
+import { useObservedValue } from '../useObservedValue.js';
+import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 
 
-export function NotebookCellActionBar({ cell, children }: { cell: IPositronNotebookCell; children: React.ReactNode }) {
+interface NotebookCellActionBarProps {
+	cell: IPositronNotebookCell;
+	children: React.ReactNode;
+	isHovered: boolean;
+}
 
-	return <div className='positron-notebooks-cell-action-bar'>
+export function NotebookCellActionBar({ cell, children, isHovered }: NotebookCellActionBarProps) {
+	const services = usePositronReactServicesContext();
+	const commandService = services.commandService;
+	const instance = useNotebookInstance();
+	const registry = NotebookCellActionBarRegistry.getInstance();
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+	const selectionStatus = useSelectionStatus(cell);
+
+	// Use observable values for reactive updates
+	const mainActions = useObservedValue(registry.mainActions) ?? [];
+
+	// Determine visibility using the extracted hook
+	const shouldShowActionBar = useActionBarVisibility(isHovered, isMenuOpen, selectionStatus);
+
+	const handleActionClick = (action: INotebookCellActionBarItem) => {
+		// If action needs cell context, ensure cell is selected first
+		if (action.needsCellContext) {
+			// Select the cell if not already selected
+			const currentState = instance.selectionStateMachine.state.get();
+			const isSelected = (currentState.type !== 'NoSelection' &&
+				currentState.type !== 'EditingSelection' &&
+				currentState.selected.includes(cell));
+
+			if (!isSelected) {
+				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+			}
+		}
+
+		// Execute the command (without passing cell as argument)
+		commandService.executeCommand(action.commandId);
+	};
+
+	return <div
+		aria-hidden={!shouldShowActionBar}
+		aria-label={localize('cellActions', 'Cell actions')}
+		className={`positron-notebooks-cell-action-bar ${shouldShowActionBar ? 'visible' : 'hidden'}`}
+		role='toolbar'
+	>
+		{/* Render cell-specific actions (e.g., run button for code cells) */}
 		{children}
-		<ActionButton
-			ariaLabel={(() => localize('deleteCell', 'Delete cell'))()}
-			onPressed={() => cell.delete()}
-		>
-			<div className='button-icon codicon codicon-trash' />
-		</ActionButton>
+
+		{/* Render contributed main actions - will auto-update when registry changes */}
+		{mainActions.map(action => (
+			<ActionButton
+				key={action.commandId}
+				ariaLabel={action.commandId} // TODO: Use CommandCenter.title when available
+				onPressed={() => handleActionClick(action)}
+			>
+				<div className={`button-icon codicon ${action.icon}`} />
+			</ActionButton>
+		))}
+
+		{/* Dropdown menu for additional actions */}
+		<NotebookCellMoreActionsMenu
+			cell={cell}
+			commandService={commandService}
+			instance={instance}
+			onMenuStateChange={setIsMenuOpen}
+		/>
 	</div>;
 }
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -39,6 +39,8 @@ export function NotebookCellActionBar({ cell, children, isHovered }: NotebookCel
 
 	// Use observable values for reactive updates
 	const mainActions = useObservedValue(registry.mainActions) ?? [];
+	const menuActions = useObservedValue(registry.menuActions) ?? [];
+	const hasMenuActions = menuActions.length > 0;
 
 	// Determine visibility using the extracted hook
 	const shouldShowActionBar = useActionBarVisibility(isHovered, isMenuOpen, selectionStatus);
@@ -81,13 +83,15 @@ export function NotebookCellActionBar({ cell, children, isHovered }: NotebookCel
 			</ActionButton>
 		))}
 
-		{/* Dropdown menu for additional actions */}
-		<NotebookCellMoreActionsMenu
-			cell={cell}
-			commandService={commandService}
-			instance={instance}
-			onMenuStateChange={setIsMenuOpen}
-		/>
+		{/* Dropdown menu for additional actions - only render if there are menu actions */}
+		{hasMenuActions ? (
+			<NotebookCellMoreActionsMenu
+				cell={cell}
+				commandService={commandService}
+				instance={instance}
+				onMenuStateChange={setIsMenuOpen}
+			/>
+		) : null}
 	</div>;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
@@ -9,10 +9,6 @@
 
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 
-	.positron-notebooks-cell-action-bar {
-		visibility: hidden;
-	}
-
 	&[data-is-running='true'] {
 		outline: 1px solid var(--vscode-focusBorder);
 		animation: running-cell-pulse 2s ease-in-out infinite;
@@ -20,26 +16,6 @@
 
 	&.selected {
 		outline: 1px solid var(--vscode-focusBorder);
-	}
-
-	&.editing,
-	&.selected,
-	&:hover {
-		.positron-notebooks-cell-action-bar {
-			visibility: visible;
-		}
-	}
-
-	.positron-notebooks-cell-action-bar {
-		visibility: hidden;
-	}
-
-	&.editing,
-	&.selected,
-	&:hover {
-		.positron-notebooks-cell-action-bar {
-			visibility: visible;
-		}
 	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -7,21 +7,28 @@
 import './NotebookCellWrapper.css';
 
 // React.
-import React from 'react';
+import React, { useState } from 'react';
 
 // Other dependencies.
+import { localize } from '../../../../../nls.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useSelectionStatus } from './useSelectionStatus.js';
 import { useObservedValue } from '../useObservedValue.js';
+import { NotebookCellActionBar } from './NotebookCellActionBar.js';
 
-export function NotebookCellWrapper({ cell, children }: { cell: IPositronNotebookCell; children: React.ReactNode }) {
+export function NotebookCellWrapper({ cell, actionBarChildren, children }: {
+	cell: IPositronNotebookCell;
+	actionBarChildren: React.ReactNode;
+	children: React.ReactNode;
+}) {
 	const cellRef = React.useRef<HTMLDivElement>(null);
 	const selectionStateMachine = useNotebookInstance().selectionStateMachine;
 	const selectionStatus = useSelectionStatus(cell);
 	const executionStatus = useObservedValue(cell.executionStatus);
+	const [isHovered, setIsHovered] = useState(false);
 
 	React.useEffect(() => {
 		if (cellRef.current) {
@@ -30,11 +37,18 @@ export function NotebookCellWrapper({ cell, children }: { cell: IPositronNoteboo
 		}
 	}, [cell, cellRef]);
 
+
+	const cellType = cell.kind === CellKind.Code ? 'Code' : 'Markdown';
+	const isSelected = selectionStatus === CellSelectionStatus.Selected || selectionStatus === CellSelectionStatus.Editing;
+
 	return <div
 		ref={cellRef}
+		aria-label={localize('notebookCell', '{0} cell', cellType)}
+		aria-selected={isSelected}
 		className={`positron-notebook-cell positron-notebook-${cell.kind === CellKind.Code ? 'code' : 'markdown'}-cell ${selectionStatus}`}
 		data-is-running={executionStatus === 'running'}
 		data-testid='notebook-cell'
+		role='article'
 		tabIndex={0}
 		onClick={(e) => {
 			const clickTarget = e.nativeEvent.target as HTMLElement;
@@ -58,7 +72,12 @@ export function NotebookCellWrapper({ cell, children }: { cell: IPositronNoteboo
 			const addMode = e.shiftKey || e.ctrlKey || e.metaKey;
 			selectionStateMachine.selectCell(cell, addMode ? CellSelectionType.Add : CellSelectionType.Normal);
 		}}
+		onMouseEnter={() => setIsHovered(true)}
+		onMouseLeave={() => setIsHovered(false)}
 	>
+		<NotebookCellActionBar cell={cell} isHovered={isHovered}>
+			{actionBarChildren}
+		</NotebookCellActionBar>
 		{children}
 	</div>;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -21,7 +21,7 @@ import { NotebookCellActionBar } from './NotebookCellActionBar.js';
 
 export function NotebookCellWrapper({ cell, actionBarChildren, children }: {
 	cell: IPositronNotebookCell;
-	actionBarChildren: React.ReactNode;
+	actionBarChildren?: React.ReactNode;
 	children: React.ReactNode;
 }) {
 	const cellRef = React.useRef<HTMLDivElement>(null);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -15,7 +15,6 @@ import { isParsedTextOutput } from '../getOutputContents.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
 import { localize } from '../../../../../nls.js';
-import { NotebookCellActionBar } from './NotebookCellActionBar.js';
 import { CellTextOutput } from './CellTextOutput.js';
 import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
@@ -59,10 +58,10 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 	const isRunning = executionStatus === 'running';
 
 	return (
-		<NotebookCellWrapper cell={cell}>
-			<NotebookCellActionBar cell={cell}>
-				<CellExecutionControls isRunning={isRunning} onRun={() => cell.run()} />
-			</NotebookCellActionBar>
+		<NotebookCellWrapper
+			actionBarChildren={<CellExecutionControls isRunning={isRunning} onRun={() => cell.run()} />}
+			cell={cell}
+		>
 			<div className='positron-notebook-code-cell-contents'>
 				<CellEditorMonacoWidget cell={cell} />
 				<CellOutputsSection outputs={outputContents} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -16,27 +16,11 @@ import { useObservedValue } from '../useObservedValue.js';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
 import { localize } from '../../../../../nls.js';
 import { CellTextOutput } from './CellTextOutput.js';
-import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellExecutionInfoIcon } from './CellExecutionInfoIcon.js';
 
-interface CellExecutionControlsProps {
-	isRunning: boolean;
-	onRun: () => void;
-}
-
-function CellExecutionControls({ isRunning, onRun }: CellExecutionControlsProps) {
-	return (
-		<ActionButton
-			ariaLabel={isRunning ? localize('stopExecution', 'Stop execution') : localize('runCell', 'Run cell')}
-			onPressed={onRun}
-		>
-			<div className={`button-icon codicon ${isRunning ? 'codicon-primitive-square' : 'codicon-run'}`} />
-		</ActionButton>
-	);
-}
 
 interface CellOutputsSectionProps {
 	outputs: NotebookCellOutputs[] | undefined;
@@ -54,12 +38,9 @@ function CellOutputsSection({ outputs = [] }: CellOutputsSectionProps) {
 
 export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 	const outputContents = useObservedValue(cell.outputs);
-	const executionStatus = useObservedValue(cell.executionStatus);
-	const isRunning = executionStatus === 'running';
 
 	return (
 		<NotebookCellWrapper
-			actionBarChildren={<CellExecutionControls isRunning={isRunning} onRun={() => cell.run()} />}
 			cell={cell}
 		>
 			<div className='positron-notebook-code-cell-contents'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -13,8 +13,6 @@ import React from 'react';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { Markdown } from './Markdown.js';
-import { localize } from '../../../../../nls.js';
-import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookMarkdownCell } from '../PositronNotebookCells/PositronNotebookMarkdownCell.js';
 
@@ -25,13 +23,6 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 
 	return (
 		<NotebookCellWrapper
-			actionBarChildren={
-				<ActionButton
-					ariaLabel={editorShown ? localize('hideEditor', 'Hide editor') : localize('showEditor', 'Show editor')}
-					onPressed={() => cell.run()} >
-					<div className={`button-icon codicon ${editorShown ? 'codicon-run' : 'codicon-primitive-square'}`} />
-				</ActionButton>
-			}
 			cell={cell}
 		>
 			<div className='cell-contents'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 
 // Other dependencies.
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
-import { NotebookCellActionBar } from './NotebookCellActionBar.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { Markdown } from './Markdown.js';
 import { localize } from '../../../../../nls.js';
@@ -25,15 +24,16 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 	const editorShown = useObservedValue(cell.editorShown);
 
 	return (
-		<NotebookCellWrapper cell={cell}>
-
-			<NotebookCellActionBar cell={cell}>
+		<NotebookCellWrapper
+			actionBarChildren={
 				<ActionButton
 					ariaLabel={editorShown ? localize('hideEditor', 'Hide editor') : localize('showEditor', 'Show editor')}
 					onPressed={() => cell.run()} >
 					<div className={`button-icon codicon ${editorShown ? 'codicon-run' : 'codicon-primitive-square'}`} />
 				</ActionButton>
-			</NotebookCellActionBar>
+			}
+			cell={cell}
+		>
 			<div className='cell-contents'>
 				{editorShown ? <CellEditorMonacoWidget cell={cell} /> : null}
 				<div className='positron-notebook-markup-rendered' onDoubleClick={() => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
+
+interface CellActionButtonProps {
+	ariaLabel: string;
+	onPressed: () => void;
+	children: React.ReactNode;
+	buttonRef?: React.RefObject<HTMLButtonElement>;
+	ariaHasPopup?: boolean | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
+	ariaExpanded?: boolean;
+}
+
+/**
+ * Standardized action button component for notebook cell actions.
+ * Provides consistent styling and behavior across all cell action buttons.
+ */
+export function CellActionButton({ ariaLabel, onPressed, children, buttonRef, ariaHasPopup, ariaExpanded }: CellActionButtonProps) {
+	// We need to wrap the Button in a div to add additional ARIA attributes
+	// since the Button component doesn't pass through extra props
+	const button = (
+		<Button
+			ref={buttonRef}
+			ariaLabel={ariaLabel}
+			className='action action-button'
+			onPressed={onPressed}
+		>
+			{children}
+		</Button>
+	);
+
+	// If we have additional ARIA attributes, wrap in a div
+	if (ariaHasPopup !== undefined || ariaExpanded !== undefined) {
+		return (
+			<div
+				aria-expanded={ariaExpanded}
+				aria-haspopup={ariaHasPopup}
+			>
+				{button}
+			</div>
+		);
+	}
+
+	return button;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -14,11 +14,13 @@ import { IPositronNotebookInstance } from '../../../../../services/positronNoteb
 import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 import { CellActionButton } from './CellActionButton.js';
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
+import { INotebookCellActionBarItem } from './actionBarRegistry.js';
 
 interface NotebookCellMoreActionsMenuProps {
 	instance: IPositronNotebookInstance;
 	commandService: ICommandService;
 	cell: IPositronNotebookCell;
+	menuActions: INotebookCellActionBarItem[];
 	onMenuStateChange: (isOpen: boolean) => void;
 }
 
@@ -30,6 +32,7 @@ export function NotebookCellMoreActionsMenu({
 	instance,
 	commandService,
 	cell,
+	menuActions,
 	onMenuStateChange
 }: NotebookCellMoreActionsMenuProps) {
 	const buttonRef = useRef<HTMLButtonElement>(null);
@@ -40,7 +43,7 @@ export function NotebookCellMoreActionsMenu({
 			return;
 		}
 
-		const entries = buildMoreActionsMenuItems(instance, commandService, cell);
+		const entries = buildMoreActionsMenuItems(instance, commandService, cell, menuActions);
 
 		onMenuStateChange(true);
 		setIsMenuOpen(true);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -38,27 +38,33 @@ export function NotebookCellMoreActionsMenu({
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
-	const showMoreActionsMenu = async () => {
+	const showMoreActionsMenu = () => {
 		if (!buttonRef.current) {
 			return;
 		}
 
-		const entries = buildMoreActionsMenuItems(instance, commandService, cell, menuActions);
-
-		onMenuStateChange(true);
-		setIsMenuOpen(true);
-
 		try {
-			await showCustomContextMenu({
+			const entries = buildMoreActionsMenuItems(instance, commandService, cell, menuActions);
+
+			setIsMenuOpen(true);
+			onMenuStateChange(true);
+
+			showCustomContextMenu({
 				anchorElement: buttonRef.current,
 				popupPosition: 'auto',
 				popupAlignment: 'auto',
 				width: 'auto',
-				entries
+				entries,
+				onClose: () => {
+					setIsMenuOpen(false);
+					onMenuStateChange(false);
+				}
 			});
-		} finally {
-			onMenuStateChange(false);
+		} catch (error) {
+			// If the menu fails to show for whatever reason, make sure we don't
+			// get stuck in a bad state.
 			setIsMenuOpen(false);
+			onMenuStateChange(false);
 		}
 	};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React, { useRef } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { showCustomContextMenu } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
+import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellActionButton } from './CellActionButton.js';
+import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
+
+interface NotebookCellMoreActionsMenuProps {
+	instance: IPositronNotebookInstance;
+	commandService: ICommandService;
+	cell: IPositronNotebookCell;
+	onMenuStateChange: (isOpen: boolean) => void;
+}
+
+/**
+ * More actions dropdown menu component for notebook cells.
+ * Encapsulates all dropdown menu logic including state management and menu display.
+ */
+export function NotebookCellMoreActionsMenu({
+	instance,
+	commandService,
+	cell,
+	onMenuStateChange
+}: NotebookCellMoreActionsMenuProps) {
+	const buttonRef = useRef<HTMLButtonElement>(null);
+	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+
+	const showMoreActionsMenu = async () => {
+		if (!buttonRef.current) {
+			return;
+		}
+
+		const entries = buildMoreActionsMenuItems(instance, commandService, cell);
+
+		onMenuStateChange(true);
+		setIsMenuOpen(true);
+
+		try {
+			await showCustomContextMenu({
+				anchorElement: buttonRef.current,
+				popupPosition: 'auto',
+				popupAlignment: 'auto',
+				width: 'auto',
+				entries
+			});
+		} finally {
+			onMenuStateChange(false);
+			setIsMenuOpen(false);
+		}
+	};
+
+	return (
+		<CellActionButton
+			ariaExpanded={isMenuOpen}
+			ariaHasPopup='menu'
+			ariaLabel={localize('moreActions', 'More actions')}
+			buttonRef={buttonRef}
+			onPressed={showMoreActionsMenu}
+		>
+			<div className='button-icon codicon codicon-ellipsis' />
+		</CellActionButton>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -29,7 +29,7 @@ export function buildMoreActionsMenuItems(
 	// PR2 will add copy/paste actions here
 	return menuActions.map(action => new CustomContextMenuItem({
 		commandId: action.commandId,
-		label: action.commandId, // TODO: Use CommandCenter.title when available
+		label: String(action.label ?? action.commandId), // TODO: Use CommandCenter.title when available
 		icon: action.icon,
 		onSelected: () => {
 			// IMPORTANT: Ensure the cell from this menu is selected before executing

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -30,7 +30,7 @@ export function buildMoreActionsMenuItems(
 	return actions.map(action => new CustomContextMenuItem({
 		commandId: action.commandId,
 		label: String(action.label ?? action.commandId), // TODO: Use CommandCenter.title when available
-		icon: action.icon,
+		icon: action.icon?.startsWith('codicon-') ? action.icon.slice(8) : action.icon,
 		onSelected: () => {
 			// IMPORTANT: Ensure the cell from this menu is selected before executing
 			// Otherwise the command would operate on whatever cell is currently selected

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { CustomContextMenuItem } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenuItem.js';
+import { CustomContextMenuEntry } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
+import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
+import { NotebookCellActionBarRegistry } from './actionBarRegistry.js';
+
+/**
+ * Build the menu entries for the "more actions" dropdown menu.
+ * This provides a clean extension point for adding new actions via the registry.
+ */
+export function buildMoreActionsMenuItems(
+	instance: IPositronNotebookInstance,
+	commandService: ICommandService,
+	cell: IPositronNotebookCell
+): CustomContextMenuEntry[] {
+	const registry = NotebookCellActionBarRegistry.getInstance();
+	// Get current value from observable
+	const menuActions = registry.menuActions.get();
+
+	// Convert registry items to menu entries
+	// For PR1, this will return empty as no menu actions are registered yet
+	// PR2 will add copy/paste actions here
+	return menuActions.map(action => new CustomContextMenuItem({
+		commandId: action.commandId,
+		label: action.commandId, // TODO: Use CommandCenter.title when available
+		icon: action.icon,
+		onSelected: () => {
+			// IMPORTANT: Ensure the cell from this menu is selected before executing
+			// Otherwise the command would operate on whatever cell is currently selected
+			if (action.needsCellContext) {
+				const currentState = instance.selectionStateMachine.state.get();
+				const isSelected = (currentState.type !== 'NoSelection' &&
+					currentState.type !== 'EditingSelection' &&
+					currentState.selected.includes(cell));
+
+				if (!isSelected) {
+					instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+				}
+			}
+
+			// Execute command - it will now operate on the correct cell
+			commandService.executeCommand(action.commandId);
+		}
+	}));
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -9,7 +9,7 @@ import { CustomContextMenuEntry } from '../../../../../../workbench/browser/posi
 import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
-import { NotebookCellActionBarRegistry } from './actionBarRegistry.js';
+import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 
 /**
  * Build the menu entries for the "more actions" dropdown menu.
@@ -18,16 +18,16 @@ import { NotebookCellActionBarRegistry } from './actionBarRegistry.js';
 export function buildMoreActionsMenuItems(
 	instance: IPositronNotebookInstance,
 	commandService: ICommandService,
-	cell: IPositronNotebookCell
+	cell: IPositronNotebookCell,
+	menuActions?: INotebookCellActionBarItem[]
 ): CustomContextMenuEntry[] {
-	const registry = NotebookCellActionBarRegistry.getInstance();
-	// Get current value from observable
-	const menuActions = registry.menuActions.get();
+	// Use provided menuActions or fallback to getting all from registry
+	const actions = menuActions ?? NotebookCellActionBarRegistry.getInstance().menuActions.get();
 
 	// Convert registry items to menu entries
 	// For PR1, this will return empty as no menu actions are registered yet
 	// PR2 will add copy/paste actions here
-	return menuActions.map(action => new CustomContextMenuItem({
+	return actions.map(action => new CustomContextMenuItem({
 		commandId: action.commandId,
 		label: String(action.label ?? action.commandId), // TODO: Use CommandCenter.title when available
 		icon: action.icon,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+
+/**
+ * Interface for notebook cell action bar items that define how commands appear in the UI.
+ */
+export interface INotebookCellActionBarItem {
+	/** VS Code command ID to execute */
+	commandId: string;
+	/** Codicon class for the button icon (optional) */
+	icon?: string;
+	/** Location in UI - either main action bar or dropdown menu */
+	position: 'main' | 'menu';
+	/** Sort order within position (lower numbers appear first) */
+	order?: number;
+	/** Visibility condition using VS Code context keys (optional) */
+	when?: ContextKeyExpression;
+	/** If true, the cell will be selected before executing the command */
+	needsCellContext?: boolean;
+}
+
+/**
+ * Registry for notebook cell action bar items. Uses singleton pattern and provides
+ * observable arrays for reactive UI updates.
+ */
+export class NotebookCellActionBarRegistry {
+	private static instance: NotebookCellActionBarRegistry;
+	private items = new Map<string, INotebookCellActionBarItem>();
+
+	// Observable arrays for reactive UI updates
+	private _mainActions = observableValue<INotebookCellActionBarItem[]>('mainActions', []);
+	private _menuActions = observableValue<INotebookCellActionBarItem[]>('menuActions', []);
+
+	// Event emitter for changes
+	private _onDidChange = new Emitter<void>();
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	/**
+	 * Gets the singleton instance of the registry.
+	 */
+	static getInstance(): NotebookCellActionBarRegistry {
+		if (!this.instance) {
+			this.instance = new NotebookCellActionBarRegistry();
+		}
+		return this.instance;
+	}
+
+	/**
+	 * Registers an action bar item in the registry.
+	 * @param item The action bar item to register
+	 * @returns A disposable to unregister the item
+	 */
+	register(item: INotebookCellActionBarItem): IDisposable {
+		this.items.set(item.commandId, item);
+		this.updateObservables();
+		this._onDidChange.fire();
+
+		return {
+			dispose: () => {
+				this.items.delete(item.commandId);
+				this.updateObservables();
+				this._onDidChange.fire();
+			}
+		};
+	}
+
+	/**
+	 * Updates the observable arrays based on the current items.
+	 */
+	private updateObservables(): void {
+		// Update main actions
+		const mainActions = Array.from(this.items.values())
+			.filter(item => item.position === 'main')
+			.sort((a, b) => (a.order ?? 50) - (b.order ?? 50));
+		this._mainActions.set(mainActions, undefined);
+
+		// Update menu actions
+		const menuActions = Array.from(this.items.values())
+			.filter(item => item.position === 'menu')
+			.sort((a, b) => (a.order ?? 50) - (b.order ?? 50));
+		this._menuActions.set(menuActions, undefined);
+	}
+
+	/**
+	 * Gets the observable array of main action bar actions.
+	 */
+	get mainActions(): ISettableObservable<INotebookCellActionBarItem[]> {
+		return this._mainActions;
+	}
+
+	/**
+	 * Gets the observable array of dropdown menu actions.
+	 */
+	get menuActions(): ISettableObservable<INotebookCellActionBarItem[]> {
+		return this._menuActions;
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -26,6 +26,10 @@ export interface INotebookCellActionBarItem {
 	needsCellContext?: boolean;
 }
 
+
+// Default order for actions that don't specify an order.
+const DEFAULT_ORDER = 50;
+
 /**
  * Registry for notebook cell action bar items. Uses singleton pattern and provides
  * observable arrays for reactive UI updates.
@@ -78,13 +82,13 @@ export class NotebookCellActionBarRegistry {
 		// Update main actions
 		const mainActions = Array.from(this.items.values())
 			.filter(item => item.position === 'main')
-			.sort((a, b) => (a.order ?? 50) - (b.order ?? 50));
+			.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
 		this._mainActions.set(mainActions, undefined);
 
 		// Update menu actions
 		const menuActions = Array.from(this.items.values())
 			.filter(item => item.position === 'menu')
-			.sort((a, b) => (a.order ?? 50) - (b.order ?? 50));
+			.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
 		this._menuActions.set(menuActions, undefined);
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -30,6 +30,8 @@ export interface INotebookCellActionBarItem {
 	needsCellContext?: boolean;
 	/** Cell-specific condition that determines if this command applies to a given cell */
 	cellCondition?: CellConditionPredicate;
+	/** Category of the action bar item. Items that share the same category will be grouped together. */
+	category?: string;
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -7,6 +7,7 @@ import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { ILocalizedString } from '../../../../../../platform/action/common/action.js';
 
 /**
  * Interface for notebook cell action bar items that define how commands appear in the UI.
@@ -14,6 +15,8 @@ import { ISettableObservable, observableValue } from '../../../../../../base/com
 export interface INotebookCellActionBarItem {
 	/** VS Code command ID to execute */
 	commandId: string;
+	/** Command label, for display purposes, if not defined, use the commandId */
+	label?: ILocalizedString | string;
 	/** Codicon class for the button icon (optional) */
 	icon?: string;
 	/** Location in UI - either main action bar or dropdown menu */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -8,6 +8,7 @@ import { ContextKeyExpression } from '../../../../../../platform/contextkey/comm
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ILocalizedString } from '../../../../../../platform/action/common/action.js';
+import { CellConditionPredicate } from './cellConditions.js';
 
 /**
  * Interface for notebook cell action bar items that define how commands appear in the UI.
@@ -27,6 +28,8 @@ export interface INotebookCellActionBarItem {
 	when?: ContextKeyExpression;
 	/** If true, the cell will be selected before executing the command */
 	needsCellContext?: boolean;
+	/** Cell-specific condition that determines if this command applies to a given cell */
+	cellCondition?: CellConditionPredicate;
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -5,13 +5,21 @@
 
 import { CellKind, IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 
+/** The type of notebook cell */
+/** The type of notebook cell */
+export enum NotebookCellType {
+	Code = 'code',
+	Markdown = 'markdown',
+	Raw = 'raw'
+}
+
 /**
  * Information about a cell's type and position within a notebook.
  * This is passed to cell condition predicates to determine if a command should be available.
  */
 export interface ICellInfo {
 	/** The type of cell: code, markdown, or raw */
-	cellType: 'code' | 'markdown' | 'raw';
+	cellType: NotebookCellType;
 	/** Zero-based index of the cell within the notebook */
 	cellIndex: number;
 	/** Total number of cells in the notebook */
@@ -45,8 +53,8 @@ export function createCellInfo(
 	totalCells: number
 ): ICellInfo {
 	return {
-		cellType: cell.kind === CellKind.Code ? 'code' :
-			cell.kind === CellKind.Markup ? 'markdown' : 'raw',
+		cellType: cell.kind === CellKind.Code ? NotebookCellType.Code :
+			cell.kind === CellKind.Markup ? NotebookCellType.Markdown : NotebookCellType.Raw,
 		cellIndex,
 		totalCells,
 		isFirstCell: cellIndex === 0,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -24,12 +24,13 @@ export interface ICellInfo {
 	cellIndex: number;
 	/** Total number of cells in the notebook */
 	totalCells: number;
-	/** True if this is the first cell in the notebook */
+	/** Cell is first in the notebook */
 	isFirstCell: boolean;
-	/** True if this is the last cell in the notebook */
+	/** Cell is last in the notebook */
 	isLastCell: boolean;
-	/** True if this is the only cell in the notebook */
+	/** Cell is the only cell in the notebook */
 	isOnlyCell: boolean;
+	/** Cell is actively executing/running */
 	isRunning: boolean;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -22,6 +22,7 @@ export interface ICellInfo {
 	isLastCell: boolean;
 	/** True if this is the only cell in the notebook */
 	isOnlyCell: boolean;
+	isRunning: boolean;
 }
 
 /**
@@ -50,7 +51,10 @@ export function createCellInfo(
 		totalCells,
 		isFirstCell: cellIndex === 0,
 		isLastCell: cellIndex === totalCells - 1,
-		isOnlyCell: totalCells === 1
+		isOnlyCell: totalCells === 1,
+		// TODO: There is a tiny chance that the cell is running but the status is not yet updated.
+		// If this happens we will probably need to make the cell info an observable.
+		isRunning: cell.executionStatus.get() === 'running'
 	};
 }
 
@@ -66,6 +70,9 @@ export const CellConditions = {
 
 	/** Only raw cells */
 	isRaw: (info: ICellInfo) => info.cellType === 'raw',
+
+	/** Is running */
+	isRunning: (info: ICellInfo) => info.isRunning,
 
 	/** Not the first cell (has cells above) */
 	notFirst: (info: ICellInfo) => !info.isFirstCell,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/commandUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/commandUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
+
+export interface IPositronNotebookCommandKeybinding {
+	/** Primary keybinding */
+	primary?: number;
+	/** Secondary keybindings */
+	secondary?: number[];
+	/** Platform-specific keybindings for macOS */
+	mac?: { primary: number; secondary?: number[]; };
+	/** Platform-specific keybindings for Windows */
+	win?: { primary: number; secondary?: number[]; };
+	/** Platform-specific keybindings for Linux */
+	linux?: { primary: number; secondary?: number[]; };
+	/** Keybinding weight (defaults to KeybindingWeight.EditorContrib) */
+	weight?: number;
+	/** Context condition (defaults to POSITRON_NOTEBOOK_EDITOR_FOCUSED) */
+	when?: ContextKeyExpression;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -35,6 +35,9 @@ export interface IRegisterCellCommandOptions {
 	actionBar?: {
 		/** Codicon class for the button icon */
 		icon: string;
+		// TODO: Add ability for custom jsx to be used here that takes the cell
+		// as a prop. Would allow for dynamic icons and more polished
+		// transitions etc..
 		/** Location in UI - either main action bar or dropdown menu */
 		position: 'main' | 'menu';
 		/** Sort order within position (lower numbers appear first) */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
+import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
+import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
+
+/**
+ * Options for registering a cell command.
+ */
+export interface IRegisterCellCommandOptions {
+	/** If true, handler is called for each selected cell */
+	multiSelect?: boolean;
+
+	/** Optional UI registration for the action bar */
+	actionBar?: {
+		/** Codicon class for the button icon */
+		icon: string;
+		/** Location in UI - either main action bar or dropdown menu */
+		position: 'main' | 'menu';
+		/** Sort order within position (lower numbers appear first) */
+		order?: number;
+		/** Visibility condition using VS Code context keys */
+		when?: ContextKeyExpression;
+	};
+}
+
+/**
+ * Helper function to register a command that operates on notebook cells.
+ * Automatically handles getting the selected cell(s) from the active notebook.
+ * Optionally registers the command in the cell action bar UI.
+ *
+ * @param commandId The command ID to register
+ * @param handler The function to execute with the selected cell(s)
+ * @param options Optional configuration for the command and UI
+ * @returns Disposable to unregister both command and UI
+ */
+export function registerCellCommand(
+	commandId: string,
+	handler: (cell: IPositronNotebookCell, accessor: ServicesAccessor) => void,
+	options?: IRegisterCellCommandOptions
+): IDisposable {
+	const disposables = new DisposableStore();
+
+	// Register the command
+	const commandDisposable = CommandsRegistry.registerCommand(commandId, (accessor: ServicesAccessor) => {
+		const notebookService = accessor.get(IPositronNotebookService);
+		const activeNotebook = notebookService.getActiveInstance();
+		if (!activeNotebook) {
+			return;
+		}
+
+		if (options?.multiSelect) {
+			// Handle multiple selected cells
+			const currentState = activeNotebook.selectionStateMachine.state.get();
+			let selectedCells: IPositronNotebookCell[] = [];
+
+			if (currentState.type === 'SingleSelection' || currentState.type === 'MultiSelection') {
+				selectedCells = currentState.selected;
+			} else if (currentState.type === 'EditingSelection') {
+				selectedCells = [currentState.selectedCell];
+			}
+
+			for (const cell of selectedCells) {
+				handler(cell, accessor);
+			}
+		} else {
+			// Handle single cell
+			const cell = activeNotebook.selectionStateMachine.getSelectedCell();
+			if (cell) {
+				handler(cell, accessor);
+			}
+		}
+	});
+	disposables.add(commandDisposable);
+
+	// Optionally register UI metadata
+	if (options?.actionBar) {
+		const uiItem: INotebookCellActionBarItem = {
+			commandId,
+			icon: options.actionBar.icon,
+			position: options.actionBar.position,
+			order: options.actionBar.order,
+			when: options.actionBar.when,
+			needsCellContext: true  // Always true for cell commands
+		};
+
+		const uiDisposable = NotebookCellActionBarRegistry.getInstance().register(uiItem);
+		disposables.add(uiDisposable);
+	}
+
+	return disposables;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -40,6 +40,9 @@ export interface IRegisterCellCommandOptions {
 		// transitions etc..
 		/** Location in UI - either main action bar or dropdown menu */
 		position: 'main' | 'menu';
+		/** Category of the action bar item. Items that share the same category
+		 * will be grouped together. Ignored for "main" position actions. */
+		category?: string;
 		/** Sort order within position (lower numbers appear first) */
 		order?: number;
 		/** Visibility condition using VS Code context keys */
@@ -138,6 +141,7 @@ export function registerCellCommand({
 			label: humanReadableLabel,
 			icon: actionBar.icon,
 			position: actionBar.position,
+			category: actionBar.category,
 			order: actionBar.order,
 			when: actionBar.when,
 			needsCellContext: true,  // Always true for cell commands

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
@@ -5,12 +5,12 @@
 
 import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ICommandMetadata, CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
-import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
+import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 
 /**
  * Helper function to register a command that operates on the notebook instance.
@@ -29,22 +29,7 @@ export function registerNotebookCommand({
 }: {
 	commandId: string;
 	handler: (notebook: IPositronNotebookInstance, accessor: ServicesAccessor) => void;
-	keybinding?: {
-		/** Primary keybinding */
-		primary?: number;
-		/** Secondary keybindings */
-		secondary?: number[];
-		/** Platform-specific keybindings for macOS */
-		mac?: { primary: number; secondary?: number[]; };
-		/** Platform-specific keybindings for Windows */
-		win?: { primary: number; secondary?: number[]; };
-		/** Platform-specific keybindings for Linux */
-		linux?: { primary: number; secondary?: number[]; };
-		/** Keybinding weight (defaults to KeybindingWeight.EditorContrib) */
-		weight?: number;
-		/** Context condition (defaults to POSITRON_NOTEBOOK_EDITOR_FOCUSED) */
-		when?: ContextKeyExpression;
-	};
+		keybinding?: IPositronNotebookCommandKeybinding;
 	metadata?: ICommandMetadata;
 }): IDisposable {
 	const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { ICommandMetadata, CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
+import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
+
+/**
+ * Helper function to register a command that operates on the notebook instance.
+ * Automatically handles getting the active notebook instance.
+ * Optionally registers keybindings for the command.
+ *
+ * @param commandId The command ID to register
+ * @param handler The function to execute with the active notebook instance
+ * @param keybinding Optional keybinding configuration
+ * @param metadata Optional command metadata including description, args, and return type
+ * @returns Disposable to unregister both command and keybinding
+ */
+
+export function registerNotebookCommand({
+	commandId, handler, keybinding, metadata
+}: {
+	commandId: string;
+	handler: (notebook: IPositronNotebookInstance, accessor: ServicesAccessor) => void;
+	keybinding?: {
+		/** Primary keybinding */
+		primary?: number;
+		/** Secondary keybindings */
+		secondary?: number[];
+		/** Platform-specific keybindings for macOS */
+		mac?: { primary: number; secondary?: number[]; };
+		/** Platform-specific keybindings for Windows */
+		win?: { primary: number; secondary?: number[]; };
+		/** Platform-specific keybindings for Linux */
+		linux?: { primary: number; secondary?: number[]; };
+		/** Keybinding weight (defaults to KeybindingWeight.EditorContrib) */
+		weight?: number;
+		/** Context condition (defaults to POSITRON_NOTEBOOK_EDITOR_FOCUSED) */
+		when?: ContextKeyExpression;
+	};
+	metadata?: ICommandMetadata;
+}): IDisposable {
+	const disposables = new DisposableStore();
+
+	// Register the command
+	const commandDisposable = CommandsRegistry.registerCommand({
+		id: commandId,
+		handler: (accessor: ServicesAccessor) => {
+			const notebookService = accessor.get(IPositronNotebookService);
+			const activeNotebook = notebookService.getActiveInstance();
+			if (!activeNotebook) {
+				return;
+			}
+
+			handler(activeNotebook, accessor);
+		},
+		metadata: metadata
+	});
+	disposables.add(commandDisposable);
+
+	// Optionally register keybinding
+	if (keybinding) {
+		const keybindingDisposable = KeybindingsRegistry.registerKeybindingRule({
+			id: commandId,
+			weight: keybinding.weight ?? KeybindingWeight.EditorContrib,
+			when: keybinding.when ?? POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			primary: keybinding.primary,
+			secondary: keybinding.secondary,
+			mac: keybinding.mac,
+			win: keybinding.win,
+			linux: keybinding.linux
+		});
+		disposables.add(keybindingDisposable);
+	}
+
+	return disposables;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CellSelectionStatus } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+
+/**
+ * Hook to determine if the action bar should be visible based on cell state.
+ * Centralizes visibility logic for better maintainability and testing.
+ */
+export function useActionBarVisibility(
+	isHovered: boolean,
+	isMenuOpen: boolean,
+	selectionStatus: CellSelectionStatus
+): boolean {
+	return isMenuOpen || isHovered ||
+		selectionStatus === CellSelectionStatus.Selected ||
+		selectionStatus === CellSelectionStatus.Editing;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -354,7 +354,6 @@ registerNotebookKeybinding({
 });
 
 
-
 /**
  * Register a keybinding for the Positron Notebook editor. These are typically used to intercept
  * existing notebook keybindings/commands and run them on positron notebooks instead.

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -261,31 +261,7 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 );
 
 
-//#region Keybindings
-
-
-registerCellCommand({
-	commandId: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
-	handler: (cell) => cell.insertCodeCellAbove(),
-	keybinding: {
-		primary: KeyCode.KeyA
-	},
-	metadata: {
-		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
-	}
-});
-
-registerCellCommand({
-	commandId: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
-	handler: (cell) => cell.insertCodeCellBelow(),
-	keybinding: {
-		primary: KeyCode.KeyB
-	},
-	metadata: {
-		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
-	}
-});
-
+//#region Notebook Commands
 registerNotebookCommand({
 	commandId: 'positronNotebook.focusUp',
 	handler: (notebook) => notebook.selectionStateMachine.moveUp(false),
@@ -334,6 +310,55 @@ registerNotebookCommand({
 	}
 });
 
+//#endregion Notebook Commands
+
+//#region Cell Commands
+// Register delete command with UI in one call
+// For built-in commands, we don't need to manage the disposable since they live
+// for the lifetime of the application
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
+	handler: (cell) => cell.insertCodeCellAbove(),
+	keybinding: {
+		primary: KeyCode.KeyA
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
+	handler: (cell) => cell.insertCodeCellBelow(),
+	keybinding: {
+		primary: KeyCode.KeyB
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
+	}
+});
+
+registerCellCommand(
+	{
+		commandId: 'positronNotebook.cell.delete',
+		handler: (cell) => cell.delete(),
+		multiSelect: true,  // Delete all selected cells
+		actionBar: {
+			icon: 'codicon-trash',
+				position: 'main',
+				order: 100
+		},
+		keybinding: {
+			primary: KeyCode.Backspace,
+			secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)]
+		},
+		metadata: {
+			description: localize('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),
+		}
+	}
+);
+
 registerCellCommand({
 	commandId: 'positronNotebook.cell.executeAndFocusContainer',
 	handler: (cell) => cell.run(),
@@ -362,33 +387,6 @@ registerCellCommand({
 		description: localize('positronNotebook.cell.executeAndSelectBelow', "Execute cell and select below")
 	}
 });
-
-
-//#endregion Keybindings
-
-//#region Cell Commands
-// Register delete command with UI in one call
-// For built-in commands, we don't need to manage the disposable since they live
-// for the lifetime of the application
-registerCellCommand(
-	{
-		commandId: 'positronNotebook.cell.delete',
-		handler: (cell) => cell.delete(),
-		multiSelect: true,  // Delete all selected cells
-		actionBar: {
-			icon: 'codicon-trash',
-				position: 'main',
-				order: 100
-		},
-		keybinding: {
-			primary: KeyCode.Backspace,
-			secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)]
-		},
-		metadata: {
-			description: localize('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),
-		}
-	}
-);
 //#endregion Cell Commands
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -267,10 +267,8 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 registerCellCommand({
 	commandId: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
 	handler: (cell) => cell.insertCodeCellAbove(),
-	options: {
-		keybinding: {
-			primary: KeyCode.KeyA
-		}
+	keybinding: {
+		primary: KeyCode.KeyA
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
@@ -280,10 +278,8 @@ registerCellCommand({
 registerCellCommand({
 	commandId: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
 	handler: (cell) => cell.insertCodeCellBelow(),
-	options: {
-		keybinding: {
-			primary: KeyCode.KeyB
-		}
+	keybinding: {
+		primary: KeyCode.KeyB
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
@@ -341,10 +337,8 @@ registerNotebookCommand({
 registerCellCommand({
 	commandId: 'positronNotebook.cell.executeAndFocusContainer',
 	handler: (cell) => cell.run(),
-	options: {
-		keybinding: {
-			primary: KeyMod.CtrlCmd | KeyCode.Enter
-		}
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.Enter
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.execute', "Execute cell")
@@ -361,10 +355,8 @@ registerCellCommand({
 			notebook.selectionStateMachine.moveDown(false);
 		}
 	},
-	options: {
-		keybinding: {
-			primary: KeyMod.Shift | KeyCode.Enter
-		}
+	keybinding: {
+		primary: KeyMod.Shift | KeyCode.Enter
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.executeAndSelectBelow', "Execute cell and select below")
@@ -382,17 +374,15 @@ registerCellCommand(
 	{
 		commandId: 'positronNotebook.cell.delete',
 		handler: (cell) => cell.delete(),
-		options: {
-			multiSelect: true,  // Delete all selected cells
-			actionBar: {
-				icon: 'codicon-trash',
+		multiSelect: true,  // Delete all selected cells
+		actionBar: {
+			icon: 'codicon-trash',
 				position: 'main',
 				order: 100
-			},
-			keybinding: {
-				primary: KeyCode.Backspace,
-				secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)]
-			}
+		},
+		keybinding: {
+			primary: KeyCode.Backspace,
+			secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)]
 		},
 		metadata: {
 			description: localize('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -384,14 +384,20 @@ function registerNotebookKeybinding({ id, onRun, ...opts }: {
 // Register delete command with UI in one call
 // For built-in commands, we don't need to manage the disposable since they live
 // for the lifetime of the application
-registerCellCommand('positronNotebook.cell.delete',
-	(cell) => cell.delete(),
+registerCellCommand(
 	{
-		multiSelect: true,  // Delete all selected cells
-		actionBar: {
-			icon: 'codicon-trash',
-			position: 'main',
-			order: 100
+		commandId: 'positronNotebook.cell.delete',
+		handler: (cell) => cell.delete(),
+		options: {
+			multiSelect: true,  // Delete all selected cells
+			actionBar: {
+				icon: 'codicon-trash',
+				position: 'main',
+				order: 100
+			}
+		},
+		metadata: {
+			description: localize('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),
 		}
 	}
 );

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -325,7 +325,7 @@ registerCellCommand({
 		primary: KeyCode.KeyA
 	},
 	actionBar: {
-		icon: 'codicon-add',
+		icon: 'codicon-arrow-up',
 		position: 'menu',
 		order: 100
 	},
@@ -341,7 +341,7 @@ registerCellCommand({
 		primary: KeyCode.KeyB
 	},
 	actionBar: {
-		icon: 'codicon-add',
+		icon: 'codicon-arrow-down',
 		position: 'menu',
 		order: 100
 	},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -323,6 +323,11 @@ registerCellCommand({
 	keybinding: {
 		primary: KeyCode.KeyA
 	},
+	actionBar: {
+		icon: 'codicon-add',
+		position: 'menu',
+		order: 100
+	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
 	}
@@ -333,6 +338,11 @@ registerCellCommand({
 	handler: (cell) => cell.insertCodeCellBelow(),
 	keybinding: {
 		primary: KeyCode.KeyB
+	},
+	actionBar: {
+		icon: 'codicon-add',
+		position: 'menu',
+		order: 100
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -8,7 +8,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
-import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry, WorkbenchPhase, IWorkbenchContribution, registerWorkbenchContribution2 } from '../../../common/contributions.js';
@@ -25,10 +25,7 @@ import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { PositronNotebookEditorInput, PositronNotebookEditorInputOptions } from './PositronNotebookEditorInput.js';
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-import { ICommandAndKeybindingRule, KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
-import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { checkPositronNotebookEnabled } from './positronNotebookExperimentalConfig.js';
 import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from '../../../services/workingCopy/common/workingCopyEditorService.js';
@@ -37,11 +34,7 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { isEqual } from '../../../../base/common/resources.js';
 import { NotebookWorkingCopyTypeIdentifier } from '../../notebook/common/notebookCommon.js';
 import { registerCellCommand } from './notebookCells/actionBar/registerCellCommand.js';
-
-
-
-
-
+import { registerNotebookCommand } from './notebookCells/actionBar/registerNotebookCommand.js';
 
 
 /**
@@ -269,115 +262,116 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 
 //#region Keybindings
-registerNotebookKeybinding({
-	id: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
-	primary: KeyCode.KeyA,
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.insertCodeCellAndFocusContainer('above');
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
-	primary: KeyCode.KeyB,
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.insertCodeCellAndFocusContainer('below');
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.focusUp',
-	primary: KeyCode.UpArrow,
-	secondary: [KeyCode.KeyK],
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.selectionStateMachine.moveUp(false);
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.focusDown',
-	primary: KeyCode.DownArrow,
-	secondary: [KeyCode.KeyJ],
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.selectionStateMachine.moveDown(false);
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.addSelectionDown',
-	primary: KeyMod.Shift | KeyCode.DownArrow,
-	secondary: [KeyMod.Shift | KeyCode.KeyJ],
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.selectionStateMachine.moveDown(true);
-	}
-});
 
 
-registerNotebookKeybinding({
-	id: 'positronNotebook.addSelectionUp',
-	primary: KeyMod.Shift | KeyCode.UpArrow,
-	secondary: [KeyMod.Shift | KeyCode.KeyK],
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.selectionStateMachine.moveUp(true);
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.cell.delete',
-	primary: KeyCode.Backspace,
-	secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)],
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.deleteCell();
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.cell.executeAndFocusContainer',
-	primary: KeyMod.CtrlCmd | KeyCode.Enter,
-	onRun: ({ activeNotebook }) => {
-		activeNotebook.selectionStateMachine.getSelectedCell()?.run();
-	}
-});
-
-registerNotebookKeybinding({
-	id: 'positronNotebook.cell.executeAndSelectBelow',
-	primary: KeyMod.Shift | KeyCode.Enter,
-	onRun: ({ activeNotebook }) => {
-		const selectedCell = activeNotebook.selectionStateMachine.getSelectedCell();
-		if (selectedCell) {
-			selectedCell.run();
-			activeNotebook.selectionStateMachine.moveDown(false);
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
+	handler: (cell) => cell.insertCodeCellAbove(),
+	options: {
+		keybinding: {
+			primary: KeyCode.KeyA
 		}
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
+	handler: (cell) => cell.insertCodeCellBelow(),
+	options: {
+		keybinding: {
+			primary: KeyCode.KeyB
+		}
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
+	}
+});
+
+registerNotebookCommand({
+	commandId: 'positronNotebook.focusUp',
+	handler: (notebook) => notebook.selectionStateMachine.moveUp(false),
+	keybinding: {
+		primary: KeyCode.UpArrow,
+		secondary: [KeyCode.KeyK]
+	},
+	metadata: {
+		description: localize('positronNotebook.focusUp', "Move focus up")
+	}
+});
+
+registerNotebookCommand({
+	commandId: 'positronNotebook.focusDown',
+	handler: (notebook) => notebook.selectionStateMachine.moveDown(false),
+	keybinding: {
+		primary: KeyCode.DownArrow,
+		secondary: [KeyCode.KeyJ]
+	},
+	metadata: {
+		description: localize('positronNotebook.focusDown', "Move focus down")
+	}
+});
+
+registerNotebookCommand({
+	commandId: 'positronNotebook.addSelectionDown',
+	handler: (notebook) => notebook.selectionStateMachine.moveDown(true),
+	keybinding: {
+		primary: KeyMod.Shift | KeyCode.DownArrow,
+		secondary: [KeyMod.Shift | KeyCode.KeyJ]
+	},
+	metadata: {
+		description: localize('positronNotebook.addSelectionDown', "Extend selection down")
+	}
+});
+
+registerNotebookCommand({
+	commandId: 'positronNotebook.addSelectionUp',
+	handler: (notebook) => notebook.selectionStateMachine.moveUp(true),
+	keybinding: {
+		primary: KeyMod.Shift | KeyCode.UpArrow,
+		secondary: [KeyMod.Shift | KeyCode.KeyK]
+	},
+	metadata: {
+		description: localize('positronNotebook.addSelectionUp', "Extend selection up")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.executeAndFocusContainer',
+	handler: (cell) => cell.run(),
+	options: {
+		keybinding: {
+			primary: KeyMod.CtrlCmd | KeyCode.Enter
+		}
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.execute', "Execute cell")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.executeAndSelectBelow',
+	handler: (cell, accessor) => {
+		cell.run();
+		const notebookService = accessor.get(IPositronNotebookService);
+		const notebook = notebookService.getActiveInstance();
+		if (notebook) {
+			notebook.selectionStateMachine.moveDown(false);
+		}
+	},
+	options: {
+		keybinding: {
+			primary: KeyMod.Shift | KeyCode.Enter
+		}
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.executeAndSelectBelow', "Execute cell and select below")
 	}
 });
 
 
-/**
- * Register a keybinding for the Positron Notebook editor. These are typically used to intercept
- * existing notebook keybindings/commands and run them on positron notebooks instead.
- * @param id The id of the command to run. E.g. 'positronNotebook.focusDown'
- * @param keys The primary keybinding to use.
- * @param macKeys The primary and secondary keybindings to use on macOS.
- * @param onRun A function to run when the keybinding is triggered. Will be called if there is an
- * active notebook instance.
- */
-function registerNotebookKeybinding({ id, onRun, ...opts }: {
-	id: string;
-	onRun: (args: { activeNotebook: IPositronNotebookInstance; accessor: ServicesAccessor }) => void;
-} & Pick<ICommandAndKeybindingRule, 'primary' | 'secondary' | 'mac' | 'linux' | 'win'>) {
-	KeybindingsRegistry.registerCommandAndKeybindingRule({
-		id: id,
-		weight: KeybindingWeight.EditorContrib,
-		when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
-		handler: (accessor) => {
-			const notebookService = accessor.get(IPositronNotebookService);
-			const activeNotebook = notebookService.getActiveInstance();
-			if (!activeNotebook) { return; }
-			onRun({ activeNotebook, accessor });
-		},
-		...opts
-	});
-}
 //#endregion Keybindings
 
 //#region Cell Commands
@@ -394,6 +388,10 @@ registerCellCommand(
 				icon: 'codicon-trash',
 				position: 'main',
 				order: 100
+			},
+			keybinding: {
+				primary: KeyCode.Backspace,
+				secondary: [KeyChord(KeyCode.KeyD, KeyCode.KeyD)]
 			}
 		},
 		metadata: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -36,6 +36,7 @@ import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/wor
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { NotebookWorkingCopyTypeIdentifier } from '../../notebook/common/notebookCommon.js';
+import { registerCellCommand } from './notebookCells/actionBar/registerCellCommand.js';
 
 
 
@@ -268,6 +269,8 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 
 //#region Keybindings
+
+
 registerNotebookKeybinding({
 	id: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
 	primary: KeyCode.KeyA,
@@ -351,6 +354,7 @@ registerNotebookKeybinding({
 });
 
 
+
 /**
  * Register a keybinding for the Positron Notebook editor. These are typically used to intercept
  * existing notebook keybindings/commands and run them on positron notebooks instead.
@@ -378,5 +382,22 @@ function registerNotebookKeybinding({ id, onRun, ...opts }: {
 	});
 }
 //#endregion Keybindings
+
+//#region Cell Commands
+// Register delete command with UI in one call
+// For built-in commands, we don't need to manage the disposable since they live
+// for the lifetime of the application
+registerCellCommand('positronNotebook.cell.delete',
+	(cell) => cell.delete(),
+	{
+		multiSelect: true,  // Delete all selected cells
+		actionBar: {
+			icon: 'codicon-trash',
+			position: 'main',
+			order: 100
+		}
+	}
+);
+//#endregion Cell Commands
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -327,7 +327,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-arrow-up',
 		position: 'menu',
-		order: 100
+		order: 100,
+		category: 'Cell'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
@@ -343,7 +344,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-arrow-down',
 		position: 'menu',
-		order: 100
+		order: 100,
+		category: 'Cell'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
@@ -358,7 +360,8 @@ registerCellCommand(
 		actionBar: {
 			icon: 'codicon-trash',
 			position: 'main',
-			order: 100
+			order: 100,
+			category: 'Cell'
 		},
 		keybinding: {
 			primary: KeyCode.Backspace,
@@ -385,7 +388,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-play',
 		position: 'main',
-		order: CELL_EXECUTION_POSITION
+		order: CELL_EXECUTION_POSITION,
+		category: 'Execution'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.execute', "Execute cell")
@@ -405,7 +409,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-stop',
 		position: 'main',
-		order: CELL_EXECUTION_POSITION
+		order: CELL_EXECUTION_POSITION,
+		category: 'Execution'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.stopExecution', "Stop cell execution")
@@ -457,7 +462,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-run-above',
 		position: 'menu',
-		order: 20
+		order: 20,
+		category: 'Execution'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.runAllAbove', "Run all code cells above this cell")
@@ -489,7 +495,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-run-below',
 		position: 'menu',
-		order: 21
+		order: 21,
+		category: 'Execution'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.runAllBelow', "Run all code cells below this cell")
@@ -508,7 +515,8 @@ registerCellCommand({
 	actionBar: {
 		icon: 'codicon-primitive-square',  // Will need to be dynamic based on editor state
 		position: 'main',
-		order: 10
+		order: 10,
+		category: 'Markdown'
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.toggleMarkdownEditor', "Toggle markdown editor visibility")

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -373,8 +373,14 @@ registerCellCommand(
 registerCellCommand({
 	commandId: 'positronNotebook.cell.executeAndFocusContainer',
 	handler: (cell) => cell.run(),
+	cellCondition: CellConditions.isCode,  // Only show on code cells
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Enter
+	},
+	actionBar: {
+		icon: 'codicon-play',
+		position: 'main',
+		order: 10
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.execute', "Execute cell")

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -370,20 +370,45 @@ registerCellCommand(
 	}
 );
 
+// Make sure the run and stop commands are in the same place so they replace one another.
+const CELL_EXECUTION_POSITION = 10;
 registerCellCommand({
 	commandId: 'positronNotebook.cell.executeAndFocusContainer',
 	handler: (cell) => cell.run(),
-	cellCondition: CellConditions.isCode,  // Only show on code cells
+	cellCondition: CellConditions.and(
+		CellConditions.isCode,
+		CellConditions.not(CellConditions.isRunning)
+	),  // Only show on code cells that are not running
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Enter
 	},
 	actionBar: {
 		icon: 'codicon-play',
 		position: 'main',
-		order: 10
+		order: CELL_EXECUTION_POSITION
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.execute', "Execute cell")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.stopExecution',
+	handler: (cell) => cell.run(), // Run called when cell is executing is stop
+	cellCondition: CellConditions.and(
+		CellConditions.isCode,
+		CellConditions.isRunning
+	),  // Only show on code cells that are running
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.Enter
+	},
+	actionBar: {
+		icon: 'codicon-stop',
+		position: 'main',
+		order: CELL_EXECUTION_POSITION
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.stopExecution', "Stop cell execution")
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -269,8 +269,6 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 
 //#region Keybindings
-
-
 registerNotebookKeybinding({
 	id: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
 	primary: KeyCode.KeyA,

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
@@ -70,6 +70,16 @@ export interface IPositronNotebookCell extends Disposable {
 	run(): void;
 
 	/**
+	 * Insert a new code cell above this cell
+	 */
+	insertCodeCellAbove(): void;
+
+	/**
+	 * Insert a new code cell below this cell
+	 */
+	insertCodeCellBelow(): void;
+
+	/**
 	 * Type guard for checking if cell is a markdown cell
 	 */
 	isMarkdownCell(): this is IPositronNotebookMarkdownCell;

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -137,8 +137,9 @@ export interface IPositronNotebookInstance {
 	 * and focuses the container.
 	 *
 	 * @param aboveOrBelow Whether to insert the cell above or below the current selection
+	 * @param referenceCell Optional cell to insert relative to. If not provided, uses the currently selected cell
 	 */
-	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below'): void;
+	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
 
 	/**
 	 * Removes a cell from the notebook.

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -344,4 +344,35 @@ export class PositronNotebooks extends Notebooks {
 			'positron.notebook.enabled': true,
 		}, { reload: true });
 	}
+
+	/**
+	 * Helper function to delete cell using action bar delete button
+	 */
+	async deleteCellWithActionBar(cellIndex = 0): Promise<void> {
+		await test.step(`Delete cell ${cellIndex} using action bar`, async () => {
+			// Get the current cell count before deletion
+			const initialCount = await this.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+
+			// Get the specific cell
+			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+
+			// Hover over the cell to make the action bar visible
+			await cell.hover();
+
+			// Find and click the delete button in the action bar
+			const deleteButton = cell.getByLabel('positronNotebook.cell.delete');
+
+			// Wait for the delete button to be visible
+			await expect(deleteButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+
+			// Click the delete button
+			await deleteButton.click();
+
+			// Wait for the deletion to complete by checking cell count decreased
+			await expect(this.code.driver.page.locator('[data-testid="notebook-cell"]')).toHaveCount(initialCount - 1, { timeout: DEFAULT_TIMEOUT });
+
+			// Give a small delay for focus to settle
+			await this.code.driver.page.waitForTimeout(100);
+		});
+	}
 }

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -11,16 +11,30 @@ import test, { expect, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
 
 const DEFAULT_TIMEOUT = 10000;
+
 /**
  * Notebooks functionality exclusive to Positron notebooks.
  */
 export class PositronNotebooks extends Notebooks {
 	positronNotebook: Locator;
 
+	// Selector constants for Positron notebook elements
+	private static readonly RUN_CELL_LABEL = /execute cell/i;
+	private static readonly NOTEBOOK_CELL_SELECTOR = '[data-testid="notebook-cell"]';
+	private static readonly NEW_CODE_CELL_LABEL = /new code cell/i;
+	private static readonly MONACO_EDITOR_SELECTOR = '.positron-cell-editor-monaco-widget textarea';
+	private static readonly CELL_EXECUTING_LABEL = /cell is executing/i;
+	private static readonly CELL_EXECUTION_INFO_LABEL = /cell execution info/i;
+	private static readonly NOTEBOOK_KERNEL_STATUS_LABEL = /notebook kernel status/i;
+	private static readonly DELETE_CELL_LABEL = /delete the selected cell/i;
+	private static readonly POSITRON_NOTEBOOK_SELECTOR = '.positron-notebook';
+	private static readonly CELL_STATUS_SYNC_SELECTOR = '.cell-status-item-has-runnable .codicon-sync';
+	private static readonly DETECTING_KERNELS_TEXT = /detecting kernels/i;
+
 	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys) {
 		super(code, quickinput, quickaccess, hotKeys);
 
-		this.positronNotebook = this.code.driver.page.locator('.positron-notebook').first();
+		this.positronNotebook = this.code.driver.page.locator(PositronNotebooks.POSITRON_NOTEBOOK_SELECTOR).first();
 	}
 
 	// -- Actions --
@@ -42,7 +56,7 @@ export class PositronNotebooks extends Notebooks {
 	async selectCellAtIndex(cellIndex: number): Promise<void> {
 		await test.step(`Select cell at index: ${cellIndex}`, async () => {
 			// Use semantic selector
-			await this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex).click();
+			await this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex).click();
 		});
 	}
 
@@ -50,7 +64,7 @@ export class PositronNotebooks extends Notebooks {
 	 * Get the current number of cells in the notebook
 	 */
 	private async getCellCount(): Promise<number> {
-		return await this.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+		return await this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).count();
 	}
 
 	/**
@@ -59,7 +73,7 @@ export class PositronNotebooks extends Notebooks {
 	private async createNewCodeCell(index: number): Promise<void> {
 		await test.step(`Create new code cell at index ${index}`, async () => {
 			// Find all "New Code Cell" buttons - they appear between cells
-			const addCellButtons = this.code.driver.page.getByLabel('New Code Cell');
+			const addCellButtons = this.code.driver.page.getByLabel(PositronNotebooks.NEW_CODE_CELL_LABEL);
 			const buttonCount = await addCellButtons.count();
 
 			if (buttonCount === 0) {
@@ -71,7 +85,7 @@ export class PositronNotebooks extends Notebooks {
 			await addCellButtons.last().click();
 
 			// Wait for the new cell to appear
-			await expect(this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(index)).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+			await expect(this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(index)).toBeVisible({ timeout: DEFAULT_TIMEOUT });
 		});
 	}
 
@@ -97,12 +111,9 @@ export class PositronNotebooks extends Notebooks {
 			// Now select and fill the cell (existing logic)
 			await this.selectCellAtIndex(cellIndex);
 
-			// Find the Monaco editor within the Positron cell
-			const editorSelector = '.positron-cell-editor-monaco-widget textarea';
-
 			// Get the specific cell's editor
-			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-			const editor = cell.locator(editorSelector);
+			const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
+			const editor = cell.locator(PositronNotebooks.MONACO_EDITOR_SELECTOR);
 
 			// Ensure editor is focused and type/fill the code
 			await editor.focus();
@@ -123,13 +134,13 @@ export class PositronNotebooks extends Notebooks {
 			await this.selectCellAtIndex(cellIndex);
 
 			// Find and click the run button for this specific cell
-			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-			const runButton = cell.getByLabel('Run cell');
+			const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
+			const runButton = cell.getByLabel(PositronNotebooks.RUN_CELL_LABEL);
 
 			await runButton.click();
 
 			// Wait for execution to complete by checking the execution spinner is gone
-			const spinner = cell.getByLabel('Cell is executing');
+			const spinner = cell.getByLabel(PositronNotebooks.CELL_EXECUTING_LABEL);
 
 			// Wait for spinner to appear (cell is executing)
 			await expect(spinner).toBeVisible({ timeout: DEFAULT_TIMEOUT }).catch(() => {
@@ -150,8 +161,8 @@ export class PositronNotebooks extends Notebooks {
 			await this.selectCellAtIndex(cellIndex);
 
 			// Find and click the run button for this specific cell
-			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-			const runButton = cell.getByLabel('Run cell');
+			const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
+			const runButton = cell.getByLabel(PositronNotebooks.RUN_CELL_LABEL);
 
 			await runButton.click();
 		});
@@ -179,13 +190,13 @@ export class PositronNotebooks extends Notebooks {
 			}
 
 			// Get the cell once and reuse the reference
-			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+			const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
 
 			// Select the cell
 			await cell.click();
 
 			// Find and fill the Monaco editor
-			const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
+			const editor = cell.locator(PositronNotebooks.MONACO_EDITOR_SELECTOR);
 			await editor.focus();
 
 			if (delay) {
@@ -195,7 +206,7 @@ export class PositronNotebooks extends Notebooks {
 			}
 
 			// Find and click the run button
-			const runButton = cell.getByLabel('Run cell');
+			const runButton = cell.getByLabel(PositronNotebooks.RUN_CELL_LABEL);
 			await runButton.click();
 
 			// // Wait for execution to complete
@@ -216,8 +227,8 @@ export class PositronNotebooks extends Notebooks {
 	 * Get execution info icon for a specific cell
 	 */
 	getExecutionInfoIcon(cellIndex = 0): Locator {
-		const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-		return cell.getByLabel('Cell execution info');
+		const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
+		return cell.getByLabel(PositronNotebooks.CELL_EXECUTION_INFO_LABEL);
 	}
 
 
@@ -255,11 +266,11 @@ export class PositronNotebooks extends Notebooks {
 			await this.expectToBeVisible();
 
 			// Wait for kernel detection to complete
-			await expect(this.code.driver.page.locator('.cell-status-item-has-runnable .codicon-sync')).not.toBeVisible({ timeout: 30000 });
-			await expect(this.code.driver.page.locator('text="Detecting Kernels"')).not.toBeVisible({ timeout: 30000 });
+			await expect(this.code.driver.page.locator(PositronNotebooks.CELL_STATUS_SYNC_SELECTOR)).not.toBeVisible({ timeout: 30000 });
+			await expect(this.code.driver.page.getByText(PositronNotebooks.DETECTING_KERNELS_TEXT)).not.toBeVisible({ timeout: 30000 });
 
 			// Get the kernel status badge using aria-label
-			const kernelStatusBadge = this.code.driver.page.getByLabel(/notebook kernel status/i);
+			const kernelStatusBadge = this.code.driver.page.getByLabel(PositronNotebooks.NOTEBOOK_KERNEL_STATUS_LABEL);
 			await expect(kernelStatusBadge).toBeVisible({ timeout: 5000 });
 
 			try {
@@ -351,16 +362,16 @@ export class PositronNotebooks extends Notebooks {
 	async deleteCellWithActionBar(cellIndex = 0): Promise<void> {
 		await test.step(`Delete cell ${cellIndex} using action bar`, async () => {
 			// Get the current cell count before deletion
-			const initialCount = await this.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+			const initialCount = await this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).count();
 
 			// Get the specific cell
-			const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+			const cell = this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR).nth(cellIndex);
 
 			// Hover over the cell to make the action bar visible
 			await cell.hover();
 
 			// Find and click the delete button in the action bar
-			const deleteButton = cell.getByLabel(/delete the selected cell/i);
+			const deleteButton = cell.getByLabel(PositronNotebooks.DELETE_CELL_LABEL);
 
 			// Wait for the delete button to be visible
 			await expect(deleteButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });
@@ -369,7 +380,7 @@ export class PositronNotebooks extends Notebooks {
 			await deleteButton.click();
 
 			// Wait for the deletion to complete by checking cell count decreased
-			await expect(this.code.driver.page.locator('[data-testid="notebook-cell"]')).toHaveCount(initialCount - 1, { timeout: DEFAULT_TIMEOUT });
+			await expect(this.code.driver.page.locator(PositronNotebooks.NOTEBOOK_CELL_SELECTOR)).toHaveCount(initialCount - 1, { timeout: DEFAULT_TIMEOUT });
 
 			// Give a small delay for focus to settle
 			await this.code.driver.page.waitForTimeout(100);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -360,7 +360,7 @@ export class PositronNotebooks extends Notebooks {
 			await cell.hover();
 
 			// Find and click the delete button in the action bar
-			const deleteButton = cell.getByLabel('positronNotebook.cell.delete');
+			const deleteButton = cell.getByLabel(/delete the selected cell/i);
 
 			// Wait for the delete button to be visible
 			await expect(deleteButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra/index.js';
+import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * Helper function to get cell count
+ */
+async function getCellCount(app: Application): Promise<number> {
+	return await app.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+}
+
+/**
+ * Helper function to get cell content for identification
+ */
+async function getCellContent(app: Application, cellIndex: number): Promise<string> {
+	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+	const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
+	return await editor.inputValue();
+}
+
+
+test.describe('Cell Deletion Action Bar Behavior', {
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+
+	test('Cell deletion using action bar', async function ({ app, settings }) {
+		// Enable Positron notebooks
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+		// Enable screen reader support so we can programmatically get cell content (for the test)
+		await settings.set({ 'editor.accessibilitySupport': 'on' });
+
+		await app.workbench.notebooks.createNewNotebook();
+		await app.workbench.notebooksPositron.expectToBeVisible();
+
+		// ========================================
+		// Setup: Create 6 cells with distinct content
+		// ========================================
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 0', 0);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 1', 1);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 2', 2);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 3', 3);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 4', 4);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 5', 5);
+
+		// Verify we have 6 cells
+		expect(await getCellCount(app)).toBe(6);
+
+		// ========================================
+		// Test 1: Delete a selected cell (cell 2)
+		// ========================================
+		// Select cell 2 explicitly
+		await app.workbench.notebooksPositron.selectCellAtIndex(2);
+
+		// Verify cell 2 has correct content before deletion
+		expect(await getCellContent(app, 2)).toBe('# Cell 2');
+
+		// Delete the selected cell using action bar
+		await app.workbench.notebooksPositron.deleteCellWithActionBar(2);
+
+		// Verify cell count decreased
+		expect(await getCellCount(app)).toBe(5);
+
+		// Verify what was cell 3 is now at index 2
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+
+		// ========================================
+		// Test 2: Delete a non-selected (hovered) cell (cell 4, originally cell 5)
+		// ========================================
+		// Select a different cell (cell 0) first
+		await app.workbench.notebooksPositron.selectCellAtIndex(0);
+
+		// Verify cell 4 has correct content before deletion
+		expect(await getCellContent(app, 4)).toBe('# Cell 5');
+
+		// Delete cell 4 (which is NOT selected) by hovering and clicking action bar
+		await app.workbench.notebooksPositron.deleteCellWithActionBar(4);
+
+		// Verify cell count decreased
+		expect(await getCellCount(app)).toBe(4);
+
+		// Verify the remaining cells are correct
+		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		expect(await getCellContent(app, 1)).toBe('# Cell 1');
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+
+		// ========================================
+		// Test 3: Delete last cell (cell 3, originally cell 4)
+		// ========================================
+		// Verify we're at the last cell with correct content
+		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+
+		// Delete the last cell using action bar
+		await app.workbench.notebooksPositron.deleteCellWithActionBar(3);
+
+		// Verify cell count decreased
+		expect(await getCellCount(app)).toBe(3);
+
+		// Verify remaining cells
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+
+		// ========================================
+		// Test 4: Delete first cell (cell 0)
+		// ========================================
+		// Verify we're at the first cell with correct content
+		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+
+		// Delete the first cell using action bar
+		await app.workbench.notebooksPositron.deleteCellWithActionBar(0);
+
+		// Verify cell count decreased
+		expect(await getCellCount(app)).toBe(2);
+
+		// Verify what was cell 1 is now at index 0
+		expect(await getCellContent(app, 0)).toBe('# Cell 1');
+
+		// ========================================
+		// Test 5: Delete remaining cells
+		// ========================================
+		// Delete until only one cell remains
+		while (await getCellCount(app) > 1) {
+			const currentCount = await getCellCount(app);
+			await app.workbench.notebooksPositron.deleteCellWithActionBar(0);
+
+			// Verify count decreased
+			expect(await getCellCount(app)).toBe(currentCount - 1);
+		}
+
+		// Verify we still have at least one cell
+		expect(await getCellCount(app)).toBeGreaterThanOrEqual(1);
+
+		// ========================================
+		// Cleanup
+		// ========================================
+		// Close the notebook without saving
+		await app.workbench.notebooks.closeNotebookWithoutSaving();
+	});
+});

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -23,21 +23,20 @@ async function getCellCount(app: Application): Promise<number> {
  */
 async function getCellContent(app: Application, cellIndex: number): Promise<string> {
 	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-	const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
-	return await editor.inputValue();
+	const editor = cell.locator('.positron-cell-editor-monaco-widget .view-lines');
+	const content = await editor.textContent();
+	return content ?? '';
 }
 
 
 test.describe('Cell Deletion Action Bar Behavior', {
-	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
 }, () => {
 
 	test('Cell deletion using action bar', async function ({ app, settings }) {
 		// Enable Positron notebooks
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
-		// Enable screen reader support so we can programmatically get cell content (for the test)
-		await settings.set({ 'editor.accessibilitySupport': 'on' });
 
 		await app.workbench.notebooks.createNewNotebook();
 		await app.workbench.notebooksPositron.expectToBeVisible();
@@ -62,7 +61,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(2);
 
 		// Verify cell 2 has correct content before deletion
-		expect(await getCellContent(app, 2)).toBe('# Cell 2');
+		expect(await getCellContent(app, 2)).toBe('# Cell 2');
 
 		// Delete the selected cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(2);
@@ -71,7 +70,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(5);
 
 		// Verify what was cell 3 is now at index 2
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 2: Delete a non-selected (hovered) cell (cell 4, originally cell 5)
@@ -80,7 +79,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(0);
 
 		// Verify cell 4 has correct content before deletion
-		expect(await getCellContent(app, 4)).toBe('# Cell 5');
+		expect(await getCellContent(app, 4)).toBe('# Cell 5');
 
 		// Delete cell 4 (which is NOT selected) by hovering and clicking action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(4);
@@ -89,16 +88,16 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(4);
 
 		// Verify the remaining cells are correct
-		expect(await getCellContent(app, 0)).toBe('# Cell 0');
-		expect(await getCellContent(app, 1)).toBe('# Cell 1');
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
-		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		expect(await getCellContent(app, 1)).toBe('# Cell 1');
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await getCellContent(app, 3)).toBe('# Cell 4');
 
 		// ========================================
 		// Test 3: Delete last cell (cell 3, originally cell 4)
 		// ========================================
 		// Verify we're at the last cell with correct content
-		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+		expect(await getCellContent(app, 3)).toBe('# Cell 4');
 
 		// Delete the last cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(3);
@@ -107,13 +106,13 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(3);
 
 		// Verify remaining cells
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await getCellContent(app, 2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 4: Delete first cell (cell 0)
 		// ========================================
 		// Verify we're at the first cell with correct content
-		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		expect(await getCellContent(app, 0)).toBe('# Cell 0');
 
 		// Delete the first cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(0);
@@ -122,7 +121,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(2);
 
 		// Verify what was cell 1 is now at index 0
-		expect(await getCellContent(app, 0)).toBe('# Cell 1');
+		expect(await getCellContent(app, 0)).toBe('# Cell 1');
 
 		// ========================================
 		// Test 5: Delete remaining cells


### PR DESCRIPTION
Addresses #8791.

### Summary

This PR implements a contributable cell action bar system for Positron notebooks, establishing the infrastructure for extensions and other parts of the codebase to dynamically register actions that appear in notebook cell action bars. The implementation follows VS Code patterns by separating command execution from UI metadata and using a registry system.

**Context menus are now functional** - several actions have been implemented using the `"menu"` position, including cell movement actions (Move Cell Up/Down) and execution actions (Run Above/Below), organized by categories.

**Run button has been migrated** - The primary run/stop button functionality has been successfully converted to use the contributable system with proper cell conditions for showing run vs stop states.

The implementation was inspired by the positron action bar along with the vscode notebooks and their notebook contribution helper functions. 


<img width="952" height="553" alt="image" src="https://github.com/user-attachments/assets/a491fcb2-b055-489e-b385-a6f146deb020" />

_More menu with groupings for related actions_

<img width="972" height="482" alt="image" src="https://github.com/user-attachments/assets/f16e4bda-c25c-486d-9b2e-564d466a0b07" />

_Conditional system lets actions only show when applicable. Here the "run cells above" action is absent because that doesn't make sense for the first cell._

### Architecture

**Command and UI Separation:**
- Commands are registered through VS Code's `CommandsRegistry` for execution logic
- UI metadata is registered separately through `NotebookCellActionBarRegistry` for display configuration
- This enables commands to work everywhere (command palette, keyboard shortcuts, API calls)

**Registry System:**
- `NotebookCellActionBarRegistry` - Singleton registry managing cell action bar contributions
- Observable arrays for reactive UI updates when actions are added/removed so dynamically added actions are automatically reflected.
- Support for main action bar (primary actions) and dropdown menu (secondary actions)
- Configurable sorting, visibility conditions, context requirements, and cell-specific conditions

**Cell Condition System:**
- `CellConditionPredicate` functions determine if commands apply to specific cells based on type, position, and state
- `ICellInfo` provides cell metadata (type, index, position flags, execution status)
- Pre-built conditions in `CellConditions` helper (isCode, isMarkdown, notFirst, notLast, isRunning, etc.)
- Composable logic operators (and, or, not) for complex conditions

**Helper Function:**
- `registerCellCommand()` - Convenient API to register both command and UI metadata in one call
- Automatic cell selection handling with multi-select support
- Optional UI registration with position, icon, visibility configuration, and cell conditions
- Integrated keybinding support

### Key Features

```typescript
// Run button with conditional visibility based on execution state
registerCellCommand({
    commandId: 'positronNotebook.cell.executeAndFocusContainer',
    handler: (cell) => cell.run(),
    cellCondition: CellConditions.and(
        CellConditions.isCode,
        CellConditions.not(CellConditions.isRunning)  // Only show when not running
    ),
    actionBar: {
        icon: 'codicon-play',
        position: 'main',
        order: 10
    },
    keybinding: {
        primary: KeyMod.CtrlCmd | KeyCode.Enter
    }
});

// Stop button replaces run button when cell is executing
registerCellCommand({
    commandId: 'positronNotebook.cell.stopExecution',
    handler: (cell) => cell.run(), // Run called when executing acts as stop
    cellCondition: CellConditions.and(
        CellConditions.isCode,
        CellConditions.isRunning  // Only show when running
    ),
    actionBar: {
        icon: 'codicon-stop',
        position: 'main',
        order: 10  // Same position as run button for seamless replacement
    }
});
```

**UI Metadata Interface:**
```typescript
interface INotebookCellActionBarItem {
	/** VS Code command ID to execute */
	commandId: string;
	/** Command label, for display purposes, if not defined, use the commandId */
	label?: ILocalizedString | string;
	/** Codicon class for the button icon (optional) */
	icon?: string;
	/** Location in UI - either main action bar or dropdown menu */
	position: 'main' | 'menu';
	/** Sort order within position (lower numbers appear first) */
	order?: number;
	/** Visibility condition using VS Code context keys (optional) */
	when?: ContextKeyExpression;
	/** If true, the cell will be selected before executing the command */
	needsCellContext?: boolean;
	/** Cell-specific condition that determines if this command applies to a given cell */
	cellCondition?: CellConditionPredicate;
	/** Category of the action bar item. Items that share the same category will be grouped together. */
	category?: string;
}
```

### Implementation Details

**Refactored Components:**
- `NotebookCellActionBar.tsx` now renders contributed actions dynamically using observable arrays
- Registry integration with automatic cell context handling
- All existing cell actions (run, stop, delete) now use the contributable system
- Cell-type-specific actions maintain their behavior while being fully integrated

**Context Menu System:**
- `NotebookCellMoreActionsMenu.tsx` renders menu actions grouped by category with separators
- Automatic cell selection when executing commands from the dropdown menu
- Dynamic menu population based on registry contents

**Migration Complete:**
- **Run/Stop button**: Converted with conditional visibility based on execution state
- **Delete functionality**: Converted with multi-select support and keyboard shortcuts preserved
- **Cell movement**: Move Up/Down actions available in context menu
- **Execution actions**: Run Above/Below commands in context menu
- **Markdown editing**: Toggle editor for markdown cells

**Currently Implemented Actions:**
- **Main Action Bar**: Run/Stop (conditional), Delete (main), Toggle Markdown Editor
- **Context Menu**:
  - **Cell Category**: Move Cell Up, Move Cell Down  
  - **Execution Category**: Run Above, Run Below

### File Structure
```
notebookCells/
├── actionBar/
│   ├── actionBarRegistry.ts          # Registry for UI metadata
│   ├── cellConditions.ts             # Cell condition system with helpers
│   ├── registerCellCommand.ts        # Helper for command/keybinding/UI registration  
│   ├── actionBarMenuItems.ts         # Context menu builder with category grouping
│   ├── CellActionButton.tsx          # Reusable button component
│   ├── NotebookCellMoreActionsMenu.tsx # Context menu component
│   └── useActionBarVisibility.ts     # Visibility hook
└── NotebookCellActionBar.tsx         # Main action bar using registry system
```

### Release Notes

#### New Features
- Cell action bar context menu with categorized actions
- Cell movement commands available via dropdown menu  
- Run Above/Below commands for targeted execution
- Unified contributable action system for all cell actions

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:win

There is a new e2e test for the delete action being run from the action bar. This verifies that the contributions are being properly registered and are functional. 

Manual testing:
- Open a notebook with multiple cells
- Verify the run button appears on code cells and changes to stop when executing
- Click the "..." menu button to verify the context menu appears with categorized actions
- Test Move Cell Up/Down actions to verify cell reordering works
- Test Run Above/Below actions to verify partial execution works  
- Test delete functionality from both main action bar and multi-select
- Verify actions respect cell conditions (e.g., Move Up disabled for first cell, Run only on code cells)
- Test markdown cell edit toggle functionality
- Verify keyboard shortcuts still work (Ctrl+Enter for run, Backspace/dd for delete, etc.)
- Ensure functionality works across multiple open notebooks