### PR TITLE
Data Explorer: clear pinned state when searching or sorting

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -267,6 +267,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @returns A Promise<void> that resolves when the data is sorted.
 	 */
 	override async sortData(columnSorts: IColumnSortKey[]): Promise<void> {
+		// Clear pinned rows whenever a sort is applied to avoid
+		// the bug where pinned row data is in the wrong position.
+		// See https://github.com/posit-dev/positron/issues/9344
+		this.clearPinnedRows();
+
 		// Set the sort columns.
 		await this._dataExplorerClientInstance.setSortColumns(columnSorts.map(columnSort => ({
 			column_index: columnSort.columnIndex,
@@ -788,6 +793,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @returns A Promise<FilterResult> that resolves when the operation is complete.
 	 */
 	async setRowFilters(filters: Array<RowFilter>): Promise<void> {
+		// Clear pinned rows whenever a filter is applied to avoid
+		// the bug where pinned row data is in the wrong position.
+		// See https://github.com/posit-dev/positron/issues/9344
+		this.clearPinnedRows();
+
 		// Set the row filters.
 		await this._dataExplorerClientInstance.setRowFilters(filters);
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -131,9 +131,10 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 					reject(new Error(`${commandName} not registered within 30 seconds`));
 				}, 30000);
 
-				CommandsRegistry.onDidRegisterCommand((id: string) => {
+				const disposable = CommandsRegistry.onDidRegisterCommand((id: string) => {
 					if (id === commandName) {
 						clearTimeout(timeoutId);
+						disposable.dispose();
 						resolve();
 					}
 				});

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -197,5 +197,29 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow5, indexOffset);
 			await dataExplorer.grid.expectColumnHeadersToBe(columnOrder.pinCol4);
 		});
+
+		test(`${env} - Pinned rows are cleared when sort or filter changes`, async function ({ app }) {
+			const { dataExplorer } = app.workbench;
+
+			// pin row 5
+			await dataExplorer.grid.pinRow(5);
+			await dataExplorer.grid.expectRowsToBePinned([5], indexOffset);
+			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow5, indexOffset);
+
+			// sort by column 4 - this should clear pinned rows
+			await dataExplorer.grid.sortColumnBy(4, 'Sort Descending');
+			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
+			await dataExplorer.grid.expectRowOrderToBe(rowOrder.default, indexOffset);
+
+			// pin row 6
+			await dataExplorer.grid.pinRow(6);
+			await dataExplorer.grid.expectRowsToBePinned([6], indexOffset);
+			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow6, indexOffset);
+
+			// clear sort by column 4 - this should also clear pinned rows
+			await dataExplorer.grid.sortColumnBy(4, 'Clear Sorting');
+			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
+			await dataExplorer.grid.expectRowOrderToBe(rowOrder.default, indexOffset);
+		});
 	});
 }

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -201,25 +201,77 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 		test(`${env} - Pinned rows are cleared when sort or filter changes`, async function ({ app }) {
 			const { dataExplorer } = app.workbench;
 
+			const expectedDataOriginal = [
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 }
+			];
+			const expectedDataPinRow5 = [
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 }
+			];
+			const expectedDataSortColumn4Asc = [
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+			];
+			const expectedDataSortColumn4AscPinRow6 = [
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+			];
+
+			// maximize to ensure all rows/columns are rendered and visible
+			await dataExplorer.maximize(true);
+
 			// pin row 5
 			await dataExplorer.grid.pinRow(5);
 			await dataExplorer.grid.expectRowsToBePinned([5], indexOffset);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow5, indexOffset);
+			await dataExplorer.grid.verifyTableData(expectedDataPinRow5);
 
 			// sort by column 4 - this should clear pinned rows
-			await dataExplorer.grid.sortColumnBy(4, 'Sort Descending');
+			await dataExplorer.grid.sortColumnBy(4, 'Sort Ascending');
 			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.default, indexOffset);
+			await dataExplorer.grid.verifyTableData(expectedDataSortColumn4Asc);
 
 			// pin row 6
 			await dataExplorer.grid.pinRow(6);
 			await dataExplorer.grid.expectRowsToBePinned([6], indexOffset);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow6, indexOffset);
+			await dataExplorer.grid.verifyTableData(expectedDataSortColumn4AscPinRow6);
 
 			// clear sort by column 4 - this should also clear pinned rows
 			await dataExplorer.grid.sortColumnBy(4, 'Clear Sorting');
 			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.default, indexOffset);
+			await dataExplorer.grid.verifyTableData(expectedDataOriginal);
 		});
 	});
 }

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -172,82 +172,62 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 			await dataExplorer.grid.expectCellToBeSelected(1, 2);
 		});
 
-		test(`${env} - Column sorting doesn't impact pin locations`, {
+		test(`${env} - Column sorting removes pinned rows`, {
 			annotation: [
 				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9344' },
 			],
 		}, async function ({ app }) {
-			if (env !== 'DuckDB') { test.skip(); }  // Once issue 9344 is fixed, we can enable for R and Python
 			const { dataExplorer } = app.workbench;
 
-			// pin column 4
-			await dataExplorer.grid.pinColumn(4);
-			await dataExplorer.grid.expectColumnsToBePinned(['column4']);
-			await dataExplorer.grid.expectColumnHeadersToBe(columnOrder.pinCol4);
-
-			// pin row 5
-			await dataExplorer.grid.pinRow(5);
-			await dataExplorer.grid.expectRowsToBePinned([5], indexOffset);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow5, indexOffset);
-
-			// sort by column 4
-			await dataExplorer.grid.sortColumnBy(4, 'Sort Descending');
-			await dataExplorer.grid.expectRowsToBePinned([5], indexOffset);
-			await dataExplorer.grid.expectColumnsToBePinned(['column4']);
-			await dataExplorer.grid.expectRowOrderToBe(rowOrder.pinRow5, indexOffset);
-			await dataExplorer.grid.expectColumnHeadersToBe(columnOrder.pinCol4);
-		});
-
-		test(`${env} - Pinned rows are cleared when sort or filter changes`, async function ({ app }) {
-			const { dataExplorer } = app.workbench;
-
+			// When verifying table data, we only check the visible rows/columns to keep tests stable across environments
+			// because the window size is only big enough to fit the first 7 columns.
 			const expectedDataOriginal = [
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 }
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 }
 			];
 			const expectedDataPinRow5 = [
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 }
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 }
 			];
 			const expectedDataSortColumn4Asc = [
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
 			];
 			const expectedDataSortColumn4AscPinRow6 = [
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15, 'column8': 84, 'column9': 38 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36, 'column8': 92, 'column9': 58 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76, 'column8': 82, 'column9': 29 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15, 'column8': 79, 'column9': 20 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39, 'column8': 80, 'column9': 99 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82, 'column8': 12, 'column9': 7 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98, 'column8': 80, 'column9': 24 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80, 'column8': 37, 'column9': 61 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21, 'column8': 92, 'column9': 95 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13, 'column8': 14, 'column9': 39 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
 			];
 
 			// maximize to ensure all rows/columns are rendered and visible

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -255,7 +255,6 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 
 			// pin row 5
 			await dataExplorer.grid.pinRow(5);
-			await dataExplorer.grid.expectRowsToBePinned([5], indexOffset);
 			await dataExplorer.grid.verifyTableData(expectedDataPinRow5);
 
 			// sort by column 4 - this should clear pinned rows
@@ -265,7 +264,6 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 
 			// pin row 6
 			await dataExplorer.grid.pinRow(6);
-			await dataExplorer.grid.expectRowsToBePinned([6], indexOffset);
 			await dataExplorer.grid.verifyTableData(expectedDataSortColumn4AscPinRow6);
 
 			// clear sort by column 4 - this should also clear pinned rows

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -179,21 +179,10 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 		}, async function ({ app }) {
 			const { dataExplorer } = app.workbench;
 
-			// When verifying table data, we only check the visible rows/columns to keep tests stable across environments
-			// because the window size is only big enough to fit the first 7 columns.
-			const expectedDataOriginal = [
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 }
-			];
-			const expectedDataPinRow5 = [
+			// The Positron window size determines how many columns are visible in the DOM.
+			// When verifying the table data, we only check the data for the first 7 columns
+			// because those are the only columns that get rendered based off the window size.
+			const dataPinRow5 = [
 				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
 				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
 				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
@@ -205,51 +194,82 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
 				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 }
 			];
-			const expectedDataSortColumn4Asc = [
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
+			const dataPinRow5AndCol4 = [
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 }
 			];
-			const expectedDataSortColumn4AscPinRow6 = [
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
+			const dataPinCol4SortCol4 = [
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 }
+			];
+			const dataSortCol4PinRow6 = [
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 }
+			];
+			const dataPinCol4 = [
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 }
 			];
 
 			// maximize to ensure all rows/columns are rendered and visible
 			await dataExplorer.maximize(true);
 
 			// pin row 5
-			await dataExplorer.grid.pinRow(5);
-			await dataExplorer.grid.verifyTableData(expectedDataPinRow5);
+			await dataExplorer.grid.pinRow(5); // pins the 6th row
+			await dataExplorer.grid.verifyTableData(dataPinRow5);
 
-			// sort by column 4 - this should clear pinned rows
-			await dataExplorer.grid.sortColumnBy(4, 'Sort Ascending');
+			// pin column 4
+			await dataExplorer.grid.pinColumn(4); // pins 'column4'
+			await dataExplorer.grid.expectColumnsToBePinned(['column4']);
+			await dataExplorer.grid.verifyTableData(dataPinRow5AndCol4);
+
+			// sort 'column 4' - this should only clear the pinned rows
+			await dataExplorer.grid.sortColumnBy(1, 'Sort Descending');
 			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
-			await dataExplorer.grid.verifyTableData(expectedDataSortColumn4Asc);
+			await dataExplorer.grid.expectColumnsToBePinned(['column4']);
+			await dataExplorer.grid.verifyTableData(dataPinCol4SortCol4);
 
 			// pin row 6
-			await dataExplorer.grid.pinRow(6);
-			await dataExplorer.grid.verifyTableData(expectedDataSortColumn4AscPinRow6);
+			await dataExplorer.grid.pinRow(6); // pins the 7th row in the current sort order
+			await dataExplorer.grid.verifyTableData(dataSortCol4PinRow6);
 
-			// clear sort by column 4 - this should also clear pinned rows
-			await dataExplorer.grid.sortColumnBy(4, 'Clear Sorting');
+			// clear 'column4' sort - this should only clear the pinned rows
+			await dataExplorer.grid.sortColumnBy(1, 'Clear Sorting');
+			await dataExplorer.grid.expectColumnsToBePinned(['column4']);
 			await dataExplorer.grid.expectRowsToBePinned([], indexOffset);
-			await dataExplorer.grid.verifyTableData(expectedDataOriginal);
+			await dataExplorer.grid.verifyTableData(dataPinCol4);
 		});
 	});
 }


### PR DESCRIPTION
Addresses #9344 and a leaky disposable warning.

This PR changes how row pinning + searching/sorting work in the Data Explorer.

Row pinning currently only works when the data shape/order in the data grid doesn't change. We can think of searching and sorting as an action that changes the dataset entirely as far as row pinning is concerned. So anytime, we do anything that may change the shape of the dataset, or the order of data in cells, we need to remove all pinned rows because we have no way of knowing what data should be in the cells for the pinned row.

The new behavior in the data explorer is as follows: Anytime the search or sort state CHANGES for the main data grid, we remove all pinned rows. The resulting view in the data grid will be of the filtered/sorted data without any pinned rows. Clearing a search or sort will also cause all pinned rows to become unpinned.

There is some nuance to this change because row pinning does work with a filtered/sorted dataset if the dataset has been sorted/filtered FIRST, and then rows are pinned. In this case, the pinned rows should contain the correct data. If a user attempts to change the search or sort parameters after a row has pinned, we need to clear the pinned rows.

--

The following leaky disposable warning when opening files via DuckDB has also been resolved in this PR:

<img width="1453" height="160" alt="Screenshot 2025-09-24 at 10 37 26 AM" src="https://github.com/user-attachments/assets/50757414-d5c4-43ad-9820-c3ad63f94c89" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

I'm including some repro steps for different scenarios we should test against.

**Sorting and pinning** 
1. Open `qa-example-content/data-files/small_file.csv` file 
2. Sort `column0` in `ascending` order
3. Pin row 9 (the value in the cell is 97 and it was originally in row 6)
4. OBSERVE that the row is pinned at the top 
5. Sort `column1` in `ascending` order
6. OBSERVE that the pinned row is removed and data is sorted (it looks like sorting is only using `column1` sort)

https://github.com/user-attachments/assets/0e9e6932-c383-4387-8dd9-28381d48e597

**Clearing column sorting**
1. Open `qa-example-content/data-files/small_file.csv` file 
2. Sort `column0` in `descending` order
3. Sort `column2` in `ascending` order
4. Pin row 4 (the value in the cell is 41 and it was originally in row 5)
5. OBSERVE that the row is pinned at the top (it looks like sorting is only using `column1` sort)
6. Click on `Clear Column Sorting` button
7. OBSERVE that the sort parameters and pinned row are removed. This is the behavior we should expect because clearing the sort is also a sort/search state change. 

https://github.com/user-attachments/assets/e4ac47f2-3b34-488b-9e48-7efcc4d3853b

**Searching and pinning**
1. Open `qa-example-content/data-files/small_file.csv` file 
2. Sort `column4` in `descending` order
4. Pin row 9 (the value in the cell is 8 and it was originally in row 1)
5. OBSERVE that the row is pinned at the top
6. Add filter: `column3 is greater than 13`
8. OBSERVE that the pinned row is removed but the search and sort parameters remain.

https://github.com/user-attachments/assets/aa40aa78-185c-4100-8317-0cbbf2c53fb4

@:data-explorer @:web @:win