### PR TITLE
data explorer: add + guard keybinding for convert-to-code

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -61,7 +61,6 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { getPathForFile } from '../../../../platform/dnd/browser/dnd.js';
-import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR } from '../../positronDataExplorerEditor/browser/positronDataExplorerContextKeys.js';
 
 export const NEW_FILE_COMMAND_ID = 'explorer.newFile';
 export const NEW_FILE_LABEL = nls.localize2('newFile', "New File...");
@@ -839,9 +838,7 @@ export class CompareWithClipboardAction extends Action2 {
 			title: CompareWithClipboardAction.LABEL,
 			f1: true,
 			category: Categories.File,
-			keybinding: {
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib, when: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR.negate()
-			},
+			keybinding: { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib },
 			metadata: {
 				description: nls.localize2('compareWithClipboardMeta', "Opens a new diff editor to compare the active file with the contents of the clipboard.")
 			}

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -61,6 +61,7 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { getPathForFile } from '../../../../platform/dnd/browser/dnd.js';
+import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR } from '../../positronDataExplorerEditor/browser/positronDataExplorerContextKeys.js';
 
 export const NEW_FILE_COMMAND_ID = 'explorer.newFile';
 export const NEW_FILE_LABEL = nls.localize2('newFile', "New File...");
@@ -838,7 +839,9 @@ export class CompareWithClipboardAction extends Action2 {
 			title: CompareWithClipboardAction.LABEL,
 			f1: true,
 			category: Categories.File,
-			keybinding: { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib },
+			keybinding: {
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib, when: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR.negate()
+			},
 			metadata: {
 				description: nls.localize2('compareWithClipboardMeta', "Opens a new diff editor to compare the active file with the contents of the clipboard.")
 			}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -816,7 +816,7 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 						POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING,
 						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 				),
-				weight: KeybindingWeight.EditorContrib,
+				weight: KeybindingWeight.WorkbenchContrib + 1,
 				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC),
 			},
 			icon: Codicon.code,

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -808,6 +808,17 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 					POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING,
 					POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 			),
+			keybinding: {
+				when: ContextKeyExpr.and(
+					POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
+					POSITRON_DATA_EXPLORER_CODE_SYNTAXES_AVAILABLE,
+					ContextKeyExpr.or(
+						POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING,
+						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
+				),
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: undefined,
+			},
 			icon: Codicon.code,
 			menu: [
 				{

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -816,8 +816,8 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 						POSITRON_DATA_EXPLORER_IS_COLUMN_SORTING,
 						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 				),
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: undefined,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KeyQ,
 			},
 			icon: Codicon.code,
 			menu: [

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -817,7 +817,7 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 				),
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KeyQ,
+				primary: KeyMod.Shift | KeyCode.KeyC | KeyCode.KeyV,
 			},
 			icon: Codicon.code,
 			menu: [

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -817,7 +817,7 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 				),
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.Shift | KeyCode.KeyC | KeyCode.KeyV,
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyK,
 			},
 			icon: Codicon.code,
 			menu: [

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -5,7 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { DEFAULT_EDITOR_ASSOCIATION, EditorResourceAccessor, IEditorPane } from '../../../common/editor.js';
-import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -817,7 +817,7 @@ class PositronDataExplorerConvertToCodeModalAction extends Action2 {
 						POSITRON_DATA_EXPLORER_IS_ROW_FILTERING)
 				),
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyK,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC),
 			},
 			icon: Codicon.code,
 			menu: [


### PR DESCRIPTION
EDIT: updated to document the keybinding we landed on 👾 

We have to add _a_ keybinding in order to have the when clause be evaluated, so I made it `Cmd/Ctrl+K C`, but no strong feelings about this if folks like something else!

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- https://github.com/posit-dev/positron/issues/9278 Fixes bug where keybindings can forcibly open Convert to Code modal


### QA Notes

- try `Cmd/Ctrl+K C` in a file, no Convert to Code modal
- try `Cmd/Ctrl+K C` in a data explorer with no filters or sorts, no Convert to Code modal
- try `Cmd/Ctrl+K C` in a data explorer with filters or sorts, see Convert to Code modal