### PR TITLE
Positron Notebooks: Simplify saving untitled notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -85,7 +85,7 @@ export interface IPositronNotebookInstance {
 	 * Observable reference to the current runtime session for the notebook.
 	 * This manages the connection to the kernel and execution environment.
 	 */
-	readonly currentRuntime: IObservable<ILanguageRuntimeSession | undefined>;
+	readonly runtimeSession: IObservable<ILanguageRuntimeSession | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.


### PR DESCRIPTION
This simplifies how we handle saving untitled notebooks, and gets it more in line with Code OSS expectations. IIUC the expectation is that the untitled editor closes and a new editor opens, with the view state passed along (we don't handle view state just yet but the rest should work). A step toward https://github.com/posit-dev/positron/issues/9454.

We were also missing the `onDidRevertUntitled` listener.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Saving an untitled notebook should not open any ghost editors, should retain the runtime session, and should remove the dirty state.

Shouldn't be any regressions with untitled files.