### PR TITLE
Data Explorer: Display column labels from R in tooltips over column headers, summary panel

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -141,6 +141,9 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Determine whether the column is selected.
 	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
 
+	// Render the column title
+	const renderedColumn = renderLeadingTrailingWhitespace(props.column?.name);
+
 	// Render.
 	return (
 		<div

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -10,6 +10,7 @@ import './dataGridColumnHeader.css';
 import React, { MouseEvent, useRef } from 'react';
 
 // Other dependencies.
+import * as nls from '../../../../nls.js';
 import { IDataColumn } from '../interfaces/dataColumn.js';
 import { selectionType } from '../utilities/mouseUtilities.js';
 import { ColumnSelectionState } from '../classes/dataGridInstance.js';
@@ -47,6 +48,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Reference hooks.
 	const ref = useRef<HTMLDivElement>(undefined!);
 	const sortingButtonRef = useRef<HTMLButtonElement>(undefined!);
+	const titleRef = useRef<HTMLDivElement>(undefined!);
 
 	/**
 	 * onMouseDown handler.
@@ -97,6 +99,39 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 		await context.instance.showColumnContextMenu(props.columnIndex, sortingButtonRef.current);
 	};
 
+	/**
+	 * titleMouseOver event handler.
+	 */
+	const titleMouseOver = () => {
+		if (!props.column || !context.instance.hoverManager) {
+			return;
+		}
+
+		// Check if this is a PositronDataExplorerColumn with access to columnSchema
+		const explorerColumn = props.column as any;
+		if (!explorerColumn.columnSchema) {
+			return;
+		}
+
+		// Create tooltip content with type and label if present
+		const typePrefix = nls.localize('positronDataGrid.columnHeader.type', "Type:");
+		let tooltipContent = `${typePrefix} ${explorerColumn.columnSchema.type_name}`;
+
+		if (explorerColumn.columnSchema.column_label) {
+			tooltipContent += `\n${explorerColumn.columnSchema.column_label}`;
+		}
+
+		// Show hover with text content
+		context.instance.hoverManager.showHover(titleRef.current, tooltipContent);
+	};
+
+	/**
+	 * titleMouseLeave event handler.
+	 */
+	const titleMouseLeave = () => {
+		context.instance.hoverManager?.hideHover();
+	};
+
 	// Get the column sort key.
 	const columnSortKey = context.instance.columnSortKey(props.columnIndex);
 
@@ -144,7 +179,14 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				}}
 			>
 				<div className='title-description'>
-					<div className='title'>{renderLeadingTrailingWhitespace(props.column?.name)}</div>
+					<div
+						ref={titleRef}
+						className='title'
+						onMouseLeave={titleMouseLeave}
+						onMouseOver={titleMouseOver}
+					>
+						{renderedColumn}
+					</div>
 					{props.column?.description &&
 						<div className='description'>{props.column.description}</div>
 					}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -50,6 +50,7 @@ interface ColumnSummaryCellProps {
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
+	const columnNameRef = useRef<HTMLDivElement>(undefined!);
 
 	/**
 	 * Determines whether summary stats is supported.
@@ -558,7 +559,19 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 						)
 					}
 				/>
-				<div className='column-name'>
+				<div
+					ref={columnNameRef}
+					className='column-name'
+					onMouseLeave={() => props.instance.hoverManager.hideHover()}
+					onMouseOver={() => {
+						if (props.columnSchema.column_label) {
+							props.instance.hoverManager.showHover(
+								columnNameRef.current,
+								props.columnSchema.column_label
+							);
+						}
+					}}
+				>
 					{renderedColumn}
 				</div>
 				{!expanded && <ColumnSparkline />}

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -57,7 +57,8 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 	 * Gets the description.
 	 */
 	get description() {
-		return this._columnSchema.type_name;
+		// Show column label if available, otherwise show type
+		return this._columnSchema.column_label || this._columnSchema.type_name;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -57,8 +57,7 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 	 * Gets the description.
 	 */
 	get description() {
-		// Show column label if available, otherwise show type
-		return this._columnSchema.column_label || this._columnSchema.type_name;
+		return this._columnSchema.type_name;
 	}
 
 	/**


### PR DESCRIPTION
Initial attempt to address #2971. This adds an optional "column_label" parameter to ColumnSchema to allow this information to be returned from R. I added tooltips when hoving over the column headers, and a tooltip to show the description in the summary pane if present. (Claude Code implemented this PR with a bunch of feedback from me)

https://github.com/user-attachments/assets/e3f9721d-5355-49f6-89f0-132e9e0903bc

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Display R column labels in tooltips in the Data Explorer summary panel and column headers and if they have been set.

#### Bug Fixes

- N/A


### QA Notes

You can use a data frame like this

```R
# Create test data frame
test_df <- data.frame(
  id = 1:5,
  age = c(25, 30, 35, 40, 45),
  income = c(50000, 65000, 75000, 90000, 110000),
  score = c(85.5, 92.0, 88.5, 95.2, 87.8),
  active = c(TRUE, FALSE, TRUE, TRUE, FALSE)
)
# Add labels to only some columns
attr(test_df$age, "label") <- "Age in years"
attr(test_df$income, "label") <- "Annual salary (USD)"
attr(test_df$score, "label") <- "Performance score (%)"
```

@:data-explorer