### PR TITLE
e2e: add app version and build number to perf metrics

### DIFF
--- a/test/e2e/utils/metrics/api.ts
+++ b/test/e2e/utils/metrics/api.ts
@@ -11,7 +11,8 @@ import {
 	LOCAL_API_URL,
 	platformOs,
 	platformVersion,
-	MetricResponse
+	MetricResponse,
+	positronVersion
 } from './metric-base.js';
 import { SPEC_NAME } from '../../fixtures/test-setup/constants.js';
 
@@ -28,6 +29,8 @@ export type PerfMetric = {
 
 export type MetricPayload = {
 	timestamp: string;
+	app_version: string;
+	build_number: string;
 	platform_os: string;
 	platform_version: string;
 	runtime_env: string;
@@ -99,6 +102,8 @@ function createMetricPayload(metric: PerfMetric, isElectronApp: boolean): Metric
 		timestamp: new Date().toISOString(),
 		platform_os: platformOs,
 		platform_version: platformVersion,
+		app_version: positronVersion?.positronVersion || 'unknown',
+		build_number: positronVersion?.buildNumber || 'unknown',
 		runtime_env: isElectronApp ? 'electron' : 'chromium',
 		run_id: process.env.GITHUB_RUN_ID ?? process.env.RUN_ID ?? 'unknown',
 		feature_area,

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -5,10 +5,15 @@
 
 import os from 'os';
 import { DataExplorerShortcutOptions } from './metric-data-explorer.js';
+import { getPositronVersion } from '../../infra/test-runner/test-setup.js';
 
 export const CONNECT_API_KEY = process.env.CONNECT_API_KEY!;
 export const PROD_API_URL = 'https://connect.posit.it/e2e-test-insights-api/metrics';
 export const LOCAL_API_URL = 'http://127.0.0.1:8000/metrics';
+
+//-----------------------
+// Platform Information
+//-----------------------
 
 export const platformOs = (() => {
 	const osMap = {
@@ -21,6 +26,8 @@ export const platformOs = (() => {
 })();
 
 export const platformVersion = os.release();
+
+export const positronVersion = getPositronVersion();
 
 //-----------------------
 // Base Metric Types


### PR DESCRIPTION
### Summary

Updated the payload that we are sending to e2e-test-insights API to include the app version and build #.

### QA Notes

n/a
