### PR TITLE
Assistant: Improve `executeCode` context and likelihood of correct usage

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -369,7 +369,7 @@
       {
         "name": "executeCode",
         "displayName": "Execute Code",
-        "modelDescription": "Execute a piece of code in the specified programming language. Only use this tool if you absolutely need to execute code, otherwise reply directly to the user with markdown code snippets.",
+        "modelDescription": "Execute a piece of code in the specified programming language and return the result. You prefer to show code over running it unless given an imperative. You prefer this tool to the terminal and other ways of running code when there is a session available with the correct language.",
         "icon": "$(play)",
         "toolReferenceName": "executeCode",
         "userDescription": "Execute code in the console",
@@ -377,6 +377,10 @@
         "inputSchema": {
           "type": "object",
           "properties": {
+            "sessionIdentifier": {
+              "type": "string",
+              "description": "The identifier of the session to execute the code in."
+            },
             "code": {
               "type": "string",
               "description": "The code to execute."

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -119,6 +119,7 @@ export function registerAssistantTools(
 	context.subscriptions.push(selectionEditTool);
 
 	const executeCodeTool = vscode.lm.registerTool<{
+		sessionIdentifier: string;
 		code: string;
 		language: string;
 		summary: string;
@@ -200,7 +201,8 @@ export function registerAssistantTools(
 						true,  // allow incomplete input, so that incomplete statements error right away
 						positron.RuntimeCodeExecutionMode.Interactive,
 						positron.RuntimeErrorBehavior.Stop,
-						observer);
+						observer,
+						options.input.sessionIdentifier);
 
 				// Currently just the text/plain output is returned
 				const output = execResult['text/plain'];

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1803,6 +1803,10 @@ declare module 'positron' {
 		 * @param errorBehavior Possible error behavior for a language runtime, currently ignored by kernels
 		 * @param observer An optional observer for the execution. This object will be notified of
 		 *  execution events, such as output, error, and completion.
+		 * @param sessionId An optional session ID to execute the code in. If
+		 * not provided, an appropriate session will be chosen, and if no
+		 * session for the desired language is running at all, a new session
+		 * will be started.
 		 * @returns A Thenable that resolves with the result of the code execution,
 		 *  as a map of MIME types to values.
 		 */
@@ -1812,7 +1816,8 @@ declare module 'positron' {
 			allowIncomplete?: boolean,
 			mode?: RuntimeCodeExecutionMode,
 			errorBehavior?: RuntimeErrorBehavior,
-			observer?: ExecutionObserver): Thenable<Record<string, any>>;
+			observer?: ExecutionObserver,
+			sessionId?: string): Thenable<Record<string, any>>;
 
 		/**
 		 * Register a language runtime manager with Positron.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1804,9 +1804,9 @@ declare module 'positron' {
 		 * @param observer An optional observer for the execution. This object will be notified of
 		 *  execution events, such as output, error, and completion.
 		 * @param sessionId An optional session ID to execute the code in. If
-		 * not provided, an appropriate session will be chosen, and if no
-		 * session for the desired language is running at all, a new session
-		 * will be started.
+		 *  not provided, an appropriate session will be chosen, and if no
+		 *  session for the desired language is running at all, a new session
+		 *  will be started.
 		 * @returns A Thenable that resolves with the result of the code execution,
 		 *  as a map of MIME types to values.
 		 */

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1692,8 +1692,9 @@ export class MainThreadLanguageRuntime
 	}
 
 	$executeCode(languageId: string,
-		code: string,
 		extensionId: string,
+		sessionId: string | undefined,
+		code: string,
 		focus: boolean,
 		allowIncomplete?: boolean,
 		mode?: RuntimeCodeExecutionMode,
@@ -1709,7 +1710,7 @@ export class MainThreadLanguageRuntime
 		};
 
 		return this._positronConsoleService.executeCode(
-			languageId, code, attribution, focus, allowIncomplete, mode, errorBehavior, executionId);
+			languageId, sessionId, code, attribution, focus, allowIncomplete, mode, errorBehavior, executionId);
 	}
 
 	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): Promise<void> {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -88,9 +88,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior, observer): Thenable<Record<string, any>> {
+			executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior, observer, sessionId): Thenable<Record<string, any>> {
 				const extensionId = extension.identifier.value;
-				return extHostLanguageRuntime.executeCode(languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, observer);
+				return extHostLanguageRuntime.executeCode(languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, observer, sessionId);
 			},
 			registerLanguageRuntimeManager(
 				languageId: string,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -44,7 +44,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(runtimeId: string): void;
-	$executeCode(languageId: string, extensionId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string): Promise<string>;
+	$executeCode(languageId: string, extensionId: string, sessionId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string): Promise<string>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata | undefined>;
 	$getRegisteredRuntimes(): Promise<ILanguageRuntimeMetadata[]>;
 	$getActiveSessions(): Promise<ActiveRuntimeSessionMetadata[]>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -44,7 +44,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(runtimeId: string): void;
-	$executeCode(languageId: string, extensionId: string, sessionId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string): Promise<string>;
+	$executeCode(languageId: string, extensionId: string, sessionId: string | undefined, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string): Promise<string>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata | undefined>;
 	$getRegisteredRuntimes(): Promise<ILanguageRuntimeMetadata[]>;
 	$getActiveSessions(): Promise<ActiveRuntimeSessionMetadata[]>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1240,7 +1240,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		// more or less fixed since it's part of the public API, but the
 		// internal parameter order can be more logical.
 		this._proxy.$executeCode(
-			languageId, extensionId, sessionId || '', code, focus, allowIncomplete, mode, errorBehavior, executionId).then(
+			languageId, extensionId, sessionId, code, focus, allowIncomplete, mode, errorBehavior, executionId).then(
 				(sessionId) => {
 					// Bind the session ID to the observer so we can use it later
 					executionObserver.sessionId = sessionId;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1225,7 +1225,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		allowIncomplete?: boolean,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		observer?: IExecutionObserver): Promise<Record<string, any>> {
+		observer?: IExecutionObserver,
+		sessionId?: string): Promise<Record<string, any>> {
 
 		// Create a UUID and an observer for this execution request
 		const executionId = generateUuid();
@@ -1234,8 +1235,12 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 		// Begin the code execution. This returns a promise that resolves to the
 		// session ID of the session assigned (or created) to run the code.
+		//
+		// The parameter order gets rearranged here; the API parameter order is
+		// more or less fixed since it's part of the public API, but the
+		// internal parameter order can be more logical.
 		this._proxy.$executeCode(
-			languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, executionId).then(
+			languageId, extensionId, sessionId || '', code, focus, allowIncomplete, mode, errorBehavior, executionId).then(
 				(sessionId) => {
 					// Bind the session ID to the observer so we can use it later
 					executionObserver.sessionId = sessionId;

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1104,7 +1104,12 @@ export function registerLanguageRuntimeActions() {
 				};
 
 			consoleService.executeCode(
-				args.langId, args.code, attribution, !!args.focus, true /* execute the code even if incomplete */);
+				args.langId,
+				undefined /* no particular session */,
+				args.code,
+				attribution,
+				!!args.focus,
+				true /* execute the code even if incomplete */);
 		}
 	});
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -63,6 +63,7 @@ class PositronAssistantContribution extends Disposable implements IWorkbenchCont
 				};
 				consoleService.executeCode(
 					context.languageId || '',
+					undefined, // run in any session
 					context.code,
 					attribution,
 					true, // focus

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -413,7 +413,7 @@ export function registerPositronConsoleActions() {
 			// Ask the Positron console service to execute the code. Do not focus the console as
 			// this will rip focus away from the editor.
 			if (!await positronConsoleService.executeCode(
-				languageId, code, attribution, false, allowIncomplete, opts.mode, opts.errorBehavior)) {
+				languageId, undefined /* run in any session */, code, attribution, false, allowIncomplete, opts.mode, opts.errorBehavior)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -116,6 +116,9 @@ export interface IPositronConsoleService {
 	 * Executes code in a PositronConsoleInstance.
 	 *
 	 * @param languageId The language ID.
+	 * @param sessionId The session ID. This can be empty, in which case an appropriate session
+	 *   will be chosen, and if no session for the desired language is running at all, a new
+	 *   session will be started.
 	 * @param code The code.
 	 * @param attribution An optional attribution object that describes the source of the code.
 	 * @param focus A value which indicates whether to focus Positron console instance.
@@ -127,6 +130,7 @@ export interface IPositronConsoleService {
 	 * @returns The session ID that was assigned to execute the code.
 	 */
 	executeCode(languageId: string,
+		sessionId: string | undefined,
 		code: string,
 		attribution: IConsoleCodeAttribution,
 		focus: boolean,

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -163,6 +163,7 @@ export class TestPositronConsoleService implements IPositronConsoleService {
 	 */
 	async executeCode(
 		languageId: string,
+		sessionId: string | undefined,
 		code: string,
 		attribution: IConsoleCodeAttribution,
 		focus: boolean,


### PR DESCRIPTION
This change contains a couple of tweaks to `executeCode` to address some problems we've seen with the way the model uses it.

Most importantly, the model must now tell Assistant _which session_ to run the code in rather than only specifying a language. This makes it (almost) impossible for the model to try to run, say, bash code in an R session.

(To do this it was necessary to plumb the session ID all the way through the API, which I think will be helpful in other contexts; please excuse the parameter ordering issues as I didn't want to shuffle parameters that extensions are already using)

Secondly, we now tell the model to prefer this tool over other ways of running code when a session is available. It likely isn't foolproof but empirically it helps Copilot Chat realize it can just run stuff right in the Positron console instead of trying to start a terminal.

<img width="451" height="611" alt="image" src="https://github.com/user-attachments/assets/e6548e68-ab16-4c48-a2a1-1b136ba0c7d7" />


Addresses https://github.com/posit-dev/positron/issues/8727
Addresses https://github.com/posit-dev/positron/issues/9511

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing Assistant to occasionally try to execute code with the wrong language in a Positron console (#8727)


### QA Notes

To help Copilot Chat realize it can use this tool, I had to tone down the language around only using it when necessary. I think that language was partially responsible for Copilot always reaching for the Terminal (now here we have two ways of running code but only _one_ of them says not to use it unless I have to...)

So the main risk of this change is that it will reintroduce some of Claude Sonnet 4's tendency to want to run code ALL THE TIME even if it doesn't need to. Please let me know if it feels like it's doing this. 

Tags: `@:assistant`
