### PR TITLE
Data Explorer: Add "cell_indices" table selection type for export_data_selection RPC

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -27,6 +27,7 @@ import {
 	DataExplorerRpc,
 	DataExplorerUiEvent,
 	DataSelectionCellRange,
+	DataSelectionCellIndices,
 	DataSelectionIndices,
 	DataSelectionRange,
 	DataSelectionSingleCell,
@@ -1624,6 +1625,20 @@ END`;
 				const columns = indices.map(i => this.fullSchema[i]);
 				const query = `SELECT ${getColumnSelectors(columns).join(',')}
 				FROM ${this.tableName}`;
+				return await exportQueryOutput(query, columns);
+			}
+			case TableSelectionKind.CellIndices: {
+				const selection = params.selection.selection as DataSelectionCellIndices;
+				const rowIndices = selection.row_indices;
+				const columnIndices = selection.column_indices;
+				const columns = columnIndices.map(i => this.fullSchema[i]);
+
+				// Create a VALUES clause to preserve the order of row indices
+				const orderValues = rowIndices.map((rowId, idx) => `(${rowId}, ${idx})`).join(', ');
+				const query = `SELECT ${getColumnSelectors(columns).join(',')}
+				FROM ${this.tableName}
+				JOIN (VALUES ${orderValues}) AS row_order(rowid, sort_order) ON ${this.tableName}.rowid = row_order.rowid
+				ORDER BY row_order.sort_order`;
 				return await exportQueryOutput(query, columns);
 			}
 		}

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -57,7 +57,6 @@ export interface DataExplorerResponse {
 // AUTO-GENERATED from data_explorer.json; do not edit. Copy from
 // positronDataExplorerComm.ts instead.
 
-
 /**
  * Result in Methods
  */
@@ -74,8 +73,8 @@ export interface OpenDatasetResult {
  */
 export interface SearchSchemaResult {
 	/**
-	 * The column indices of the matching column indices in the indicated
-	 * sort order
+	 * The column indices that match the search parameters in the indicated
+	 * sort order.
 	 */
 	matches: Array<number>;
 
@@ -202,6 +201,11 @@ export interface ColumnSchema {
 	 * Name of column as UTF-8 string
 	 */
 	column_name: string;
+
+	/**
+	 * Display label for column (e.g., from R's label attribute)
+	 */
+	column_label?: string;
 
 	/**
 	 * The position of the column within the table without any column filters
@@ -1100,6 +1104,23 @@ export interface DataSelectionCellRange {
 }
 
 /**
+ * A selection that for a rectangle of data cells defined by arrays of
+ * row and column indices
+ */
+export interface DataSelectionCellIndices {
+	/**
+	 * The selected row indices
+	 */
+	row_indices: Array<number>;
+
+	/**
+	 * The selected column indices
+	 */
+	column_indices: Array<number>;
+
+}
+
+/**
  * A contiguous selection bounded by inclusive start and end indices
  */
 export interface DataSelectionRange {
@@ -1155,7 +1176,7 @@ export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
 export type ColumnProfileParams = ColumnHistogramParams | ColumnHistogramParams | ColumnFrequencyTableParams | ColumnFrequencyTableParams;
 
 /// A union of selection types
-export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;
+export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionCellIndices | DataSelectionRange | DataSelectionIndices;
 
 /// Union of selection specifications for array_selection
 export type ArraySelection = DataSelectionRange | DataSelectionIndices;
@@ -1275,7 +1296,8 @@ export enum TableSelectionKind {
 	ColumnRange = 'column_range',
 	RowRange = 'row_range',
 	ColumnIndices = 'column_indices',
-	RowIndices = 'row_indices'
+	RowIndices = 'row_indices',
+	CellIndices = 'cell_indices'
 }
 
 /**

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -737,6 +737,23 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		};
 		await testColumnIndices([0, 2], 'int_col,float_col\n1,1.1\n2,2.2\n3,3.3\n4,NULL\nNULL,5.5e+20');
 
+		// Test CellIndices selection
+		const testCellIndices = async (rowIndices: number[], columnIndices: number[], expected: string) => {
+			await testSelection(TableSelectionKind.CellIndices, { row_indices: rowIndices, column_indices: columnIndices }, expected);
+		};
+		await testCellIndices([0, 2], [0, 2], 'int_col,float_col\n1,1.1\n3,3.3');
+		await testCellIndices([1, 3], [1, 2], 'str_col,float_col\nb,2.2\nNULL,NULL');
+		await testCellIndices([0, 1, 4], [0], 'int_col\n1\n2\nNULL');
+		// Test non-strictly-increasing row indices (order should be preserved)
+		await testCellIndices([4, 0, 2], [0], 'int_col\nNULL\n1\n3');
+		await testCellIndices([3, 1, 0], [1, 2], 'str_col,float_col\nNULL,NULL\nb,2.2\na,1.1');
+		await testCellIndices([2, 4, 1], [0, 1], `int_col,str_col\n3,c\nNULL,${longString}\n2,b`);
+		// Test non-strictly-increasing column indices (order should be preserved)
+		await testCellIndices([0, 1], [2, 0, 1], 'float_col,int_col,str_col\n1.1,1,a\n2.2,2,b');
+		await testCellIndices([1, 2], [1, 2, 0], 'str_col,float_col,int_col\nb,2.2,2\nc,3.3,3');
+		// Test both row and column indices out of order
+		await testCellIndices([2, 0], [2, 0], 'float_col,int_col\n3.3,3\n1.1,1');
+
 		// Test TSV format
 		await testSelection(TableSelectionKind.CellRange,
 			{

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -52,6 +52,7 @@ from .data_explorer_comm import (
     ConvertToCodeParams,
     DataExplorerBackendMessageContent,
     DataExplorerFrontendEvent,
+    DataSelectionCellIndices,
     DataSelectionCellRange,
     DataSelectionIndices,
     DataSelectionRange,
@@ -425,6 +426,9 @@ class DataExplorerTableView:
                 slice(sel.first_column_index, sel.last_column_index + 1),
                 fmt,
             )
+        elif kind == TableSelectionKind.CellIndices:
+            assert isinstance(sel, DataSelectionCellIndices)
+            return self._export_tabular(sel.row_indices, sel.column_indices, fmt)
         elif kind == TableSelectionKind.RowRange:
             assert isinstance(sel, DataSelectionRange)
             return self._export_tabular(

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -203,6 +203,8 @@ class TableSelectionKind(str, enum.Enum):
 
     RowIndices = "row_indices"
 
+    CellIndices = "cell_indices"
+
 
 @enum.unique
 class ExportFormat(str, enum.Enum):
@@ -1165,6 +1167,21 @@ class DataSelectionCellRange(BaseModel):
     )
 
 
+class DataSelectionCellIndices(BaseModel):
+    """
+    A selection that for a rectangle of data cells defined by arrays of
+    row and column indices
+    """
+
+    row_indices: List[StrictInt] = Field(
+        description="The selected row indices",
+    )
+
+    column_indices: List[StrictInt] = Field(
+        description="The selected column indices",
+    )
+
+
 class DataSelectionRange(BaseModel):
     """
     A contiguous selection bounded by inclusive start and end indices
@@ -1231,6 +1248,7 @@ ColumnProfileParams = Union[
 Selection = Union[
     DataSelectionSingleCell,
     DataSelectionCellRange,
+    DataSelectionCellIndices,
     DataSelectionRange,
     DataSelectionIndices,
 ]
@@ -1834,6 +1852,8 @@ TableSelection.update_forward_refs()
 DataSelectionSingleCell.update_forward_refs()
 
 DataSelectionCellRange.update_forward_refs()
+
+DataSelectionCellIndices.update_forward_refs()
 
 DataSelectionRange.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -1169,8 +1169,8 @@ class DataSelectionCellRange(BaseModel):
 
 class DataSelectionCellIndices(BaseModel):
     """
-    A selection that for a rectangle of data cells defined by arrays of
-    row and column indices
+    A rectangular cell selection defined by arrays of row and column
+    indices
     """
 
     row_indices: List[StrictInt] = Field(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2498,16 +2498,18 @@ def test_export_cell_indices_selection(dxf: DataExplorerFixture):
     result = dxf.export_data_selection("cell_indices_test", selection, "csv")
     # Should select rows in order [4, 0, 2] from column 1 -> values [24, 20, 22]
     expected_df = test_df.iloc[[4, 0, 2], [1]]
-    expected_csv = expected_df.to_csv(index=False).strip()
-    assert result["data"] == expected_csv
+    expected_csv = expected_df.to_csv(index=False).rstrip()
+    result_data = result["data"].rstrip()
+    assert result_data == expected_csv
 
     # Test case 6: Non-strictly-increasing column indices (order should be preserved)
     selection = _select_cell_indices([1], [4, 0, 2])
     result = dxf.export_data_selection("cell_indices_test", selection, "csv")
     # Should select columns in order [4, 0, 2] from row 1 -> values [51, 11, 31]
     expected_df = test_df.iloc[[1], [4, 0, 2]]
-    expected_csv = expected_df.to_csv(index=False).strip()
-    assert result["data"] == expected_csv
+    expected_csv = expected_df.to_csv(index=False).rstrip()
+    result_data = result["data"].rstrip()
+    assert result_data == expected_csv
 
     # Test case 7: Both rows and columns out of order
     selection = _select_cell_indices([3, 1], [2, 4, 0])
@@ -2516,8 +2518,9 @@ def test_export_cell_indices_selection(dxf: DataExplorerFixture):
     # Row 3: col_2=33, col_4=53, col_0=13
     # Row 1: col_2=31, col_4=51, col_0=11
     expected_df = test_df.iloc[[3, 1], [2, 4, 0]]
-    expected_csv = expected_df.to_csv(index=False).strip()
-    assert result["data"] == expected_csv
+    expected_csv = expected_df.to_csv(index=False).rstrip()
+    result_data = result["data"].rstrip()
+    assert result_data == expected_csv
 
     # Test case 8: Test with filtered data
     dxf.register_table("cell_indices_filtered", test_df)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2493,7 +2493,30 @@ def test_export_cell_indices_selection(dxf: DataExplorerFixture):
     assert result["data"] == expected_html
     assert result["format"] == "html"
 
-    # Test case 5: Test with filtered data
+    # Test case 5: Non-strictly-increasing row indices (order should be preserved)
+    selection = _select_cell_indices([4, 0, 2], [1])
+    result = dxf.export_data_selection("cell_indices_test", selection, "csv")
+    # Should select rows in order [4, 0, 2] from column 1 -> values [24, 20, 22]
+    expected_data = "col_1\n24\n20\n22"
+    assert result["data"] == expected_data
+
+    # Test case 6: Non-strictly-increasing column indices (order should be preserved)
+    selection = _select_cell_indices([1], [4, 0, 2])
+    result = dxf.export_data_selection("cell_indices_test", selection, "csv")
+    # Should select columns in order [4, 0, 2] from row 1 -> values [51, 11, 31]
+    expected_data = "col_4,col_0,col_2\n51,11,31"
+    assert result["data"] == expected_data
+
+    # Test case 7: Both rows and columns out of order
+    selection = _select_cell_indices([3, 1], [2, 4, 0])
+    result = dxf.export_data_selection("cell_indices_test", selection, "csv")
+    # Should maintain order: rows [3,1] x columns [2,4,0]
+    # Row 3: col_2=33, col_4=53, col_0=13
+    # Row 1: col_2=31, col_4=51, col_0=11
+    expected_data = "col_2,col_4,col_0\n33,53,13\n31,51,11"
+    assert result["data"] == expected_data
+
+    # Test case 8: Test with filtered data
     dxf.register_table("cell_indices_filtered", test_df)
     schema = dxf.get_schema("cell_indices_filtered")
     # Filter to keep rows where col_0 > 11 (this should keep rows 2, 3, 4)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2497,15 +2497,17 @@ def test_export_cell_indices_selection(dxf: DataExplorerFixture):
     selection = _select_cell_indices([4, 0, 2], [1])
     result = dxf.export_data_selection("cell_indices_test", selection, "csv")
     # Should select rows in order [4, 0, 2] from column 1 -> values [24, 20, 22]
-    expected_data = "col_1\n24\n20\n22"
-    assert result["data"] == expected_data
+    expected_df = test_df.iloc[[4, 0, 2], [1]]
+    expected_csv = expected_df.to_csv(index=False).strip()
+    assert result["data"] == expected_csv
 
     # Test case 6: Non-strictly-increasing column indices (order should be preserved)
     selection = _select_cell_indices([1], [4, 0, 2])
     result = dxf.export_data_selection("cell_indices_test", selection, "csv")
     # Should select columns in order [4, 0, 2] from row 1 -> values [51, 11, 31]
-    expected_data = "col_4,col_0,col_2\n51,11,31"
-    assert result["data"] == expected_data
+    expected_df = test_df.iloc[[1], [4, 0, 2]]
+    expected_csv = expected_df.to_csv(index=False).strip()
+    assert result["data"] == expected_csv
 
     # Test case 7: Both rows and columns out of order
     selection = _select_cell_indices([3, 1], [2, 4, 0])
@@ -2513,8 +2515,9 @@ def test_export_cell_indices_selection(dxf: DataExplorerFixture):
     # Should maintain order: rows [3,1] x columns [2,4,0]
     # Row 3: col_2=33, col_4=53, col_0=13
     # Row 1: col_2=31, col_4=51, col_0=11
-    expected_data = "col_2,col_4,col_0\n33,53,13\n31,51,11"
-    assert result["data"] == expected_data
+    expected_df = test_df.iloc[[3, 1], [2, 4, 0]]
+    expected_csv = expected_df.to_csv(index=False).strip()
+    assert result["data"] == expected_csv
 
     # Test case 8: Test with filtered data
     dxf.register_table("cell_indices_filtered", test_df)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2443,7 +2443,7 @@ def test_export_data_selection(dxf: DataExplorerFixture):
 
 
 def test_export_cell_indices_selection(dxf: DataExplorerFixture):
-    """Test cell_indices selection type specifically"""
+    """Test cell_indices selection type specifically."""
     # Create a simple 5x5 DataFrame for easy verification
     test_df = pd.DataFrame(
         {

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1670,7 +1670,7 @@
 			},
 			"data_selection_cell_indices": {
 				"type": "object",
-				"description": "A selection that for a rectangle of data cells defined by arrays of row and column indices",
+				"description": "A rectangular cell selection defined by arrays of row and column indices",
 				"required": [
 					"row_indices",
 					"column_indices"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1591,7 +1591,8 @@
 							"column_range",
 							"row_range",
 							"column_indices",
-							"row_indices"
+							"row_indices",
+							"cell_indices"
 						]
 					},
 					"selection": {
@@ -1604,6 +1605,10 @@
 							{
 								"name": "cell_range",
 								"$ref": "#/components/schemas/data_selection_cell_range"
+							},
+							{
+								"name": "cell_indices",
+								"$ref": "#/components/schemas/data_selection_cell_indices"
 							},
 							{
 								"name": "index_range",
@@ -1660,6 +1665,30 @@
 					"last_column_index": {
 						"type": "integer",
 						"description": "The final selected column index (inclusive)"
+					}
+				}
+			},
+			"data_selection_cell_indices": {
+				"type": "object",
+				"description": "A selection that for a rectangle of data cells defined by arrays of row and column indices",
+				"required": [
+					"row_indices",
+					"column_indices"
+				],
+				"properties": {
+					"row_indices": {
+						"type": "array",
+						"description": "The selected row indices",
+						"items": {
+							"type": "integer"
+						}
+					},
+					"column_indices": {
+						"type": "array",
+						"description": "The selected column indices",
+						"items": {
+							"type": "integer"
+						}
 					}
 				}
 			},

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1058,8 +1058,8 @@ export interface DataSelectionCellRange {
 }
 
 /**
- * A selection that for a rectangle of data cells defined by arrays of
- * row and column indices
+ * A rectangular cell selection defined by arrays of row and column
+ * indices
  */
 export interface DataSelectionCellIndices {
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1058,6 +1058,23 @@ export interface DataSelectionCellRange {
 }
 
 /**
+ * A selection that for a rectangle of data cells defined by arrays of
+ * row and column indices
+ */
+export interface DataSelectionCellIndices {
+	/**
+	 * The selected row indices
+	 */
+	row_indices: Array<number>;
+
+	/**
+	 * The selected column indices
+	 */
+	column_indices: Array<number>;
+
+}
+
+/**
  * A contiguous selection bounded by inclusive start and end indices
  */
 export interface DataSelectionRange {
@@ -1113,7 +1130,7 @@ export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
 export type ColumnProfileParams = ColumnHistogramParams | ColumnHistogramParams | ColumnFrequencyTableParams | ColumnFrequencyTableParams;
 
 /// A union of selection types
-export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;
+export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionCellIndices | DataSelectionRange | DataSelectionIndices;
 
 /// Union of selection specifications for array_selection
 export type ArraySelection = DataSelectionRange | DataSelectionIndices;
@@ -1233,7 +1250,8 @@ export enum TableSelectionKind {
 	ColumnRange = 'column_range',
 	RowRange = 'row_range',
 	ColumnIndices = 'column_indices',
-	RowIndices = 'row_indices'
+	RowIndices = 'row_indices',
+	CellIndices = 'cell_indices'
 }
 
 /**


### PR DESCRIPTION
This protocol work is needed to support exporting what the user is seeing with pinned rows and/or columns. An implementation is provided for Python and DuckDB, and I will work on a corresponding PR for R. 