### PR TITLE
Add keyboard support for context menus in data explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -152,6 +152,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				'data-grid-column-header',
 				{ pinned: props.pinned },
 			)}
+			data-column-index={props.columnIndex}
 			style={{
 				left: props.left,
 				width: props.width,

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -94,6 +94,7 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 				'data-grid-row-header',
 				{ pinned: props.pinned },
 			)}
+			data-row-index={props.rowIndex}
 			style={{
 				top: props.top,
 				height: props.height,

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -27,7 +27,6 @@ import { isElectron, isMacintosh } from '../../../../base/common/platform.js';
 import { ExtendColumnSelectionBy, ExtendRowSelectionBy } from '../classes/dataGridInstance.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 import { TableSummaryDataGridInstance } from '../../../services/positronDataExplorer/browser/tableSummaryDataGridInstance.js';
-import { TableDataDataGridInstance } from '../../../services/positronDataExplorer/browser/tableDataDataGridInstance.js';
 
 /**
  * DataGridWaffle component.
@@ -509,92 +508,6 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 				// Moves the cursor right.
 				context.instance.moveCursorRight();
-				break;
-			}
-
-			// F10 key (with modifiers for different context menus)
-			case 'F10': {
-				// We only show context menu for the TableDataDataGridInstance
-				// and not for other types of data grids, like the summary panel
-				if (context.instance instanceof TableDataDataGridInstance) {
-					// Make sure the cursor is showing in the data grid
-					if (context.instance.showCursor()) {
-						return;
-					}
-
-					// Get the location of the cursor
-					const cursorColumnIndex = context.instance.cursorColumnIndex;
-					const cursorRowIndex = context.instance.cursorRowIndex;
-
-					// Consume the default events
-					consumeEvent();
-
-					// Ctrl+Shift+F10 to show the column header context menu
-					if (e.ctrlKey && e.shiftKey) {
-						// Find the column header element
-						const columnHeaderElement = dataGridWaffleRef.current.querySelector(
-							`.data-grid-column-header[data-column-index="${cursorColumnIndex}"]`
-						) as HTMLElement;
-
-						if (columnHeaderElement) {
-							const headerRect = columnHeaderElement.getBoundingClientRect();
-							await context.instance.showColumnContextMenu(
-								cursorColumnIndex,
-								columnHeaderElement,
-								{
-									clientX: headerRect.left + headerRect.width / 2,
-									clientY: headerRect.top + headerRect.height / 2
-								}
-							);
-						}
-						return;
-					}
-
-					// Alt+Shift+F10 to show the row header context menu
-					if (e.altKey && e.shiftKey) {
-						// Find the row header element
-						const rowHeaderElement = dataGridWaffleRef.current.querySelector(
-							`.data-grid-row-header[data-row-index="${cursorRowIndex}"]`
-						) as HTMLElement;
-
-						if (rowHeaderElement) {
-							const headerRect = rowHeaderElement.getBoundingClientRect();
-							await context.instance.showRowContextMenu(
-								cursorRowIndex,
-								rowHeaderElement,
-								{
-									clientX: headerRect.left + headerRect.width / 2,
-									clientY: headerRect.top + headerRect.height / 2
-								}
-							);
-						}
-						return;
-					}
-
-					// Shift+F10 to show the cell context menu
-					if (e.shiftKey && !e.ctrlKey && !e.altKey) {
-						// Find the cell element
-						const cursorCellElement = dataGridWaffleRef.current.querySelector(
-							`#data-grid-row-cell-content-${cursorColumnIndex}-${cursorRowIndex}`
-						) as HTMLElement;
-
-						if (cursorCellElement) {
-							// Get the cell bounding rectangle to position the context menu
-							const cellRect = cursorCellElement.getBoundingClientRect();
-
-							// Position the context menu at the center of the cell
-							await context.instance.showCellContextMenu(
-								cursorColumnIndex,
-								cursorRowIndex,
-								cursorCellElement,
-								{
-									clientX: cellRect.left + cellRect.width / 2,
-									clientY: cellRect.top + cellRect.height / 2
-								}
-							);
-						}
-					}
-				}
 				break;
 			}
 		}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -512,37 +512,87 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				break;
 			}
 
-			// F10 key (with Shift for context menu)
+			// F10 key (with modifiers for different context menus)
 			case 'F10': {
-				// Only handle Shift+F10 for context menu in TableDataDataGridInstance
-				if (e.shiftKey && context.instance instanceof TableDataDataGridInstance) {
-					// Consume the event.
-					consumeEvent();
-
-					// Make sure the cursor is showing.
+				// We only show context menu for the TableDataDataGridInstance
+				// and not for other types of data grids, like the summary panel
+				if (context.instance instanceof TableDataDataGridInstance) {
+					// Make sure the cursor is showing in the data grid
 					if (context.instance.showCursor()) {
 						return;
 					}
 
-					// Find the cursor cell element to position the context menu
-					const cursorCellElement = dataGridWaffleRef.current.querySelector(
-						`#data-grid-row-cell-content-${context.instance.cursorColumnIndex}-${context.instance.cursorRowIndex}`
-					) as HTMLElement;
+					// Get the location of the cursor
+					const cursorColumnIndex = context.instance.cursorColumnIndex;
+					const cursorRowIndex = context.instance.cursorRowIndex;
 
-					if (cursorCellElement) {
-						// Get the cell bounding rectangle to position the context menu
-						const cellRect = cursorCellElement.getBoundingClientRect();
+					// Consume the default events
+					consumeEvent();
 
-						// Position the context menu at the center of the cell
-						await context.instance.showCellContextMenu(
-							context.instance.cursorColumnIndex,
-							context.instance.cursorRowIndex,
-							cursorCellElement,
-							{
-								clientX: cellRect.left + cellRect.width / 2,
-								clientY: cellRect.top + cellRect.height / 2
-							}
-						);
+					// Ctrl+Shift+F10 to show the column header context menu
+					if (e.ctrlKey && e.shiftKey) {
+						// Find the column header element
+						const columnHeaderElement = dataGridWaffleRef.current.querySelector(
+							`.data-grid-column-header[data-column-index="${cursorColumnIndex}"]`
+						) as HTMLElement;
+
+						if (columnHeaderElement) {
+							const headerRect = columnHeaderElement.getBoundingClientRect();
+							await context.instance.showColumnContextMenu(
+								cursorColumnIndex,
+								columnHeaderElement,
+								{
+									clientX: headerRect.left + headerRect.width / 2,
+									clientY: headerRect.top + headerRect.height / 2
+								}
+							);
+						}
+						return;
+					}
+
+					// Alt+Shift+F10 to show the row header context menu
+					if (e.altKey && e.shiftKey) {
+						// Find the row header element
+						const rowHeaderElement = dataGridWaffleRef.current.querySelector(
+							`.data-grid-row-header[data-row-index="${cursorRowIndex}"]`
+						) as HTMLElement;
+
+						if (rowHeaderElement) {
+							const headerRect = rowHeaderElement.getBoundingClientRect();
+							await context.instance.showRowContextMenu(
+								cursorRowIndex,
+								rowHeaderElement,
+								{
+									clientX: headerRect.left + headerRect.width / 2,
+									clientY: headerRect.top + headerRect.height / 2
+								}
+							);
+						}
+						return;
+					}
+
+					// Shift+F10 to show the cell context menu
+					if (e.shiftKey && !e.ctrlKey && !e.altKey) {
+						// Find the cell element
+						const cursorCellElement = dataGridWaffleRef.current.querySelector(
+							`#data-grid-row-cell-content-${cursorColumnIndex}-${cursorRowIndex}`
+						) as HTMLElement;
+
+						if (cursorCellElement) {
+							// Get the cell bounding rectangle to position the context menu
+							const cellRect = cursorCellElement.getBoundingClientRect();
+
+							// Position the context menu at the center of the cell
+							await context.instance.showCellContextMenu(
+								cursorColumnIndex,
+								cursorRowIndex,
+								cursorCellElement,
+								{
+									clientX: cellRect.left + cellRect.width / 2,
+									clientY: cellRect.top + cellRect.height / 2
+								}
+							);
+						}
 					}
 				}
 				break;

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -27,6 +27,7 @@ import { isElectron, isMacintosh } from '../../../../base/common/platform.js';
 import { ExtendColumnSelectionBy, ExtendRowSelectionBy } from '../classes/dataGridInstance.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 import { TableSummaryDataGridInstance } from '../../../services/positronDataExplorer/browser/tableSummaryDataGridInstance.js';
+import { TableDataDataGridInstance } from '../../../services/positronDataExplorer/browser/tableDataDataGridInstance.js';
 
 /**
  * DataGridWaffle component.
@@ -508,6 +509,42 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 				// Moves the cursor right.
 				context.instance.moveCursorRight();
+				break;
+			}
+
+			// F10 key (with Shift for context menu)
+			case 'F10': {
+				// Only handle Shift+F10 for context menu in TableDataDataGridInstance
+				if (e.shiftKey && context.instance instanceof TableDataDataGridInstance) {
+					// Consume the event.
+					consumeEvent();
+
+					// Make sure the cursor is showing.
+					if (context.instance.showCursor()) {
+						return;
+					}
+
+					// Find the cursor cell element to position the context menu
+					const cursorCellElement = dataGridWaffleRef.current.querySelector(
+						`#data-grid-row-cell-content-${context.instance.cursorColumnIndex}-${context.instance.cursorRowIndex}`
+					) as HTMLElement;
+
+					if (cursorCellElement) {
+						// Get the cell bounding rectangle to position the context menu
+						const cellRect = cursorCellElement.getBoundingClientRect();
+
+						// Position the context menu at the center of the cell
+						await context.instance.showCellContextMenu(
+							context.instance.cursorColumnIndex,
+							context.instance.cursorRowIndex,
+							cursorCellElement,
+							{
+								clientX: cellRect.left + cellRect.width / 2,
+								clientY: cellRect.top + cellRect.height / 2
+							}
+						);
+					}
+				}
 				break;
 			}
 		}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -9,7 +9,6 @@ import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { PositronDataExplorerFocused } from '../../../common/contextkeys.js';
 import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -152,10 +151,7 @@ class PositronDataExplorerCopyAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
 			},
 			f1: true,
-			precondition: ContextKeyExpr.and(
-				POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
-				PositronDataExplorerFocused
-			)
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -960,7 +960,7 @@ class PositronDataExplorerShowColumnContextMenuAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10,
+				primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.F10,
 			},
 			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
 		});

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -28,6 +28,7 @@ import { IWorkbenchEnvironmentService } from '../../../services/environment/comm
 import { showConvertToCodeModalDialog } from '../../../browser/positronModalDialogs/convertToCodeModalDialog.js';
 import { IPositronDataExplorerInstance } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.js';
 import { CodeSyntaxName } from '../../../services/languageRuntime/common/positronDataExplorerComm.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 /**
  * Positron data explorer action category.
@@ -59,6 +60,9 @@ export const enum PositronDataExplorerCommandId {
 	OpenAsPlaintext = 'workbench.action.positronDataExplorer.openAsPlaintext',
 	ConvertToCodeAction = 'workbench.action.positronDataExplorer.convertToCode',
 	ConvertToCodeModalAction = 'workbench.action.positronDataExplorer.convertToCodeModal',
+	ShowColumnContextMenuAction = 'workbench.action.positronDataExplorer.showColumnContextMenu',
+	ShowRowContextMenuAction = 'workbench.action.positronDataExplorer.showRowContextMenu',
+	ShowCellContextMenuAction = 'workbench.action.positronDataExplorer.showCellContextMenu',
 }
 
 /**
@@ -946,6 +950,181 @@ class PositronDataExplorerOpenAsPlaintextAction extends Action2 {
 }
 
 /**
+ * PositronDataExplorerShowColumnContextMenuAction action.
+ */
+class PositronDataExplorerShowColumnContextMenuAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.ShowColumnContextMenuAction,
+			title: {
+				value: localize('positronDataExplorer.showColumnContextMenu', 'Show Column Context Menu'),
+				original: 'Show Column Context Menu'
+			},
+			category,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10,
+			},
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const positronDataExplorerInstance = await getPositronDataExplorerInstance(accessor);
+		if (!positronDataExplorerInstance) {
+			return;
+		}
+
+		// Get the table data grid instance
+		const tableDataDataGridInstance = positronDataExplorerInstance.tableDataDataGridInstance;
+
+		// Get the current column the cursor is positioned at
+		const cursorColumnIndex = tableDataDataGridInstance.cursorColumnIndex;
+
+		// Find the column header element for the column the cursor is positioned at
+		// by querying the DOM
+		const columnHeaderElement = mainWindow.document.querySelector(
+			`.data-grid-column-header[data-column-index="${cursorColumnIndex}"]`
+		) as HTMLElement;
+
+		if (columnHeaderElement) {
+			const headerRect = columnHeaderElement.getBoundingClientRect();
+			await tableDataDataGridInstance.showColumnContextMenu(
+				cursorColumnIndex,
+				columnHeaderElement,
+				// position the context menu in the center of the cell
+				{
+					clientX: headerRect.left + headerRect.width / 2,
+					clientY: headerRect.top + headerRect.height / 2
+				}
+			);
+		}
+	}
+}
+
+/**
+ * PositronDataExplorerShowRowContextMenuAction action.
+ */
+class PositronDataExplorerShowRowContextMenuAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.ShowRowContextMenuAction,
+			title: {
+				value: localize('positronDataExplorer.showRowContextMenu', 'Show Row Context Menu'),
+				original: 'Show Row Context Menu'
+			},
+			category,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F10,
+			},
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const positronDataExplorerInstance = await getPositronDataExplorerInstance(accessor);
+		if (!positronDataExplorerInstance) {
+			return;
+		}
+
+		// Get the table data grid instance
+		const tableDataDataGridInstance = positronDataExplorerInstance.tableDataDataGridInstance;
+
+		// Get the current row the cursor is positioned at
+		const cursorRowIndex = tableDataDataGridInstance.cursorRowIndex;
+
+		// Find the row header element for the row the cursor is positioned at
+		// by querying the DOM
+		const rowHeaderElement = mainWindow.document.querySelector(
+			`.data-grid-row-header[data-row-index="${cursorRowIndex}"]`
+		) as HTMLElement;
+
+		if (rowHeaderElement) {
+			const headerRect = rowHeaderElement.getBoundingClientRect();
+			await tableDataDataGridInstance.showRowContextMenu(
+				cursorRowIndex,
+				rowHeaderElement,
+				// position the context menu in the center of the cell
+				{
+					clientX: headerRect.left + headerRect.width / 2,
+					clientY: headerRect.top + headerRect.height / 2
+				}
+			);
+		}
+	}
+}
+
+/**
+ * PositronDataExplorerShowCellContextMenuAction action.
+ */
+class PositronDataExplorerShowCellContextMenuAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.ShowCellContextMenuAction,
+			title: {
+				value: localize('positronDataExplorer.showCellContextMenu', 'Show Cell Context Menu'),
+				original: 'Show Cell Context Menu'
+			},
+			category,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Shift | KeyCode.F10,
+			},
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const positronDataExplorerInstance = await getPositronDataExplorerInstance(accessor);
+		if (!positronDataExplorerInstance) {
+			return;
+		}
+
+		// Get the table data grid instance
+		const tableDataDataGridInstance = positronDataExplorerInstance.tableDataDataGridInstance;
+
+		// Get the location of the cursor
+		const cursorColumnIndex = tableDataDataGridInstance.cursorColumnIndex;
+		const cursorRowIndex = tableDataDataGridInstance.cursorRowIndex;
+
+		// Find the cell element the cursor is on by querying the DOM
+		const cellElement = mainWindow.document.querySelector(
+			`#data-grid-row-cell-content-${cursorColumnIndex}-${cursorRowIndex}`
+		) as HTMLElement;
+
+		if (cellElement) {
+			const cellRect = cellElement.getBoundingClientRect();
+			await tableDataDataGridInstance.showCellContextMenu(
+				cursorColumnIndex,
+				cursorRowIndex,
+				cellElement,
+				// position the context menu in the center of the cell
+				{
+					clientX: cellRect.left + cellRect.width / 2,
+					clientY: cellRect.top + cellRect.height / 2
+				}
+			);
+		}
+	}
+}
+
+/**
  * Registers Positron data explorer actions.
  */
 export function registerPositronDataExplorerActions() {
@@ -959,4 +1138,7 @@ export function registerPositronDataExplorerActions() {
 	registerAction2(PositronDataExplorerOpenAsPlaintextAction);
 	registerAction2(PositronDataExplorerConvertToCodeAction);
 	registerAction2(PositronDataExplorerConvertToCodeModalAction);
+	registerAction2(PositronDataExplorerShowColumnContextMenuAction);
+	registerAction2(PositronDataExplorerShowRowContextMenuAction);
+	registerAction2(PositronDataExplorerShowCellContextMenuAction);
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -23,7 +23,7 @@ import { InvalidateCacheFlags, TableDataCache, WidthCalculators } from '../commo
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../common/positronDataExplorerExperimentalConfig.js';
 import { BackendState, ColumnSchema, DataSelectionCellIndices, DataSelectionIndices, DataSelectionSingleCell, ExportFormat, RowFilter, SupportStatus, TableSelection, TableSelectionKind } from '../../languageRuntime/common/positronDataExplorerComm.js';
-import { ClipboardCell, ClipboardCellIndexes, ClipboardColumnIndexes, ClipboardData, ClipboardRowIndexes, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, RowSelectionState } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
+import { ClipboardCell, ClipboardCellIndexes, ClipboardColumnIndexes, ClipboardData, ClipboardRowIndexes, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, MouseSelectionType, RowSelectionState } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { PositronReactServices } from '../../../../base/browser/positronReactServices.js';
 
 /**
@@ -388,6 +388,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorElement: HTMLElement,
 		anchorPoint?: AnchorPoint
 	): Promise<void> {
+		// Ensure the column is selected (handles both right-click and dropdown button cases)
+		await this.mouseSelectColumn(columnIndex, MouseSelectionType.Single);
+
 		// Get the supported features.
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
 		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -504,6 +504,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorElement: HTMLElement,
 		anchorPoint: AnchorPoint
 	): Promise<void> {
+		// Ensure the row is selected (handles both right-click and keyboard shortcut cases)
+		await this.mouseSelectRow(rowIndex, MouseSelectionType.Single);
+
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
 		const copySupported = this.isFeatureEnabled(features.export_data_selection.support_status);
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -407,8 +407,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			checked: false,
 			disabled: !copySupported,
 			icon: 'copy',
-			label: localize('positron.dataExplorer.copy', "Copy"),
-			onSelected: () => console.log('Copy')
+			label: localize('positron.dataExplorer.copyColumn', "Copy Column"),
+			onSelected: () => console.log('Copy Column')
 		}));
 		entries.push(new CustomContextMenuSeparator());
 		entries.push(new CustomContextMenuItem({
@@ -517,8 +517,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			checked: false,
 			disabled: !copySupported,
 			icon: 'copy',
-			label: localize('positron.dataExplorer.copy', "Copy"),
-			onSelected: () => console.log('Copy')
+			label: localize('positron.dataExplorer.copyRow', "Copy Row"),
+			onSelected: () => console.log('Copy Row')
 		}));
 		entries.push(new CustomContextMenuSeparator());
 		entries.push(new CustomContextMenuItem({


### PR DESCRIPTION
Addresses #3377 and #9315

This PR adds keyboard accessibility for context menus in the Data Explorer's main data grid. Users can now access column header, row header, and cell context menus using keyboard shortcuts.

Since the data grid doesn't support focusing/selecting the column headers and row headers via keyboard navigation, the cursor remains on the data cells. Different keyboard shortcuts will allow the user to open the column header or row header context menu of the row or column that they are currently on.

`Shift + F10` - Opens the cell context menu for the cell that has focus
`Ctrl + Shift + F10` - Opens the column header context menu based off the cell that has focus
`Alt + Shift + F10` - Opens the row header context menu based off the cell that has focus

When the context menu for a row header or column header is selected, the entire row or column will be selected/focused as well. This change allows copying an entire row or column to work as expected (#9315).

**Copy Column or Row**

https://github.com/user-attachments/assets/b3436d03-0449-457d-a3ee-b9385e71d6fe


**Keyboard Shortcuts for Context Menu**


https://github.com/user-attachments/assets/f36acc24-4c05-4fe9-81ae-bcc13fbf04a9

--

Update from 09/22/2025 to resolve the keyboard shortcut issue mentioned in https://github.com/posit-dev/positron/pull/9457#pullrequestreview-3247604236:

- we now have separate actions for each data explorer context menu (column, row, cell) which allows us to show the commands in the command palette, and also exposes the keyboard shortcuts to users via settings
- fixed a bug where the data explorer copy command was not showing up in the command palette menu because of the precondition that required the data explorer to have focus (which was always false because focus would be lost once the command palette was opened)

<img width="1468" height="544" alt="Screenshot 2025-09-22 at 5 05 48 PM" src="https://github.com/user-attachments/assets/b34117d7-56fa-4b8f-a0dd-63fe6d759a24" />

https://github.com/user-attachments/assets/f92cea39-dc8b-4586-ba7d-8d71cc320a68

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add keyboard support for context menus in data explorer (#3377)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win