### PR TITLE
e2e: change columns pinned for summary panel test

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -245,11 +245,11 @@ export class DataGrid {
 	 * Click a cell by its visual position (position is 0-based)
 	 * For example, if a column/row is pinned, the position would be index 0.
 	 */
-	async clickCell(rowPosition: number, columnIndex: number, withShift = false) {
-		await test.step(`Click cell by 0-based position: row ${rowPosition}, column ${columnIndex}`, async () => {
+	async clickCell(rowPosition: number, columnPosition: number, withShift = false) {
+		await test.step(`Click cell by 0-based position: row ${rowPosition}, column ${columnPosition}`, async () => {
 			withShift
-				? await this.cellByPosition(rowPosition, columnIndex).click({ modifiers: ['Shift'] })
-				: await this.cellByPosition(rowPosition, columnIndex).click();
+				? await this.cellByPosition(rowPosition, columnPosition).click({ modifiers: ['Shift'] })
+				: await this.cellByPosition(rowPosition, columnPosition).click();
 		});
 	}
 
@@ -258,7 +258,7 @@ export class DataGrid {
 	 * These indexes never change even with sorting, filtering, or pinning.
 	 */
 	async clickCellByIndex(rowIndex: number, columnIndex: number, withShift = false) {
-		await test.step(`Click cell by index: row ${rowIndex}, column ${columnIndex}`, async () => {
+		await test.step(`Click cell by 0-based index: row ${rowIndex}, column ${columnIndex}`, async () => {
 			withShift
 				? await this.cellByIndex(rowIndex, columnIndex).click({ modifiers: ['Shift'] })
 				: await this.cellByIndex(rowIndex, columnIndex).click();
@@ -292,7 +292,7 @@ export class DataGrid {
 	 * @param colPosition (position is 0-based)
 	 */
 	async pinColumn(colPosition: number) {
-		await test.step(`Pin column at position ${colPosition}`, async () => {
+		await test.step(`Pin column at 0-based position: ${colPosition}`, async () => {
 			await this.jumpToStart(); // make sure we are at the start so our index is accurate
 			await this.selectColumnAction(colPosition + 1, 'Pin Column'); // selectColumnAction is 1-based
 		});
@@ -303,7 +303,7 @@ export class DataGrid {
 	 * @param colPosition (position is 0-based)
 	 */
 	async unpinColumn(colPosition = 0) {
-		await test.step(`Unpin column at position ${colPosition}`, async () => {
+		await test.step(`Unpin column at 0-based position: ${colPosition}`, async () => {
 			await this.jumpToStart(); // make sure we are at the start so our index is accurate
 			await this.selectColumnAction(colPosition + 1, 'Unpin Column'); // selectColumnAction is 1-based
 		});
@@ -314,7 +314,7 @@ export class DataGrid {
 	 * @param rowPosition (position is 0-based)
 	 */
 	async pinRow(rowPosition: number) {
-		await test.step(`Pin row at position ${rowPosition}`, async () => {
+		await test.step(`Pin row at 0-based position: ${rowPosition}`, async () => {
 			await this.code.driver.page
 				// rowPosition is 0-based, nth-child is 1-based
 				.locator(`.data-grid-row-headers > div:nth-child(${rowPosition + 1})`)
@@ -328,7 +328,7 @@ export class DataGrid {
 	 * @param rowPosition (position is 0-based)
 	 */
 	async unpinRow(rowPosition = 0) {
-		await test.step(`Unpin row at position ${rowPosition}`, async () => {
+		await test.step(`Unpin row at 0-based position: ${rowPosition}`, async () => {
 			await this.code.driver.page
 				.locator(`.data-grid-row-headers > div:nth-child(${rowPosition + 1})`)
 				.click({ button: 'right' });

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -242,14 +242,14 @@ export class DataGrid {
 	}
 
 	/**
-	 * Click a cell by its visual position (Index is 0-based)
+	 * Click a cell by its visual position (position is 0-based)
 	 * For example, if a column/row is pinned, the position would be index 0.
 	 */
-	async clickCell(rowIndex: number, columnIndex: number, withShift = false) {
-		await test.step(`Click cell by 0-based position: row ${rowIndex}, column ${columnIndex}`, async () => {
+	async clickCell(rowPosition: number, columnIndex: number, withShift = false) {
+		await test.step(`Click cell by 0-based position: row ${rowPosition}, column ${columnIndex}`, async () => {
 			withShift
-				? await this.cellByPosition(rowIndex, columnIndex).click({ modifiers: ['Shift'] })
-				: await this.cellByPosition(rowIndex, columnIndex).click();
+				? await this.cellByPosition(rowPosition, columnIndex).click({ modifiers: ['Shift'] })
+				: await this.cellByPosition(rowPosition, columnIndex).click();
 		});
 	}
 
@@ -288,49 +288,49 @@ export class DataGrid {
 	}
 
 	/**
-	 * Pin a column by its visual index
-	 * @param colIndex (Index is 0-based)
+	 * Pin a column by its position
+	 * @param colPosition (position is 0-based)
 	 */
-	async pinColumn(colIndex: number) {
-		await test.step(`Pin column at index ${colIndex}`, async () => {
+	async pinColumn(colPosition: number) {
+		await test.step(`Pin column at position ${colPosition}`, async () => {
 			await this.jumpToStart(); // make sure we are at the start so our index is accurate
-			await this.selectColumnAction(colIndex + 1, 'Pin Column'); // selectColumnAction is 1-based
+			await this.selectColumnAction(colPosition + 1, 'Pin Column'); // selectColumnAction is 1-based
 		});
 	}
 
 	/**
-	 * Unpin a column by its visual index
-	 * @param colIndex (Index is 0-based)
+	 * Unpin a column by its position
+	 * @param colPosition (position is 0-based)
 	 */
-	async unpinColumn(colIndex = 0) {
-		await test.step(`Unpin column at index ${colIndex}`, async () => {
+	async unpinColumn(colPosition = 0) {
+		await test.step(`Unpin column at position ${colPosition}`, async () => {
 			await this.jumpToStart(); // make sure we are at the start so our index is accurate
-			await this.selectColumnAction(colIndex + 1, 'Unpin Column'); // selectColumnAction is 1-based
+			await this.selectColumnAction(colPosition + 1, 'Unpin Column'); // selectColumnAction is 1-based
 		});
 	}
 
 	/**
-	 * Pin a row by its visual index
-	 * @param rowIndex (Index is 0-based)
+	 * Pin a row by its position
+	 * @param rowPosition (position is 0-based)
 	 */
-	async pinRow(rowIndex: number) {
-		await test.step(`Pin row at index ${rowIndex}`, async () => {
+	async pinRow(rowPosition: number) {
+		await test.step(`Pin row at position ${rowPosition}`, async () => {
 			await this.code.driver.page
-				// rowIndex is 0-based, nth-child is 1-based
-				.locator(`.data-grid-row-headers > div:nth-child(${rowIndex + 1})`)
+				// rowPosition is 0-based, nth-child is 1-based
+				.locator(`.data-grid-row-headers > div:nth-child(${rowPosition + 1})`)
 				.click({ button: 'right' });
 			await this.code.driver.page.getByRole('button', { name: 'Pin Row' }).click();
 		});
 	}
 
 	/**
-	 * Unpin a row by its visual index
-	 * @param rowIndex (Index is 0-based)
+	 * Unpin a row by its position
+	 * @param rowPosition (position is 0-based)
 	 */
-	async unpinRow(rowIndex = 0) {
-		await test.step(`Unpin row at index ${rowIndex}`, async () => {
+	async unpinRow(rowPosition = 0) {
+		await test.step(`Unpin row at position ${rowPosition}`, async () => {
 			await this.code.driver.page
-				.locator(`.data-grid-row-headers > div:nth-child(${rowIndex + 1})`)
+				.locator(`.data-grid-row-headers > div:nth-child(${rowPosition + 1})`)
 				.click({ button: 'right' });
 			await this.code.driver.page.getByRole('button', { name: 'Unpin Row' }).click();
 		});

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -16,10 +16,10 @@ import { test, tags } from '../_test.setup';
 const columnOrder = {
 	default: ['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9'],
 	descending: ['column9', 'column8', 'column7', 'column6', 'column5', 'column4', 'column3', 'column2', 'column1', 'column0'],
-	pinCol4Col1Col6_ascending: ['column4', 'column1', 'column6', 'column0', 'column2', 'column3', 'column5', 'column7', 'column8', 'column9'],
-	pinCol4Col1Col6_descending: ['column4', 'column1', 'column6', 'column9', 'column8', 'column7', 'column5', 'column3', 'column2', 'column0'],
-	pinCol4Col6_ascending: ['column4', 'column6', 'column0', 'column1', 'column2', 'column3', 'column5', 'column7', 'column8', 'column9'],
-	pinCol4Col6_descending: ['column4', 'column6', 'column9', 'column8', 'column7', 'column5', 'column3', 'column2', 'column1', 'column0'],
+	pinCol3Col1Col4_ascending: ['column3', 'column1', 'column4', 'column0', 'column2', 'column5', 'column6', 'column7', 'column8', 'column9'],
+	pinCol3Col1Col4_descending: ['column3', 'column1', 'column4', 'column9', 'column8', 'column7', 'column6', 'column5', 'column2', 'column0'],
+	pinCol3Col4_ascending: ['column3', 'column4', 'column0', 'column1', 'column2', 'column5', 'column6', 'column7', 'column8', 'column9'],
+	pinCol3Col4_descending: ['column3', 'column4', 'column9', 'column8', 'column7', 'column6', 'column5', 'column2', 'column1', 'column0'],
 };
 
 test.use({
@@ -113,28 +113,28 @@ test.describe('Data Explorer: Summary Panel', { tag: [tags.WIN, tags.WEB, tags.D
 		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.default);
 
 		// verify pinned columns stay at front of summary panel list
+		await dataExplorer.grid.pinColumn(3);
+		await dataExplorer.grid.pinColumn(2); // position 2: "column1"
 		await dataExplorer.grid.pinColumn(4);
-		await dataExplorer.grid.pinColumn(2); // pin index 2: "column1"
-		await dataExplorer.grid.pinColumn(6);
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_ascending);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol3Col1Col4_ascending);
 
 		// verify sort behavior with pinned columns
 		await dataExplorer.summaryPanel.sortBy('Name, Descending');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col1Col6_descending);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol3Col1Col4_descending);
 
 		// verify unpinning columns returns them to correct location in summary panel list
 		await dataExplorer.grid.unpinColumn(1); // unpin index 1: "column1"
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col6_descending);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol3Col4_descending);
 
 		// verify search with pinned columns
-		await dataExplorer.summaryPanel.search('3');
-		await dataExplorer.summaryPanel.expectColumnCountToBe(3); // pinned "column4" and "column6" + "column3"
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column4', 'column6', 'column3']);
+		await dataExplorer.summaryPanel.search('7');
+		await dataExplorer.summaryPanel.expectColumnCountToBe(3); // pinned "column3" and "column4" + "column7"
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column3', 'column4', 'column7']);
 
 		// verify column order after clearing search with pins and sort applied
 		await dataExplorer.summaryPanel.sortBy('Name, Ascending');
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column4', 'column6', 'column3']);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(['column3', 'column4', 'column7']);
 		await dataExplorer.summaryPanel.clearSearch();
-		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol4Col6_ascending);
+		await dataExplorer.summaryPanel.expectColumnOrderToBe(columnOrder.pinCol3Col4_ascending);
 	});
 });


### PR DESCRIPTION
### Summary

Noticed that Windows failed because the viewport is much smaller and pinning column 7 (in original test) would require scrolling. Therefore, adjusted columns used in test to avoid scrolling (and failure). 

### QA Notes

@:data-explorer @:web @:win