### PR TITLE
Fix for multiple editors error message when running the new notebook …

### DIFF
--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -97,7 +97,16 @@ export function activate(context: vscode.ExtensionContext, serializer: vscode.No
 			nbformat_minor: defaultNotebookFormat.minor,
 		};
 		const doc = await vscode.workspace.openNotebookDocument('jupyter-notebook', data);
-		await vscode.window.showNotebookDocument(doc);
+
+		// Check if Positron notebooks are configured as the default editor for .ipynb files
+		const editorAssociations = vscode.workspace.getConfiguration('workbench').get<Record<string, string>>('editorAssociations') || {};
+		const usingPositronNotebooks = editorAssociations['*.ipynb'] === 'workbench.editor.positronNotebook';
+
+		// Only call showNotebookDocument if Positron is not the default editor,
+		// since openNotebookDocument already opens the editor when Positron is default
+		if (!usingPositronNotebooks) {
+			await vscode.window.showNotebookDocument(doc);
+		}
 	}));
 	// --- End Positron ---
 


### PR DESCRIPTION
Addresses #9392 

The problem was caused by the `openNotebookDocument` method opening the editor for positron notebooks already which then confused the `showNotebookDocument` call specifically in the `newUntitledIpynb` command. 

## QA notes

The original issue circumstance should be solved. 

Alternatively you could get the same error just by opening the command palette and running `Create: New Jupyter Notebook`. 