### PR TITLE
Positron Notebooks: Refactor observables and add `cell.index`

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/EnvironmentProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/EnvironmentProvider.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 // Other dependencies.
 import { ISize } from '../../../../base/browser/positronReactRenderer.js';
-import { ISettableObservable } from '../../../../base/common/observable.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 
 /**
@@ -18,7 +18,7 @@ interface EnvironmentBundle {
 	/**
 	 * An observable for the size of the notebook.
 	 */
-	size: ISettableObservable<ISize>;
+	size: IObservable<ISize>;
 
 	/**
 	 * A callback to get the scoped context key service for a given container.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -3,10 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISettableObservable } from '../../../../base/common/observable.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { SelectionStateMachine } from './selectionMachine.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
@@ -43,7 +43,7 @@ export interface IPositronNotebookInstance {
 	 * Unique identifier for the notebook instance. Used for debugging and claiming
 	 * ownership of various resources.
 	 */
-	id: string;
+	readonly id: string;
 
 	/**
 	 * URI of the notebook file being edited. This serves as the unique identifier
@@ -73,31 +73,31 @@ export interface IPositronNotebookInstance {
 	 * Observable array of cells that make up the notebook. Changes to this array
 	 * will trigger UI updates in connected views.
 	 */
-	cells: ISettableObservable<IPositronNotebookCell[]>;
+	readonly cells: IObservable<IPositronNotebookCell[]>;
 
 	/**
 	 * Observable status of the notebook's kernel connection. UI elements can
 	 * react to changes in kernel connectivity.
 	 */
-	kernelStatus: ISettableObservable<KernelStatus>;
+	readonly kernelStatus: IObservable<KernelStatus>;
 
 	/**
 	 * Observable reference to the current runtime session for the notebook.
 	 * This manages the connection to the kernel and execution environment.
 	 */
-	currentRuntime: ISettableObservable<ILanguageRuntimeSession | undefined>;
+	readonly currentRuntime: IObservable<ILanguageRuntimeSession | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.
 	 * Handles complex selection scenarios like multi-select and keyboard navigation.
 	 */
-	selectionStateMachine: SelectionStateMachine;
+	readonly selectionStateMachine: SelectionStateMachine;
 
 	/**
 	 * Indicates whether this notebook instance has been disposed.
 	 * Used to prevent operations on destroyed instances.
 	 */
-	isDisposed: boolean;
+	readonly isDisposed: boolean;
 
 	/**
 	 * Indicates whether this notebook is read-only and cannot be edited.

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookVisibilityContext.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookVisibilityContext.tsx
@@ -5,14 +5,14 @@
 
 // React.
 import React, { PropsWithChildren, createContext, useContext } from 'react';
+import { IObservable } from '../../../../base/common/observable.js';
 
 // Other dependencies.
-import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
 
 /**
  * Create the notebook visibility context.
  */
-const NotebookVisibilityContext = createContext<ISettableObservable<boolean>>(undefined!);
+const NotebookVisibilityContext = createContext<IObservable<boolean>>(undefined!);
 
 /**
  * Provider component for notebook visibility state
@@ -20,7 +20,7 @@ const NotebookVisibilityContext = createContext<ISettableObservable<boolean>>(un
 export const NotebookVisibilityProvider = ({
 	isVisible,
 	children
-}: PropsWithChildren<{ isVisible: ISettableObservable<boolean> }>) => {
+}: PropsWithChildren<{ isVisible: IObservable<boolean> }>) => {
 	return (
 		<NotebookVisibilityContext.Provider value={isVisible}>
 			{children}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -5,15 +5,15 @@
 
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { ISettableObservable } from '../../../../../base/common/observable.js';
+import { IObservable, ISettableObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { CellRevealType, INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType } from '../selectionMachine.js';
 
-export type ExecutionStatus = 'running' | 'pending' | 'unconfirmed' | 'idle';
+export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 export enum CellSelectionStatus {
 	Unselected = 'unselected',
@@ -30,7 +30,12 @@ export interface IPositronNotebookCell extends Disposable {
 	/**
 	 * The kind of cell
 	 */
-	kind: CellKind;
+	readonly kind: CellKind;
+
+	/**
+	 * The current zero-based index of the cell in the notebook
+	 */
+	get index(): number;
 
 	/**
 	 * Cell specific uri for the cell within the notebook
@@ -45,12 +50,12 @@ export interface IPositronNotebookCell extends Disposable {
 	/**
 	 * Current execution status for this cell
 	 */
-	executionStatus: ISettableObservable<ExecutionStatus, void>;
+	readonly executionStatus: IObservable<ExecutionStatus>;
 
 	/**
 	 * Current selection status for this cell
 	 */
-	selectionStatus: ISettableObservable<CellSelectionStatus, void>;
+	readonly selectionStatus: ISettableObservable<CellSelectionStatus>;
 
 	/**
 	 * The content of the cell. This is the raw text of the cell.
@@ -60,12 +65,12 @@ export interface IPositronNotebookCell extends Disposable {
 	/**
 	 * The notebook text model for the cell.
 	 */
-	cellModel: PositronNotebookCellTextModel;
+	readonly cellModel: PositronNotebookCellTextModel;
 
 	/**
 	 * The cell's code editor widget.
 	 */
-	editor: ICodeEditor | undefined;
+	readonly editor: ICodeEditor | undefined;
 
 	/**
 	 * Get the handle number for cell from cell model
@@ -165,33 +170,33 @@ export interface IPositronNotebookCell extends Disposable {
  * Cell that contains code that can be executed
  */
 export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
-	kind: CellKind.Code;
+	readonly kind: CellKind.Code;
 
 
 	/**
 	 * Current cell outputs as an observable
 	 */
-	outputs: ISettableObservable<NotebookCellOutputs[], void>;
+	readonly outputs: IObservable<NotebookCellOutputs[]>;
 
 	/**
 	 * Duration of the last execution in milliseconds
 	 */
-	lastExecutionDuration: ISettableObservable<number | undefined>;
+	readonly lastExecutionDuration: IObservable<number | undefined>;
 
 	/**
 	 * Execution order number for the last execution
 	 */
-	lastExecutionOrder: ISettableObservable<number | undefined>;
+	readonly lastExecutionOrder: IObservable<number | undefined>;
 
 	/**
 	 * Whether the last execution was successful
 	 */
-	lastRunSuccess: ISettableObservable<boolean | undefined>;
+	readonly lastRunSuccess: IObservable<boolean | undefined>;
 
 	/**
 	 * Timestamp when the last execution ended
 	 */
-	lastRunEndTime: ISettableObservable<number | undefined>;
+	readonly lastRunEndTime: IObservable<number | undefined>;
 }
 
 
@@ -200,17 +205,17 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
  * Cell that contains markdown content
  */
 export interface IPositronNotebookMarkdownCell extends IPositronNotebookCell {
-	kind: CellKind.Markup;
+	readonly kind: CellKind.Markup;
 
 	/**
 	 * Observable content of cell. Equivalent to the cell's content, but as an observable
 	 */
-	markdownString: ISettableObservable<string | undefined>;
+	readonly markdownString: IObservable<string | undefined>;
 
 	/**
 	 * Observable that indicates whether the editor is currently shown
 	 */
-	editorShown: ISettableObservable<boolean>;
+	readonly editorShown: IObservable<boolean>;
 
 	/**
 	 * Toggle the editor for this cell
@@ -259,9 +264,9 @@ export type ParsedOutput = ParsedTextOutput |
 
 
 export interface NotebookCellOutputs {
-	outputId: string;
-	outputs: NotebookCellOutputItem[];
-	parsed: ParsedOutput;
+	readonly outputId: string;
+	readonly outputs: NotebookCellOutputItem[];
+	readonly parsed: ParsedOutput;
 	preloadMessageResult?: NotebookPreloadOutputResults | undefined;
 }
 
@@ -270,8 +275,8 @@ export interface NotebookCellOutputs {
  */
 export interface PositronNotebookCellTextModel {
 	readonly uri: URI;
-	handle: number;
-	language: string;
-	cellKind: CellKind;
-	outputs: Pick<NotebookCellOutputs, 'outputId' | 'outputs'>[];
+	readonly handle: number;
+	readonly language: string;
+	readonly cellKind: CellKind;
+	readonly outputs: Pick<NotebookCellOutputs, 'outputId' | 'outputs'>[];
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -39,6 +39,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	) {
 		super();
 
+		// Observable of internal metadata to derive execution status and timing info
+		// e.g. as used in PositronNotebookCodeCell
 		this._internalMetadata = observableFromEvent(
 			this,
 			this.cellModel.onDidChangeInternalMetadata,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { observableFromEvent } from '../../../../../base/common/observable.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
@@ -14,73 +14,43 @@ import { IPositronNotebookCodeCell, NotebookCellOutputs } from './IPositronNoteb
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { pickPreferredOutputItem } from './notebookOutputUtils.js';
 import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
-import { INotebookExecutionStateService, NotebookExecutionType } from '../../../notebook/common/notebookExecutionStateService.js';
+import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
 
 export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implements IPositronNotebookCodeCell {
 	override kind: CellKind.Code = CellKind.Code;
-	outputs: ISettableObservable<NotebookCellOutputs[]>;
+	outputs;
 
 	// Execution timing observables
-	lastExecutionDuration: ISettableObservable<number | undefined>;
-	lastExecutionOrder: ISettableObservable<number | undefined>;
-	lastRunSuccess: ISettableObservable<boolean | undefined>;
-	lastRunEndTime: ISettableObservable<number | undefined>;
+	lastExecutionDuration;
+	lastExecutionOrder;
+	lastRunSuccess;
+	lastRunEndTime;
 
 	constructor(
 		cellModel: NotebookCellTextModel,
 		private instance: PositronNotebookInstance,
+		@INotebookExecutionStateService _executionStateService: INotebookExecutionStateService,
 		@ITextModelService _textModelResolverService: ITextModelService,
 		@IPositronWebviewPreloadService private _webviewPreloadService: IPositronWebviewPreloadService,
-		@INotebookExecutionStateService private _executionStateService: INotebookExecutionStateService
 	) {
-		super(cellModel, instance, _textModelResolverService);
+		super(cellModel, instance, _executionStateService, _textModelResolverService);
 
-		this.outputs = observableValue<NotebookCellOutputs[], void>('cellOutputs', this.parseCellOutputs());
+		this.outputs = observableFromEvent(this, this.cellModel.onDidChangeOutputs, () => {
+			/** @description cellOutputs */
+			return this.parseCellOutputs();
+		});
 
-		// Initialize execution timing observables
-		this.lastExecutionDuration = observableValue<number | undefined, void>('positronNotebookCodeCell.lastExecutionDuration', this.calculateExecutionDuration());
-		this.lastExecutionOrder = observableValue<number | undefined, void>('positronNotebookCodeCell.lastExecutionOrder', cellModel.internalMetadata.executionOrder);
-		this.lastRunSuccess = observableValue<boolean | undefined, void>('positronNotebookCodeCell.lastRunSuccess', cellModel.internalMetadata.lastRunSuccess ?? undefined);
-		this.lastRunEndTime = observableValue<number | undefined, void>('positronNotebookCodeCell.lastRunEndTime', cellModel.internalMetadata.runEndTime ?? undefined);
-
-		// Listen for changes to the cell outputs and update the observable
-		this._register(
-			this.cellModel.onDidChangeOutputs(() => {
-				this.outputs.set(this.parseCellOutputs(), undefined);
-			})
-		);
-
-		// Listen for changes to the internal metadata to update execution timing
-		this._register(
-			this.cellModel.onDidChangeInternalMetadata(() => {
-				this.updateExecutionInfo();
-			})
-		);
-
-		// Listen for execution state changes
-		this._register(
-			this._executionStateService.onDidChangeExecution(e => {
-				if (e.type === NotebookExecutionType.cell && e.affectsCell(this.cellModel.uri)) {
-					this.updateExecutionInfo();
-				}
-			})
-		);
-	}
-
-	private calculateExecutionDuration(): number | undefined {
-		const { runStartTime, runEndTime } = this.cellModel.internalMetadata;
-		if (typeof runStartTime === 'number' && typeof runEndTime === 'number') {
-			return Math.max(0, runEndTime - runStartTime);
-		}
-		return undefined;
-	}
-
-	private updateExecutionInfo(): void {
-		const metadata = this.cellModel.internalMetadata;
-		this.lastExecutionDuration.set(this.calculateExecutionDuration(), undefined);
-		this.lastExecutionOrder.set(metadata.executionOrder ?? undefined, undefined);
-		this.lastRunSuccess.set(metadata.lastRunSuccess ?? undefined, undefined);
-		this.lastRunEndTime.set(metadata.runEndTime ?? undefined, undefined);
+		// Execution timing observables
+		this.lastExecutionDuration = this._internalMetadata.map(({ runStartTime, runEndTime }) => {
+			/** @description lastExecutionDuration */
+			if (typeof runStartTime === 'number' && typeof runEndTime === 'number') {
+				return Math.max(0, runEndTime - runStartTime);
+			}
+			return undefined;
+		});
+		this.lastExecutionOrder = this._internalMetadata.map(m => /** @description lastExecutionOrder */ m.executionOrder);
+		this.lastRunSuccess = this._internalMetadata.map(m => /** @description lastRunSuccess */ m.lastRunSuccess);
+		this.lastRunEndTime = this._internalMetadata.map(m => /** @description lastRunEndTime */ m.runEndTime);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -40,7 +40,7 @@ export function PositronNotebookComponent() {
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			<PositronNotebookHeader notebookInstance={notebookInstance} />
 			<div ref={containerRef} className='positron-notebook-cells-container'>
-				{notebookCells?.length ? notebookCells?.map((cell, index) => <>
+				{notebookCells.length ? notebookCells.map((cell, index) => <>
 					<NotebookCell key={cell.handleId} cell={cell as PositronNotebookCellGeneral} />
 					<AddCellButtons index={index + 1} />
 				</>) : <div>{localize('noCells', 'No cells')}</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -207,7 +207,7 @@ export class PositronNotebookEditor extends EditorPane {
 	/**
 	 * Size as an observable so it can be lazily passed into the React component.
 	 */
-	private _size = observableValue<ISize>('size', { width: 0, height: 0 });
+	private readonly _size = observableValue<ISize>('size', { width: 0, height: 0 });
 
 	/**
 	 * Observable tracking if the editor is currently visible

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
 import { ICompositeCodeEditor, IEditor } from '../../../../editor/common/editorCommon.js';
-import { SelectionState } from '../../../services/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
 
 /**
@@ -33,14 +33,10 @@ export class PositronNotebookEditorControl extends Disposable implements ICompos
 		super();
 
 		// Update the active code editor when the notebook selection state changes.
-		this._register(this._notebookInstance.selectionStateMachine.onNewState((state) => {
-			if (state.type === SelectionState.EditingSelection) {
-				this._activeCodeEditor = state.selectedCell.editor;
-			} else if (state.type === SelectionState.NoSelection) {
-				this._activeCodeEditor = undefined;
-			} else {
-				this._activeCodeEditor = state.selected[0]?.editor;
-			}
+		this._register(autorun(reader => {
+			const selectionStateMachine = this._notebookInstance.selectionStateMachine;
+			selectionStateMachine.state.read(reader);
+			this._activeCodeEditor = selectionStateMachine.getSelectedCells()[0]?.editor;
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
@@ -7,6 +7,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { ICompositeCodeEditor, IEditor } from '../../../../editor/common/editorCommon.js';
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
+import { getSelectedCells } from './selectionMachine.js';
 
 /**
  * The PositronNotebookEditorControl is used by features like inline chat, debugging, and outlines
@@ -36,7 +37,9 @@ export class PositronNotebookEditorControl extends Disposable implements ICompos
 		this._register(autorun(reader => {
 			const selectionStateMachine = this._notebookInstance.selectionStateMachine;
 			selectionStateMachine.state.read(reader);
-			this._activeCodeEditor = selectionStateMachine.getSelectedCells()[0]?.editor;
+			// We currently assume that the first selected cell is the "active" one,
+			// but we should probably explicitly track the active cell in the selection state.
+			this._activeCodeEditor = getSelectedCells(selectionStateMachine.state.get())[0]?.editor;
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType, getSelectedCells, SelectionStateMachine } from '../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType, getSelectedCell, getSelectedCells, SelectionStateMachine } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookService } from '../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from './IPositronNotebookInstance.js';
@@ -556,7 +556,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			const cellIndex = referenceCell.index;
 			index = cellIndex >= 0 ? cellIndex : undefined;
 		} else {
-			index = this.selectionStateMachine.getSelectedCell()?.index;
+			index = getSelectedCell(this.selectionStateMachine.state.get())?.index;
 		}
 
 		if (index === undefined) {
@@ -571,7 +571,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cellToDelete The cell to delete. If not provided, deletes the currently selected cell
 	 */
 	deleteCell(cellToDelete?: IPositronNotebookCell): void {
-		const cell = cellToDelete ?? this.selectionStateMachine.getSelectedCell();
+		const cell = cellToDelete ?? getSelectedCell(this.selectionStateMachine.state.get());
 
 		if (!cell) {
 			return;
@@ -949,7 +949,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	clearCellOutput(cell?: IPositronNotebookCell, skipContentEvent: boolean = false): void {
 		this._assertTextModel();
 
-		const targetCell = cell ?? this.selectionStateMachine.getSelectedCell();
+		const targetCell = cell ?? getSelectedCell(this.selectionStateMachine.state.get());
 		if (!targetCell) {
 			return;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 
 import { EditorExtensionsRegistry, IEditorContributionDescription } from '../../../../../editor/browser/editorExtensions.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
-import { Event } from '../../../../../base/common/event.js';
 
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
@@ -22,6 +21,7 @@ import { useEnvironment } from '../EnvironmentProvider.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNotebookCell.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { autorun } from '../../../../../base/common/observable.js';
 
 /**
  *
@@ -103,7 +103,8 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		}));
 
 		// Resize the editor as the window resizes.
-		disposables.add(Event.fromObservable(environment.size)(() => {
+		disposables.add(autorun(reader => {
+			environment.size.read(reader);
 			resizeEditor();
 		}));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { localize } from '../../../../../nls.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType } from '../../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType } from '../selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { NotebookCellActionBar } from './NotebookCellActionBar.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -23,10 +23,10 @@ import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 
 
 interface CellOutputsSectionProps {
-	outputs: NotebookCellOutputs[] | undefined;
+	outputs: NotebookCellOutputs[];
 }
 
-function CellOutputsSection({ outputs = [] }: CellOutputsSectionProps) {
+function CellOutputsSection({ outputs }: CellOutputsSectionProps) {
 	return (
 		<div className={`positron-notebook-code-cell-outputs positron-notebook-cell-outputs ${outputs.length > 0 ? 'has-outputs' : 'no-outputs'}`} data-testid='cell-output'>
 			{outputs?.map((output) => (

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -33,7 +33,7 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 					cell.toggleEditor();
 				}}>
 					{
-						markdownString ?
+						markdownString.length > 0 ?
 							<Markdown content={markdownString} />
 							: <div className='empty-output-msg'>
 								Empty markup cell. {editorShown ? '' : 'Double click to edit'}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
-import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType } from '../../selectionMachine.js';
 import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { INotebookCellActionBarItem } from './actionBarRegistry.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -8,7 +8,7 @@ import { CustomContextMenuItem } from '../../../../../../workbench/browser/posit
 import { CustomContextMenuEntry } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType } from '../../selectionMachine.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { CustomContextMenuSeparator } from '../../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -5,8 +5,7 @@
 
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
-import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { ObservableMap } from '../../../../../../base/common/observable.js';
 import { ILocalizedString } from '../../../../../../platform/action/common/action.js';
 import { CellConditionPredicate } from './cellConditions.js';
 
@@ -47,16 +46,45 @@ const DEFAULT_ORDER = 50;
  */
 export class NotebookCellActionBarRegistry {
 	private static instance: NotebookCellActionBarRegistry;
-	private items = new Map<string, INotebookCellActionBarItem>();
+	private items = new ObservableMap<string, INotebookCellActionBarItem>();
 
-	// Observable arrays for reactive UI updates
-	private _mainActions = observableValue<INotebookCellActionBarItem[]>('mainActions', []);
-	private _menuActions = observableValue<INotebookCellActionBarItem[]>('menuActions', []);
-	private _leftActions = observableValue<INotebookCellActionBarItem[]>('leftActions', []);
+	/**
+	 * The observable array of main action bar actions.
+	 */
+	public readonly mainActions;
 
-	// Event emitter for changes
-	private _onDidChange = new Emitter<void>();
-	readonly onDidChange: Event<void> = this._onDidChange.event;
+	/**
+	 * The observable array of dropdown menu actions.
+	 */
+	public readonly menuActions;
+
+	/**
+	 * The observable array of left action bar actions.
+	 */
+	public readonly leftActions;
+
+	constructor() {
+		this.mainActions = this.items.observable.map(this, items =>
+			/** @description mainActions */
+			Array.from(items.values())
+				.filter(item => item.position === 'main')
+				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
+		);
+
+		this.menuActions = this.items.observable.map(this, items =>
+			/** @description menuActions */
+			Array.from(items.values())
+				.filter(item => item.position === 'menu')
+				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
+		);
+
+		this.leftActions = this.items.observable.map(this, items =>
+			/** @description leftActions */
+			Array.from(items.values())
+				.filter(item => item.position === 'left')
+				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
+		);
+	}
 
 	/**
 	 * Gets the singleton instance of the registry.
@@ -75,59 +103,10 @@ export class NotebookCellActionBarRegistry {
 	 */
 	register(item: INotebookCellActionBarItem): IDisposable {
 		this.items.set(item.commandId, item);
-		this.updateObservables();
-		this._onDidChange.fire();
-
 		return {
 			dispose: () => {
 				this.items.delete(item.commandId);
-				this.updateObservables();
-				this._onDidChange.fire();
 			}
 		};
-	}
-
-	/**
-	 * Updates the observable arrays based on the current items.
-	 */
-	private updateObservables(): void {
-		// Update main actions
-		const mainActions = Array.from(this.items.values())
-			.filter(item => item.position === 'main')
-			.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
-		this._mainActions.set(mainActions, undefined);
-
-		// Update menu actions
-		const menuActions = Array.from(this.items.values())
-			.filter(item => item.position === 'menu')
-			.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
-		this._menuActions.set(menuActions, undefined);
-
-		// Update left actions
-		const leftActions = Array.from(this.items.values())
-			.filter(item => item.position === 'left')
-			.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
-		this._leftActions.set(leftActions, undefined);
-	}
-
-	/**
-	 * Gets the observable array of main action bar actions.
-	 */
-	get mainActions(): ISettableObservable<INotebookCellActionBarItem[]> {
-		return this._mainActions;
-	}
-
-	/**
-	 * Gets the observable array of dropdown menu actions.
-	 */
-	get menuActions(): ISettableObservable<INotebookCellActionBarItem[]> {
-		return this._menuActions;
-	}
-
-	/**
-	 * Gets the observable array of left-positioned actions.
-	 */
-	get leftActions(): ISettableObservable<INotebookCellActionBarItem[]> {
-		return this._leftActions;
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -32,6 +32,8 @@ export interface ICellInfo {
 	isOnlyCell: boolean;
 	/** Cell is actively executing/running */
 	isRunning: boolean;
+	/** Cell is queued for execution */
+	isPending: boolean;
 }
 
 /**
@@ -44,15 +46,14 @@ export type CellConditionPredicate = (cellInfo: ICellInfo) => boolean;
 /**
  * Creates ICellInfo from a cell and its position in the notebook.
  * @param cell The notebook cell
- * @param cellIndex The cell's index in the notebook
  * @param totalCells Total number of cells in the notebook
  * @returns Cell information object
  */
 export function createCellInfo(
 	cell: IPositronNotebookCell,
-	cellIndex: number,
 	totalCells: number
 ): ICellInfo {
+	const cellIndex = cell.index;
 	return {
 		cellType: cell.kind === CellKind.Code ? NotebookCellType.Code :
 			cell.kind === CellKind.Markup ? NotebookCellType.Markdown : NotebookCellType.Raw,
@@ -63,7 +64,8 @@ export function createCellInfo(
 		isOnlyCell: totalCells === 1,
 		// TODO: There is a tiny chance that the cell is running but the status is not yet updated.
 		// If this happens we will probably need to make the cell info an observable.
-		isRunning: cell.executionStatus.get() === 'running'
+		isRunning: cell.executionStatus.get() === 'running',
+		isPending: cell.executionStatus.get() === 'pending',
 	};
 }
 
@@ -82,6 +84,9 @@ export const CellConditions = {
 
 	/** Is running */
 	isRunning: (info: ICellInfo) => info.isRunning,
+
+	/** Is pending */
+	isPending: (info: ICellInfo) => info.isPending,
 
 	/** Not the first cell (has cells above) */
 	notFirst: (info: ICellInfo) => !info.isFirstCell,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -14,7 +14,7 @@ import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positr
 import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 import { CellConditionPredicate, createCellInfo } from './cellConditions.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
-import { getSelectedCells } from '../../../../../services/positronNotebook/browser/selectionMachine.js';
+import { getSelectedCell, getSelectedCells } from '../../selectionMachine.js';
 
 /**
  * Options for registering a cell command.
@@ -65,18 +65,17 @@ export function registerCellCommand({
 	const disposables = new DisposableStore();
 
 	// Helper to check if a cell passes the cell condition
-	const cellPassesCondition = (cell: IPositronNotebookCell, activeNotebook: any) => {
+	const cellPassesCondition = (cell: IPositronNotebookCell, activeNotebook: IPositronNotebookInstance) => {
 		if (!cellCondition) {
 			return true;
 		}
 
-		const cells = activeNotebook.cells.get();
-		const cellIndex = cells.indexOf(cell);
-		if (cellIndex === -1) {
+		if (cell.index === -1) {
 			return false;
 		}
 
-		const cellInfo = createCellInfo(cell, cellIndex, cells.length);
+		const cells = activeNotebook.cells.get();
+		const cellInfo = createCellInfo(cell, cells.length);
 		return cellCondition(cellInfo);
 	};
 
@@ -102,7 +101,7 @@ export function registerCellCommand({
 				}
 			} else {
 				// Handle single cell
-				const cell = activeNotebook.selectionStateMachine.getSelectedCell();
+				const cell = getSelectedCell(activeNotebook.selectionStateMachine.state.get());
 				if (cell && cellPassesCondition(cell, activeNotebook)) {
 					handler(cell, activeNotebook, accessor);
 				}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
@@ -18,8 +18,7 @@ export function useActionsForCell(cell: IPositronNotebookCell): Record<CellActio
 	const registry = NotebookCellActionBarRegistry.getInstance();
 	const instance = useNotebookInstance();
 	const cells = instance.cells.get();
-	const cellIndex = cells.indexOf(cell);
-	const cellInfo = createCellInfo(cell, cellIndex, cells.length);
+	const cellInfo = createCellInfo(cell, cells.length);
 
 	const forCellFilter = (action: INotebookCellActionBarItem) => {
 		return !action.cellCondition || action.cellCondition(cellInfo);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -378,8 +378,9 @@ registerCellCommand({
 	handler: (cell) => cell.run(),
 	cellCondition: CellConditions.and(
 		CellConditions.isCode,
-		CellConditions.not(CellConditions.isRunning)
-	),  // Only show on code cells that are not running
+		CellConditions.not(CellConditions.isRunning),
+		CellConditions.not(CellConditions.isPending),
+	),  // Only show on code cells that are not running or pending
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Enter
 	},
@@ -399,8 +400,11 @@ registerCellCommand({
 	handler: (cell) => cell.run(), // Run called when cell is executing is stop
 	cellCondition: CellConditions.and(
 		CellConditions.isCode,
-		CellConditions.isRunning
-	),  // Only show on code cells that are running
+		CellConditions.or(
+			CellConditions.isRunning,
+			CellConditions.isPending,
+		)
+	),  // Only show on code cells that are running or pending
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Enter
 	},
@@ -435,9 +439,9 @@ registerCellCommand({
 	commandId: 'positronNotebook.cell.runAllAbove',
 	handler: (cell, notebook) => {
 		const cells = notebook.cells.get();
-		const cellIndex = cells.indexOf(cell);
 
 		// Run all code cells above the current cell
+		const cellIndex = cell.index;
 		for (let i = 0; i < cellIndex; i++) {
 			const targetCell = cells[i];
 			if (targetCell.isCodeCell()) {
@@ -466,10 +470,9 @@ registerCellCommand({
 		if (!notebook) { return; }
 
 		const cells = notebook.cells.get();
-		const cellIndex = cells.indexOf(cell);
 
 		// Run all code cells below the current cell
-		for (let i = cellIndex + 1; i < cells.length; i++) {
+		for (let i = cell.index + 1; i < cells.length; i++) {
 			const targetCell = cells[i];
 			if (targetCell.isCodeCell()) {
 				targetCell.run();

--- a/src/vs/workbench/contrib/positronNotebook/browser/useObservedValue.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useObservedValue.tsx
@@ -7,29 +7,25 @@
 import React from 'react';
 
 // Other dependencies.
-import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
-import { Event } from '../../../../base/common/event.js';
+import { autorun, IObservable } from '../../../../base/common/observable.js';
 
 /**
  * Automatically updates the component when the observable changes.
  * @param observable Observable value with value to be extracted
- * @param map Optional mapping function to transform the observable value into a different value.
- * @returns The current value of the observable or undefined if the observable is not set.
+ * @returns The current value of the observable.
  */
-export function useObservedValue<T>(observable: ISettableObservable<T>): T | undefined;
-export function useObservedValue<T, M extends (x: T) => unknown>(observable: ISettableObservable<T>, map: M): M extends (x: T) => infer Out ? Out : never;
-export function useObservedValue<T, M>(observable: ISettableObservable<T>, map?: (x: T) => unknown): T | undefined | M extends (x: T) => infer Out ? Out : never {
-
-	const [value, setValue] = React.useState(() => typeof map === 'function' ? map(observable.get()) : observable.get());
+export function useObservedValue<T>(observable: IObservable<T>): T {
+	const [value, setValue] = React.useState(observable.get());
 
 	React.useEffect(() => {
-		const onObservableChange = Event.fromObservable(observable);
-		const observer = onObservableChange((val) => {
-			setValue(typeof map === 'function' ? map(val) : val);
+		const disposable = autorun(reader => {
+			const val = observable.read(reader);
+			setValue(val);
 		});
+		return () => {
+			disposable.dispose();
+		};
+	}, [observable]);
 
-		return observer.dispose;
-	}, [map, observable]);
-
-	return value as T | undefined | M extends (x: T) => infer Out ? Out : never;
+	return value;
 }


### PR DESCRIPTION
This refactors a few things:

1. Use more of the observable system, particularly in the selection state machine.
2. Cells now derive their execution status from the notebook execution state service.
3. Cells now have an `index` helper getter.
4. Moved more modules to resolve import layering lint errors.

_(Note: I used Claude for some of this, and may have accidentally committed some unnecessary changes)_

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Nothing should break!