### PR TITLE
PositroNB cell selection design

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -44,7 +44,7 @@
 
 	/* Size variables used throughout notebooks */
 	--vscode-positronNotebook-header-h: 30px;
-	--vscode-positronNotebook-cell-radius: 6px;
+	--vscode-positronNotebook-cell-radius: 8px;
 	--vscode-positronNotebook-action-bar-h: 22px;
 	--vscode-positronNotebook-action-bar-inset: calc(
 		var(--vscode-positronNotebook-action-bar-h) / 2

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -13,6 +13,7 @@
 
 	&:focus-within {
 		outline: 1px solid var(--vscode-focusBorder);
+		outline-offset: -1px;
 	}
 
 	.positron-monaco-editor-container {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 .positron-cell-editor-monaco-widget {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -87,14 +87,14 @@
 		width: 100%;
 	}
 
-	/* Adjust margin of first item in markdown cell */
+	/* Remove top margin from first element in markdown cell */
 	*:first-child {
-		margin-top: 0px;
+		margin-top: 0;
 	}
 
-	/* h1 tags don't need top margin */
-	h1:first-child {
-		margin-top: 0;
+	/* Remove bottom margin from last element in markdown cell */
+	*:last-child {
+		margin-bottom: 0;
 	}
 
 	/* Removes bottom margin when only one item exists in markdown cell */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -42,7 +42,7 @@
 	bottom: var(--_positron-notebook-selection-bar-inset);
 }
 
-/* Don't round bottom corner for editor bar to make it look like a continuous bar*/
+/* Don't round bottom corner for editor bar to make it look like a continuous bar */
 .positron-notebook-cell.selected .positron-notebook-editor-container::before,
 .positron-notebook-cell.editing .positron-notebook-editor-container::before {
 	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -60,7 +60,13 @@
 }
 
 /* When outputs are empty, round both corners of editor bar */
-.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs:empty) .positron-notebook-editor-container::before,
-.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs:empty) .positron-notebook-editor-container::before {
+.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::before,
+.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::before {
 	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
+}
+
+/* When editor container is empty, round both corners of outputs bar (This is the case when markdown has been rendered but doesn't have an editor open) */
+.positron-notebook-cell.selected:has(.positron-notebook-editor-container.editor-hidden) .positron-notebook-cell-outputs::before {
+	top: var(--_positron-notebook-selection-bar-top-offset);
+	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Define common properties for the selection bar */
+.positron-notebook-cell {
+	--_positron-notebook-selection-bar-radius: var(--vscode-positronNotebook-cell-radius);
+	--_positron-notebook-selection-bar-width: 7px;
+	--_positron-notebook-selection-bar-top-offset: 5px;
+	--_positron-notebook-selection-bar-inset: 0;
+}
+
+/* Base styles for selected and editing states */
+.positron-notebook-cell.selected,
+.positron-notebook-cell.editing {
+	position: relative;
+	/* Otherwise the outline is forced by monaco styles */
+	outline: none !important;
+}
+
+/* Position containers relative for selection bar placement */
+.positron-notebook-cell.selected .positron-notebook-editor-container,
+.positron-notebook-cell.selected .positron-notebook-cell-outputs,
+.positron-notebook-cell.editing .positron-notebook-editor-container,
+.positron-notebook-cell.editing .positron-notebook-cell-outputs {
+	position: relative;
+}
+
+/* Common base styles for all selection bars */
+.positron-notebook-cell.selected .positron-notebook-editor-container::before,
+.positron-notebook-cell.editing .positron-notebook-editor-container::before,
+.positron-notebook-cell.selected .positron-notebook-cell-outputs::before,
+.positron-notebook-cell.editing .positron-notebook-cell-outputs::before {
+	content: "";
+	position: absolute;
+	width: var(--_positron-notebook-selection-bar-width);
+	background-color: var(--vscode-focusBorder);
+	z-index: 1;
+	left: var(--_positron-notebook-selection-bar-inset);
+	top: var(--_positron-notebook-selection-bar-inset);
+	bottom: var(--_positron-notebook-selection-bar-inset);
+}
+
+/* Don't round bottom corner for editor bar to make it look like a continuous bar*/
+.positron-notebook-cell.selected .positron-notebook-editor-container::before,
+.positron-notebook-cell.editing .positron-notebook-editor-container::before {
+	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);
+	border-bottom-left-radius: 0;
+}
+
+/* Specific positioning for outputs bar */
+.positron-notebook-cell.selected .positron-notebook-cell-outputs::before,
+.positron-notebook-cell.editing .positron-notebook-cell-outputs::before {
+	/* Push bar down slightly so there's a gap between the editor and outputs */
+	top: var(--_positron-notebook-selection-bar-top-offset);
+	/* Don't round top corner for outputs bar to make it look like a continuous bar*/
+	border-top-left-radius: 0;
+	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
+}
+
+/* When outputs are empty, round both corners of editor bar */
+.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs:empty) .positron-notebook-editor-container::before,
+.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs:empty) .positron-notebook-editor-container::before {
+	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -67,6 +67,6 @@
 
 /* When editor container is empty, round both corners of outputs bar (This is the case when markdown has been rendered but doesn't have an editor open) */
 .positron-notebook-cell.selected:has(.positron-notebook-editor-container.editor-hidden) .positron-notebook-cell-outputs::before {
-	top: var(--_positron-notebook-selection-bar-top-offset);
+	top: var(--_positron-notebook-selection-bar-inset);
 	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
@@ -13,10 +13,6 @@
 		outline: 1px solid var(--vscode-focusBorder);
 		animation: running-cell-pulse 2s ease-in-out infinite;
 	}
-
-	&.selected {
-		outline: 1px solid var(--vscode-focusBorder);
-	}
 }
 
 @keyframes running-cell-pulse {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -5,6 +5,7 @@
 
 // CSS.
 import './NotebookCellWrapper.css';
+import './NotebookCellSelection.css';
 
 // React.
 import React, { useState } from 'react';
@@ -56,12 +57,18 @@ export function NotebookCellWrapper({ cell, actionBarChildren, children }: {
 			// 'positron-cell-editor-monaco-widget' then don't run the select code as the editor
 			// widget itself handles that logic
 			const childOfEditor = clickTarget.closest('.positron-cell-editor-monaco-widget');
-			if (childOfEditor || selectionStatus === CellSelectionStatus.Editing) {
+			if (childOfEditor) {
 				return;
 			}
 
 			// If the clicked element is a link, let it do its thing.
 			if (clickTarget.tagName === 'A') {
+				return;
+			}
+
+			// If we're in editing mode and clicking outside the editor, exit editing mode
+			if (selectionStatus === CellSelectionStatus.Editing) {
+				selectionStateMachine.exitEditor();
 				return;
 			}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -14,6 +14,7 @@
 		}
 
 		&:empty {
+			/* Dont show empty outputs at all */
 			display: none;
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -28,7 +28,7 @@ interface CellOutputsSectionProps {
 
 function CellOutputsSection({ outputs = [] }: CellOutputsSectionProps) {
 	return (
-		<div className='positron-notebook-code-cell-outputs' data-testid='cell-output'>
+		<div className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs' data-testid='cell-output'>
 			{outputs?.map((output) => (
 				<CellOutput key={output.outputId} {...output} />
 			))}
@@ -44,7 +44,9 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 			cell={cell}
 		>
 			<div className='positron-notebook-code-cell-contents'>
-				<CellEditorMonacoWidget cell={cell} />
+				<div className='positron-notebook-editor-container'>
+					<CellEditorMonacoWidget cell={cell} />
+				</div>
 				<CellOutputsSection outputs={outputContents} />
 			</div>
 			<CellExecutionInfoIcon cell={cell} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -28,7 +28,7 @@ interface CellOutputsSectionProps {
 
 function CellOutputsSection({ outputs = [] }: CellOutputsSectionProps) {
 	return (
-		<div className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs' data-testid='cell-output'>
+		<div className={`positron-notebook-code-cell-outputs positron-notebook-cell-outputs ${outputs.length > 0 ? 'has-outputs' : 'no-outputs'}`} data-testid='cell-output'>
 			{outputs?.map((output) => (
 				<CellOutput key={output.outputId} {...output} />
 			))}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -25,8 +25,10 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 		<NotebookCellWrapper
 			cell={cell}
 		>
-			<div className='cell-contents positron-notebook-cell-outputs'>
+			<div className={`positron-notebook-editor-container ${editorShown ? '' : 'editor-hidden'}`}>
 				{editorShown ? <CellEditorMonacoWidget cell={cell} /> : null}
+			</div>
+			<div className='cell-contents positron-notebook-cell-outputs'>
 				<div className='positron-notebook-markup-rendered' onDoubleClick={() => {
 					cell.toggleEditor();
 				}}>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -25,7 +25,7 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 		<NotebookCellWrapper
 			cell={cell}
 		>
-			<div className='cell-contents'>
+			<div className='cell-contents positron-notebook-cell-outputs'>
 				{editorShown ? <CellEditorMonacoWidget cell={cell} /> : null}
 				<div className='positron-notebook-markup-rendered' onDoubleClick={() => {
 					cell.toggleEditor();


### PR DESCRIPTION
Addresses #9259.

This PR updates the visual design of notebook cell selection in Positron, introducing a cleaner selection bar design that provides better visual cohesion across different cell states.

### Summary

The main changes include:
- Replaced the outline-based selection with a colored bar on the left side of cells
- Extended the selection bar to include cell outputs when the cell is selected
- Maintained the familiar outline style for cells in editing mode
- Added support for CSS custom properties scoped to components to avoid global pollution

The new selection design provides clearer visual feedback about which cell is currently selected, whether viewing or editing, and maintains consistency across cells with and without outputs.

### Screenshots


### Selected cell with output showing selection bar extending to outputs
<img width="869" height="920" alt="image" src="https://github.com/user-attachments/assets/7d10d4c8-9856-46db-b8f7-31e4e6204598" />

### Cell in editing mode showing traditional outline around editor
<img width="868" height="921" alt="image" src="https://github.com/user-attachments/assets/c844423d-54c1-432c-a609-08cbbaacc68a" />

### Small cell with no outputs
<img width="226" height="82" alt="image" src="https://github.com/user-attachments/assets/bf3a98b4-828c-4297-abdd-ce82b08dfb35" />


### Release Notes

#### New Features

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:editor

1. Open any Jupyter notebook in Positron
2. Navigate between cells using arrow keys or mouse clicks
3. Verify the selection bar appears on the left side of the selected cell
4. For cells with output, verify the selection bar extends to include the output area
5. Double-click or press Enter to edit a cell and verify the editing outline appears around the editor
6. Test with both code and markdown cells to ensure consistent behavior
