### PR TITLE
assistant: bump `@github/copilot-language-server` to `^1.367.0`

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.57.0",
-        "@github/copilot-language-server": "^1.335.0",
+        "@github/copilot-language-server": "^1.367.0",
         "@vscode/prompt-tsx": "^0.4.0-alpha.5",
         "vscode-languageclient": "^9.0.1"
       },
@@ -1223,16 +1223,88 @@
       }
     },
     "node_modules/@github/copilot-language-server": {
-      "version": "1.335.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-language-server/-/copilot-language-server-1.335.0.tgz",
-      "integrity": "sha512-uX5t6kOlWau4WtpL/WQLL8qADE4iHSfbDojYRVq8kTIjg1u5w6Ty7wqddnfyPUIpTltifsBVoHjHpW5vdhf55g==",
-      "license": "https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features",
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server/-/copilot-language-server-1.367.0.tgz",
+      "integrity": "sha512-gkH1Sp3SA+BWHl2h/yIdy1kYOREesTp1CC+IrxYIUNjy0cjdkOm5rcF6oO6BIcJttRwT9Ug8C1J5guVXhWcsSg==",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "bin": {
         "copilot-language-server": "dist/language-server.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-language-server-darwin-arm64": "1.367.0",
+        "@github/copilot-language-server-darwin-x64": "1.367.0",
+        "@github/copilot-language-server-linux-arm64": "1.367.0",
+        "@github/copilot-language-server-linux-x64": "1.367.0",
+        "@github/copilot-language-server-win32-x64": "1.367.0"
       }
+    },
+    "node_modules/@github/copilot-language-server-darwin-arm64": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server-darwin-arm64/-/copilot-language-server-darwin-arm64-1.367.0.tgz",
+      "integrity": "sha512-RvU/r/heRW0x4dchB/zfb+sUGHHXXFqT+ujFqtGeTy0NoBJlbuHEZt/9uUb09reHUVLtsJgA/NMiuM0Ffbe0fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@github/copilot-language-server-darwin-x64": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server-darwin-x64/-/copilot-language-server-darwin-x64-1.367.0.tgz",
+      "integrity": "sha512-gBko0MnYTwvgKeogGoYsamzlZysy5EiRyf0UffMeyU890PtoOrrx3sTRyid21/AnkFbtbbaJCUO13qDPzgAYSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@github/copilot-language-server-linux-arm64": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server-linux-arm64/-/copilot-language-server-linux-arm64-1.367.0.tgz",
+      "integrity": "sha512-fELeHDxgBLxWmWP8Igi7s2HOdkRMn85BOzBu+iUxmK4US9JDBTW1Fi6g+w5yyLgVXZKHw1uIBOnciSuwtdApag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@github/copilot-language-server-linux-x64": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server-linux-x64/-/copilot-language-server-linux-x64-1.367.0.tgz",
+      "integrity": "sha512-+w436KnasBiWKXayTmvfwjyJ0yHavIDqD1PWV4+MAB5y2ehXbivMswInbc2q1C88NnfA0HhFzqxbXVqrTyKUkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@github/copilot-language-server-win32-x64": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-language-server-win32-x64/-/copilot-language-server-win32-x64-1.367.0.tgz",
+      "integrity": "sha512-7xp9FfasDqVoMCllA3yq6SNxop4V4RilOGLvFZc6eKvz145xeNUm8AQVXmHQJKscyVS8UFGazKWb2jAgGzVR/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -601,7 +601,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.57.0",
-    "@github/copilot-language-server": "^1.335.0",
+    "@github/copilot-language-server": "^1.367.0",
     "@vscode/prompt-tsx": "^0.4.0-alpha.5",
     "vscode-languageclient": "^9.0.1"
   },


### PR DESCRIPTION
- Addresses: https://github.com/posit-dev/positron/issues/9255
- Bumps `@github/copilot-language-server` in the Assistant extension to https://github.com/github/copilot-language-server-release/releases/tag/1.367.0

### Release Notes

#### New Features

- Assistant: bumped Copilot Language Server to `1.367.0` (#9255)

### QA Notes

The following should continue to work on Win/Lin/Mac:

- Logging in and out to Copilot in the Provider Configuration Dialog
- Inline completions in code files
- Chat with Copilot as the model provider