### PR TITLE
python: change default locator to js

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -805,7 +805,7 @@
                     "type": "string"
                 },
                 "python.locator": {
-                    "default": "native",
+                    "default": "js",
                     "markdownDescription": "%python.locator.description%",
                     "enum": [
                         "js",

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -1,4 +1,5 @@
 {
+    "python.locator": "native",
     "interpreters.startupBehavior": "manual",
     "positron.r.kernel.logLevel": "trace",
     "python.languageServerLogLevel": "debug",


### PR DESCRIPTION
We're getting reports of "unsupported python 0.0.1" on windows machines with PET enabled, where the resolution is to change Python locators. For now, we'll just swap the default back since we're close to a release, but hopefully this can be resolved in the `positron-python` extension.

Partially addresses #9186 by way of avoiding the problem 😬 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Revert #9111 by making Javascript Python locator the default.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
