### PR TITLE
Positron Assistant: Support for Anthropic and OpenAI-compatible models

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -270,6 +270,14 @@
       {
         "vendor": "anthropic-compatible",
         "displayName": "Anthropic Compatible"
+      },
+      {
+        "vendor": "openai",
+        "displayName": "OpenAI"
+      },
+      {
+        "vendor": "openrouter",
+        "displayName": "OpenRouter"
       }
     ],
     "languageModelTools": [

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -266,6 +266,10 @@
       {
         "vendor": "anthropic",
         "displayName": "Anthropic"
+      },
+      {
+        "vendor": "anthropic-compatible",
+        "displayName": "Anthropic Compatible"
       }
     ],
     "languageModelTools": [

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -91,7 +91,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 					maxInputTokens: 0,
 					maxOutputTokens: this.maxOutputTokens,
 					capabilities: this.capabilities,
-					isUserSelectable: false,
+					isUserSelectable: true,
 					isDefault: true,
 
 				},

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -91,7 +91,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 					maxInputTokens: 0,
 					maxOutputTokens: this.maxOutputTokens,
 					capabilities: this.capabilities,
-					isUserSelectable: true,
+					isUserSelectable: false,
 					isDefault: true,
 
 				},

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -84,8 +84,8 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		if (!models || models.length === 0) {
 			const returnVal = [
 				{
-					id: 'default',
-					name: 'Default',
+					id: this._config.model,
+					name: 'Anthropic-compatible',
 					family: this.provider,
 					version: this._config.model,
 					maxInputTokens: 0,
@@ -131,7 +131,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		const anthropicMessages = toAnthropicMessages(messages);
 
 		const body: Anthropic.MessageStreamParams = {
-			model: model.version, // CRUCIAL: use version here as id and name are pre-defined values
+			model: model.id,
 			max_tokens: options.modelOptions?.maxTokens ?? this.maxOutputTokens,
 			tools,
 			tool_choice,

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -59,6 +59,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			model: 'deepseek-chat',
 			toolCalls: true,
 			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
+			baseUrl: 'https://api.deepseek.com/anthropic'
 		},
 	};
 
@@ -72,7 +73,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		this.id = _config.id;
 		this._client = client ?? new Anthropic({
 			apiKey: _config.apiKey,
-			baseURL: 'https://api.deepseek.com/anthropic'
+			baseURL: _config.baseUrl,
 		});
 		this.version = '';
 		this.maxInputTokens = 0;

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -53,7 +53,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			id: 'anthropic-compatible',
 			displayName: 'Anthropic Compatible'
 		},
-		supportedOptions: ['apiKey', 'apiKeyEnvVar'],
+		supportedOptions: ['apiKey', 'apiKeyEnvVar', 'baseUrl'],
 		defaults: {
 			name: 'DeepSeek',
 			model: 'deepseek-chat',

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -53,12 +53,11 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			id: 'anthropic-compatible',
 			displayName: 'Anthropic Compatible'
 		},
-		supportedOptions: ['apiKey', 'apiKeyEnvVar', 'baseUrl'],
+		supportedOptions: ['apiKey', 'baseUrl'],
 		defaults: {
 			name: 'DeepSeek',
 			model: 'deepseek-chat',
 			toolCalls: true,
-			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
 			baseUrl: 'https://api.deepseek.com/anthropic'
 		},
 	};

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -1,0 +1,591 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import Anthropic from '@anthropic-ai/sdk';
+import { ModelConfig } from './config';
+import { isLanguageModelImagePart, LanguageModelImagePart } from './languageModelParts.js';
+import { isChatImagePart, isCacheBreakpointPart, parseCacheBreakpoint, processMessages } from './utils.js';
+import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
+import { log, recordTokenUsage, recordRequestTokenUsage } from './extension.js';
+import { availableModels } from './models.js';
+
+/**
+ * Options for controlling cache behavior in the Anthropic language model.
+ */
+export interface CacheControlOptions {
+	/** Add a cache breakpoint to the system prompt (default: true). */
+	system?: boolean;
+}
+
+/**
+ * Block params that set cache breakpoints.
+ */
+type CacheControllableBlockParam = Anthropic.TextBlockParam |
+	Anthropic.ImageBlockParam |
+	Anthropic.ToolUseBlockParam |
+	Anthropic.ToolResultBlockParam;
+
+export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageModelChatProvider2 {
+	name: string;
+	provider: string;
+	family: string;
+	id: string;
+	version: string;
+	maxInputTokens: number;
+	maxOutputTokens: number;
+	tokenCount: number = 0;
+
+	capabilities = {
+		vision: true,
+		toolCalling: true,
+		agentMode: true,
+	};
+
+	private readonly _client: Anthropic;
+
+	static source: positron.ai.LanguageModelSource = {
+		type: positron.PositronLanguageModelType.Chat,
+		provider: {
+			id: 'anthropic-compatible',
+			displayName: 'Anthropic Compatible'
+		},
+		supportedOptions: ['apiKey', 'apiKeyEnvVar'],
+		defaults: {
+			name: 'DeepSeek',
+			model: 'deepseek-chat',
+			toolCalls: true,
+			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
+		},
+	};
+
+	constructor(
+		private readonly _config: ModelConfig,
+		private readonly _context?: vscode.ExtensionContext,
+		client?: Anthropic,
+	) {
+		this.name = _config.name;
+		this.family = this.provider = _config.provider;
+		this.id = _config.id;
+		this._client = client ?? new Anthropic({
+			apiKey: _config.apiKey,
+			baseURL: 'https://api.deepseek.com/anthropic'
+		});
+		this.version = '';
+		this.maxInputTokens = 0;
+		this.maxOutputTokens = _config.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT;
+	}
+
+	async prepareLanguageModelChat(options: { silent: boolean }, token: vscode.CancellationToken): Promise<vscode.LanguageModelChatInformation[]> {
+		const models = availableModels.get(this.provider);
+
+		if (!models || models.length === 0) {
+			return [
+				{
+					id: this.id,
+					name: this.name,
+					family: this.provider,
+					version: this._context?.extension.packageJSON.version ?? '',
+					maxInputTokens: 0,
+					maxOutputTokens: this.maxOutputTokens,
+					capabilities: this.capabilities,
+
+				}
+			];
+		}
+
+		const languageModels: vscode.LanguageModelChatInformation[] = models.map(model => ({
+			id: model.identifier,
+			name: model.name,
+			family: this._config.provider,
+			version: model.identifier, // 1.103.0 TODO: is there a better value? this may vary between providers
+			maxInputTokens: this.maxInputTokens,
+			maxOutputTokens: this.maxOutputTokens,
+			capabilities: this.capabilities,
+			isDefault: model === models[0],
+			isUserSelectable: true,
+		}));
+
+		return languageModels;
+	}
+
+	async provideLanguageModelChatResponse(
+		model: vscode.LanguageModelChatInformation,
+		messages: vscode.LanguageModelChatMessage2[],
+		options: vscode.LanguageModelChatRequestOptions,
+		progress: vscode.Progress<vscode.ChatResponseFragment2>,
+		token: vscode.CancellationToken
+	) {
+		const cacheControlOptions = isCacheControlOptions(options.modelOptions?.cacheControl)
+			? options.modelOptions.cacheControl
+			: undefined;
+		const tools = options.tools && toAnthropicTools(options.tools);
+		const tool_choice = options.toolMode && toAnthropicToolChoice(options.toolMode);
+		const system = options.modelOptions?.system &&
+			toAnthropicSystem(options.modelOptions.system, cacheControlOptions?.system);
+		const anthropicMessages = toAnthropicMessages(messages);
+
+		const body: Anthropic.MessageStreamParams = {
+			model: model.id,
+			max_tokens: options.modelOptions?.maxTokens ?? this.maxOutputTokens,
+			tools,
+			tool_choice,
+			system,
+			messages: anthropicMessages,
+		};
+
+		const stream = this._client.messages.stream(body);
+
+		// Log request information - the request ID is only available upon connection.
+		stream.on('connect', () => {
+			log.info(`[anthropic] Start request ${stream.request_id} to ${model.id}: ${anthropicMessages.length} messages`);
+			if (log.logLevel <= vscode.LogLevel.Trace) {
+				log.trace(`[anthropic] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
+			} else {
+				const userMessages = body.messages.filter(m => m.role === 'user');
+				const assistantMessages = body.messages.filter(m => m.role === 'assistant');
+				log.debug(
+					`[anthropic] SEND messages.stream [${stream.request_id}]: ` +
+					`model: ${body.model}; ` +
+					`cache options: ${cacheControlOptions ? JSON.stringify(cacheControlOptions) : 'default'}; ` +
+					`tools: ${body.tools?.map(t => t.name).sort().join(', ') ?? 'none'}; ` +
+					`tool choice: ${body.tool_choice ? JSON.stringify(body.tool_choice) : 'default'}; ` +
+					`system chars: ${body.system ? JSON.stringify(body.system).length : 0}; ` +
+					`user messages: ${userMessages.length}; ` +
+					`user message characters: ${JSON.stringify(userMessages).length}; ` +
+					`assistant messages: ${assistantMessages.length}; ` +
+					`assistant message characters: ${JSON.stringify(assistantMessages).length}`
+				);
+			}
+		});
+
+		token.onCancellationRequested(() => {
+			stream.abort();
+		});
+
+		stream.on('contentBlock', (contentBlock) => {
+			this.onContentBlock(contentBlock, progress);
+		});
+
+		stream.on('text', (textDelta) => {
+			this.onText(textDelta, progress);
+		});
+
+		try {
+			await stream.done();
+		} catch (error) {
+			if (error instanceof Anthropic.APIError) {
+				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
+				let data: any;
+				try {
+					data = JSON.parse(error.message);
+				} catch {
+					// Ignore JSON parse errors.
+				}
+				if (data?.error?.type === 'overloaded_error') {
+					throw new Error(`Anthropic's API is temporarily overloaded.`);
+				}
+			} else if (error instanceof Anthropic.AnthropicError) {
+				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
+				// This can happen if the API key was not persisted correctly.
+				if (error.message.startsWith('Could not resolve authentication method')) {
+					throw new Error('Something went wrong when storing the Anthropic API key. ' +
+						'Please delete and recreate the model configuration.');
+				}
+			}
+			throw error;
+		}
+
+		// Log usage information.
+		const message = await stream.finalMessage();
+		if (log.logLevel <= vscode.LogLevel.Trace) {
+			log.trace(`[anthropic] RECV messages.stream [${stream.request_id}]: ${JSON.stringify(message, null, 2)}`);
+		} else {
+			log.debug(
+				`[anthropic] RECV messages.stream [${stream.request_id}]`);
+			log.info(`[anthropic] Finished request ${stream.request_id}; usage: ${JSON.stringify(message.usage)}`);
+		}
+
+		// Record token usage
+		if (message.usage && this._context) {
+			const inputTokens = message.usage.input_tokens || 0;
+			const outputTokens = message.usage.output_tokens || 0;
+			recordTokenUsage(this._context, this.provider, inputTokens, outputTokens);
+
+			// Also record token usage by request ID if available
+			const requestId = (options.modelOptions as any)?.requestId;
+			if (requestId) {
+				recordRequestTokenUsage(requestId, this.provider, inputTokens, outputTokens);
+			}
+		}
+
+		// Return token usage information for display in the chat UI
+		return message.usage ? {
+			tokenUsage: {
+				inputTokens: message.usage.input_tokens || 0,
+				outputTokens: message.usage.output_tokens || 0
+			}
+		} : undefined;
+	}
+
+	get providerName(): string {
+		return AnthropicCompatibleLanguageModel.source.provider.displayName;
+	}
+
+	private onContentBlock(block: Anthropic.ContentBlock, progress: vscode.Progress<vscode.ChatResponseFragment2>): void {
+		switch (block.type) {
+			case 'tool_use':
+				return this.onToolUseBlock(block, progress);
+		}
+	}
+
+	private onToolUseBlock(block: Anthropic.ToolUseBlock, progress: vscode.Progress<vscode.ChatResponseFragment2>): void {
+		progress.report({
+			index: 0,
+			part: new vscode.LanguageModelToolCallPart(block.id, block.name, block.input as any),
+		});
+	}
+
+	private onText(textDelta: string, progress: vscode.Progress<vscode.ChatResponseFragment2>): void {
+		progress.report({
+			index: 0,
+			part: new vscode.LanguageModelTextPart(textDelta),
+		});
+	}
+
+	async provideTokenCount(model: vscode.LanguageModelChatInformation, text: string | vscode.LanguageModelChatMessage2, token: vscode.CancellationToken): Promise<number> {
+		const messages: Anthropic.MessageParam[] = [];
+		if (typeof text === 'string') {
+			// For empty string, return 0 tokens
+			if (text.trim() === '') {
+				return 0;
+			}
+			// Otherwise, treat it as a user message
+			messages.push({
+				role: 'user',
+				content: [
+					{
+						type: 'text',
+						text,
+					},
+				],
+			});
+		} else {
+			// For LanguageModelChatMessage, ensure it has non-empty message content
+			messages.push(...toAnthropicMessages([text]));
+			if (messages.length === 0) {
+				return 0;
+			}
+		}
+		const result = await this._client.messages.countTokens({
+			model: model.id,
+			messages,
+		});
+		return result.input_tokens;
+	}
+
+	async resolveConnection(token: vscode.CancellationToken): Promise<Error | undefined> {
+		try {
+			// DeepSeek might not support the models endpoint, so we test with a simple message
+			await this._client.messages.create({
+				model: this._config.model || 'deepseek-chat',
+				max_tokens: 1,
+				messages: [
+					{
+						role: 'user',
+						content: [{ type: 'text', text: 'Connection test' }]
+					}
+				]
+			});
+			return undefined;
+		} catch (error: any) {
+			// If it's a 404, it might be the models endpoint that's not supported
+			// but the messages endpoint could still work
+			if (error.status === 404) {
+				// Return a more specific error indicating the endpoint might not be supported
+				return new Error(`API endpoint returned 404. This might indicate that DeepSeek's Anthropic compatibility doesn't support this endpoint. Please check the DeepSeek documentation for supported endpoints.`);
+			}
+			return error as Error;
+		}
+	}
+}
+
+function toAnthropicMessages(messages: vscode.LanguageModelChatMessage2[]): Anthropic.MessageParam[] {
+	let userMessageIndex = 0;
+	let assistantMessageIndex = 0;
+	const anthropicMessages = processMessages(messages).map((message) => {
+		const source = message.role === vscode.LanguageModelChatMessageRole.User ?
+			`User message ${userMessageIndex++}` :
+			`Assistant message ${assistantMessageIndex++}`;
+		return toAnthropicMessage(message, source);
+	});
+	return anthropicMessages;
+}
+
+function toAnthropicMessage(message: vscode.LanguageModelChatMessage2, source: string): Anthropic.MessageParam {
+	switch (message.role) {
+		case vscode.LanguageModelChatMessageRole.Assistant:
+			return toAnthropicAssistantMessage(message, source);
+		case vscode.LanguageModelChatMessageRole.User:
+			return toAnthropicUserMessage(message, source);
+		default:
+			throw new Error(`Unsupported message role: ${message.role}`);
+	}
+}
+
+function toAnthropicAssistantMessage(message: vscode.LanguageModelChatMessage2, source: string): Anthropic.MessageParam {
+	const content: Anthropic.ContentBlockParam[] = [];
+	for (let i = 0; i < message.content.length; i++) {
+		const [part, nextPart] = [message.content[i], message.content[i + 1]];
+		const dataPart = nextPart instanceof vscode.LanguageModelDataPart ? nextPart : undefined;
+		if (part instanceof vscode.LanguageModelTextPart) {
+			content.push(toAnthropicTextBlock(part, source, dataPart));
+		} else if (part instanceof vscode.LanguageModelToolCallPart) {
+			content.push(toAnthropicToolUseBlock(part, source, dataPart));
+		} else if (part instanceof vscode.LanguageModelDataPart) {
+			// Skip extra data parts. They're handled in part conversion.
+		} else {
+			throw new Error('Unsupported part type on assistant message');
+		}
+	}
+	return {
+		role: 'assistant',
+		content,
+	};
+}
+
+function toAnthropicUserMessage(message: vscode.LanguageModelChatMessage2, source: string): Anthropic.MessageParam {
+	const content: Anthropic.ContentBlockParam[] = [];
+	for (let i = 0; i < message.content.length; i++) {
+		const [part, nextPart] = [message.content[i], message.content[i + 1]];
+		const dataPart = nextPart instanceof vscode.LanguageModelDataPart ? nextPart : undefined;
+		if (part instanceof vscode.LanguageModelTextPart) {
+			content.push(toAnthropicTextBlock(part, source, dataPart));
+		} else if (part instanceof vscode.LanguageModelToolResultPart) {
+			content.push(toAnthropicToolResultBlock(part, source, dataPart));
+		} else if (part instanceof vscode.LanguageModelToolResultPart2) {
+			content.push(toAnthropicToolResultBlock(part, source, dataPart));
+		} else if (part instanceof vscode.LanguageModelDataPart) {
+			if (isChatImagePart(part)) {
+				content.push(chatImagePartToAnthropicImageBlock(part, source, dataPart));
+			} else {
+				// Skip other data parts.
+			}
+		} else {
+			throw new Error('Unsupported part type on user message');
+		}
+	}
+	return {
+		role: 'user',
+		content,
+	};
+}
+
+function toAnthropicTextBlock(
+	part: vscode.LanguageModelTextPart,
+	source: string,
+	dataPart?: vscode.LanguageModelDataPart,
+): Anthropic.TextBlockParam {
+	return withCacheControl(
+		{
+			type: 'text',
+			text: part.value,
+		},
+		source,
+		dataPart,
+	);
+}
+
+function toAnthropicToolUseBlock(
+	part: vscode.LanguageModelToolCallPart,
+	source: string,
+	dataPart?: vscode.LanguageModelDataPart,
+): Anthropic.ToolUseBlockParam {
+	return withCacheControl(
+		{
+			type: 'tool_use',
+			id: part.callId,
+			name: part.name,
+			input: part.input,
+		},
+		source,
+		dataPart,
+	);
+}
+
+function toAnthropicToolResultBlock(
+	part: vscode.LanguageModelToolResultPart,
+	source: string,
+	dataPart?: vscode.LanguageModelDataPart,
+): Anthropic.ToolResultBlockParam {
+	const content: Anthropic.ToolResultBlockParam['content'] = [];
+	for (let i = 0; i < part.content.length; i++) {
+		const [resultPart, resultNextPart] = [part.content[i], part.content[i + 1]];
+		const resultDataPart = resultNextPart instanceof vscode.LanguageModelDataPart ? resultNextPart : undefined;
+		if (resultPart instanceof vscode.LanguageModelTextPart) {
+			content.push(toAnthropicTextBlock(resultPart, source, resultDataPart));
+		} else if (isLanguageModelImagePart(resultPart)) {
+			content.push(languageModelImagePartToAnthropicImageBlock(resultPart, source, resultDataPart));
+		} else if (resultPart instanceof vscode.LanguageModelDataPart) {
+			// Skip data parts.
+		} else {
+			throw new Error('Unsupported part type on tool result part content');
+		}
+	}
+	return withCacheControl(
+		{
+			type: 'tool_result',
+			tool_use_id: part.callId,
+			content,
+		},
+		source,
+		dataPart,
+	);
+}
+
+function chatImagePartToAnthropicImageBlock(
+	part: vscode.LanguageModelDataPart,
+	source: string,
+	dataPart?: vscode.LanguageModelDataPart,
+): Anthropic.ImageBlockParam {
+	return withCacheControl(
+		{
+			type: 'image',
+			source: {
+				type: 'base64',
+				// We may pass an unsupported mime type; let Anthropic throw the error.
+				media_type: part.mimeType as Anthropic.Base64ImageSource['media_type'],
+				data: Buffer.from(part.data).toString('base64'),
+			},
+		},
+		source,
+		dataPart,
+	);
+}
+
+function languageModelImagePartToAnthropicImageBlock(
+	part: LanguageModelImagePart,
+	source: string,
+	dataPart?: vscode.LanguageModelDataPart,
+): Anthropic.ImageBlockParam {
+	return withCacheControl(
+		{
+			type: 'image',
+			source: {
+				type: 'base64',
+				// We may pass an unsupported mime type; let Anthropic throw the error.
+				media_type: part.value.mimeType as Anthropic.Base64ImageSource['media_type'],
+				data: part.value.base64,
+			},
+		},
+		source,
+		dataPart,
+	);
+}
+
+function toAnthropicTools(tools: vscode.LanguageModelChatTool[]): Anthropic.ToolUnion[] {
+	if (tools.length === 0) {
+		return [];
+	}
+	const anthropicTools = tools.map(tool => toAnthropicTool(tool));
+
+	// Ensure a stable sort order for prompt caching.
+	anthropicTools.sort((a, b) => a.name.localeCompare(b.name));
+
+	return anthropicTools;
+}
+
+function toAnthropicTool(tool: vscode.LanguageModelChatTool): Anthropic.ToolUnion {
+	const input_schema = tool.inputSchema as Anthropic.Tool.InputSchema ?? {
+		type: 'object',
+		properties: {},
+	};
+	return {
+		name: tool.name,
+		description: tool.description,
+		input_schema,
+	};
+}
+
+function toAnthropicToolChoice(toolMode: vscode.LanguageModelChatToolMode): Anthropic.ToolChoice | undefined {
+	switch (toolMode) {
+		case vscode.LanguageModelChatToolMode.Auto:
+			return {
+				type: 'auto',
+			};
+		case vscode.LanguageModelChatToolMode.Required:
+			return {
+				type: 'any',
+			};
+		default:
+			// Should not happen.
+			throw new Error(`Unsupported tool mode: ${toolMode}`);
+	}
+}
+
+function toAnthropicSystem(system: unknown, cacheSystem = true): Anthropic.MessageCreateParams['system'] {
+	if (typeof system === 'string') {
+		const anthropicSystem: Anthropic.MessageCreateParams['system'] = [{
+			type: 'text',
+			text: system,
+		}];
+
+		if (cacheSystem) {
+			// Add a cache breakpoint to the last system prompt block.
+			const lastSystemBlock = anthropicSystem[anthropicSystem.length - 1];
+			lastSystemBlock.cache_control = { type: 'ephemeral' };
+			log.debug(`[anthropic] Adding cache breakpoint to system prompt`);
+		}
+
+		return anthropicSystem;
+	}
+
+	// Check if it's an array of parts.
+	if (Array.isArray(system) && system.every(part => (part instanceof vscode.LanguageModelTextPart) ||
+		(part instanceof vscode.LanguageModelDataPart))) {
+		const anthropicSystem: Anthropic.MessageCreateParams['system'] = [];
+		for (let i = 0; i < system.length; i++) {
+			const [part, nextPart] = [system[i], system[i + 1]];
+			const dataPart = nextPart instanceof vscode.LanguageModelDataPart ? nextPart : undefined;
+			if (part instanceof vscode.LanguageModelTextPart) {
+				anthropicSystem.push(toAnthropicTextBlock(part, 'System prompt', dataPart));
+			}
+		}
+		return anthropicSystem;
+	}
+
+	throw new Error(`Unexpected system prompt value`);
+}
+
+function isCacheControlOptions(options: unknown): options is CacheControlOptions {
+	if (typeof options !== 'object' || options === null) {
+		return false;
+	}
+	const cacheControlOptions = options as CacheControlOptions;
+	return cacheControlOptions.system === undefined || typeof cacheControlOptions.system === 'boolean';
+}
+
+function withCacheControl<T extends CacheControllableBlockParam>(
+	part: T,
+	source: string,
+	dataPart: vscode.LanguageModelDataPart | undefined,
+): T {
+	if (!isCacheBreakpointPart(dataPart)) {
+		return part;
+	}
+
+	try {
+		const cachBreakpoint = parseCacheBreakpoint(dataPart);
+		log.debug(`[anthropic] Adding cache breakpoint to ${part.type} part. Source: ${source}`);
+		return {
+			...part,
+			cache_control: cachBreakpoint,
+		};
+	} catch (error) {
+		log.error(`[anthropic] Failed to parse cache breakpoint: ${error}`);
+		return part;
+	}
+}

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -306,7 +306,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			// but the messages endpoint could still work
 			if (error.status === 404) {
 				// Return a more specific error indicating the endpoint might not be supported
-				return new Error(`API endpoint returned 404. This might indicate that DeepSeek's Anthropic compatibility doesn't support this endpoint. Please check the DeepSeek documentation for supported endpoints.`);
+				return new Error(`API endpoint returned 404. This might indicate that this endpoint does not support the Anthropic API. Please check the API documentation for supported endpoints.`);
 			}
 			return error as Error;
 		}

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -58,7 +58,6 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			name: 'DeepSeek',
 			model: 'deepseek-chat',
 			toolCalls: true,
-			baseUrl: 'https://api.deepseek.com/anthropic'
 		},
 	};
 
@@ -290,9 +289,9 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 
 	async resolveConnection(token: vscode.CancellationToken): Promise<Error | undefined> {
 		try {
-			// DeepSeek might not support the models endpoint, so we test with a simple message
+			// Custom API might not support the models endpoint, so we test with a simple message
 			await this._client.messages.create({
-				model: this._config.model || 'deepseek-chat',
+				model: this._config.model,
 				max_tokens: 1,
 				messages: [
 					{

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -87,11 +87,12 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 					id: 'default',
 					name: 'Default',
 					family: this.provider,
-					version: 'default',
+					version: this._config.model,
 					maxInputTokens: 0,
 					maxOutputTokens: this.maxOutputTokens,
 					capabilities: this.capabilities,
 					isUserSelectable: true,
+					isDefault: true,
 
 				},
 			];
@@ -110,7 +111,6 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			isUserSelectable: true,
 		}));
 
-		log.info(`[Anthropic-Compatible]: return models: ${JSON.stringify(languageModels, null, 2)}`);
 		return languageModels;
 	}
 
@@ -131,7 +131,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		const anthropicMessages = toAnthropicMessages(messages);
 
 		const body: Anthropic.MessageStreamParams = {
-			model: model.id,
+			model: model.version, // CRUCIAL: use version here as id and name are pre-defined values
 			max_tokens: options.modelOptions?.maxTokens ?? this.maxOutputTokens,
 			tools,
 			tool_choice,

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -109,6 +109,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			isUserSelectable: true,
 		}));
 
+		log.info(`[Anthropic-Compatible]: return models: ${JSON.stringify(languageModels, null, 2)}`);
 		return languageModels;
 	}
 
@@ -143,12 +144,12 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		stream.on('connect', () => {
 			log.info(`[anthropic] Start request ${stream.request_id} to ${model.id}: ${anthropicMessages.length} messages`);
 			if (log.logLevel <= vscode.LogLevel.Trace) {
-				log.trace(`[anthropic] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
+				log.trace(`[anthropic-compatible] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
 			} else {
 				const userMessages = body.messages.filter(m => m.role === 'user');
 				const assistantMessages = body.messages.filter(m => m.role === 'assistant');
 				log.debug(
-					`[anthropic] SEND messages.stream [${stream.request_id}]: ` +
+					`[anthropic-compatible] SEND messages.stream [${stream.request_id}]: ` +
 					`model: ${body.model}; ` +
 					`cache options: ${cacheControlOptions ? JSON.stringify(cacheControlOptions) : 'default'}; ` +
 					`tools: ${body.tools?.map(t => t.name).sort().join(', ') ?? 'none'}; ` +
@@ -178,7 +179,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 			await stream.done();
 		} catch (error) {
 			if (error instanceof Anthropic.APIError) {
-				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
+				log.warn(`[anthropic-compatible] Error in messages.stream [${stream.request_id}]: ${error.message}`);
 				let data: any;
 				try {
 					data = JSON.parse(error.message);
@@ -189,7 +190,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 					throw new Error(`Anthropic's API is temporarily overloaded.`);
 				}
 			} else if (error instanceof Anthropic.AnthropicError) {
-				log.warn(`[anthropic] Error in messages.stream [${stream.request_id}]: ${error.message}`);
+				log.warn(`[anthropic-compatible] Error in messages.stream [${stream.request_id}]: ${error.message}`);
 				// This can happen if the API key was not persisted correctly.
 				if (error.message.startsWith('Could not resolve authentication method')) {
 					throw new Error('Something went wrong when storing the Anthropic API key. ' +
@@ -202,11 +203,11 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		// Log usage information.
 		const message = await stream.finalMessage();
 		if (log.logLevel <= vscode.LogLevel.Trace) {
-			log.trace(`[anthropic] RECV messages.stream [${stream.request_id}]: ${JSON.stringify(message, null, 2)}`);
+			log.trace(`[anthropic-compatible] RECV messages.stream [${stream.request_id}]: ${JSON.stringify(message, null, 2)}`);
 		} else {
 			log.debug(
-				`[anthropic] RECV messages.stream [${stream.request_id}]`);
-			log.info(`[anthropic] Finished request ${stream.request_id}; usage: ${JSON.stringify(message.usage)}`);
+				`[anthropic-compatible] RECV messages.stream [${stream.request_id}]`);
+			log.info(`[anthropic-compatible] Finished request ${stream.request_id}; usage: ${JSON.stringify(message.usage)}`);
 		}
 
 		// Record token usage
@@ -537,7 +538,7 @@ function toAnthropicSystem(system: unknown, cacheSystem = true): Anthropic.Messa
 			// Add a cache breakpoint to the last system prompt block.
 			const lastSystemBlock = anthropicSystem[anthropicSystem.length - 1];
 			lastSystemBlock.cache_control = { type: 'ephemeral' };
-			log.debug(`[anthropic] Adding cache breakpoint to system prompt`);
+			log.debug(`[anthropic-compatible] Adding cache breakpoint to system prompt`);
 		}
 
 		return anthropicSystem;
@@ -579,13 +580,13 @@ function withCacheControl<T extends CacheControllableBlockParam>(
 
 	try {
 		const cachBreakpoint = parseCacheBreakpoint(dataPart);
-		log.debug(`[anthropic] Adding cache breakpoint to ${part.type} part. Source: ${source}`);
+		log.debug(`[anthropic-compatible] Adding cache breakpoint to ${part.type} part. Source: ${source}`);
 		return {
 			...part,
 			cache_control: cachBreakpoint,
 		};
 	} catch (error) {
-		log.error(`[anthropic] Failed to parse cache breakpoint: ${error}`);
+		log.error(`[anthropic-compatible] Failed to parse cache breakpoint: ${error}`);
 		return part;
 	}
 }

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -143,7 +143,7 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 
 		// Log request information - the request ID is only available upon connection.
 		stream.on('connect', () => {
-			log.info(`[anthropic] Start request ${stream.request_id} to ${model.id}: ${anthropicMessages.length} messages`);
+			log.info(`[anthropic-compatible] Start request ${stream.request_id} to ${model.id}: ${anthropicMessages.length} messages`);
 			if (log.logLevel <= vscode.LogLevel.Trace) {
 				log.trace(`[anthropic-compatible] SEND messages.stream [${stream.request_id}]: ${JSON.stringify(body, null, 2)}`);
 			} else {

--- a/extensions/positron-assistant/src/anthropic-compatible.ts
+++ b/extensions/positron-assistant/src/anthropic-compatible.ts
@@ -55,8 +55,8 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		},
 		supportedOptions: ['apiKey', 'baseUrl'],
 		defaults: {
-			name: 'DeepSeek',
-			model: 'deepseek-chat',
+			name: 'Default',
+			model: 'default',
 			toolCalls: true,
 		},
 	};
@@ -82,18 +82,20 @@ export class AnthropicCompatibleLanguageModel implements positron.ai.LanguageMod
 		const models = availableModels.get(this.provider);
 
 		if (!models || models.length === 0) {
-			return [
+			const returnVal = [
 				{
-					id: this.id,
-					name: this.name,
+					id: 'default',
+					name: 'Default',
 					family: this.provider,
-					version: this._context?.extension.packageJSON.version ?? '',
+					version: 'default',
 					maxInputTokens: 0,
 					maxOutputTokens: this.maxOutputTokens,
 					capabilities: this.capabilities,
+					isUserSelectable: true,
 
-				}
+				},
 			];
+			return returnVal;
 		}
 
 		const languageModels: vscode.LanguageModelChatInformation[] = models.map(model => ({

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -18,6 +18,7 @@ import { generateCommitMessage } from './git.js';
 import { TokenTracker } from './tokens.js';
 import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 import { AnthropicLanguageModel } from './anthropic.js';
+import { AnthropicCompatibleLanguageModel } from './anthropic-compatible.js';
 import { registerParticipantDetectionProvider } from './participantDetection.js';
 import { registerAssistantCommands } from './commands/index.js';
 
@@ -273,6 +274,7 @@ export function recordRequestTokenUsage(requestId: string, provider: string, inp
 	const enabledProviders = vscode.workspace.getConfiguration('positron.assistant').get('approximateTokenCount', [] as string[]);
 
 	enabledProviders.push(AnthropicLanguageModel.source.provider.id); // ensure anthropicId is always included
+	enabledProviders.push(AnthropicCompatibleLanguageModel.source.provider.id);
 
 	if (!enabledProviders.includes(provider)) {
 		return; // Skip if token counting is disabled for this provider

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -19,6 +19,7 @@ import { markBedrockCacheBreakpoint, processMessages, toAIMessage } from './util
 import { AmazonBedrockProvider, createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel } from './anthropic';
+import { AnthropicCompatibleLanguageModel } from './anthropic-compatible';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { log, recordRequestTokenUsage, recordTokenUsage } from './extension.js';
 
@@ -796,6 +797,7 @@ export function getLanguageModels() {
 	const languageModels = [
 		...testLanguageModels,
 		anthropicClass,
+		AnthropicCompatibleLanguageModel,
 		AzureLanguageModel,
 		GoogleLanguageModel,
 		MistralLanguageModel,

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -29,6 +29,7 @@ const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privac
 
 const apiKeyInputLabel = localize('positron.languageModelConfig.apiKeyInputLabel', 'API Key');
 const baseUrLInputLabel = localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
+const modelNameInputLabel = localize('positron.languageModelConfig.modelNameInputLabel', 'Model');
 const signInButtonLabel = localize('positron.languageModelConfig.signIn', 'Sign in');
 const signOutButtonLabel = localize('positron.languageModelConfig.signOut', 'Sign out');
 
@@ -140,7 +141,7 @@ function interpolate(text: string, value: (key: string) => React.ReactNode | und
  */
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const { authMethod, authStatus, config, source } = props;
-	const { apiKey, baseUrl } = config;
+	const { apiKey, baseUrl, model } = config;
 	const hasEnvApiKey = !!source.defaults.apiKeyEnvVar && source.defaults.apiKeyEnvVar.signedIn;
 	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasEnvApiKey;
 	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN && !hasEnvApiKey;
@@ -154,9 +155,15 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 	const onBaseUrlChange = (newBaseUrl: string) => {
 		props.onChange({ ...props.config, baseUrl: newBaseUrl });
 	};
+	const onModelNameChange = (newModel: string) => {
+		props.onChange({ ...props.config, model: newModel });
+	};
 
 	return <>
-		{needBaseUrl && <BaseUrl baseUrl={baseUrl} onChange={onBaseUrlChange} />}
+		{needBaseUrl && <div className='language-model-container input'>
+			<BaseUrl baseUrl={baseUrl} onChange={onBaseUrlChange} />
+			<ModelName modelName={model} onChange={onModelNameChange} />
+		</div>}
 		{!hasEnvApiKey && <div className='language-model-container input'>
 			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onApiKeyChange} />}
 			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
@@ -192,6 +199,24 @@ const BaseUrl = (props: { baseUrl?: string, onChange: (newBaseUrl: string) => vo
 				type='text'
 				value={props.baseUrl ?? ''}
 				onChange={e => { props.onChange(e.currentTarget.value) }} />
+		</div>
+	</>)
+}
+
+const ModelName = (props: { modelName?: string, onChange: (newModelName: string) => void }) => {
+	const displayValue = props.modelName === 'default' ? '' : (props.modelName ?? '');
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.currentTarget.value;
+        // If the value is empty, return "default", otherwise return the actual value
+        props.onChange(value === '' ? 'default' : value);
+    };
+	return (<>
+		<div className='language-model-authentication-container' id='api-key-input'>
+			<LabeledTextInput
+				label={modelNameInputLabel}
+				type='text'
+				value={displayValue}
+				onChange={handleChange} />
 		</div>
 	</>)
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -28,6 +28,7 @@ const providerTermsOfServiceLabel = localize('positron.languageModelConfig.terms
 const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privacyPolicy', 'Privacy Policy');
 
 const apiKeyInputLabel = localize('positron.languageModelConfig.apiKeyInputLabel', 'API Key');
+const baseUrLInputLabel = localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
 const signInButtonLabel = localize('positron.languageModelConfig.signIn', 'Sign in');
 const signOutButtonLabel = localize('positron.languageModelConfig.signOut', 'Sign out');
 
@@ -139,20 +140,25 @@ function interpolate(text: string, value: (key: string) => React.ReactNode | und
  */
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const { authMethod, authStatus, config, source } = props;
-	const { apiKey } = config;
+	const { apiKey, baseUrl } = config;
 	const hasEnvApiKey = !!source.defaults.apiKeyEnvVar && source.defaults.apiKeyEnvVar.signedIn;
 	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasEnvApiKey;
 	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN && !hasEnvApiKey;
+	const needBaseUrl = source.supportedOptions.includes('baseUrl') && authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN;
 
 	// This currently only updates the API key for the provider, but in the future it may be extended to support
 	// additional configuration options for language models.
-	const onChange = (newApiKey: string) => {
+	const onApiKeyChange = (newApiKey: string) => {
 		props.onChange({ ...props.config, apiKey: newApiKey });
+	};
+	const onBaseUrlChange = (newBaseUrl: string) => {
+		props.onChange({ ...props.config, baseUrl: newBaseUrl });
 	};
 
 	return <>
 		{!hasEnvApiKey && <div className='language-model-container input'>
-			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onChange} />}
+			{needBaseUrl && <BaseUrl baseUrl={baseUrl} onChange={onApiKeyChange} />}
+			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onBaseUrlChange} />}
 			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
 			{showCancelButton &&
 				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
@@ -173,6 +179,18 @@ const ApiKey = (props: { apiKey?: string, onChange: (newApiKey: string) => void 
 				label={apiKeyInputLabel}
 				type='password'
 				value={props.apiKey ?? ''}
+				onChange={e => { props.onChange(e.currentTarget.value) }} />
+		</div>
+	</>)
+}
+
+const BaseUrl = (props: { baseUrl?: string, onChange: (newBaseUrl: string) => void }) => {
+	return (<>
+		<div className='language-model-authentication-container' id='api-key-input'>
+			<LabeledTextInput
+				label={baseUrLInputLabel}
+				type='text'
+				value={props.baseUrl ?? ''}
 				onChange={e => { props.onChange(e.currentTarget.value) }} />
 		</div>
 	</>)

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -156,9 +156,9 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 	};
 
 	return <>
+		{needBaseUrl && <BaseUrl baseUrl={baseUrl} onChange={onBaseUrlChange} />}
 		{!hasEnvApiKey && <div className='language-model-container input'>
-			{needBaseUrl && <BaseUrl baseUrl={baseUrl} onChange={onApiKeyChange} />}
-			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onBaseUrlChange} />}
+			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onApiKeyChange} />}
 			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
 			{showCancelButton &&
 				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>


### PR DESCRIPTION
### Release Notes

#### New Features

- Allows users to add *Anthropic-compatible* models to Positron Assistant, such as DeepSeek, with customised URL and model name. (Only 1 model allowed, though)
- Expose OpenAI and OpenRouter models through the `package.json` of Positron Assistant

#### Bug Fixes

- N/A

### QA Notes

Addresses #8007. Although #8007 requests support for OpenAI-compatible models, many in the discussion also call for Anthropic-compatible model support, therefore the latter is also implemented.

### User Instruction:
To enable this feature, add to `settings.json`:
```json
"positron.assistant.enabledProviders": ["anthropic-compatible", "openai", "openrouter"]
```

And then you can add these models through the normal UI:

<img width="600" height="397" alt="image" src="https://github.com/user-attachments/assets/0a516754-3bb2-45ee-a0f8-d787b44d0bf7" />