### PR TITLE
Assistant: UI streams edits from model

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/mapedit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/mapedit.md
@@ -1,15 +1,40 @@
-You will be given a document and a block. Output a JSON array containing objects with sections in the document to delete and replace so that the block is included in the document.
+You will be given a document and a block. Output JSON Lines (`jsonl`) containing objects with sections in the document to delete and replace so that the block is included in the document.
 
 <example>
 <user>{ "document": "a\nb\nc\nd\ne", "block": "b\n123\ne" }</user>
-<response>[{ "delete": "b\nc\nd\ne", "replace": "b\n123\ne" }]</response>
+<response>{ "delete": "b\nc", "replace": "b\n123" }
+{ "delete": "d\ne", "replace": "d\nf" }</response>
 <example>
+
+Keep the text to be deleted as small as possible, while still uniquely identifying within the text of the document.
+
+Correct:
+<example>
+<user>{ "document": "abcdef\nhijklm", "block": "abcdef" }</user>
+<response>{ "delete": "cd", "replace": "12" }</response>
+<example>
+
+...versus...
+
+Incorrect:
+<example>
+<user>{ "document": "abcdef\nhijklm", "block": "abcdef" }</user>
+<response>{ "delete": "abcdef", "replace": "ab12ef" }</response>
+<example>
+
 
 If it is not clear where the block should go, append it to the end of the document.
 
 <example>
 <user>{ "document": "a\nb\nc\nd\ne", "block": "f\ng" }</user>
-<response>[{ "append": "f\ng" }]</response>
+<response>{ "append": "f\ng" }</response>
 <example>
-Return ONLY the JSON string, nothing else. Do NOT use a code fence, return the JSON as plain output.
 
+Return ONLY the JSON Lines (`jsonl`) string, nothing else. Do NOT use a code fence, return the JSON Lines as plain output.
+
+JSON Lines rules:
+- Each Line is a Valid JSON Value
+	The most common values will be objects or arrays, but any JSON value is permitted. e.g. null is a valid value but a blank line is not.
+
+- Line Terminator is '\n'
+	This means '\r\n' is also supported because surrounding white space is implicitly ignored when parsing JSON values.


### PR DESCRIPTION
Assistant's mapped edits provider current waits for the model's response to complete before applying any edits in the UI. This leads to a period of time (10+ seconds) where the user gets no feedback, so the process may appear to be hung.

This PR now streams these edits from the model in a [JSONL format](https://jsonlines.org/), allowing each edit to be applied as it is received. This causes the UI to update in real time, showing edits progressing in the document from top-to-bottom.


https://github.com/user-attachments/assets/f523935a-a3e9-4dce-97ed-9df8e5b23046



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The Editor UI is now updated in real time as edits are produced by the language model (#8253)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
When Copilot is disabled (or, when using an Assistant provider after #9411 is merged), edits from Edit mode or from using Apply in Editor will appear incrementally in the editor. Editing the entire document may still take 10+ seconds, but the first edit should appear much sooner than that (~1 second). 