### PR TITLE
E2E test: give quarto python a huge timeout as installs take place

### DIFF
--- a/test/e2e/tests/quarto/quarto-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-python.test.ts
@@ -21,6 +21,6 @@ test.describe('Quarto - Python', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () 
 
 		// Viewer tab is targeted by corresponding iframe. It is assumed that the report fully loads once title 'Example Report' appears
 		const title = app.workbench.viewer.getViewerFrame().frameLocator('iframe').getByText('Example Report');
-		await expect(title).toBeVisible({ timeout: 45000 });
+		await expect(title).toBeVisible({ timeout: 60000 });
 	});
 });


### PR DESCRIPTION
Giving this test a huge timeout to avoid:

https://d38p2avprg8il3.cloudfront.net/playwright-report-17304078213-9283/index.html#?testId=1d7aa90bd574809017f8-ec60410e370bef3ac904&q=s:flaky
