### PR TITLE
Data Explorer: Fix DuckDB sorted data copy-paste, add unit tests for Python to verify correct behavior

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1618,9 +1618,11 @@ END`;
 			case TableSelectionKind.RowIndices: {
 				const selection = params.selection.selection as DataSelectionIndices;
 				const indices = selection.indices;
+				const whereCondition = this._whereClause
+					? `${this._whereClause} AND rowid IN (${indices.join(', ')})`
+					: `\nWHERE rowid IN (${indices.join(', ')})`;
 				const query = `SELECT ${getColumnSelectors(this.fullSchema).join(',')}
-				FROM ${this.tableName}${this._whereClause}
-				WHERE rowid IN (${indices.join(', ')})${this._sortClause}`;
+				FROM ${this.tableName}${whereCondition}${this._sortClause}`;
 				return await exportQueryOutput(query, this.fullSchema);
 			}
 			case TableSelectionKind.ColumnIndices: {

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1578,7 +1578,7 @@ END`;
 				const columnIndex = selection.column_index;
 				const schema = this.fullSchema[columnIndex];
 				const selector = getColumnSelectors([schema])[0];
-				const query = `SELECT ${selector} FROM ${this.tableName} LIMIT 1 OFFSET ${rowIndex};`;
+				const query = `SELECT ${selector} FROM ${this.tableName}${this._whereClause}${this._sortClause} LIMIT 1 OFFSET ${rowIndex};`;
 				const result = await this.db.runQuery(query);
 				return {
 					data: result.toArray()[0][result.schema.names[0]],
@@ -1593,7 +1593,7 @@ END`;
 				const columnEnd = selection.last_column_index;
 				const columns = this.fullSchema.slice(columnStart, columnEnd + 1);
 				const query = `SELECT ${getColumnSelectors(columns).join(',')}
-				FROM ${this.tableName}
+				FROM ${this.tableName}${this._whereClause}${this._sortClause}
 				LIMIT ${rowEnd - rowStart + 1} OFFSET ${rowStart};`;
 				return await exportQueryOutput(query, columns);
 			}
@@ -1602,7 +1602,7 @@ END`;
 				const rowStart = selection.first_index;
 				const rowEnd = selection.last_index;
 				const query = `SELECT ${getColumnSelectors(this.fullSchema).join(',')}
-				FROM ${this.tableName}
+				FROM ${this.tableName}${this._whereClause}${this._sortClause}
 				LIMIT ${rowEnd - rowStart + 1} OFFSET ${rowStart};`;
 				return await exportQueryOutput(query, this.fullSchema);
 			}
@@ -1612,15 +1612,15 @@ END`;
 				const columnEnd = selection.last_index;
 				const columns = this.fullSchema.slice(columnStart, columnEnd + 1);
 				const query = `SELECT ${getColumnSelectors(columns).join(',')}
-				FROM ${this.tableName}`;
+				FROM ${this.tableName}${this._whereClause}${this._sortClause}`;
 				return await exportQueryOutput(query, columns);
 			}
 			case TableSelectionKind.RowIndices: {
 				const selection = params.selection.selection as DataSelectionIndices;
 				const indices = selection.indices;
 				const query = `SELECT ${getColumnSelectors(this.fullSchema).join(',')}
-				FROM ${this.tableName}
-				WHERE rowid IN (${indices.join(', ')})`;
+				FROM ${this.tableName}${this._whereClause}
+				WHERE rowid IN (${indices.join(', ')})${this._sortClause}`;
 				return await exportQueryOutput(query, this.fullSchema);
 			}
 			case TableSelectionKind.ColumnIndices: {
@@ -1628,7 +1628,7 @@ END`;
 				const indices = selection.indices;
 				const columns = indices.map(i => this.fullSchema[i]);
 				const query = `SELECT ${getColumnSelectors(columns).join(',')}
-				FROM ${this.tableName}`;
+				FROM ${this.tableName}${this._whereClause}${this._sortClause}`;
 				return await exportQueryOutput(query, columns);
 			}
 			case TableSelectionKind.CellIndices: {

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1661,7 +1661,7 @@ class PandasView(DataExplorerTableView):
         buf = StringIO()
 
         if fmt == ExportFormat.Csv:
-            to_export.to_csv(buf, index=False)
+            to_export.to_csv(buf, index=False, sep=",")
         elif fmt == ExportFormat.Tsv:
             to_export.to_csv(buf, sep="\t", index=False)
         elif fmt == ExportFormat.Html:

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2495,7 +2495,7 @@ def test_export_data_selection_with_sort(dxf: DataExplorerFixture):
         result = dxf.export_data_selection(table_name, selection, "csv")
 
         # Parse the CSV result to get the values
-        lines = result["data"].split("\n")
+        lines = result["data"].splitlines()
         header = lines[0]
         values = [line.strip() for line in lines[1:] if line.strip()]
 
@@ -2510,7 +2510,7 @@ def test_export_data_selection_with_sort(dxf: DataExplorerFixture):
         result_range = dxf.export_data_selection(table_name, selection_range, "csv")
 
         # Parse the CSV result
-        lines_range = result_range["data"].split("\n")
+        lines_range = result_range["data"].splitlines()
         header_range = lines_range[0]
         values_range = [line.split(",")[0] for line in lines_range[1:] if line.strip()]
 
@@ -2534,7 +2534,7 @@ def test_export_data_selection_with_sort(dxf: DataExplorerFixture):
     selection = _select_column_indices([1])
     result = dxf.export_data_selection("pandas_sorted", selection, "csv")
 
-    lines = result["data"].split("\n")
+    lines = result["data"].splitlines()
     values = [line.strip() for line in lines[1:] if line.strip()]
     expected_filtered_sorted = ["c", "d", "e"]
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2343,7 +2343,7 @@ def _pandas_export_table(x, fmt):
     """Helper to export pandas DataFrame to various formats with proper line ending handling."""
     buf = StringIO()
     if fmt == "csv":
-        x.to_csv(buf, index=False)
+        x.to_csv(buf, index=False, sep=",")
     elif fmt == "tsv":
         x.to_csv(buf, sep="\t", index=False)
     elif fmt == "html":


### PR DESCRIPTION
This is the DuckDB side of the solution for #9316, going together with the Ark PR https://github.com/posit-dev/ark/pull/924.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix a bug exporting whole columns from the data explorer after sorting would not return the data in the sorted order. This affected the R and raw data file (DuckDB) backends.

### QA Notes

See bug report in #9316. 

@:data-explorer