### PR TITLE
Improve error messages with AWS auth

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1059,7 +1059,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 878,
+        "line_number": 895,
         "is_secret": false
       }
     ],

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1059,7 +1059,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 895,
+        "line_number": 896,
         "is_secret": false
       }
     ],

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1059,7 +1059,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 874,
+        "line_number": 878,
         "is_secret": false
       }
     ],

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -95,6 +95,10 @@
       "filename": "build/secrets/.secrets.baseline"
     },
     {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1055,7 +1059,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 874,
         "is_secret": false
       }
     ],
@@ -1601,16 +1605,6 @@
         "is_secret": false
       }
     ],
-    "src/vs/workbench/api/node/loopbackServer.ts": [
-      {
-        "type": "AWS Access Key",
-        "filename": "src/vs/workbench/api/node/loopbackServer.ts",
-        "hashed_secret": "094ab4147707513f945937285ac0a6ef8472a356",
-        "is_verified": false,
-        "line_number": 184,
-        "is_secret": false
-      }
-    ],
     "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1676,16 +1670,6 @@
         "hashed_secret": "3a8f125da17a2c187d430daf0045e0fdfa707bdd",
         "is_verified": false,
         "line_number": 299,
-        "is_secret": false
-      }
-    ],
-    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
-      {
-        "type": "IBM Cloud IAM Key",
-        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
-        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
-        "is_verified": false,
-        "line_number": 96,
         "is_secret": false
       }
     ],

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -133,8 +133,7 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 			await registerModelWithAPI(config, context);
 			registeredModels.push(config);
 		} catch (e) {
-			const failedMessage = vscode.l10n.t('Positron Assistant: Failed to register model configurations.');
-			vscode.window.showErrorMessage(`${failedMessage} ${e}`);
+			vscode.window.showErrorMessage(`${e}`);
 		}
 	}
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -538,7 +538,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 	}
 
 	/**
-	 * Parses for specific ai-sdk errors. Then parses provider specific errors.
+	 * Parses for specific ai-sdk errors.
 	 * @param error The error object returned by the provider.
 	 * @returns A user-friendly error message or undefined if not specifically handled.
 	 */
@@ -836,10 +836,10 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 		}
 
 		if (name === 'CredentialsProviderError') {
-			return vscode.l10n.t(`Invalid AWS credentials. ${message}`);
+			return vscode.l10n.t(`Invalid AWS credentials. {0}`, message);
 		}
 
-		return vscode.l10n.t(`AWS Bedrock error: ${message}`);
+		return vscode.l10n.t(`AWS Bedrock error: {0}`, message);
 	}
 }
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -478,8 +478,12 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 				if (ai.APICallError.isInstance(part.error)) {
 					const responseBody = part.error.responseBody;
 					if (responseBody) {
-						const json = JSON.parse(responseBody);
-						throw new Error(`${json.message ?? json}`);
+						try {
+							const json = JSON.parse(responseBody);
+							throw new Error(`${json.message ?? json}`);
+						} catch (_error) {
+							throw new Error(responseBody);
+						}
 					}
 				}
 
@@ -812,7 +816,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 	override parseProviderError(error: any): string | undefined {
 		if ((error as any).name) {
 			const name = (error as any).name;
-			const message = (error as any).message ?? 'Please check your configuration as the the credentials may have expired.';
+			const message = (error as any).message ?? 'Please check your configuration as the credentials may have expired.';
 			if (name === 'CredentialsProviderError') {
 				return vscode.l10n.t(`Invalid AWS credentials. ${message}`);
 			}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -142,3 +142,7 @@
 .language-model-modal-dialog .content-area {
 	padding: 16px 16px 0 16px;
 }
+
+.language-model-error.error-msg {
+	word-break: break-word;
+}


### PR DESCRIPTION
Address #8489

Handles AWS API and `CredentialsProviderError` errors. The message is extracted to show as an error message. AWS provides clear error messages as to why the credentials are invalid. I added in a check for an inaccessible model since that is a general `ai.APICallError`, which might provide better error messages for other providers.

Message if model is not enabled in AWS. This occurs if the model is not enabled in Bedrock.
<img width="369" height="106" alt="image" src="https://github.com/user-attachments/assets/0e342fbb-8998-41be-b3ee-80bcd1226d50" />

Message when the API key is invalid. I used an invalid session token.
<img width="460" height="114" alt="image" src="https://github.com/user-attachments/assets/3ef413a7-d873-4f72-9ead-6359c33b9173" />

Message when the credentials have expired. When using `aws sso login`, I manually expired the credentials by modifying the json file in `~/.aws/sso/cache` so that `expiresAt` triggers the expiry. 
<img width="464" height="158" alt="image" src="https://github.com/user-attachments/assets/16bb7678-b60b-4fa1-8e46-0ed60c446459" />


### Release Notes

#### New Features

- Improve error messages with AWS authentication

#### Bug Fixes

- N/A


### QA Notes