### PR TITLE
notebooks: prompt user to change session working directory if saving untitled nb

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -259,7 +259,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 
 				// Call updateNotebookSessionUri on the runtime service
 				// This updates internal mappings and emits events that other components listen for
-				const sessionId = this._runtimeSessionService.updateNotebookSessionUri(this.resource, target);
+				const sessionId = await this._runtimeSessionService.updateNotebookSessionUri(this.resource, target);
 
 				if (sessionId) {
 					// Log success to aid debugging session transfer issues

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -74,6 +74,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+	 * @param height The height of the dialog (optional; defaults to 200)
 	 *
 	 * @returns A dialog instance, with an event that fires when the user makes a selection.
 	 */
@@ -81,7 +82,8 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		title: string,
 		message: string,
 		okButtonTitle?: string,
-		cancelButtonTitle?: string
+		cancelButtonTitle?: string,
+		height?: number,
 	): IModalDialogPromptInstance {
 		// Create the modal React renderer.
 		const renderer = new PositronModalReactRenderer();
@@ -99,9 +101,10 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 			choiceEmitter.fire(false);
 			choiceEmitter.dispose();
 		};
+		const heightValue = height ?? 200;
 
 		renderer.render(
-			<PositronModalDialog height={200} renderer={renderer} title={title} width={400} onCancel={cancelHandler}>
+			<PositronModalDialog height={heightValue} renderer={renderer} title={title} width={400} onCancel={cancelHandler}>
 				<ContentArea>
 					{renderHtml(
 						message,
@@ -203,6 +206,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+	 * @param height The height of the dialog (optional; defaults to 200)
 	 *
 	 * @returns A promise that resolves to true if the user clicked OK, or false
 	 *   if the user clicked Cancel.
@@ -210,10 +214,12 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	showSimpleModalDialogPrompt(title: string,
 		message: string,
 		okButtonTitle?: string | undefined,
-		cancelButtonTitle?: string | undefined): Promise<boolean> {
+		cancelButtonTitle?: string | undefined,
+		height?: number,
+	): Promise<boolean> {
 
 		// Show the dialog and return a promise that resolves to the user's choice.
-		const dialog = this.showModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
+		const dialog = this.showModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle, height);
 		return new Promise<boolean>((resolve) => {
 			const disposable = dialog.onChoice((choice) => {
 				disposable.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -262,7 +262,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 			// Call updateNotebookSessionUri on the runtime service
 			// This updates internal mappings and emits events that other components listen for
-			const sessionId = this._runtimeSessionService.updateNotebookSessionUri(this.resource, target);
+			const sessionId = await this._runtimeSessionService.updateNotebookSessionUri(this.resource, target);
 
 			if (sessionId) {
 				// Log success to aid debugging session transfer issues

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -114,7 +114,7 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 
 	foregroundSession: ILanguageRuntimeSession | undefined;
 
-	updateNotebookSessionUri(oldUri: URI, newUri: URI): string | undefined {
+	async updateNotebookSessionUri(oldUri: URI, newUri: URI): Promise<string | undefined> {
 		return undefined;
 	}
 

--- a/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
+++ b/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -58,6 +58,7 @@ export interface IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+	 * @param height The height of the dialog (optional; defaults to 200)
 	 *
 	 * @returns A dialog instance, with an event that fires when the user makes a selection.
 	 */
@@ -65,7 +66,8 @@ export interface IPositronModalDialogsService {
 		title: string,
 		message: string,
 		okButtonTitle?: string,
-		cancelButtonTitle?: string
+		cancelButtonTitle?: string,
+		height?: number,
 	): IModalDialogPromptInstance;
 
 	/**
@@ -78,6 +80,7 @@ export interface IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 * @param cancelButtonTitle The title of the Cancel button (optional; defaults to 'Cancel')
+	 * @param height The height of the dialog (optional; defaults to 200)
 	 *
 	 * @returns A promise that resolves to true if the user clicked OK, or false
 	 *   if the user clicked Cancel.
@@ -86,7 +89,8 @@ export interface IPositronModalDialogsService {
 		title: string,
 		message: string,
 		okButtonTitle?: string,
-		cancelButtonTitle?: string
+		cancelButtonTitle?: string,
+		height?: number,
 	): Promise<boolean>;
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -2438,8 +2438,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 		// Untildify for comparison
 		const userHome = await this._pathService.userHome();
-		const currentWorkingDirectoryResolved = untildify(currentWorkingDirectory, userHome.scheme === Schemas.file ? userHome.fsPath : userHome.path);
-		const newWorkingDirectoryResolved = untildify(newWorkingDirectory, userHome.scheme === Schemas.file ? userHome.fsPath : userHome.path);
+		const userHomePath = userHome.scheme === Schemas.file ? userHome.fsPath : userHome.path;
+		const currentWorkingDirectoryResolved = untildify(currentWorkingDirectory, userHomePath);
+		const newWorkingDirectoryResolved = untildify(newWorkingDirectory, userHomePath);
 
 		if (currentWorkingDirectoryResolved !== newWorkingDirectoryResolved) {
 			const result = await this._positronModalDialogsService.showSimpleModalDialogPrompt(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -30,6 +30,9 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { NotebookSetting } from '../../../contrib/notebook/common/notebookCommon.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IPathService } from '../../path/common/pathService.js';
+import { untildify } from '../../../../base/common/labels.js';
+import { Schemas } from '../../../../base/common/network.js';
 
 /**
  * The maximum number of active sessions a user can have running at a time.
@@ -176,6 +179,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IFileService private readonly _fileService: IFileService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IPathService private readonly _pathService: IPathService,
 	) {
 
 		super();
@@ -2314,7 +2318,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param newUri The new URI of the notebook (typically a file:// URI after saving)
 	 * @returns The session ID of the updated session, or undefined if no update occurred
 	 */
-	updateNotebookSessionUri(oldUri: URI, newUri: URI): string | undefined {
+	async updateNotebookSessionUri(oldUri: URI, newUri: URI): Promise<string | undefined> {
 
 		// Find the session associated with the old URI
 		const session = this._notebookSessionsByNotebookUri.get(oldUri);
@@ -2337,8 +2341,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			return undefined;
 		}
 
-		// Remember the session ID for return value
+		// Remember the session ID and old working directory for return value
 		const sessionId = session.sessionId;
+		const oldWorkingDirectory = session.dynState.currentWorkingDirectory;
+		let workingDirectoryWasChanged = false;
 
 		try {
 			// Operations are performed in a specific order to maintain atomic-like behavior
@@ -2350,11 +2356,12 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// so even if the next steps fail, the session is still accessible via some URI
 			this._notebookSessionsByNotebookUri.set(newUri, session);
 
-			// 2. Then update the session's notebook URI in its dynamic state
+			// 2. Then update the session's notebook URI and working directory in its dynamic state
 			// Why: This ensures the session's internal references are consistent
 			// with our mapping, which helps debugging and ensures session properties
 			// reflect current reality
 			session.dynState.currentNotebookUri = newUri;
+			workingDirectoryWasChanged = await this.promptAndUpdateWorkingDirectoryIfChanged(session, newUri);
 
 			// 3. Finally remove the old mapping - we do this last because it's
 			// the most likely to fail if ResourceMap has internal inconsistency
@@ -2397,14 +2404,61 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				this._notebookSessionsByNotebookUri.delete(newUri);
 			}
 
-			// 3. Restore original URI in session state if needed
+			// 3. Restore original URI and working directory in session state if needed
 			// Why: Keep the session's internal state consistent with our mappings
 			if (session.dynState.currentNotebookUri === newUri) {
 				session.dynState.currentNotebookUri = oldUri;
 			}
+			if (workingDirectoryWasChanged) {
+				await session.setWorkingDirectory(oldWorkingDirectory);
+			}
 
 			return undefined;
 		}
+	}
+
+	/**
+	 * Prompts the user to update the session's working directory if it has changed
+	 * due to a notebook URI change, and updates it if the user chooses to do so.
+	 *
+	 * @param session The runtime session to potentially update.
+	 * @param newUri The new notebook URI to resolve the working directory from.
+	 * @returns Whether the working directory was changed
+	 */
+	private async promptAndUpdateWorkingDirectoryIfChanged(
+		session: ILanguageRuntimeSession,
+		newUri: URI
+	): Promise<boolean> {
+		let wasChanged = false;
+		const currentWorkingDirectory = session.dynState.currentWorkingDirectory;
+		const newWorkingDirectory = await this.resolveNotebookWorkingDirectory(newUri);
+		if (!newWorkingDirectory) {
+			return false;
+		}
+
+		// Untildify for comparison
+		const userHome = await this._pathService.userHome();
+		const currentWorkingDirectoryResolved = untildify(currentWorkingDirectory, userHome.scheme === Schemas.file ? userHome.fsPath : userHome.path);
+		const newWorkingDirectoryResolved = untildify(newWorkingDirectory, userHome.scheme === Schemas.file ? userHome.fsPath : userHome.path);
+
+		if (currentWorkingDirectoryResolved !== newWorkingDirectoryResolved) {
+			const result = await this._positronModalDialogsService.showSimpleModalDialogPrompt(
+				localize('positron.notebook.workingDirectoryChanged.title', 'Working Directory Changed'),
+				localize(
+					'positron.notebook.workingDirectoryChanged',
+					'The suggested working directory for this notebook has changed from <code>{0}</code> to <code>{1}</code>. Would you like to update the session\'s working directory?',
+					currentWorkingDirectoryResolved,
+					newWorkingDirectoryResolved
+				),
+				localize('positron.notebook.updateWorkingDirectory', 'Update'),
+				localize('positron.notebook.keepCurrent', 'Keep')
+			);
+			if (result) {
+				await session.setWorkingDirectory(newWorkingDirectory);
+				wasChanged = true;
+			}
+		}
+		return wasChanged;
 	}
 }
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -551,7 +551,7 @@ export interface IRuntimeSessionService {
 	 * @param newUri The new URI of the notebook (typically a file:// URI after saving)
 	 * @returns The session ID of the updated session, or undefined if no update occurred
 	 */
-	updateNotebookSessionUri(oldUri: URI, newUri: URI): string | undefined;
+	updateNotebookSessionUri(oldUri: URI, newUri: URI): Promise<string | undefined>;
 
 	/**
 	 * Updates the active languages with the update service. This has to be pushed to the update

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1146,7 +1146,7 @@ suite('Positron - RuntimeSessionService', () => {
 		assert.strictEqual(sessionBeforeUpdate, session, 'Session should be accessible via untitled URI before update');
 
 		// Update the session's URI
-		const returnedSessionId = runtimeSessionService.updateNotebookSessionUri(untitledUri, savedUri);
+		const returnedSessionId = await runtimeSessionService.updateNotebookSessionUri(untitledUri, savedUri);
 
 		// Verify returned sessionId matches the session's ID
 		assert.strictEqual(returnedSessionId, session.sessionId, 'Function should return the correct session ID');
@@ -1166,7 +1166,7 @@ suite('Positron - RuntimeSessionService', () => {
 		const newUri = URI.file('/path/to/new/notebook.ipynb');
 
 		// Attempt to update a non-existent session
-		const returnedSessionId = runtimeSessionService.updateNotebookSessionUri(nonExistentUri, newUri);
+		const returnedSessionId = await runtimeSessionService.updateNotebookSessionUri(nonExistentUri, newUri);
 
 		// Verify no session ID is returned
 		assert.strictEqual(returnedSessionId, undefined,

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1140,6 +1140,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 		// Start a notebook session with the untitled URI
 		const session = await startSession(runtime, LanguageRuntimeSessionMode.Notebook, untitledUri);
+		await timeout(0);
 
 		// Ensure the session is retrievable with the untitled URI
 		const sessionBeforeUpdate = runtimeSessionService.getNotebookSessionForNotebookUri(untitledUri);
@@ -1158,6 +1159,9 @@ suite('Positron - RuntimeSessionService', () => {
 		// Verify the session is accessible via the new URI
 		const newUriSession = runtimeSessionService.getNotebookSessionForNotebookUri(savedUri);
 		assert.strictEqual(newUriSession, session, 'Session should be accessible via new URI');
+
+		// Verify the working directory changed
+		assert.strictEqual(session.getWorkingDirectory(), '/path/to/saved', 'Working directory should update to new URI parent folder');
 	});
 
 	test('updateNotebookSessionUri returns undefined when session not found', async () => {

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -26,9 +26,8 @@ import { IPositronModalDialogsService } from '../../../positronModalDialogs/comm
 import { RuntimeSessionService } from '../../common/runtimeSession.js';
 import { IRuntimeSessionService, RuntimeStartMode } from '../../common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession } from './testLanguageRuntimeSession.js';
-import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService, TestDirectoryFileService } from '../../../../test/common/positronWorkbenchTestServices.js';
+import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService, TestDirectoryFileService, TestPathService } from '../../../../test/common/positronWorkbenchTestServices.js';
 import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService, TestContextService } from '../../../../test/common/workbenchTestServices.js';
-import { TestPathService } from '../../../../test/browser/workbenchTestServices.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -28,11 +28,13 @@ import { IRuntimeSessionService, RuntimeStartMode } from '../../common/runtimeSe
 import { TestLanguageRuntimeSession } from './testLanguageRuntimeSession.js';
 import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService, TestDirectoryFileService } from '../../../../test/common/positronWorkbenchTestServices.js';
 import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService, TestContextService } from '../../../../test/common/workbenchTestServices.js';
+import { TestPathService } from '../../../../test/browser/workbenchTestServices.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IPathService } from '../../../path/common/pathService.js';
 
 export function createRuntimeServices(
 	instantiationService: TestInstantiationService,
@@ -48,6 +50,7 @@ export function createRuntimeServices(
 	instantiationService.stub(IWorkspaceContextService, new TestContextService());
 	instantiationService.stub(IConfigurationResolverService, new TestConfigurationResolverService());
 	instantiationService.stub(IFileService, disposables.add(new TestDirectoryFileService()));
+	instantiationService.stub(IPathService, new TestPathService());
 	instantiationService.stub(ILanguageRuntimeService, disposables.add(instantiationService.createInstance(LanguageRuntimeService)));
 	instantiationService.stub(IPositronModalDialogsService, new TestPositronModalDialogService());
 	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { posix } from '../../../base/common/path.js';
 import { IProcessEnvironment } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { ICommandService, ICommandEvent, CommandsRegistry } from '../../../platform/commands/common/commands.js';
@@ -247,7 +248,8 @@ export class TestPathService implements IPathService {
 	declare readonly _serviceBrand: undefined;
 
 	get path(): Promise<any> {
-		throw new Error('Method not implemented.');
+		// For tests, return posix path since most tests expect Unix-like behavior
+		return Promise.resolve(posix);
 	}
 
 	get defaultUriScheme(): string {

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -114,7 +114,8 @@ export class TestPositronModalDialogService implements IPositronModalDialogsServ
 		throw new Error('Method not implemented.');
 	}
 	showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Promise<boolean> {
-		throw new Error('Method not implemented.');
+		// implement this one for runtimeSession tests
+		return Promise.resolve(true);
 	}
 	showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Promise<null> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -22,6 +22,7 @@ import { ILanguageRuntimeMetadata } from '../../services/languageRuntime/common/
 import { IPositronModalDialogsService, ShowConfirmationModalDialogOptions, IModalDialogPromptInstance } from '../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { ILanguageRuntimeSessionManager, IRuntimeSessionMetadata, ILanguageRuntimeSession } from '../../services/runtimeSession/common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession } from '../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
+import { IPathService } from '../../services/path/common/pathService.js';
 
 export class TestNotebookExecutionService implements INotebookExecutionService {
 	declare readonly _serviceBrand: undefined;
@@ -240,6 +241,38 @@ export class TestDirectoryFileService implements IFileService {
 	watch(): IDisposable { return { dispose: () => { } }; }
 	getWriteEncoding(): any { throw new Error('Not implemented'); }
 	dispose(): void { }
+}
+
+export class TestPathService implements IPathService {
+	declare readonly _serviceBrand: undefined;
+
+	get path(): Promise<any> {
+		throw new Error('Method not implemented.');
+	}
+
+	get defaultUriScheme(): string {
+		return 'file';
+	}
+
+	get resolvedUserHome(): URI | undefined {
+		return URI.file('/home/test');
+	}
+
+	userHome(options: { preferLocal: true }): URI;
+	userHome(options?: { preferLocal: boolean }): Promise<URI>;
+	userHome(options?: { preferLocal: boolean }): URI | Promise<URI> {
+		return URI.file('/home/test');
+	}
+
+	hasValidBasename(resource: URI, basename?: string): Promise<boolean>;
+	hasValidBasename(resource: URI, os: any, basename?: string): boolean;
+	hasValidBasename(_resource: URI, _osOrBasename?: string | any, _basename?: string): boolean | Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
+
+	fileURI(_path: string): Promise<URI> {
+		throw new Error('Method not implemented.');
+	}
 }
 
 /**


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9022. Adds a modal that pops up when a notebook is moved (including saving an untitled notebook) that allows the session working directory to be changed without destroying the session.

This doesn't currently work for "moving" a notebook (dragging it through the file explorer or saving-as) because of https://github.com/posit-dev/positron/issues/9089. For some reason that workflow isn't triggering the `saveAs` code like it should be, which would also correctly move the URI. I'll scope that fix to that issue.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- https://github.com/posit-dev/positron/issues/9022 When saving untitled notebooks, you can now fix their working directory without losing data.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:notebooks @:web @:win

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
A bunch of cases I can think of. In each case there shouldn't be data loss (any existing variables should still be there).

- Save an untitled notebook outside of a workspace. The modal should pop up if you save it somewhere besides your home dir.
- Save an untitled notebook inside of a workspace. The modal should pop up if you save it somewhere besides the workspace root.
- Try without/with the `notebook.workingDirectory` setting set. If set, the modal should only pop up if the resolved setting would change.
    - Watch out for https://github.com/posit-dev/positron/issues/9631. In fact that issue may make it impossible to validate this setting behavior.
- Try clicking on "keep" vs "update" and ensure they behave as expected
- Try web and windows