### PR TITLE
Add uv install to windows workflow

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -110,6 +110,12 @@ jobs:
         with:
           python-version: "3.10.10"
 
+      # Pinning UV due to https://github.com/rstudio/reticulate/issues/1811
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.7.22"
+
       - name: Install node dependencies
         env:
           npm_config_arch: x64

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -25,6 +25,7 @@ export class Terminal {
 		await this.terminalTab.click();
 	}
 
+	// Note, this doesn't work for Windows
 	async waitForTerminalText(
 		terminalText: string,
 		options: {

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -29,7 +29,7 @@ test.describe('New UV Environment', {
 			console.warn(`Failed to delete ${projPath}:`, err);
 		}
 	});
-
+	// This is skipped for windows because we can't get the text from the Terminal
 	test('Python - Add new UV environment', async function ({ app, openFolder }) {
 
 		await app.workbench.terminal.clickTerminalTab();

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -23,7 +23,7 @@ test.describe('New Folder Flow: Jupyter Project', {
 
 	// Removing WIN tag until we get uv into windows CI as this expects uv to be the interpreter
 	test('Jupyter Folder Defaults', {
-		tag: [tags.CRITICAL, tags.INTERPRETER]
+		tag: [tags.CRITICAL, tags.INTERPRETER, tags.WIN]
 	}, async function ({ app, settings }) {
 		const folderName = addRandomNumSuffix('python-notebook-runtime');
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -12,7 +12,6 @@ test.use({
 });
 
 // Not running conda test on windows because conda reeks havoc on selecting the correct python interpreter
-// Not running uv either because it is not installed on windows for now
 test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FOLDER_FLOW, tags.WEB] }, () => {
 	const folderTemplate = FolderTemplate.PYTHON_PROJECT;
 
@@ -93,7 +92,7 @@ test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FO
 		await verifyPyprojectTomlNotCreated(app);
 	});
 
-	test('New env: uv environment', { tag: [tags.CRITICAL] }, async function ({ app }) {
+	test('New env: uv environment', { tag: [tags.CRITICAL, tags.WIN] }, async function ({ app }) {
 		const folderName = addRandomNumSuffix('new-uv');
 
 		await createNewFolder(app, {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8783

Add `uv` install step.  Note, it is still pinned to a previous `uv` version due to a reticulate issue.

Only a few tests were enabled as some require pulling the terminal text and we can't do that on windows yet.

### QA Notes
@:win

See passing results: https://github.com/posit-dev/positron/actions/runs/17413873343/job/49437470133?pr=9263

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
