### PR TITLE
Fix Assistant tests

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -21,6 +21,21 @@ import { log } from './extension.js';
  * instructions and context for embedding in Copilot prompts.
  */
 export class PositronAssistantApi {
+
+	/** The singleton instance. */
+	private static _instance?: PositronAssistantApi;
+
+	/** An emitter for sign-in events */
+	private _signInEmitter = new vscode.EventEmitter<string>();
+
+	/** Get or create the singleton instance. */
+	public static get() {
+		if (!PositronAssistantApi._instance) {
+			PositronAssistantApi._instance = new PositronAssistantApi();
+		}
+		return PositronAssistantApi._instance;
+	}
+
 	/**
 	 * Generates assistant prompt content.
 	 *
@@ -82,6 +97,25 @@ export class PositronAssistantApi {
 	 */
 	public getEnabledTools(request: vscode.ChatRequest, tools: readonly vscode.LanguageModelToolInformation[]): Array<string> {
 		return getEnabledTools(request, tools);
+	}
+
+	/**
+	 * Called from the Assistant side to notify that a provider has signed in
+	 *
+	 * @param provider The provider that signed in
+	 */
+	public notifySignIn(provider: string) {
+		log.info(`[Assistant API] Provider signed in: ${provider}`);
+		this._signInEmitter.fire(provider)
+	}
+
+	/**
+	 * Notifies other extensions of a sign-in event
+	 *
+	 * @returns The event
+	 */
+	public onProviderSignIn(callback: (s: string) => void): vscode.Disposable {
+		return this._signInEmitter.event(callback);
 	}
 }
 

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -9,6 +9,7 @@ import { getLanguageModels } from './models';
 import { completionModels } from './completion';
 import { clearTokenUsage, disposeModels, log, registerModel } from './extension';
 import { CopilotService } from './copilot.js';
+import { PositronAssistantApi } from './api.js';
 
 export interface StoredModelConfig extends Omit<positron.ai.LanguageModelConfig, 'apiKey'> {
 	id: string;
@@ -239,6 +240,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 
 		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
 
+		PositronAssistantApi.get().notifySignIn(name);
+
 		vscode.window.showInformationMessage(
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
@@ -273,6 +276,9 @@ async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources:
 		}
 
 		await saveModel(userConfig, sources, storage, context);
+
+		PositronAssistantApi.get().notifySignIn(userConfig.provider);
+
 	} catch (error) {
 		if (error instanceof vscode.CancellationError) {
 			return;

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -335,5 +335,5 @@ export function activate(context: vscode.ExtensionContext) {
 			}));
 	}
 
-	return new PositronAssistantApi();
+	return PositronAssistantApi.get();
 }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -903,10 +903,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
 			const addLanguageModelMessage = hasAdditionalModels
 				? localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider")
-				: localize('positronAssistant.addLanguageModelMessageAnthropic', "Add Anthropic as a Chat Provider");
+				: localize('positronAssistant.addLanguageModelMessageAnthropic', "Add a Chat Provider");
 			welcomeText = hasAdditionalModels
 				? localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n")
-				: localize('positronAssistant.welcomeMessageAnthropic', "To use Positron Assistant Chat, you must first authenticate with Anthropic.\n");
+				: localize('positronAssistant.welcomeMessageAnthropic', "To use Positron Assistant Chat, you must first authenticate with Anthropic or Github.\n");
 			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.configureModels)`;
 		} else {
 			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -13,7 +13,7 @@ test.use({
 /**
  * Test suite for the setup of Positron Assistant.
  */
-test.describe.skip('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
+test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
 	/**
 	 * Verifies that the Positron Assistant can be opened and that the
 	 * add model button is visible in the interface. Once Assistant is on by default,


### PR DESCRIPTION
This change fixes a test regression in Assistant tests caused by Copilot registering stuff even if you aren't signed in to Github. The extension supports a provisional 'installed but not signed in' state, but we don't support that in Positron.

The fix is to prevent the Copilot extension from fully activating if Copilot isn't signed in.

This on its own would have been pretty straightforward, but we also _do_ want the extension to activate right away when Copilot is signed in, so you don't need to restart Positron after signing in. So most of the change is plumbing to notify the Copilot extension when sign-in is complete and have it fully activate at that time.

Test tags: `@:assistant`