### PR TITLE
Data Explorer: Fix DuckDB frequency table calculation, bugs with test infrastructure

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -449,11 +449,11 @@ class ColumnProfileEvaluator {
 			SELECT ${quotedName} AS value, COUNT(*) AS freq
 			FROM ${this.tableName} ${composedPred}
 			GROUP BY 1
-			LIMIT ${params.limit}
 		)
 		SELECT value::VARCHAR AS value, freq
 		FROM freq_table
-		ORDER BY freq DESC, value ASC;`) as Table<any>;
+		ORDER BY freq DESC, value ASC
+		LIMIT ${params.limit};`) as Table<any>;
 
 		const values: string[] = [];
 		const counts: number[] = [];

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -1290,7 +1290,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		await activateExtension();
 
 		// Create a promise that will resolve when we receive the column profile event
-		let resolveProfilePromise: (value: any) => void;
+		let resolveProfilePromise: (value: any) => void = () => { };
 		const profilePromise = new Promise<any>(resolve => {
 			resolveProfilePromise = resolve;
 		});


### PR DESCRIPTION
Addresses #9538. The limit clause was placed in a position before the sorting of the frequency counts took place which would result in incorrect results some of the time. This bug lurked for a while, so this adds tests to confirm the correct behavior.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix a non-deterministic bug where frequency table sparklines might be incorrect when looking at raw data file in the data explorer.

### QA Notes

Compare the sparkline values for the "flights.parquet" dataset between the DuckDB (click on a data file) and a data frame loaded in Python or R.

@:data-explorer