### PR TITLE
e2e: add sql test to `convert-to-code.test.ts`

### DIFF
--- a/test/e2e/pages/clipboard.ts
+++ b/test/e2e/pages/clipboard.ts
@@ -40,7 +40,7 @@ export class Clipboard {
 			const clipboardText = await this.getClipboardText();
 			expect(clipboardText).toBe(expectedText);
 		}).toPass({ timeout: 20000 });
-	}
+	};
 
 	async setClipboardText(text: string): Promise<void> {
 		// Grant permissions to write to clipboard


### PR DESCRIPTION
### Summary
Expanded `convert-to-code.test.ts` to include test case for Duck DB / sql code generation.

### QA Notes

@:data-exploer @:web @:win