### PR TITLE
Positron Notebooks: Improve editor resolution

### DIFF
--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -97,16 +97,7 @@ export function activate(context: vscode.ExtensionContext, serializer: vscode.No
 			nbformat_minor: defaultNotebookFormat.minor,
 		};
 		const doc = await vscode.workspace.openNotebookDocument('jupyter-notebook', data);
-
-		// Check if Positron notebooks are configured as the default editor for .ipynb files
-		const editorAssociations = vscode.workspace.getConfiguration('workbench').get<Record<string, string>>('editorAssociations') || {};
-		const usingPositronNotebooks = editorAssociations['*.ipynb'] === 'workbench.editor.positronNotebook';
-
-		// Only call showNotebookDocument if Positron is not the default editor,
-		// since openNotebookDocument already opens the editor when Positron is default
-		if (!usingPositronNotebooks) {
-			await vscode.window.showNotebookDocument(doc);
-		}
+		await vscode.window.showNotebookDocument(doc);
 	}));
 	// --- End Positron ---
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
@@ -16,16 +16,6 @@ import { ExtHostContext, ExtHostNotebookDocumentsShape, MainThreadNotebookDocume
 import { NotebookDto } from './mainThreadNotebookDto.js';
 import { SerializableObjectWithBuffers } from '../../services/extensions/common/proxyIdentifier.js';
 import { IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
-// --- Start Positron ---
-import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
-import { INotificationService } from '../../../platform/notification/common/notification.js';
-import { ILogService } from '../../../platform/log/common/log.js';
-import { IEditorService } from '../../services/editor/common/editorService.js';
-import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
-import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
-import { PositronNotebookEditorInput } from '../../contrib/positronNotebook/browser/PositronNotebookEditorInput.js';
-import { usingPositronNotebooks } from '../../services/positronNotebook/common/positronNotebookUtils.js';
-// --- End Positron ---
 
 export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsShape {
 
@@ -38,14 +28,6 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 	constructor(
 		extHostContext: IExtHostContext,
 		@INotebookEditorModelResolverService private readonly _notebookEditorModelResolverService: INotebookEditorModelResolverService,
-		// --- Start Positron ---
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IEditorService private readonly _editorService: IEditorService,
-		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@INotificationService private readonly _notificationService: INotificationService,
-		@ILogService private readonly _logService: ILogService,
-		// --- End Positron ---
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostNotebookDocuments);
@@ -145,13 +127,6 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 	}
 
 	async $tryCreateNotebook(options: { viewType: string; content?: NotebookDataDto }): Promise<UriComponents> {
-		// --- Start Positron ---
-		// Hook for custom notebook creation (e.g. Positron)
-		const customResult = await this._tryCreateCustomNotebook(options);
-		if (customResult) {
-			return customResult;
-		}
-		// --- End Positron ---
 		if (options.content) {
 			const ref = await this._notebookEditorModelResolverService.resolve({ untitledResource: undefined }, options.viewType);
 
@@ -177,65 +152,6 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 			return notebook.uri;
 		}
 	}
-	// --- Start Positron ---
-	protected async _tryCreateCustomNotebook(options: { viewType: string; content?: NotebookDataDto }): Promise<UriComponents | undefined> {
-		const isJupyterViewType = options.viewType === 'jupyter-notebook' || options.viewType === 'interactive';
-
-		if (isJupyterViewType && usingPositronNotebooks(this._configurationService)) {
-			this._logService.trace('[Positron] Creating new notebook with Positron editor based on configuration');
-
-			try {
-				// Create the notebook model first (same as VS Code logic)
-				const ref = await this._notebookEditorModelResolverService.resolve(
-					{ untitledResource: undefined },
-					options.viewType
-				);
-
-				// untitled notebooks are disposed when they get saved. we should not hold a reference
-				// to such a disposed notebook and therefore dispose the reference as well
-				Event.once(ref.object.notebook.onWillDispose)(() => {
-					ref.dispose();
-				});
-
-				// Apply content if provided
-				if (options.content) {
-					const data = NotebookDto.fromNotebookDataDto(options.content);
-					ref.object.notebook.reset(data.cells, data.metadata, ref.object.notebook.transientOptions);
-				}
-
-				const uri = ref.object.resource;
-
-				// Get the preferred editor group
-				const preferredGroup = this._editorGroupsService.activeGroup;
-
-				// Create Positron notebook editor input
-				const editorInput = PositronNotebookEditorInput.getOrCreate(
-					this._instantiationService,
-					uri,
-					undefined,
-				);
-
-				// Open the editor
-				await this._editorService.openEditor(editorInput, undefined, preferredGroup);
-
-				// Mark as dirty since it's new
-				await this._proxy.$acceptDirtyStateChanged(uri, true);
-
-				return uri.toJSON();
-			} catch (error) {
-				// Log error and show warning to user
-				this._logService.error('[Positron] Failed to create notebook with Positron editor:', error);
-				this._notificationService.warn(
-					`Failed to create notebook with Positron editor. Falling back to VS Code editor. Error: ${(error as Error).message}`
-				);
-				// Return undefined to fall back to VS Code logic
-			}
-		}
-
-		// Default implementation does nothing - allows VS Code logic to proceed
-		return undefined;
-	}
-	// --- End Positron ---
 
 	async $tryOpenNotebook(uriComponents: UriComponents): Promise<URI> {
 		const uri = URI.revive(uriComponents);
@@ -249,63 +165,9 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 			});
 		}
 
-		// --- Start Positron ---
-		// Hook for custom notebook opening (e.g. Positron)
-		const customResult = await this._tryOpenCustomNotebook(uriComponents, ref);
-		if (customResult) {
-			return customResult;
-		}
-		// --- End Positron ---
 		this._modelReferenceCollection.add(uri, ref);
 		return uri;
 	}
-	// --- Start Positron ---
-	protected async _tryOpenCustomNotebook(uriComponents: UriComponents, ref: any): Promise<URI | undefined> {
-		const uri = URI.revive(uriComponents);
-		const resourcePath = uri.path.toLowerCase();
-		const isJupyterNotebook = resourcePath.endsWith('.ipynb');
-
-		if (isJupyterNotebook && usingPositronNotebooks(this._configurationService)) {
-			this._logService.trace('[Positron] Opening notebook with Positron editor based on editor association for:', uri.toString());
-
-			try {
-				// Get the preferred editor group
-				const preferredGroup = this._editorGroupsService.activeGroup;
-
-				// Create Positron notebook editor input
-				const editorInput = PositronNotebookEditorInput.getOrCreate(
-					this._instantiationService,
-					uri,
-					undefined,
-					ref.object.viewType
-				);
-
-				// Open the editor
-				await this._editorService.openEditor(editorInput, undefined, preferredGroup);
-
-				// Handle untitled notebook case
-				if (uri.scheme === 'untitled') {
-					await this._proxy.$acceptDirtyStateChanged(uri, true);
-				}
-
-				// Add the reference to the collection
-				this._modelReferenceCollection.add(uri, ref);
-
-				return uri;
-			} catch (error) {
-				// Log error and show warning to user
-				this._logService.error('[Positron] Failed to open notebook with Positron editor:', error);
-				this._notificationService.warn(
-					`Failed to open notebook with Positron editor. Falling back to VS Code editor. Error: ${(error as Error).message}`
-				);
-				// Return undefined to fall back to VS Code logic
-			}
-		}
-
-		// Default implementation does nothing - allows VS Code logic to proceed
-		return undefined;
-	}
-	// --- End Positron ---
 
 	async $trySaveNotebook(uriComponents: UriComponents) {
 		const uri = URI.revive(uriComponents);

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../contrib/positronNotebook/common/positronNotebookCommon.js';
+// --- End Positron ---
 import { DisposableStore, dispose } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
@@ -16,11 +19,6 @@ import { IEditorGroupsService } from '../../services/editor/common/editorGroupsS
 import { IEditorService } from '../../services/editor/common/editorService.js';
 import { IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, ExtHostNotebookEditorsShape, INotebookDocumentShowOptions, INotebookEditorViewColumnInfo, MainThreadNotebookEditorsShape, NotebookEditorRevealType } from '../common/extHost.protocol.js';
-// --- Start Positron ---
-import { IPositronNotebookService } from '../../services/positronNotebook/browser/positronNotebookService.js';
-import { PositronNotebookEditorInput } from '../../contrib/positronNotebook/browser/PositronNotebookEditorInput.js';
-import { isEqual } from '../../../base/common/resources.js';
-// --- End Positron ---
 
 class MainThreadNotebook {
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -5,6 +5,8 @@
 
 // --- Start Positron ---
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../contrib/positronNotebook/common/positronNotebookCommon.js';
+import { checkPositronNotebookEnabled } from '../../contrib/positronNotebook/browser/positronNotebookExperimentalConfig.js';
+import { usingPositronNotebooks } from '../../services/positronNotebook/common/positronNotebookUtils.js';
 // --- End Positron ---
 import { DisposableStore, dispose } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
@@ -111,13 +113,21 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 			label: options.label,
 			override: viewType
 		};
+		// --- Start Positron ---
+		// If Positron notebooks are enabled and set to default, use it.
+		// The editor resolver services uses the `override` to select the editor to open.
+		if (checkPositronNotebookEnabled(this._configurationService) &&
+			usingPositronNotebooks(this._configurationService)) {
+			editorOptions.override = POSITRON_NOTEBOOK_EDITOR_ID;
+		}
+		// --- End Positron ---
 
 		const editorPane = await this._editorService.openEditor({ resource: URI.revive(resource), options: editorOptions }, columnToEditorGroup(this._editorGroupService, this._configurationService, options.position));
 		// --- Start Positron ---
 		if (editorPane?.getId() === POSITRON_NOTEBOOK_EDITOR_ID) {
 			// Positron notebook is already open, just return a synthetic ID
 			// We can't return the actual notebook editor ID because Positron notebooks
-			// don't implement INotebookEditor interface yet
+			// don't implement INotebookEditor interface yet (https://github.com/posit-dev/positron/issues/9440)
 			const uri = URI.revive(resource);
 			return `positron-notebook-${uri.toString()}`;
 		}

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -48,9 +48,6 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 		@IEditorService private readonly _editorService: IEditorService,
 		@INotebookEditorService private readonly _notebookEditorService: INotebookEditorService,
 		@IEditorGroupsService private readonly _editorGroupService: IEditorGroupsService,
-		// --- Start Positron ---
-		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
-		// --- End Positron ---
 		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostNotebookEditors);
@@ -105,24 +102,6 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 	}
 
 	async $tryShowNotebookDocument(resource: UriComponents, viewType: string, options: INotebookDocumentShowOptions): Promise<string> {
-		// --- Start Positron ---
-		// Check if a Positron notebook is already open for this resource
-		const uri = URI.revive(resource);
-		for (const positronInstance of this._positronNotebookService.listInstances(uri)) {
-			if (positronInstance.connectedToEditor) {
-				// Find the editor pane containing this Positron notebook
-				for (const editorPane of this._editorService.visibleEditorPanes) {
-					const input = editorPane.input;
-					if (input instanceof PositronNotebookEditorInput && isEqual(input.resource, uri)) {
-						// Positron notebook is already open, just return a synthetic ID
-						// We can't return the actual notebook editor ID because Positron notebooks
-						// don't implement INotebookEditor interface
-						return `positron-notebook-${uri.toString()}`;
-					}
-				}
-			}
-		}
-		// --- End Positron ---
 		const editorOptions: INotebookEditorOptions = {
 			cellSelections: options.selections,
 			preserveFocus: options.preserveFocus,

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -115,6 +115,15 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 		};
 
 		const editorPane = await this._editorService.openEditor({ resource: URI.revive(resource), options: editorOptions }, columnToEditorGroup(this._editorGroupService, this._configurationService, options.position));
+		// --- Start Positron ---
+		if (editorPane?.getId() === POSITRON_NOTEBOOK_EDITOR_ID) {
+			// Positron notebook is already open, just return a synthetic ID
+			// We can't return the actual notebook editor ID because Positron notebooks
+			// don't implement INotebookEditor interface yet
+			const uri = URI.revive(resource);
+			return `positron-notebook-${uri.toString()}`;
+		}
+		// --- End Positron ---
 		const notebookEditor = getNotebookEditorFromEditorPane(editorPane);
 
 		if (notebookEditor) {

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -231,6 +231,14 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		if (editor) {
 			return editor;
 		}
+		// --- Start Positron ---
+		// Positron notebooks don't implement INotebookEditor yet, so mock the result.
+		// This will lead to unexpected errors in extensions that use this API
+		// until we implement INotebookEditor (https://github.com/posit-dev/positron/issues/9440).
+		if (editorId.startsWith('positron-notebook-')) {
+			return {} as any;
+		}
+		// --- End Positron ---
 
 		if (editorId) {
 			throw new Error(`Could NOT open editor for "${notebook.uri.toString()}" because another editor opened in the meantime.`);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -62,9 +62,6 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou
 import { NotebookRendererMessagingService } from './services/notebookRendererMessagingServiceImpl.js';
 import { INotebookRendererMessagingService } from '../common/notebookRendererMessagingService.js';
 import { INotebookCellOutlineDataSourceFactory, NotebookCellOutlineDataSourceFactory } from './viewModel/notebookOutlineDataSourceFactory.js';
-// --- Start Positron ---
-import { checkPositronNotebookEnabled } from '../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
-// --- End Positron ---
 
 // Editor Controller
 import './controller/coreActions.js';
@@ -772,6 +769,9 @@ class NotebookEditorManager implements IWorkbenchContribution {
 	private readonly _disposables = new DisposableStore();
 
 	constructor(
+		// --- Start Positron ---
+		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
+		// --- End Positron ---
 		@IEditorService private readonly _editorService: IEditorService,
 		@INotebookEditorModelResolverService private readonly _notebookEditorModelService: INotebookEditorModelResolverService,
 		@IEditorGroupsService editorGroups: IEditorGroupsService

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -774,9 +774,6 @@ class NotebookEditorManager implements IWorkbenchContribution {
 	constructor(
 		@IEditorService private readonly _editorService: IEditorService,
 		@INotebookEditorModelResolverService private readonly _notebookEditorModelService: INotebookEditorModelResolverService,
-		// --- Start Positron ---
-		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
-		// --- End Positron ---
 		@IEditorGroupsService editorGroups: IEditorGroupsService
 	) {
 		// OPEN notebook editor for models that have turned dirty without being visible in an editor
@@ -834,9 +831,6 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 		@IWorkingCopyEditorService private readonly _workingCopyEditorService: IWorkingCopyEditorService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@INotebookService private readonly _notebookService: INotebookService,
-		// --- Start Positron ---
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		// --- End Positron ---
 	) {
 		super();
 
@@ -844,14 +838,6 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 	}
 
 	async handles(workingCopy: IWorkingCopyIdentifier): Promise<boolean> {
-		// --- Start Positron ---
-		// If this is a .ipynb file and Positron notebooks are enabled,
-		// let the Positron handler take care of it
-		if (workingCopy.resource.path.endsWith('.ipynb') &&
-			checkPositronNotebookEnabled(this._configurationService)) {
-			return false;
-		}
-		// --- End Positron ---
 		const viewType = this.handlesSync(workingCopy);
 		if (!viewType) {
 			return false;

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start Positron ---
+import { checkPositronNotebookEnabled } from '../../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
+// --- End Positron ---
 import { localize } from '../../../../../nls.js';
 import { toAction } from '../../../../../base/common/actions.js';
 import { createErrorWithActions } from '../../../../../base/common/errorMessage.js';
@@ -49,9 +52,6 @@ import { SnapshotContext } from '../../../../services/workingCopy/common/fileWor
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { ICellRange } from '../../common/notebookRange.js';
-// --- Start Positron ---
-import { checkPositronNotebookEnabled } from '../../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
-// --- End Positron ---
 
 
 export class NotebookProviderInfoStore extends Disposable {
@@ -351,9 +351,6 @@ export class NotebookProviderInfoStore extends Disposable {
 			));
 			// Then register the schema handler as exclusive for that notebook
 			// --- Start Positron ---
-			// If Positron notebooks are enabled,
-			// let the Positron notebook cell handler take care of it.
-
 			// disposables.add(this._editorResolverService.registerEditor(
 			// 	`${Schemas.vscodeNotebookCell}:/**/${ globPattern } `,
 			// 	{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
@@ -361,6 +358,10 @@ export class NotebookProviderInfoStore extends Disposable {
 			// 	notebookCellFactoryObject
 			// ));
 
+			// The cell handler is specifically for opening and focusing a cell by URI
+			// e.g. vscode.window.showTextDocument(cell.document).
+			// The editor resolver service expects a single handler with 'exclusive' priority,
+			// so don't register this one if Positron notebooks are enabled.
 			if (!checkPositronNotebookEnabled(this._configurationService)) {
 				disposables.add(this._editorResolverService.registerEditor(
 					`${Schemas.vscodeNotebookCell}:/**/${globPattern} `,

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -85,7 +85,7 @@ export interface IPositronNotebookInstance {
 	 * Observable reference to the current runtime session for the notebook.
 	 * This manages the connection to the kernel and execution environment.
 	 */
-	readonly currentRuntime: IObservable<ILanguageRuntimeSession | undefined>;
+	readonly runtimeSession: IObservable<ILanguageRuntimeSession | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -35,7 +35,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		public readonly cellModel: NotebookCellTextModel,
 		protected readonly _instance: PositronNotebookInstance,
 		@INotebookExecutionStateService private readonly _executionStateService: INotebookExecutionStateService,
-		@ITextModelService private readonly textModelResolverService: ITextModelService,
+		@ITextModelService private readonly _textModelService: ITextModelService,
 	) {
 		super();
 
@@ -100,7 +100,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	async getTextEditorModel(): Promise<ITextModel> {
-		const modelRef = await this.textModelResolverService.createModelReference(this.uri);
+		const modelRef = await this._textModelService.createModelReference(this.uri);
 		return modelRef.object.textEditorModel;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -274,12 +274,6 @@ export class PositronNotebookEditor extends EditorPane {
 			);
 		}
 
-		if (input.notebookInstance === undefined) {
-			throw new Error(
-				'Notebook instance is undefined. This should have been created in the constructor.'
-			);
-		}
-
 		// We're setting the options on the input here so that the input can resolve the model
 		// without having to pass the options to the resolve method.
 		input.editorOptions = options;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -21,7 +21,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
-import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 
 /**
  * Options for Positron notebook editor input, including backup support.
@@ -58,10 +58,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 	private _identifier = `Positron Notebook | Input(${this.uniqueId}) |`;
 	//#region Static Properties
-	/**
-	 * Gets the type ID.
-	 */
-	static readonly ID: string = 'workbench.input.positronNotebook';
 
 	/**
 	 * Editor options. For use in resolving the editor model.
@@ -92,7 +88,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 
 	public readonly viewType = 'jupyter-notebook';
 
-	notebookInstance: PositronNotebookInstance | undefined;
+	notebookInstance: PositronNotebookInstance;
 
 	//#endregion Static Properties
 	//#region Constructor & Dispose
@@ -123,8 +119,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * dispose override method.
 	 */
 	override dispose(): void {
-		// Dispose the notebook instance if it exists
-		this.notebookInstance?.dispose();
+		this.notebookInstance.dispose();
 
 		// Call the base class's dispose method
 		super.dispose();
@@ -136,7 +131,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * Gets the type identifier.
 	 */
 	override get typeId(): string {
-		return PositronNotebookEditorInput.ID;
+		return POSITRON_NOTEBOOK_EDITOR_INPUT_ID;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -104,8 +104,10 @@ class PositronNotebookContribution extends Disposable {
 		// Register for cells in .ipynb files
 		this._register(this.editorResolverService.registerEditor(
 			`${Schemas.vscodeNotebookCell}:/**/*.ipynb`,
-			// We have to use exclusive priority because vscode.window.showTextDocument(cell.document)
-			// restricts to editors with exclusive priority.
+			// The cell handler is specifically for opening and focusing a cell by URI
+			// e.g. vscode.window.showTextDocument(cell.document).
+			// The editor resolver service expects a single handler with 'exclusive' priority.
+			// This one is only registered if Positron notebooks are enabled.
 			// This does not seem to be an issue for file schemes (registered above).
 			{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
 			{

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -77,7 +77,20 @@ class PositronNotebookContribution extends Disposable {
 				}
 			},
 			{
-				createEditorInput: async ({ resource, options }) => {
+				createUntitledEditorInput: async ({ resource, options }) => {
+					// We should handle undefined resource as in notebookEditorServiceImpl.ts,
+					// but resource seems to always be defined so we throw for now to simplify
+					if (!resource) {
+						throw new Error(`Cannot create untitled Positron notebook editor without a resource`);
+					}
+					const notebookEditorInput = PositronNotebookEditorInput.getOrCreate(
+						this.instantiationService,
+						resource,
+						undefined,
+					);
+					return { editor: notebookEditorInput, options };
+				},
+				createEditorInput: ({ resource, options }) => {
 					const notebookEditorInput = PositronNotebookEditorInput.getOrCreate(
 						this.instantiationService,
 						resource,
@@ -102,7 +115,7 @@ class PositronNotebookContribution extends Disposable {
 				}
 			},
 			{
-				createEditorInput: async (editorInput) => {
+				createEditorInput: (editorInput) => {
 					const parsed = CellUri.parse(editorInput.resource);
 					if (!parsed) {
 						throw new Error(`Invalid cell URI: ${editorInput.resource.toString()}`);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -35,7 +35,7 @@ import { registerCellCommand } from './notebookCells/actionBar/registerCellComma
 import { registerNotebookCommand } from './notebookCells/actionBar/registerNotebookCommand.js';
 import { CellConditions } from './notebookCells/actionBar/cellConditions.js';
 import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
-import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 
 
 /**
@@ -255,7 +255,7 @@ class PositronNotebookEditorSerializer implements IEditorSerializer {
 }
 
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
-	PositronNotebookEditorInput.ID,
+	POSITRON_NOTEBOOK_EDITOR_INPUT_ID,
 	PositronNotebookEditorSerializer
 );
 

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -4,3 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const POSITRON_NOTEBOOK_EDITOR_ID = 'workbench.editor.positronNotebook';
+export const POSITRON_NOTEBOOK_EDITOR_INPUT_ID = 'workbench.input.positronNotebook';


### PR DESCRIPTION
This PR simplifies how we handle editor resolution when Positron notebooks are enabled, addressing #9454. With the other recent changes to editor registration and untitled file handling, we can remove a bunch of hooks and just set the `override` field to our editor ID.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Nothing should break, particularly when creating new notebooks, editing and saving untitled notebooks, opening notebooks.

@:notebooks