### PR TITLE
Fix run magic to prevent misinterpretation of file paths with dash options

### DIFF
--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -117,7 +117,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                     // For now, just use the full path, passed through JSON encoding
                     // to ensure that it is properly escaped.
                     if (fsStat) {
-                        const command = `%run ${JSON.stringify(filePath)}`;
+                        // Use -- to ensure everything after is treated as the path, not flags
+                        // This prevents paths with -m (or other dash options) from being misinterpreted
+                        const command = `%run -- ${JSON.stringify(filePath)}`;
                         positron.runtime.executeCode('python', command, false, true);
                     }
                 } catch (e) {


### PR DESCRIPTION
This is currently a speculative fix for https://github.com/posit-dev/positron/issues/8948. I'm going to make some Windows builds for us to try out with this change.

EDIT: Working well, I believe!

This proposed fix is based on:

- https://ipython.readthedocs.io/en/8.31.0/interactive/magics.html#magic-run
- https://stackoverflow.com/questions/7610001/what-is-the-purpose-of-the-m-switch


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed mishandling of `-m` in Windows paths for the Python `%run` magic.


### QA Notes

This bug is Windows only. If a path contains `-m`, you should now be able to use the "Run" button in the Editor Action Bar to successfully run the file. For example, a file called `test-m-exec.py` containing this should run without error:

```python
print(1 + 1)
```