### PR TITLE
assistant: construct git repo path using platform-specific path separator

### DIFF
--- a/extensions/positron-assistant/src/git.ts
+++ b/extensions/positron-assistant/src/git.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as path from 'path';
 
 import { API as GitAPI, GitExtension, Repository, Status, Change } from '../../git/src/api/git.js';
 import { MD_DIR } from './constants';
@@ -87,7 +88,8 @@ export async function getCommitChanges(repoUri: vscode.Uri, hash: string, parent
 	if (!repo) {
 		throw new Error('Repository not found');
 	}
-	return repo.diffBetween(parentHash, hash, repoUri.fsPath + '/.');
+	const repoPath = repoUri.fsPath + path.sep + '.';
+	return repo.diffBetween(parentHash, hash, repoPath);
 }
 
 /** Get current workspace git repository changes as text summaries */


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/9125
- fixes a platform-dependent path separator issue preventing a commit diff from being generated on Windows

### Release Notes

#### Bug Fixes

- Assistant: fixed issue preventing git commit info from being constructed on Windows (#9125)


### QA Notes

@:assistant

- see https://github.com/posit-dev/positron/issues/9125 for steps