### PR TITLE
Assistant: Improve git integration logging and model selection

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import { EncryptedSecretStorage, expandConfigToSource, getEnabledProviders, getModelConfiguration, getModelConfigurations, getStoredModels, GlobalSecretStorage, logStoredModels, ModelConfig, SecretStorage, showConfigurationDialog, StoredModelConfig } from './config';
 import { createModelConfigsFromEnv, newLanguageModelChatProvider } from './models';
 import { registerMappedEditsProvider } from './edits';
-import { registerParticipants } from './participants';
+import { ParticipantService, registerParticipants } from './participants';
 import { newCompletionProvider, registerHistoryTracking } from './completion';
 import { registerAssistantTools } from './tools.js';
 import { registerCopilotService } from './copilot.js';
@@ -188,10 +188,14 @@ function registerConfigureModelsCommand(context: vscode.ExtensionContext, storag
 	);
 }
 
-function registerGenerateCommitMessageCommand(context: vscode.ExtensionContext) {
+function registerGenerateCommitMessageCommand(
+	context: vscode.ExtensionContext,
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-assistant.generateCommitMessage', () => {
-			generateCommitMessage(context);
+			generateCommitMessage(context, participantService, log);
 		})
 	);
 }
@@ -231,7 +235,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 
 	// Commands
 	registerConfigureModelsCommand(context, storage);
-	registerGenerateCommitMessageCommand(context);
+	registerGenerateCommitMessageCommand(context, participantService, log);
 	registerExportChatCommands(context);
 
 	// Register mapped edits provider

--- a/extensions/positron-assistant/src/git.ts
+++ b/extensions/positron-assistant/src/git.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as positron from 'positron';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -192,7 +193,14 @@ async function getModel(participantService: ParticipantService): Promise<vscode.
 		}
 	}
 
-	// Fall back to the first available model.
+	// Fall back to the first model for the currently selected provider.
+	const currentProvider = await positron.ai.getCurrentProvider();
+	if (currentProvider) {
+		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		return models[0];
+	}
+
+	// Fall back to the first available model from any provider.
 	const models = await vscode.lm.selectChatModels();
 	if (models.length === 0) {
 		throw new Error('No language models available for git commit message generation');

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -55,6 +55,7 @@ export interface IPositronAssistantParticipant extends vscode.ChatParticipant {
 export class ParticipantService implements vscode.Disposable {
 	private readonly _participants = new Map<ParticipantID, IPositronAssistantParticipant>();
 	private readonly _sessionModels = new Map<string, string>(); // sessionId -> modelId
+	private _lastSessionModel: string | undefined;
 
 	registerParticipant(participant: IPositronAssistantParticipant): void {
 		this._participants.set(participant.id, participant);
@@ -90,6 +91,7 @@ export class ParticipantService implements vscode.Disposable {
 	 * @param modelId The language model ID used for this session
 	 */
 	trackSessionModel(sessionId: string, modelId: string): void {
+		this._lastSessionModel = modelId;
 		this._sessionModels.set(sessionId, modelId);
 	}
 
@@ -101,6 +103,15 @@ export class ParticipantService implements vscode.Disposable {
 	 */
 	getSessionModel(sessionId: string): string | undefined {
 		return this._sessionModels.get(sessionId);
+	}
+
+	/**
+	 * Get the most recently used model ID.
+	 *
+	 * @returns The model ID if exists, undefined otherwise
+	 */
+	getCurrentSessionModel(): string | undefined {
+		return this._lastSessionModel;
 	}
 
 	dispose() {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2270,6 +2270,29 @@ declare module 'positron' {
 		}
 
 		/**
+		 * A chat language model provider.
+		 */
+		export interface ChatProvider {
+			readonly id: string;
+			readonly displayName: string;
+		}
+
+		/**
+		 * Get the current langauge model provider.
+		 */
+		export function getCurrentProvider(): Thenable<ChatProvider | undefined>;
+
+		/**
+		 * Get all the available langauge model providers.
+		 */
+		export function getProviders(): Thenable<ChatProvider[]>;
+
+		/**
+		 * Set the current language chat provider.
+		 */
+		export function setCurrentProvider(id: string): Thenable<ChatProvider | undefined>;
+
+		/**
 		 * Checks if completions are enabled for the given file.
 		 * @param uri The file URI to check if completions are enabled.
 		 * @returns A Thenable that resolves to true if completions should be enabled for the file, false otherwise.

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -9,6 +9,7 @@ import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IChatAgentData, IChatAgentService } from '../../../contrib/chat/common/chatAgents.js';
 import { ChatModel, IExportableChatData } from '../../../contrib/chat/common/chatModel.js';
 import { IChatProgress, IChatService } from '../../../contrib/chat/common/chatService.js';
+import { ILanguageModelsService, IPositronChatProvider } from '../../../contrib/chat/common/languageModels.js';
 import { IChatRequestData, IPositronAssistantService, IPositronChatContext, IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IChatProgressDto } from '../../common/extHost.protocol.js';
@@ -24,7 +25,8 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 		extHostContext: IExtHostContext,
 		@IPositronAssistantService private readonly _positronAssistantService: IPositronAssistantService,
 		@IChatService private readonly _chatService: IChatService,
-		@IChatAgentService private readonly _chatAgentService: IChatAgentService
+		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
+		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 	) {
 		super();
 		// Create the proxy for the extension host.
@@ -126,5 +128,28 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 
 		// Use the language model ignored files service to check if the file should be excluded
 		return this._positronAssistantService.areCompletionsEnabled(uri);
+	}
+
+	/**
+	 * Get the current langauge model provider.
+	 */
+	async $getCurrentProvider(): Promise<IPositronChatProvider | undefined> {
+		return this._languageModelsService.currentProvider;
+	}
+
+	/**
+	 * Get all the available langauge model providers.
+	 */
+	async $getProviders(): Promise<IPositronChatProvider[]> {
+		return this._languageModelsService.getLanguageModelProviders();
+	}
+
+	/**
+	 * Set the current language chat provider.
+	 */
+	async $setCurrentProvider(id: string): Promise<IPositronChatProvider | undefined> {
+		const provider = this._languageModelsService.getLanguageModelProviders().find(p => p.id === id);
+		this._languageModelsService.currentProvider = provider;
+		return provider;
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -293,6 +293,15 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			areCompletionsEnabled(file: vscode.Uri): Promise<boolean> {
 				return extHostAiFeatures.areCompletionsEnabled(file);
 			},
+			getCurrentProvider(): Promise<positron.ai.ChatProvider | undefined> {
+				return extHostAiFeatures.getCurrentProvider();
+			},
+			getProviders(): Promise<positron.ai.ChatProvider[]> {
+				return extHostAiFeatures.getProviders();
+			},
+			setCurrentProvider(id: string): Promise<positron.ai.ChatProvider | undefined> {
+				return extHostAiFeatures.setCurrentProvider(id);
+			},
 		};
 
 		// --- End Positron ---

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -18,6 +18,7 @@ import { IChatAgentData } from '../../../contrib/chat/common/chatAgents.js';
 import { PlotRenderSettings } from '../../../services/positronPlots/common/positronPlots.js';
 import { QueryTableSummaryResult, Variable } from '../../../services/languageRuntime/common/positronVariablesComm.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
+import { IPositronChatProvider } from '../../../contrib/chat/common/languageModels.js';
 
 // NOTE: This check is really to ensure that extHost.protocol is included by the TypeScript compiler
 // as a dependency of this module, and therefore that it's initialized first. This is to avoid a
@@ -165,11 +166,17 @@ export interface MainThreadAiFeaturesShape {
 	$addLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$areCompletionsEnabled(file: UriComponents): Thenable<boolean>;
+	$getCurrentProvider(): Thenable<IPositronChatProvider | undefined>;
+	$getProviders(): Thenable<IPositronChatProvider[]>;
+	$setCurrentProvider(id: string): Thenable<IPositronChatProvider | undefined>;
 }
 
 export interface ExtHostAiFeaturesShape {
 	$responseLanguageModelConfig(id: string, config: IPositronLanguageModelConfig, action: string): Thenable<void>;
 	$onCompleteLanguageModelConfig(id: string): void;
+	getCurrentProvider(): Thenable<IPositronChatProvider | undefined>;
+	getProviders(): Thenable<IPositronChatProvider[]>;
+	setCurrentProvider(id: string): Thenable<IPositronChatProvider | undefined>;
 }
 
 export interface MainThreadPlotsServiceShape {

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -16,6 +16,7 @@ import { IChatRequestData, IPositronChatContext, IPositronLanguageModelConfig, I
 import { IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../contrib/chat/common/constants.js';
+import { IPositronChatProvider } from '../../../contrib/chat/common/languageModels.js';
 
 export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape {
 
@@ -108,4 +109,17 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 	async areCompletionsEnabled(file: vscode.Uri): Promise<boolean> {
 		return this._proxy.$areCompletionsEnabled(file);
 	}
+
+	async getCurrentProvider(): Promise<IPositronChatProvider | undefined> {
+		return this._proxy.$getCurrentProvider();
+	}
+
+	async getProviders(): Promise<IPositronChatProvider[]> {
+		return this._proxy.$getProviders();
+	}
+
+	async setCurrentProvider(id: string): Promise<IPositronChatProvider | undefined> {
+		return this._proxy.$setCurrentProvider(id);
+	}
+
 }


### PR DESCRIPTION
This PR addresses both:
 * https://github.com/posit-dev/positron/issues/9287
 * https://github.com/posit-dev/positron/issues/9288

Changes:
 * Logging to the Assistant output pane has been added during the git commit message generation process.
 * The last used model ID is tracked in the `ParticipantService` and used to select which model is used when generating git commit messages. Note that we do not have our usual access to a the chat request object here, which is where we normally get the model ID.
 * The previous model selection behaviour is retained as a fallback.
 * If something goes wrong, it is emitted in the logs, and shown in the UI.
 
## QA

As mentioned in https://github.com/posit-dev/positron/issues/9287, getting into a situation where a provider is broken can be tricky. Expired credentials on bedrock is the easiest way.

Nevertheless, with this PR we should now observe:

* Success and failure logging when generating a git commit in the Assistant logs.
* UI errors when generation fails.

To test that the selected model is updating:

1) Start a new Assistant chat message with a given provider/model, say hello to the model.
2) Add some dummy changes to a workspace with a git repo and generate a git commit message.
3) Ensure that the model in the git commit message log matches the last used LLM provider.
4) Repeat from 1) with a different provider/model.

---


https://github.com/user-attachments/assets/793eb3d0-019a-4313-ae28-f8342b2879ab


