### PR TITLE
Add command to fill symbol to end of line

### DIFF
--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -6,6 +6,7 @@
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { EditorAction, registerEditorAction, ServicesAccessor } from '../../../browser/editorExtensions.js';
 import { ISingleEditOperation } from '../../../common/core/editOperation.js';
+import * as nls from '../../../../nls.js';
 import { IPosition } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
 import { Selection } from '../../../common/core/selection.js';
@@ -175,8 +176,7 @@ export class FillToEndOfLineAction extends EditorAction {
 	constructor() {
 		super({
 			id: FillToEndOfLineAction.ID,
-			label: 'Fill Symbol to End of Line',
-			alias: 'Fill Symbol to End of Line',
+			label: nls.localize2('positron.fillToEndOfline', 'Fill Symbol to End of Line'),
 			precondition: EditorContextKeys.writable,
 		});
 	}

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -210,7 +210,7 @@ export class FillToEndOfLineAction extends EditorAction {
 			// Only fill if target column is greater than current position
 			if (targetColumn > currentColumn) {
 				const fillLength = targetColumn - currentColumn;
-				const fillString = fillChar.repeat(fillLength + 1);
+				const fillString = fillChar.repeat(fillLength + 1) + '\n';
 
 				commands.push(new ReplaceCommand(new Range(lineNumber, currentColumn, lineNumber, currentColumn), fillString));
 			}

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -18,6 +18,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { EnterOperation } from '../../../common/cursor/cursorTypeEditOperations.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 
 interface IPositronCommentMarkers {
 	startText: string;
@@ -225,6 +226,10 @@ export class FillToEndOfLineAction extends EditorAction {
 			id: FillToEndOfLineAction.ID,
 			label: nls.localize2('positron.fillToEndOfline', 'Fill Symbol to End of Line'),
 			precondition: EditorContextKeys.writable,
+			kbOpts: {
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyL),
+				weight: 100
+			}
 		});
 	}
 


### PR DESCRIPTION
Adds a command that fills a symbol from the cursor position to the end of the line, like this:

```
# foo <fill>
=>
# foo --------------------------------------------------------------
```

By default, it'll fill from the cursor position to column 80 with the `-` character, like the _Insert Dashes_ addin: https://github.com/mine-cetinkaya-rundel/addmins/blob/master/R/insert_dashes.R

However, it is a little more flexible:

### Fill with custom character

If the character to the _left_ of your cursor is a symbol, it will use that instead of `-` as the fill character. So e.g:

```
// ** foo **<fill>
=>
// ** foo ***************************************************
```

### Fill to custom column

If you have defined any ruler columns, it will fill to the first ruler column instead of column 80.

### Roll-your-own

Finally, the command can be called from extensions with arguments specifying the fill character and fill column.

Default keybinding: <kbd>Cmd</kbd> <kbd>K</kbd>, <kbd>L</kbd> (mnemonic: fill to end of **L**ine).

Addresses https://github.com/posit-dev/positron/issues/9114

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- New command _Fill Symbol to End of Line_ to fill the remainder of the line with a given symbol, such as `-` (#9114)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
