### PR TITLE
Assistant: Track and show cached tokens in UI, and stream token usage in responses

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -1051,7 +1055,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 836,
+        "line_number": 840,
         "is_secret": false
       }
     ],
@@ -1734,5 +1738,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-04T21:49:18Z"
+  "generated_at": "2025-09-05T12:16:42Z"
 }

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -514,6 +514,23 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 			// `cacheReadInputTokens` and `cacheWriteInputTokens`
 			const usage = other.bedrock.usage as Record<string, any>;
 
+			// Report token usage information as part of the output stream.
+			const meta_input = usage.input_tokens || 0;
+			const meta_output = usage.output_tokens || 0;
+			const meta_cache_write = usage.cacheWriteInputTokens || 0;
+			const meta_cache_read = usage.cacheReadInputTokens || 0;
+			const part: any = vscode.LanguageModelDataPart.json({
+				type: 'usage', data: {
+					prompt_tokens: meta_input + meta_cache_read + meta_cache_write,
+					output_tokens: meta_output,
+					cached_tokens: meta_cache_read,
+					provider_metadata: {
+						bedrock: usage,
+					},
+				}
+			});
+			progress.report({ index: 0, part: part });
+
 			// Add the input and output tokens to the usage object
 			usage.inputTokens = inputCount;
 			usage.outputTokens = outputCount;

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -21,6 +21,7 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel } from './anthropic';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { log, recordRequestTokenUsage, recordTokenUsage } from './extension.js';
+import { TokenUsage } from './tokens.js';
 
 /**
  * Models used by chat participants and for vscode.lm.* API functionality.
@@ -166,19 +167,14 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider2 {
 
 		// Record token usage if context is available
 		if (this._context) {
-			const inputCount = await this.provideTokenCount(model, inputText, token);
-			const outputCount = await this.provideTokenCount(model, response, token);
-			recordTokenUsage(this._context, this.provider, inputCount, outputCount);
-			tokenUsage = {
-				provider: this.provider,
-				inputTokens: inputCount,
-				outputTokens: outputCount,
-			};
-
+			const inputTokens = await this.provideTokenCount(model, inputText, token);
+			const outputTokens = await this.provideTokenCount(model, response, token);
+			tokenUsage = { inputTokens, outputTokens, cachedTokens: 0 };
+			recordTokenUsage(this._context, this.provider, tokenUsage);
 			// Also record token usage by request ID if available
 			const requestId = (options.modelOptions as any)?.requestId;
 			if (requestId) {
-				recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
+				recordRequestTokenUsage(requestId, this.provider, tokenUsage);
 			}
 		}
 
@@ -493,56 +489,47 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 
 		// ai-sdk provides token usage in the result but it's not clear how it is calculated
 		const usage = await result.usage;
-		const outputCount = usage.completionTokens;
-		const inputCount = usage.promptTokens;
+		const metadata = await result.providerMetadata;
+		const tokens: TokenUsage = {
+			inputTokens: usage.promptTokens,
+			outputTokens: usage.completionTokens,
+			cachedTokens: 0,
+			providerMetadata: metadata,
+		};
+
+		// Log Bedrock usage if available
+		if (metadata && metadata.bedrock && metadata.bedrock.usage) {
+			// Get the Bedrock usage object; it typically contains
+			// `cacheReadInputTokens` and `cacheWriteInputTokens`
+			const metaUsage = metadata.bedrock.usage as Record<string, any>;
+
+			// Update the usage to take into account cache hits
+			tokens.inputTokens += metaUsage.cacheWriteInputTokens || 0;
+			tokens.cachedTokens += metaUsage.cacheReadInputTokens || 0;
+
+			// Report token usage information as part of the output stream.
+			const part: any = vscode.LanguageModelDataPart.json({ type: 'usage', data: tokens });
+			progress.report({ index: 0, part: part });
+
+			// Log the Bedrock usage
+			log.debug(`[${this._config.name}]: Bedrock usage: ${JSON.stringify(usage, null, 2)}`);
+		}
 
 		if (requestId) {
-			recordRequestTokenUsage(requestId, this.provider, inputCount, outputCount);
+			recordRequestTokenUsage(requestId, this.provider, tokens);
 		}
 
 		if (this._context) {
-			recordTokenUsage(this._context, this.provider, inputCount, outputCount);
+			recordTokenUsage(this._context, this.provider, tokens);
 		}
 
-		const other = await result.providerMetadata;
-
-		log.info(`[vercel]: End request ${requestId}; usage: ${inputCount} input tokens, ${outputCount} output tokens`);
-
-		// Log Bedrock usage if available
-		if (other && other.bedrock && other.bedrock.usage) {
-			// Get the Bedrock usage object; it typically contains
-			// `cacheReadInputTokens` and `cacheWriteInputTokens`
-			const usage = other.bedrock.usage as Record<string, any>;
-
-			// Report token usage information as part of the output stream.
-			const meta_input = usage.input_tokens || 0;
-			const meta_output = usage.output_tokens || 0;
-			const meta_cache_write = usage.cacheWriteInputTokens || 0;
-			const meta_cache_read = usage.cacheReadInputTokens || 0;
-			const part: any = vscode.LanguageModelDataPart.json({
-				type: 'usage', data: {
-					prompt_tokens: meta_input + meta_cache_read + meta_cache_write,
-					output_tokens: meta_output,
-					cached_tokens: meta_cache_read,
-					provider_metadata: {
-						bedrock: usage,
-					},
-				}
-			});
-			progress.report({ index: 0, part: part });
-
-			// Add the input and output tokens to the usage object
-			usage.inputTokens = inputCount;
-			usage.outputTokens = outputCount;
-
-			// Log the Bedrock usage
-			log.debug(`[${this._config.name}]: Bedrock usage: ${JSON.stringify(other.bedrock.usage, null, 2)}`);
-		}
+		log.info(`[vercel]: End request ${requestId}; usage: ${tokens.inputTokens} input tokens (+${tokens.cachedTokens} cached), ${tokens.outputTokens} output tokens`);
 	}
 
 	async provideTokenCount(model: vscode.LanguageModelChatInformation, text: string | vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2, token: vscode.CancellationToken): Promise<number> {
-		// TODO: This is a very naive approximation, a model specific tokenizer should be used.
-		return typeof text === 'string' ? text.length : JSON.stringify(text.content).length;
+		// TODO: This is a naive approximation, a model specific tokenizer should be used.
+		const len = typeof text === 'string' ? text.length : JSON.stringify(text.content).length;
+		return Math.ceil(len / 4);
 	}
 }
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -19,6 +19,7 @@ import { log, getRequestTokenUsage } from './extension.js';
 import { IChatRequestHandler } from './commands/index.js';
 import { getCommitChanges } from './git.js';
 import { getEnabledTools, getPositronContextPrompts } from './api.js';
+import { TokenUsage } from './tokens.js';
 
 export enum ParticipantID {
 	/** The participant used in the chat pane in Ask mode. */
@@ -588,7 +589,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		messages: (vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2)[],
 		tools: vscode.LanguageModelChatTool[],
 		system: string,
-	): Promise<{ inputTokens?: number; outputTokens?: number } | undefined> {
+	): Promise<{ provider: string; tokens: TokenUsage } | undefined> {
 		if (token.isCancellationRequested) {
 			return;
 		}

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -20,7 +20,46 @@ class MockAnthropicClient {
 			Parameters<Anthropic['messages']['stream']>,
 			ReturnType<Anthropic['messages']['stream']>
 		>().returns(mock<MessageStream>({
-			on: (event, listener) => mock<MessageStream>({}),
+			on: (event, listener) => {
+				if (event === 'streamEvent') {
+					const _listener = listener as (event: Anthropic.Messages.RawMessageStreamEvent) => void;
+					const events: Anthropic.Messages.RawMessageStreamEvent[] = [{
+						type: 'message_start',
+						message: {
+							id: 'mock-message-id',
+							model: 'mock-model',
+							type: "message",
+							stop_reason: null,
+							stop_sequence: null,
+							role: 'assistant',
+							content: [],
+							usage: {
+								server_tool_use: null,
+								cache_creation_input_tokens: 7000,
+								cache_read_input_tokens: 0,
+								input_tokens: 200,
+								output_tokens: 0,
+								service_tier: "standard"
+							},
+						}
+					}, {
+						type: 'message_delta',
+						delta: {
+							stop_reason: "end_turn",
+							stop_sequence: null,
+						},
+						usage: {
+							server_tool_use: null,
+							cache_creation_input_tokens: 7000,
+							cache_read_input_tokens: 0,
+							input_tokens: 200,
+							output_tokens: 2000,
+						},
+					}];
+					events.forEach(event => _listener(event));
+				}
+				return mock<MessageStream>({});
+			},
 			abort: () => { },
 			done: () => Promise.resolve(),
 			finalMessage: () => Promise.resolve(mock<Anthropic.Message>({})),
@@ -34,10 +73,17 @@ type ChatMessageValidateInfo = {
 	validate: (content: any[]) => void;
 };
 
+type MockAnthropicProgress = {
+	report: sinon.SinonStub<Parameters<vscode.Progress<{
+		index: number;
+		part: vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart | vscode.LanguageModelDataPart;
+	}>['report']>, void>;
+};
+
 suite('AnthropicLanguageModel', () => {
 	let model: AnthropicLanguageModel;
 	let mockClient: MockAnthropicClient;
-	let progress: vscode.Progress<vscode.ChatResponseFragment2>;
+	let progress: MockAnthropicProgress;
 	let cancellationToken: vscode.CancellationToken;
 
 	setup(() => {
@@ -144,6 +190,35 @@ suite('AnthropicLanguageModel', () => {
 			msg.content.some((content: any) => content.type === 'text' && content.text === nonEmptyText)
 		);
 		assert.strictEqual(hasMessageWithNonEmptyContent, true, 'Messages with non-empty content should be included');
+	});
+
+
+	suite('provideLanguageModelResponse response streaming behaviour', () => {
+		test('token usage is streamed back as part of the response', async () => {
+			const decoder = new TextDecoder();
+			const messages = [vscode.LanguageModelChatMessage.User('Token usage test')];
+			await provideLanguageModelResponse(messages);
+
+			const initialData = progress.report.getCall(0).args[0].part;
+			const initialExpected = { type: 'usage', data: { prompt_tokens: 7200, output_tokens: 0, cached_tokens: 0 } };
+			assert.ok(initialData instanceof vscode.LanguageModelDataPart, 'Initial response should be a LanguageModelDataPart');
+			assert.strictEqual(initialData.mimeType, 'text/x-json', 'Initial response should have `application/json` mimeType');
+
+			const initialObject = JSON.parse(decoder.decode(initialData.data));
+			assert.ok("provider_metadata" in initialObject.data, 'Initial response contains additional provider specific metadata.');
+			delete initialObject.data["provider_metadata"];
+			assert.deepStrictEqual(initialObject, initialExpected, 'Remaining initial usage data should decode as expected');
+
+			const finalData = progress.report.getCall(1).args[0].part;
+			const finalExpected = { type: 'usage', data: { prompt_tokens: 7200, output_tokens: 2000, cached_tokens: 0 } };
+			assert.ok(finalData instanceof vscode.LanguageModelDataPart, 'Final response should be a LanguageModelDataPart');
+			assert.strictEqual(finalData.mimeType, 'text/x-json', 'Final response should have `application/json` mimeType');
+
+			const finalObject = JSON.parse(decoder.decode(finalData.data));
+			assert.ok("provider_metadata" in finalObject.data, 'Final response contains additional provider specific metadata.');
+			delete finalObject.data["provider_metadata"];
+			assert.deepStrictEqual(finalObject, finalExpected, 'Remaining final usage data should decode as expected');
+		});
 	});
 
 	suite('provideLanguageModelResponse processes LanguageModelToolCallPart and LanguageModelToolResultPart contents correctly', () => {

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -35,9 +35,9 @@ class MockAnthropicClient {
 							content: [],
 							usage: {
 								server_tool_use: null,
-								cache_creation_input_tokens: 7000,
-								cache_read_input_tokens: 0,
-								input_tokens: 200,
+								cache_creation_input_tokens: 20,
+								cache_read_input_tokens: 20,
+								input_tokens: 80,
 								output_tokens: 0,
 								service_tier: "standard"
 							},
@@ -50,10 +50,10 @@ class MockAnthropicClient {
 						},
 						usage: {
 							server_tool_use: null,
-							cache_creation_input_tokens: 7000,
-							cache_read_input_tokens: 0,
-							input_tokens: 200,
-							output_tokens: 2000,
+							cache_creation_input_tokens: 20,
+							cache_read_input_tokens: 20,
+							input_tokens: 80,
+							output_tokens: 50,
 						},
 					}];
 					events.forEach(event => _listener(event));
@@ -200,23 +200,23 @@ suite('AnthropicLanguageModel', () => {
 			await provideLanguageModelResponse(messages);
 
 			const initialData = progress.report.getCall(0).args[0].part;
-			const initialExpected = { type: 'usage', data: { prompt_tokens: 7200, output_tokens: 0, cached_tokens: 0 } };
+			const initialExpected = { type: 'usage', data: { inputTokens: 100, outputTokens: 0, cachedTokens: 20 } };
 			assert.ok(initialData instanceof vscode.LanguageModelDataPart, 'Initial response should be a LanguageModelDataPart');
 			assert.strictEqual(initialData.mimeType, 'text/x-json', 'Initial response should have `application/json` mimeType');
 
 			const initialObject = JSON.parse(decoder.decode(initialData.data));
-			assert.ok("provider_metadata" in initialObject.data, 'Initial response contains additional provider specific metadata.');
-			delete initialObject.data["provider_metadata"];
+			assert.ok("providerMetadata" in initialObject.data, 'Initial response contains additional provider specific metadata.');
+			delete initialObject.data["providerMetadata"];
 			assert.deepStrictEqual(initialObject, initialExpected, 'Remaining initial usage data should decode as expected');
 
 			const finalData = progress.report.getCall(1).args[0].part;
-			const finalExpected = { type: 'usage', data: { prompt_tokens: 7200, output_tokens: 2000, cached_tokens: 0 } };
+			const finalExpected = { type: 'usage', data: { inputTokens: 100, outputTokens: 50, cachedTokens: 20 } };
 			assert.ok(finalData instanceof vscode.LanguageModelDataPart, 'Final response should be a LanguageModelDataPart');
 			assert.strictEqual(finalData.mimeType, 'text/x-json', 'Final response should have `application/json` mimeType');
 
 			const finalObject = JSON.parse(decoder.decode(finalData.data));
-			assert.ok("provider_metadata" in finalObject.data, 'Final response contains additional provider specific metadata.');
-			delete finalObject.data["provider_metadata"];
+			assert.ok("providerMetadata" in finalObject.data, 'Final response contains additional provider specific metadata.');
+			delete finalObject.data["providerMetadata"];
 			assert.deepStrictEqual(finalObject, finalExpected, 'Remaining final usage data should decode as expected');
 		});
 	});

--- a/extensions/positron-assistant/src/test/tokens.test.ts
+++ b/extensions/positron-assistant/src/test/tokens.test.ts
@@ -72,38 +72,42 @@ suite('TokenTracker', () => {
 
 		test('should restore valid token usage from stored data', () => {
 			const storedData = JSON.stringify([
-				[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }],
-				[TEST_PROVIDER_ID, { input: 200, output: 75 }]
+				[ANTHROPIC_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }],
+				[TEST_PROVIDER_ID, { inputTokens: 200, outputTokens: 75, cachedTokens: 20 }]
 			]);
 			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
 
 			const tracker = new TokenTracker(mockContext);
 
 			// Should set context for both providers
-			assert.strictEqual(executeCommandStub.callCount, 4);
+			assert.strictEqual(executeCommandStub.callCount, 6);
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.cached`, 20));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 200));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 75));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, 20));
 		});
 
 		test('should filter out invalid entries from stored data', () => {
 			const storedData = JSON.stringify([
-				[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }], // valid
+				[ANTHROPIC_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }], // valid
 				['invalid-entry'], // invalid - missing usage data
-				[TEST_PROVIDER_ID, { input: 'not-a-number', output: 75 }], // invalid - input not a number
-				['another-provider', { input: 200, output: 100 }] // valid
+				[TEST_PROVIDER_ID, { inputTokens: 'not-a-number', outputTokens: 75, cachedTokens: 20 }], // invalid - input not a number
+				['another-provider', { inputTokens: 200, outputTokens: 100, cachedTokens: 20 }] // valid
 			]);
 			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
 
 			const tracker = new TokenTracker(mockContext);
 
-			// Should only set context for valid entries (2 providers * 2 context keys each)
-			assert.strictEqual(executeCommandStub.callCount, 4);
+			// Should only set context for valid entries (2 providers * 3 context keys each)
+			assert.strictEqual(executeCommandStub.callCount, 6);
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.cached`, 20));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.another-provider.tokenCount.input`, 200));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.another-provider.tokenCount.output`, 100));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.another-provider.tokenCount.cached`, 20));
 		});
 
 		test('should handle JSON parse errors gracefully', () => {
@@ -165,7 +169,7 @@ suite('TokenTracker', () => {
 		test('should clear tokens for disabled providers when configuration changes', () => {
 			// Set up initial state with tokens for test provider
 			const storedData = JSON.stringify([
-				[TEST_PROVIDER_ID, { input: 100, output: 50 }]
+				[TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }]
 			]);
 			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
 
@@ -195,6 +199,7 @@ suite('TokenTracker', () => {
 			// Should clear context for the disabled provider
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, undefined));
 
 			// Should update workspace state
 			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, sinon.match.string));
@@ -242,14 +247,15 @@ suite('TokenTracker', () => {
 			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
 
 			// Now add tokens for the enabled provider
-			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 });
 
 			// Should set context for the provider
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 100));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, 20));
 
 			// Should update workspace state
-			const expectedData = JSON.stringify([[TEST_PROVIDER_ID, { input: 100, output: 50 }]]);
+			const expectedData = JSON.stringify([[TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }]]);
 			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
 		});
 
@@ -266,12 +272,13 @@ suite('TokenTracker', () => {
 			// Reset call count after initialization
 			executeCommandStub.resetHistory();
 
-			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
-			tracker.addTokens(TEST_PROVIDER_ID, 75, 25);
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 0 });
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 25, outputTokens: 25, cachedTokens: 100 });
 
 			// Should set context with accumulated values
-			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 175));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, 125));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, 75));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, 100));
 		});
 
 		test('should skip adding tokens for disabled provider', () => {
@@ -286,7 +293,7 @@ suite('TokenTracker', () => {
 			executeCommandStub.resetHistory();
 			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
 
-			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 0 });
 
 			// Should not set context or update state for disabled provider
 			assert.strictEqual(executeCommandStub.callCount, 0);
@@ -305,14 +312,15 @@ suite('TokenTracker', () => {
 			executeCommandStub.resetHistory();
 			(mockWorkspaceState.update as sinon.SinonStub).resetHistory();
 
-			tracker.addTokens(ANTHROPIC_PROVIDER_ID, 100, 50);
+			tracker.addTokens(ANTHROPIC_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 });
 
 			// Should set context for Anthropic provider even when not in config
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.input`, 100));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.output`, 50));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${ANTHROPIC_PROVIDER_ID}.tokenCount.cached`, 20));
 
 			// Should update workspace state
-			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { input: 100, output: 50 }]]);
+			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }]]);
 			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
 		});
 	});
@@ -320,7 +328,7 @@ suite('TokenTracker', () => {
 	suite('clearTokens', () => {
 		test('should clear tokens for existing provider', () => {
 			const storedData = JSON.stringify([
-				[TEST_PROVIDER_ID, { input: 100, output: 50 }]
+				[TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }]
 			]);
 			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
 
@@ -335,6 +343,7 @@ suite('TokenTracker', () => {
 			// Should delete context for the provider
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, undefined));
 
 			// Should update workspace state with empty data
 			const expectedData = JSON.stringify([]);
@@ -359,8 +368,8 @@ suite('TokenTracker', () => {
 
 		test('should preserve other providers when clearing one', () => {
 			const storedData = JSON.stringify([
-				[TEST_PROVIDER_ID, { input: 100, output: 50 }],
-				[ANTHROPIC_PROVIDER_ID, { input: 200, output: 75 }]
+				[TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 20 }],
+				[ANTHROPIC_PROVIDER_ID, { inputTokens: 200, outputTokens: 75, cachedTokens: 20 }]
 			]);
 			(mockWorkspaceState.get as sinon.SinonStub).withArgs(TOKEN_COUNT_KEY).returns(storedData);
 
@@ -375,9 +384,10 @@ suite('TokenTracker', () => {
 			// Should delete context for the cleared provider
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.input`, undefined));
 			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.output`, undefined));
+			assert.ok(executeCommandStub.calledWith('setContext', `positron-assistant.${TEST_PROVIDER_ID}.tokenCount.cached`, undefined));
 
 			// Should update workspace state with remaining provider
-			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { input: 200, output: 75 }]]);
+			const expectedData = JSON.stringify([[ANTHROPIC_PROVIDER_ID, { inputTokens: 200, outputTokens: 75, cachedTokens: 20 }]]);
 			assert.ok((mockWorkspaceState.update as sinon.SinonStub).calledWith(TOKEN_COUNT_KEY, expectedData));
 		});
 	});
@@ -392,8 +402,8 @@ suite('TokenTracker', () => {
 			const tracker = new TokenTracker(mockContext);
 
 			// Add tokens
-			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
-			tracker.addTokens(TEST_PROVIDER_ID, 25, 10);
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 0 });
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 25, outputTokens: 10, cachedTokens: 100 });
 
 			// Clear tokens
 			tracker.clearTokens(TEST_PROVIDER_ID);
@@ -414,8 +424,8 @@ suite('TokenTracker', () => {
 			const tracker = new TokenTracker(mockContext);
 
 			// Add tokens for both providers
-			tracker.addTokens(TEST_PROVIDER_ID, 100, 50);
-			tracker.addTokens('another-provider', 200, 75);
+			tracker.addTokens(TEST_PROVIDER_ID, { inputTokens: 100, outputTokens: 50, cachedTokens: 0 });
+			tracker.addTokens('another-provider', { inputTokens: 200, outputTokens: 75, cachedTokens: 0 });
 
 			// Clear only one provider
 			tracker.clearTokens(TEST_PROVIDER_ID);
@@ -426,7 +436,7 @@ suite('TokenTracker', () => {
 			assert.ok(lastCall, 'Expected at least one call to update');
 			const finalData = JSON.parse(lastCall.args[1]);
 			assert.strictEqual(finalData.length, 1);
-			assert.deepStrictEqual(finalData[0], ['another-provider', { input: 200, output: 75 }]);
+			assert.deepStrictEqual(finalData[0], ['another-provider', { inputTokens: 200, outputTokens: 75, cachedTokens: 0 }]);
 		});
 	});
 });

--- a/extensions/positron-assistant/src/tokens.ts
+++ b/extensions/positron-assistant/src/tokens.ts
@@ -6,9 +6,24 @@
 import * as vscode from 'vscode';
 import { AnthropicLanguageModel } from './anthropic.js';
 
+export type TokenUsage = {
+	/** The number of input tokens, not including tokens read from cache. */
+	inputTokens: number;
+	/** The number of output tokens in responses. */
+	outputTokens: number;
+	/** The number of tokens that have been read from cache. */
+	cachedTokens: number;
+	/** Provider specific metadata with additional usage details. */
+	providerMetadata?: any;
+};
+
+export function isTokenUsage(obj: any): obj is TokenUsage {
+	return obj && typeof obj.inputTokens === 'number' && typeof obj.outputTokens === 'number' && typeof obj.cachedTokens === 'number';
+}
+
 export class TokenTracker {
 	private static DEFAULT_PROVIDERS = [AnthropicLanguageModel.source.provider.id];
-	private _tokenUsage: Map<string, { input: number; output: number }> = new Map();
+	private _tokenUsage: Map<string, TokenUsage> = new Map();
 	private _enabledProviders: Set<string> = new Set([...TokenTracker.DEFAULT_PROVIDERS]);
 
 	private readonly TOKEN_COUNT_KEY = 'positron.assistant.tokenCounts';
@@ -18,7 +33,7 @@ export class TokenTracker {
 
 		if (!tokenTrackerData || typeof tokenTrackerData !== 'string') {
 			// Initialize with an empty Map if no data is found
-			this._tokenUsage = new Map<string, { input: number; output: number }>();
+			this._tokenUsage = new Map<string, TokenUsage>();
 		} else {
 
 			try {
@@ -31,22 +46,21 @@ export class TokenTracker {
 						typeof entry[0] === 'string' &&
 						typeof entry[1] === 'object' &&
 						entry[1] !== null &&
-						typeof entry[1].input === 'number' &&
-						typeof entry[1].output === 'number'
+						isTokenUsage(entry[1])
 					);
 					this._tokenUsage = new Map(validEntries);
 				} else {
-					this._tokenUsage = new Map<string, { input: number; output: number }>();
+					this._tokenUsage = new Map<string, TokenUsage>();
 				}
 			} catch (error) {
 				// Handle JSON parse errors or undefined tokenTrackerData
-				this._tokenUsage = new Map<string, { input: number; output: number }>();
+				this._tokenUsage = new Map<string, TokenUsage>();
 			}
 		}
 
 		// set context for each provider's token count
 		for (const [provider, tokens] of this._tokenUsage.entries()) {
-			this.updateContext(provider, tokens.input, tokens.output);
+			this.updateContext(provider, tokens.inputTokens, tokens.outputTokens, tokens.cachedTokens);
 		}
 
 		// Read initial configuration
@@ -70,21 +84,22 @@ export class TokenTracker {
 		});
 	}
 
-	public addTokens(provider: string, inputTokens: number, outputTokens: number): void {
+	public addTokens(provider: string, tokens: TokenUsage): void {
 		if (!this._enabledProviders.has(provider)) {
 			return; // Skip if token counting is disabled
 		}
 
 		if (!this._tokenUsage.has(provider)) {
-			this._tokenUsage.set(provider, { input: 0, output: 0 });
+			this._tokenUsage.set(provider, { inputTokens: 0, outputTokens: 0, cachedTokens: 0 });
 		}
 
 		const currentTokens = this._tokenUsage.get(provider)!;
-		currentTokens.input += inputTokens;
-		currentTokens.output += outputTokens;
+		currentTokens.inputTokens += tokens.inputTokens;
+		currentTokens.outputTokens += tokens.outputTokens;
+		currentTokens.cachedTokens += tokens.cachedTokens;
 
 		this._tokenUsage.set(provider, currentTokens);
-		this.updateContext(provider, currentTokens.input, currentTokens.output);
+		this.updateContext(provider, currentTokens.inputTokens, currentTokens.outputTokens, currentTokens.cachedTokens);
 		this._context.workspaceState.update(this.TOKEN_COUNT_KEY, JSON.stringify(Array.from(this._tokenUsage.entries())));
 	}
 
@@ -96,8 +111,9 @@ export class TokenTracker {
 		}
 	}
 
-	private updateContext(provider: string, input?: number, output?: number): void {
+	private updateContext(provider: string, input?: number, output?: number, cached?: number): void {
 		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.input`, input);
 		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.output`, output);
+		vscode.commands.executeCommand('setContext', `positron-assistant.${provider}.tokenCount.cached`, cached);
 	}
 }

--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -102,6 +102,10 @@ class LanguageModelResponse {
 				out = new extHostTypes.LanguageModelTextPart(fragment.part.value, fragment.part.audience);
 			} else if (fragment.part.type === 'data') {
 				out = new extHostTypes.LanguageModelTextPart('');
+				// --- Start Positron ---
+				// Enable LanguageModelDataPart fragments in the response stream
+				out = new extHostTypes.LanguageModelDataPart(fragment.part.value.data.buffer, fragment.part.value.mimeType) as any;
+				// --- End Positron ---
 			} else {
 				out = new extHostTypes.LanguageModelToolCallPart(fragment.part.toolCallId, fragment.part.name, fragment.part.parameters);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1862,24 +1862,26 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	/**
 	 * Calculate the total token usage from a view model's items
 	 */
-	private calculateTotalTokenUsage(viewModel: any): { totalInputTokens: number; totalOutputTokens: number } | undefined {
+	private calculateTotalTokenUsage(viewModel: any): { totalInputTokens: number; totalOutputTokens: number; totalCachedTokens: number } | undefined {
 		if (!viewModel) {
 			return undefined;
 		}
 
 		let totalInputTokens = 0;
 		let totalOutputTokens = 0;
+		let totalCachedTokens = 0;
 		let hasAnyTokenUsage = false;
 
 		for (const item of viewModel.getItems()) {
 			if (isResponseVM(item) && item.tokenUsage && item.isComplete) {
-				totalInputTokens += item.tokenUsage.inputTokens;
-				totalOutputTokens += item.tokenUsage.outputTokens;
+				totalInputTokens += item.tokenUsage.tokens.inputTokens;
+				totalOutputTokens += item.tokenUsage.tokens.outputTokens;
+				totalCachedTokens += item.tokenUsage.tokens.cachedTokens;
 				hasAnyTokenUsage = true;
 			}
 		}
 
-		return hasAnyTokenUsage ? { totalInputTokens, totalOutputTokens } : undefined;
+		return hasAnyTokenUsage ? { totalInputTokens, totalOutputTokens, totalCachedTokens } : undefined;
 	}
 
 	/**
@@ -1900,7 +1902,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				dom.clearNode(this.tokenUsageContainer);
 				this.tokenUsageContainer.appendChild(
 					dom.$('.token-usage-total', undefined,
-						localize('totalTokenUsage', "Total tokens: ↑{0} ↓{1}", totalTokens.totalInputTokens, totalTokens.totalOutputTokens)
+						localize('totalTokenUsage', "Total tokens: ↑{0} ↓{1} ↩{2}", totalTokens.totalInputTokens, totalTokens.totalOutputTokens, totalTokens.totalCachedTokens)
 					)
 				);
 				this.tokenUsageContainer.style.display = 'block';

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -720,7 +720,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		const tokenUsageElements = templateData.value.getElementsByClassName('token-usage');
 		if (element.tokenUsage && element.isComplete && showTokens && experimentalTokenUsage.includes(element.tokenUsage.provider)) {
-			const tokenUsageText = localize('tokenUsage', "Tokens: ↑{0} ↓{1}", element.tokenUsage.inputTokens, element.tokenUsage.outputTokens);
+			const tokenUsageText = localize('tokenUsage', "Tokens: ↑{0} ↓{1} ↩{2}", element.tokenUsage.tokens.inputTokens, element.tokenUsage.tokens.outputTokens, element.tokenUsage.tokens.cachedTokens);
 			if (tokenUsageElements.length > 0) {
 				tokenUsageElements[0].textContent = tokenUsageText;
 			} else {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -560,10 +560,11 @@ class ChatStatusDashboard extends Disposable {
 			providers.forEach(provider => {
 				const inputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.input`);
 				const outputCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.output`);
+				const cachedCount = this.contextKeyService.getContextKeyValue(`positron-assistant.${provider.id}.tokenCount.cached`);
 				if (typeof inputCount === 'number' && typeof outputCount === 'number') {
 					const span = document.createElement('div');
 
-					span.innerText = `${provider.displayName}: ↑${inputCount} ↓${outputCount}`;
+					span.innerText = `${provider.displayName}: ↑${inputCount} ↓${outputCount} ↩${cachedCount}`;
 					details.push(span);
 				} else {
 					// add an element to the container with the name and a message

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -152,8 +152,11 @@ export interface IResponse {
 // --- Start Positron ---
 export interface IChatTokenUsage {
 	readonly provider: string;
-	readonly inputTokens: number;
-	readonly outputTokens: number;
+	readonly tokens: {
+		inputTokens: number;
+		outputTokens: number;
+		cachedTokens: number;
+	};
 }
 // --- End Positron ---
 


### PR DESCRIPTION
This PR makes two main changes:

1) Track the number of tokens read from cache, and include it in the token counting UI display.

2) Include token count usage statistics as part of the output stream for extensions using the LangaugeModel API. This feature will be useful for Databot in particular.

---

A few other notes:
* I've standardised token count reporting into a data structure as follows, based on conversations with @wch and @timtmok. This is a compromise between the raw usage responses given by OpenAI, Anthropic, and Vercel AI.

https://github.com/posit-dev/positron/blob/2767e01193fe66da9e87832f3dd97860c3b46150/extensions/positron-assistant/src/tokens.ts#L9-L18

* Adding usage information to the output stream has been done with a JSON `LanguageModelDataPart`. Upstream has almost all of the code to do this already, except it has been disabled in our current version of Code OSS. I have added a temporary change in `extHostLanguageModels.ts` to re-enable emitting `LanguageModelDataPart`s. I expect in the next upstream merge we'll be able to remove that patch.

https://github.com/posit-dev/positron/blob/34076b425bf2d7fd6a79bf0ec30965fc69263b28/src/vs/workbench/api/common/extHostLanguageModels.ts#L103-L108

* I've used the ↩ symbol to denote input tokens read from a cache hit. I would not mind another symbol, but it is IMO the best of the currently allowed Unicode:

https://github.com/posit-dev/positron/blob/a65a1831ee567de8bc9120c7376138c472b54c6c/build/hygiene.js#L85

* I've tweaked the Vercel AI provider's `provideTokenCount()` to use a slightly better approximation.

---

### QA Notes

I've tried to update the unit tests to follow the new token usage data structure and also to test the cached token count as best I can.

#### Testing

* Ensure you have `"positron.assistant.showTokenUsage.enable": true,`.
* Use Positron Assistant, observe that the number of cached input tokens increase as you talk to the model.

<img width="777" height="893" alt="Screenshot 2025-09-05 at 13 37 48" src="https://github.com/user-attachments/assets/5c2ce384-1606-470f-9e96-9e1d433b973c" />

