### PR TITLE
Turn on data explorer summary panel feature flag

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummaryEnhancementsFeatureFlag.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummaryEnhancementsFeatureFlag.ts
@@ -43,7 +43,7 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			markdownDescription: localize(
 				'positron.dataExplorer.summaryPanelEnhancements',
-				'**CAUTION**: Enable experimental Data Explorer "Summary Panel Enhancements" feature. This feature is experimental and may not work as expected. Use at your own risk.'
+				'Enable Data Explorer "Summary Panel Enhancements" feature.'
 			),
 		},
 	},

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummaryEnhancementsFeatureFlag.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummaryEnhancementsFeatureFlag.ts
@@ -4,6 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ConfigurationScope, Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { localize } from '../../../../nls.js';
 
 // The key for the feature flag that controls the
 // data explorer summary panel enhancements feature work.
@@ -25,3 +29,22 @@ export function summaryPanelEnhancementsFeatureEnabled(
 		configurationService.getValue(USE_DATA_EXPLORER_SUMMARY_PANEL_ENHANCEMENTS_KEY)
 	);
 }
+
+// Register the configuration setting to expose it in the settings UI
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_DATA_EXPLORER_SUMMARY_PANEL_ENHANCEMENTS_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.dataExplorer.summaryPanelEnhancements',
+				'**CAUTION**: Enable experimental Data Explorer "Summary Panel Enhancements" feature. This feature is experimental and may not work as expected. Use at your own risk.'
+			),
+		},
+	},
+});


### PR DESCRIPTION
Addresses #8527 

This PR exposes the summary panel feature flag as a configuration in the settings UI and turns on the setting by default.

<img width="884" height="680" alt="Screenshot 2025-09-22 at 1 10 22 PM" src="https://github.com/user-attachments/assets/36b2da22-ce26-4b7b-a695-cef6d86fd298" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Enable new data explorer summary panel features (#8527)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win 