### PR TITLE
Reduce console error/warning noise

### DIFF
--- a/src/vs/platform/update/common/positronVersion.ts
+++ b/src/vs/platform/update/common/positronVersion.ts
@@ -25,9 +25,12 @@ export interface IPositronVersion {
  *
  * @param version - The version string to parse.
  */
-export function parse(version: string): IPositronVersion {
+export function parse(version: string): IPositronVersion | undefined {
+	if (!version || version.length === 0) {
+		return undefined;
+	}
 	if (!POSITRON_VERSION_REGEX.test(version)) {
-		throw new Error('Version format must be YYYY.MM.patch-build');
+		throw new Error(`Invalid version '${version}'; format must be YYYY.MM.patch-build`);
 	}
 	const [year, month, patchBuild] = version.split('.');
 	const [patch, build] = patchBuild.split('-').map(Number);
@@ -56,6 +59,21 @@ export function compare(v1: string, v2: string): number {
 	const p1 = parse(v1);
 	const p2 = parse(v2);
 
+	// Handle empty versions
+	if (p1 === undefined && p2 === undefined) {
+		// Both versions are empty
+		return 0;
+	}
+	if (p1 === undefined) {
+		// Only v1 is empty; v2 is valid, so v1 < v2
+		return -1;
+	}
+	if (p2 === undefined) {
+		// Only v2 is empty; v1 is valid, so v1 > v2
+		return 1;
+	}
+
+	// Compare year, month, patch, and build
 	if (p1.year !== p2.year) {
 		return p1.year - p2.year;
 	}

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1398,6 +1398,12 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 		const allProperties = this.configurationRegistry.getConfigurationProperties();
 		for (const property of properties) {
 			const schema = allProperties[property];
+			// --- Start Positron ---
+			// Some experimental settings don't have a schema at all.
+			if (!schema) {
+				continue;
+			}
+			// --- End Positron ---
 			if (!schema.experiment) {
 				continue;
 			}

--- a/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
@@ -48,7 +48,10 @@ export class ExtensionsProposedApi {
 				const key = ExtensionIdentifier.toKey(k);
 				const proposalNames = value.filter(name => {
 					if (!allApiProposals[<ApiProposalName>name]) {
-						_logService.warn(`Via 'product.json#extensionEnabledApiProposals' extension '${key}' wants API proposal '${name}' but that proposal DOES NOT EXIST. Likely, the proposal has been finalized (check 'vscode.d.ts') or was abandoned.`);
+						// --- Start Positron ---
+						// We can ignore these; Positron does not track or enforce API proposal permissions.
+						// _logService.warn(`Via 'product.json#extensionEnabledApiProposals' extension '${key}' wants API proposal '${name}' but that proposal DOES NOT EXIST. Likely, the proposal has been finalized (check 'vscode.d.ts') or was abandoned.`);
+						// --- End Positron ---
 						return false;
 					}
 					return true;
@@ -59,6 +62,13 @@ export class ExtensionsProposedApi {
 	}
 
 	updateEnabledApiProposals(extensions: IExtensionDescription[]): void {
+		// --- Start Positron ---
+		// Positron does not track or enforce API proposal permissions.
+		if (extensions.length > 0) {
+			return;
+		}
+		// --- End Positron ---
+
 		for (const extension of extensions) {
 			this.doUpdateEnabledApiProposals(extension);
 		}


### PR DESCRIPTION
This change removes a good chunk (but not all) of the noisy errors and warnings in the console output that happen even in a perfectly normal Positron startup.

Addresses #9182.


## API Proposals

The biggest offender; VS Code has strict handling for API proposals and ensures that an extension explicitly declare exactly which proposals it wants; this must match the set of proposals enabled for the extension on the VS Code side. Because Positron doesn't enforce API proposals, we have allowed the API proposal sets to get very stale, resulting in many errors like these:

<img width="1025" height="505" alt="image" src="https://github.com/user-attachments/assets/8e5264d3-162e-4bf8-ac54-1081c4873ad7" />

The fix is to turn off more parts of the API proposal validation system, since we don't use it in Positron.

## Can't read properties of `experiment`

This was introduced with the upstream 103 merge. On every boot, this shows up in the console:

<img width="1023" height="259" alt="image" src="https://github.com/user-attachments/assets/7811127b-6db1-4e79-a38c-6f59db87c757" />

It appears that this is caused by experimental setting schema missing. There's a recent 103 change to tolerate this, but it doesn't handle the case where the schema is missing entirely. 

## Can't parse Positron version

This has been in builds for some time:

<img width="798" height="144" alt="image" src="https://github.com/user-attachments/assets/791903af-c42a-4c6b-bb1c-d96143066a2a" />

The problem is just that this code is sometimes called when we don't have a version _at all_ (that is, version is just an empty string), which is really fine when we're doing e.g. an update check and there is no previous version.

The fix is to allow the codepaths that parse the version to return `undefined` (i.e. "no version") when given an empty string, and to handle that value safely elsewhere.

