### PR TITLE
Update null filter labels to match summary panel

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -209,7 +209,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			identifier: RowFilterDescrType.IS_NULL,
 			title: localize(
 				'positron.addEditRowFilter.conditionIsNull',
-				"is null"
+				"is missing"
 			),
 			value: RowFilterDescrType.IS_NULL
 		}));
@@ -217,7 +217,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			identifier: RowFilterDescrType.IS_NOT_NULL,
 			title: localize(
 				'positron.addEditRowFilter.conditionIsNotNull',
-				"is not null"
+				"is not missing"
 			),
 			value: RowFilterDescrType.IS_NOT_NULL
 		}));

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -61,14 +61,14 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 			return <>
 				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
-					{localize('positron.dataExplorer.rowFilterWidget.isNull', "is null")}
+					{localize('positron.dataExplorer.rowFilterWidget.isNull', "is missing")}
 				</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotNull) {
 			return <>
 				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
-					{localize('positron.dataExplorer.rowFilterWidget.isNotNull', "is not null")}
+					{localize('positron.dataExplorer.rowFilterWidget.isNotNull', "is not missing")}
 				</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsTrue) {


### PR DESCRIPTION
Addresses #9083

The `is null` and `is not null` filter labels in the Data Explorer have been updated to now say `is missing` and `is not missing`. These labels match the label we use in the summary panel for calculating the percentage of values that are null/missing.

The change in labels should hopefully resolve the awkwardness R users experience since `na` is the value being represented by that label. 

  

https://github.com/user-attachments/assets/3647d507-f591-41b5-9170-6ad318798b19



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Update null filter labels to match summary panel (#9083)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win