### PR TITLE
e2e: add support to run playwright tests against external server

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "e2e-win": "npx playwright test --project e2e-electron --grep @:win",
     "e2e-failed": "npx playwright test --last-failed",
     "e2e-summary": "python test/e2e/create-test-summary.py test/e2e/tests",
+    "e2e-start-server": "./scripts/e2e-start-server.sh 8080 dev-token",
     "e2e-ui": "PW_UI_MODE=true npx playwright test --ui",
     "prelaunch": "node build/lib/preLaunch.js",
     "download-builtin-extensions": "node build/lib/builtInExtensions.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -91,6 +91,17 @@ export default defineConfig<ExtendedTestOptions>({
 			grep: /@:web/
 		},
 		{
+			name: 'e2e-browser-external',
+			use: {
+				web: true,
+				artifactDir: 'e2e-browser-external',
+				headless: false,
+				useExternalServer: true,
+				externalServerUrl: 'http://localhost:8080/?tkn=dev-token'
+			},
+			grep: /@:web|@:external/
+		},
+		{
 			name: 'e2e-windows',
 			use: {
 				web: false,

--- a/scripts/e2e-start-server.sh
+++ b/scripts/e2e-start-server.sh
@@ -58,12 +58,12 @@ trap cleanup EXIT
 
 # Start the server with explicit user data directory and additional e2e options
 ./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT" \
-  --user-data-dir "$USER_DATA_DIR" \
-  --disable-telemetry \
-  --disable-experiments \
-  --skip-welcome \
-  --skip-release-notes \
-  --no-cached-data \
-  --disable-updates \
-  --use-inmemory-secretstorage \
-  --disable-workspace-trust
+	--user-data-dir "$USER_DATA_DIR" \
+	--disable-telemetry \
+	--disable-experiments \
+	--skip-welcome \
+	--skip-release-notes \
+	--no-cached-data \
+	--disable-updates \
+	--use-inmemory-secretstorage \
+	--disable-workspace-trust

--- a/scripts/e2e-start-server.sh
+++ b/scripts/e2e-start-server.sh
@@ -5,9 +5,7 @@
 
 PORT=${1:-8080}
 TOKEN=${2:-dev-token}
-
-# Use a fixed user data directory for e2e testing in the home directory
-USER_DATA_DIR="$HOME/.positron-e2e-test"
+USER_DATA_DIR=${3:-"$HOME/.positron-e2e-test"}
 
 echo "Starting Positron code server for e2e testing..."
 echo "Port: $PORT"
@@ -16,47 +14,10 @@ echo "User Data Dir: $USER_DATA_DIR"
 echo "URL: http://localhost:$PORT/?tkn=$TOKEN"
 echo ""
 
-# Create user data directory structure if it doesn't exist
-mkdir -p "$USER_DATA_DIR/User"
+# Note: User data directory creation, fixture copying, and cleanup
+# are handled by the test fixture system.
 
-# Copy test fixtures (keybindings and settings) to the server's user data directory
-FIXTURES_DIR="$(dirname "$0")/../test/e2e/fixtures"
-USER_DIR="$USER_DATA_DIR/User"
-
-echo "Fixtures directory: $FIXTURES_DIR"
-echo "User directory: $USER_DIR"
-echo "Looking for keybindings.json at: $FIXTURES_DIR/keybindings.json"
-
-# Copy keybindings.json for hotkey support to User directory (user shortcuts location)
-if [ -f "$FIXTURES_DIR/keybindings.json" ]; then
-	echo "Found keybindings.json, copying to User directory..."
-	cp "$FIXTURES_DIR/keybindings.json" "$USER_DIR/keybindings.json" && echo "Successfully copied keybindings.json" || echo "Failed to copy keybindings.json"
-	ls -la "$USER_DIR/keybindings.json" || echo "keybindings.json not found after copy"
-else
-	echo "Error: keybindings.json not found at $FIXTURES_DIR/keybindings.json"
-	ls -la "$FIXTURES_DIR/" || echo "Fixtures directory not found"
-fi
-
-# Copy settings.json to User directory
-SETTINGS_FILE="$USER_DIR/settings.json"
-if [ -f "$FIXTURES_DIR/settings.json" ]; then
-	echo "Copying settings.json from test fixtures..."
-	cp "$FIXTURES_DIR/settings.json" "$SETTINGS_FILE"
-elif [ ! -f "$SETTINGS_FILE" ]; then
-	echo '{}' > "$SETTINGS_FILE"
-	echo "Created empty settings.json at $SETTINGS_FILE"
-fi
-
-# Cleanup function to remove user data directory on exit
-cleanup() {
-	echo "Cleaning up user data directory: $USER_DATA_DIR"
-	rm -rf "$USER_DATA_DIR"
-}
-
-# Set up cleanup on script exit
-trap cleanup EXIT
-
-# Start the server with explicit user data directory and additional e2e options
+# Start the server with additional e2e options
 ./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT" \
 	--user-data-dir "$USER_DATA_DIR" \
 	--disable-telemetry \

--- a/scripts/e2e-start-server.sh
+++ b/scripts/e2e-start-server.sh
@@ -6,11 +6,64 @@
 PORT=${1:-8080}
 TOKEN=${2:-dev-token}
 
+# Use a fixed user data directory for e2e testing in the home directory
+USER_DATA_DIR="$HOME/.positron-e2e-test"
+
 echo "Starting Positron code server for e2e testing..."
 echo "Port: $PORT"
 echo "Token: $TOKEN"
+echo "User Data Dir: $USER_DATA_DIR"
 echo "URL: http://localhost:$PORT/?tkn=$TOKEN"
 echo ""
 
-# Start the server
-./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT"
+# Create user data directory structure if it doesn't exist
+mkdir -p "$USER_DATA_DIR/User"
+
+# Copy test fixtures (keybindings and settings) to the server's user data directory
+FIXTURES_DIR="$(dirname "$0")/../test/e2e/fixtures"
+USER_DIR="$USER_DATA_DIR/User"
+
+echo "Fixtures directory: $FIXTURES_DIR"
+echo "User directory: $USER_DIR"
+echo "Looking for keybindings.json at: $FIXTURES_DIR/keybindings.json"
+
+# Copy keybindings.json for hotkey support to User directory (user shortcuts location)
+if [ -f "$FIXTURES_DIR/keybindings.json" ]; then
+	echo "Found keybindings.json, copying to User directory..."
+	cp "$FIXTURES_DIR/keybindings.json" "$USER_DIR/keybindings.json" && echo "Successfully copied keybindings.json" || echo "Failed to copy keybindings.json"
+	ls -la "$USER_DIR/keybindings.json" || echo "keybindings.json not found after copy"
+else
+	echo "Error: keybindings.json not found at $FIXTURES_DIR/keybindings.json"
+	ls -la "$FIXTURES_DIR/" || echo "Fixtures directory not found"
+fi
+
+# Copy settings.json to User directory
+SETTINGS_FILE="$USER_DIR/settings.json"
+if [ -f "$FIXTURES_DIR/settings.json" ]; then
+	echo "Copying settings.json from test fixtures..."
+	cp "$FIXTURES_DIR/settings.json" "$SETTINGS_FILE"
+elif [ ! -f "$SETTINGS_FILE" ]; then
+	echo '{}' > "$SETTINGS_FILE"
+	echo "Created empty settings.json at $SETTINGS_FILE"
+fi
+
+# Cleanup function to remove user data directory on exit
+cleanup() {
+	echo "Cleaning up user data directory: $USER_DATA_DIR"
+	rm -rf "$USER_DATA_DIR"
+}
+
+# Set up cleanup on script exit
+trap cleanup EXIT
+
+# Start the server with explicit user data directory and additional e2e options
+./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT" \
+  --user-data-dir "$USER_DATA_DIR" \
+  --disable-telemetry \
+  --disable-experiments \
+  --skip-welcome \
+  --skip-release-notes \
+  --no-cached-data \
+  --disable-updates \
+  --use-inmemory-secretstorage \
+  --disable-workspace-trust

--- a/scripts/e2e-start-server.sh
+++ b/scripts/e2e-start-server.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Start the Positron code server for external e2e testing
+# Usage: ./scripts/start-e2e-server.sh [port] [token]
+
+PORT=${1:-8080}
+TOKEN=${2:-dev-token}
+
+echo "Starting Positron code server for e2e testing..."
+echo "Port: $PORT"
+echo "Token: $TOKEN"
+echo "URL: http://localhost:$PORT/?tkn=$TOKEN"
+echo ""
+
+# Start the server
+./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -209,7 +209,8 @@ When creating a pull request, the test runner automatically scans the PR descrip
 1. Use the format `@:tag` anywhere in your PR description (e.g., `@:help`, `@:console`).
 2. Once added, a comment will appear on your PR confirming that the tag was found and parsed correctly.
 
-> [!NOTE] > **Add tags before the `pr-tags` job starts**. If you update tags _after_ opening the PR, push a new commit or restart the jobs to apply the changes. The PR comment will confirm the detected tags, and tests will run based on the tags present at execution time.
+> [!NOTE]
+> **Add tags before the `pr-tags` job starts**. If you update tags _after_ opening the PR, push a new commit or restart the jobs to apply the changes. The PR comment will confirm the detected tags, and tests will run based on the tags present at execution time.
 > For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
 ### Running Windows and Browser Tests
@@ -218,7 +219,6 @@ By default, only Linux E2E tests run. If you need to include additional environm
 
 - Add `@:win` to your PR description to run tests on Windows. (Note: Windows tests take longer to complete.)
 - Add `@:web` to run browser-based tests.
-- Add `@:external` to run tests against external server
 
 ## Running Tests in Github Actions
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -125,7 +125,10 @@ We use Playwright as the test framework for end-to-end tests in Positron. Make s
 #### Test Explorer
 
 1. Open the **Testing** extension.
-2. Ensure the correct project (`e2e-electron` or `e2e-browser`) is selected; otherwise, no tests will populate in the Test Explorer.
+2. Ensure the correct project is selected; otherwise, no tests will populate in the Test Explorer.
+   - `e2e-electron`: Standard Electron app testing
+   - `e2e-browser`: Browser testing with managed server
+   - `e2e-browser-external`: Browser testing with external server ⭐
 3. Expand the file tree to locate the desired test.
 4. Use the action buttons next to each test to:
    - **Run Test**: Executes the selected test.
@@ -206,9 +209,8 @@ When creating a pull request, the test runner automatically scans the PR descrip
 1. Use the format `@:tag` anywhere in your PR description (e.g., `@:help`, `@:console`).
 2. Once added, a comment will appear on your PR confirming that the tag was found and parsed correctly.
 
-> [!NOTE]
-> **Add tags before the `pr-tags` job starts**. If you update tags _after_ opening the PR, push a new commit or restart the jobs to apply the changes. The PR comment will confirm the detected tags, and tests will run based on the tags present at execution time.
-For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
+> [!NOTE] > **Add tags before the `pr-tags` job starts**. If you update tags _after_ opening the PR, push a new commit or restart the jobs to apply the changes. The PR comment will confirm the detected tags, and tests will run based on the tags present at execution time.
+> For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
 ### Running Windows and Browser Tests
 
@@ -216,6 +218,7 @@ By default, only Linux E2E tests run. If you need to include additional environm
 
 - Add `@:win` to your PR description to run tests on Windows. (Note: Windows tests take longer to complete.)
 - Add `@:web` to run browser-based tests.
+- Add `@:external` to run tests against external server
 
 ## Running Tests in Github Actions
 

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -159,6 +159,7 @@ export function ExternalServerAppFixture() {
 
 			// workaround since we have rogue sessions at startup
 			await app.workbench.sessions.expectNoStartUpMessaging();
+			await app.workbench.hotKeys.closeAllEditors();
 			await app.workbench.sessions.deleteAll();
 
 			await use(app);

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -151,6 +151,16 @@ export function AppFixture() {
 export function ExternalServerAppFixture() {
 	return async (fixtureOptions: AppFixtureOptions, use: (arg0: Application) => Promise<void>) => {
 		const { options, logsPath, logger, workerInfo } = fixtureOptions;
+
+		// For external server mode, use the server's actual user data directory
+		const serverUserDataDir = join(os.homedir(), '.positron-e2e-test');
+		const userDir = join(serverUserDataDir, 'User');
+
+		console.log('External server user data dir:', serverUserDataDir);
+		await mkdir(userDir, { recursive: true });
+		await copyFixtureFile('keybindings.json', userDir, true);
+		await copyFixtureFile('settings.json', userDir);
+
 		const app = createApp(options);
 
 		try {

--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -174,7 +174,7 @@ export class Application {
 	private async checkExternalServerWorkbenchReady(code: Code): Promise<void> {
 		// For external servers, check for key UI elements that indicate readiness
 		// instead of relying on lifecycle phases which may have already completed
-		await code.driver.page.getByRole('button', { name: 'Yes, I trust the authors' }).click();
+		// await code.driver.page.getByRole('button', { name: 'Yes, I trust the authors' }).click();
 
 		// Wait for the explorer to be visible (main workbench element)
 		await expect(code.driver.page.locator('.explorer-folders-view')).toBeVisible({ timeout: 60000 });

--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -69,6 +69,11 @@ export class Application {
 		await expect(this.code.driver.page.locator('.explorer-folders-view')).toBeVisible();
 	}
 
+	async connectToExternalServer(): Promise<void> {
+		await this._connectToExternalServer();
+		await expect(this.code.driver.page.locator('.explorer-folders-view')).toBeVisible();
+	}
+
 	async restart(options?: { workspaceOrFolder?: string; extraArgs?: string[] }): Promise<void> {
 		await measureAndLog(() => (async () => {
 			await this.stop();
@@ -96,6 +101,37 @@ export class Application {
 		}
 	}
 
+	async stopExternalServer(): Promise<void> {
+		// For external servers, we only need to close the browser connection
+		// The external server keeps running
+		if (this._code) {
+			try {
+				await this._code.driver.close();
+			} finally {
+				this._code = undefined;
+			}
+		}
+	}
+
+	private async _connectToExternalServer(): Promise<void> {
+		// Connect to external server without launching
+		const code = await this.connectToExternalApplication();
+
+		// Make sure the window is ready to interact
+		await measureAndLog(() => this.checkWindowReady(code), 'Application#checkWindowReady() [external]', this.logger);
+	}
+
+	private async connectToExternalApplication(): Promise<Code> {
+		const code = this._code = await launch({
+			...this.options,
+		});
+
+		this._workbench = new Workbench(this._code);
+		this._profiler = new Profiler(this.code);
+
+		return code;
+	}
+
 	async startTracing(name: string): Promise<void> {
 		await this._code?.startTracing(name);
 	}
@@ -121,11 +157,40 @@ export class Application {
 		// We need a rendered workbench
 		await measureAndLog(() => code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
 		await measureAndLog(() => expect(code.driver.page.locator('.monaco-workbench')).toBeVisible({ timeout: 30000 }), 'Application#checkWindowReady: wait for .monaco-workbench element', this.logger);
-		await measureAndLog(() => code.whenWorkbenchRestored(), 'Application#checkWorkbenchRestored', this.logger);
+
+		// For external servers, use a more robust readiness check
+		if (this.options.useExternalServer) {
+			await measureAndLog(() => this.checkExternalServerWorkbenchReady(code), 'Application#checkExternalServerWorkbenchReady', this.logger);
+		} else {
+			await measureAndLog(() => code.whenWorkbenchRestored(), 'Application#checkWorkbenchRestored', this.logger);
+		}
 
 		// Remote but not web: wait for a remote connection state change
 		if (this.remote) {
 			await measureAndLog(() => expect(code.driver.page.locator('.monaco-workbench .statusbar-item[id="status.host"]')).not.toContainText('Opening Remote'), 'Application#checkWindowReady: wait for remote indicator', this.logger);
 		}
+	}
+
+	private async checkExternalServerWorkbenchReady(code: Code): Promise<void> {
+		// For external servers, check for key UI elements that indicate readiness
+		// instead of relying on lifecycle phases which may have already completed
+		await code.driver.page.getByRole('button', { name: 'Yes, I trust the authors' }).click();
+
+		// Wait for the explorer to be visible (main workbench element)
+		await expect(code.driver.page.locator('.explorer-folders-view')).toBeVisible({ timeout: 60000 });
+
+		// Wait for the activity bar to be ready
+		await expect(code.driver.page.locator('.activitybar')).toBeVisible({ timeout: 30000 });
+
+		// Wait for the status bar to be ready
+		await expect(code.driver.page.locator('.statusbar')).toBeVisible({ timeout: 30000 });
+
+		// Not sure if we need this. Maybe?
+
+		// Ensure no loading indicators are present
+		// await expect(code.driver.page.locator('.monaco-progress-container.active')).toHaveCount(0, { timeout: 30000 });
+
+		// // Give a small buffer for any remaining initialization
+		// await code.driver.page.waitForTimeout(1000);
 	}
 }

--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -184,13 +184,5 @@ export class Application {
 
 		// Wait for the status bar to be ready
 		await expect(code.driver.page.locator('.statusbar')).toBeVisible({ timeout: 30000 });
-
-		// Not sure if we need this. Maybe?
-
-		// Ensure no loading indicators are present
-		// await expect(code.driver.page.locator('.monaco-progress-container.active')).toHaveCount(0, { timeout: 30000 });
-
-		// // Give a small buffer for any remaining initialization
-		// await code.driver.page.waitForTimeout(1000);
 	}
 }

--- a/test/e2e/infra/code.ts
+++ b/test/e2e/infra/code.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import { IElement, ILocaleInfo, ILocalizedStrings, ILogFile } from './driver';
 import { Logger, measureAndLog } from './logger';
 import { launch as launchPlaywrightBrowser } from './playwrightBrowser';
+import { launch as launchPlaywrightExternalServer } from './playwrightExternalServer';
 import { PlaywrightDriver } from './playwrightDriver';
 import { launch as launchPlaywrightElectron } from './playwrightElectron';
 import { teardown } from './processes';
@@ -32,6 +33,10 @@ export interface LaunchOptions {
 	readonly browser?: 'chromium' | 'webkit' | 'firefox' | 'chromium-msedge' | 'chromium-chrome';
 	readonly quality: Quality;
 	version: { major: number; minor: number; patch: number };
+	/** When true, connects to an external server instead of launching one */
+	readonly useExternalServer?: boolean;
+	/** The URL of an external server to connect to */
+	readonly externalServerUrl?: string;
 }
 
 interface ICodeInstance {
@@ -86,8 +91,20 @@ export async function launch(options: LaunchOptions): Promise<Code> {
 		throw new Error('Smoke test process has terminated, refusing to spawn Code');
 	}
 
-	// Browser smoke tests
-	if (options.web) {
+	// External server mode (browser tests against external server)
+	if (options.web && options.useExternalServer) {
+		if (!options.externalServerUrl) {
+			throw new Error('External server URL must be provided when useExternalServer is true');
+		}
+
+		const { driver } = await measureAndLog(() => launchPlaywrightExternalServer(options, options.externalServerUrl!), 'launch playwright (external server)', options.logger);
+
+		// No server process to register since we're connecting to an external one
+		return new Code(driver, options.logger, null as any, undefined, options.quality, options.version);
+	}
+
+	// Browser smoke tests (managed server)
+	else if (options.web) {
 		const { serverProcess, driver } = await measureAndLog(() => launchPlaywrightBrowser(options), 'launch playwright (browser)', options.logger);
 		registerInstance(serverProcess, options.logger, 'server');
 
@@ -110,7 +127,7 @@ export class Code {
 	constructor(
 		driver: PlaywrightDriver,
 		readonly logger: Logger,
-		private readonly mainProcess: cp.ChildProcess,
+		private readonly mainProcess: cp.ChildProcess | null,
 		private readonly safeToKill: Promise<void> | undefined,
 		readonly quality: Quality,
 		readonly version: { major: number; minor: number; patch: number },
@@ -175,6 +192,13 @@ export class Code {
 
 	async exit(): Promise<void> {
 		return measureAndLog(() => new Promise<void>(resolve => {
+			// If no main process (external server mode), just close the driver
+			if (!this.mainProcess) {
+				this.driver.close();
+				resolve();
+				return;
+			}
+
 			const pid = this.mainProcess.pid!;
 
 			let done = false;

--- a/test/e2e/infra/playwrightDriver.ts
+++ b/test/e2e/infra/playwrightDriver.ts
@@ -186,8 +186,8 @@ export class PlaywrightDriver {
 			// Ignore
 		}
 
-		// Web: Extract client logs
-		if (this.options.web) {
+		// Web: Extract client logs (skip for external servers since we don't manage them)
+		if (this.options.web && !this.options.useExternalServer) {
 			try {
 				await measureAndLog(() => this.saveWebClientLogs(), 'saveWebClientLogs()', this.options.logger);
 			} catch (error) {

--- a/test/e2e/infra/playwrightExternalServer.ts
+++ b/test/e2e/infra/playwrightExternalServer.ts
@@ -79,7 +79,7 @@ async function launchBrowser(options: LaunchOptions, serverUrl: string) {
 		`["logLevel","${options.verbose ? 'trace' : 'info'}"]`
 	].join(',')}]`;
 
-	// Construct URL for external server (assuming it follows the same pattern)
+	// Construct URL for external server
 	const workspaceParam = workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder';
 	const fullUrl = `${serverUrl}&${workspaceParam}=${URI.file(workspacePath!).path}&payload=${payloadParam}`;
 

--- a/test/e2e/infra/playwrightExternalServer.ts
+++ b/test/e2e/infra/playwrightExternalServer.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as playwright from '@playwright/test';
+import { URI } from 'vscode-uri';
+import { measureAndLog } from './logger';
+import type { LaunchOptions } from './code';
+import { PlaywrightDriver } from './playwrightDriver';
+
+/**
+ * Launches a browser against an external server (e.g., one started via ./scripts/code-server.sh)
+ */
+export async function launch(options: LaunchOptions, serverUrl: string): Promise<{ driver: PlaywrightDriver }> {
+	// Launch browser
+	const { browser, context, page, pageLoadedPromise } = await launchBrowser(options, serverUrl);
+
+	return {
+		driver: new PlaywrightDriver(browser, context, page, undefined, pageLoadedPromise, options)
+	};
+}
+
+async function launchBrowser(options: LaunchOptions, serverUrl: string) {
+	const { logger, workspacePath, tracing, snapshots, headless } = options;
+
+	const [browserType, browserChannel] = (options.browser ?? 'chromium').split('-');
+	const browser = await measureAndLog(() => playwright[browserType as unknown as 'chromium' | 'webkit' | 'firefox'].launch({
+		headless: headless ?? false,
+		timeout: 0,
+		channel: browserChannel,
+	}), 'playwright#launch', logger);
+
+	browser.on('disconnected', () => logger.log(`Playwright: browser disconnected`));
+
+	const context = await measureAndLog(() => browser.newContext(), 'browser.newContext', logger);
+
+	if (tracing) {
+		try {
+			await measureAndLog(() => context.tracing.start({ screenshots: true, snapshots }), 'context.tracing.start()', logger);
+			// Prevent duplicate tracing start calls
+			context.tracing.start = async (...args) => {
+				logger.log('Tracing is already managed, skipping default tracing start.');
+			};
+		} catch (error) {
+			logger.log(`Playwright (External Server): Failed to start playwright tracing (${error})`);
+		}
+	}
+
+	const page = await measureAndLog(() => context.newPage(), 'context.newPage()', logger);
+	await measureAndLog(() => page.setViewportSize({ width: 1200, height: 800 }), 'page.setViewportSize', logger);
+
+	if (options.verbose) {
+		context.on('page', () => logger.log(`Playwright (External Server): context.on('page')`));
+		context.on('requestfailed', e => logger.log(`Playwright (External Server): context.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
+
+		page.on('console', e => logger.log(`Playwright (External Server): window.on('console') [${e.text()}]`));
+		page.on('dialog', () => logger.log(`Playwright (External Server): page.on('dialog')`));
+		page.on('domcontentloaded', () => logger.log(`Playwright (External Server): page.on('domcontentloaded')`));
+		page.on('load', () => logger.log(`Playwright (External Server): page.on('load')`));
+		page.on('popup', () => logger.log(`Playwright (External Server): page.on('popup')`));
+		page.on('framenavigated', () => logger.log(`Playwright (External Server): page.on('framenavigated')`));
+		page.on('requestfailed', e => logger.log(`Playwright (External Server): page.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
+	}
+
+	page.on('pageerror', async (error) => logger.log(`Playwright (External Server) ERROR: page error: ${error}`));
+	page.on('crash', () => logger.log('Playwright (External Server) ERROR: page crash'));
+	page.on('close', () => logger.log('Playwright (External Server): page close'));
+	page.on('response', async (response) => {
+		if (response.status() >= 400) {
+			logger.log(`Playwright (External Server) ERROR: HTTP status ${response.status()} for ${response.url()}`);
+		}
+	});
+
+	const payloadParam = `[${[
+		'["enableProposedApi",""]',
+		'["skipWelcome", "true"]',
+		'["skipReleaseNotes", "true"]',
+		`["logLevel","${options.verbose ? 'trace' : 'info'}"]`
+	].join(',')}]`;
+
+	// Construct URL for external server (assuming it follows the same pattern)
+	const workspaceParam = workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder';
+	const fullUrl = `${serverUrl}&${workspaceParam}=${URI.file(workspacePath!).path}&payload=${payloadParam}`;
+
+	logger.log(`Connecting to external server: ${fullUrl}`);
+
+	const gotoPromise = measureAndLog(() => page.goto(fullUrl), 'page.goto() [external server]', logger);
+	const pageLoadedPromise = page.waitForLoadState('load');
+
+	await gotoPromise;
+
+	return { browser, context, page, pageLoadedPromise };
+}

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -17,10 +17,7 @@ export class HotKeys {
 	}
 
 	private isExternalBrowser(): boolean {
-		// Check if we're running against an external server (browser mode)
-		// This can be detected by checking if the URL contains port 8080
-		const currentUrl = this.code.driver.page.url();
-		return currentUrl.includes('8080');
+		return this.code.driver.page.url().includes('8080');
 	}
 
 	// ----------------------
@@ -28,27 +25,27 @@ export class HotKeys {
 	// ----------------------
 
 	public async copy() {
-		await this.pressHotKeys('Cmd+C');
+		await this.pressHotKeys('Cmd+C', 'Copy');
 	}
 
 	public async cut() {
-		await this.pressHotKeys('Cmd+X');
+		await this.pressHotKeys('Cmd+X', 'Cut');
 	}
 
 	public async paste() {
-		await this.pressHotKeys('Cmd+V');
+		await this.pressHotKeys('Cmd+V', 'Paste');
 	}
 
 	public async redo() {
-		await this.pressHotKeys('Cmd+Shift+Z');
+		await this.pressHotKeys('Cmd+Shift+Z', 'Redo');
 	}
 
 	public async selectAll() {
-		await this.pressHotKeys('Cmd+A');
+		await this.pressHotKeys('Cmd+A', 'Select All');
 	}
 
 	public async undo() {
-		await this.pressHotKeys('Cmd+Z');
+		await this.pressHotKeys('Cmd+Z', 'Undo');
 	}
 
 	// ------------------------
@@ -68,11 +65,11 @@ export class HotKeys {
 	// --------------------
 
 	public async openFile() {
-		await this.pressHotKeys('Cmd+O');
+		await this.pressHotKeys('Cmd+O', 'Open File');
 	}
 
 	public async save() {
-		await this.pressHotKeys('Cmd+S');
+		await this.pressHotKeys('Cmd+S', 'Save');
 	}
 
 	// -------------------------
@@ -81,6 +78,12 @@ export class HotKeys {
 
 	public async closeAllEditors() {
 		await this.pressHotKeys('Cmd+K Cmd+W', 'Close all editors');
+		if (this.isExternalBrowser()) {
+			const dontSaveButton = this.code.driver.page.getByRole('button', { name: 'Don\'t Save' });
+			if (await dontSaveButton.isVisible()) {
+				await dontSaveButton.click();
+			}
+		}
 	}
 
 	public async closeTab() {
@@ -170,7 +173,7 @@ export class HotKeys {
 	// -------------------------
 
 	public async closeWorkspace() {
-		await this.pressHotKeys('Cmd+J W');
+		await this.pressHotKeys('Cmd+J W', 'Close workspace');
 		await expect(this.code.driver.page.locator('.explorer-folders-view')).not.toBeVisible();
 	}
 

--- a/test/e2e/pages/quickaccess.ts
+++ b/test/e2e/pages/quickaccess.ts
@@ -42,6 +42,10 @@ export class QuickAccess {
 		// Clear editor history to ensure Quick Access is not "polluted"
 		await this.runCommand('workbench.action.clearEditorHistory');
 
+		if (this.code.driver.page.url().includes('8080')) {
+			await this.code.driver.page.getByRole('button', { name: 'Clear', exact: true }).click();
+		}
+
 		await expect(async () => {
 			// Open Quick Access and wait for the elements to appear
 			await this.openQuickAccessWithRetry(QuickAccessKind.Files, searchValue);

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -239,6 +239,9 @@ export class Sessions {
 				await this.delete(sessionIds[i]);
 			}
 
+			// Workaround for external browser
+			try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
+
 			await expect(this.page.getByText('There is no session running.')).toBeVisible();
 		});
 	}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -140,7 +140,11 @@ export class Sessions {
 						await this.page.getByTestId('trash-session').click();
 						return;
 					} else {
-						throw new Error(`Cannot delete session ${sessionId} because it does not exist`);
+						if (this.code.driver.page.url().includes('8080')) {
+							return; // workaround for external browser
+						} else {
+							throw new Error(`Cannot delete session ${sessionId} because it does not exist`);
+						}
 					}
 				} else {
 					const sessionTab = this.getSessionTab(sessionId);
@@ -240,9 +244,11 @@ export class Sessions {
 			}
 
 			// Workaround for external browser
-			try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
-
-			await expect(this.page.getByText('There is no session running.')).toBeVisible();
+			if (this.code.driver.page.url().includes('8080')) {
+				try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
+			} else {
+				await expect(this.page.getByText('There is no session running.')).toBeVisible();
+			}
 		});
 	}
 

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -76,6 +76,9 @@ export async function verifyVenvEnvStarts(app: Application) {
 
 export async function verifyUvEnvStarts(app: Application) {
 	await test.step('Verify uv environment starts', async () => {
+		if (app.code.driver.page.url().includes('8080')) {
+			app.code.driver.page.getByRole('button', { name: 'Yes' }).click();
+		}
 		await app.workbench.console.waitForConsoleContents(/(Uv: .+) started./);
 	});
 }


### PR DESCRIPTION
### Summary

Adds the ability to run tests against external server.
1. Start server: `npm run e2e-start-server`
2. Select project: `e2e-browser-external`
3. Run tests the way you normally do...

Note: there seems to be some bugs related to sessions (sessions persisting and not deleting), I added some logic to handle those  a bit better, but it's still a little buggy. I'll be opening ticket for that shortly.

### QA Notes

Not enabling these in CI or anything yet, just getting things ready.
