### PR TITLE
Update summary panel to use new layout manager changes

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -210,10 +210,19 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	override async fetchData(invalidateCache?: boolean) {
 		const rowDescriptor = this.firstRow;
 		if (rowDescriptor) {
-			await this._tableSummaryCache.update({
-				invalidateCache: !!invalidateCache,
-				columnIndices: this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR),
-			})
+			// Get the layout indices for visible data.
+			const columnIndices = this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR);
+
+			// Only update the cache if layout indices array is not empty.
+			// This avoids accidentally clearing the cache during UI state
+			// transitions (like resizing) which cause layout indices to be
+			// temporarily empty.
+			if (columnIndices.length > 0 || invalidateCache) {
+				await this._tableSummaryCache.update({
+					invalidateCache: !!invalidateCache,
+					columnIndices,
+				});
+			}
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -402,6 +402,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		await this.updateLayoutEntries();
 		// invalidate the cache when the search and sort is removed
 		await this.fetchData(this.hasNoSearchOrSort());
+		// Force a re-render when the search or sort options change
+		this.fireOnDidUpdateEvent();
 	}
 
 	/**
@@ -413,6 +415,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		await this.updateLayoutEntries();
 		// invalidate the cache when the search and sort is removed
 		await this.fetchData(this.hasNoSearchOrSort());
+		// Force a re-render when the search or sort options change
+		this.fireOnDidUpdateEvent();
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -195,6 +195,12 @@ export class TableSummaryCache extends Disposable {
 		// Clear the trim cache timeout.
 		this.clearTrimCacheTimeout();
 
+		// If we have empty column indices and we're not invalidating the cache, skip the update.
+		// This can happen during UI state transitions (like resizing) when layoutHeight is 0.
+		if (updateDescriptor.columnIndices.length === 0 && !updateDescriptor.invalidateCache) {
+			return;
+		}
+
 		// If a cache update is already in progress, set the pending update descriptor and return.
 		// This allows cache updates that are happening in rapid succession to overwrite one another
 		// so that only the last one gets processed. (For example, this happens when a user drags a
@@ -268,8 +274,12 @@ export class TableSummaryCache extends Disposable {
 				// Release the trim cache timeout.
 				this._trimCacheTimeout = undefined;
 
-				// Trim the cache.
-				this.trimCache(new Set(columnIndices));
+				// Only trim the cache if we have actual column indices to preserve.
+				// This prevents accidentally clearing all cached data when columnIndices is an empty array
+				// which happens during UI state transitions (e.g., during resizing when layoutHeight is 0).
+				if (columnIndices.length > 0) {
+					this.trimCache(new Set(columnIndices));
+				}
 			}, TRIM_CACHE_TIMEOUT);
 		}
 	}

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -6,17 +6,14 @@
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { arrayFromIndexRange } from './utils.js';
 import { DataExplorerClientInstance } from '../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { dataExplorerExperimentalFeatureEnabled } from './positronDataExplorerExperimentalConfig.js';
-import { ColumnDisplayType, ColumnHistogramParamsMethod, ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema, SearchSchemaSortOrder, SearchSchemaResult } from '../../languageRuntime/common/positronDataExplorerComm.js';
-import { summaryPanelEnhancementsFeatureEnabled } from './positronDataExplorerSummaryEnhancementsFeatureFlag.js';
+import { ColumnDisplayType, ColumnHistogramParamsMethod, ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema } from '../../languageRuntime/common/positronDataExplorerComm.js';
 
 /**
  * Constants.
  */
 const TRIM_CACHE_TIMEOUT = 3000;
-const OVERSCAN_FACTOR = 3;
 const SMALL_HISTOGRAM_NUM_BINS = 80;
 const LARGE_HISTOGRAM_NUM_BINS = 200;
 const SMALL_FREQUENCY_TABLE_LIMIT = 8;
@@ -28,10 +25,7 @@ const UPDATE_EVENT_DEBOUNCE_DELAY = 50;
  */
 interface UpdateDescriptor {
 	invalidateCache: boolean;
-	searchText?: string;
-	sortOption?: SearchSchemaSortOrder;
-	firstColumnIndex: number;
-	screenColumns: number;
+	columnIndices: number[];
 }
 
 /**
@@ -61,18 +55,6 @@ export class TableSummaryCache extends Disposable {
 	private _debouncedUpdateTimeout?: Timeout;
 
 	/**
-	 * The search text used to filter the dataset in the column schema
-	 * and column profile caches. The last search text value is maintained
-	 * to avoid unnecessary cache updates when the search text has not changed.
-	 */
-	private _searchText?: string;
-
-	/**
-	 * The sort option used to order the summary rows.
-	 */
-	private _sortOption?: SearchSchemaSortOrder;
-
-	/**
 	 * Gets or sets the columns.
 	 */
 	private _columns = 0;
@@ -81,19 +63,6 @@ export class TableSummaryCache extends Disposable {
 	 * Gets or sets the rows.
 	 */
 	private _rows = 0;
-
-	/**
-	 * An array that maps a position index in the data grid to a column index for the original dataset.
-	 * This array is always populated and serves as the single source of truth for determining the
-	 * display position and order of the summary rows.
-	 *
-	 * For un-modified datasets: [0, 1, 2, 3, 4, ...] (position and column index are the same)
-	 * For search or sort results: [0, 5, 12, 25, ...] (position and column index may differ)
-	 *
-	 * _displayPositionOrder[0] = 5 means the first row in the data grid should display data
-	 * for the 6th column (index 5) from the original un-modified dataset.
-	 */
-	private _displayPositionOrder: number[] = [];
 
 	/**
 	 * The expanded columns set is used to track which columns are expanded
@@ -177,14 +146,6 @@ export class TableSummaryCache extends Disposable {
 		return this._rows;
 	}
 
-	/**
-	 * Gets the display position order array.
-	 * This array maps display positions to original column indices.
-	 */
-	get displayPositionOrder() {
-		return this._displayPositionOrder;
-	}
-
 	//#endregion Public Properties
 
 	//#region Public Events
@@ -199,47 +160,31 @@ export class TableSummaryCache extends Disposable {
 	//#region Public Methods
 
 	/**
-	 * Returns a value which indicates whether the specified display index is expanded.
-	 * @param displayIndex The display position index for the column.
-	 * @returns A value which indicates whether the specified display index is expanded.
+	 * Returns a value which indicates whether the specified column index is expanded.
+	 * @param columnIndex The column index.
+	 * @returns A value which indicates whether the specified column index is expanded.
 	 */
-	isColumnExpanded(displayIndex: number) {
-		const originalIndex = summaryPanelEnhancementsFeatureEnabled(this._configurationService)
-			? this._displayPositionOrder[displayIndex]
-			: displayIndex;
-
-		return originalIndex !== undefined ? this._expandedColumns.has(originalIndex) : false;
+	isColumnExpanded(columnIndex: number) {
+		// With the layout manager integration, columnIndex should be the original column index
+		return this._expandedColumns.has(columnIndex);
 	}
 
 	/**
-	 * Toggles the expanded state of the specified display index.
-	 * @param displayIndex The display position index for the column.
+	 * Toggles the expanded state of the specified column index.
+	 * @param columnIndex The column index.
 	 */
-	async toggleExpandColumn(displayIndex: number) {
-		// Convert display index to original column index.
-		const originalIndex = summaryPanelEnhancementsFeatureEnabled(this._configurationService)
-			? this._displayPositionOrder[displayIndex]
-			: displayIndex;
-
-		if (originalIndex === undefined) {
-			return;
-		}
-
-		// If the column is expanded, collpase it, fire the onDidUpdate event, and return.
-		if (this._expandedColumns.has(originalIndex)) {
-			this._expandedColumns.delete(originalIndex);
+	async toggleExpandColumn(columnIndex: number) {
+		// If the column is expanded, collapse it, fire the onDidUpdate event, and return.
+		if (this._expandedColumns.has(columnIndex)) {
+			this._expandedColumns.delete(columnIndex);
 			this._onDidUpdateEmitter.fire();
 			return;
 		}
 
-		// Expand the column.
-		this._expandedColumns.add(originalIndex);
-
-		// Fire the onDidUpdate event.
+		// Otherewise, expand it, fire the onDidUpdate event, and fetch the column profile data.
+		this._expandedColumns.add(columnIndex);
 		this._onDidUpdateEmitter.fire();
-
-		// Update the column profile cache.
-		await this.updateColumnProfileCache([originalIndex]);
+		await this.updateColumnProfileCache([columnIndex]);
 	}
 
 	/**
@@ -262,38 +207,23 @@ export class TableSummaryCache extends Disposable {
 		// Set the updating flag.
 		this._updating = true;
 
-		// Destructure the update descriptor.
-		const {
-			invalidateCache,
-			firstColumnIndex,
-			screenColumns
-		} = updateDescriptor;
-
 		// Get the size of the data.
 		const tableState = await this._dataExplorerClientInstance.getBackendState();
 		this._columns = tableState.table_shape.num_columns;
 		this._rows = tableState.table_shape.num_rows;
 
-		// Set the start column index and the end column index of the columns to cache.
-		const overscanColumns = screenColumns * OVERSCAN_FACTOR;
-		const startColumnIndex = Math.max(
-			0,
-			firstColumnIndex - overscanColumns
-		);
-		const endColumnIndex = Math.min(
-			this._columns - 1,
-			firstColumnIndex + screenColumns + overscanColumns
-		);
+		// Sort the column and row indices in the update descriptor.
+		updateDescriptor.columnIndices.sort((a, b) => a - b);
 
 		// Set the column indices of the column schema we need to load.
 		let columnIndices: number[];
-		if (invalidateCache) {
-			columnIndices = arrayFromIndexRange(startColumnIndex, endColumnIndex);
+		if (updateDescriptor.invalidateCache) {
+			columnIndices = updateDescriptor.columnIndices;
 		} else {
 			columnIndices = [];
-			for (let columnIndex = startColumnIndex; columnIndex <= endColumnIndex; columnIndex++) {
-				if (!this._columnSchemaCache.has(columnIndex)) {
-					columnIndices.push(columnIndex);
+			for (const index of updateDescriptor.columnIndices) {
+				if (!this._columnSchemaCache.has(index)) {
+					columnIndices.push(index);
 				}
 			}
 		}
@@ -302,14 +232,14 @@ export class TableSummaryCache extends Disposable {
 		const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
 
 		// Invalidate the cache, if we're supposed to.
-		if (invalidateCache) {
+		if (updateDescriptor.invalidateCache) {
 			this._columnSchemaCache.clear();
 			this._columnProfileCache.clear();
 		}
 
 		// Cache the column schema that was returned.
-		for (let i = 0; i < tableSchema.columns.length; i++) {
-			this._columnSchemaCache.set(columnIndices[i], tableSchema.columns[i]);
+		for (const columnSchema of tableSchema.columns) {
+			this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
 		}
 
 		// Fire the onDidUpdate event.
@@ -332,14 +262,14 @@ export class TableSummaryCache extends Disposable {
 		}
 
 		// Schedule trimming the cache.
-		if (!invalidateCache) {
+		if (!updateDescriptor.invalidateCache) {
 			// Set the trim cache timeout.
 			this._trimCacheTimeout = setTimeout(() => {
 				// Release the trim cache timeout.
 				this._trimCacheTimeout = undefined;
 
 				// Trim the cache.
-				this.trimCache(arrayFromIndexRange(startColumnIndex, endColumnIndex));
+				this.trimCache(new Set(columnIndices));
 			}, TRIM_CACHE_TIMEOUT);
 		}
 	}
@@ -350,192 +280,7 @@ export class TableSummaryCache extends Disposable {
 	 * @param updateDescriptor The update descriptor containing the new search and sort parameters
 	 */
 	async update2(updateDescriptor: UpdateDescriptor): Promise<void> {
-		// Clear the trim cache timeout.
-		this.clearTrimCacheTimeout();
-
-		// If a cache update is already in progress, set the pending update descriptor and return.
-		// This allows cache updates that are happening in rapid succession to overwrite one another
-		// so that only the last one gets processed. (For example, this happens when a user drags a
-		// scrollbar rapidly.)
-		if (this._updating) {
-			this._pendingUpdateDescriptor = updateDescriptor;
-			return;
-		}
-
-		// Set the updating flag.
-		this._updating = true;
-
-		// Destructure the update descriptor.
-		const {
-			invalidateCache,
-			searchText,
-			sortOption,
-			firstColumnIndex,
-			screenColumns
-		} = updateDescriptor;
-
-		this._searchText = searchText;
-		this._sortOption = sortOption;
-
-		// Get the size of the data.
-		const tableState = await this._dataExplorerClientInstance.getBackendState();
-		this._columns = tableState.table_shape.num_columns;
-		this._rows = tableState.table_shape.num_rows;
-
-		// The overscan factor determines how many additional columns to cache
-		// to ensure smooth scrolling and rendering. Considered to be part of
-		// the data that is viewable.
-		const overscanColumns = screenColumns * OVERSCAN_FACTOR;
-		// Determine the first column index to start caching from.
-		const startColumnIndex = Math.max(
-			0,
-			firstColumnIndex - overscanColumns
-		);
-		// Determines the minimum number of columns we need to cache
-		// to fill the screen (including overscan).
-		const endColumnIndex = Math.min(
-			tableState.table_shape.num_columns - 1,
-			firstColumnIndex + screenColumns + overscanColumns
-		);
-
-		// the indices of the column that we need to fetch data for and then cache
-		let columnIndices: number[] = [];
-		// the search/sort results from the backend
-		let searchResult: SearchSchemaResult | undefined = undefined;
-		// Variables to track the viewable start and end indices when search/sort is present
-		let viewableStartIndex: number | undefined = undefined;
-		let viewableEndIndex: number | undefined = undefined;
-
-		// When search text or sort options is present, we always need to get the full sorted order first
-		if (this._searchText || this._sortOption) {
-			// Use the new search method that supports backend search and sort
-			searchResult = await this._dataExplorerClientInstance.searchSchema2({
-				searchText: this._searchText,
-				sortOption: this._sortOption,
-			});
-		}
-
-		// Determine what columns we need to fetch data for and then store in cache
-		if (searchResult && searchResult.matches.length > 0) {
-			// For sorted/searched results, calculate viewable columns within the search/sort results
-			viewableStartIndex = Math.max(0, firstColumnIndex - overscanColumns);
-			viewableEndIndex = Math.min(
-				searchResult.matches.length - 1,
-				firstColumnIndex + screenColumns + overscanColumns
-			);
-			const viewableColumns = searchResult.matches.slice(viewableStartIndex, viewableEndIndex + 1);
-
-			// If the cache is invalidated we will need to load all the columns in view into
-			// the cache again otherwise, we just need the missing columns should be in view.
-			// The cache will be updated with the data for the columns in `columnIndices`
-			columnIndices = invalidateCache
-				? viewableColumns
-				: viewableColumns.filter(columnIndex => !this._columnSchemaCache.has(columnIndex));
-		} else if (!searchResult || searchResult.matches.length === 0) {
-			// No search results, which means we have nothing to cache
-			columnIndices = [];
-		} else {
-			const viewableColumns = arrayFromIndexRange(startColumnIndex, endColumnIndex);
-			if (invalidateCache) {
-				// No search/sort, so we need indices of all columns in viewable range
-				// since we're clearing and replacing the caches
-				columnIndices = viewableColumns;
-			} else {
-				// No search/sort, get all column indices in viewable range that aren't already cached
-				columnIndices = viewableColumns.filter(columnIndex => !this._columnSchemaCache.has(columnIndex));
-			}
-		}
-
-		// Update cache and display order based on the columns we need data for
-		if (searchResult) {
-			if (searchResult.matches.length > 0) {
-				// Calculate viewable columns within within search/sort results
-				const viewportStartIndex = Math.max(0, firstColumnIndex - overscanColumns);
-				const viewportEndIndex = Math.min(
-					searchResult.matches.length - 1,
-					firstColumnIndex + screenColumns + overscanColumns
-				);
-
-				// Get the column indices of the viewable columns
-				const viewableColumns = searchResult.matches.slice(viewportStartIndex, viewportEndIndex + 1);
-
-				// Fetch schema for any columns we need to load
-				if (columnIndices.length > 0) {
-					const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
-
-					// Clear cache if invalidating to avoid stale data
-					if (invalidateCache) {
-						this._columnSchemaCache.clear();
-						this._columnProfileCache.clear();
-					}
-
-					// Cache the column schema
-					for (const columnSchema of tableSchema.columns) {
-						this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
-					}
-				}
-
-				// Set display order to the viewable slice of sorted results
-				this._displayPositionOrder = viewableColumns;
-
-				// Update the columns count to the total number of matches (not just searched results in view)
-				this._columns = searchResult.matches.length;
-			} else {
-				// No matches found, clear display
-				this._displayPositionOrder = [];
-				this._columns = 0;
-			}
-		} else {
-			// No search/sort, use getSchema to fetch the viewable data
-			if (columnIndices.length > 0) {
-				const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
-
-				// If we are invalidating the cache, we need to clear it before updating
-				if (invalidateCache) {
-					this._columnSchemaCache.clear();
-					this._columnProfileCache.clear();
-				}
-
-				// Cache the column schema
-				for (const columnSchema of tableSchema.columns) {
-					this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
-				}
-			}
-
-			// Update the display position order to include all columns in the view range
-			this._displayPositionOrder = arrayFromIndexRange(startColumnIndex, endColumnIndex);
-		}
-
-		// Fire the onDidUpdate event.
-		this._onDidUpdateEmitter.fire();
-
-		// Update the column profile cache for the appropriate column indices
-		await this.updateColumnProfileCache(this._displayPositionOrder);
-
-		// Clear the updating flag.
-		this._updating = false;
-
-		// If there's a pending update descriptor, update the cache again.
-		if (this._pendingUpdateDescriptor) {
-			// Get the pending update descriptor and clear it.
-			const pendingUpdateDescriptor = this._pendingUpdateDescriptor;
-			this._pendingUpdateDescriptor = undefined;
-
-			// Update the cache for the pending update descriptor.
-			return this.update2(pendingUpdateDescriptor);
-		}
-
-		// Schedule trimming the cache.
-		if (!invalidateCache) {
-			// Set the trim cache timeout.
-			this._trimCacheTimeout = setTimeout(() => {
-				// Release the trim cache timeout.
-				this._trimCacheTimeout = undefined;
-
-				// Trim the cache.
-				this.trimCache(this._displayPositionOrder);
-			}, TRIM_CACHE_TIMEOUT);
-		}
+		// TODO
 	}
 
 	/**
@@ -554,27 +299,21 @@ export class TableSummaryCache extends Disposable {
 	}
 
 	/**
-	 * Gets the column schema for the specified display index.
-	 * @param displayIndex The display position index for the column.
-	 * @returns The column schema for the specified display index.
+	 * Gets the column schema for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column schema for the specified column index.
 	 */
-	getColumnSchema(displayIndex: number) {
-		const originalIndex = summaryPanelEnhancementsFeatureEnabled(this._configurationService)
-			? this._displayPositionOrder[displayIndex]
-			: displayIndex;
-		return originalIndex !== undefined ? this._columnSchemaCache.get(originalIndex) : undefined;
+	getColumnSchema(columnIndex: number) {
+		return this._columnSchemaCache.get(columnIndex);
 	}
 
 	/**
-	 * Gets the column profile for the specified display index.
-	 * @param displayIndex The display position index for the column.
-	 * @returns The column profile for the specified display index.
+	 * Gets the column profile for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column profile for the specified column index.
 	 */
-	getColumnProfile(displayIndex: number) {
-		const originalIndex = summaryPanelEnhancementsFeatureEnabled(this._configurationService)
-			? this._displayPositionOrder[displayIndex]
-			: displayIndex;
-		return originalIndex !== undefined ? this._columnProfileCache.get(originalIndex) : undefined;
+	getColumnProfile(columnIndex: number) {
+		return this._columnProfileCache.get(columnIndex);
 	}
 
 	//#endregion Public Methods
@@ -811,20 +550,17 @@ export class TableSummaryCache extends Disposable {
 	 * Trims the data in the cache if the key is not in the provided list.
 	 * @param columnIndicesToKeep The array of column indices to keep in the cache.
 	 */
-	private trimCache(columnIndicesToKeep: number[]) {
-		// Create a set for faster lookup of indices to keep.
-		const indicesToKeepSet = new Set(columnIndicesToKeep);
-
+	private trimCache(columnIndices: Set<number>) {
 		// Trim the column schema cache.
 		for (const columnIndex of this._columnSchemaCache.keys()) {
-			if (!indicesToKeepSet.has(columnIndex)) {
+			if (!columnIndices.has(columnIndex)) {
 				this._columnSchemaCache.delete(columnIndex);
 			}
 		}
 
 		// Trim the column profile cache.
 		for (const columnIndex of this._columnProfileCache.keys()) {
-			if (!indicesToKeepSet.has(columnIndex)) {
+			if (!columnIndices.has(columnIndex)) {
 				this._columnProfileCache.delete(columnIndex);
 			}
 		}

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -275,15 +275,6 @@ export class TableSummaryCache extends Disposable {
 	}
 
 	/**
-	 * New update method that supports search and sort work being done
-	 * behind the USE_DATA_EXPLORER_SUMMARY_PANEL_ENHANCEMENTS_KEY setting
-	 * @param updateDescriptor The update descriptor containing the new search and sort parameters
-	 */
-	async update2(updateDescriptor: UpdateDescriptor): Promise<void> {
-		// TODO
-	}
-
-	/**
 	 * Refreshes the column profile cache.
 	 */
 	async refreshColumnProfiles(): Promise<void> {

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -12,15 +12,6 @@ export interface Range {
 }
 
 /**
- * Creates an array from an index range.
- * @param startIndex The start index.
- * @param endIndex The end index.
- * @returns An array with the specified index range.
- */
-export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
-	Array.from({ length: endIndex - startIndex + 1 }, (_, i) => startIndex + i);
-
-/**
  * Determines whether an array of numbers is contiguous.
  * @param array The array of numbers.
  * @returns true if the array is contiguous; otherwise, false.

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -691,7 +691,7 @@ export class SummaryPanel {
 
 	async clearSort() {
 		await test.step('Clear sort in summary panel', async () => {
-			await this.clearColumnSortingButton.click();
+			await this.sortBy('Original');
 		});
 	}
 

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -639,8 +639,6 @@ export class SummaryPanel {
 	private sortFilter: Locator;
 	private columnSummary: Locator;
 	private columnSummaryName: Locator;
-	private actionBar: Locator;
-	private clearColumnSortingButton: Locator;
 	private verticalScrollbar: Locator;
 
 	constructor(private code: Code, private workbench: Workbench,) {
@@ -650,8 +648,6 @@ export class SummaryPanel {
 		this.sortFilter = this.summaryFilterBar.getByRole('button', { name: 'Sort summary row data' });
 		this.columnSummary = this.summaryPanel.locator('.column-summary');
 		this.columnSummaryName = this.columnSummary.locator('.column-name');
-		this.actionBar = this.code.driver.page.locator('.editor-action-bar');
-		this.clearColumnSortingButton = this.actionBar.getByRole('button', { name: 'Clear Column Sorting' });
 		this.verticalScrollbar = this.summaryPanel.locator('div.data-grid-scrollbar-slider');
 	}
 

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -63,8 +63,8 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 
 		// search with no results
 		await dataExplorer.summaryPanel.search('snickerdoodle');
-		// await dataExplorer.summaryPanel.expectColumnCountToBe(0); <-- NEW: search isn't working
-		// await dataExplorer.summaryPanel.expectEmptyState(); // <--- no empty state created in UI yet
+		await dataExplorer.summaryPanel.expectColumnCountToBe(0);
+		//await dataExplorer.summaryPanel.expectEmptyState(); // <--- no empty state created in UI yet
 	});
 
 	test('Summary Panel: Sort', async function ({ app, openDataFile }) {
@@ -92,10 +92,10 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column9', 'column8', 'column7', 'column6', 'column5', 'column4', 'column3', 'column2', 'column1', 'column0']);
 
 		// verify changing sort retains expansion for correct column
-		// await dataExplorer.summaryPanel.clearSort();
-		// await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		// await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
-		// await dataExplorer.summaryPanel.expectColumnToBe({ index: 0, name: 'column0', expanded: false });
-		// await dataExplorer.summaryPanel.expectColumnToBe({ index: 9, name: 'column9', expanded: true });
+		await dataExplorer.summaryPanel.clearSort();
+		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnToBe({ index: 0, name: 'column0', expanded: false });
+		await dataExplorer.summaryPanel.expectColumnToBe({ index: 9, name: 'column9', expanded: true });
 	});
 });

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -50,15 +50,15 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		// verify collapse and expand retains in search
 		await dataExplorer.summaryPanel.expandColumnProfile();
 		await dataExplorer.summaryPanel.expectColumnProfileToBeExpanded(0);
-		await dataExplorer.summaryPanel.hide()
+		await dataExplorer.summaryPanel.hide();
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectColumnProfileToBeExpanded(0);
 		await dataExplorer.summaryPanel.expectColumnCountToBe(1);
 
 		// clear search and ensure col profile still expanded
-		await dataExplorer.summaryPanel.clearSearch()
+		await dataExplorer.summaryPanel.clearSearch();
 		await dataExplorer.summaryPanel.expectColumnCountToBe(10);
-		await dataExplorer.summaryPanel.expectColumnProfileToBeCollapsed(0)
+		await dataExplorer.summaryPanel.expectColumnProfileToBeCollapsed(0);
 		await dataExplorer.summaryPanel.expectColumnProfileToBeExpanded(9);
 
 		// search with no results

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -40,6 +40,8 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.waitForIdle();
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectColumnCountToBe(10);
+		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
 
 		// perform basic search
 		await dataExplorer.summaryPanel.search('column9');
@@ -56,15 +58,16 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		// clear search and ensure col profile still expanded
 		await dataExplorer.summaryPanel.clearSearch()
 		await dataExplorer.summaryPanel.expectColumnCountToBe(10);
-		// await dataExplorer.summaryPanel.expectColumnProfileToBeExpanded(0); // <--- BUG, being fixed in filter branch
+		await dataExplorer.summaryPanel.expectColumnProfileToBeCollapsed(0)
+		await dataExplorer.summaryPanel.expectColumnProfileToBeExpanded(9);
 
 		// search with no results
 		await dataExplorer.summaryPanel.search('snickerdoodle');
-		await dataExplorer.summaryPanel.expectColumnCountToBe(0);
+		// await dataExplorer.summaryPanel.expectColumnCountToBe(0); <-- NEW: search isn't working
 		// await dataExplorer.summaryPanel.expectEmptyState(); // <--- no empty state created in UI yet
 	});
 
-	test.skip('Summary Panel: Sort', async function ({ app, openDataFile }) {
+	test('Summary Panel: Sort', async function ({ app, openDataFile }) {
 		const { dataExplorer } = app.workbench;
 
 		await openDataFile(join('data-files', 'small_file.csv'));
@@ -91,7 +94,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		// verify changing sort retains expansion for correct column
 		// await dataExplorer.summaryPanel.clearSort();
 		// await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		// await dataExplorer.summaryPanel.expectColumnNamesOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		// await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
 		// await dataExplorer.summaryPanel.expectColumnToBe({ index: 0, name: 'column0', expanded: false });
 		// await dataExplorer.summaryPanel.expectColumnToBe({ index: 9, name: 'column9', expanded: true });
 	});


### PR DESCRIPTION
This PR updates the summary panel to utilize the changes made to the layout manager that add support for pinning.

This change should resolve the rendering mismatch, and scrolling bugs we were seeing with searching and sorting in the summary panel.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win