### PR TITLE
positroNB cut copy paste cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -219,6 +219,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Sets the DOM element that contains the cells for the notebook.
 	 * @param container The container element to set, or undefined to clear
 	 */
+	/**
+	 * Sets the DOM element that contains the cells for the notebook.
+	 * @param container The container element to set, or undefined to clear
+	 */
 	setCellsContainer(container: HTMLElement | undefined | null): void {
 		// Clean up any existing listeners
 		this._cellsContainerListeners.clear();
@@ -459,6 +463,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Public Methods
 
+	/**
+	 * Runs the specified cells in the notebook.
+	 * @param cells The cells to run
+	 * @throws Error if no cells are provided
+	 */
 	async runCells(cells: IPositronNotebookCell[]): Promise<void> {
 		if (!cells) {
 			throw new Error(localize('noCells', "No cells to run"));
@@ -466,11 +475,20 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		await this._runCells(cells);
 	}
 
+	/**
+	 * Runs all cells in the notebook.
+	 */
 	async runAllCells(): Promise<void> {
 		await this._runCells(this._cells);
 	}
 
 
+	/**
+	 * Adds a new cell to the notebook at the specified index.
+	 * @param type The type of cell to add (`CellKind`)
+	 * @param index The position where the cell should be inserted
+	 * @throws Error if no language is set for the notebook
+	 */
 	addCell(type: CellKind, index: number): void {
 		this._assertTextModel();
 
@@ -513,6 +531,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._onDidChangeContent.fire();
 	}
 
+	/**
+	 * Inserts a new code cell above or below the reference cell (or selected cell if no reference is provided).
+	 * @param aboveOrBelow Whether to insert the cell above or below the reference
+	 * @param referenceCell Optional reference cell. If not provided, uses the currently selected cell
+	 */
 	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
 		let index: number | null;
 
@@ -532,6 +555,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.addCell(CellKind.Code, index + (aboveOrBelow === 'above' ? 0 : 1));
 	}
 
+	/**
+	 * Deletes a single cell from the notebook.
+	 * @param cellToDelete The cell to delete. If not provided, deletes the currently selected cell
+	 */
 	deleteCell(cellToDelete?: IPositronNotebookCell): void {
 		const cell = cellToDelete ?? this.selectionStateMachine.getSelectedCell();
 
@@ -541,6 +568,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.deleteCells([cell]);
 	}
 
+	/**
+	 * Deletes multiple cells from the notebook.
+	 * @param cellsToDelete Array of cells to delete
+	 */
 	deleteCells(cellsToDelete: IPositronNotebookCell[]): void {
 		this._assertTextModel();
 
@@ -643,6 +674,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 
+	/**
+	 * Sets the cell that is currently being edited.
+	 * @param cell The cell to set as editing, or undefined to clear editing state
+	 */
 	setEditingCell(cell: IPositronNotebookCell | undefined): void {
 		if (cell === undefined) {
 			return;
@@ -650,6 +685,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.selectionStateMachine.selectCell(cell, CellSelectionType.Edit);
 	}
 
+	/**
+	 * Checks if the notebook contains a specific code editor.
+	 * @param editor The code editor to check for
+	 * @returns True if the editor belongs to one of the notebook's cells, false otherwise
+	 */
 	hasCodeEditor(editor: ICodeEditor): boolean {
 		for (const cell of this._cells) {
 			if (cell.editor && cell.editor === editor) {
@@ -659,6 +699,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return false;
 	}
 
+	/**
+	 * Attaches the notebook view to a DOM container.
+	 * @param container The DOM element to render the notebook into
+	 */
 	async attachView(container: HTMLElement) {
 		this.detachView();
 		this._container = container;
@@ -712,6 +756,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		};
 	}
 
+	/**
+	 * Detaches the notebook view from its container and cleans up resources.
+	 */
 	detachView(): void {
 		this._container = undefined;
 		this._logService.info(this.id, 'detachView');
@@ -721,6 +768,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._detachModel();
 	}
 
+	/**
+	 * Closes the notebook instance and disposes of all resources.
+	 */
 	close(): void {
 		this._logService.info(this.id, 'Closing a notebook instance');
 		this.dispose();
@@ -913,6 +963,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to clear outputs from. If not provided, uses the currently selected cell.
 	 * @param skipContentEvent If true, won't fire the content change event (useful for batch operations)
 	 */
+	/**
+	 * Clears the output of a specific cell in the notebook.
+	 * @param cell The cell to clear outputs from. If not provided, uses the currently selected cell
+	 * @param skipContentEvent If true, won't fire the content change event (useful for batch operations)
+	 */
 	clearCellOutput(cell?: IPositronNotebookCell, skipContentEvent: boolean = false): void {
 		this._assertTextModel();
 
@@ -1007,6 +1062,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Flag to track if the clipboard contains cut cells (vs copied cells)
 	 */
 	private _isClipboardCut: boolean = false;
+
+	/**
+	 * Copies the specified cells to the clipboard.
+	 * @param cells The cells to copy. If not provided, copies the currently selected cells
+	 */
 	copyCells(cells?: IPositronNotebookCell[]): void {
 		const cellsToCopy = cells || this.getSelectedCells();
 
@@ -1026,6 +1086,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._logService.debug(`Copied ${cellsToCopy.length} cells to clipboard`);
 	}
 
+	/**
+	 * Cuts the specified cells to the clipboard (copies then deletes them).
+	 * @param cells The cells to cut. If not provided, cuts the currently selected cells
+	 */
 	cutCells(cells?: IPositronNotebookCell[]): void {
 		const cellsToCut = cells || this.getSelectedCells();
 
@@ -1041,6 +1105,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.deleteCells(cellsToCut);
 	}
 
+	/**
+	 * Pastes cells from the clipboard at the specified index.
+	 * @param index The position to paste cells at. If not provided, pastes after the last selected cell
+	 */
 	pasteCells(index?: number): void {
 		if (!this.canPaste()) {
 			return;
@@ -1090,6 +1158,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._onDidChangeContent.fire();
 	}
 
+	/**
+	 * Pastes cells from the clipboard above the first selected cell.
+	 */
 	pasteCellsAbove(): void {
 		const selection = this.getSelectedCells();
 		if (selection.length > 0) {
@@ -1100,6 +1171,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}
 	}
 
+	/**
+	 * Checks if there are cells available to paste from the clipboard.
+	 * @returns True if cells can be pasted, false otherwise
+	 */
 	canPaste(): boolean {
 		return this._clipboardCells.length > 0;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -657,20 +657,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				}
 			}, 0));
 		}
-
-		// After the content change fires and cells are synced, explicitly set the selection
-		// to maintain focus on the appropriate cell after deletion
-		if (targetFocusIndex !== null) {
-			this._register(disposableTimeout(() => {
-				if (targetFocusIndex !== null && targetFocusIndex < this._cells.length) {
-					const cellToFocus = this._cells[targetFocusIndex];
-					if (cellToFocus) {
-						this.selectionStateMachine.selectCell(cellToFocus, CellSelectionType.Normal);
-						cellToFocus.focus();
-					}
-				}
-			}, 0));
-		}
 	}
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
-import { CellSelectionType, SelectionStateMachine, SelectionState } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
@@ -1068,7 +1068,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cells The cells to copy. If not provided, copies the currently selected cells
 	 */
 	copyCells(cells?: IPositronNotebookCell[]): void {
-		const cellsToCopy = cells || this.getSelectedCells();
+		const cellsToCopy = cells || this.selectionStateMachine.getSelectedCells();
 
 		if (cellsToCopy.length === 0) {
 			return;
@@ -1091,7 +1091,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cells The cells to cut. If not provided, cuts the currently selected cells
 	 */
 	cutCells(cells?: IPositronNotebookCell[]): void {
-		const cellsToCut = cells || this.getSelectedCells();
+		const cellsToCut = cells || this.selectionStateMachine.getSelectedCells();
 
 		if (cellsToCut.length === 0) {
 			return;
@@ -1162,7 +1162,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Pastes cells from the clipboard above the first selected cell.
 	 */
 	pasteCellsAbove(): void {
-		const selection = this.getSelectedCells();
+		const selection = this.selectionStateMachine.getSelectedCells();
 		if (selection.length > 0) {
 			const firstSelectedIndex = this.cells.get().indexOf(selection[0]);
 			this.pasteCells(firstSelectedIndex);
@@ -1179,25 +1179,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this._clipboardCells.length > 0;
 	}
 
-	// Helper method to get selected cells
-	private getSelectedCells(): IPositronNotebookCell[] {
-		const state = this.selectionStateMachine.state.get();
-
-		switch (state.type) {
-			case SelectionState.SingleSelection:
-			case SelectionState.MultiSelection:
-				return state.selected;
-			case SelectionState.EditingSelection:
-				return [state.selectedCell];
-			case SelectionState.NoSelection:
-			default:
-				return [];
-		}
-	}
 
 	// Helper method to get insertion index
 	private getInsertionIndex(): number {
-		const selections = this.getSelectedCells();
+		const selections = this.selectionStateMachine.getSelectedCells();
 		if (selections.length > 0) {
 			const lastSelectedIndex = this.cells.get().indexOf(selections[selections.length - 1]);
 			return lastSelectedIndex + 1;

--- a/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPositronNotebookCell, CellKind } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { ICellDto2 } from '../../notebook/common/notebookCommon.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+
+/**
+ * Converts a Positron notebook cell to ICellDto2 format for clipboard storage.
+ * This preserves all cell data without creating standalone text models.
+ */
+export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
+	const cellModel = cell.cellModel;
+
+	return {
+		source: cell.getContent(),
+		language: cellModel.language,
+		mime: undefined,
+		cellKind: cellModel.cellKind,
+		outputs: cellModel.outputs.map(output => ({
+			outputId: output.outputId,
+			outputs: output.outputs.map(item => ({
+				mime: item.mime,
+				data: item.data
+			}))
+		})),
+		metadata: {},
+		internalMetadata: {},
+		collapseState: undefined
+	};
+}
+
+/**
+ * Serializes cells to a JSON string for system clipboard storage.
+ * This enables pasting cells into other applications or notebooks.
+ */
+export function serializeCellsToClipboard(cells: IPositronNotebookCell[]): string {
+	const cellsData = cells.map(cell => {
+		const cellModel = cell.cellModel;
+
+		// Create a serializable representation of the cell
+		const cellData = {
+			cell_type: cellModel.cellKind === CellKind.Code ? 'code' : 'markdown',
+			source: splitIntoLines(cell.getContent()),
+			metadata: {},
+			// For code cells, include outputs
+			...(cellModel.cellKind === CellKind.Code ? {
+				outputs: cellModel.outputs.map(output => ({
+					output_type: 'display_data',
+					data: output.outputs.reduce((acc, item) => {
+						// Convert output items to a format compatible with Jupyter
+						acc[item.mime] = item.data.toString();
+						return acc;
+					}, {} as Record<string, string>),
+					metadata: {}
+				})),
+				execution_count: null
+			} : {})
+		};
+
+		return cellData;
+	});
+
+	// Wrap in a notebook-like structure for compatibility
+	const notebookData = {
+		cells: cellsData,
+		metadata: {
+			kernelspec: {},
+			language_info: {}
+		},
+		nbformat: 4,
+		nbformat_minor: 2
+	};
+
+	return JSON.stringify(notebookData, null, 2);
+}
+
+/**
+ * Deserializes cells from a clipboard string to ICellDto2 format.
+ * Handles both Positron and standard Jupyter notebook formats.
+ */
+export function deserializeCellsFromClipboard(clipboardData: string): ICellDto2[] | null {
+	try {
+		const data = JSON.parse(clipboardData);
+
+		// Check if it's a notebook format (has cells array)
+		const cells = data.cells || (Array.isArray(data) ? data : null);
+
+		if (!cells) {
+			return null;
+		}
+
+		return cells.map((cellData: any) => {
+			// Determine cell kind
+			const cellKind = cellData.cell_type === 'code' ? CellKind.Code : CellKind.Markup;
+
+			// Handle source - could be array of strings or single string
+			const source = Array.isArray(cellData.source)
+				? cellData.source.join('')
+				: (cellData.source || '');
+
+			// Handle outputs for code cells
+			const outputs = [];
+			if (cellKind === CellKind.Code && cellData.outputs) {
+				for (const output of cellData.outputs) {
+					const outputItems = [];
+
+					// Handle different output formats
+					if (output.data) {
+						for (const [mime, content] of Object.entries(output.data)) {
+							outputItems.push({
+								mime,
+								data: VSBuffer.fromString(content as string)
+							});
+						}
+					} else if (output.text) {
+						// Handle stream outputs
+						outputItems.push({
+							mime: 'text/plain',
+							data: VSBuffer.fromString(Array.isArray(output.text) ? output.text.join('') : output.text)
+						});
+					}
+
+					if (outputItems.length > 0) {
+						outputs.push({
+							outputId: output.output_id || crypto.randomUUID(),
+							outputs: outputItems
+						});
+					}
+				}
+			}
+
+			// Return ICellDto2 format
+			return {
+				source,
+				language: cellData.language || (cellKind === CellKind.Code ? 'python' : 'markdown'),
+				mime: cellData.mime,
+				cellKind,
+				outputs,
+				metadata: cellData.metadata || {},
+				internalMetadata: {
+					executionOrder: cellData.execution_count || undefined,
+					lastRunSuccess: undefined,
+					runStartTime: undefined,
+					runEndTime: undefined
+				},
+				collapseState: undefined
+			};
+		});
+	} catch (error) {
+		// Failed to parse clipboard data
+		return null;
+	}
+}
+
+/**
+ * Helper function to split content into lines for Jupyter format
+ */
+function splitIntoLines(content: string): string[] {
+	if (!content) {
+		return [];
+	}
+
+	// Split by newlines but preserve the newline characters
+	const lines = content.split(/(\r?\n)/);
+	const result: string[] = [];
+
+	for (let i = 0; i < lines.length; i += 2) {
+		if (i + 1 < lines.length) {
+			result.push(lines[i] + lines[i + 1]);
+		} else if (lines[i]) {
+			result.push(lines[i]);
+		}
+	}
+
+	return result;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -63,15 +63,8 @@ export function NotebookCellActionBar({ cell, children, isHovered }: NotebookCel
 	const handleActionClick = (action: INotebookCellActionBarItem) => {
 		// If action needs cell context, ensure cell is selected first
 		if (action.needsCellContext) {
-			// Select the cell if not already selected
-			const currentState = instance.selectionStateMachine.state.get();
-			const isSelected = (currentState.type !== 'NoSelection' &&
-				currentState.type !== 'EditingSelection' &&
-				currentState.selected.includes(cell));
-
-			if (!isSelected) {
-				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-			}
+			// Select the cell (the method handles checking if already selected)
+			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 		}
 
 		// Execute the command (without passing cell as argument)

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -40,14 +40,7 @@ export function buildMoreActionsMenuItems(
 					// IMPORTANT: Ensure the cell from this menu is selected before executing
 					// Otherwise the command would operate on whatever cell is currently selected
 					if (action.needsCellContext) {
-						const currentState = instance.selectionStateMachine.state.get();
-						const isSelected = (currentState.type !== 'NoSelection' &&
-							currentState.type !== 'EditingSelection' &&
-							currentState.selected.includes(cell));
-
-						if (!isSelected) {
-							instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-						}
+						instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 					}
 
 					// Execute command - it will now operate on the correct cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -115,14 +115,7 @@ export function registerCellCommand({
 
 			if (multiSelect) {
 				// Handle multiple selected cells
-				const currentState = activeNotebook.selectionStateMachine.state.get();
-				let selectedCells: IPositronNotebookCell[] = [];
-
-				if (currentState.type === 'SingleSelection' || currentState.type === 'MultiSelection') {
-					selectedCells = currentState.selected;
-				} else if (currentState.type === 'EditingSelection') {
-					selectedCells = [currentState.selectedCell];
-				}
+				const selectedCells = activeNotebook.selectionStateMachine.getSelectedCells();
 
 				// Filter cells based on cell condition and execute handler
 				for (const cell of selectedCells) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -25,7 +25,6 @@ import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { PositronNotebookEditorInput, PositronNotebookEditorInputOptions } from './PositronNotebookEditorInput.js';
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { checkPositronNotebookEnabled } from './positronNotebookExperimentalConfig.js';
 import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from '../../../services/workingCopy/common/workingCopyEditorService.js';
@@ -419,13 +418,9 @@ registerCellCommand({
 
 registerCellCommand({
 	commandId: 'positronNotebook.cell.executeAndSelectBelow',
-	handler: (cell, accessor) => {
+	handler: (cell, notebook) => {
 		cell.run();
-		const notebookService = accessor.get(IPositronNotebookService);
-		const notebook = notebookService.getActiveInstance();
-		if (notebook) {
-			notebook.selectionStateMachine.moveDown(false);
-		}
+		notebook.selectionStateMachine.moveDown(false);
 	},
 	cellCondition: CellConditions.isCode,  // Only show on code cells
 	keybinding: {
@@ -439,11 +434,7 @@ registerCellCommand({
 // Example of position-based conditions
 registerCellCommand({
 	commandId: 'positronNotebook.cell.runAllAbove',
-	handler: (cell, accessor) => {
-		const notebookService = accessor.get(IPositronNotebookService);
-		const notebook = notebookService.getActiveInstance();
-		if (!notebook) { return; }
-
+	handler: (cell, notebook) => {
 		const cells = notebook.cells.get();
 		const cellIndex = cells.indexOf(cell);
 
@@ -472,9 +463,7 @@ registerCellCommand({
 
 registerCellCommand({
 	commandId: 'positronNotebook.cell.runAllBelow',
-	handler: (cell, accessor) => {
-		const notebookService = accessor.get(IPositronNotebookService);
-		const notebook = notebookService.getActiveInstance();
+	handler: (cell, notebook) => {
 		if (!notebook) { return; }
 
 		const cells = notebook.cells.get();
@@ -522,6 +511,84 @@ registerCellCommand({
 		description: localize('positronNotebook.cell.toggleMarkdownEditor', "Toggle markdown editor visibility")
 	}
 });
+
+
+// Copy cells command - Cmd/Ctrl+C
+registerCellCommand({
+	commandId: 'positronNotebook.copyCells',
+	handler: (cell, notebook) => notebook.copyCells(),
+	multiSelect: true,  // Copy all selected cells
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+		mac: {
+			primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+		},
+	},
+	actionBar: {
+		icon: 'codicon-copy',
+		position: 'menu',
+		category: 'Clipboard',
+		order: 10
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.copyCells', "Copy Cell")
+	}
+});
+
+// Cut cells command - Cmd/Ctrl+X
+registerCellCommand({
+	commandId: 'positronNotebook.cutCells',
+	handler: (cell, notebook) => notebook.cutCells(),
+	multiSelect: true,  // Cut all selected cells
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.KeyX,
+	},
+	actionBar: {
+		position: 'menu',
+		category: 'Clipboard',
+		order: 20
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.cutCells', "Cut Cell")
+	}
+});
+
+// Paste cells command - Cmd/Ctrl+V
+registerCellCommand({
+	commandId: 'positronNotebook.pasteCells',
+	handler: (cell, notebook) => notebook.pasteCells(),
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.KeyV,
+		win: { primary: KeyMod.CtrlCmd | KeyCode.KeyV, secondary: [KeyMod.Shift | KeyCode.Insert] },
+		linux: { primary: KeyMod.CtrlCmd | KeyCode.KeyV, secondary: [KeyMod.Shift | KeyCode.Insert] },
+	},
+	actionBar: {
+		position: 'menu',
+		category: 'Clipboard',
+		order: 40
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.pasteCells', "Paste Cell Below")
+	}
+});
+
+// Paste cells above command - Cmd/Ctrl+Shift+V
+registerCellCommand({
+	commandId: 'positronNotebook.pasteCellsAbove',
+	handler: (cell, notebook) => notebook.pasteCellsAbove(),
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV,
+	},
+	actionBar: {
+		position: 'menu',
+		category: 'Clipboard',
+		order: 30
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.pasteCellsAbove', "Paste Cell Above")
+	}
+});
+
 
 //#endregion Cell Commands
 

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -100,6 +100,11 @@ export interface IPositronNotebookInstance {
 	isDisposed: boolean;
 
 	/**
+	 * Indicates whether this notebook is read-only and cannot be edited.
+	 */
+	readonly isReadOnly: boolean;
+
+	/**
 	 * Event that fires when the cells container is scrolled
 	 */
 	readonly onDidScrollCellsContainer: Event<void>;
@@ -167,4 +172,35 @@ export interface IPositronNotebookInstance {
 	 * Closes the notebook instance.
 	 */
 	close(): void;
+
+	/**
+	 * Copies the specified cells to the clipboard.
+	 * If no cells are provided, copies the currently selected cells.
+	 * @param cells Optional array of cells to copy. If not provided, uses current selection.
+	 */
+	copyCells(cells?: IPositronNotebookCell[]): void;
+
+	/**
+	 * Cuts the specified cells (copies to clipboard and removes from notebook).
+	 * If no cells are provided, cuts the currently selected cells.
+	 * @param cells Optional array of cells to cut. If not provided, uses current selection.
+	 */
+	cutCells(cells?: IPositronNotebookCell[]): void;
+
+	/**
+	 * Pastes cells from the clipboard at the specified index.
+	 * If no index is provided, pastes after the current selection.
+	 * @param index Optional index to paste at. If not provided, pastes after current selection.
+	 */
+	pasteCells(index?: number): void;
+
+	/**
+	 * Pastes cells from the clipboard above the current selection.
+	 */
+	pasteCellsAbove(): void;
+
+	/**
+	 * Returns whether there are cells available to paste from the clipboard.
+	 */
+	canPaste(): boolean;
 }

--- a/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
@@ -105,19 +105,42 @@ export class SelectionStateMachine extends Disposable {
 	 * @param editMode If true, the cell will be selected in edit mode.
 	 */
 	selectCell(cell: IPositronNotebookCell, selectType: CellSelectionType = CellSelectionType.Normal): void {
-		if (selectType === CellSelectionType.Normal || this._state.type === SelectionState.NoSelection && selectType === CellSelectionType.Add) {
+		// For Normal selection, check if cell is already the only selected cell
+		if (selectType === CellSelectionType.Normal) {
+			if (this._state.type === SelectionState.SingleSelection && this._state.selected[0] === cell) {
+				// Cell is already selected in single selection mode, nothing to do
+				return;
+			}
 			this._setState({ type: SelectionState.SingleSelection, selected: [cell] });
 			return;
 		}
 
+		// For Edit selection, check if cell is already being edited
 		if (selectType === CellSelectionType.Edit) {
+			if (this._state.type === SelectionState.EditingSelection && this._state.selectedCell === cell) {
+				// Cell is already being edited, nothing to do
+				return;
+			}
 			this._setState({ type: SelectionState.EditingSelection, selectedCell: cell });
 			return;
 		}
 
-		if (this._state.type === SelectionState.SingleSelection || this._state.type === SelectionState.MultiSelection) {
-			this._setState({ type: SelectionState.MultiSelection, selected: [...this._state.selected, cell] });
-			return;
+		// For Add selection
+		if (selectType === CellSelectionType.Add) {
+			if (this._state.type === SelectionState.NoSelection) {
+				this._setState({ type: SelectionState.SingleSelection, selected: [cell] });
+				return;
+			}
+
+			if (this._state.type === SelectionState.SingleSelection || this._state.type === SelectionState.MultiSelection) {
+				// Check if cell is already in the selection
+				if (this._state.selected.includes(cell)) {
+					// Cell is already selected, nothing to do
+					return;
+				}
+				this._setState({ type: SelectionState.MultiSelection, selected: [...this._state.selected, cell] });
+				return;
+			}
 		}
 
 		// Shouldn't get here.
@@ -228,6 +251,41 @@ export class SelectionStateMachine extends Disposable {
 			return null;
 		}
 		return this._state.selectedCell;
+	}
+
+	/**
+	 * Get all selected cells based on the current selection state.
+	 * @returns An array of selected cells, empty if no selection.
+	 */
+	getSelectedCells(): IPositronNotebookCell[] {
+		switch (this._state.type) {
+			case SelectionState.SingleSelection:
+			case SelectionState.MultiSelection:
+				return this._state.selected;
+			case SelectionState.EditingSelection:
+				return [this._state.selectedCell];
+			case SelectionState.NoSelection:
+			default:
+				return [];
+		}
+	}
+
+	/**
+	 * Check if a specific cell is currently selected.
+	 * @param cell The cell to check
+	 * @returns True if the cell is selected, false otherwise
+	 */
+	isCellSelected(cell: IPositronNotebookCell): boolean {
+		switch (this._state.type) {
+			case SelectionState.SingleSelection:
+			case SelectionState.MultiSelection:
+				return this._state.selected.includes(cell);
+			case SelectionState.EditingSelection:
+				return this._state.selectedCell === cell;
+			case SelectionState.NoSelection:
+			default:
+				return false;
+		}
 	}
 
 	//#endregion Public Methods

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -386,4 +386,14 @@ export class PositronNotebooks extends Notebooks {
 			await this.code.driver.page.waitForTimeout(100);
 		});
 	}
+
+	/**
+	 * Get cell content for identification
+	 */
+	async getCellContent(cellIndex: number): Promise<string> {
+		const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+		const editor = cell.locator('.positron-cell-editor-monaco-widget .view-lines');
+		const content = await editor.textContent();
+		return content ?? '';
+	}
 }

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -18,15 +18,7 @@ async function getCellCount(app: Application): Promise<number> {
 	return await app.code.driver.page.locator('[data-testid="notebook-cell"]').count();
 }
 
-/**
- * Helper function to get cell content for identification
- */
-async function getCellContent(app: Application, cellIndex: number): Promise<string> {
-	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-	const editor = cell.locator('.positron-cell-editor-monaco-widget .view-lines');
-	const content = await editor.textContent();
-	return content ?? '';
-}
+
 
 
 test.describe('Cell Deletion Action Bar Behavior', {
@@ -61,7 +53,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(2);
 
 		// Verify cell 2 has correct content before deletion
-		expect(await getCellContent(app, 2)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
 
 		// Delete the selected cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(2);
@@ -70,7 +62,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(5);
 
 		// Verify what was cell 3 is now at index 2
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 2: Delete a non-selected (hovered) cell (cell 4, originally cell 5)
@@ -79,7 +71,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(0);
 
 		// Verify cell 4 has correct content before deletion
-		expect(await getCellContent(app, 4)).toBe('# Cell 5');
+		expect(await app.workbench.notebooksPositron.getCellContent(4)).toBe('# Cell 5');
 
 		// Delete cell 4 (which is NOT selected) by hovering and clicking action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(4);
@@ -88,16 +80,16 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(4);
 
 		// Verify the remaining cells are correct
-		expect(await getCellContent(app, 0)).toBe('# Cell 0');
-		expect(await getCellContent(app, 1)).toBe('# Cell 1');
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
-		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 4');
 
 		// ========================================
 		// Test 3: Delete last cell (cell 3, originally cell 4)
 		// ========================================
 		// Verify we're at the last cell with correct content
-		expect(await getCellContent(app, 3)).toBe('# Cell 4');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 4');
 
 		// Delete the last cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(3);
@@ -106,13 +98,13 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(3);
 
 		// Verify remaining cells
-		expect(await getCellContent(app, 2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 4: Delete first cell (cell 0)
 		// ========================================
 		// Verify we're at the first cell with correct content
-		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
 
 		// Delete the first cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(0);
@@ -121,7 +113,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(2);
 
 		// Verify what was cell 1 is now at index 0
-		expect(await getCellContent(app, 0)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 1');
 
 		// ========================================
 		// Test 5: Delete remaining cells

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -1,0 +1,273 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra/index.js';
+import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * Helper function to get the currently focused cell index
+ */
+async function getFocusedCellIndex(app: Application): Promise<number | null> {
+	const cells = app.code.driver.page.locator('[data-testid="notebook-cell"]');
+	const cellCount = await cells.count();
+
+	for (let i = 0; i < cellCount; i++) {
+		const cell = cells.nth(i);
+		// Check if the cell is focused by looking for focus indicators
+		const isFocused = await cell.evaluate((element) => {
+			// Check if any child element has focus or if the cell has focus-related classes
+			return element.contains(document.activeElement) ||
+				element.classList.contains('focused') ||
+				element.querySelector('.focused') !== null ||
+				element.querySelector(':focus') !== null;
+		});
+
+		if (isFocused) {
+			return i;
+		}
+	}
+	return null;
+}
+
+/**
+ * Helper function to get cell count
+ */
+async function getCellCount(app: Application): Promise<number> {
+	return await app.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+}
+
+/**
+ * Helper function to get cell content for identification
+ */
+async function getCellContent(app: Application, cellIndex: number): Promise<string> {
+	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
+	const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
+	return await editor.inputValue();
+}
+
+/**
+ * Helper function to copy cells using keyboard shortcut
+ */
+async function copyCellsWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+	await app.code.driver.page.keyboard.press(`${modifierKey}+KeyC`);
+}
+
+/**
+ * Helper function to cut cells using keyboard shortcut
+ */
+async function cutCellsWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+	await app.code.driver.page.keyboard.press(`${modifierKey}+KeyX`);
+}
+
+/**
+ * Helper function to paste cells using keyboard shortcut
+ */
+async function pasteCellsWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+	await app.code.driver.page.keyboard.press(`${modifierKey}+KeyV`);
+}
+
+test.describe('Notebook Cell Copy-Paste Behavior', {
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+		// Configure Positron as the notebook editor
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+		// Enable screen reader support so we can programmatically get cell content
+		await settings.set({ 'editor.accessibilitySupport': 'on' });
+	});
+
+	test('Cell copy-paste behavior - comprehensive test', async function ({ app }) {
+		// Setup: Create notebook and select kernel once
+		await app.workbench.notebooks.createNewNotebook();
+		await app.workbench.notebooksPositron.expectToBeVisible();
+
+		// ========================================
+		// Setup: Create 5 cells with distinct content
+		// ========================================
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 0', 0);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 1', 1);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 2', 2);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 3', 3);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell 4', 4);
+
+		// Verify we have 5 cells
+		expect(await getCellCount(app)).toBe(5);
+
+		// ========================================
+		// Test 1: Copy single cell and paste at end
+		// ========================================
+		await app.workbench.notebooksPositron.selectCellAtIndex(2);
+
+		// Verify cell 2 is selected and has correct content
+		expect(await getFocusedCellIndex(app)).toBe(2);
+		expect(await getCellContent(app, 2)).toBe('# Cell 2');
+
+		// Copy the cell
+		await copyCellsWithKeyboard(app);
+
+		// Focus should remain on the copied cell
+		expect(await getFocusedCellIndex(app)).toBe(2);
+
+		// Move to last cell and paste after it
+		await app.workbench.notebooksPositron.selectCellAtIndex(4);
+		await pasteCellsWithKeyboard(app);
+
+		// Verify cell count increased
+		expect(await getCellCount(app)).toBe(6);
+
+		// Verify the pasted cell has the correct content (should be at index 5)
+		expect(await getCellContent(app, 5)).toBe('# Cell 2');
+
+		// Focus should be on the pasted cell
+		expect(await getFocusedCellIndex(app)).toBe(5);
+
+		// ========================================
+		// Test 2: Cut single cell and paste at different position
+		// ========================================
+		await app.workbench.notebooksPositron.selectCellAtIndex(1);
+
+		// Verify we're at cell 1 with correct content
+		expect(await getCellContent(app, 1)).toBe('# Cell 1');
+
+		// Cut the cell
+		await cutCellsWithKeyboard(app);
+
+		// Verify cell count decreased
+		expect(await getCellCount(app)).toBe(5);
+
+		// Focus should move to what was cell 2 (now at index 1)
+		expect(await getFocusedCellIndex(app)).toBe(1);
+		expect(await getCellContent(app, 1)).toBe('# Cell 2');
+
+		// Move to index 3 and paste
+		await app.workbench.notebooksPositron.selectCellAtIndex(3);
+		await pasteCellsWithKeyboard(app);
+
+		// Verify cell count is back to 6
+		expect(await getCellCount(app)).toBe(6);
+
+		// Verify the pasted cell has correct content at index 4
+		expect(await getCellContent(app, 4)).toBe('# Cell 1');
+
+		// Focus should be on the pasted cell
+		expect(await getFocusedCellIndex(app)).toBe(4);
+
+		// ========================================
+		// Test 3: Copy cell and paste multiple times (clipboard persistence)
+		// ========================================
+		await app.workbench.notebooksPositron.selectCellAtIndex(0);
+
+		// Copy cell 0
+		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		await copyCellsWithKeyboard(app);
+
+		// Paste at position 2
+		await app.workbench.notebooksPositron.selectCellAtIndex(2);
+		await pasteCellsWithKeyboard(app);
+
+		// Verify first paste
+		expect(await getCellCount(app)).toBe(7);
+		expect(await getCellContent(app, 3)).toBe('# Cell 0');
+
+		// Paste again at position 5
+		await app.workbench.notebooksPositron.selectCellAtIndex(5);
+		await pasteCellsWithKeyboard(app);
+
+		// Verify second paste
+		expect(await getCellCount(app)).toBe(8);
+		expect(await getCellContent(app, 6)).toBe('# Cell 0');
+
+		// ========================================
+		// Test 4: Cut and paste at beginning of notebook
+		// ========================================
+		// Select a middle cell to cut
+		await app.workbench.notebooksPositron.selectCellAtIndex(4);
+		const cellToMoveContent = await getCellContent(app, 4);
+
+		// Cut the cell
+		await cutCellsWithKeyboard(app);
+
+		// Verify cell removed
+		expect(await getCellCount(app)).toBe(7);
+
+		// Focus should move to what was at index 5 (now at index 4)
+		expect(await getFocusedCellIndex(app)).toBe(4);
+
+		// Move to first cell and paste
+		// Note: Paste typically inserts after the current cell
+		await app.workbench.notebooksPositron.selectCellAtIndex(0);
+		await pasteCellsWithKeyboard(app);
+
+		// Verify cell count restored
+		expect(await getCellCount(app)).toBe(8);
+
+		// Verify pasted cell is at index 1 (pasted after cell 0)
+		expect(await getCellContent(app, 1)).toBe(cellToMoveContent);
+
+		// Focus should be on the pasted cell at index 1
+		expect(await getFocusedCellIndex(app)).toBe(1);
+
+		// ========================================
+		// Test 5: Focus behavior validation after operations
+		// ========================================
+		// Test copy: focus stays on source
+		await app.workbench.notebooksPositron.selectCellAtIndex(3);
+		const copySourceIndex = await getFocusedCellIndex(app);
+		await copyCellsWithKeyboard(app);
+		expect(await getFocusedCellIndex(app)).toBe(copySourceIndex);
+
+		// Test cut: focus moves to next cell (or stays if last)
+		await app.workbench.notebooksPositron.selectCellAtIndex(2);
+		await cutCellsWithKeyboard(app);
+		const focusAfterCut = await getFocusedCellIndex(app);
+		expect(focusAfterCut).toBe(2); // Focus stays at same index, but content changes
+
+		// Test paste: focus moves to pasted cell
+		await app.workbench.notebooksPositron.selectCellAtIndex(4);
+		await pasteCellsWithKeyboard(app);
+		expect(await getFocusedCellIndex(app)).toBe(5); // Pasted after index 4
+
+		// ========================================
+		// Test 6: Cut all cells and verify notebook can be empty
+		// ========================================
+		// Delete cells until only one remains
+		while (await getCellCount(app) > 1) {
+			await app.workbench.notebooksPositron.selectCellAtIndex(0);
+			await cutCellsWithKeyboard(app);
+		}
+
+		// Verify we have exactly one cell
+		expect(await getCellCount(app)).toBe(1);
+
+		// Cut the last cell - in Positron notebooks, this may be allowed
+		await cutCellsWithKeyboard(app);
+
+		// Check if notebook can be empty (Positron may allow 0 cells)
+		const finalCount = await getCellCount(app);
+		expect(finalCount).toBeLessThanOrEqual(1);
+
+		// ========================================
+		// Cleanup
+		// ========================================
+		// Close the notebook without saving
+		await app.workbench.notebooks.closeNotebookWithoutSaving();
+	});
+
+});

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -44,15 +44,6 @@ async function getCellCount(app: Application): Promise<number> {
 }
 
 /**
- * Helper function to get cell content for identification
- */
-async function getCellContent(app: Application, cellIndex: number): Promise<string> {
-	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
-	const editor = cell.locator('.positron-cell-editor-monaco-widget textarea');
-	return await editor.inputValue();
-}
-
-/**
  * Helper function to copy cells using keyboard shortcut
  */
 async function copyCellsWithKeyboard(app: Application): Promise<void> {
@@ -89,8 +80,6 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 		// Configure Positron as the notebook editor
 		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
-		// Enable screen reader support so we can programmatically get cell content
-		await settings.set({ 'editor.accessibilitySupport': 'on' });
 	});
 
 	test('Cell copy-paste behavior - comprehensive test', async function ({ app }) {
@@ -117,7 +106,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify cell 2 is selected and has correct content
 		expect(await getFocusedCellIndex(app)).toBe(2);
-		expect(await getCellContent(app, 2)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
 
 		// Copy the cell
 		await copyCellsWithKeyboard(app);
@@ -133,7 +122,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		expect(await getCellCount(app)).toBe(6);
 
 		// Verify the pasted cell has the correct content (should be at index 5)
-		expect(await getCellContent(app, 5)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(5)).toBe('# Cell 2');
 
 		// Focus should be on the pasted cell
 		expect(await getFocusedCellIndex(app)).toBe(5);
@@ -144,7 +133,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(1);
 
 		// Verify we're at cell 1 with correct content
-		expect(await getCellContent(app, 1)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
 
 		// Cut the cell
 		await cutCellsWithKeyboard(app);
@@ -154,7 +143,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Focus should move to what was cell 2 (now at index 1)
 		expect(await getFocusedCellIndex(app)).toBe(1);
-		expect(await getCellContent(app, 1)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 2');
 
 		// Move to index 3 and paste
 		await app.workbench.notebooksPositron.selectCellAtIndex(3);
@@ -164,7 +153,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		expect(await getCellCount(app)).toBe(6);
 
 		// Verify the pasted cell has correct content at index 4
-		expect(await getCellContent(app, 4)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(4)).toBe('# Cell 1');
 
 		// Focus should be on the pasted cell
 		expect(await getFocusedCellIndex(app)).toBe(4);
@@ -175,7 +164,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(0);
 
 		// Copy cell 0
-		expect(await getCellContent(app, 0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
 		await copyCellsWithKeyboard(app);
 
 		// Paste at position 2
@@ -184,7 +173,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify first paste
 		expect(await getCellCount(app)).toBe(7);
-		expect(await getCellContent(app, 3)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 0');
 
 		// Paste again at position 5
 		await app.workbench.notebooksPositron.selectCellAtIndex(5);
@@ -192,14 +181,14 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify second paste
 		expect(await getCellCount(app)).toBe(8);
-		expect(await getCellContent(app, 6)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(6)).toBe('# Cell 0');
 
 		// ========================================
 		// Test 4: Cut and paste at beginning of notebook
 		// ========================================
 		// Select a middle cell to cut
 		await app.workbench.notebooksPositron.selectCellAtIndex(4);
-		const cellToMoveContent = await getCellContent(app, 4);
+		const cellToMoveContent = await app.workbench.notebooksPositron.getCellContent(4);
 
 		// Cut the cell
 		await cutCellsWithKeyboard(app);
@@ -219,7 +208,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		expect(await getCellCount(app)).toBe(8);
 
 		// Verify pasted cell is at index 1 (pasted after cell 0)
-		expect(await getCellContent(app, 1)).toBe(cellToMoveContent);
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe(cellToMoveContent);
 
 		// Focus should be on the pasted cell at index 1
 		expect(await getFocusedCellIndex(app)).toBe(1);


### PR DESCRIPTION
Addresses #8746.

### Summary

This PR adds cut, copy, and paste functionality for cells in Positron notebooks. Users can now manipulate notebook cells using:
- Keyboard shortcuts (`Ctrl+X`/`Cmd+X` for cut, `Ctrl+C`/`Cmd+C` for copy, `Ctrl+V`/`Cmd+V` for paste)
- Action bar commands in the cell actions bar

The implementation includes a new clipboard utility system that handles cell content serialization and maintains proper cell ordering when pasting. Cut operations properly remove the source cell, while copy operations preserve it.
<img width="794" height="492" alt="image" src="https://github.com/user-attachments/assets/c2de7874-62ad-4257-b401-94791a9801d5" />

### Release Notes

#### New Features

#### Bug Fixes
- N/A

### QA Notes

There is a new e2e test for this behavior: `test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts`

@:notebooks

1. Create a new Positron notebook with multiple cells containing different content types (code, markdown)
2. Test cut functionality:
   - Select a cell and press `Ctrl+X`/`Cmd+X` (or use action bar)
   - Verify the cell is removed from its original position
   - Paste with `Ctrl+V`/`Cmd+V` in a new location
   - Verify the cell appears in the new location with original content
3. Test copy functionality:
   - Select a cell and press `Ctrl+C`/`Cmd+C` (or use action bar) 
   - Verify the original cell remains in place
   - Paste with `Ctrl+V`/`Cmd+V` in a new location
   - Verify a duplicate cell appears with identical content
4. Test multiple cell operations and verify proper cell ordering is maintained
5. Test with different cell types (code cells with various languages, markdown cells)
