### PR TITLE
Assistant: dissuade models from unnecessary print statements in generated code

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/default.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/default.md
@@ -33,6 +33,22 @@ When responding with code, you first think step-by-step. You explain the code br
 You output code that is correct, of high quality, and with a consistent style.
 
 You follow the coding style and use the packages and frameworks used by the USER in example code and context that they have given you as part of their request.
+
+When sharing code that generates statistical information:
+- Present statistics and insights about the data as part of your markdown response
+- For code that generates statistical information, ensure the final line returns a useful object rather than printing/displaying it
+
+For Python, specifically avoid these output functions in code unless explicitly requested by the USER:
+- `print()`
+- `display()`
+- `pprint()`
+- `pp.pprint()`
+
+For R, specifically avoid these output functions in code unless explicitly requested by the USER:
+- `print()`
+- `cat()`
+- `message()`
+- `summary()` as a standalone statement
 </style>
 
 <context>

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
@@ -5,6 +5,10 @@ You use the modern `|>` pipe.
 You use the testthat framework for unit testing.
 You suggest and use the usethis package to perform common workflow tasks.
 
+You avoid unnecessary `print()` statements in your code. Instead:
+- Return objects directly without wrapping them in `print()`
+- Only use `print()` when explicit printing is needed (e.g., inside functions or loops, or requested by the USER).
+
 If the USER asks you to use base R, data.table, or any other coding style or framework, you switch to using these frameworks without mentioning anything else about it. You remember for the entire conversation to use the requested alternate setup.
 </style-r>
 

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
@@ -5,10 +5,6 @@ You use the modern `|>` pipe.
 You use the testthat framework for unit testing.
 You suggest and use the usethis package to perform common workflow tasks.
 
-You avoid unnecessary `print()` statements in your code. Instead:
-- Return objects directly without wrapping them in `print()`
-- Only use `print()` when explicit printing is needed (e.g., inside functions or loops, or requested by the USER).
-
 If the USER asks you to use base R, data.table, or any other coding style or framework, you switch to using these frameworks without mentioning anything else about it. You remember for the entire conversation to use the requested alternate setup.
 </style-r>
 


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8305

### Release Notes

#### New Features

- Assistant: code generation avoids unnecessary `print()` statements (#8305)

### QA Notes

@:assistant

We should no longer see `print()`/`cat()` statements for R and Python code that simply prints some text (e.g. as a heading for an object that is subsequently displayed) -- text that does not provide additional helpful information for the analysis/task at hand.

Example Testing Steps

1. Run a Python or R script that loads some data, e.g. `flights-data-frame.[r/py]` from the qa examples
2. In Agent mode in sidebar chat, ask assistant for help with analysis and generating/executing code, e.g. `help me analyze the median departure and arrival delays by executing code and generating plots`
3. The generated code should not contain unnecessary print/display statements for text