### PR TITLE
Fix leaked disposable warnings in the help pane

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -130,10 +130,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		const disposableStore = new DisposableStore();
 
 		// Add the onDidChangeTitle event handler.
-		currentHelpEntry.onDidChangeTitle(() => {
+		disposableStore.add(currentHelpEntry.onDidChangeTitle(() => {
 			// Set the current help title.
 			setCurrentHelpTitle(currentHelpEntry.title);
-		});
+		}));
 
 		// Return the cleanup function.
 		return () => disposableStore.dispose();

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -467,7 +467,7 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 			});
 
 			// Add the onMessage event handler to the help overlay webview.
-			this._helpOverlayWebview.onMessage(async e => {
+			this._register(this._helpOverlayWebview.onMessage(async e => {
 				const message = e.message as PositronHelpMessage;
 				switch (message.id) {
 					// positron-help-interactive message.
@@ -574,7 +574,7 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 						break;
 					}
 				}
-			});
+			}));
 
 			// Set the HTML of the help overlay webview.
 			this._helpOverlayWebview.setHtml(
@@ -646,13 +646,13 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 		helpOverlayWebview.claim(element, DOM.getWindow(element), undefined);
 		helpOverlayWebview.layoutWebviewOverElement(element);
 
-		helpOverlayWebview.onDidFocus(() => {
+		this._register(helpOverlayWebview.onDidFocus(() => {
 			this.helpFocusedContextKey.set(true);
-		});
+		}));
 
-		helpOverlayWebview.onDidBlur(() => {
+		this._register(helpOverlayWebview.onDidBlur(() => {
 			this.helpFocusedContextKey.set(false);
-		});
+		}));
 
 		// Run logic for animating cases.
 		ensureWebviewSizeCorrectWhenAnimating();

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -754,9 +754,9 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		);
 
 		// Add the onDidNavigate event handler.
-		helpEntry.onDidNavigate(url => {
+		this._register(helpEntry.onDidNavigate(url => {
 			this.navigate(helpEntry.sourceUrl, url);
-		});
+		}));
 
 		// Add the help entry.
 		this.addHelpEntry(helpEntry);


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/9201

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Should not see new leaked disposables warnings when launching the help pane.

@:help
