### PR TITLE
E2E test: fix notebook test flake (allow regex matching for tabs)

### DIFF
--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -41,10 +41,24 @@ export class Editors {
 		});
 	}
 
-	async waitForActiveTab(fileName: string, isDirty: boolean = false): Promise<void> {
-		await expect(this.code.driver.page.locator(`.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"][data-resource-name$="${fileName}"]`)).toBeVisible();
+	escapeRegex(s: string) {
+		return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	}
 
+	async waitForActiveTab(fileName: string | RegExp, isDirty: boolean = false): Promise<void> {
+		const { page } = this.code.driver;
+		const base = `.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"]`;
+		const active = page.locator(base);
+
+		// Ensure we’re looking at exactly one active tab
+		await expect(active).toHaveCount(1);
+		await expect(active).toBeVisible();
+
+		const attrMatcher =
+			fileName instanceof RegExp ? fileName : new RegExp(`${this.escapeRegex(fileName)}$`);
+
+		await expect(active).toHaveAttribute('data-resource-name', attrMatcher);
+	}
 	async waitForActiveTabNotDirty(fileName: string): Promise<void> {
 		await expect(
 			this.code.driver.page.locator(
@@ -87,8 +101,38 @@ export class Editors {
 		}).toPass();
 	}
 
-	async waitForTab(fileName: string, isDirty: boolean = false): Promise<void> {
-		await expect(this.code.driver.page.locator(`.tabs-container div.tab${isDirty ? '.dirty' : ''}[data-resource-name$="${fileName}"]`)).toBeVisible();
+	async waitForTab(fileName: string | RegExp, isDirty: boolean = false): Promise<void> {
+		const { page } = this.code.driver;
+		const base = `.tabs-container div.tab${isDirty ? '.dirty' : ''}`;
+
+		if (fileName instanceof RegExp) {
+			// Find the *exact* data-resource-name of the first tab whose value matches the regex
+			const matchedName = await page.locator(`${base}[data-resource-name]`).evaluateAll(
+				(els, pattern) => {
+					const rx = new RegExp(pattern.source, pattern.flags);
+					for (const el of els) {
+						const v = el.getAttribute('data-resource-name') || '';
+						if (rx.test(v)) { return v; }
+					}
+					return null;
+				},
+				{ source: fileName.source, flags: fileName.flags }
+			);
+
+			if (!matchedName) {
+				throw new Error(`No tab found with data-resource-name matching ${fileName}`);
+			}
+
+			await expect(
+				page.locator(`${base}[data-resource-name="${matchedName}"]`)
+			).toBeVisible();
+
+		} else {
+			// Original ends-with behavior for plain strings
+			await expect(
+				page.locator(`${base}[data-resource-name$="${fileName}"]`)
+			).toBeVisible();
+		}
 	}
 
 	async waitForSCMTab(fileName: string): Promise<void> {

--- a/test/e2e/pages/notebooksVscode.ts
+++ b/test/e2e/pages/notebooksVscode.ts
@@ -25,7 +25,7 @@ export class VsCodeNotebooks extends Notebooks {
 	/**
 	 * Verify: a VS Code notebook is visible on the page.
 	 */
-	async expectToBeVisible(timeout = 5000): Promise<void> {
+	async expectToBeVisible(timeout = 25000): Promise<void> {
 		await test.step('Verify VS Code notebook is visible', async () => {
 			await expect(this.startChatButton).toBeVisible({ timeout });
 		});

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -102,7 +102,7 @@ test.describe('Positron notebook opening and saving', {
 		await notebooksPositron.expectToBeVisible();
 
 		// Verify only the expected tab is open (new notebooks are named Untitled-N.ipynb)
-		await editors.waitForTab('Untitled-1.ipynb', true); // true = isDirty
+		await editors.waitForTab(/^Untitled-\d+\.ipynb$/, true); // true = isDirty
 
 		// Count tabs before reload (checking for multiple tabs with same file is the ghost editor symptom)
 		const tabsBefore = await app.code.driver.page.locator('.tabs-container div.tab').count();
@@ -133,6 +133,6 @@ test.describe('Positron notebook opening and saving', {
 		test.expect(vscodeNotebookElements).toBe(0);
 
 		// Additional verification: ensure the active tab is still the restored untitled notebook
-		await editors.waitForActiveTab('Untitled-1.ipynb', true); // true = isDirty
+		await editors.waitForActiveTab(/^Untitled-\d+\.ipynb$/, true); // true = isDirty
 	});
 });


### PR DESCRIPTION
Notebook flake fix. We were looking for the wrong filename when the full suite of file tests was run. Added support for regex matching the filename so that it will work when run in the suite or by itself.

### QA Notes

@:notebooks @:top-action-bar
