### PR TITLE
Assistant: Core chat support for multiple mapped edits providers

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatCodeMapper.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatCodeMapper.ts
@@ -10,6 +10,9 @@ import { ICodeMapperProvider, ICodeMapperRequest, ICodeMapperResponse, ICodeMapp
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostCodeMapperShape, ExtHostContext, ICodeMapperProgressDto, ICodeMapperRequestDto, MainContext, MainThreadCodeMapperShape } from '../common/extHost.protocol.js';
 import { NotebookDto } from './mainThreadNotebookDto.js';
+// --- Start Positron ---
+import { ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
+// --- End Positron ---
 
 @extHostNamedCustomer(MainContext.MainThreadCodeMapper)
 export class MainThreadChatCodemapper extends Disposable implements MainThreadCodeMapperShape {
@@ -27,9 +30,18 @@ export class MainThreadChatCodemapper extends Disposable implements MainThreadCo
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostCodeMapper);
 	}
 
-	$registerCodeMapperProvider(handle: number, displayName: string): void {
+	// --- Start Positron ---
+	// Pass extensionId when registering code mapper providers
+	// to allow selection based on current chat provider
+
+	// $registerCodeMapperProvider(handle: number, displayName: string): void {
+	$registerCodeMapperProvider(handle: number, extensionId: ExtensionIdentifier, displayName: string): void {
+		// --- End Positron ---
 		const impl: ICodeMapperProvider = {
 			displayName,
+			// --- Start Positron ---
+			extension: extensionId,
+			// --- End Positron ---
 			mapCode: async (uiRequest: ICodeMapperRequest, response: ICodeMapperResponse, token: CancellationToken) => {
 				const requestId = String(MainThreadChatCodemapper._requestHandlePool++);
 				this._responseMap.set(requestId, response);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1348,7 +1348,14 @@ export interface ICodeMapperNotebookEditDto {
 export type ICodeMapperProgressDto = Dto<ICodeMapperTextEdit> | Dto<ICodeMapperNotebookEditDto>;
 
 export interface MainThreadCodeMapperShape extends IDisposable {
-	$registerCodeMapperProvider(handle: number, displayName: string): void;
+	// --- Start Positron ---
+	// Assistant & Copilot contribute providers
+	// Include extensionId when registering code mapper providers
+	// to allow selection based on current chat provider
+
+	// $registerCodeMapperProvider(handle: number, displayName: string): void;
+	$registerCodeMapperProvider(handle: number, extensionId: ExtensionIdentifier, displayName: string): void;
+	// --- End Positron ---
 	$unregisterCodeMapperProvider(handle: number): void;
 	$handleProgress(requestId: string, data: ICodeMapperProgressDto): Promise<void>;
 }

--- a/src/vs/workbench/api/common/extHostCodeMapper.ts
+++ b/src/vs/workbench/api/common/extHostCodeMapper.ts
@@ -69,7 +69,10 @@ export class ExtHostCodeMapper implements extHostProtocol.ExtHostCodeMapperShape
 
 	registerMappedEditsProvider(extension: IExtensionDescription, provider: vscode.MappedEditsProvider2): vscode.Disposable {
 		const handle = ExtHostCodeMapper._providerHandlePool++;
-		this._proxy.$registerCodeMapperProvider(handle, extension.displayName ?? extension.name);
+		// --- Start Positron ---
+		// this._proxy.$registerCodeMapperProvider(handle, extension.displayName ?? extension.name);
+		this._proxy.$registerCodeMapperProvider(handle, extension.identifier, extension.displayName ?? extension.name);
+		// --- End Positron ---
 		this.providers.set(handle, provider);
 		return {
 			dispose: () => {

--- a/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
@@ -93,6 +93,7 @@ export class CodeMapperService implements ICodeMapperService {
 				if (extension) {
 					const provider = this.providers.find(p => p.extension.value === extension.value);
 					if (provider) {
+						console.info(`Using code mapper provider from extension ${extension.value} for model ${modelId}`);
 						return await provider.mapCode(request, response, token);
 					}
 				}

--- a/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
@@ -9,6 +9,11 @@ import { URI } from '../../../../base/common/uri.js';
 import { TextEdit } from '../../../../editor/common/languages.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ICellEditOperation } from '../../notebook/common/notebookCommon.js';
+// --- Start Positron ---
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { ILanguageModelsService } from './languageModels.js';
+import { IChatService } from './chatService.js';
+// --- End Positron ---
 
 export interface ICodeMapperResponse {
 	textEdit: (resource: URI, textEdit: TextEdit[]) => void;
@@ -34,6 +39,9 @@ export interface ICodeMapperResult {
 }
 
 export interface ICodeMapperProvider {
+	// --- Start Positron ---
+	readonly extension: ExtensionIdentifier;
+	// --- End Positron ---
 	readonly displayName: string;
 	mapCode(request: ICodeMapperRequest, response: ICodeMapperResponse, token: CancellationToken): Promise<ICodeMapperResult | undefined>;
 }
@@ -51,6 +59,12 @@ export class CodeMapperService implements ICodeMapperService {
 	_serviceBrand: undefined;
 
 	public readonly providers: ICodeMapperProvider[] = [];
+	// --- Start Positron ---
+	constructor(
+		@IChatService private readonly _chatService: IChatService,
+		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
+	) { }
+	// --- End Positron ---
 
 	registerCodeMapperProvider(handle: number, provider: ICodeMapperProvider): IDisposable {
 		this.providers.push(provider);
@@ -65,6 +79,27 @@ export class CodeMapperService implements ICodeMapperService {
 	}
 
 	async mapCode(request: ICodeMapperRequest, response: ICodeMapperResponse, token: CancellationToken) {
+		// --- Start Positron ---
+		// If we can determine the extension that provided the model currently in use,
+		// prefer the code mapper provider from that same extension.
+		// This allows, for example, Copilot to use its own code mapper provider
+		// when Copilot is the current chat model.
+
+		if (request.chatSessionId) {
+			const modelId = this._chatService.getSession(request.chatSessionId)?.getRequests().at(0)?.modelId;
+			if (modelId) {
+				const model = this._languageModelsService.lookupLanguageModel(modelId);
+				const extension = model?.extension;
+				if (extension) {
+					const provider = this.providers.find(p => p.extension.value === extension.value);
+					if (provider) {
+						return await provider.mapCode(request, response, token);
+					}
+				}
+			}
+		}
+		// Otherwise, fall back to the first registered provider.
+		// --- End Positron ---
 		for (const provider of this.providers) {
 			const result = await provider.mapCode(request, response, token);
 			if (token.isCancellationRequested) {


### PR DESCRIPTION
After the Copilot merge, edits from chat were applied using whichever extension (Copilot, Assistant) was registered first. This gave inconsistent behavior: 
- Copilot is faster, Assistant is slower
- Copilot provides live feedback as edits are applied, Assistant applies them all in one batch

This PR changes logic in core to make a best effort to use the same extension contributing the current chat provider to apply the edits. So, if a user is using a Copilot model, Copilot will apply the edits with the above benefits. Conversely, Assistant models will use the Assistant implementation.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- When using Edit mode, or Apply in Editor, the same extension that provides the chat model will also handle mapping the edits to the file (#8253)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->


The user perception may not be clear (esp. after #9387 is merged) - so, a console log is written when a provider is positively chosen:
`"Using code mapper provider from extension ${extension.value} for model ${modelId}"`

This should align with either Copilot or Assistant, whichever is in use.
