### PR TITLE
Fix problem with Variables Pane group/sort menu buttons by tracking state

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
@@ -7,7 +7,7 @@
 import './groupingMenuButton.css';
 
 // React.
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -16,6 +16,7 @@ import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/b
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
 import { PositronVariablesGrouping } from '../../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
 /**
  * Localized strings.
@@ -30,15 +31,34 @@ export const GroupingMenuButton = () => {
 	// Context hooks.
 	const positronVariablesContext = usePositronVariablesContext();
 
+	// State for current grouping
+	const [currentGrouping, setCurrentGrouping] = useState<PositronVariablesGrouping | undefined>();
+
+	// Subscribe to changes in entries (which happen when grouping changes)
+	useEffect(() => {
+		const disposableStore = new DisposableStore();
+
+		if (positronVariablesContext.activePositronVariablesInstance) {
+			// Subscribe to entries changes
+			disposableStore.add(
+				positronVariablesContext.activePositronVariablesInstance.onDidChangeEntries(() => {
+					setCurrentGrouping(positronVariablesContext.activePositronVariablesInstance?.grouping);
+				})
+			);
+
+			// Set initial value
+			setCurrentGrouping(positronVariablesContext.activePositronVariablesInstance.grouping);
+		}
+
+		return () => disposableStore.dispose();
+	}, [positronVariablesContext.activePositronVariablesInstance]);
+
 	// Builds the actions.
 	const actions = () => {
 		// This can't happen.
 		if (positronVariablesContext.activePositronVariablesInstance === undefined) {
 			return [];
 		}
-
-		// Get the current grouping.
-		const grouping = positronVariablesContext.activePositronVariablesInstance.grouping;
 
 		// Build the actions.
 		const actions: IAction[] = [];
@@ -50,7 +70,7 @@ export const GroupingMenuButton = () => {
 			tooltip: '',
 			class: undefined,
 			enabled: true,
-			checked: grouping === PositronVariablesGrouping.None,
+			checked: currentGrouping === PositronVariablesGrouping.None,
 			run: () => {
 				if (!positronVariablesContext.activePositronVariablesInstance) {
 					return;
@@ -71,7 +91,7 @@ export const GroupingMenuButton = () => {
 			tooltip: '',
 			class: undefined,
 			enabled: true,
-			checked: grouping === PositronVariablesGrouping.Kind,
+			checked: currentGrouping === PositronVariablesGrouping.Kind,
 			run: () => {
 				if (!positronVariablesContext.activePositronVariablesInstance) {
 					return;
@@ -89,7 +109,7 @@ export const GroupingMenuButton = () => {
 			tooltip: '',
 			class: undefined,
 			enabled: true,
-			checked: grouping === PositronVariablesGrouping.Size,
+			checked: currentGrouping === PositronVariablesGrouping.Size,
 			run: () => {
 				if (!positronVariablesContext.activePositronVariablesInstance) {
 					return;

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -242,6 +242,9 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 */
 	set highlightRecent(highlighRecent: boolean) {
 		this._highlightRecent = highlighRecent;
+
+		// Update entries to trigger onDidChangeEntries event
+		this.updateEntries();
 	}
 
 	/**


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8921

Claude Code and I wrote this together, and I do think I learned a lot from experimenting in a part of the code base I am less familiar with. We were setting `checked` on all these actions for the context menus, but we were not tracking the state in any way; it never re-rendered those check marks in the context menu.

@:variables

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed state management for checkmarks in Variables pane context menus for sorting and grouping.


### QA Notes

- Run some code like this so you have a collection of objects in the Variables Pane:

```r
x <- rep("", 10)

for (i in 1:10) {
  x[i] <- paste("Howdy!", paste0(rep("🤠", i), collapse = ""))
}

y <- ggplot2::diamonds

aa <- function(formula) {
  lm(formula, data = mtcars)
}

bb <- function(foo) {
  summary(aa(foo))
}
```

- By default the objects are grouped by "Kind" and sorted by "Name"
- Change the grouping and confirm that the check updates in the context menu
- Change the sorting and confirm the check updates in that context menu as well
- You should be able to switch back and forth between all the options in both context menus
- You should also be able to toggle the "Highlight recent values" option
