### PR TITLE
e2e: add test exercising summary panel feats with pins

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -777,8 +777,10 @@ export class SummaryPanel {
 
 	async expectColumnOrderToBe(columnNames: string[]) {
 		await test.step('Verify column order in summary panel', async () => {
-			const actualOrder = await this.columnSummaryName.allInnerTexts();
-			expect(actualOrder).toEqual(columnNames);
+			await expect(async () => {
+				const actualOrder = await this.columnSummaryName.allInnerTexts();
+				expect(actualOrder).toEqual(columnNames);
+			}, 'summary panel column order').toPass({ timeout: 5000 });
 		});
 	}
 

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -114,7 +114,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 
 		// verify pinned columns stay at front of summary panel list
 		await dataExplorer.grid.pinColumn(4);
-		await dataExplorer.grid.pinColumn(2); // pin "column1"
+		await dataExplorer.grid.pinColumn(2); // pin index 2: "column1"
 		await dataExplorer.grid.pinColumn(6);
 		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_ascending);
 
@@ -123,7 +123,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_descending);
 
 		// verify unpinning columns returns them to correct location in summary panel list
-		await dataExplorer.grid.unpinColumn(1); // unpin "column1"
+		await dataExplorer.grid.unpinColumn(1); // unpin index 1: "column1"
 		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col6_descending);
 
 		// verify search with pinned columns

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -13,6 +13,15 @@
 import { join } from 'path';
 import { test, tags } from '../_test.setup';
 
+const columnOrder = {
+	default: ['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9'],
+	descending: ['column9', 'column8', 'column7', 'column6', 'column5', 'column4', 'column3', 'column2', 'column1', 'column0'],
+	pinCol4Col1Col6_ascending: ['column4', 'column1', 'column6', 'column0', 'column2', 'column3', 'column5', 'column7', 'column8', 'column9'],
+	pinCol4Col1Col6_descending: ['column4', 'column1', 'column6', 'column9', 'column8', 'column7', 'column5', 'column3', 'column2', 'column0'],
+	pinCol4Col6_ascending: ['column4', 'column6', 'column0', 'column1', 'column2', 'column3', 'column5', 'column7', 'column8', 'column9'],
+	pinCol4Col6_descending: ['column4', 'column6', 'column9', 'column8', 'column7', 'column5', 'column3', 'column2', 'column1', 'column0'],
+};
+
 test.use({
 	suiteId: __filename
 });
@@ -27,7 +36,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Summary Panel: Search', async function ({ app, openDataFile }) {
+	test('Summary Panel: Search', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
 		// view data in data explorer
@@ -36,7 +45,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectColumnCountToBe(10);
 		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.default);
 
 		// perform basic search
 		await dataExplorer.summaryPanel.search('column9');
@@ -62,7 +71,7 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		//await dataExplorer.summaryPanel.expectEmptyState(); // <--- no empty state created in UI yet
 	});
 
-	test('Summary Panel: Sort', async function ({ app, openDataFile }) {
+	test('Summary Panel: Sort', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
 		// view data in data explorer
@@ -70,11 +79,11 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.waitForIdle();
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.default);
 
 		// perform sort
 		await dataExplorer.summaryPanel.sortBy('Name, Descending');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column9', 'column8', 'column7', 'column6', 'column5', 'column4', 'column3', 'column2', 'column1', 'column0']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.descending);
 
 		// verify column collapse and expand retains in sort
 		await dataExplorer.summaryPanel.expandColumnProfile(0);
@@ -82,17 +91,17 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.hide();
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectColumnToBe({ index: 0, name: 'column9', expanded: true });
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column9', 'column8', 'column7', 'column6', 'column5', 'column4', 'column3', 'column2', 'column1', 'column0']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.descending);
 
 		// verify changing sort retains expansion for correct column
 		await dataExplorer.summaryPanel.clearSort();
 		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.default);
 		await dataExplorer.summaryPanel.expectColumnToBe({ index: 0, name: 'column0', expanded: false });
 		await dataExplorer.summaryPanel.expectColumnToBe({ index: 9, name: 'column9', expanded: true });
 	});
 
-	test('Summary Panel: Behavior with Pins', async function ({ app, openDataFile }) {
+	test('Summary Panel: Behavior with Pins', async function ({ app }) {
 		const { dataExplorer } = app.workbench;
 
 		// view data in data explorer
@@ -101,31 +110,31 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.show();
 		await dataExplorer.summaryPanel.expectColumnCountToBe(10);
 		await dataExplorer.summaryPanel.expectSortToBeBy('Original');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.default);
 
 		// verify pinned columns stay at front of summary panel list
-		await dataExplorer.grid.pinColumn(5);
+		await dataExplorer.grid.pinColumn(4);
 		await dataExplorer.grid.pinColumn(2); // pin "column1"
-		await dataExplorer.grid.pinColumn(7);
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column1', 'column7', 'column0', 'column2', 'column3', 'column4', 'column6', 'column8', 'column9']);
+		await dataExplorer.grid.pinColumn(6);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_ascending);
 
 		// verify sort behavior with pinned columns
 		await dataExplorer.summaryPanel.sortBy('Name, Descending');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column1', 'column7', 'column9', 'column8', 'column6', 'column4', 'column3', 'column2', 'column0']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_descending);
 
 		// verify unpinning columns returns them to correct location in summary panel list
 		await dataExplorer.grid.unpinColumn(1); // unpin "column1"
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column7', 'column9', 'column8', 'column6', 'column4', 'column3', 'column2', 'column1', 'column0']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col6_descending);
 
 		// verify search with pinned columns
-		await dataExplorer.summaryPanel.search('4');
-		await dataExplorer.summaryPanel.expectColumnCountToBe(3); // pinned "column5" and "column7" + "column4"
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column7', 'column4']);
+		await dataExplorer.summaryPanel.search('3');
+		await dataExplorer.summaryPanel.expectColumnCountToBe(3); // pinned "column4" and "column6" + "column3"
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column4', 'column6', 'column3']);
 
 		// verify column order after clearing search with pins and sort applied
 		await dataExplorer.summaryPanel.sortBy('Name, Ascending');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column7', 'column4']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column4', 'column6', 'column3']);
 		await dataExplorer.summaryPanel.clearSearch();
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column5', 'column7', 'column0', 'column1', 'column2', 'column3', 'column4', 'column6', 'column8', 'column9']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col6_ascending);
 	});
 });

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -19,16 +19,9 @@ test.use({
 
 test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.DATA_EXPLORER] }, () => {
 
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'dataExplorer.summaryPanelEnhancements': true
-		}, { reload: 'web' });
-	});
-
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();
 	});
-
 
 	test('Summary Panel: Search', async function ({ app, openDataFile }) {
 		const { dataExplorer } = app.workbench;


### PR DESCRIPTION
### Summary

Added e2e test to cover interaction of both summary panel search/sort and pins at the same time.

### QA Notes

@:data-explorer @:web