### PR TITLE
e2e: fix & enable tests due to settings.clear() restarting app

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -1,7 +1,4 @@
 {
-    "security.workspace.trust.startupPrompt": "never",
-    "security.workspace.trust.enabled": false,
-    "security.workspace.trust.banner": "never",
     "python.locator": "native",
     "interpreters.startupBehavior": "manual",
     "positron.r.kernel.logLevel": "trace",

--- a/test/e2e/fixtures/settingsWorkbench.json
+++ b/test/e2e/fixtures/settingsWorkbench.json
@@ -1,0 +1,5 @@
+{
+    "security.workspace.trust.startupPrompt": "never",
+    "security.workspace.trust.enabled": false,
+    "security.workspace.trust.banner": "never"
+}

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -101,11 +101,13 @@ async function copyUserSettingsToContainer(): Promise<void> {
 	const fixturesDir = path.join(ROOT_PATH, 'test/e2e/fixtures');
 	const userSettingsFile = path.join(fixturesDir, 'settings.json');
 	const dockerSettingsFile = path.join(fixturesDir, 'settingsDocker.json');
+	const workbenchSettingsFile = path.join(fixturesDir, 'settingsWorkbench.json');
 
 	// Merge settings
 	const mergedSettings = {
 		...JSON.parse(fs.readFileSync(userSettingsFile, 'utf8')),
 		...JSON.parse(fs.readFileSync(dockerSettingsFile, 'utf8')),
+		...JSON.parse(fs.readFileSync(workbenchSettingsFile, 'utf8')),
 	};
 
 	// Create temporary merged settings file

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -111,7 +111,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 		});
 	});
 
-	test.describe.skip('Import without Positron settings', () => {
+	test.describe('Import without Positron settings', () => {
 		test.beforeEach(async ({ settings }) => {
 			await settings.clear();
 		});

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-folder-templates.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-folder-templates.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('New Folder Flow: Template visibility via Interpreter Settings', {
+test.describe('New Folder Flow: Template visibility via Interpreter Settings', {
 	tag: [tags.INTERPRETER, tags.WEB, tags.MODAL, tags.NEW_FOLDER_FLOW]
 }, () => {
 

--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -25,7 +25,7 @@ test.describe('Notebook Working Directory Configuration', {
 		await app.workbench.notebooks.closeNotebookWithoutSaving();
 	});
 
-	test.skip('Default working directory is the notebook parent', async function ({ app, settings }) {
+	test('Default working directory is the notebook parent', async function ({ app, settings }) {
 		await settings.clear();
 		await verifyWorkingDirectoryEndsWith(app.workbench.notebooks, 'working-directory-notebook');
 	});


### PR DESCRIPTION
### Summary

Fixes failures introduced by https://github.com/posit-dev/positron/pull/9477 where `settings.clear()` would quit the app. This was happening because I added new Workbench-specific settings, and anytime `settings.json` was modified (e.g., through `settings.clear()`), saving the file forced an unexpected reboot.

Those settings are now only applied for Workbench.
Future note: if we ever need to clear settings (rare - only a few tests rely on it), we’ll need to adjust the behavior to preserve these particular settings or else a reboot will still be required.

### QA Notes

@:vscode-settings @:new-folder-flow