### PR TITLE
Bump Ark to 0.1.207

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -967,7 +967,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.205"
+      "ark": "0.1.207"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:

- https://github.com/posit-dev/ark/pull/905 (cc @DavisVaughan)
  Addresses https://github.com/posit-dev/positron/issues/7681

- https://github.com/posit-dev/ark/pull/906 (cc @atheriel)

- https://github.com/posit-dev/ark/pull/909 (cc @wesm)
  Progress towards https://github.com/posit-dev/positron/issues/2971

- https://github.com/posit-dev/ark/pull/910
  Addresses https://github.com/posit-dev/positron/issues/8790


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed a bug that prevented `demo(graphics)` from being interactive the first time around (#7681).


### QA Notes

See linked PRs https://github.com/posit-dev/ark/pull/905 and https://github.com/posit-dev/ark/pull/910