### PR TITLE
Fix cell editor size

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/EnvironmentProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/EnvironmentProvider.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 // Other dependencies.
 import { ISize } from '../../../../base/browser/positronReactRenderer.js';
-import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
+import { ISettableObservable } from '../../../../base/common/observable.js';
 import { IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 
 /**
@@ -18,7 +18,7 @@ interface EnvironmentBundle {
 	/**
 	 * An observable for the size of the notebook.
 	 */
-	sizeObservable: ISettableObservable<ISize>;
+	size: ISettableObservable<ISize>;
 
 	/**
 	 * A callback to get the scoped context key service for a given container.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -468,7 +468,7 @@ export class PositronNotebookEditor extends EditorPane {
 			<NotebookVisibilityProvider isVisible={this._isVisible}>
 				<NotebookInstanceProvider instance={notebookInstance}>
 					<EnvironentProvider environmentBundle={{
-						sizeObservable: this._size,
+						size: this._size,
 						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
 					}}>
 						<PositronNotebookComponent />


### PR DESCRIPTION
Main goal here is to correctly size cell code editors, so things like breakpoints are accessible. Also removed some parts that didn't seem to be doing anything - hopefully nothing breaks! Addresses https://github.com/posit-dev/positron/issues/9245.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

