### PR TITLE
E2E test: bump rocky images to 44

### DIFF
--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     container:
-      image: ghcr.io/posit-dev/positron-rocky8-amd64:42
+      image: ghcr.io/posit-dev/positron-rocky8-amd64:44
       options: --user 0:0
       # Static PAT is needed because the bot can't pass a token to the job for security reasons
       credentials:
@@ -99,7 +99,7 @@ jobs:
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
     services:
       postgres:
-        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:42
+        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:44
         credentials:
           username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
           password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}


### PR DESCRIPTION
Just bumping the version of the images I am working on. Will only affect my testing.

### QA Notes

