### PR TITLE
Claude Code: Improve instructions for launching Positron and running extension tests

### DIFF
--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -1,0 +1,69 @@
+# Launching Positron - Quick Reference
+
+## CRITICAL: Non-Blocking Launch Protocol
+
+When asked to "launch positron" or "start positron", follow this EXACT sequence:
+
+### Step 1: Check daemons (if not already confirmed running)
+```bash
+ps aux | grep -E "npm.*watch-(client|extensions)d" | grep -v grep
+```
+
+### Step 2: Start missing daemons (if needed)
+```bash
+# Run these in background, don't wait for output
+npm run watch-clientd &
+npm run watch-extensionsd &
+# Wait briefly for initial startup
+sleep 10
+```
+
+### Step 3: Launch Positron in background
+```bash
+# ALWAYS use run_in_background=true for this command
+./scripts/code.sh &
+```
+
+### Step 4: IMMEDIATELY respond to user
+After launching, immediately confirm with a brief message like:
+- "Positron launched in background"
+- "Positron is starting"
+- "Done, Positron is running"
+
+DO NOT:
+- Wait for process verification
+- Check if Positron actually started successfully 
+- Monitor shell output
+- Block the session waiting for anything
+
+The user can check status themselves if needed. Your job is to launch and immediately return control.
+
+## Common Mistakes to Avoid
+
+1. **Blocking after launch**: Never pause after running `./scripts/code.sh &`
+2. **Unnecessary verification**: Don't automatically verify the process started
+3. **Monitoring output**: Don't use BashOutput to check on the launch unless asked
+4. **Long explanations**: Just confirm it's launched and move on
+
+## Example Interaction
+
+User: "launch positron"
+Assistant: [runs background launch command]
+Assistant: "Positron launched in background"
+[Session continues without pause]
+
+## Testing Extensions
+
+When asked to test extensions, use:
+```bash
+npm run test-extension -- -l <extension-name>
+```
+
+NOT:
+```bash
+npm test  # Wrong - this doesn't work for extensions
+```
+
+Examples:
+- `npm run test-extension -- -l positron-duckdb`
+- `npm run test-extension -- -l positron-python`

--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -25,6 +25,7 @@ npm run watch-extensionsd &
 # - "Watching for file changes"
 # - "Found 0 errors"
 # This typically takes 30-60 seconds from daemon start
+# Note: May take longer (2-3 minutes) on slower machines or during initial builds
 ```
 
 ### Step 4: Launch Positron in background

--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -11,20 +11,29 @@ ps aux | grep -E "npm.*watch-(client|extensions)d" | grep -v grep
 
 ### Step 2: Start missing daemons (if needed)
 ```bash
-# Run these in background, don't wait for output
+# Run these in background
 npm run watch-clientd &
 npm run watch-extensionsd &
-# Wait briefly for initial startup
-sleep 10
 ```
 
-### Step 3: Launch Positron in background
+### Step 3: Wait for compilation to complete
+**CRITICAL**: You MUST verify that both daemons have finished their initial compilation before launching Positron.
+```bash
+# Check daemon output using BashOutput tool to verify compilation is complete
+# Look for messages like:
+# - "Finished compilation" 
+# - "Watching for file changes"
+# - "Found 0 errors"
+# This typically takes 30-60 seconds from daemon start
+```
+
+### Step 4: Launch Positron in background
 ```bash
 # ALWAYS use run_in_background=true for this command
 ./scripts/code.sh &
 ```
 
-### Step 4: IMMEDIATELY respond to user
+### Step 5: IMMEDIATELY respond to user
 After launching, immediately confirm with a brief message like:
 - "Positron launched in background"
 - "Positron is starting"

--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -62,18 +62,3 @@ Assistant: [runs background launch command]
 Assistant: "Positron launched in background"
 [Session continues without pause]
 
-## Testing Extensions
-
-When asked to test extensions, use:
-```bash
-npm run test-extension -- -l <extension-name>
-```
-
-NOT:
-```bash
-npm test  # Wrong - this doesn't work for extensions
-```
-
-Examples:
-- `npm run test-extension -- -l positron-duckdb`
-- `npm run test-extension -- -l positron-python`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,17 @@ Positron is a next-generation data science IDE built on VS Code, designed for Py
 
 ## 🚨 CRITICAL: Development Startup
 
-**ALWAYS read `.claude/build-system.md` before launching Positron!**
-This file contains critical instructions for ensuring build daemons are running. Never skip this step.
+**For launching Positron: ALWAYS read `.claude/launch-positron.md` first!**
+This file contains the exact non-blocking launch protocol to avoid session blocking.
+
+**For build details: See `.claude/build-system.md`**
+This file contains detailed build daemon and compilation instructions.
 
 ## Using Modular Prompts
 
 To work effectively on specific areas of Positron, ask Claude to include relevant context files:
 
+- **Launching Positron**: `Please read .claude/launch-positron.md` - **CRITICAL: Non-blocking launch protocol**
 - **E2E Testing**: `Please read .claude/e2e-testing.md` - For working with Playwright end-to-end tests
 - **Extensions**: `Please read .claude/extensions.md` - For Positron-specific extensions development
 - **Data Explorer**: `Please read .claude/data-explorer.md` - For data viewing and exploration features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This is the main coordination file for Claude Code when working on Positron. Based on your specific task, include the appropriate modular context file(s) from `dev_prompts/`.
 
+## Communication Guidelines
+
+When working on this project, maintain clear and neutral communication:
+- Use professional, direct language as you would with a mid-level colleague
+- Carefully evaluate assertions and suggestions before accepting them
+- Respectfully push back when something seems incorrect or unclear
+- Avoid overly agreeable or sycophantic responses (e.g., "You're absolutely right")
+- Focus on technical accuracy and practical solutions
+- Ask clarifying questions when requirements are ambiguous
+
 ## Project Overview
 
 Positron is a next-generation data science IDE built on VS Code, designed for Python and R development with enhanced data science workflows.
@@ -42,16 +52,19 @@ npm run watch-extensionsd & # Extensions compilation daemon
 sleep 30
 
 # STEP 4: Launch Positron (ONLY after daemons are confirmed running)
+# IMPORTANT: Always run in background to avoid blocking Claude Code session
 # On macOS/Linux:
 ./scripts/code.sh &
 # On Windows:
 start ./scripts/code.bat
 
-# STEP 5: Verify Positron launched successfully
+# STEP 5: Verify Positron launched successfully (optional - don't block session)
 # On macOS/Linux:
 sleep 10 && ps aux | grep -i "positron\|code" | grep -v grep
 # On Windows:
 timeout /t 10 /nobreak >nul && tasklist | findstr /i "positron electron"
+
+# NOTE: Once launched in background, Claude Code session remains available for other tasks
 
 # Run tests (after Positron is running)
 npm test
@@ -76,7 +89,16 @@ This project has a Claude Code hook configured that automatically handles most c
 
 ### Testing
 ```bash
-# Run specific e2e test
+# Extension tests (preferred for extension development)
+npm run test-extension -- -l <extension-name>
+# Examples:
+npm run test-extension -- -l positron-duckdb
+npm run test-extension -- -l positron-python
+
+# Extension tests with pattern matching
+npm run test-extension -- -l positron-duckdb --grep "histogram"
+
+# E2E tests (for UI integration testing)
 npx playwright test <test-name>.test.ts --project e2e-electron --reporter list
 
 # Run all tests in a category


### PR DESCRIPTION
I was encountering issues where CC was waiting a long time (30 seconds or more) after running code.sh, this improves that by splitting off the launch instructions into a separate MD document.. I also had found that it would guess wrong about running extension tests (despite the instructions in positron-duckdb.md, for example), so this improves the testing section to help point it in the right direction. As we have more testing modalities, this section will need to be refined / expanded.

I also added a Communication section to be more neutral, direct, less sycophantic. 