### PR TITLE
Use Positron specific key for last known version

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -104,7 +104,7 @@ function isMajorMinorUpdate(before: IPositronVersion, after: IPositronVersion): 
 export class ProductContribution implements IWorkbenchContribution {
 
 	// --- Start Positron ---
-	public static readonly KEY = 'releaseNotes/lastVersion';
+	public static readonly KEY = 'positronReleaseNotes/lastVersion';
 	// --- End Positron ---
 
 	constructor(


### PR DESCRIPTION
Address #9273 

This was using the CodeOSS key for storing the last known version. Older versions of Positron would have stored the CodeOSS version and the update to support Positron release notes would be comparing that version to a Positron version, which are incompatible.

This should fix any future problems by using a key that we know would only store the Positron version (we use calver instead of semver).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Positron checking last known version that used to store CodeOSS version


### QA Notes