### PR TITLE
Add support for pinning in summary panel

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -38,8 +38,14 @@
 	min-width: 0;
 	min-height: 0;
 	display: grid;
+	grid-template-columns: 100%;
 	grid-row: main-row / end-rows;
 	grid-column: left-column / collapsed-left-spacer;
+	grid-template-rows: [summary-row-action-bar] 36px [data-grid] 1fr [end-rows];
+}
+
+.data-explorer-panel .data-explorer .left-column .data-grid-container {
+	grid-row: data-grid / end-rows;
 }
 
 .data-explorer-panel .data-explorer .collapsed-left-spacer {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -45,6 +45,8 @@
 }
 
 .data-explorer-panel .data-explorer .left-column .data-grid-container {
+	/* min-height: 0 allows the data grid to shrink properly when the panel is resized */
+	min-height: 0;
 	grid-row: data-grid / end-rows;
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -348,12 +348,14 @@ export const DataExplorer = () => {
 						instance={context.instance.tableSchemaDataGridInstance}
 					/>
 				}
-				<PositronDataGrid
-					instance={layout === PositronDataExplorerLayout.SummaryOnLeft ?
-						context.instance.tableSchemaDataGridInstance :
-						context.instance.tableDataDataGridInstance
-					}
-				/>
+				<div className='data-grid-container'>
+					<PositronDataGrid
+						instance={layout === PositronDataExplorerLayout.SummaryOnLeft ?
+							context.instance.tableSchemaDataGridInstance :
+							context.instance.tableDataDataGridInstance
+						}
+					/>
+				</div>
 			</div>
 			{layout === PositronDataExplorerLayout.SummaryOnLeft && columnsCollapsed &&
 				<div className='collapsed-left-spacer' />

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
@@ -11,4 +11,5 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	border-bottom: 1px solid var(--vscode-positronDataGrid-border);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.css
@@ -7,9 +7,11 @@
 	height: 36px;
 	min-width: 0;
 	min-height: 0;
-	overflow: hidden;
 	display: flex;
+	overflow: hidden;
 	align-items: center;
+	box-sizing: border-box;
 	justify-content: space-between;
+	grid-row: summary-row-action-bar / data-grid;
 	border-bottom: 1px solid var(--vscode-positronDataGrid-border);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -33,6 +33,19 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(instance.sortOption || SearchSchemaSortOrder.Original);
 
 	/**
+	 * Initialize the search text input when the instance changes.
+	 * This ensures the search text is displayed correctly when switching between tabs.
+	 */
+	useEffect(() => {
+		const instanceSearchText = instance.searchText || '';
+		setSearchText(instanceSearchText);
+		// Update the filter input field
+		if (filterRef.current) {
+			filterRef.current.setFilterText(instanceSearchText);
+		}
+	}, [instance]);
+
+	/**
 	 * Update the debounced search text after a delay.
 	 * This is to prevent excessive search requests while the user is typing.
 	 */

--- a/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
@@ -617,8 +617,8 @@ export class LayoutManager {
 				return index;
 			}
 
-			// Return the entry-mapped index. This will naturally return undefined, if the index is invalid.
-			return this._entryMap[index];
+			// Return the inverse entry-mapped index. This will naturally return undefined, if the index is invalid.
+			return this._inverseEntryMap.get(index);
 		}
 
 		// If the index is pinned, return its position.

--- a/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
@@ -617,8 +617,8 @@ export class LayoutManager {
 				return index;
 			}
 
-			// Return the entry-mapped index. This will naturally return undefined, if the index is invalid.
-			return this._entryMap[index];
+			// Return the position index. This will naturally return undefined, if the index is invalid.
+			return this._inverseEntryMap.get(index);
 		}
 
 		// If the index is pinned, return its position.

--- a/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
@@ -617,8 +617,8 @@ export class LayoutManager {
 				return index;
 			}
 
-			// Return the position index. This will naturally return undefined, if the index is invalid.
-			return this._inverseEntryMap.get(index);
+			// Return the entry-mapped index. This will naturally return undefined, if the index is invalid.
+			return this._entryMap[index];
 		}
 
 		// If the index is pinned, return its position.

--- a/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
@@ -222,14 +222,7 @@ export class LayoutManager {
 		}
 
 		// Calculate the default unpinned layout entries size. This accounts for all entries.
-		let size = this._entryCount * this._defaultSize;
-
-		// Account for pinned indexes by subtracting the default size for each one.
-		for (const pinnedIndex of this._pinnedIndexes) {
-			if (pinnedIndex < this._entryCount) {
-				size -= this._defaultSize;
-			}
-		}
+		let size = (this._entryCount - this._pinnedIndexes.size) * this._defaultSize;
 
 		// Account for custom entry sizes by subtracting the default size and adding the custom entry size for each one.
 		for (const [customEntrySizeIndex, customEntrySize] of this._customEntrySizes) {

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -217,6 +217,26 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 			// Enter key.
 			case 'Enter': {
+				// Check if this is a summary panel instance
+				const isSummaryPanel = context.instance instanceof TableSummaryDataGridInstance;
+
+				if (isSummaryPanel) {
+					// Consume the event.
+					consumeEvent();
+
+					// Make sure the cursor is showing.
+					if (context.instance.showCursor()) {
+						return;
+					}
+
+					// Expand or collapse the row in the summary panel.
+					const summaryInstance = context.instance as TableSummaryDataGridInstance;
+
+					// Only allow toggle if summary stats are supported for this column
+					if (summaryInstance.canToggleColumnExpansion(summaryInstance.cursorRowIndex)) {
+						await summaryInstance.toggleExpandColumn(summaryInstance.cursorRowIndex);
+					}
+				}
 				break;
 			}
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -26,6 +26,8 @@ import { FontConfigurationManager } from '../../fontConfigurationManager.js';
 import { isElectron, isMacintosh } from '../../../../base/common/platform.js';
 import { ExtendColumnSelectionBy, ExtendRowSelectionBy } from '../classes/dataGridInstance.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
+import { TableSummaryDataGridInstance } from '../../../services/positronDataExplorer/browser/tableSummaryDataGridInstance.js';
+
 /**
  * DataGridWaffle component.
  * @param ref The foreard ref.
@@ -164,6 +166,32 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 		// Process the code.
 		switch (e.code) {
+			// Tab key - for summary panel navigation
+			case 'Tab': {
+				// Check if this is a summary panel instance
+				const isSummaryPanel = context.instance instanceof TableSummaryDataGridInstance;
+
+				if (isSummaryPanel) {
+					// Consume the event.
+					consumeEvent();
+
+					// Make sure the cursor is showing.
+					if (context.instance.showCursor()) {
+						return;
+					}
+
+					// Move the cursor to the next/previous row.
+					if (e.shiftKey) {
+						// Shift+Tab moves to previous row
+						context.instance.moveCursorUp();
+					} else {
+						// Tab moves to the next row
+						context.instance.moveCursorDown();
+					}
+				}
+				break;
+			}
+
 			// Space key.
 			case 'Space': {
 				// Make sure the cursor is showing.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -21,8 +21,7 @@ import { VectorFrequencyTable } from './vectorFrequencyTable.js';
 import { ColumnProfileBoolean } from './columnProfileBoolean.js';
 import { ColumnProfileDatetime } from './columnProfileDatetime.js';
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
-import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
-import { dataExplorerExperimentalFeatureEnabled } from '../../common/positronDataExplorerExperimentalConfig.js';
+import { ColumnDisplayType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { renderLeadingTrailingWhitespace } from './tableDataCell.js';
 
 /**
@@ -50,29 +49,6 @@ interface ColumnSummaryCellProps {
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
-
-	/**
-	 * Determines whether summary stats is supported.
-	 * @returns true, if summary stats is supported; otherwise, false.
-	 */
-	const isSummaryStatsSupported = () => {
-		// Determine the summary stats support status.
-		const columnProfilesFeatures = props.instance.getSupportedFeatures().get_column_profiles;
-		const summaryStatsSupportStatus = columnProfilesFeatures.supported_types.find(status =>
-			status.profile_type === ColumnProfileType.SummaryStats
-		);
-
-		// If the summary status support status is undefined, return false.
-		if (!summaryStatsSupportStatus) {
-			return false;
-		}
-
-		// Return the summary stats support status.
-		return dataExplorerExperimentalFeatureEnabled(
-			summaryStatsSupportStatus.support_status,
-			props.instance.configurationService
-		);
-	};
 
 	/**
 	 * ColumnSparkline component.
@@ -484,29 +460,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	const expanded = props.instance.isColumnExpanded(props.columnIndex);
 
 	// Set the summary stats supported flag.
-	let summaryStatsSupported;
-	switch (props.columnSchema.type_display) {
-		case ColumnDisplayType.Number:
-		case ColumnDisplayType.Boolean:
-		case ColumnDisplayType.String:
-		case ColumnDisplayType.Date:
-		case ColumnDisplayType.Datetime:
-		case ColumnDisplayType.Object:
-			summaryStatsSupported = isSummaryStatsSupported();
-			break;
-		case ColumnDisplayType.Time:
-		case ColumnDisplayType.Interval:
-		case ColumnDisplayType.Array:
-		case ColumnDisplayType.Struct:
-		case ColumnDisplayType.Unknown:
-			summaryStatsSupported = false;
-			break;
-
-		// This shouldn't ever happen.
-		default:
-			summaryStatsSupported = false;
-			break;
-	}
+	const summaryStatsSupported = props.instance.canToggleColumnExpansion(props.columnIndex);
 
 	const renderedColumn = renderLeadingTrailingWhitespace(props.columnSchema.column_name);
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -175,6 +175,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			)
 		);
 
+		// Add the onDidChangePinnedColumns event handler.
+		this._register(
+			this._tableDataDataGridInstance.onDidChangePinnedColumns(pinnedColumns =>
+				// Update the pinned rows in the summary data grid instance.
+				this._tableSchemaDataGridInstance.updatePinnedRows(pinnedColumns)
+			)
+		);
+
 		// Add the onDidRequestFocus event handler.
 		this._register(this.onDidRequestFocus(() => {
 			const uri = PositronDataExplorerUri.generate(this._dataExplorerClientInstance.identifier);

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -177,10 +177,10 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 		// Add the onDidChangePinnedColumns event handler.
 		this._register(
-			this._tableDataDataGridInstance.onDidChangePinnedColumns(pinnedColumns =>
+			this._tableDataDataGridInstance.onDidChangePinnedColumns(async pinnedColumns => {
 				// Update the pinned rows in the summary data grid instance.
-				this._tableSchemaDataGridInstance.updatePinnedRows(pinnedColumns)
-			)
+				await this._tableSchemaDataGridInstance.updatePinnedRows(pinnedColumns);
+			})
 		);
 
 		// Add the onDidRequestFocus event handler.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -57,6 +57,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _hoverManager: PositronActionBarHoverManager;
 
+	/**
+	 * The onDidChangePinnedColumns event emitter.
+	 * This event is fired when the pinned columns change.
+	 * This event returns the array of pinned column indexes.
+	 */
+	private readonly _onDidChangePinnedColumns = this._register(new Emitter<number[]>());
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -222,6 +229,38 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	//#endregion DataGridInstance Properties
 
 	//#region DataGridInstance Methods
+
+	/**
+	 * Pins a column and fires the onDidPinnedColumnsChange event.
+	 *
+	 * This allows the summary panel to keep the pinned/unpinned
+	 * columns in sync with the data grid.
+	 *
+	 * @param columnIndex The index of the column to pin.
+	 */
+	override pinColumn(columnIndex: number) {
+		// Call the parent method
+		super.pinColumn(columnIndex);
+
+		// Fire the event with current pinned column indices
+		this._onDidChangePinnedColumns.fire(this._columnLayoutManager.pinnedIndexes);
+	}
+
+	/**
+	 * Unpins a column and fires the onDidPinnedColumnsChange event.
+	 *
+	 * This allows the summary panel to keep the pinned/unpinned
+	 * columns in sync with the data grid.
+	 *
+	 * @param columnIndex The index of the column to unpin.
+	 */
+	override unpinColumn(columnIndex: number) {
+		// Call the parent method
+		super.unpinColumn(columnIndex);
+
+		// Fire the event with current pinned column indices
+		this._onDidChangePinnedColumns.fire(this._columnLayoutManager.pinnedIndexes);
+	}
 
 	/**
 	 * Sorts the data.
@@ -664,6 +703,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * The onAddFilter event.
 	 */
 	readonly onAddFilter = this._onAddFilterEmitter.event;
+
+	/**
+	 * The onDidChangePinnedColumns event.
+	 */
+	readonly onDidChangePinnedColumns = this._onDidChangePinnedColumns.event;
 
 	//#region Public Methods
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -84,9 +84,12 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			columnResize: false,
 			rowResize: false,
 			columnPinning: false,
-			// Enable row pinning so that trhe layout height is properly calculated. Note that in
-			// TableSummaryDataGridInstance, pinned rows are actually pinned columns, and there is
-			// not UI in the table summary panel to pin/unpin rows.
+			// We need to enable row pinning so the layout height is properly calculated
+			// when there are pinned rows in the TableSummaryDataGridInstance.
+			// In TableSummaryDataGridInstance, pinned rows are actually pinned columns
+			// There is no UI in the table summary panel to pin/unpin rows. Instead, rows
+			// are pinned/unpinned programatically when a user pin/unpins a column in the main
+			// data grid.
 			rowPinning: true,
 			maximumPinnedRows: 10,
 			horizontalScrollbar: false,

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -403,6 +403,22 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Updates the pinned rows in the summary panel.
+	 *
+	 * Note: The summary panel pins column indices as rows.
+	 * This is because the summary panel is a single column data grid
+	 * where each row represents a column from the main data grid.
+	 *
+	 * @param pinnedColumnIndices An array of column indices to pin as rows in the summary panel.
+	 */
+	updatePinnedRows(pinnedColumnIndices: number[]): void {
+		// Update the pinned indexes in the row layout manager.
+		this._rowLayoutManager.setPinnedIndexes(pinnedColumnIndices);
+		// Force a re-render when the pinned columns change
+		this.fireOnDidUpdateEvent();
+	}
+
+	/**
 	 * Sets the column name search filter.
 	 * @param searchText The search text used to filter column names (case insensitive).
 	 */

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -567,20 +567,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 			// Create a combined entry map that includes both pinned columns and search results
 			// Pinned columns should appear first, followed by search results that aren't already pinned
-			const combinedEntries: number[] = [];
-
-			// Add pinned columns first
-			pinnedColumns.forEach(pinnedColumn => {
-				combinedEntries.push(pinnedColumn);
-			});
-
-			// Add search results that aren't already pinned
 			const pinnedSet = new Set(pinnedColumns);
-			searchResults.matches.forEach(matchedColumn => {
-				if (!pinnedSet.has(matchedColumn)) {
-					combinedEntries.push(matchedColumn);
-				}
-			});
+			const combinedEntries: number[] = [
+				...pinnedColumns,
+				...searchResults.matches.filter(matchedColumn => !pinnedSet.has(matchedColumn))
+			];
 
 			this._rowLayoutManager.setEntries(combinedEntries.length, undefined, combinedEntries);
 		}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -53,7 +53,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * If no sort option is set, the summary rows
 	 * are displayed in their original order.
 	 */
-	private _sortOption?: SearchSchemaSortOrder;
+	private _sortOption: SearchSchemaSortOrder = SearchSchemaSortOrder.Original;
 
 	/**
 	 * The onDidSelectColumn event emitter.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -84,7 +84,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			columnResize: false,
 			rowResize: false,
 			columnPinning: false,
-			rowPinning: false,
+			// Enable row pinning so that trhe layout height is properly calculated. Note that in
+			// TableSummaryDataGridInstance, pinned rows are actually pinned columns, and there is
+			// not UI in the table summary panel to pin/unpin rows.
+			rowPinning: true,
+			maximumPinnedRows: 10,
 			horizontalScrollbar: false,
 			verticalScrollbar: true,
 			scrollbarThickness: 14,
@@ -564,7 +568,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			// Get current pinned indexes from the layout manager BEFORE doing anything else
 			// This is important because setEntries() can clear the pinned indexes if they're not
 			// in the new entry map
-			const pinnedColumns = Array.from(this._rowLayoutManager.pinnedIndexes);
+			const pinnedColumns = this._rowLayoutManager.pinnedIndexes;
 
 			// When there is a search or sort option, we need to tell the layout manager
 			// to use the filtered table shape and render both pinned columns and search results.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -508,6 +508,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			await this.updateLayoutEntries();
 			// Invalidate the cache when pinned columns change with active search/sort
 			await this.fetchData(true);
+		} else {
+			this.fetchData(false);
 		}
 
 		// Force a re-render when the pinned columns change

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -76,6 +76,8 @@ function createMockTableSummaryDataGridInstance(overrides: Partial<TableSummaryD
 		getColumnProfileSmallHistogram: () => undefined,
 		getColumnProfileSmallFrequencyTable: () => undefined,
 		isColumnExpanded: () => false,
+		canToggleColumnExpansion: () => true,
+		isSummaryStatsSupported: () => true,
 		scrollToRow: async () => { },
 		setCursorRow: () => { },
 		toggleExpandColumn: async () => { },

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableSummaryDataGridInstance.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableSummaryDataGridInstance.test.ts
@@ -1,0 +1,186 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import sinon from 'sinon';
+import { Emitter } from '../../../../../base/common/event.js';
+import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
+import { TableSummaryCache } from '../../common/tableSummaryCache.js';
+import { DataExplorerClientInstance } from '../../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { NullHoverService } from '../../../../../platform/hover/test/browser/nullHoverService.js';
+import {
+	ColumnDisplayType,
+	SearchSchemaSortOrder,
+	BackendState,
+	ColumnProfileType,
+	SupportStatus,
+	SchemaUpdateEvent
+} from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
+
+suite('TableSummaryDataGridInstance', () => {
+	let instance: TableSummaryDataGridInstance;
+	let mockTableSummaryCache: TableSummaryCache;
+	let sandbox: sinon.SinonSandbox;
+	let originalServices: any;
+
+	// Mock backend state
+	const mockBackendState: BackendState = {
+		display_name: 'test-table',
+		table_shape: { num_rows: 100, num_columns: 10 },
+		table_unfiltered_shape: { num_rows: 100, num_columns: 10 },
+		has_row_labels: false,
+		column_filters: [],
+		row_filters: [],
+		sort_keys: [],
+		supported_features: {
+			search_schema: {
+				support_status: SupportStatus.Supported,
+				supported_types: []
+			},
+			set_column_filters: {
+				support_status: SupportStatus.Supported,
+				supported_types: []
+			},
+			set_row_filters: {
+				support_status: SupportStatus.Supported,
+				supports_conditions: SupportStatus.Supported,
+				supported_types: []
+			},
+			get_column_profiles: {
+				support_status: SupportStatus.Supported,
+				supported_types: [
+					{
+						profile_type: ColumnProfileType.SummaryStats,
+						support_status: SupportStatus.Supported
+					}
+				]
+			},
+			export_data_selection: {
+				support_status: SupportStatus.Supported,
+				supported_formats: []
+			},
+			set_sort_columns: {
+				support_status: SupportStatus.Supported
+			},
+			convert_to_code: {
+				support_status: SupportStatus.Supported
+			}
+		}
+	};
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+
+		// Store original services to restore later
+		originalServices = PositronReactServices.services;
+
+		// Mock PositronReactServices.services
+		const mockServices: Partial<PositronReactServices> = {
+			configurationService: new TestConfigurationService(),
+			hoverService: NullHoverService
+		};
+		PositronReactServices.services = mockServices as PositronReactServices;
+
+		// Create mock data explorer client
+		const mockDataExplorerClient: Partial<DataExplorerClientInstance> = {
+			onDidSchemaUpdate: new Emitter<SchemaUpdateEvent>().event,
+			onDidDataUpdate: new Emitter<void>().event,
+			onDidUpdateBackendState: new Emitter<BackendState>().event,
+			getBackendState: sandbox.stub().resolves(mockBackendState),
+			searchSchema2: sandbox.stub().resolves({ matches: [0, 1, 2] }),
+			getSupportedFeatures: sandbox.stub().returns(mockBackendState.supported_features),
+			dispose: sandbox.stub()
+		};
+
+		// Create mock table summary cache
+		const partialMockTableSummaryCache: Partial<TableSummaryCache> = {
+			columns: 10,
+			rows: 100,
+			isColumnExpanded: sandbox.stub().returns(false),
+			getColumnSchema: sandbox.stub(),
+			getColumnProfile: sandbox.stub(),
+			toggleExpandColumn: sandbox.stub().resolves(),
+			onDidUpdate: new Emitter<void>().event,
+			update: sandbox.stub().resolves(),
+			dispose: sandbox.stub()
+		};
+		mockTableSummaryCache = partialMockTableSummaryCache as TableSummaryCache;
+
+		// Create the instance
+		instance = new TableSummaryDataGridInstance(
+			mockDataExplorerClient as DataExplorerClientInstance,
+			mockTableSummaryCache as TableSummaryCache,
+		);
+	});
+
+	teardown(() => {
+		instance.dispose();
+		// Restore original services
+		if (originalServices) {
+			PositronReactServices.services = originalServices;
+		}
+		sandbox.restore();
+	});
+
+	test('columns should always return 1', () => {
+		assert.strictEqual(instance.columns, 1);
+	});
+
+	test('rows should return cache columns count', () => {
+		assert.strictEqual(instance.rows, 10);
+	});
+
+	test('setSearchText should trigger layout update', async () => {
+		const spy = sandbox.spy(instance, 'fetchData');
+		await instance.setSearchText('test');
+		assert(spy.called);
+	});
+
+	test('setSortOption should trigger layout update', async () => {
+		const spy = sandbox.spy(instance, 'fetchData');
+		await instance.setSortOption(SearchSchemaSortOrder.DescendingName);
+		assert(spy.called);
+	});
+
+	test('isColumnExpanded should delegate to cache', () => {
+		(mockTableSummaryCache.isColumnExpanded as sinon.SinonStub).returns(true);
+		assert.strictEqual(instance.isColumnExpanded(5), true);
+		assert((mockTableSummaryCache.isColumnExpanded as sinon.SinonStub).calledWith(5));
+	});
+
+	test('canToggleColumnExpansion should return false for unsupported column types', () => {
+		const unsupportedColumnSchema = getColumnSchema('test', 0, 'unknown', ColumnDisplayType.Unknown);
+		(mockTableSummaryCache.getColumnSchema as sinon.SinonStub).returns(unsupportedColumnSchema);
+		assert.strictEqual(instance.canToggleColumnExpansion(0), false);
+	});
+
+	test('canToggleColumnExpansion should return true for supported column types when feature is enabled', () => {
+		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Number);
+		(mockTableSummaryCache.getColumnSchema as sinon.SinonStub).returns(supportedColumnSchema);
+		assert.strictEqual(instance.canToggleColumnExpansion(0), true);
+	});
+
+	test('toggleExpandColumn should update row layout manager', async () => {
+		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Number);
+		(mockTableSummaryCache.getColumnSchema as sinon.SinonStub).returns(supportedColumnSchema);
+		await instance.toggleExpandColumn(0);
+		assert((mockTableSummaryCache.toggleExpandColumn as sinon.SinonStub).calledWith(0));
+	});
+
+	test('getColumnProfileNullCount should delegate to cache', () => {
+		const mockProfile = { null_count: 5 };
+		(mockTableSummaryCache.getColumnProfile as sinon.SinonStub).returns(mockProfile);
+		const result = instance.getColumnProfileNullCount(0);
+		assert.strictEqual(result, 5);
+		assert((mockTableSummaryCache.getColumnProfile as sinon.SinonStub).calledWith(0));
+	});
+
+	// Ensure that all disposables are cleaned up.
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
Addresses #9196, #8570

When a column is pinned in the data grid, the corresponding row for that column also gets pinned in the summary panel. The order of the pinned columns will match the order in the data grid. For example, if columns 1, 9, 6 are pinned (in that order), then the pinned rows in the summary panel should also be 1, 9, 6. Pinned rows will not show up in the un-pinned rows section. When a column is un-pinned, the summary panel will immediately unpin the corresponding row as well.

When searching/sorting in the summary panel, the pinned rows should always be present at the top, with the search results listed below. If a pinned row would be in the search results, it should instead not show up twice in the dataset but only show up once as a pinned row. 

This PR also adds some missing keyboard support for the summary panel. You can now use `tab` and `shift+tab` to navigate through the rows. Pressing enter when focused on a row should allow you to expand/collapse the details for that row.

https://github.com/user-attachments/assets/2b0ab111-cee0-4b15-ac68-326ddc371f4b


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:data-explorer @:web @:win