### PR TITLE
Add additional categories for `positron-r` extension

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -10,7 +10,8 @@
   },
   "categories": [
     "Programming Languages",
-    "Data Science"
+    "Data Science",
+    "Debuggers"
   ],
   "main": "./out/extension.js",
   "capabilities": {

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -9,7 +9,8 @@
     "vscode": "^1.65.0"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Data Science"
   ],
   "main": "./out/extension.js",
   "capabilities": {


### PR DESCRIPTION
Addresses #8163

Before this PR, our R language pack extension _only_ had the category "Programming Languages", so it only showed up under the "Programming Languages" section of the extensions view. This PR adds an additional couple of categories so it also shows up under "Features". Now they are both in both places:

<img width="447" height="996" alt="Screenshot_2025-09-12_at_6_19_07 PM" src="https://github.com/user-attachments/assets/2bf65b90-7493-4f0c-b400-da3c3cb1a0db" />

The categories for the Python language pack extension are:

```json
"categories": [
        "Programming Languages",
        "Debuggers",
        "Other",
        "Data Science",
        "Machine Learning"
    ]
```

These categories are most useful for extensions that actually get published on the marketplaces, so I don't think we need to think _too_ hard about what to put here, but I chose "Data Science" and "Debuggers".


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

If you search for `@builtin` in the Extensions view, both the R and Python language pack extensions should show up both under "Features" and "Programming Languages".
