### PR TITLE
E2E test: notebook select env fix

### DIFF
--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -85,9 +85,9 @@ export class Notebooks {
 
 			await this.code.driver.page.locator(KERNEL_DROPDOWN).click();
 			await this.quickinput.waitForQuickInputOpened();
-			await this.code.driver.page.getByText('Select Another Kernel...').click();
-			await this.quickinput.selectQuickInputElementContaining(`${kernelGroup} Environments...`);
-			await this.quickinput.selectQuickInputElementContaining(desiredKernel);
+			await this.code.driver.page.getByText('Select Environment...').click();
+			await this.quickinput.type(desiredKernel);
+			await this.quickinput.selectQuickInputElementContaining(`${kernelGroup} ${desiredKernel}`);
 			await this.quickinput.waitForQuickInputClosed();
 
 			// Wait for kernel initialization


### PR DESCRIPTION
The process to pick a notebook interpreter changed a while back. Now you click Select Environment... and then get the session picker. This attempts to handle that but is tricky to test because selectInterpreter in notebooks.ts has several possible paths.

### QA Notes

@:notebooks @:web
