### PR TITLE
Fix UI comm's `call_method` RPC

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -570,10 +570,6 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	 * @returns The result of the request
 	 */
 	performUiCommRequest(req: UICommRequest, uiCommId: string): Promise<any> {
-		// Create the request. This uses a JSON-RPC 2.0 format, with an
-		// additional `msg_type` field to indicate that this is a request type
-		// for the UI comm.
-		//
 		// NOTE: Currently using nested RPC messages for convenience but
 		// we'd like to do better
 		const request = {
@@ -583,6 +579,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				method: req.method,
 				params: req.args
 			},
+			id: createUniqueId(),
 		};
 
 		const commMsg: JupyterCommMsg = {


### PR DESCRIPTION
Follow-up to https://github.com/posit-dev/positron/pull/9109 to fix broken CI.

Also needed to include `id` field in the request manually constructed for `call_method`, so Ark can determine this is a request and not a notification.

Full test suite passed (https://github.com/posit-dev/positron/actions/runs/17891078455/job/50871542689)