### PR TITLE
Refactor parent folder update logic in `FolderNameLocationStep` component

### DIFF
--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
@@ -148,14 +148,19 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 		);
 	};
 
-	// Navigate to the next step in the flow, based on the selected project type.
-	const nextStep = async () => {
-		// Update the parent folder URI in the context before navigating to the next step.
+	// Update the parent folder URI in the context.
+	const updateParentFolder = async () => {
 		context.parentFolder = await combineLabelWithPathUri(
 			parentFolder,
 			context.parentFolder,
 			pathService
 		);
+	};
+
+	// Navigate to the next step in the flow, based on the selected project type.
+	const nextStep = async () => {
+		// Update the parent folder URI in the context before navigating to the next step.
+		await updateParentFolder();
 
 		switch (context.folderTemplate) {
 			case FolderTemplate.RProject:
@@ -202,7 +207,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 	} else {
 		okNextButtonConfig = {
 			okButtonConfig: {
-				onClick: props.accept,
+				onClick: async () => {
+					await updateParentFolder();
+					props.accept();
+				},
 				disable: okNextButtonDisabled,
 				title: (() => localize(
 					'positronNewFolderFlow.createButtonTitle',


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8905

The "Empty Folder" template does not have a `nextStep`, so it was skipping the part of the logic that updated where the new folder gets put.

@:new-folder-flow

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed bug in parent folder handling ("Location") for _Workspaces: New Folder from Template..._ when using the "Empty Folder" template.


### QA Notes

- Run _Workspaces: New Folder from Template..._ and choose "Empty Folder"
- Choose a parent folder ("Location") that is _not_ the default
- Confirm that the new folder is created where you specified (not the default)
- Run _Workspaces: New Folder from Template..._ again and choose a different option
- Again, choose a parent folder ("Location") that is _not_ the default
- Confirm that this new folder also is created where you specified