### PR TITLE
Dispose dialog before starting folder creation from git repo

### DIFF
--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -114,9 +114,8 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 					throw new Error(localize('positron.gitRepoNotProvided', "A git repository URL was not provided."));
 				}
 				// Dispose dialog immediately, then start cloning
-				const repoInfo = { ...result };
 				props.renderer.dispose();
-				await props.createFolder(repoInfo);
+				await props.createFolder(result);
 			}}
 			onCancel={() => props.renderer.dispose()}
 		>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -113,8 +113,10 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 				if (isInputEmpty(result.repo)) {
 					throw new Error(localize('positron.gitRepoNotProvided', "A git repository URL was not provided."));
 				}
-				await props.createFolder(result);
+				// Dispose dialog immediately, then start cloning
+				const repoInfo = { ...result };
 				props.renderer.dispose();
+				await props.createFolder(repoInfo);
 			}}
 			onCancel={() => props.renderer.dispose()}
 		>


### PR DESCRIPTION
This is a very simple change to address https://github.com/posit-dev/positron/issues/8704.

Before this PR, the dialog for _Workspaces: New Folder from Git..._ did not dismiss until the whole git clone was done; this means that the user could click OK a whole bunch of times and then we'd try to clone over and over again.

This PR changes the behavior so the dialog dismisses right away. The notification for the git clone then comes up, so there is still good feedback for the user about what is happening.

@:new-folder-flow

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed dialog dismiss behavior for _Workspaces: New Folder from Git..._ command.


### QA Notes

With this change, you should no longer be able to click OK multiple times in the _Workspaces: New Folder from Git..._ dialog. You should still get good feedback about what is happening during the process of getting the repo.
