### PR TITLE
Mark internal positron extensions as private (#9137)

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -31,7 +31,7 @@ runs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-        POSITRON_GITHUB_PAT: ${{ github.token }}
+        POSITRON_GITHUB_RO_PAT: ${{ github.token }}
       run: |
         # Install node-gyp; this is required by some packages
         npm i --global node-gyp

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --fetch-timeout 120000
         env:
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
 
       - name: Run `gulp prePublishNonBundle`
         run: npm run prePublish
@@ -287,7 +287,7 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --fetch-timeout 120000
         env:
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
 
       - name: Run `gulp prePublishNonBundle`
         run: npm run prePublish
@@ -402,7 +402,7 @@ jobs:
         env:
           TEST_FILES_SUFFIX: testvirtualenvs
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
         with:
           run: npm run testSingleWorkspace
@@ -412,7 +412,7 @@ jobs:
       - name: Run single-workspace tests
         env:
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
         with:
           run: npm run testSingleWorkspace
@@ -422,7 +422,7 @@ jobs:
       - name: Run debugger tests
         env:
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
         with:
           run: npm run testDebugger
@@ -435,7 +435,7 @@ jobs:
 
       - name: Run smoke tests
         env:
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         run: |
           npx tsc && node ./out/test/smokeTest.js
         if: matrix.test-suite == 'smoke'

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -72,13 +72,13 @@ jobs:
       - name: Get & install latest release
         id: get_latest_release
         run: |
-          response=$(curl -s -H "Authorization: token ${{ secrets.POSITRON_GITHUB_PAT }}" "https://api.github.com/repos/posit-dev/positron-builds/releases")
+          response=$(curl -s -H "Authorization: token ${{ secrets.POSITRON_GITHUB_RO_PAT }}" "https://api.github.com/repos/posit-dev/positron-builds/releases")
           latest_tag=$(echo "${response}" | jq -r '.[0].tag_name')
           asset_url=$(echo "${response}" | jq -r '.[0].assets[] | select(.name|match("deb")) | .url')
           filename=$(echo "${response}" | jq -r '.[0].assets[] | select(.name|match("deb")) | .name')
           echo "Latest release: ${latest_tag}"
           echo "Downloading ${filename} from ${asset_url}..."
-          curl -L -H "Accept: application/octet-stream" -H "Authorization: token ${{ secrets.POSITRON_GITHUB_PAT }}" "${asset_url}" -o "${filename}"
+          curl -L -H "Accept: application/octet-stream" -H "Authorization: token ${{ secrets.POSITRON_GITHUB_RO_PAT }}" "${asset_url}" -o "${filename}"
           sudo dpkg -i "${filename}"
 
       - name: Setup E2E Test Environment

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -172,7 +172,7 @@ jobs:
         uses: ./.github/actions/install-license
         if: ${{ inputs.install_license }}
         with:
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          github-token: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
           license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
       - name: Setup E2E Test Environment

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -95,7 +95,7 @@ jobs:
           npm_config_arch: x64
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-          POSITRON_GITHUB_PAT: ${{ github.token }}
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         shell: pwsh
         # nvm on windows does not see .nvmrc
         #

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Positron License
         uses: ./.github/actions/install-license
         with:
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          github-token: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
           license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
       # one integration test needs this: Connections pane works for R

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Positron License
         uses: ./.github/actions/install-license
         with:
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          github-token: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
           license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
       # one unit test needs this: Can list tables and fields from R connections

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-code-cells/package.json
+++ b/extensions/positron-code-cells/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "publisher": "positron",
   "version": "0.0.1",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-ipywidgets/package.json
+++ b/extensions/positron-ipywidgets/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/extensions/positron-javascript/package.json
+++ b/extensions/positron-javascript/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-notebooks/package.json
+++ b/extensions/positron-notebooks/package.json
@@ -4,6 +4,7 @@
   "description": "Positron Notebook Helpers",
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-proxy/package.json
+++ b/extensions/positron-proxy/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-python/scripts/install-pet.ts
+++ b/extensions/positron-python/scripts/install-pet.ts
@@ -266,7 +266,7 @@ async function main() {
     // set it. We try the following in order:
 
     // (1) The GITHUB_PAT environment variable.
-    // (2) The POSITRON_GITHUB_PAT environment variable.
+    // (2) The POSITRON_GITHUB_RO_PAT environment variable.
     // (3) The git config setting 'credential.https://api.github.com.token'.
 
     // (1) Get the GITHUB_PAT from the environment.
@@ -274,10 +274,10 @@ async function main() {
     if (githubPat) {
         console.log('Using Github PAT from environment variable GITHUB_PAT.');
     } else {
-        // (2) Try POSITRON_GITHUB_PAT (it's what the build script sets)
-        githubPat = process.env.POSITRON_GITHUB_PAT;
+        // (2) Try POSITRON_GITHUB_RO_PAT (it's what the build script sets)
+        githubPat = process.env.POSITRON_GITHUB_RO_PAT;
         if (githubPat) {
-            console.log('Using Github PAT from environment variable POSITRON_GITHUB_PAT.');
+            console.log('Using Github PAT from environment variable POSITRON_GITHUB_RO_PAT.');
         }
     }
 

--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -80,7 +80,7 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     // information, there are a lot of ways to set it. We try the following in order:
 
     // (1) The GITHUB_PAT environment variable.
-    // (2) The POSITRON_GITHUB_PAT environment variable.
+    // (2) The POSITRON_GITHUB_RO_PAT environment variable.
     // (3) The git config setting 'credential.https://api.github.com.token'.
     // (4) The git credential store.
 
@@ -90,10 +90,10 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     if (githubPat) {
         console.log('Using Github PAT from environment variable GITHUB_PAT.');
     } else {
-        // (2) Try POSITRON_GITHUB_PAT (it's what the build script sets)
-        githubPat = process.env.POSITRON_GITHUB_PAT;
+        // (2) Try POSITRON_GITHUB_RO_PAT (it's what the build script sets)
+        githubPat = process.env.POSITRON_GITHUB_RO_PAT;
         if (githubPat) {
-            console.log('Using Github PAT from environment variable POSITRON_GITHUB_PAT.');
+            console.log('Using Github PAT from environment variable POSITRON_GITHUB_RO_PAT.');
         }
     }
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.2",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -262,7 +262,7 @@ async function main() {
 	// set it. We try the following in order:
 
 	// (1) The GITHUB_PAT environment variable.
-	// (2) The POSITRON_GITHUB_PAT environment variable.
+	// (2) The POSITRON_GITHUB_RO_PAT environment variable.
 	// (3) The git config setting 'credential.https://api.github.com.token'.
 
 	// (1) Get the GITHUB_PAT from the environment.
@@ -270,10 +270,10 @@ async function main() {
 	if (githubPat) {
 		console.log('Using Github PAT from environment variable GITHUB_PAT.');
 	} else {
-		// (2) Try POSITRON_GITHUB_PAT (it's what the build script sets)
-		githubPat = process.env.POSITRON_GITHUB_PAT;
+		// (2) Try POSITRON_GITHUB_RO_PAT (it's what the build script sets)
+		githubPat = process.env.POSITRON_GITHUB_RO_PAT;
 		if (githubPat) {
-			console.log('Using Github PAT from environment variable POSITRON_GITHUB_PAT.');
+			console.log('Using Github PAT from environment variable POSITRON_GITHUB_RO_PAT.');
 		}
 	}
 

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-run-app/package.json
+++ b/extensions/positron-run-app/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "0.0.1",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "publisher": "positron",
   "version": "0.0.1",
+  "private": true,
   "engines": {
     "vscode": "^1.61.0"
   },

--- a/extensions/positron-supervisor/scripts/install-kallichore-server.ts
+++ b/extensions/positron-supervisor/scripts/install-kallichore-server.ts
@@ -274,7 +274,7 @@ async function main() {
 	// ways to set it. We try the following in order:
 
 	// (1) The GITHUB_PAT environment variable.
-	// (2) The POSITRON_GITHUB_PAT environment variable.
+	// (2) The POSITRON_GITHUB_RO_PAT environment variable.
 	// (3) The git config setting 'credential.https://api.github.com.token'.
 
 	// (1) Get the GITHUB_PAT from the environment.
@@ -282,10 +282,10 @@ async function main() {
 	if (githubPat) {
 		console.log('Using Github PAT from environment variable GITHUB_PAT.');
 	} else {
-		// (2) Try POSITRON_GITHUB_PAT (it's what the build script sets)
-		githubPat = process.env.POSITRON_GITHUB_PAT;
+		// (2) Try POSITRON_GITHUB_RO_PAT (it's what the build script sets)
+		githubPat = process.env.POSITRON_GITHUB_RO_PAT;
 		if (githubPat) {
-			console.log('Using Github PAT from environment variable POSITRON_GITHUB_PAT.');
+			console.log('Using Github PAT from environment variable POSITRON_GITHUB_RO_PAT.');
 		}
 	}
 

--- a/extensions/positron-viewer/package.json
+++ b/extensions/positron-viewer/package.json
@@ -7,6 +7,7 @@
   ],
   "version": "1.0.0",
   "publisher": "positron",
+  "private": true,
   "engines": {
     "vscode": "^1.70.0"
   },


### PR DESCRIPTION
Backport https://github.com/posit-dev/positron/commit/6aaa9a8f361ceae3294938d75a6e9441e500a256 to 2025.08.1

The following positron built-in extensions aren't published to NPM as standalone extensions and are under the licensing terms of the repository. This marker does not stop them from being bundled into the product, but does control how they are handled by third-party dependency licensing scanning tools. Their dependencies will still be tracked, but they themselves will not be listed as independent components in their own right.