### PR TITLE
Make `r.sourceCurrentFileWithEcho` the default "Run" command in R files with the same keybinding as RStudio

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -488,7 +488,7 @@
         "when": "isRPackage"
       },
       {
-        "command": "r.sourceCurrentFile",
+        "command": "r.sourceCurrentFileWithEcho",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
         "when": "editorLangId == r && !isRPackage && !positron.hasCodeCells"
@@ -607,17 +607,17 @@
       ],
       "editor/title/run": [
         {
-          "command": "r.sourceCurrentFile",
-          "group": "navigation@0",
-          "icon": "$(play)",
-          "title": "%r.command.sourceCurrentFile.title%",
-          "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
-        },
-        {
           "command": "r.sourceCurrentFileWithEcho",
           "group": "navigation@0",
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFileWithEcho.title%",
+          "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
+        },
+        {
+          "command": "r.sourceCurrentFile",
+          "group": "navigation@1",
+          "icon": "$(play)",
+          "title": "%r.command.sourceCurrentFile.title%",
           "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
         },
         {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9129

We originally made this behavior consistent between Python and R, but we have had multiple reports of surprise by the behavior for R since the RStudio behavior is so ingrained for folks. We're going to try it this way now.


### Release Notes


#### New Features

- R: The keyboard shortcuts for _R: Source R File_ and _R: Source R File with Echo_ are now consistent with RStudio's defaults.

#### Bug Fixes

- N/A


### QA Notes

The example from https://github.com/posit-dev/positron/issues/9129 is a good one to use. After this PR, the default (first) option in the "Run" menu is now _with_ echo and we have the same keyboard shortcuts as RStudio: <kbd>Cmd/Ctrl+Shift+S</kbd> for without echo and <kbd>Cmd/Ctrl+Shift+Enter</kbd> for with echo.
