### PR TITLE
Assistant: executeCode tool renders code properly

### DIFF
--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -134,11 +134,14 @@ export function registerAssistantTools(
 		 * @returns A vscode.PreparedToolInvocation object
 		 */
 		prepareInvocation: async (options, token) => {
+			const codeBlock = new vscode.MarkdownString();
+			codeBlock.appendCodeblock(options.input.code, options.input.language);
 
 			// Ask user for confirmation before proceeding
 			const result: vscode.PreparedToolInvocation = {
 				// The command (code to run)
-				invocationMessage: options.input.code,
+				// Now a Markdown string to enable rich code block rendering
+				invocationMessage: codeBlock,
 
 				// The language (used for syntax highlighting)
 				// language: options.input.language,
@@ -146,7 +149,9 @@ export function registerAssistantTools(
 				/// The message shown to confirm that the user wants to run the code.
 				confirmationMessages: {
 					title: options.input.summary ?? vscode.l10n.t('Run Code'),
-					message: `\`\`\`${options.input.language}\n${options.input.code}\n\`\`\``
+					// Markdown string to enable rich code block rendering
+					// Standard string loses copy/apply in editor actions
+					message: codeBlock
 				},
 			};
 			return result;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -119,7 +119,12 @@ export class ToolConfirmationSubPart extends BaseChatToolInvocationSubPart {
 			));
 		} else {
 			const codeBlockRenderOptions: ICodeBlockRenderOptions = {
-				hideToolbar: true,
+				// --- Start Positron ---
+				// Show the toolbar for code execution tool confirmations to allow copy/apply in editor
+
+				// hideToolbar: true,
+				hideToolbar: toolInvocation.toolId !== 'executeCode',
+				// --- End Positron ---
 				reserveWidth: 19,
 				verticalPadding: 5,
 				editorOptions: {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -25,6 +25,9 @@ import { ToolConfirmationSubPart } from './chatToolConfirmationSubPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 import { ChatToolOutputSubPart } from './chatToolOutputPart.js';
 import { ChatToolProgressSubPart } from './chatToolProgressPart.js';
+// --- Start Positron ---
+import { ChatToolMarkdownProgressPart } from './chatToolMarkdownProgressPart.js';
+// --- End Positron ---
 
 export class ChatToolInvocationPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;
@@ -136,6 +139,14 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				this.currentWidthDelegate
 			);
 		}
+		// --- Start Positron ---
+		// Custom rendering for code block of executeCode tool
+		// This is after it is executed or canceled
+		// Before execution is handled by the first if-block in this method
+		if (this.toolInvocation.toolId === 'executeCode') {
+			return this.instantiationService.createInstance(ChatToolMarkdownProgressPart, this.toolInvocation, this.context, this.renderer, this.editorPool, this.currentWidthDelegate, this.codeBlockStartIndex, this.codeBlockModelCollection);
+		}
+		// --- End Positron ---
 
 		return this.instantiationService.createInstance(ChatToolProgressSubPart, this.toolInvocation, this.context, this.renderer);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolMarkdownProgressPart.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IChatMarkdownContent, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
+import { CodeBlockModelCollection } from '../../../common/codeBlockModelCollection.js';
+import { IChatCodeBlockInfo } from '../../chat.js';
+import { ICodeBlockRenderOptions } from '../../codeBlockPart.js';
+import { IChatContentPartRenderContext } from '../chatContentParts.js';
+import { ChatMarkdownContentPart, EditorPool } from '../chatMarkdownContentPart.js';
+import { ChatCustomProgressPart } from '../chatProgressContentPart.js';
+import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
+
+
+/**
+ * A chat content part for rendering a tool invocation with Markdown content with rich code blocks.
+ * Logic adapted from the ChatTerminalMarkdownProgressPart, removing terminal-specific logic.
+ */
+export class ChatToolMarkdownProgressPart extends BaseChatToolInvocationSubPart {
+	public readonly domNode: HTMLElement;
+
+	private markdownPart: ChatMarkdownContentPart | undefined;
+	public get codeblocks(): IChatCodeBlockInfo[] {
+		return this.markdownPart?.codeblocks ?? [];
+	}
+
+	constructor(
+		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
+		context: IChatContentPartRenderContext,
+		renderer: MarkdownRenderer,
+		editorPool: EditorPool,
+		currentWidthDelegate: () => number,
+		codeBlockStartIndex: number,
+		codeBlockModelCollection: CodeBlockModelCollection,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super(toolInvocation);
+
+		const content = toolInvocation.invocationMessage;
+		const chatMarkdownContent: IChatMarkdownContent = {
+			kind: 'markdownContent',
+			content: typeof content === 'string' ? new MarkdownString(content) : content,
+		};
+
+		const codeBlockRenderOptions: ICodeBlockRenderOptions = {
+			hideToolbar: toolInvocation.toolId !== 'executeCode',
+			reserveWidth: 19,
+			verticalPadding: 5,
+			editorOptions: {
+				wordWrap: 'on'
+			}
+		};
+		this.markdownPart = this._register(instantiationService.createInstance(ChatMarkdownContentPart, chatMarkdownContent, context, editorPool, false, codeBlockStartIndex, renderer, currentWidthDelegate(), codeBlockModelCollection, { codeBlockRenderOptions }));
+		this._register(this.markdownPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
+		const icon = !toolInvocation.isConfirmed ?
+			Codicon.error :
+			toolInvocation.isComplete ?
+				Codicon.check : ThemeIcon.modify(Codicon.loading, 'spin');
+		const progressPart = instantiationService.createInstance(ChatCustomProgressPart, this.markdownPart.domNode, icon);
+		this.domNode = progressPart.domNode;
+	}
+}


### PR DESCRIPTION
The 1.103 merge changed tool interfaces, and the `executeCode` tool moved from using an internal terminal-specific tool API to the new public tool API. This changed the flow of how blocks were rendered.

This PR updates the code paths in core to add a special case for `executeCode` which allows the generated code to be rendered using rich, interactive code blocks once again. 

<img width="563" height="600" alt="Screenshot 2025-09-05 at 3 24 10 PM" src="https://github.com/user-attachments/assets/07e7b498-f460-4f58-8f8b-9c72576dec99" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- The action toolbar is now present on code generated for the `executeCode` tool, allowing users to copy/apply in editor/etc. (#7040)
- The code maintains proper styling & interactivity even once executed/discarded. (#9183)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:assistant

We want to make sure that code in this case has the floating toolbar and maintains styling:
- Before execution,
- After execution,
- After canceling/discarding,
- After reloading Positron

You have to be sure that Assistant is actually calling `executeCode` and not just generating a code block; the prompt in #7040 was reliable in testing this in Agent mode.