### PR TITLE
Bump Ark to 0.1.208

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -972,7 +972,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.207"
+      "ark": "0.1.208"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
This brings in:

- https://github.com/posit-dev/ark/pull/914
- https://github.com/posit-dev/ark/pull/916

### Release Notes

#### New Features

- New selection backend for R Data Explorer which addresses https://github.com/posit-dev/positron/issues/9383

#### Bug Fixes

- R: Fixed how `Surv` objects are represented and formatted in the Data Explorer and Variables pane https://github.com/posit-dev/positron/issues/8053