### PR TITLE
Positro nb shift enter fix

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1421,13 +1421,13 @@
                 "command": "python.execInConsole",
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
-                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused && !pythonAppFramework"
+                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused && !pythonAppFramework && !positronNotebookCellEditorFocused"
             },
             {
                 "command": "python.execSelectionInConsole",
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
-                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused"
+                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && !jupyter.ownsSelection && !notebookEditorFocused && !positronNotebookCellEditorFocused"
             }
         ],
         "languages": [

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -32,6 +32,7 @@ import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../serv
 import { IExecutionHistoryService } from '../../../services/positronHistory/common/executionHistoryService.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 
 /**
  * Positron console command ID's.
@@ -216,7 +217,8 @@ export function registerPositronConsoleActions() {
 				category,
 				precondition: ContextKeyExpr.and(
 					EditorContextKeys.editorTextFocus,
-					NOTEBOOK_EDITOR_FOCUSED.toNegated()
+					NOTEBOOK_EDITOR_FOCUSED.toNegated(),
+					POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
 				),
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -107,6 +107,11 @@ export interface IPositronNotebookCell extends Disposable {
 	 */
 	isCodeCell(): this is IPositronNotebookCodeCell;
 
+	/**
+	 * Check if this cell is the last cell in the notebook
+	 */
+	isLastCell(): boolean;
+
 
 	/**
 	 * Set focus to this cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -123,6 +123,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this.kind === CellKind.Code;
 	}
 
+	isLastCell(): boolean {
+		const cells = this._instance.cells.get();
+		return this.index === cells.length - 1;
+	}
+
 	select(type: CellSelectionType): void {
 		this._instance.selectionStateMachine.selectCell(this, type);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
@@ -12,6 +12,7 @@ import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { IPositronNotebookMarkdownCell } from './IPositronNotebookCell.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
+import { CellSelectionType } from '../selectionMachine.js';
 
 export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral implements IPositronNotebookMarkdownCell {
 
@@ -36,7 +37,12 @@ export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral im
 	}
 
 	toggleEditor(): void {
-		this.editorShown.set(!this.editorShown.get(), undefined);
+		const editorStartingOpen = this.editorShown.get();
+		this.editorShown.set(!editorStartingOpen, undefined);
+		// Make sure cell stays selected if we're closing the editor
+		if (editorStartingOpen) {
+			this.select(CellSelectionType.Normal);
+		}
 	}
 
 	override async showEditor(focus = false): Promise<ICodeEditor | undefined> {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -22,6 +22,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNotebookCell.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { autorun } from '../../../../../base/common/observable.js';
+import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../../../services/positronNotebook/browser/ContextKeysManager.js';
 
 /**
  *
@@ -76,12 +77,17 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 			editor.setModel(model);
 		});
 
+		// Bind the cell editor focused context key
+		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editorContextKeyService);
+
 		disposables.add(editor.onDidFocusEditorWidget(() => {
 			instance.setEditingCell(cell);
+			cellEditorFocusedKey.set(true);
 		}));
 
-		// disposables.add(editor.onDidBlurEditorWidget(() => {
-		// }));
+		disposables.add(editor.onDidBlurEditorWidget(() => {
+			cellEditorFocusedKey.set(false);
+		}));
 
 		/**
 		 * Resize the editor widget to fill the width of its container and the height of its

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -62,7 +62,7 @@ export function createCellInfo(
 		cellIndex,
 		totalCells,
 		isFirstCell: cellIndex === 0,
-		isLastCell: cellIndex === totalCells - 1,
+		isLastCell: cell.isLastCell(),
 		isOnlyCell: totalCells === 1,
 		// TODO: There is a tiny chance that the cell is running but the status is not yet updated.
 		// If this happens we will probably need to make the cell info an observable.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/cellConditions.ts
@@ -34,6 +34,8 @@ export interface ICellInfo {
 	isRunning: boolean;
 	/** Cell is queued for execution */
 	isPending: boolean;
+	/** Cell is a markdown cell and the editor is open */
+	markdownEditorOpen: boolean;
 }
 
 /**
@@ -66,6 +68,7 @@ export function createCellInfo(
 		// If this happens we will probably need to make the cell info an observable.
 		isRunning: cell.executionStatus.get() === 'running',
 		isPending: cell.executionStatus.get() === 'pending',
+		markdownEditorOpen: cell.isMarkdownCell() ? cell.editorShown.get() : false,
 	};
 }
 
@@ -87,6 +90,9 @@ export const CellConditions = {
 
 	/** Is pending */
 	isPending: (info: ICellInfo) => info.isPending,
+
+	/** Markdown cell with editor open */
+	markdownEditorOpen: (info: ICellInfo) => info.markdownEditorOpen,
 
 	/** Not the first cell (has cells above) */
 	notFirst: (info: ICellInfo) => !info.isFirstCell,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -10,7 +10,7 @@ import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNote
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 import { CellConditionPredicate, createCellInfo } from './cellConditions.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
@@ -134,7 +134,7 @@ export function registerCellCommand({
 		const keybindingDisposable = KeybindingsRegistry.registerKeybindingRule({
 			id: commandId,
 			weight: keybinding.weight ?? KeybindingWeight.EditorContrib,
-			when: keybinding.when ?? POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			when: keybinding.when ?? POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 			primary: keybinding.primary,
 			secondary: keybinding.secondary,
 			mac: keybinding.mac,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerNotebookCommand.ts
@@ -7,7 +7,7 @@ import { IDisposable, DisposableStore } from '../../../../../../base/common/life
 import { ICommandMetadata, CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
@@ -55,7 +55,7 @@ export function registerNotebookCommand({
 		const keybindingDisposable = KeybindingsRegistry.registerKeybindingRule({
 			id: commandId,
 			weight: keybinding.weight ?? KeybindingWeight.EditorContrib,
-			when: keybinding.when ?? POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			when: keybinding.when ?? POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 			primary: keybinding.primary,
 			secondary: keybinding.secondary,
 			mac: keybinding.mac,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -527,7 +527,7 @@ registerCellCommand({
 
 // Markdown cell toggle editor command
 registerCellCommand({
-	commandId: 'positronNotebook.cell.toggleMarkdownEditor',
+	commandId: 'positronNotebook.cell.openMarkdownEditor',
 	handler: (cell) => {
 		if (cell.isMarkdownCell()) {
 			// This test is just to appease typescript, we know it's a markdown cell
@@ -535,19 +535,51 @@ registerCellCommand({
 		}
 		// Make sure cell stays focused
 	},
-	cellCondition: CellConditions.isMarkdown,  // Only on markdown cells
+	cellCondition: CellConditions.and(
+		CellConditions.isMarkdown,
+		CellConditions.not(CellConditions.markdownEditorOpen)
+	),  // Only on markdown cells with the editor closed
 	editMode: true,  // Allow command to work when focus is in the cell editor
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Enter
 	},
 	actionBar: {
-		icon: 'codicon-primitive-square',  // Will need to be dynamic based on editor state
+		icon: 'codicon-chevron-down',
 		position: 'main',
 		order: 10,
 		category: 'Markdown'
 	},
 	metadata: {
-		description: localize('positronNotebook.cell.toggleMarkdownEditor', "Toggle markdown editor visibility")
+		description: localize('positronNotebook.cell.openMarkdownEditor', "Open markdown editor")
+	}
+});
+
+
+// Markdown cell toggle editor command
+registerCellCommand({
+	commandId: 'positronNotebook.cell.collapseMarkdownEditor',
+	handler: (cell) => {
+		if (cell.isMarkdownCell()) {
+			// This test is just to appease typescript, we know it's a markdown cell
+			cell.toggleEditor();
+		}
+	},
+	cellCondition: CellConditions.and(
+		CellConditions.isMarkdown,
+		CellConditions.markdownEditorOpen
+	),  // Only on markdown cells with the editor open
+	editMode: true,  // Allow command to work when focus is in the cell editor
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.Enter
+	},
+	actionBar: {
+		icon: 'codicon-chevron-up',
+		position: 'main',
+		order: 10,
+		category: 'Markdown'
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.collapseMarkdownEditor', "Collapse markdown editor")
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -588,9 +588,7 @@ registerCellCommand({
 		}
 
 		// If this is the last cell, insert a new cell below of the same type
-		const cells = notebook.cells.get();
-		const isLastCell = cell.index === cells.length - 1;
-		if (isLastCell) {
+		if (cell.isLastCell()) {
 			notebook.addCell(cell.kind, cell.index + 1);
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -582,6 +582,11 @@ registerCellCommand({
 			cell.run();
 		}
 
+		// If the cell is a markdown cell and the editor is open, close it. Otherwise just pass over.
+		if (cell.isMarkdownCell() && cell.editorShown.get()) {
+			cell.toggleEditor();
+		}
+
 		// Move to the next cell
 		notebook.selectionStateMachine.moveDown(false);
 	},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -525,7 +525,7 @@ registerCellCommand({
 	}
 });
 
-// Markdown cell toggle editor command
+// Open markdown editor (For action bar)
 registerCellCommand({
 	commandId: 'positronNotebook.cell.openMarkdownEditor',
 	handler: (cell) => {
@@ -533,16 +533,11 @@ registerCellCommand({
 			// This test is just to appease typescript, we know it's a markdown cell
 			cell.toggleEditor();
 		}
-		// Make sure cell stays focused
 	},
 	cellCondition: CellConditions.and(
 		CellConditions.isMarkdown,
 		CellConditions.not(CellConditions.markdownEditorOpen)
 	),  // Only on markdown cells with the editor closed
-	editMode: true,  // Allow command to work when focus is in the cell editor
-	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyCode.Enter
-	},
 	actionBar: {
 		icon: 'codicon-chevron-down',
 		position: 'main',
@@ -555,7 +550,7 @@ registerCellCommand({
 });
 
 
-// Markdown cell toggle editor command
+// Collapse markdown editor (For action bar)
 registerCellCommand({
 	commandId: 'positronNotebook.cell.collapseMarkdownEditor',
 	handler: (cell) => {
@@ -568,10 +563,6 @@ registerCellCommand({
 		CellConditions.isMarkdown,
 		CellConditions.markdownEditorOpen
 	),  // Only on markdown cells with the editor open
-	editMode: true,  // Allow command to work when focus is in the cell editor
-	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyCode.Enter
-	},
 	actionBar: {
 		icon: 'codicon-chevron-up',
 		position: 'main',
@@ -580,6 +571,25 @@ registerCellCommand({
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.collapseMarkdownEditor', "Collapse markdown editor")
+	}
+});
+
+// Toggle markdown editor (For keyboard shortcuts)
+registerCellCommand({
+	commandId: 'positronNotebook.cell.toggleMarkdownEditor',
+	handler: (cell) => {
+		if (cell.isMarkdownCell()) {
+			// This test is just to appease typescript, we know it's a markdown cell
+			cell.toggleEditor();
+		}
+	},
+	cellCondition: CellConditions.isMarkdown,
+	editMode: true,  // Allow command to work when focus is in the cell editor
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.Enter
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.toggleMarkdownEditor', "Toggle markdown editor")
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -587,6 +587,13 @@ registerCellCommand({
 			cell.toggleEditor();
 		}
 
+		// If this is the last cell, insert a new cell below of the same type
+		const cells = notebook.cells.get();
+		const isLastCell = cell.index === cells.length - 1;
+		if (isLastCell) {
+			notebook.addCell(cell.kind, cell.index + 1);
+		}
+
 		// Move to the next cell
 		notebook.selectionStateMachine.moveDown(false);
 	},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -530,10 +530,16 @@ registerCellCommand({
 	commandId: 'positronNotebook.cell.toggleMarkdownEditor',
 	handler: (cell) => {
 		if (cell.isMarkdownCell()) {
+			// This test is just to appease typescript, we know it's a markdown cell
 			cell.toggleEditor();
 		}
+		// Make sure cell stays focused
 	},
 	cellCondition: CellConditions.isMarkdown,  // Only on markdown cells
+	editMode: true,  // Allow command to work when focus is in the cell editor
+	keybinding: {
+		primary: KeyMod.CtrlCmd | KeyCode.Enter
+	},
 	actionBar: {
 		icon: 'codicon-primitive-square',  // Will need to be dynamic based on editor state
 		position: 'main',

--- a/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
@@ -8,11 +8,15 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 
 /**
- * Context key that is set when the Positron notebook editor is focused. Used for rerouting
- * actions meant for vscode notebooks.
+	 * Context key that is set when the Positron notebook editor container is focused. This will _not_ be true when the user is editing a cell.
  */
-export const POSITRON_NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorFocused', false);
+export const POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorContainerFocused', false);
 
+/**
+ * Context key that is set when a cell editor (Monaco editor within a notebook cell) is focused.
+ * This is more specific than EditorContextKeys.editorTextFocus which applies to ANY Monaco editor.
+ */
+export const POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false);
 
 /**
  * Class to handle context keys for positron notebooks
@@ -44,7 +48,7 @@ export class PositronNotebookContextKeyManager extends Disposable {
 		this._container = container;
 		this._scopedContextKeyService = this._contextKeyService.createScoped(this._container);
 
-		this.positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
+		this.positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED.bindTo(this._scopedContextKeyService);
 
 		const focusTracker = this._register(DOM.trackFocus(container));
 		this._register(focusTracker.onDidFocus(() => {


### PR DESCRIPTION
Addresses #8918.

This PR fixes the Shift+Enter and Cmd+Enter keybindings in Positron Notebooks to match user expectations from Jupyter and Google Colab. Previously, Shift+Enter would cause the cursor to disappear and Cmd+Enter wouldn't execute cells when editing.

### Summary

The PR introduces a new `editMode` option in the `registerCellCommand` function that allows keybindings to work when users are actively editing cells, not just selecting them. This ensures:

- **Shift+Enter**: Now executes the cell and moves to the next cell, even when editing
- **Cmd+Enter**: Now executes the cell and stays in place, working from both selection and edit modes

The implementation also includes proper handling for markdown cells with Shift+Enter, where execution is skipped but navigation still occurs.

New behavior summary:

```mermaid
flowchart TD
    Start([User Presses Key in Notebook Cell])
    
    Start --> CellType{Cell Type?}
    
    CellType -->|Code Cell| CodeCell[Code Cell]
    CellType -->|Markdown Cell| MarkdownCell[Markdown Cell]
    
    CodeCell --> CodeKey{Which Key?}
    
    CodeKey -->|Shift+Enter| CodeShiftEnter[/"Shift+Enter<br/>(works in both edit & select modes)"/]
    CodeShiftEnter --> CodeRun1[Execute Cell]
    CodeRun1 --> ExitEdit1{In Edit Mode?}
    ExitEdit1 -->|Yes| ExitEditor1[Exit Editor]
    ExitEdit1 -->|No| MoveNext1[Move to Next Cell]
    ExitEditor1 --> MoveNext1
    
    CodeKey -->|Cmd+Enter| CodeCmdEnter[/"Cmd+Enter<br/>(works in both edit & select modes)"/]
    CodeCmdEnter --> CodeRun2[Execute Cell]
    CodeRun2 --> StayInPlace[Stay in Same Cell<br/>Keep Current Mode]
    
    MarkdownCell --> MDKey{Which Key?}
    
    MDKey -->|Shift+Enter| MDShiftEnter[/"Shift+Enter<br/>(works in both edit & select modes)"/]
    MDShiftEnter --> MDCheck{In Edit Mode?}
    MDCheck -->|Yes| ExitMDEditor[Exit Editor]
    MDCheck -->|No| MDMoveNext[Move to Next Cell]
    ExitMDEditor --> MDMoveNext
    
    MDKey -->|Cmd+Enter| MDCmdEnter[/"Cmd+Enter<br/>(works in both edit & select modes)"/]
    MDCmdEnter --> ToggleEditor{Editor Open?}
    ToggleEditor -->|Yes| CloseEditor[Close Editor]
    ToggleEditor -->|No| OpenEditor[Open Editor]
    CloseEditor --> StayMD[Stay in Same Cell]
    OpenEditor --> StayMD
    
    style CodeShiftEnter fill:#e1f5fe
    style CodeCmdEnter fill:#e1f5fe
    style MDShiftEnter fill:#f3e5f5
    style MDCmdEnter fill:#f3e5f5
    style Start fill:#fff3e0
    
    classDef newBehavior fill:#c8e6c9,stroke:#4caf50,stroke-width:2px
    class CodeShiftEnter,CodeCmdEnter,MDShiftEnter,MDCmdEnter newBehavior
```


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Shift+Enter and Cmd+Enter keybindings in notebooks to match Jupyter/Colab behavior (#8918)

### QA Notes

@:notebooks

1. Open a Positron Notebook with both code and markdown cells
2. Test Shift+Enter behavior:
   - Click into a code cell to edit it
   - Press Shift+Enter
   - Verify: Cell executes and cursor moves to next cell
   - Try the same on a markdown cell - should move to next cell without execution
3. Test Cmd+Enter behavior:
   - Click into a code cell to edit it  
   - Press Cmd+Enter (Ctrl+Enter on Windows/Linux)
   - Verify: Cell executes and cursor stays in the same cell
4. Test that both keybindings work when:
   - Just selecting cells (not editing)
   - Actively editing cell content
   - On both code and markdown cells
