### PR TITLE
Data Explorer: Do not parse strings to floats in frequency table tooltips

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
@@ -58,8 +58,8 @@ const FrequencyCount = React.memo(({
 		if (typeof val === 'number') {
 			return val.toPrecision(4);
 		}
-		const num = parseFloat(String(val));
-		return !isNaN(num) ? num.toPrecision(4) : val;
+		// Keep strings as strings - no parsing
+		return val;
 	};
 
 	const formattedValue = formatValue(value);


### PR DESCRIPTION
Addresses #9525.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix bug in data explorer sparkline tooltips where a string value like "9E" would get incorrectly converted to a float for a frequency table tooltip.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

@:data-explorer


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
