### PR TITLE
Positron Notebooks: Fix kernel selection

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -271,7 +271,7 @@ export interface NotebookCellOutputs {
 }
 
 /**
- * Lightweight copy of the vscode `NotebookCellTextModel` interface.
+ * Partial interface of the vscode `NotebookCellTextModel` class.
  */
 export interface PositronNotebookCellTextModel {
 	readonly uri: URI;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -15,7 +15,6 @@ import { DisposableStore, MutableDisposable } from '../../../../base/common/life
 import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
 import { localize } from '../../../../nls.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
@@ -99,7 +98,6 @@ export class PositronNotebookEditor extends EditorPane {
 		@ITextResourceConfigurationService
 		configurationService: ITextResourceConfigurationService,
 		@IStorageService storageService: IStorageService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ILogService private readonly _logService: ILogService,
 	) {
@@ -258,7 +256,8 @@ export class PositronNotebookEditor extends EditorPane {
 		// This has to be done before we `await super.setInput` since that fires events
 		// with listeners that call `this.getControl()` expecting an up-to-date control
 		// i.e. with `activeCodeEditor` being the editor of the selected cell in the notebook.
-		this._control.value = new PositronNotebookEditorControl(input.notebookInstance);
+		const { notebookInstance } = input;
+		this._control.value = new PositronNotebookEditorControl(notebookInstance);
 
 		await super.setInput(input, options, context, token);
 
@@ -274,6 +273,8 @@ export class PositronNotebookEditor extends EditorPane {
 			);
 		}
 
+		notebookInstance.setModel(model.notebook);
+
 		// Trigger the selection change event when the notebook was edited.
 		this._instanceDisposableStore.add(
 			model.notebook.onDidChangeContent(() =>
@@ -285,7 +286,7 @@ export class PositronNotebookEditor extends EditorPane {
 
 		this._renderReact();
 
-		input.notebookInstance.attachView(this._parentDiv);
+		notebookInstance.attachView(this._parentDiv);
 	}
 
 	override clearInput(): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -259,12 +259,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		}
 
 		// Set the notebook instance model
-		notebookInstance.setModel(model.notebook);
-
-		// Apply any options to the notebook instance
-		if (options) {
-			notebookInstance.setOptions(options);
-		}
+		notebookInstance.setModel(model.notebook, options?.viewState);
 
 		// Trigger the selection change event when the notebook was edited.
 		this._instanceDisposableStore.add(

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -258,7 +258,13 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 			);
 		}
 
+		// Set the notebook instance model
 		notebookInstance.setModel(model.notebook);
+
+		// Apply any options to the notebook instance
+		if (options) {
+			notebookInstance.setOptions(options);
+		}
 
 		// Trigger the selection change event when the notebook was edited.
 		this._instanceDisposableStore.add(


### PR DESCRIPTION
This fixes kernel selection when:

1. Saving an untitled notebook (https://github.com/posit-dev/positron/issues/9021)
2. Opening a new notebook - we now autoselect the kernel matching the current globally selected runtime using the same logic as done in https://github.com/posit-dev/positron/pull/2498.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Save an untitled notebook and ensure that the kernel is not lost.

Open a new notebook while Python is the globally selected interpreter and check that a Python kernel starts.

@:notebooks