### PR TITLE
Data Explorer: Add column label to data explorer column schema in comm protocol

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -357,6 +357,11 @@ class ColumnSchema(BaseModel):
         description="Name of column as UTF-8 string",
     )
 
+    column_label: Optional[StrictStr] = Field(
+        default=None,
+        description="Display label for column (e.g., from R's label attribute)",
+    )
+
     column_index: StrictInt = Field(
         description="The position of the column within the table without any column filters",
     )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -965,8 +965,8 @@ def test_query_table_summary(shell: PositronShell, variables_comm: DummyComm):
                 "num_rows": 5,
                 "num_columns": 2,
                 "column_schemas": [
-                    '{"column_name": "a", "column_index": 0, "type_name": "int64", "type_display": "number", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
-                    '{"column_name": "b", "column_index": 1, "type_name": "bool", "type_display": "boolean", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
+                    '{"column_name": "a", "column_label": null, "column_index": 0, "type_name": "int64", "type_display": "number", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
+                    '{"column_name": "b", "column_label": null, "column_index": 1, "type_name": "bool", "type_display": "boolean", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
                 ],
                 "column_profiles": [
                     '{"column_name": "a", "type_display": "number", "summary_stats": {"type_display": "number", "number_stats": {"min_value": "1.0000", "max_value": "5.0000", "mean": "3.0000", "median": "3.0000", "stdev": "1.5811"}, "string_stats": null, "boolean_stats": null, "date_stats": null, "datetime_stats": null, "other_stats": null}}',

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -521,6 +521,10 @@
 						"type": "string",
 						"description": "Name of column as UTF-8 string"
 					},
+					"column_label": {
+						"type": "string",
+						"description": "Display label for column (e.g., from R's label attribute)"
+					},
 					"column_index": {
 						"type": "integer",
 						"description": "The position of the column within the table without any column filters"

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -157,6 +157,11 @@ export interface ColumnSchema {
 	column_name: string;
 
 	/**
+	 * Display label for column (e.g., from R's label attribute)
+	 */
+	column_label?: string;
+
+	/**
 	 * The position of the column within the table without any column filters
 	 */
 	column_index: number;


### PR DESCRIPTION
This splits the protocol changes off from #9179 so these can be merged right away (since we have some other protocol changes needed), so we can consider the right way to display the labels in the UI separately. The corresponding R changes have already been merged.

@:data-explorer