### PR TITLE
Add additonal editor focus context key for clear console action keybinding

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -89,7 +89,7 @@ export function registerPositronConsoleActions() {
 				f1: true,
 				category,
 				keybinding: {
-					when: PositronConsoleFocused,
+					when: ContextKeyExpr.or(EditorContextKeys.focus, PositronConsoleFocused),
 					weight: KeybindingWeight.WorkbenchContrib,
 					primary: KeyMod.CtrlCmd | KeyCode.KeyL,
 					mac: {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9155


### Release Notes


#### New Features

- The <kbd>Ctrl+L</kbd> keybinding to clear the console now works when the editor is focused, in addition to when the console is focused.

#### Bug Fixes

- N/A


### QA Notes


If you have run code in console, you can clear it using <kbd>Ctrl+L</kbd> both when the console is focused (old) and when the editor is focused (new).
