### PR TITLE
ci: bump timeout for tests

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -71,7 +71,7 @@ jobs:
     name: ${{ inputs.display_name }}
     runs-on:
       labels: [windows-latest-8x]
-    timeout-minutes: 100
+    timeout-minutes: 120
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       pull_request:
-        description: 'Is this a pull request run?'
+        description: "Is this a pull request run?"
         required: false
         default: false
         type: boolean
@@ -22,7 +22,7 @@ jobs:
   integration-tests:
     name: integration
     runs-on: ubuntu-latest-4x
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
@@ -68,7 +68,7 @@ jobs:
       - name: Setup R
         uses: ./.github/actions/install-r
         with:
-            version: "4.4.0"
+          version: "4.4.0"
 
       - name: Compile Integration Tests
         run: npm run --prefix test/integration/browser compile


### PR DESCRIPTION
### Summary
Jobs are taking longer to run and timing out, so giving them some more time.


### QA Notes

n/a
