### PR TITLE
Remove using update version for extension check

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -2171,10 +2171,15 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			case StateType.Downloaded:
 			case StateType.Updating:
 			case StateType.Ready: {
+				// --- Start Positron ---
+				// Removing for now until the release update metadata populates with the CodeOSS version
+				/*
 				const version = this.updateService.state.update.productVersion;
 				if (version && semver.valid(version)) {
 					return { version, date: this.updateService.state.update.timestamp ? new Date(this.updateService.state.update.timestamp).toISOString() : undefined };
 				}
+				*/
+				// --- End Positron ---
 			}
 		}
 		return undefined;


### PR DESCRIPTION
Address #9258 

This removes the check on a pending update to get the application version. I'll re-enable and modify to use the CodeOSS version once the [build has updated](https://github.com/posit-dev/positron-builds/pull/538) to generate the CodeOSS version in the release metadata.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix incompatible version when checking for extension updates


### QA Notes
Steps to reproduce:
1. Run Positron long enough that there is an update available
2. Allow the update to download but do not restart to update
3. Run an extension update (available as a command "Check for Extension Updates")