### PR TITLE
Restore Copilot language server binaries

### DIFF
--- a/extensions/positron-assistant/scripts/install-copilot-language-server.ts
+++ b/extensions/positron-assistant/scripts/install-copilot-language-server.ts
@@ -69,7 +69,7 @@ async function main() {
 
 			// Use --force to prevent npm from blocking the installation due to
 			// CPU architecture mismatch
-			const npmInstallCmd = `npm install ${packageName} --force`;
+			const npmInstallCmd = `npm install ${packageName}@${npmVersion} --force`;
 			console.log(npmInstallCmd);
 			execSync(npmInstallCmd, { stdio: 'inherit' });
 		}

--- a/extensions/positron-assistant/scripts/install-copilot-language-server.ts
+++ b/extensions/positron-assistant/scripts/install-copilot-language-server.ts
@@ -53,8 +53,7 @@ async function main() {
 	// Bundle both arm64 and x64 for macOS, and use the one that matches the
 	// current architecture on Linux.
 	const targetArches = platform() === 'win32' ? ['x64'] :
-		platform() === 'darwin' ? ['arm64', 'x64'] :
-			[process.env.npm_config_arch || arch()];
+		[process.env.npm_config_arch || arch()];
 
 	// Copy the server for each target architecture.
 	for (const targetArch of targetArches) {
@@ -63,7 +62,7 @@ async function main() {
 			path.join(bundleDir, targetArch) : bundleDir;
 
 		await mkdir(serverDir, { recursive: true });
-		const npmServerPath = path.join(npmDir, 'native', `${platform()}-${targetArch}`, serverName);
+		const npmServerPath = path.join(`${npmDir}-${platform()}-${targetArch}`, serverName);
 		const bundledServerPath = path.join(serverDir, serverName);
 		await copyFile(npmServerPath, bundledServerPath);
 	}

--- a/extensions/positron-assistant/scripts/install-copilot-language-server.ts
+++ b/extensions/positron-assistant/scripts/install-copilot-language-server.ts
@@ -64,12 +64,13 @@ async function main() {
 		// On macOS, we need both the x64 and arm64 versions of the language
 		// server. By default npm just installs the one for the current CPU
 		// architecture.
-		if (platform() === 'darwin') {
+		if (platform() === 'darwin' && process.env.GITHUB_ACTIONS) {
 			console.log(`Installing ${packageName} (${targetArch})...`);
 
 			// Use --force to prevent npm from blocking the installation due to
-			// CPU architecture mismatch
-			const npmInstallCmd = `npm install ${packageName}@${npmVersion} --force`;
+			// CPU architecture mismatch, and --no-save to prevent modifying
+			// package.json/lock files
+			const npmInstallCmd = `npm install ${packageName}@${npmVersion} --force --no-save`;
 			console.log(npmInstallCmd);
 			execSync(npmInstallCmd, { stdio: 'inherit' });
 		}

--- a/extensions/positron-assistant/scripts/install-copilot-language-server.ts
+++ b/extensions/positron-assistant/scripts/install-copilot-language-server.ts
@@ -64,7 +64,7 @@ async function main() {
 		// On macOS, we need both the x64 and arm64 versions of the language
 		// server. By default npm just installs the one for the current CPU
 		// architecture.
-		if (platform() === 'darwin' && process.env.GITHUB_ACTIONS) {
+		if (platform() === 'darwin') {
 			console.log(`Installing ${packageName} (${targetArch})...`);
 
 			// Use --force to prevent npm from blocking the installation due to


### PR DESCRIPTION
The recent update to the Copilot LSP had the side effect of _removing_ the binary entirely due to some furniture rearrangement on Microsoft's part -- the native binaries are no longer all installed by default; instead each one is a separate npm package.

The annoying thing about this is that only the correct package for your OS gets installed, but when doing cross-compilation we need to get packages for other OS's. So now we need to force install a couple of packages on macOS to pick up both architectures. 

Addresses https://github.com/posit-dev/positron/issues/9384.