### PR TITLE
Add snowflake support to connections pane

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -178,6 +178,10 @@ jobs:
             python: '3.12'
           - os: 'ubuntu-latest'
             python: '3.13'
+    env:
+      SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+      SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+      SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
 
     steps:
       - name: Checkout

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -43,6 +43,7 @@ syrupy==4.9.1
 torch==2.7.1
 scipy==1.13.1; python_version == '3.9'
 scipy==1.15.3; python_version >= '3.10'
+snowflake-connector-python==3.17.2
 SQLAlchemy==2.0.41
 
 # putting this last like test-requirements.txt

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -925,7 +925,7 @@ class SnowflakeConnection(Connection):
             cursor = conn.cursor()
             cursor.execute("SELECT CURRENT_ACCOUNT()")
             self.host = cursor.fetchone()[0]
-        except Exception as e:
+        except Exception:
             self.host = "<unknown>"
 
         self.display_name = f"Snowflake ({self.host})"

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -978,7 +978,6 @@ class SnowflakeConnection(Connection):
 
         database, schema, table = path
 
-        # Use DuckDB's native pandas integration via .df() method
         query = f'SELECT * FROM "{database.name}"."{schema.name}"."{table.name}" LIMIT 1000;'
         var_name = var_name or "conn"
         preview = self.conn.cursor().execute(query).fetch_pandas_all()

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import uuid
 from typing import TYPE_CHECKING, Any, Tuple, TypedDict
@@ -304,6 +305,8 @@ class ConnectionsService:
             return SQLAlchemyConnection(obj)
         elif safe_isinstance(obj, "duckdb", "DuckDBPyConnection"):
             return DuckDBConnection(obj)
+        elif safe_isinstance(obj, "snowflake.connector", "SnowflakeConnection"):
+            return SnowflakeConnection(obj)
         else:
             type_name = type(obj).__name__
             raise UnsupportedConnectionError(f"Unsupported connection type {type(obj)}")
@@ -317,6 +320,7 @@ class ConnectionsService:
                 safe_isinstance(obj, "sqlite3", "Connection")
                 or safe_isinstance(obj, "sqlalchemy", "Engine")
                 or safe_isinstance(obj, "duckdb", "DuckDBPyConnection")
+                or safe_isinstance(obj, "snowflake.connector", "SnowflakeConnection")
             )
         except Exception as err:
             logger.error(f"Error checking supported {err}")
@@ -901,6 +905,90 @@ class DuckDBConnection(Connection):
 
     def list_object_types(self):
         return {
+            "table": ConnectionObjectInfo({"contains": "data", "icon": None}),
+            "view": ConnectionObjectInfo({"contains": "data", "icon": None}),
+            "schema": ConnectionObjectInfo({"contains": None, "icon": None}),
+        }
+
+    def disconnect(self):
+        self.conn.close()  # type: ignore
+
+
+class SnowflakeConnection(Connection):
+    """Support for Snowflake Connection connections to databases."""
+
+    def __init__(self, conn: Any):
+        self.conn = conn
+        self.icon = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTYxLjA2MzIgMjguMjk2NEw1My43Mzg1IDMyLjQzOTVMNjEuMDYzMiAzNi41ODI1QzYyLjkyNTUgMzcuNjMwNSA2My41NDYyIDM5Ljk0NTggNjIuNDc4NSA0MS43NDkyQzYxLjQxMDkgNDMuNTUyNyA1OS4wNTIgNDQuMTYxOSA1Ny4xODk4IDQzLjEzODRMNDQuMDU0OCAzNS43Mjk2QzQzLjE4NTggMzUuMjQyMSA0Mi41NjUxIDM0LjQ2MjMgNDIuMjkxOSAzMy41ODQ5QzQyLjE2NzggMzMuMTcwNiA0Mi4wOTMzIDMyLjc1NjMgNDIuMTE4MSAzMi4zNjYzQzQyLjExODEgMzIuMDczOSA0Mi4xNjc4IDMxLjc4MTQgNDIuMjQyMyAzMS40NjQ2QzQyLjUxNTQgMzAuNTM4NSA0My4xMTEzIDI5LjcwOTkgNDQuMDMgMjkuMTk4MUw1Ny4xNjUgMjEuNzg5M0M1OS4wMDI0IDIwLjc0MTMgNjEuMzg2IDIxLjM3NSA2Mi40NTM3IDIzLjE3ODVDNjMuNTIxNCAyNC45ODE5IDYyLjkwMDYgMjcuMjk3MiA2MS4wMzg0IDI4LjM0NTFMNjEuMDYzMiAyOC4yOTY0Wk01NC4xMTA5IDQ4LjM3ODFMNDAuOTc2IDQwLjk2OTNDNDAuMjgwNyA0MC41Nzk0IDM5LjQ4NjIgNDAuNDA4OCAzOC43NDEzIDQwLjQ4MTlDMzYuNzMwMSA0MC42MjgxIDM1LjE2NTggNDIuMjYxIDM1LjE2NTggNDQuMjM1MVY1OS4wNTI3QzM1LjE2NTggNjEuMTQ4NiAzNi44NzkxIDYyLjgzMDIgMzkuMDM5MiA2Mi44MzAyQzQxLjE5OTQgNjIuODMwMiA0Mi45MTI3IDYxLjE0ODYgNDIuOTEyNyA1OS4wNTI3VjUwLjc2NjVMNTAuMjYyMyA1NC45MDk2QzUyLjA5OTcgNTUuOTU3NSA1NC40ODM0IDU1LjM0ODMgNTUuNTUxIDUzLjU0NDhDNTYuNjE4NyA1MS43NDEzIDU1Ljk5OCA0OS40MjYxIDU0LjEzNTcgNDguMzc4MUg1NC4xMTA5Wk0zOC45NjQ4IDMzLjkwMTdMMzMuNTAyMiAzOS4yMzlDMzMuMzUzMiAzOS4zODUyIDMzLjA1NTMgMzkuNTMxNCAzMi44MDcgMzkuNTMxNEgzMS4xOTNDMzAuOTY5NiAzOS41MzE0IDMwLjY3MTYgMzkuNDA5NiAzMC40OTc4IDM5LjIzOUwyNS4wMzUzIDMzLjkwMTdDMjQuODg2MyAzMy43NTU1IDI0Ljc2MjEgMzMuNDM4NyAyNC43NjIxIDMzLjI0MzdWMzEuNjg0QzI0Ljc2MjEgMzEuNDY0NiAyNC44ODYzIDMxLjE3MjIgMjUuMDM1MyAzMS4wMDE2TDMwLjQ5NzggMjUuNjY0M0MzMC42NDY4IDI1LjUxODEgMzAuOTY5NiAyNS4zOTYyIDMxLjE5MyAyNS4zOTYySDMyLjgwN0MzMy4wMzA0IDI1LjM5NjIgMzMuMzI4NCAyNS41MTgxIDMzLjUwMjIgMjUuNjY0M0wzOC45NjQ4IDMxLjAwMTZDMzkuMTEzNyAzMS4xNDc4IDM5LjIzNzkgMzEuNDY0NiAzOS4yMzc5IDMxLjY4NFYzMy4yNDM3QzM5LjIzNzkgMzMuNDYzMSAzOS4xMTM3IDMzLjc1NTUgMzguOTY0OCAzMy45MDE3Wk0zNC41OTQ3IDMyLjQxNTFDMzQuNTk0NyAzMi4xOTU4IDM0LjQ3MDYgMzEuOTAzMyAzNC4yOTY4IDMxLjczMjdMMzIuNzA3NiAzMC4xOTczQzMyLjU1ODcgMzAuMDUxMSAzMi4yMzU5IDI5LjkyOTIgMzIuMDEyNCAyOS45MjkySDMxLjkzNzlDMzEuNzE0NSAyOS45MjkyIDMxLjQxNjUgMzAuMDUxMSAzMS4yNjc1IDMwLjE5NzNMMjkuNjc4NCAzMS43MzI3QzI5LjUyOTQgMzEuOTAzMyAyOS40MDUzIDMyLjE5NTggMjkuNDA1MyAzMi40MTUxVjMyLjQ2MzhDMjkuNDA1MyAzMi42ODMyIDI5LjUyOTQgMzIuOTc1NiAyOS42Nzg0IDMzLjEyMTlMMzEuMjY3NSAzNC42NTcyQzMxLjQxNjUgMzQuODAzNSAzMS43MzkzIDM0LjkyNTMgMzEuOTM3OSAzNC45MjUzSDMyLjAxMjRDMzIuMjM1OSAzNC45MjUzIDMyLjUzMzggMzQuODAzNSAzMi43MDc2IDM0LjY1NzJMMzQuMjk2OCAzMy4xMjE5QzM0LjQ0NTcgMzIuOTc1NiAzNC41OTQ3IDMyLjY1ODggMzQuNTk0NyAzMi40NjM4VjMyLjQxNTFaTTkuODg5MDkgMTYuNDc2NEwyMy4wMjQgMjMuODg1MkMyMy43MTkzIDI0LjI3NTIgMjQuNTEzOCAyNC40NDU4IDI1LjI1ODcgMjQuMzcyNkMyNy4yNjk5IDI0LjIyNjQgMjguODM0MiAyMi41OTM2IDI4LjgzNDIgMjAuNTk1MVY1Ljc3NzUxQzI4LjgzNDIgMy43MDU5NyAyNy4wOTYxIDIgMjQuOTYwOCAyQzIyLjgyNTQgMiAyMS4wODczIDMuNjgxNiAyMS4wODczIDUuNzc3NTFWMTQuMDYzN0wxMy43Mzc3IDkuOTIwNkMxMS45MDAzIDguODcyNjQgOS41NDE0NyA5LjUwNjI5IDguNDQ4OTcgMTEuMzA5N0M3LjM4MTI4IDEzLjExMzIgOC4wMDIwMyAxNS40Mjg1IDkuODY0MjYgMTYuNDc2NEg5Ljg4OTA5Wk0zOC43NDEzIDI0LjM5N0MzOS40ODYyIDI0LjQ0NTggNDAuMjgwNyAyNC4yOTk1IDQwLjk3NiAyMy45MDk2TDU0LjExMDkgMTYuNTAwOEM1NS45NzMxIDE1LjQ1MjggNTYuNTkzOSAxMy4xMzc2IDU1LjUyNjIgMTEuMzM0MUM1NC40NTg1IDkuNTMwNjYgNTIuMDk5NyA4LjkyMTM4IDUwLjIzNzUgOS45NDQ5N0w0Mi44ODc5IDE0LjA4OFY1LjgwMTg5QzQyLjg4NzkgMy43MzAzNCA0MS4xNDk4IDIuMDI0MzcgMzkuMDE0NCAyLjAyNDM3QzM2Ljg3OTEgMi4wMjQzNyAzNS4xNDEgMy43MDU5NyAzNS4xNDEgNS44MDE4OVYyMC42MTk1QzM1LjE0MSAyMi42MTc5IDM2LjcwNTIgMjQuMjUwOCAzOC43MTY1IDI0LjM5N0gzOC43NDEzWk0yNS4yODM2IDQwLjQ4MTlDMjQuNTM4NyA0MC40MDg4IDIzLjc0NDEgNDAuNTc5NCAyMy4wNDg5IDQwLjk2OTNMOS45MTM5MiA0OC4zNzgxQzguMDc2NTIgNDkuNDI2MSA3LjQzMDk1IDUxLjc0MTMgOC40OTg2MyA1My41NDQ4QzkuNTY2MzEgNTUuMzQ4MyAxMS45MjUxIDU1Ljk1NzUgMTMuNzg3NCA1NC45MDk2TDIxLjEzNyA1MC43NjY1VjU5LjA1MjdDMjEuMTM3IDYxLjE0ODYgMjIuODc1MSA2Mi44MzAyIDI1LjAxMDQgNjIuODMwMkMyNy4xNDU4IDYyLjgzMDIgMjguODgzOSA2MS4xNDg2IDI4Ljg4MzkgNTkuMDUyN1Y0NC4yMzUxQzI4Ljg4MzkgNDIuMjM2NiAyNy4yOTQ4IDQwLjYwMzggMjUuMzA4NCA0MC40ODE5SDI1LjI4MzZaTTIxLjcwODEgMzMuNTYwNUMyMS44MzIyIDMzLjE0NjIgMjEuODgxOSAzMi43MzE5IDIxLjg4MTkgMzIuMzQyQzIxLjg4MTkgMzIuMDQ5NSAyMS44MzIyIDMxLjc1NzEgMjEuNzMyOSAzMS40NDAzQzIxLjQ4NDYgMzAuNTE0MSAyMC44NjM4IDI5LjY4NTUgMTkuOTQ1MSAyOS4xNzM3TDYuODEwMiAyMS43NjQ5QzQuOTQ3OTcgMjAuNzE3IDIuNTg5MTQgMjEuMzUwNiAxLjUyMTQ2IDIzLjE1NDFDMC40NTM3NzcgMjQuOTU3NSAxLjA3NDUzIDI3LjI3MjggMi45MzY3NiAyOC4zMjA4TDEwLjI2MTUgMzIuNDYzOEwyLjkzNjc2IDM2LjYwNjlDMS4wNzQ1MyAzNy42NTQ5IDAuNDUzNzc3IDM5Ljk3MDEgMS41MjE0NiA0MS43NzM2QzIuNTg5MTQgNDMuNTc3IDQuOTQ3OTcgNDQuMTg2MyA2LjgxMDIgNDMuMTYyN0wxOS45NDUxIDM1Ljc1MzlDMjAuODM5IDM1LjI2NjUgMjEuNDM0OSAzNC40ODY2IDIxLjcwODEgMzMuNjA5M1YzMy41NjA1WiIgZmlsbD0iIzI5QjVFOCIvPgo8L3N2Zz4K"
+
+        try:
+            cursor = conn.cursor()
+            cursor.execute("SELECT CURRENT_ACCOUNT()")
+            self.host = cursor.fetchone()[0]
+        except Exception as e:
+            self.host = "<unknown>"
+
+        self.display_name = f"Snowflake ({self.host})"
+        self.type = "Snowflake"
+
+    def list_objects(self, path: list[ObjectSchema]):
+        if len(path) == 0:
+            res = self.conn.cursor().execute("SHOW DATABASES;")
+            return [
+                ConnectionObject({"name": row[1], "kind": "database"}) for row in res.fetchall()
+            ]
+
+        if len(path) == 1:
+            database = path[0]
+            res = self.conn.cursor().execute(f"SHOW SCHEMAS in DATABASE {database.name}")
+            return [ConnectionObject({"name": row[1], "kind": "schema"}) for row in res.fetchall()]
+
+        if len(path) == 2:
+            database, schema = path
+            tables = self.conn.cursor().execute(
+                f"SHOW TABLES in SCHEMA {database.name}.{schema.name}"
+            )
+            views = self.conn.cursor().execute(
+                f"SHOW VIEWS in SCHEMA {database.name}.{schema.name}"
+            )
+            return [
+                ConnectionObject({"name": row[1], "kind": "table"}) for row in tables.fetchall()
+            ] + [ConnectionObject({"name": row[1], "kind": "view"}) for row in views.fetchall()]
+
+        raise ValueError(f"Path length must be at most 2, but got {len(path)}. Path: {path}")
+
+    def list_fields(self, path):
+        if len(path) != 3:
+            raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
+
+        database, schema, table = path
+
+        res = self.conn.cursor().execute(
+            f"SHOW COLUMNS IN {database.name}.{schema.name}.{table.name}"
+        )
+        return [
+            ConnectionObjectFields({"name": row[2], "dtype": json.loads(row[3])["type"]})
+            for row in res.fetchall()
+        ]
+
+    def preview_object(self, path, var_name: str | None = None):
+        if len(path) != 3:
+            raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
+
+        database, schema, table = path
+
+        # Use DuckDB's native pandas integration via .df() method
+        query = f'SELECT * FROM "{database.name}"."{schema.name}"."{table.name}" LIMIT 1000;'
+        var_name = var_name or "conn"
+        preview = self.conn.cursor().execute(query).fetch_pandas_all()
+        sql = (
+            f"# {table.name} = {var_name}.execute({query!r}).df() # where {var_name} is your connection variable",
+        )
+        return preview, sql
+
+    def list_object_types(self):
+        return {
+            "database": ConnectionObjectInfo({"contains": None, "icon": None}),
             "table": ConnectionObjectInfo({"contains": "data", "icon": None}),
             "view": ConnectionObjectInfo({"contains": "data", "icon": None}),
             "schema": ConnectionObjectInfo({"contains": None, "icon": None}),

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -930,6 +930,7 @@ class SnowflakeConnection(Connection):
 
         self.display_name = f"Snowflake ({self.host})"
         self.type = "Snowflake"
+        self.code = self._make_code()
 
     def list_objects(self, path: list[ObjectSchema]):
         if len(path) == 0:
@@ -996,3 +997,14 @@ class SnowflakeConnection(Connection):
 
     def disconnect(self):
         self.conn.close()  # type: ignore
+
+    def _make_code(self):
+        args = ["account", "authenticator", "host", "user", "password", "port"]
+        code = "import snowflake.connector\ncon = snowflake.connector.connect(\n"
+        for arg in args:
+            val = getattr(self.conn, f"_{arg}")
+            if val is not None:
+                val = repr(val)
+                code += f"    {arg}={val},\n"
+        code += ")\n"
+        return code

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1164,6 +1164,18 @@ class DuckDBConnectionInspector(BaseConnectionInspector):
         return True
 
 
+class SnowflakeConnectionInspector(BaseConnectionInspector):
+    CLASS_QNAME = ("snowflake.connector.connection.SnowflakeConnection",)
+
+    def _is_active(self, value) -> bool:
+        try:
+            # a connection is active if you can acquire a cursor from it
+            value.cursor()
+        except Exception:
+            return False
+        return True
+
+
 class IbisExprInspector(PositronInspector["ibis.Expr"]):
     def has_children(self) -> bool:
         return False
@@ -1202,6 +1214,7 @@ INSPECTOR_CLASSES: dict[str, type[PositronInspector]] = {
     **dict.fromkeys(SQLiteConnectionInspector.CLASS_QNAME, SQLiteConnectionInspector),
     **dict.fromkeys(SQLAlchemyEngineInspector.CLASS_QNAME, SQLAlchemyEngineInspector),
     **dict.fromkeys(DuckDBConnectionInspector.CLASS_QNAME, DuckDBConnectionInspector),
+    **dict.fromkeys(SnowflakeConnectionInspector.CLASS_QNAME, SnowflakeConnectionInspector),
     "ibis.Expr": IbisExprInspector,
     "boolean": BooleanInspector,
     "bytes": BytesInspector,

--- a/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
@@ -3,6 +3,7 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
+import os
 import sqlite3
 from typing import Tuple
 
@@ -15,6 +16,18 @@ try:
     HAS_DUCKDB = True
 except ImportError:
     HAS_DUCKDB = False
+
+
+try:
+    if "SNOWFLAKE_ACCOUNT" in os.environ:
+        import snowflake.connector
+
+        HAS_SNOWFLAKE = True
+    else:
+        HAS_SNOWFLAKE = False
+except ImportError:
+    HAS_SNOWFLAKE = False
+
 
 from positron.access_keys import encode_access_key
 from positron.connections import ConnectionsService
@@ -50,6 +63,18 @@ def get_duckdb_connection():
     con = duckdb.connect(":memory:")
     add_default_data(lambda sql: con.execute(sql))
     return con
+
+
+def get_snowflake_connection():
+    if not HAS_SNOWFLAKE:
+        pytest.skip("Snowflake not available")
+
+    return snowflake.connector.connect(
+        account=os.getenv("SNOWFLAKE_ACCOUNT"),
+        user=os.getenv("SNOWFLAKE_USER"),
+        password=os.getenv("SNOWFLAKE_PASSWORD"),
+        warehouse="DEFAULT_WH",
+    )
 
 
 def get_sqlite_connections():
@@ -269,6 +294,152 @@ class TestDuckDBConnectionsService:
                     {"kind": "catalog", "name": "memory"},
                     {"kind": "schema", "name": "main"},
                     {"kind": "table", "name": "movie"},
+                ]
+            },
+            method="preview_object",
+            comm_id=comm_id,
+        )
+        dummy_comm.handle_msg(msg)
+        # cleanup the data_explorer state, so we don't break its own tests
+        connections_service._kernel.data_explorer_service.shutdown()  # noqa: SLF001
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert result is None
+
+
+@pytest.mark.skipif(not HAS_SNOWFLAKE, reason="Snowflake not available")
+class TestSnowflakeConnectionsService:
+    DATABASE_NAME = "POSITRON_CONNECTIONS_PANE_TESTS"
+    SCHEMA_NAME = "PUBLIC"
+    TABLE_NAME = "FLIGHTS"
+
+    def test_register_connection(self, connections_service: ConnectionsService):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+        assert comm_id in connections_service.comms
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            [],
+            [{"kind": "database", "name": DATABASE_NAME}],
+            [
+                {"kind": "database", "name": DATABASE_NAME},
+                {"kind": "schema", "name": SCHEMA_NAME},
+            ],
+        ],
+    )
+    def test_contains_data(self, connections_service: ConnectionsService, path):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="contains_data", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert result is False
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ([], "data:image"),
+            ([{"kind": "database", "name": DATABASE_NAME}], ""),
+            (
+                [
+                    {"kind": "database", "name": DATABASE_NAME},
+                    {"kind": "schema", "name": SCHEMA_NAME},
+                ],
+                "",
+            ),
+        ],
+    )
+    def test_get_icon(self, connections_service: ConnectionsService, path, expected):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="get_icon", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        if expected == "":
+            assert result == expected
+        else:
+            assert expected in result
+
+    @pytest.mark.parametrize(
+        ("path", "expected_contains"),
+        [
+            ([], DATABASE_NAME),
+            ([{"kind": "database", "name": DATABASE_NAME}], SCHEMA_NAME),
+            (
+                [
+                    {"kind": "database", "name": DATABASE_NAME},
+                    {"kind": "schema", "name": SCHEMA_NAME},
+                ],
+                TABLE_NAME,
+            ),
+        ],
+    )
+    def test_list_objects(self, connections_service: ConnectionsService, path, expected_contains):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(params={"path": path}, method="list_objects", comm_id=comm_id)
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+
+        # Check that expected item is in the results
+        names = [item["name"] for item in result]
+        assert expected_contains in names
+
+    def test_list_fields(self, connections_service: ConnectionsService):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(
+            params={
+                "path": [
+                    {"kind": "database", "name": self.DATABASE_NAME},
+                    {"kind": "schema", "name": self.SCHEMA_NAME},
+                    {"kind": "table", "name": self.TABLE_NAME},
+                ]
+            },
+            method="list_fields",
+            comm_id=comm_id,
+        )
+        dummy_comm.handle_msg(msg)
+        result = dummy_comm.messages[0]["data"]["result"]
+        assert len(result) == 19
+        nms = [field["name"] for field in result]
+        assert "AIR_TIME" in nms
+
+    def test_preview_object(self, connections_service: ConnectionsService):
+        con = get_snowflake_connection()
+        comm_id = connections_service.register_connection(con)
+
+        dummy_comm = DummyComm(TARGET_NAME, comm_id=comm_id)
+        connections_service.on_comm_open(dummy_comm)
+        dummy_comm.messages.clear()
+
+        msg = _make_msg(
+            params={
+                "path": [
+                    {"kind": "database", "name": self.DATABASE_NAME},
+                    {"kind": "schema", "name": self.SCHEMA_NAME},
+                    {"kind": "table", "name": self.TABLE_NAME},
                 ]
             },
             method="preview_object",

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -22,6 +22,7 @@ pytest-mock
 syrupy
 torch
 scipy
+snowflake-connector-python
 sqlalchemy
 
 # putting this last because holoviews is picky about dependency versions (including bokeh),

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -199,17 +199,25 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 						case 'character':
 						case 'string':
 						case 'varchar':
+						case 'text':
 							return 'positron-data-type-string';
 						case 'integer':
 						case 'numeric':
 						case 'float':
 						case 'double':
+						case 'fixed':
+						case 'real':
 							return 'positron-data-type-number';
 						case 'boolean':
 						case 'bool':
 							return 'positron-data-type-boolean';
+						case 'date':
+							return 'positron-data-type-date';
 						case 'timestamp':
+						case 'timestamp_ltz':
 							return 'positron-data-type-date-time';
+						case 'array':
+							return 'positron-data-type-array';
 						default:
 							return 'positron-data-type-unknown';
 					}


### PR DESCRIPTION
Addresses #8580

TODO:

- [x] add tests
- [x] add code generation for re-connection
- [x] variables pane integration

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added support for the python Snowflake connector in the Connections Pane (#8580) 

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Request a Snowflake Developer account with IT, then use:

```
con = snowflake.connector.connect(
    account='<our snowflake account w/ the snowflake.info part>',
    authenticator='externalbrowser',
    user='<your work mail>'
)

%connection_show con
```


