### PR TITLE
e2e Testing: Remove web from PositronNB tests

### DIFF
--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -73,8 +73,9 @@ async function pasteCellsWithKeyboard(app: Application): Promise<void> {
 	await app.code.driver.page.keyboard.press(`${modifierKey}+KeyV`);
 }
 
+// Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Notebook Cell Copy-Paste Behavior', {
-	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);


### PR DESCRIPTION
Due to https://github.com/posit-dev/positron/issues/9193 this disables the Positron Notebook test on web

### QA Notes
@:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
