### PR TITLE
Assistant: Use user selected model (#9227)

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1051,7 +1055,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 819,
+        "line_number": 833,
         "is_secret": false
       }
     ],
@@ -1734,5 +1738,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-25T17:39:02Z"
+  "generated_at": "2025-08-29T13:42:08Z"
 }

--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -28,7 +28,7 @@
         "@types/mocha": "^9.1.0",
         "@types/node": "^20",
         "@types/sinon": "^17.0.3",
-        "ai": "^4.1.46",
+        "ai": "^4.3.19",
         "eslint": "^9.13.0",
         "google-auth-library": "^9.15.1",
         "mocha": "^9.2.1",
@@ -292,14 +292,14 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.1.18.tgz",
-      "integrity": "sha512-2wlWug6NVAc8zh3pgqtvwPkSNTdA6Q4x9CmrNXCeHcXfJkJ+MuHFQz/I7Wb7mLRajf0DAxsFLIhHyBCEuTkDNw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "2.1.10",
-        "@ai-sdk/ui-utils": "1.1.16",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -308,21 +308,18 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.0.0"
+        "zod": "^3.23.8"
       },
       "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
         "zod": {
           "optional": true
         }
       }
     },
     "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -333,14 +330,13 @@
       }
     },
     "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "eventsource-parser": "^3.0.0",
+        "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
       },
@@ -348,41 +344,31 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.1.16.tgz",
-      "integrity": "sha512-jfblR2yZVISmNK2zyNzJZFtkgX57WDAUQXcmn3XUBJyo8LFsADu+/vYMn5AOyBi9qJT0RBk11PEtIxIqvByw3Q==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "@ai-sdk/provider-utils": "2.1.10",
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
         "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -393,14 +379,13 @@
       }
     },
     "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "eventsource-parser": "^3.0.0",
+        "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
       },
@@ -408,12 +393,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2460,16 +2440,16 @@
       }
     },
     "node_modules/ai": {
-      "version": "4.1.46",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.1.46.tgz",
-      "integrity": "sha512-VTvAktT69IN1qcNAv7OlcOuR0q4HqUlhkVacrWmMlEoprYykF9EL5RY8IECD5d036Wqg0walwbSKZlA2noHm1A==",
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "@ai-sdk/provider-utils": "2.1.10",
-        "@ai-sdk/react": "1.1.18",
-        "@ai-sdk/ui-utils": "1.1.16",
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
         "@opentelemetry/api": "1.9.0",
         "jsondiffpatch": "0.6.0"
       },
@@ -2478,21 +2458,18 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.0.0"
+        "zod": "^3.23.8"
       },
       "peerDependenciesMeta": {
         "react": {
-          "optional": true
-        },
-        "zod": {
           "optional": true
         }
       }
     },
     "node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2503,14 +2480,13 @@
       }
     },
     "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "eventsource-parser": "^3.0.0",
+        "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
       },
@@ -2518,12 +2494,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.23.8"
       }
     },
     "node_modules/ajv": {
@@ -4377,9 +4348,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.2.tgz",
-      "integrity": "sha512-RosxFpiabojs75IwQ316DGoDRmOqtiAj0tg8wCcbEu4CiLZBs/a9QNtHV7TUfDXmmlgqij/NqzKq/eLelyv9xA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4552,9 +4523,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4801,9 +4772,9 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz",
-      "integrity": "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -575,7 +575,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^20",
     "@types/sinon": "^17.0.3",
-    "ai": "^4.1.46",
+    "ai": "^4.3.19",
     "eslint": "^9.13.0",
     "google-auth-library": "^9.15.1",
     "mocha": "^9.2.1",

--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -128,7 +128,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		const anthropicMessages = toAnthropicMessages(messages);
 
 		const body: Anthropic.MessageStreamParams = {
-			model: this._config.model,
+			model: model.id,
 			max_tokens: options.modelOptions?.maxTokens ?? this.maxOutputTokens,
 			tools,
 			tool_choice,
@@ -140,7 +140,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 
 		// Log request information - the request ID is only available upon connection.
 		stream.on('connect', () => {
-			log.info(`[anthropic] Start request ${stream.request_id} to ${this._config.model}: ${anthropicMessages.length} messages`);
+			log.info(`[anthropic] Start request ${stream.request_id} to ${model.id}: ${anthropicMessages.length} messages`);
 			if (log.logLevel <= vscode.LogLevel.Trace) {
 				log.trace(`[anthropic] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
 			} else {
@@ -280,7 +280,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			}
 		}
 		const result = await this._client.messages.countTokens({
-			model: this._config.model,
+			model: model.id,
 			messages,
 		});
 		return result.input_tokens;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2041,7 +2041,6 @@ declare module 'positron' {
 			id: string;
 
 			providerName: string;
-			maxOutputTokens: number;
 
 			// signals a change from the provider to the editor so that prepareLanguageModelChat is called again
 			onDidChange?: vscode.Event<void>;


### PR DESCRIPTION
- Cherry-picks https://github.com/posit-dev/positron/pull/9227 to main
- Addresses https://github.com/posit-dev/positron/issues/9226

Description from @georgestagg's original PR below 👇 

---

Addresses #9226.

I think this broke when the Code OSS language model proposed API changed to introduce `prepareLanguageModelChat()`.

These changes essentially defer selection of the model ID until the very last second in e.g. `provideLanguageModelChatResponse()` and other methods, rather than trying to store a specific model ID on a class property such as `this._config` or `this.model`, since a single language model provider instance can now handle multiple model IDs.

## QA

* Open Positron
* Open Assistant, select a non-default model for your provider, e.g. Claude 4 Opus.
* Send a request, watching the Assistant log output pane.
* Ensure that the right model is selected by watching the model ID reported in the logs.

* Repeat for the Anthropic and the AWS Bedrock providers, to cover both the Anthropic SDK and Vercel AI SDK code paths.

* We should probably also check the `maxOutputTokens` config setting still works, since I've had to tweak that code.

<img width="950" height="63" alt="Screenshot 2025-08-29 at 14 50 24" src="https://github.com/user-attachments/assets/82585446-7dac-46cd-9255-fc187647ddb4" />
<img width="945" height="59" alt="Screenshot 2025-08-29 at 14 50 51" src="https://github.com/user-attachments/assets/364d1270-9f03-44af-84de-d19d7ed63761" />
