### PR TITLE
Allow usage of private css variables

### DIFF
--- a/build/lib/stylelint/validateVariableNames.js
+++ b/build/lib/stylelint/validateVariableNames.js
@@ -29,6 +29,12 @@ function getVariableNameValidator() {
         while (match = RE_VAR_PROP.exec(value)) {
             const variableName = match[1];
             if (variableName && !allVariables.has(variableName) && !iconVariable.test(variableName)) {
+                // --- Start Positron ---
+                // Skip validation for private variables (those starting with --_)
+                if (variableName.startsWith('--_')) {
+                    continue;
+                }
+                // --- End Positron ---
                 report(variableName);
             }
         }

--- a/build/lib/stylelint/validateVariableNames.ts
+++ b/build/lib/stylelint/validateVariableNames.ts
@@ -32,6 +32,12 @@ export function getVariableNameValidator(): IValidator {
 		while (match = RE_VAR_PROP.exec(value)) {
 			const variableName = match[1];
 			if (variableName && !allVariables.has(variableName) && !iconVariable.test(variableName)) {
+				// --- Start Positron ---
+				// Skip validation for private variables (those starting with --_)
+				if (variableName.startsWith('--_')) {
+					continue;
+				}
+				// --- End Positron ---
 				report(variableName);
 			}
 		}


### PR DESCRIPTION
This PR updates the css variable name validator to allow for "private" variables. These are CSS variables not meant for themeing etc but used to simplify the implementation of styles. 

Often adding simple design-tokens to the outer scope of a component and then using those within for individual styles (e.g. matching border radius with widths etc...) makes for much cleaner and easier to reason about css. 

Prior to this PR I often found myself creating more opaque and harder to maintain css in an effort to avoid the commit hook hygiene tests. 


Here's an example of how these are used from #9294

```css
/* Define common properties for the selection bar */
.positron-notebook-cell {
	--_positron-notebook-selection-bar-radius: var(--vscode-positronNotebook-cell-radius);
	--_positron-notebook-selection-bar-width: 7px;
	--_positron-notebook-selection-bar-top-offset: 5px;
	--_positron-notebook-selection-bar-inset: 0;
}

/* Base styles for selected and editing states */
.positron-notebook-cell.selected,
.positron-notebook-cell.editing {
	position: relative;
	/* Otherwise the outline is forced by monaco styles */
	outline: none !important;
}

/* Position containers relative for selection bar placement */
.positron-notebook-cell.selected .positron-notebook-editor-container,
.positron-notebook-cell.selected .positron-notebook-cell-outputs,
.positron-notebook-cell.editing .positron-notebook-editor-container,
.positron-notebook-cell.editing .positron-notebook-cell-outputs {
	position: relative;
}

/* Common base styles for all selection bars */
.positron-notebook-cell.selected .positron-notebook-editor-container::before,
.positron-notebook-cell.editing .positron-notebook-editor-container::before,
.positron-notebook-cell.selected .positron-notebook-cell-outputs::before,
.positron-notebook-cell.editing .positron-notebook-cell-outputs::before {
	content: "";
	position: absolute;
	width: var(--_positron-notebook-selection-bar-width);
	background-color: var(--vscode-focusBorder);
	z-index: 1;
	left: var(--_positron-notebook-selection-bar-inset);
	top: var(--_positron-notebook-selection-bar-inset);
	bottom: var(--_positron-notebook-selection-bar-inset);
}

/* Don't round bottom corner for editor bar to make it look like a continuous bar*/
.positron-notebook-cell.selected .positron-notebook-editor-container::before,
.positron-notebook-cell.editing .positron-notebook-editor-container::before {
	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);
	border-bottom-left-radius: 0;
}

/* Specific positioning for outputs bar */
.positron-notebook-cell.selected .positron-notebook-cell-outputs::before,
.positron-notebook-cell.editing .positron-notebook-cell-outputs::before {
	/* Push bar down slightly so there's a gap between the editor and outputs */
	top: var(--_positron-notebook-selection-bar-top-offset);
	/* Don't round top corner for outputs bar to make it look like a continuous bar*/
	border-top-left-radius: 0;
	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
}

/* When outputs are empty, round both corners of editor bar */
.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::before,
.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::before {
	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
}

/* When editor container is empty, round both corners of outputs bar (This is the case when markdown has been rendered but doesn't have an editor open) */
.positron-notebook-cell.selected:has(.positron-notebook-editor-container.editor-hidden) .positron-notebook-cell-outputs::before {
	top: var(--_positron-notebook-selection-bar-inset);
	border-top-left-radius: var(--_positron-notebook-selection-bar-radius);
}
```

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

This is purely a dev-ops change so nothing should change in the output. PR #9294 uses this so if that gets merged before this there may be build warnings?
