### PR TITLE
Bugfix/data explorer ux inconsistencies

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.css
+++ b/src/vs/base/browser/ui/positronComponents/button/button.css
@@ -13,6 +13,10 @@
 	text-align: unset !important;
 }
 
+.positron-button.disabled {
+	cursor: default;
+}
+
 .hc-black .positron-button:not(.border),
 .hc-light .positron-button:not(.border) {
 	border: 1px solid transparent;

--- a/src/vs/base/browser/ui/positronComponents/button/button.css
+++ b/src/vs/base/browser/ui/positronComponents/button/button.css
@@ -22,8 +22,8 @@
 	border: 1px solid transparent;
 }
 
-.hc-black .positron-button:hover,
-.hc-light .positron-button:hover {
+.hc-black .positron-button:hover:not(.disabled),
+.hc-light .positron-button:hover:not(.disabled) {
 	border: 1px dashed var(--vscode-focusBorder);
 }
 

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -42,12 +42,12 @@
 	border: 1px solid var(--vscode-positronActionBar-selectBorder);
 }
 
-.action-bar-button:hover {
+.action-bar-button:hover:not(.disabled) {
 	background: var(--vscode-positronActionBar-hoverBackground);
 }
 
-.hc-black .action-bar-button:hover,
-.hc-light .action-bar-button:hover {
+.hc-black .action-bar-button:hover:not(.disabled),
+.hc-light .action-bar-button:hover:not(.disabled) {
 	border: 1px dashed var(--vscode-focusBorder);
 }
 
@@ -117,7 +117,7 @@
 	padding: 0 4px;
 }
 
-.action-bar-button-icon.enabled-split:hover {
+.action-bar-button-icon.enabled-split:hover:not(.disabled) {
 	padding: 0 4px;
 	border-radius: 4px;
 	filter: brightness(90%);
@@ -134,7 +134,7 @@
 	padding: 0 5px;
 }
 
-.action-bar-button-drop-down-button:hover {
+.action-bar-button-drop-down-button:hover:not(.disabled) {
 	border-radius: 4px;
 	filter: brightness(90%);
 	background: var(--vscode-positronActionBar-hoverBackground);

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -28,6 +28,10 @@
 	color: var(--vscode-positronActionBar-foreground);
 }
 
+.action-bar-button.disabled {
+	cursor: default;
+}
+
 .action-bar-button.checked {
 	background: var(--vscode-positronActionBar-hoverBackground);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.css
@@ -23,7 +23,15 @@
 }
 
 .row-filter-widget:hover {
-	background-color: var(--vscode-positronDataExplorer-contrastBackground);
+	background-color: var(--vscode-positronActionBar-hoverBackground);
+}
+
+/*
+ * remove hover effect from edit filter button when hovering over the
+ * clear filter button to help differentiate both buttons
+ */
+.row-filter-widget:has(.clear-filter-button:hover) {
+	background-color: var(--vscode-positronDataExplorer-background);
 }
 
 .row-filter-widget .boolean-operator {
@@ -68,13 +76,15 @@
 	align-items: center;
 	box-sizing: border-box;
 	justify-content: center;
+	/* the transparent border prevents layout shift when hovering over button */
+	border: 1px solid transparent;
 }
 
 .row-filter-widget .clear-filter-button:hover {
-	border: 1px solid var(--vscode-positronDataExplorer-border);
-
-	/* outline: 1px solid var(--vscode-focusBorder); */
-	background-color: var(--vscode-positronDataExplorer-contrastBackground);
+	/* add filter property to make hover style match the actionBarButton style */
+	filter: brightness(90%);
+	border: 1px solid var(--vscode-positronActionBar-selectBorder);
+	background-color: var(--vscode-positronActionBar-hoverBackground);
 }
 
 .row-filter-widget .clear-button:focus {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -12,6 +12,7 @@ import React, { forwardRef } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../../../../nls.js';
 import { Button } from '../../../../../../../../base/browser/ui/positronComponents/button/button.js';
+import { usePositronDataExplorerContext } from '../../../../../positronDataExplorerContext.js';
 import {
 	RowFilterDescriptor,
 	RowFilterDescriptorComparison,
@@ -41,6 +42,8 @@ interface RowFilterWidgetProps {
  * @returns The rendered component.
  */
 export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProps>((props, ref) => {
+	const context = usePositronDataExplorerContext();
+
 	// Compute the title.
 	const title = (() => {
 		if (props.rowFilter instanceof RowFilterDescriptorIsEmpty) {
@@ -137,6 +140,8 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 		<Button
 			ref={ref}
 			className={buttonClass}
+			hoverManager={context.instance.tableDataDataGridInstance.hoverManager}
+			tooltip={localize('positron.dataExplorer.editFilter', "Edit Filter")}
 			onPressed={() => props.onEdit()}
 		>
 			<div className='title'>
@@ -144,6 +149,8 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 			</div>
 			<Button
 				className='clear-filter-button'
+				hoverManager={context.instance.tableDataDataGridInstance.hoverManager}
+				tooltip={localize('positron.dataExplorer.clearFilter', "Clear Filter")}
 				onPressed={() => props.onClear()}>
 				<div className={'codicon codicon-positron-clear-filter'} />
 			</Button>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
@@ -27,6 +27,12 @@
 	background-color: var(--vscode-positronDataExplorer-background);
 }
 
+/* high contrast theme support for manage filter button */
+.hc-black .data-explorer-panel .row-filter-bar .row-filter-button:hover,
+.hc-light .data-explorer-panel .row-filter-bar .row-filter-button:hover {
+	border: 1px dashed var(--vscode-focusBorder) !important;
+}
+
 .data-explorer-panel .row-filter-bar .row-filter-button:focus {
 	outline: none !important;
 }
@@ -72,6 +78,12 @@
 	justify-content: center;
 	border: 1px solid var(--vscode-positronDataExplorer-border);
 	background-color: var(--vscode-positronDataExplorer-background);
+}
+
+/* high contrast theme support for add filter button */
+.hc-black .data-explorer-panel .row-filter-bar .filter-entries .add-row-filter-button:hover:not(.disabled),
+.hc-light .data-explorer-panel .row-filter-bar .filter-entries .add-row-filter-button:hover:not(.disabled) {
+	border: 1px dashed var(--vscode-focusBorder) !important;
 }
 
 .data-explorer-panel .row-filter-bar .filter-entries .add-row-filter-button.disabled {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
@@ -27,6 +27,10 @@
 	background-color: var(--vscode-positronDataExplorer-background);
 }
 
+.data-explorer-panel .row-filter-bar .row-filter-button:hover {
+	background-color: var(--vscode-positronActionBar-hoverBackground);
+}
+
 /* high contrast theme support for manage filter button */
 .hc-black .data-explorer-panel .row-filter-bar .row-filter-button:hover,
 .hc-light .data-explorer-panel .row-filter-bar .row-filter-button:hover {
@@ -78,6 +82,10 @@
 	justify-content: center;
 	border: 1px solid var(--vscode-positronDataExplorer-border);
 	background-color: var(--vscode-positronDataExplorer-background);
+}
+
+.data-explorer-panel .row-filter-bar .filter-entries .add-row-filter-button:hover:not(.disabled) {
+	background-color: var(--vscode-positronActionBar-hoverBackground);
 }
 
 /* high contrast theme support for add filter button */

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -247,8 +247,10 @@ export const RowFilterBar = () => {
 		<div ref={ref} className='row-filter-bar'>
 			<Button
 				ref={rowFilterButtonRef}
-				ariaLabel={(() => localize('positron.dataExplorer.filtering', "Filtering"))()}
+				ariaLabel={(() => localize('positron.dataExplorer.manageFilters', "Manage Filters"))()}
 				className='row-filter-button'
+				hoverManager={context.instance.tableDataDataGridInstance.hoverManager}
+				tooltip={localize('positron.dataExplorer.manageFilters', "Manage Filters")}
 				onPressed={filterButtonPressedHandler}
 			>
 				<div className='codicon codicon-positron-row-filter' />
@@ -281,6 +283,8 @@ export const RowFilterBar = () => {
 					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add Filter"))()}
 					className='add-row-filter-button'
 					disabled={!canFilter}
+					hoverManager={context.instance.tableDataDataGridInstance.hoverManager}
+					tooltip={localize('positron.dataExplorer.addFilter', "Add Filter")}
 					onPressed={() => addRowFilterHandler(
 						addFilterButtonRef.current,
 						rowFilterDescriptors.length === 0


### PR DESCRIPTION
This PR addresses some of the UX inconsistency that was present in the Data Explorer from #8935.

* Added tooltips to the filter buttons in the data explorer action bar
* Increased color contrast for hover styling on the filter widgets in the action bar
* Added unique hover styling to the "clear" filter button contained within a filter widget
* Changed the cursor style to the default option for disabled buttons so they don't look clickable
* Removed hover styling from disabled buttons so they don't look clickable
  * The disable styling will effect all disabled buttons in the action bar
* Fixed a bug where the hover styling for the add filter button was missing when a high contrast theme is used

**Tooltips**

<img width="1203" height="511" alt="Screenshot 2025-09-22 at 3 25 44 PM" src="https://github.com/user-attachments/assets/18943e6b-12b9-4ba8-b524-eca70acd2dfe" />

<img width="1203" height="511" alt="Screenshot 2025-09-22 at 3 26 03 PM" src="https://github.com/user-attachments/assets/9bc27e22-36cf-46b4-bd9f-c0c3b1a37288" />

<img width="1203" height="511" alt="Screenshot 2025-09-22 at 3 26 37 PM" src="https://github.com/user-attachments/assets/424cde3b-6021-41ff-a5de-42a3bd2066d9" />

<img width="1203" height="511" alt="Screenshot 2025-09-22 at 3 26 57 PM" src="https://github.com/user-attachments/assets/d80c4c74-0393-4292-93ac-bcc7b11196db" />

**Improve disabled button cursor/hover styles**

https://github.com/user-attachments/assets/267d77d5-ae3a-435a-87ec-a0a06943596d

**Improved hover styling for filter widget button**

https://github.com/user-attachments/assets/f43e3e08-d990-4b32-9a06-a28c2217bb6c

**Fixed hover styling for buttons with high contrast theme**

https://github.com/user-attachments/assets/fd3af8f3-3f07-4afd-94bc-5e43788990b9

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Addresses UX issues with tooltips and buttons in Data Explorer (#8935)

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win