### PR TITLE
ci: add pr comment workflow back in

### DIFF
--- a/.github/workflows/pr-e2e-comment.yml
+++ b/.github/workflows/pr-e2e-comment.yml
@@ -1,0 +1,31 @@
+name: "PR: Comment"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - edited
+
+jobs:
+  e2e-tags:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.state != 'closed' }} # Skip job if PR is closed
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Parse Tags from PR Body
+        id: pr-tags
+        run: bash scripts/pr-tags-parse.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Update PR Comment with Tags
+        run: bash ./scripts/pr-e2e-comment.sh "<!-- PR Tags -->" "${{ env.tags }}"
+        env:
+          tags: ${{ steps.pr-tags.outputs.tags }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Summary

I noticed that our PRs didn't have a comment regarding which test tags they were running. Turns out it was accidentally deleted by the last upstream merge (https://github.com/posit-dev/positron/pull/9033). Adding it back in.

### QA Notes

n/a
