### PR TITLE
PositroNB right hand cell action menu items

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -27,7 +27,7 @@ export function NotebookCellActionBar({ cell, children }: NotebookCellActionBarP
 	const actionsForCell = useActionsForCell(cell);
 	const instance = useNotebookInstance();
 	const mainActions = actionsForCell.main;
-	const mainRightActions = actionsForCell['main-right'];
+	const mainRightActions = actionsForCell['mainRight'];
 	const menuActions = actionsForCell.menu;
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 	const selectionStatus = useObservedValue(cell.selectionStatus);
@@ -65,7 +65,7 @@ export function NotebookCellActionBar({ cell, children }: NotebookCellActionBarP
 			/>
 		) : null}
 
-		{/* Render contributed main-right actions - will auto-update when registry changes */}
+		{/* Render contributed mainRight actions - will auto-update when registry changes */}
 		{mainRightActions.map(action => (
 			<CellActionButton
 				key={action.commandId}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -27,6 +27,7 @@ export function NotebookCellActionBar({ cell, children }: NotebookCellActionBarP
 	const actionsForCell = useActionsForCell(cell);
 	const instance = useNotebookInstance();
 	const mainActions = actionsForCell.main;
+	const mainRightActions = actionsForCell['main-right'];
 	const menuActions = actionsForCell.menu;
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 	const selectionStatus = useObservedValue(cell.selectionStatus);
@@ -63,6 +64,15 @@ export function NotebookCellActionBar({ cell, children }: NotebookCellActionBarP
 				onMenuStateChange={setIsMenuOpen}
 			/>
 		) : null}
+
+		{/* Render contributed main-right actions - will auto-update when registry changes */}
+		{mainRightActions.map(action => (
+			<CellActionButton
+				key={action.commandId}
+				action={action}
+				cell={cell}
+			/>
+		))}
 	</div>;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -13,7 +13,7 @@ import { CellConditionPredicate } from './cellConditions.js';
 /**
  * The position of a cell action bar item.
  */
-export type CellActionPosition = 'main' | 'menu' | 'left';
+export type CellActionPosition = 'main' | 'main-right' | 'menu' | 'left';
 /**
  * Interface for notebook cell action bar items that define how commands appear in the UI.
  */
@@ -24,7 +24,7 @@ export interface INotebookCellActionBarItem {
 	label?: ILocalizedString | string;
 	/** Codicon class for the button icon (optional) */
 	icon?: string;
-	/** Location in UI - either main action bar or dropdown menu */
+	/** Location in UI - main action bar, main-right action bar, dropdown menu, or left action bar */
 	position: CellActionPosition;
 	/** Sort order within position (lower numbers appear first) */
 	order?: number;
@@ -54,6 +54,11 @@ export class NotebookCellActionBarRegistry {
 	public readonly mainActions;
 
 	/**
+	 * The observable array of main-right action bar actions.
+	 */
+	public readonly mainRightActions;
+
+	/**
 	 * The observable array of dropdown menu actions.
 	 */
 	public readonly menuActions;
@@ -68,6 +73,13 @@ export class NotebookCellActionBarRegistry {
 			/** @description mainActions */
 			Array.from(items.values())
 				.filter(item => item.position === 'main')
+				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
+		);
+
+		this.mainRightActions = this.items.observable.map(this, items =>
+			/** @description mainRightActions */
+			Array.from(items.values())
+				.filter(item => item.position === 'main-right')
 				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
 		);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarRegistry.ts
@@ -13,7 +13,7 @@ import { CellConditionPredicate } from './cellConditions.js';
 /**
  * The position of a cell action bar item.
  */
-export type CellActionPosition = 'main' | 'main-right' | 'menu' | 'left';
+export type CellActionPosition = 'main' | 'mainRight' | 'menu' | 'left';
 /**
  * Interface for notebook cell action bar items that define how commands appear in the UI.
  */
@@ -24,7 +24,7 @@ export interface INotebookCellActionBarItem {
 	label?: ILocalizedString | string;
 	/** Codicon class for the button icon (optional) */
 	icon?: string;
-	/** Location in UI - main action bar, main-right action bar, dropdown menu, or left action bar */
+	/** Location in UI - main action bar, mainRight action bar, dropdown menu, or left action bar */
 	position: CellActionPosition;
 	/** Sort order within position (lower numbers appear first) */
 	order?: number;
@@ -54,7 +54,7 @@ export class NotebookCellActionBarRegistry {
 	public readonly mainActions;
 
 	/**
-	 * The observable array of main-right action bar actions.
+	 * The observable array of mainRight action bar actions.
 	 */
 	public readonly mainRightActions;
 
@@ -79,7 +79,7 @@ export class NotebookCellActionBarRegistry {
 		this.mainRightActions = this.items.observable.map(this, items =>
 			/** @description mainRightActions */
 			Array.from(items.values())
-				.filter(item => item.position === 'main-right')
+				.filter(item => item.position === 'mainRight')
 				.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
 		);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
@@ -35,7 +35,7 @@ export function useActionsForCell(cell: IPositronNotebookCell): Record<CellActio
 	return {
 		left: leftActions,
 		main: mainActions,
-		'main-right': mainRightActions,
+		mainRight: mainRightActions,
 		menu: menuActions
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/useActionsForCell.tsx
@@ -28,11 +28,14 @@ export function useActionsForCell(cell: IPositronNotebookCell): Record<CellActio
 	const leftActions = allLeftActions.filter(forCellFilter);
 	const allMainActions = useObservedValue(registry.mainActions) ?? [];
 	const mainActions = allMainActions.filter(forCellFilter);
+	const allMainRightActions = useObservedValue(registry.mainRightActions) ?? [];
+	const mainRightActions = allMainRightActions.filter(forCellFilter);
 	const allMenuActions = useObservedValue(registry.menuActions) ?? [];
 	const menuActions = allMenuActions.filter(forCellFilter);
 	return {
 		left: leftActions,
 		main: mainActions,
+		'main-right': mainRightActions,
 		menu: menuActions
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -357,7 +357,7 @@ registerCellCommand(
 		multiSelect: true,  // Delete all selected cells
 		actionBar: {
 			icon: 'codicon-trash',
-			position: 'main',
+			position: 'main-right',
 			order: 100,
 			category: 'Cell'
 		},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -357,7 +357,7 @@ registerCellCommand(
 		multiSelect: true,  // Delete all selected cells
 		actionBar: {
 			icon: 'codicon-trash',
-			position: 'main-right',
+			position: 'mainRight',
 			order: 100,
 			category: 'Cell'
 		},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -455,7 +455,7 @@ registerCellCommand({
 	),
 	actionBar: {
 		icon: 'codicon-run-above',
-		position: 'menu',
+		position: 'main',
 		order: 20,
 		category: 'Execution'
 	},
@@ -485,7 +485,7 @@ registerCellCommand({
 	),
 	actionBar: {
 		icon: 'codicon-run-below',
-		position: 'menu',
+		position: 'main',
 		order: 21,
 		category: 'Execution'
 	},


### PR DESCRIPTION
Addresses #9260.

This PR adds support for a new `mainRight` position in the notebook cell action bar, allowing actions to be displayed to the right of the "more actions" menu (ellipsis). The delete action has been moved to this new position as requested.

Additionally, the "run all above" and "run all below" commands have been moved from the dropdown menu to the main action bar for better visibility and easier access.

<img width="238" height="187" alt="image" src="https://github.com/user-attachments/assets/cb4c875a-ce63-4508-bfdd-c318ba6605b2" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks

1. Open a Jupyter notebook with multiple cells
2. Verify the delete icon (trash) appears to the right of the more actions menu (ellipsis) in the cell action bar
3. Verify the "run all above" and "run all below" icons appear in the main action bar (left of ellipsis)
4. Test that all actions work correctly:
   - Click delete icon to remove a cell
   - Click "run all above" to execute cells above the current one
   - Click "run all below" to execute cells below the current one
5. Verify the more actions menu still contains other cell actions
