### PR TITLE
Positron Notebooks: Open via cell URI

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
@@ -213,7 +213,6 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 					this._instantiationService,
 					uri,
 					undefined,
-					options.viewType
 				);
 
 				// Open the editor

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -349,12 +349,12 @@ export class NotebookProviderInfoStore extends Disposable {
 			// Then register the schema handler as exclusive for that notebook
 			disposables.add(this._editorResolverService.registerEditor(
 				`${Schemas.vscodeNotebookCell}:/**/${globPattern}`,
-// --- Start Positron ---
+				// --- Start Positron ---
 				// Use the original contributed priority instead of 'exclusive' to allow
 				// the Positron notebook editor to be configured as the default by users.
 				// See: https://github.com/posit-dev/positron/issues/9253.
 				// { ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
-notebookEditorInfo,
+				notebookEditorInfo,
 				// --- End Positron ---
 				notebookEditorOptions,
 				notebookCellFactoryObject

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -349,7 +349,13 @@ export class NotebookProviderInfoStore extends Disposable {
 			// Then register the schema handler as exclusive for that notebook
 			disposables.add(this._editorResolverService.registerEditor(
 				`${Schemas.vscodeNotebookCell}:/**/${globPattern}`,
-				{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
+// --- Start Positron ---
+				// Use the original contributed priority instead of 'exclusive' to allow
+				// the Positron notebook editor to be configured as the default by users.
+				// See: https://github.com/posit-dev/positron/issues/9253.
+				// { ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
+notebookEditorInfo,
+				// --- End Positron ---
 				notebookEditorOptions,
 				notebookCellFactoryObject
 			));

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -5,9 +5,9 @@
 
 import { ISettableObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { CellKind, IPositronNotebookCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
-import { SelectionStateMachine } from './selectionMachine.js';
-import { ILanguageRuntimeSession } from '../../runtimeSession/common/runtimeSessionService.js';
+import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
+import { SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -104,7 +104,9 @@ export interface IPositronNotebookCell extends Disposable {
 	focus(): void;
 
 	/**
-	 * Set focus on the editor within the cell
+	 * Show the cell's editor.
+	 * @param focus Whether to focus the editor after showing it. Default: false.
+	 * @returns Promise that resolves to the editor when it is available, or undefined if the editor could not be shown.
 	 */
 	showEditor(focus?: boolean): Promise<ICodeEditor | undefined>;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -3,15 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VSBuffer } from '../../../../base/common/buffer.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
-import { ISettableObservable } from '../../../../base/common/observable.js';
-import { URI } from '../../../../base/common/uri.js';
-import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
-import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
-import { CellRevealType, INotebookEditorOptions } from '../../../contrib/notebook/browser/notebookBrowser.js';
-import { NotebookPreloadOutputResults } from '../../positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { CellSelectionType } from './selectionMachine.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ISettableObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { CellRevealType, INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
+import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
+import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'unconfirmed' | 'idle';
 
@@ -121,7 +121,7 @@ export interface IPositronNotebookCell extends Disposable {
 
 	reveal(type?: CellRevealType): void;
 
-	setOptions(options: INotebookEditorOptions): Promise<void>;
+	setOptions(options: INotebookEditorOptions | undefined): Promise<void>;
 
 	/**
 	 * Deselect this cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -121,8 +121,16 @@ export interface IPositronNotebookCell extends Disposable {
 	 */
 	select(type: CellSelectionType): void;
 
+	/**
+	 * Reveal the cell in the viewport
+	 * @param type Reveal type.
+	 */
 	reveal(type?: CellRevealType): void;
 
+	/**
+	 * Apply notebook editor options to this cell. Used by the IDE to select and/or reveal the cell.
+	 * @param options Notebook editor options to apply.
+	 */
 	setOptions(options: INotebookEditorOptions | undefined): Promise<void>;
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -146,7 +146,6 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return editor;
 	}
 
-
 	defocusEditor(): void {
 		// Send focus to the enclosing cell itself to blur the editor
 		this.focus();

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -129,7 +129,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 
 	async setEditorOptions(options: ITextEditorOptions | undefined): Promise<void> {
 		if (options) {
-			const editor = await this.showEditor(!options.preserveFocus);
+			const editor = await this.showEditor(!(options.preserveFocus ?? true));
 			if (editor) {
 				applyTextEditorOptions(options, editor, ScrollType.Immediate);
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -10,7 +10,7 @@ import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { parseOutputData } from '../getOutputContents.js';
 import { PositronNotebookCellGeneral } from './PositronNotebookCell.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
-import { IPositronNotebookCodeCell, NotebookCellOutputs } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCodeCell, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { pickPreferredOutputItem } from './notebookOutputUtils.js';
 import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
@@ -9,7 +9,7 @@ import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCe
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { PositronNotebookCellGeneral } from './PositronNotebookCell.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
-import { IPositronNotebookMarkdownCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookMarkdownCell } from './IPositronNotebookCell.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 
 export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral implements IPositronNotebookMarkdownCell {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
@@ -3,14 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { disposableTimeout } from '../../../../../base/common/async.js';
-import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue, waitForState } from '../../../../../base/common/observable.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { PositronNotebookCellGeneral } from './PositronNotebookCell.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { IPositronNotebookMarkdownCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 
 export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral implements IPositronNotebookMarkdownCell {
 
@@ -41,15 +41,13 @@ export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral im
 		this.editorShown.set(!this.editorShown.get(), undefined);
 	}
 
-	override run(): void {
-		this.toggleEditor();
+	override async showEditor(focus = false): Promise<ICodeEditor | undefined> {
+		this.editorShown.set(true, undefined);
+		await waitForState(this._editor, (editor) => editor !== undefined);
+		return super.showEditor(focus);
 	}
 
-	override focusEditor(): void {
-		this.editorShown.set(true, undefined);
-		// Need a timeout here so that the editor is shown before we try to focus it.
-		this._register(disposableTimeout(() => {
-			super.focusEditor();
-		}, 0));
+	override run(): void {
+		this.toggleEditor();
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NotebookCellOutputItem } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { NotebookCellOutputItem } from './IPositronNotebookCell.js';
 
 /**
  * Get the priority of a mime type for sorting purposes

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -71,6 +71,8 @@ const POSITRON_NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY =
 
 
 export class PositronNotebookEditor extends EditorPane {
+	static readonly ID = 'workbench.editor.positronNotebook';
+
 	/**
 	 * Value to keep track of what instance of the editor this is.
 	 * Used for keeping track of the editor in the logs.
@@ -119,7 +121,7 @@ export class PositronNotebookEditor extends EditorPane {
 	) {
 		// Call the base class's constructor.
 		super(
-			PositronNotebookEditorInput.EditorID,
+			PositronNotebookEditor.ID,
 			_group,
 			telemetryService,
 			themeService,
@@ -219,7 +221,7 @@ export class PositronNotebookEditor extends EditorPane {
 
 	// Getter for notebook instance to avoid having to cast the input every time.
 	get notebookInstance() {
-		return (this.input as PositronNotebookEditorInput)?.notebookInstance;
+		return this.input && (this.input as PositronNotebookEditorInput)?.notebookInstance;
 	}
 
 	protected override setEditorVisible(visible: boolean): void {
@@ -345,6 +347,14 @@ export class PositronNotebookEditor extends EditorPane {
 		super.clearInput();
 	}
 
+	// TODO: Called when a cell URI is opened but its notebook editor pane is already open i.e. the cell editorinput matches the existing notebook one
+	//       Should then focus/reveal the cell
+	override async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
+		super.setOptions(options);
+		if (options) {
+			this.notebookInstance?.setOptions(options);
+		}
+	}
 
 	getInput(): PositronNotebookEditorInput {
 		if (!this._input) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -344,11 +344,14 @@ export class PositronNotebookEditor extends EditorPane {
 		super.clearInput();
 	}
 
-	// TODO: Called when a cell URI is opened but its notebook editor pane is already open i.e. the cell editorinput matches the existing notebook one
-	//       Should then focus/reveal the cell
 	override async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
+		// Called when the editor is already open and receives new options.
+		// Should update the editor to reflect the given options,
+		// such as selecting or revealing a cell or range in a cell editor.
+
 		super.setOptions(options);
 
+		// Pass the options to the notebook instance
 		if (this.notebookInstance) {
 			this.notebookInstance.setOptions(options);
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -50,6 +50,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { NotebookVisibilityProvider } from './NotebookVisibilityContext.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { PositronNotebookEditorControl } from './PositronNotebookEditorControl.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 
 
 /*
@@ -71,8 +72,6 @@ const POSITRON_NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY =
 
 
 export class PositronNotebookEditor extends EditorPane {
-	static readonly ID = 'workbench.editor.positronNotebook';
-
 	/**
 	 * Value to keep track of what instance of the editor this is.
 	 * Used for keeping track of the editor in the logs.
@@ -121,7 +120,7 @@ export class PositronNotebookEditor extends EditorPane {
 	) {
 		// Call the base class's constructor.
 		super(
-			PositronNotebookEditor.ID,
+			POSITRON_NOTEBOOK_EDITOR_ID,
 			_group,
 			telemetryService,
 			themeService,
@@ -368,8 +367,7 @@ export class PositronNotebookEditor extends EditorPane {
 	getViewModel(textModel: NotebookTextModel) {
 		this._logService.info(this._identifier, 'getViewModel');
 
-		const { notebookInstance } = this;
-		if (!notebookInstance) {
+		if (!this.notebookInstance) {
 			throw new Error('Notebook instance is not set.');
 		}
 
@@ -377,9 +375,10 @@ export class PositronNotebookEditor extends EditorPane {
 			throw new Error('Scoped instantiation service is not set. Make sure the editor has been created.');
 		}
 
-		const notebookOptions = notebookInstance.notebookOptions;
+		const notebookOptions = this.notebookInstance.notebookOptions;
 
 
+		const { notebookInstance } = this;
 		const viewContext = new ViewContext(
 			notebookOptions,
 			new NotebookEventDispatcher(),
@@ -393,7 +392,7 @@ export class PositronNotebookEditor extends EditorPane {
 			textModel,
 			viewContext,
 			this.getLayoutInfo(),
-			{ isReadOnly: notebookInstance.isReadOnly }
+			{ isReadOnly: this.notebookInstance.isReadOnly }
 		);
 
 		// Emit an event into the view context for layout change so things can get initialized

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -21,7 +21,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
-import { PositronNotebookEditor } from './PositronNotebookEditor.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 
 /**
  * Options for Positron notebook editor input, including backup support.
@@ -76,7 +76,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * @param resource The resource (aka file) for the notebook we're working with.
 	 * @param preferredResource The preferred resource. See the definition of
 	 * `EditorInputWithPreferredResource` for more info.
-	 	 * @param options Options for the notebook editor input.
+	 * @param options Options for the notebook editor input.
 	 */
 	static getOrCreate(instantiationService: IInstantiationService, resource: URI, preferredResource: URI | undefined, options: PositronNotebookEditorInputOptions = {}) {
 
@@ -102,7 +102,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	constructor(
 		readonly resource: URI,
-				public readonly options: PositronNotebookEditorInputOptions = {},
+		public readonly options: PositronNotebookEditorInputOptions = {},
 		// Borrow notebook resolver service from vscode notebook renderer.
 		@INotebookEditorModelResolverService private readonly _notebookModelResolverService: INotebookEditorModelResolverService,
 		@INotebookService private readonly _notebookService: INotebookService,
@@ -168,7 +168,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * Gets the editor identifier.
 	 */
 	override get editorId(): string {
-		return PositronNotebookEditor.ID;
+		return POSITRON_NOTEBOOK_EDITOR_ID;
 	}
 
 	/**
@@ -341,7 +341,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 		return {
 			resource: this.resource,
 			options: {
-				override: PositronNotebookEditor.ID
+				override: POSITRON_NOTEBOOK_EDITOR_ID
 			}
 		};
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -21,6 +21,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
+import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 
 /**
  * Options for Positron notebook editor input, including backup support.
@@ -63,11 +64,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	static readonly ID: string = 'workbench.input.positronNotebook';
 
 	/**
-	 * Gets the editor ID.
-	 */
-	static readonly EditorID: string = 'workbench.editor.positronNotebook';
-
-	/**
 	 * Editor options. For use in resolving the editor model.
 	 */
 	editorOptions: IEditorOptions | undefined = undefined;
@@ -80,20 +76,21 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * @param resource The resource (aka file) for the notebook we're working with.
 	 * @param preferredResource The preferred resource. See the definition of
 	 * `EditorInputWithPreferredResource` for more info.
-	 * @param viewType The view type for the notebook. Aka `'jupyter-notebook;`.
-	 * @param options Options for the notebook editor input.
+	 	 * @param options Options for the notebook editor input.
 	 */
-	static getOrCreate(instantiationService: IInstantiationService, resource: URI, preferredResource: URI | undefined, viewType: string, options: PositronNotebookEditorInputOptions = {}) {
+	static getOrCreate(instantiationService: IInstantiationService, resource: URI, preferredResource: URI | undefined, options: PositronNotebookEditorInputOptions = {}) {
 
 		// In the vscode-notebooks there is some caching work done here for looking for editors that
 		// exist etc. We may need that eventually but not now.
-		return instantiationService.createInstance(PositronNotebookEditorInput, resource, viewType, options);
+		return instantiationService.createInstance(PositronNotebookEditorInput, resource, options);
 	}
 
 
 	// TODO: Describe why this is here.
 	// This is a reference to the model that is currently being edited in the editor.
 	private _editorModelReference: IReference<IResolvedNotebookEditorModel> | null = null;
+
+	public readonly viewType = 'jupyter-notebook';
 
 	notebookInstance: PositronNotebookInstance | undefined;
 
@@ -105,8 +102,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	constructor(
 		readonly resource: URI,
-		public readonly viewType: string,
-		public readonly options: PositronNotebookEditorInputOptions = {},
+				public readonly options: PositronNotebookEditorInputOptions = {},
 		// Borrow notebook resolver service from vscode notebook renderer.
 		@INotebookEditorModelResolverService private readonly _notebookModelResolverService: INotebookEditorModelResolverService,
 		@INotebookService private readonly _notebookService: INotebookService,
@@ -172,7 +168,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * Gets the editor identifier.
 	 */
 	override get editorId(): string {
-		return PositronNotebookEditorInput.EditorID;
+		return PositronNotebookEditor.ID;
 	}
 
 	/**
@@ -345,7 +341,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 		return {
 			resource: this.resource,
 			options: {
-				override: PositronNotebookEditorInput.EditorID
+				override: PositronNotebookEditor.ID
 			}
 		};
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -463,8 +463,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Public Methods
 
-	async setOptions(options: INotebookEditorOptions): Promise<void> {
-		if (options.cellOptions) {
+	async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
+		if (options?.cellOptions) {
 			for (const cell of this._cells) {
 				if (isEqual(cell.uri, options.cellOptions.resource)) {
 					await cell.setOptions(options);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -25,7 +25,7 @@ import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebook
 import { CellSelectionType, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
-import { IPositronNotebookInstance, KernelStatus } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance, KernelStatus } from './IPositronNotebookInstance.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -463,6 +463,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Public Methods
 
+	/**
+	 * Sets editor options for the notebook or a specific cell.
+	 * If cellOptions.resource is provided, applies options to that cell.
+	 * @param options Editor options to set
+	 */
 	async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
 		const cellUri = options?.cellOptions?.resource;
 		const cell = cellUri && this._cells.find(cell => isEqual(cell.uri, cellUri));

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -21,7 +21,7 @@ import { createNotebookCell } from './PositronNotebookCells/createNotebookCell.j
 import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
-import { IPositronNotebookCell } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
@@ -464,13 +464,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// #region Public Methods
 
 	async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
-		if (options?.cellOptions) {
-			for (const cell of this._cells) {
-				if (isEqual(cell.uri, options.cellOptions.resource)) {
-					await cell.setOptions(options);
-					return;
-				}
-			}
+		const cellUri = options?.cellOptions?.resource;
+		const cell = cellUri && this._cells.find(cell => isEqual(cell.uri, cellUri));
+		if (cell) {
+			await cell.setOptions(options);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
@@ -3,9 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IPositronNotebookCell, CellKind } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
 import { ICellDto2 } from '../../notebook/common/notebookCommon.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
+import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
  * Converts a Positron notebook cell to ICellDto2 format for clipboard storage.
@@ -53,6 +53,7 @@ export function serializeCellsToClipboard(cells: IPositronNotebookCell[]): strin
 						// Convert output items to a format compatible with Jupyter
 						acc[item.mime] = item.data.toString();
 						return acc;
+						// eslint-disable-next-line local/code-no-dangerous-type-assertions
 					}, {} as Record<string, string>),
 					metadata: {}
 				})),

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -6,7 +6,7 @@
 import { NotebookCellOutputTextModel } from '../../notebook/common/model/notebookCellOutputTextModel.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { ICellOutput } from '../../notebook/common/notebookCommon.js';
-import { ParsedOutput, ParsedTextOutput } from '../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { ParsedOutput, ParsedTextOutput } from './PositronNotebookCells/IPositronNotebookCell.js';
 
 type CellOutputInfo = { id: string; content: string };
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 // Other dependencies.
 import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
-import { ParsedTextOutput } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOptions.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -12,7 +12,7 @@ import React, { useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { IPositronNotebookCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useSelectionStatus } from './useSelectionStatus.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -12,7 +12,7 @@ import React, { useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
-import { CellSelectionStatus, IPositronNotebookCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useSelectionStatus } from './useSelectionStatus.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -10,7 +10,7 @@ import './NotebookCodeCell.css';
 import React from 'react';
 
 // Other dependencies.
-import { NotebookCellOutputs } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { NotebookCellOutputs } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { isParsedTextOutput } from '../getOutputContents.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -11,7 +11,7 @@ import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { showCustomContextMenu } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
 import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
-import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellActionButton } from './CellActionButton.js';
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
 import { INotebookCellActionBarItem } from './actionBarRegistry.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -10,7 +10,7 @@ import React, { useRef } from 'react';
 import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { showCustomContextMenu } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
-import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellActionButton } from './CellActionButton.js';
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -6,7 +6,7 @@
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { CustomContextMenuItem } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuEntry } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
-import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -7,7 +7,7 @@ import { ICommandService } from '../../../../../../platform/commands/common/comm
 import { CustomContextMenuItem } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuEntry } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
 import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
-import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { CustomContextMenuSeparator } from '../../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CellKind, IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellKind, IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 
 /** The type of notebook cell */
 /** The type of notebook cell */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -6,7 +6,7 @@
 import { CommandsRegistry, ICommandMetadata } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
-import { IPositronNotebookCell } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -14,7 +14,7 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platfor
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 import { CellConditionPredicate, createCellInfo } from './cellConditions.js';
-import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
@@ -8,7 +8,7 @@ import { ICommandMetadata, CommandsRegistry } from '../../../../../../platform/c
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
-import { IPositronNotebookInstance } from '../../../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 
@@ -29,7 +29,7 @@ export function registerNotebookCommand({
 }: {
 	commandId: string;
 	handler: (notebook: IPositronNotebookInstance, accessor: ServicesAccessor) => void;
-		keybinding?: IPositronNotebookCommandKeybinding;
+	keybinding?: IPositronNotebookCommandKeybinding;
 	metadata?: ICommandMetadata;
 }): IDisposable {
 	const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionBarVisibility.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CellSelectionStatus } from '../../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellSelectionStatus } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
  * Hook to determine if the action bar should be visible based on cell state.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useSelectionStatus.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useSelectionStatus.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 // Other dependencies.
-import { CellSelectionStatus, IPositronNotebookCell } from '../../../../services/positronNotebook/browser/IPositronNotebookCell.js';
+import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { SelectionState } from '../../../../services/positronNotebook/browser/selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -91,7 +91,10 @@ class PositronNotebookContribution extends Disposable {
 		// Register for cells in .ipynb files
 		this._register(this.editorResolverService.registerEditor(
 			`${Schemas.vscodeNotebookCell}:/**/*.ipynb`,
-			notebookEditorInfo,
+			// We have to use exclusive priority because vscode.window.showTextDocument(cell.document)
+			// restricts to editors with exclusive priority.
+			// This does not seem to be an issue for file schemes (registered above).
+			{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
 			{
 				singlePerResource: true,
 				canSupportResource: (resource: URI) => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -35,6 +35,7 @@ import { registerCellCommand } from './notebookCells/actionBar/registerCellComma
 import { registerNotebookCommand } from './notebookCells/actionBar/registerNotebookCommand.js';
 import { CellConditions } from './notebookCells/actionBar/cellConditions.js';
 import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 
 
 /**
@@ -58,7 +59,7 @@ class PositronNotebookContribution extends Disposable {
 
 	private registerEditor(): void {
 		const notebookEditorInfo: RegisteredEditorInfo = {
-			id: PositronNotebookEditor.ID,
+			id: POSITRON_NOTEBOOK_EDITOR_ID,
 			label: localize('positronNotebook', "Positron Notebook"),
 			detail: localize('positronNotebook.detail', "Provided by Positron"),
 			priority: RegisteredEditorPriority.option
@@ -206,7 +207,7 @@ class PositronNotebookWorkingCopyEditorHandler extends Disposable implements IWo
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(
 		PositronNotebookEditor,
-		PositronNotebookEditor.ID,
+		POSITRON_NOTEBOOK_EDITOR_ID,
 		localize('positronNotebookEditor', "Positron Notebook Editor")
 	),
 	[

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const POSITRON_NOTEBOOK_EDITOR_ID = 'workbench.editor.positronNotebook';

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -106,7 +106,7 @@ The system uses VS Code's `IEditorResolverService` to register the Positron note
 editorResolverService.registerEditor(
     '*.ipynb',
     {
-        id: PositronNotebookEditorInput.EditorID,
+        id: PositronNotebookEditor.ID,
         label: localize('positronNotebook', "Positron Notebook"),
         priority: RegisteredEditorPriority.option // Always available in "Open With..." menu
     },

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -116,7 +116,6 @@ editorResolverService.registerEditor(
     },
     {
         createEditorInput: async ({ resource, options }) => {
-            const viewType = await this.detectNotebookViewType(resource);
             const editorInput = PositronNotebookEditorInput.getOrCreate(...);
             return { editor: editorInput, options };
         }
@@ -203,7 +202,6 @@ static getOrCreate(
     instantiationService: IInstantiationService,
     resource: URI,
     preferredResource: URI | undefined,
-    viewType: string,
     options: PositronNotebookEditorInputOptions = {}
 )
 ```

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -106,7 +106,7 @@ The system uses VS Code's `IEditorResolverService` to register the Positron note
 editorResolverService.registerEditor(
     '*.ipynb',
     {
-        id: PositronNotebookEditor.ID,
+        id: POSITRON_NOTEBOOK_EDITOR_ID,
         label: localize('positronNotebook', "Positron Notebook"),
         priority: RegisteredEditorPriority.option // Always available in "Open With..." menu
     },

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
@@ -14,7 +14,7 @@ import { ITestInstantiationService } from '../../../../test/browser/workbenchTes
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
 import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
-import { PositronNotebookEditor } from '../../browser/PositronNotebookEditor.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
 
 // Mock implementation for testing static editor registration
 class MockPositronNotebookContribution extends DisposableStore {
@@ -38,7 +38,7 @@ class MockPositronNotebookContribution extends DisposableStore {
 		this._currentRegistration = this.editorResolverService.registerEditor(
 			'*.ipynb',
 			{
-				id: PositronNotebookEditor.ID,
+				id: POSITRON_NOTEBOOK_EDITOR_ID,
 				label: 'Positron Notebook',
 				priority: RegisteredEditorPriority.option
 			},
@@ -139,7 +139,7 @@ suite('Positron Notebook Configuration Handling', () => {
 
 		// Verify editor is registered
 		let editors = editorResolverService.getEditors();
-		let positronEditor = editors.find(e => e.id === PositronNotebookEditor.ID);
+		let positronEditor = editors.find(e => e.id === POSITRON_NOTEBOOK_EDITOR_ID);
 		assert.ok(positronEditor);
 
 		// Dispose contribution
@@ -147,7 +147,7 @@ suite('Positron Notebook Configuration Handling', () => {
 
 		// Verify editor is no longer registered
 		editors = editorResolverService.getEditors();
-		positronEditor = editors.find(e => e.id === PositronNotebookEditor.ID);
+		positronEditor = editors.find(e => e.id === POSITRON_NOTEBOOK_EDITOR_ID);
 		assert.strictEqual(positronEditor, undefined);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookConfigurationHandling.test.ts
@@ -14,6 +14,7 @@ import { ITestInstantiationService } from '../../../../test/browser/workbenchTes
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
 import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
+import { PositronNotebookEditor } from '../../browser/PositronNotebookEditor.js';
 
 // Mock implementation for testing static editor registration
 class MockPositronNotebookContribution extends DisposableStore {
@@ -37,7 +38,7 @@ class MockPositronNotebookContribution extends DisposableStore {
 		this._currentRegistration = this.editorResolverService.registerEditor(
 			'*.ipynb',
 			{
-				id: PositronNotebookEditorInput.EditorID,
+				id: PositronNotebookEditor.ID,
 				label: 'Positron Notebook',
 				priority: RegisteredEditorPriority.option
 			},
@@ -53,7 +54,6 @@ class MockPositronNotebookContribution extends DisposableStore {
 						this.instantiationService,
 						resource,
 						undefined,
-						'jupyter-notebook',
 						{ startDirty: false }
 					);
 					return { editor: editorInput };
@@ -139,7 +139,7 @@ suite('Positron Notebook Configuration Handling', () => {
 
 		// Verify editor is registered
 		let editors = editorResolverService.getEditors();
-		let positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		let positronEditor = editors.find(e => e.id === PositronNotebookEditor.ID);
 		assert.ok(positronEditor);
 
 		// Dispose contribution
@@ -147,7 +147,7 @@ suite('Positron Notebook Configuration Handling', () => {
 
 		// Verify editor is no longer registered
 		editors = editorResolverService.getEditors();
-		positronEditor = editors.find(e => e.id === PositronNotebookEditorInput.EditorID);
+		positronEditor = editors.find(e => e.id === PositronNotebookEditor.ID);
 		assert.strictEqual(positronEditor, undefined);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -42,6 +42,7 @@ import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
 import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
+import { PositronNotebookEditor } from '../../browser/PositronNotebookEditor.js';
 
 suite.skip('Positron Notebook Editor Resolution', () => {
 	// Suite skipped: Positron notebook editor is behind feature flag (positron.notebook.enabled=false by default)
@@ -67,7 +68,7 @@ suite.skip('Positron Notebook Editor Resolution', () => {
 		const registration = editorResolverService.registerEditor(
 			'*.ipynb',
 			{
-				id: PositronNotebookEditorInput.EditorID,
+				id: PositronNotebookEditor.ID,
 				label: 'Positron Notebook',
 				priority: priority
 			},
@@ -83,7 +84,6 @@ suite.skip('Positron Notebook Editor Resolution', () => {
 						instantiationService,
 						resource,
 						undefined,
-						'jupyter-notebook',
 						{ startDirty: false }
 					);
 					return { editor: editorInput };

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookEditorResolution.test.ts
@@ -42,7 +42,7 @@ import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { PositronNotebookEditorInput } from '../../browser/PositronNotebookEditorInput.js';
 import { usingPositronNotebooks } from '../../../../services/positronNotebook/common/positronNotebookUtils.js';
 import { createPositronNotebookTestServices } from './testUtils.js';
-import { PositronNotebookEditor } from '../../browser/PositronNotebookEditor.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
 
 suite.skip('Positron Notebook Editor Resolution', () => {
 	// Suite skipped: Positron notebook editor is behind feature flag (positron.notebook.enabled=false by default)
@@ -68,7 +68,7 @@ suite.skip('Positron Notebook Editor Resolution', () => {
 		const registration = editorResolverService.registerEditor(
 			'*.ipynb',
 			{
-				id: PositronNotebookEditor.ID,
+				id: POSITRON_NOTEBOOK_EDITOR_ID,
 				label: 'Positron Notebook',
 				priority: priority
 			},

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -14,7 +14,7 @@ import { NotebookMultiMessagePlotClient } from '../../positronPlots/browser/note
 import { UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { isWebviewDisplayMessage, getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
-import { IPositronNotebookInstance } from '../../../services/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 
 /**
  * Format of output from a notebook cell

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookCell.ts
@@ -9,7 +9,9 @@ import { ISettableObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { CellRevealType, INotebookEditorOptions } from '../../../contrib/notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../positronWebviewPreloads/browser/positronWebviewPreloadService.js';
+import { CellSelectionType } from './selectionMachine.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'unconfirmed' | 'idle';
 
@@ -104,12 +106,22 @@ export interface IPositronNotebookCell extends Disposable {
 	/**
 	 * Set focus on the editor within the cell
 	 */
-	focusEditor(): void;
+	showEditor(focus?: boolean): Promise<ICodeEditor | undefined>;
 
 	/**
 	 * Remove focus from within monaco editor and out to the cell itself
 	 */
 	defocusEditor(): void;
+
+	/**
+	 * Select this cell
+	 * @param type Selection type.
+	 */
+	select(type: CellSelectionType): void;
+
+	reveal(type?: CellRevealType): void;
+
+	setOptions(options: INotebookEditorOptions): Promise<void>;
 
 	/**
 	 * Deselect this cell

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -5,7 +5,7 @@
 
 import { ISettableObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { CellKind, IPositronNotebookCell } from './IPositronNotebookCell.js';
+import { CellKind, IPositronNotebookCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { SelectionStateMachine } from './selectionMachine.js';
 import { ILanguageRuntimeSession } from '../../runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';

--- a/src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 import { usingPositronNotebooks as utilUsingPositronNotebooks } from '../common/positronNotebookUtils.js';
 import { isEqual } from '../../../../base/common/resources.js';
 

--- a/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
@@ -205,7 +205,7 @@ export class SelectionStateMachine extends Disposable {
 		this._setState({ type: SelectionState.EditingSelection, selectedCell: cellToEdit });
 		// Timeout here avoids the problem of enter applying to the editor widget itself.
 		this._register(
-			disposableTimeout(() => cellToEdit.focusEditor(), 0)
+			disposableTimeout(async () => await cellToEdit.showEditor(true), 0)
 		);
 	}
 

--- a/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/selectionMachine.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
-import { IPositronNotebookCell } from './IPositronNotebookCell.js';
+import { IPositronNotebookCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/services/positronWebviewPreloads/browser/positronWebviewPreloadService.ts
+++ b/src/vs/workbench/services/positronWebviewPreloads/browser/positronWebviewPreloadService.ts
@@ -7,7 +7,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Event } from '../../../../base/common/event.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IPositronPlotClient } from '../../positronPlots/common/positronPlots.js';
-import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 
 export const POSITRON_HOLOVIEWS_ID = 'positronWebviewPreloadService';
 


### PR DESCRIPTION
Adds support for Positron Notebooks to open via cell URIs, for example, to navigate to cell source code by clicking breakpoints in the debugging pane (#9253).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

See #9253 for repro.