### PR TITLE
Fix up runtime discovery with progress notification and improved user feedback

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -19,6 +19,7 @@ import { ExtensionsRegistry } from '../../extensions/common/extensionsRegistry.j
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { ILifecycleService, ShutdownReason } from '../../lifecycle/common/lifecycle.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
@@ -128,6 +129,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IPositronNewFolderService private readonly _newFolderService: IPositronNewFolderService,
+		@IProgressService private readonly _progressService: IProgressService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -662,11 +664,25 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			return;
 		}
 
-		// Set up event to notify when runtimes are added.
+		// Remember the old set of runtimes so we can report any new ones
 		const oldRuntimes = this._languageRuntimeService.registeredRuntimes;
-		this._register(
-			this._languageRuntimeService.onDidChangeRuntimeStartupPhase(
-				(phase) => {
+		this._logService.debug('[Runtime startup] Refreshing runtime discovery.');
+		this._discoveryCompleteByExtHostId.forEach((_, extHostId, m) => {
+			m.set(extHostId, false);
+		});
+
+		// Start progress for the discovery process
+		await this._progressService.withProgress({
+			location: ProgressLocation.Notification,
+			title: nls.localize('positron.runtimeStartupService.discoveringRuntimes', 'Discovering interpreters...'),
+			cancellable: false
+		}, async (progress) => {
+			// Start the discovery process
+			this.discoverAllRuntimes();
+
+			// Wait for discovery to complete
+			await new Promise<void>((resolve) => {
+				this._languageRuntimeService.onDidChangeRuntimeStartupPhase(phase => {
 					if (phase === RuntimeStartupPhase.Complete) {
 						const newRuntimes = this._languageRuntimeService.registeredRuntimes;
 						const addedRuntimes = newRuntimes.filter(newRuntime => {
@@ -674,27 +690,22 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 								return oldRuntime.runtimeId === newRuntime.runtimeId;
 							});
 						});
-
-						// If any runtimes were added, show a notification.
+						// Use addedRuntimes here and resolve the promise
 						if (addedRuntimes.length > 0) {
 							this._notificationService.info(nls.localize('positron.runtimeStartupService.runtimesAddedMessage',
 								"Found {0} new interpreter{1}: {2}.",
 								addedRuntimes.length,
 								addedRuntimes.length > 1 ? 's' : '',
 								addedRuntimes.map(runtime => { return runtime.runtimeName; }).join(', ')));
+						} else {
+							this._notificationService.info(nls.localize('positron.runtimeStartupService.noNewRuntimesMessage',
+								"No new interpreters found."));
 						}
+						resolve();
 					}
-				}
-			)
-		);
-
-		this._logService.debug('[Runtime startup] Refreshing runtime discovery.');
-		this._discoveryCompleteByExtHostId.forEach((_, extHostId, m) => {
-			m.set(extHostId, false);
+				});
+			});
 		});
-
-		this.discoverAllRuntimes();
-
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -682,7 +682,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 			// Wait for discovery to complete
 			await new Promise<void>((resolve) => {
-				this._languageRuntimeService.onDidChangeRuntimeStartupPhase(phase => {
+				const disposable = this._languageRuntimeService.onDidChangeRuntimeStartupPhase(phase => {
 					if (phase === RuntimeStartupPhase.Complete) {
 						const newRuntimes = this._languageRuntimeService.registeredRuntimes;
 						const addedRuntimes = newRuntimes.filter(newRuntime => {
@@ -702,6 +702,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 								"No new interpreters found."));
 						}
 						resolve();
+						disposable.dispose();
 					}
 				});
 			});


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8404

With this PR, we now show a progress notification when users explicitly call _Interpreter: Discover All Interpreters_. It looks like this while discovery is going on (which can take a while, but if a user really explicitly said to do this, probably the right option):

<img width="1368" height="994" alt="Screenshot 2025-09-01 at 3 20 49 PM" src="https://github.com/user-attachments/assets/78ca42b0-38f5-4e79-a7ed-19a7dc26dec6" />

If nothing new is found, the progress notification resolves and then you see this:

<img width="1368" height="994" alt="Screenshot 2025-09-01 at 3 21 04 PM" src="https://github.com/user-attachments/assets/235a0614-e208-4eb4-98b7-5900d0e12573" />

If something new _is_ found, the progress notification resolves and then you see this:

<img width="1368" height="994" alt="Screenshot 2025-09-01 at 3 22 41 PM" src="https://github.com/user-attachments/assets/30aec486-28fd-4bde-835f-9f2764973439" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Improved user feedback when using the command _Interpreter: Discover All Interpreters_.

#### Bug Fixes

- N/A


### QA Notes

The command _Interpreter: Discover All Interpreters_ will not run unless the first round of discovery is done, which runs quietly in the background. This may take longer than you expect. Once you _can_ run it:

- Look at all your interpreter options in Positron
- Add a new one via the regular terminal (for example, a new rig version)
- Look at all your interpreter choices and see that your new one is not there yet
- Execute the command, and note the new progress notification
- Look at all your interpreter choices and see that now the new one is there
- Execute the command again, and see the same progress notification
- Note the message telling you nothing new was found