### PR TITLE
data explorer: add placeholder code for connections-based dataframes

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -498,9 +498,6 @@ class ConnectionsService:
         self, conn: Connection, request: PreviewObjectRequest
     ) -> None:
         res, sql_string = conn.preview_object(request.params.path)
-        if sql_string:
-            sql_string = [sql_string]
-            sql_string.insert(0, "# Load table into pandas dataframe, eg:")
         title = request.params.path[-1].name
         self._kernel.data_explorer_service.register_table(res, title, sql_string=sql_string)
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -722,9 +722,9 @@ class SQLAlchemyConnection(Connection):
         )
         stmt = sqlalchemy.sql.select(table).limit(1000)
         sql_string = f"""# table = sqlalchemy.Table(
-        #    {table.name}, sqlalchemy.MetaData(), autoload_with=conn, schema={schema.name}
+        #    {table.name!r}, sqlalchemy.MetaData(), autoload_with=conn, schema={schema.name!r}
         # ) # where conn is your connection variable
-        # {table.name} = pd.read_sql(sqlalchemy.sql.select(table, conn.connect()))
+        # {table.name} = pd.read_sql(sqlalchemy.sql.select(table), conn.connect())
         """
         # using conn.connect() is safer then using the conn directly and is also supported
         # with older pandas versions such as 1.5

--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -473,7 +473,8 @@ class CodeConverter:
         filter_setup, filter_chain = self._convert_row_filters()
         sort_setup, sort_chain = self._convert_sort_keys()
         if self.sql_string:
-            builder.add_operation(self.sql_string, [])
+            sql = ["# Load table into pandas dataframe, eg:", self.sql_string]
+            builder.add_operation(sql, [])
         builder.add_operation(filter_setup, filter_chain)
         builder.add_operation(sort_setup, sort_chain)
 

--- a/extensions/positron-python/python_files/posit/positron/convert.py
+++ b/extensions/positron-python/python_files/posit/positron/convert.py
@@ -450,12 +450,14 @@ class CodeConverter:
         params: ConvertToCodeParams,
         *,
         was_series: bool = False,
+        sql_string: Optional[str] = None,
     ):
         self.table = table
         self.table_name: str = table_name
         self.params: ConvertToCodeParams = params
         self.was_series = was_series
         self.syntax_name = params.code_syntax_name.code_syntax_name
+        self.sql_string = sql_string
 
     def build_code(self) -> List[StrictStr]:
         """Convert operations to code strings.
@@ -470,7 +472,8 @@ class CodeConverter:
         # Add operations to the builder
         filter_setup, filter_chain = self._convert_row_filters()
         sort_setup, sort_chain = self._convert_sort_keys()
-
+        if self.sql_string:
+            builder.add_operation(self.sql_string, [])
         builder.add_operation(filter_setup, filter_chain)
         builder.add_operation(sort_setup, sort_chain)
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -18,7 +18,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Optional,
     Tuple,
 )
 
@@ -959,8 +958,8 @@ def _box_datetime_stats(
 
 
 class UnsupportedView(DataExplorerTableView):
-    def __init__(self, table, comm, state, job_queue):
-        super().__init__(table, comm, state, job_queue)
+    def __init__(self, table, comm, state, job_queue, sql_string: str | None = None):
+        super().__init__(table, comm, state, job_queue, sql_string)
 
 
 # Special value codes for the protocol

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -11,8 +11,8 @@ import polars as pl
 import pytest
 import pytz
 
-from posit.positron.connections_comm import ObjectSchema
 from positron.connections import DuckDBConnection, SQLAlchemyConnection, SQLite3Connection
+from positron.connections_comm import ObjectSchema
 from positron.data_explorer import DataExplorerService
 from positron.data_explorer_comm import CodeSyntaxName, FilterComparisonOp
 from positron.utils import var_guid
@@ -31,12 +31,16 @@ from .test_data_explorer import (
 
 try:
     import duckdb
+
+    has_duckdb = True
 except ImportError:
-    duckdb = False
+    has_duckdb = False
 try:
     import sqlalchemy
+
+    has_sqlalchemy = True
 except ImportError:
-    sqlalchemy = False
+    has_sqlalchemy = False
 
 
 SIMPLE_POLARS_DF = pl.DataFrame(SIMPLE_PANDAS_DF.drop(columns=["f"]))
@@ -735,7 +739,7 @@ def test_sqlite_connection_code():
 def test_sqlalchemy_connection_code():
     """Test that SQLAlchemyConnection returns the correct SQL code in preview_object."""
     # Type checking needs to know sqlalchemy is a module here, not False
-    if not sqlalchemy:
+    if not has_sqlalchemy:
         pytest.skip("SQLAlchemy is not installed")
 
     # Create an in-memory SQLite database using SQLAlchemy
@@ -775,7 +779,7 @@ def test_sqlalchemy_connection_code():
 def test_duckdb_connection_code():
     """Test that DuckDBConnection returns the correct SQL code in preview_object."""
     # Type checking needs to know duckdb is a module here, not False
-    if not duckdb:
+    if not has_duckdb:
         pytest.skip("DuckDB is not installed")
 
     # Create an in-memory DuckDB database

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -769,7 +769,7 @@ def test_sqlalchemy_connection_code():
 
     # Check the returned SQL code
     expected_code = """# table = sqlalchemy.Table(
-        #    test, sqlalchemy.MetaData(), autoload_with=conn, schema=main
+        #    test, sqlalchemy.MetaData(), autoload_with=conn, schema='main'
         # ) # where conn is your connection variable
         # test = pd.read_sql(sqlalchemy.sql.select(table, conn.connect()))
         """

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -11,6 +11,7 @@ import polars as pl
 import pytest
 import pytz
 
+from posit.positron.connections_comm import ObjectSchema
 from positron.connections import DuckDBConnection, SQLAlchemyConnection, SQLite3Connection
 from positron.data_explorer import DataExplorerService
 from positron.data_explorer_comm import CodeSyntaxName, FilterComparisonOp
@@ -714,9 +715,9 @@ def test_sqlite_connection_code():
     # Create a SQLite3Connection and test the preview_object method
     connection = SQLite3Connection(conn)
 
-    # Create the schema and table objects
-    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
-    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+    # Create proper ObjectSchema instances
+    schema = ObjectSchema(kind="schema", name="main")
+    table = ObjectSchema(kind="table", name="test")
 
     # Call the preview_object method
     df, code = connection.preview_object([schema, table])
@@ -731,9 +732,12 @@ def test_sqlite_connection_code():
     assert code == expected_code
 
 
-@pytest.mark.skipif(not sqlalchemy, reason="SQLAlchemy is not installed")
 def test_sqlalchemy_connection_code():
     """Test that SQLAlchemyConnection returns the correct SQL code in preview_object."""
+    # Type checking needs to know sqlalchemy is a module here, not False
+    if not sqlalchemy:
+        pytest.skip("SQLAlchemy is not installed")
+
     # Create an in-memory SQLite database using SQLAlchemy
     engine = sqlalchemy.create_engine("sqlite:///:memory:")
 
@@ -747,9 +751,9 @@ def test_sqlalchemy_connection_code():
     # Create a SQLAlchemyConnection and test the preview_object method
     connection = SQLAlchemyConnection(engine)
 
-    # Create the schema and table objects
-    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
-    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+    # Create proper ObjectSchema instances
+    schema = ObjectSchema(kind="schema", name="main")
+    table = ObjectSchema(kind="table", name="test")
 
     # Call the preview_object method
     df, code = connection.preview_object([schema, table])
@@ -768,9 +772,12 @@ def test_sqlalchemy_connection_code():
     assert code == expected_code
 
 
-@pytest.mark.skipif(not duckdb, reason="DuckDB is not installed")
 def test_duckdb_connection_code():
     """Test that DuckDBConnection returns the correct SQL code in preview_object."""
+    # Type checking needs to know duckdb is a module here, not False
+    if not duckdb:
+        pytest.skip("DuckDB is not installed")
+
     # Create an in-memory DuckDB database
     conn = duckdb.connect(":memory:")
 
@@ -782,10 +789,10 @@ def test_duckdb_connection_code():
     # Create a DuckDBConnection and test the preview_object method
     connection = DuckDBConnection(conn)
 
-    # Create the schema and catalog and table objects
-    catalog = type("ObjectSchema", (), {"kind": "catalog", "name": "memory"})
-    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
-    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+    # Create proper ObjectSchema instances
+    catalog = ObjectSchema(kind="catalog", name="memory")
+    schema = ObjectSchema(kind="schema", name="main")
+    table = ObjectSchema(kind="table", name="test")
 
     # Call the preview_object method
     df, code = connection.preview_object([catalog, schema, table])

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -769,9 +769,9 @@ def test_sqlalchemy_connection_code():
 
     # Check the returned SQL code
     expected_code = """# table = sqlalchemy.Table(
-        #    test, sqlalchemy.MetaData(), autoload_with=conn, schema='main'
+        #    'test', sqlalchemy.MetaData(), autoload_with=conn, schema='main'
         # ) # where conn is your connection variable
-        # test = pd.read_sql(sqlalchemy.sql.select(table, conn.connect()))
+        # test = pd.read_sql(sqlalchemy.sql.select(table), conn.connect())
         """
     assert code == expected_code
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_convert.py
@@ -4,15 +4,18 @@
 #
 
 import datetime
+import sqlite3
 
 import pandas as pd
 import polars as pl
 import pytest
 import pytz
 
-from ..data_explorer import DataExplorerService
-from ..data_explorer_comm import CodeSyntaxName, FilterComparisonOp
-from ..utils import var_guid
+from positron.connections import DuckDBConnection, SQLAlchemyConnection, SQLite3Connection
+from positron.data_explorer import DataExplorerService
+from positron.data_explorer_comm import CodeSyntaxName, FilterComparisonOp
+from positron.utils import var_guid
+
 from .conftest import DummyComm, PositronShell
 from .test_data_explorer import (
     COMPARE_OPS,
@@ -24,6 +27,16 @@ from .test_data_explorer import (
     _not_between_filter,
     _search_filter,
 )
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = False
+try:
+    import sqlalchemy
+except ImportError:
+    sqlalchemy = False
+
 
 SIMPLE_POLARS_DF = pl.DataFrame(SIMPLE_PANDAS_DF.drop(columns=["f"]))
 
@@ -687,3 +700,103 @@ def test_convert_polars_sort_to_pandas(dxf: DataExplorerConvertFixture):
         sort_keys=sort_keys,
         code_syntax_name="pandas",
     )
+
+
+# --- Connections tests ---
+def test_sqlite_connection_code():
+    """Test that SQLite3Connection returns the correct SQL code in preview_object."""
+    # Create an in-memory SQLite database with a test table
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE test (id INTEGER, name TEXT)")
+    conn.execute("INSERT INTO test VALUES (1, 'test1')")
+    conn.execute("INSERT INTO test VALUES (2, 'test2')")
+
+    # Create a SQLite3Connection and test the preview_object method
+    connection = SQLite3Connection(conn)
+
+    # Create the schema and table objects
+    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
+    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+
+    # Call the preview_object method
+    df, code = connection.preview_object([schema, table])
+
+    # Check the returned dataframe
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert list(df.columns) == ["id", "name"]
+
+    # Check the returned SQL code
+    expected_code = '# test = pd.read_sql("""SELECT * FROM main.test LIMIT 1000;""", conn) # where conn is your connection variable'
+    assert code == expected_code
+
+
+@pytest.mark.skipif(not sqlalchemy, reason="SQLAlchemy is not installed")
+def test_sqlalchemy_connection_code():
+    """Test that SQLAlchemyConnection returns the correct SQL code in preview_object."""
+    # Create an in-memory SQLite database using SQLAlchemy
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+
+    # Create a test table
+    with engine.connect() as connection:
+        connection.execute(sqlalchemy.text("CREATE TABLE test (id INTEGER, name TEXT)"))
+        connection.execute(sqlalchemy.text("INSERT INTO test VALUES (1, 'test1')"))
+        connection.execute(sqlalchemy.text("INSERT INTO test VALUES (2, 'test2')"))
+        connection.commit()
+
+    # Create a SQLAlchemyConnection and test the preview_object method
+    connection = SQLAlchemyConnection(engine)
+
+    # Create the schema and table objects
+    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
+    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+
+    # Call the preview_object method
+    df, code = connection.preview_object([schema, table])
+
+    # Check the returned dataframe
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert list(df.columns) == ["id", "name"]
+
+    # Check the returned SQL code
+    expected_code = """# table = sqlalchemy.Table(
+        #    test, sqlalchemy.MetaData(), autoload_with=conn, schema=main
+        # ) # where conn is your connection variable
+        # test = pd.read_sql(sqlalchemy.sql.select(table, conn.connect()))
+        """
+    assert code == expected_code
+
+
+@pytest.mark.skipif(not duckdb, reason="DuckDB is not installed")
+def test_duckdb_connection_code():
+    """Test that DuckDBConnection returns the correct SQL code in preview_object."""
+    # Create an in-memory DuckDB database
+    conn = duckdb.connect(":memory:")
+
+    # Create a test table
+    conn.execute("CREATE TABLE test (id INTEGER, name VARCHAR)")
+    conn.execute("INSERT INTO test VALUES (1, 'test1')")
+    conn.execute("INSERT INTO test VALUES (2, 'test2')")
+
+    # Create a DuckDBConnection and test the preview_object method
+    connection = DuckDBConnection(conn)
+
+    # Create the schema and catalog and table objects
+    catalog = type("ObjectSchema", (), {"kind": "catalog", "name": "memory"})
+    schema = type("ObjectSchema", (), {"kind": "schema", "name": "main"})
+    table = type("ObjectSchema", (), {"kind": "table", "name": "test"})
+
+    # Call the preview_object method
+    df, code = connection.preview_object([catalog, schema, table])
+
+    # Check the returned dataframe
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert list(df.columns) == ["id", "name"]
+
+    # Check the returned SQL code - using string match since the query might have quotes
+    expected_text = "# test = conn.execute("
+    assert expected_text in code
+    assert 'SELECT * FROM "memory"."main"."test" LIMIT 1000' in code
+    assert "where conn is your connection variable" in code


### PR DESCRIPTION
<img width="1708" height="1135" alt="Screenshot 2025-08-26 at 3 47 28 PM" src="https://github.com/user-attachments/assets/a42a637a-702b-48b2-8abe-8968ff589f27" />


If the pandas dataframe comes from a connection via Connections pane, add in placeholder text of how to potentially load the data.

The use of a commented out code block is to make a best-guess at how to load this data, but without making promises if folks are using a complex setup. Right now, we're assuming all db connection objects are called `comm` (and call that out to users), but if we want to do kernel-level user namespace inspection to get the actual variable name, I can add that in. I just worry that is potentially slow to look through objects in a user's namespace. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #9139 When converting code from Connections pane, offer example code to load table into pandas dataframe.


### QA Notes

@:data-explorer @:connections

To test out:
1. `pip install duckdb`

2. In a console session:

```python
import duckdb
# Create an in-memory DuckDB database
conn = duckdb.connect(":memory:")

# Create a test table
conn.execute("CREATE TABLE test (id INTEGER, name VARCHAR)")
conn.execute("INSERT INTO test VALUES (1, 'test1')")
conn.execute("INSERT INTO test VALUES (2, 'test2')")
```

3. Click the DB icon in the Variables pane for `conn`
4. In Connections pane, expand `memory` and `main` to click on table icon for `test`, to open up the table in data explorer
5. add a sort or filter
6. convert to code, see something like 

```python
# Load table into pandas dataframe, eg:
# test = conn.execute('SELECT * FROM memory.main.test LIMIT 1000').df() # where conn is your connection variable
test.sort_values(by='name', ascending=False)
```
7. try to run this in console, see `NameError`
8. uncomment the line that creates `test` object, run again.
9. see correct application of filters