### PR TITLE
Fix parameter validation when changing filter types

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -787,9 +787,13 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		// Set the selected condition.
 		setSelectedFilterType(nextSelected);
 
-		// We need to clear the filter values and error text if we are changing
-		// between filter types that have a different numbers of parameters.
-		if (filterNumParams(prevSelected) !== filterNumParams(nextSelected)) {
+		if (filterNumParams(prevSelected) === filterNumParams(nextSelected)) {
+			// If the number of parameters is the same, clear only the error text.
+			setErrorText(undefined);
+		}
+		else {
+			// We need to clear the filter values and error text if we are changing
+			// between filter types that have a different numbers of parameters.
 			if (
 				(isSingleParam(prevSelected) && isTwoParams(nextSelected)) ||
 				(isTwoParams(prevSelected) && isSingleParam(nextSelected))

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -787,13 +787,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		// Set the selected condition.
 		setSelectedFilterType(nextSelected);
 
-		if (filterNumParams(prevSelected) === filterNumParams(nextSelected)) {
-			// If the number of parameters is the same, clear only the error text.
-			setErrorText(undefined);
-		}
-		else {
-			// We need to clear the filter values and error text if we are changing
-			// between filter types that have a different numbers of parameters.
+		// We need to clear the filter values and error text if we are changing
+		// between filter types that have a different numbers of parameters.
+		if (filterNumParams(prevSelected) !== filterNumParams(nextSelected)) {
 			if (
 				(isSingleParam(prevSelected) && isTwoParams(nextSelected)) ||
 				(isTwoParams(prevSelected) && isSingleParam(nextSelected))

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -115,6 +115,18 @@ const isSingleParam = (filterType: RowFilterDescrType | undefined) => {
 };
 
 /**
+ * Checks whether a RowFilterDescrType takes two parameters.
+ * @param filterType A row filter descr type.
+ * @returns Whether the filter takes two parameters.
+ */
+const isTwoParams = (filterType: RowFilterDescrType | undefined) => {
+	if (filterType === undefined) {
+		return false;
+	}
+	return filterNumParams(filterType) === 2;
+}
+
+/**
  * AddEditRowFilterModalPopupProps interface.
  */
 interface AddEditRowFilterModalPopupProps {
@@ -768,6 +780,32 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		setErrorText(undefined);
 	};
 
+	const handleSelectionChanged = (dropDownListBoxItem: DropDownListBoxItem<RowFilterDescrType, void>) => {
+		const prevSelected = selectedFilterType;
+		const nextSelected = dropDownListBoxItem.options.identifier;
+
+		// Set the selected condition.
+		setSelectedFilterType(nextSelected);
+
+		// We need to clear the filter values and error text if we are changing
+		// between filter types that have a different numbers of parameters.
+		if (filterNumParams(prevSelected) !== filterNumParams(nextSelected)) {
+			if (
+				(isSingleParam(prevSelected) && isTwoParams(nextSelected)) ||
+				(isTwoParams(prevSelected) && isSingleParam(nextSelected))
+			) {
+				// If we are going from single param to two params, or
+				// from two params to single param, we keep the first
+				// param value and clear everything else.
+				setSecondRowFilterValue('');
+				setErrorText(undefined);
+			} else {
+				// In all other cases, we clear everything.
+				clearFilterValuesAndErrorText();
+			}
+		}
+	};
+
 	// Render.
 	return (
 		<PositronModalPopup
@@ -809,17 +847,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 						'positron.addEditRowFilter.selectCondition',
 						"Select Condition"
 					))()}
-					onSelectionChanged={dropDownListBoxItem => {
-						const prevSelected = selectedFilterType;
-						const nextSelected = dropDownListBoxItem.options.identifier;
-						// Set the selected condition.
-						setSelectedFilterType(nextSelected);
-
-						// Clear the filter values and error text.
-						if (!(isSingleParam(prevSelected) && isSingleParam(nextSelected))) {
-							clearFilterValuesAndErrorText();
-						}
-					}}
+					onSelectionChanged={handleSelectionChanged}
 				/>
 
 				{firstRowFilterParameterComponent}


### PR DESCRIPTION
Addresses #9524 

This addresses the bug in the validation check we do when a user changes the filter type on an existing filter in the Data Explorer. We support filter types that take 0, 1, or 2 parameter values. When a user changes the filter type on an existing filter we want to keep the parameter values when it makes sense. 

I've included a table below on what the new validation check does when we go from X number of parameters for a filter to Y number of parameters. In most cases when we switch to a filter type where the parameters don't match, we want to clear any existing state (parameter values and error messages) we had. The only scenario where we want to keep a parameter value is when going from 1 parameter to 2 parameters and vice versa.

| From ↓ / To → | 0 Parameters | 1 Parameter | 2 Parameters |
|--------|--------|--------|--------|
| 0 Parameters | No change | Clear everything | Clear everything |
| 1 Parameter | Clear everything | No change | Keep first parameter |
| 2 Parameters | Clear everything | Keep first parameter | No change |


https://github.com/user-attachments/assets/45561efb-5ed5-4f5d-b410-e353f6e2b55b


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix parameter validation when changing filter types (#9524)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer @:web @:win