### PR TITLE
Claude Code: miscellaneous build system improvements, breadcrumbs for cold starts

### DIFF
--- a/.claude/build-system.md
+++ b/.claude/build-system.md
@@ -1,37 +1,32 @@
 # Positron Build System & Development Workflows
 
-## Overview
+## Quick Start
 
-This document covers the Positron build system, compilation daemons, and development workflows.
-
-**For launching Positron:** See `.claude/launch-positron.md` for the non-blocking launch protocol.
+1. **Check daemon status** (always first): `ps aux | grep -E "npm.*watch-(client|extensions|e2e)d" | grep -v grep`
+2. **Start missing daemons**: `npm run watch-clientd &` and `npm run watch-extensionsd &`
+3. **Wait for compilation**: 30-60 seconds until "Finished compilation" messages
+4. **Launch Positron**: See `.claude/launch-positron.md`
 
 ## Build Daemons
 
-Positron requires compilation daemons to be running before launch:
-- **watch-clientd**: Compiles core TypeScript code in `src/`
-- **watch-extensionsd**: Compiles extensions in `extensions/`
-- **watch-e2ed**: (Optional) Compiles E2E tests in `test/e2e/`
+**Required for Positron to function:**
+- `watch-clientd`: Core TypeScript (`src/`)
+- `watch-extensionsd`: Extensions (`extensions/`)
+- `watch-e2ed`: (Optional) E2E tests (`test/e2e/`)
 
-### Why Daemons Matter:
-- Positron WILL crash if daemons aren't running
-- Extensions won't load without `watch-extensionsd`
-- Changes won't be reflected without active daemons
-- Initial compilation takes 30-60 seconds
+**Critical**: Positron crashes without running daemons. Extensions won't load without `watch-extensionsd`.
 
-## Core Development Workflows
+## Detailed Workflows
 
-### 1. Dependency Management
+### Dependency Management
+Only run `npm install` when necessary:
+- Build/launch errors on first setup
+- Clear dependency sync issues
+- User explicitly requests it
+
 ```bash
-# Ensure dependencies are in sync
-npm install
+npm install  # Only when needed
 ```
-
-**⚠️ Important:** Only run `npm install` if:
-- There are apparent build/launch errors on first setup
-- Dependencies are clearly out of sync causing compilation failures  
-- The user explicitly requests it
-- Otherwise, avoid running it unnecessarily as it's time-consuming
 
 ### 2. Build Daemons
 

--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -10,6 +10,7 @@ ps aux | grep -E "npm.*watch-(client|extensions)d" | grep -v grep
 ```
 
 ### Step 2: Start missing daemons (if needed)
+**For detailed daemon management, see `.claude/build-system.md`**
 ```bash
 # Run these in background
 npm run watch-clientd &

--- a/.claude/launch-positron.md
+++ b/.claude/launch-positron.md
@@ -17,16 +17,21 @@ npm run watch-clientd &
 npm run watch-extensionsd &
 ```
 
-### Step 3: Wait for compilation to complete
-**CRITICAL**: You MUST verify that both daemons have finished their initial compilation before launching Positron.
+### Step 3: VERIFY compilation is complete (DO NOT just wait 30 seconds!)
+**CRITICAL**: You MUST actively verify that both daemons have finished their initial compilation before launching Positron. Simply waiting 30 seconds is NOT sufficient.
+
 ```bash
-# Check daemon output using BashOutput tool to verify compilation is complete
-# Look for messages like:
-# - "Finished compilation" 
+# Use BashOutput tool to check daemon output and verify compilation is complete
+# Look for messages indicating compilation finished:
+# - "Finished compilation"
 # - "Watching for file changes"
 # - "Found 0 errors"
-# This typically takes 30-60 seconds from daemon start
-# Note: May take longer (2-3 minutes) on slower machines or during initial builds
+# - CSS compilation messages
+#
+# TIMING: Initial compilation typically takes 30-60 seconds, but can take 2-3 minutes
+# on slower machines or during initial builds. Always verify rather than guess!
+#
+# If output still shows ongoing compilation, wait longer and check again.
 ```
 
 ### Step 4: Launch Positron in background

--- a/.claude/positron-duckdb.md
+++ b/.claude/positron-duckdb.md
@@ -2,6 +2,11 @@
 
 This prompt provides context for working with the `positron-duckdb` extension, which provides DuckDB WebAssembly support for headless data exploration in Positron.
 
+**Related documentation:**
+- **Build system**: `.claude/build-system.md` - For daemon management and compilation
+- **Data Explorer UI**: `.claude/data-explorer.md` - For frontend components that use this extension
+- **Testing**: `.claude/e2e-testing.md` - For E2E tests involving data exploration
+
 ## Extension Overview
 
 **Purpose**: Provides DuckDB support for headless data explorers for previewing data files  
@@ -47,16 +52,35 @@ extensions/positron-duckdb/
 └── extension.webpack.config.js  # Build configuration
 ```
 
-## Development Commands
+## Quick Development Workflow
 
-### Testing
+### 1. Prerequisites
+Ensure build daemons are running (see `.claude/build-system.md`):
 ```bash
-# Run extension tests
+# Check daemon status first
+ps aux | grep -E "npm.*watch-extensionsd" | grep -v grep
+
+# Start if not running
+npm run watch-extensionsd &
+sleep 30  # Wait for compilation
+```
+
+### 2. Testing
+```bash
+# Run all DuckDB extension tests
 npm run test-extension -- -l positron-duckdb
 
-# Test with specific pattern
+# Test specific functionality
 npm run test-extension -- -l positron-duckdb --grep "histogram"
+npm run test-extension -- -l positron-duckdb --grep "csv"
+npm run test-extension -- -l positron-duckdb --grep "filter"
 ```
+
+### 3. Development Cycle
+1. Edit code in `extensions/positron-duckdb/src/`
+2. Watch for compilation completion in daemon output
+3. Run tests to verify changes
+4. Debug using test data in `extensions/positron-duckdb/src/test/data/`
 
 ## Key Classes and Interfaces
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Positron Development Context
 
-This is the main coordination file for Claude Code when working on Positron. Based on your specific task, include the appropriate modular context file(s) from `dev_prompts/`.
+This is the main coordination file for Claude Code when working on Positron. Based on your specific task, include the appropriate modular context file(s) from `.claude/`.
 
 ## Communication Guidelines
 
@@ -16,13 +16,17 @@ When working on this project, maintain clear and neutral communication:
 
 Positron is a next-generation data science IDE built on VS Code, designed for Python and R development with enhanced data science workflows.
 
-## 🚨 CRITICAL: Development Startup
+## 🚨 CRITICAL: Build System Requirements
 
-**For launching Positron: ALWAYS read `.claude/launch-positron.md` first!**
-This file contains the exact non-blocking launch protocol to avoid session blocking.
+**MANDATORY: Always check if build daemons are running before any development work:**
+```bash
+ps aux | grep -E "npm.*watch-(client|extensions|e2e)d" | grep -v grep
+```
 
-**For build details: See `.claude/build-system.md`**
-This file contains detailed build daemon and compilation instructions.
+**Essential workflows:**
+- **Launching Positron**: Read `.claude/launch-positron.md` for non-blocking launch protocol
+- **Build system**: Read `.claude/build-system.md` for detailed daemon management
+- **Component development**: Read specific `.claude/<component>.md` files for targeted workflows
 
 ## Using Modular Prompts
 
@@ -92,6 +96,9 @@ This project has a Claude Code hook configured that automatically handles most c
 - Inserts final newlines
 
 ### Testing
+
+**Prerequisites:** Ensure build daemons are running (see build system requirements above).
+
 ```bash
 # Extension tests (preferred for extension development)
 npm run test-extension -- -l <extension-name>
@@ -208,3 +215,19 @@ This ensures consistent, scriptable access to GitHub data and integrates well wi
 - `build/` - Build configuration and scripts
 
 Remember to read the appropriate modular prompt file(s) for your specific task area.
+
+## Development Workflow Summary
+
+1. **Check daemon status** (mandatory first step)
+2. **Start missing daemons** if needed (see `.claude/build-system.md`)
+3. **Wait for compilation** (30-60 seconds)
+4. **Launch Positron** (see `.claude/launch-positron.md` for non-blocking protocol)
+5. **Run tests/development tasks** after confirming daemons are ready
+
+## When to Use Which Documentation
+
+- **New to Positron development**: Start here in `CLAUDE.md`, then read `.claude/build-system.md`
+- **Launching Positron**: `.claude/launch-positron.md` (critical for non-blocking sessions)
+- **Extension development**: `.claude/<extension-name>.md` (e.g., `positron-duckdb.md`)
+- **E2E testing**: `.claude/e2e-testing.md`
+- **UI component work**: `.claude/data-explorer.md`, `.claude/ui-components.md`


### PR DESCRIPTION
I found from a cold start on Claude Code today that it was failing to follow instructions about launching the build daemons or run the extension tests for positron-duckdb. Seems like a regression from a few weeks ago (not sure why?) but these refinements have improved its behavior and consistency from my local testing.