### PR TITLE
e2e testing: Skipping token tests due to issue.

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -152,7 +152,8 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 });
 
 // Skipping web. See https://github.com/posit-dev/positron/issues/8568
-test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL] }, () => {
+// Skippig all due to https://github.com/posit-dev/positron/issues/9402
+test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');


### PR DESCRIPTION
Due to https://github.com/posit-dev/positron/issues/9402 I'm skipping the token tests for now.  They are just too flakey.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
