### PR TITLE
Bump Ark to 0.1.204

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -967,7 +967,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.203"
+      "ark": "0.1.204"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Sync with https://github.com/posit-dev/ark/pull/907

- Add support for table summary tool
   https://github.com/posit-dev/ark/pull/904

  Still requires https://github.com/posit-dev/positron/pull/9134

- Recurse into special constructs to find document symbols
   https://github.com/posit-dev/ark/pull/892

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Comment sections nested in control flow operations like `if` / `else` are now included in the outline (#8881).


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
