### PR TITLE
Fix obscured total token usage

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1076,10 +1076,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (this.options.renderStyle === 'compact') {
 			elements = dom.h('.interactive-input-part', [
 				dom.h('.interactive-input-and-edit-session', [
-					dom.h('.chat-editing-session@chatEditingSessionWidgetContainer'),
 					// --- Start Positron ---
 					dom.h('.chat-token-usage-status@tokenUsageContainer'),
 					// --- End Positron ---
+					dom.h('.chat-editing-session@chatEditingSessionWidgetContainer'),
 					dom.h('.interactive-input-and-side-toolbar@inputAndSideToolbar', [
 						dom.h('.chat-input-container@inputContainer', [
 							dom.h('.chat-editor-container@editorContainer'),
@@ -1097,10 +1097,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		} else {
 			elements = dom.h('.interactive-input-part', [
 				dom.h('.interactive-input-followups@followupsContainer'),
-				dom.h('.chat-editing-session@chatEditingSessionWidgetContainer'),
 				// --- Start Positron ---
 				dom.h('.chat-token-usage-status@tokenUsageContainer'),
 				// --- End Positron ---
+				dom.h('.chat-editing-session@chatEditingSessionWidgetContainer'),
 				dom.h('.interactive-input-and-side-toolbar@inputAndSideToolbar', [
 					dom.h('.chat-input-container@inputContainer', [
 						dom.h('.chat-attachments-container@attachmentsContainer', [

--- a/src/vs/workbench/contrib/chat/browser/media/positronChat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/positronChat.css
@@ -16,6 +16,14 @@
 	flex-shrink: 0;
 }
 
+/*
+Ensure proper spacing on chat-editing-session when chat-token-usage-status is hidden
+See https://github.com/posit-dev/positron/issues/9046
+*/
+.chat-token-usage-status[style*="display: none"] ~ .chat-editing-session {
+	margin-top: 4px; /* Compensate for the margin that chat-token-usage-status would have taken */
+}
+
 .chat-token-usage-status .token-usage-total {
 	display: inline-block;
 }


### PR DESCRIPTION
Address #9046 

I had a little trouble reproducing since some models error out when given a relative path to the file. Claude 4 Opus seemed to handle a file edit the best.

This moves the total token usage to above the files changed part. The files changed was designed to be adjacent to the rest of the input part so it makes sense to move the token usage up. Added another fix to adjust the spacing below the input part. It seems that there's negative margins on the files changed part that affects the spacing below the chat input area that needs to account for when the token usage is visible or not.

<img width="396" height="219" alt="image" src="https://github.com/user-attachments/assets/b2336dc0-6f94-42ad-a35b-f0909e6b7ded" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix obscured total token usage in Assistant


### QA Notes