### PR TITLE
Data Explorer: Fix UI display bug for 0 missing count for 0-length tables

### DIFF
--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -2388,6 +2388,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		// Verify that the table name is properly quoted in SQL
 		assert.strictEqual(result.converted_code[1], `FROM "${specialTableName}"`, 'Second line should properly quote the table name');
 	});
+<<<<<<< HEAD
 
 	/**
 	 * Helper function to request frequency table profiles
@@ -2601,4 +2602,47 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		assert.strictEqual(freqTable.counts.length, 0, 'Empty table should produce empty frequency table counts');
 		assert.strictEqual(freqTable.other_count, 0, 'Empty table should have 0 other_count');
 	});
+||||||| parent of 4e0e9ba97 (Add tests, try to fix problem)
+=======
+
+	test('null count profiles with zero rows should return 0', async () => {
+		// Create an empty table using direct SQL since createTempTable doesn't handle empty arrays
+		const tableName = makeTempTableName();
+		await runQuery(`CREATE TABLE ${tableName} (str_col VARCHAR, num_col INTEGER);`);
+
+		const uri = vscode.Uri.from({ scheme: 'duckdb', path: tableName });
+
+		// Test string column null count
+		const stringColumnProfile = await requestColumnProfile(
+			tableName,
+			0, // str_col column index
+			[{
+				profile_type: ColumnProfileType.NullCount
+			}],
+			randomUUID(),
+			(profile) => {
+				return profile?.null_count;
+			},
+			'String column null count should be computed for zero-row table'
+		);
+
+		assert.strictEqual(stringColumnProfile, 0, 'String column null count should be 0 for zero-row table');
+
+		// Test number column null count
+		const numberColumnProfile = await requestColumnProfile(
+			tableName,
+			1, // num_col column index
+			[{
+				profile_type: ColumnProfileType.NullCount
+			}],
+			randomUUID(),
+			(profile) => {
+				return profile?.null_count;
+			},
+			'Number column null count should be computed for zero-row table'
+		);
+
+		assert.strictEqual(numberColumnProfile, 0, 'Number column null count should be 0 for zero-row table');
+	});
+>>>>>>> 4e0e9ba97 (Add tests, try to fix problem)
 });

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2567,6 +2567,45 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
         assert results == ex_results
 
 
+def test_zero_row_null_count(dxf: DataExplorerFixture):
+    """Test null count for zero-row DataFrames."""
+    # Create empty pandas DataFrame
+    empty_pd = pd.DataFrame(
+        {
+            "str_col": pd.Series([], dtype=str),
+            "num_col": pd.Series([], dtype=int),
+            "bool_col": pd.Series([], dtype=bool),
+        }
+    )
+
+    # Create empty polars DataFrame
+    empty_pl = pl.DataFrame(
+        {
+            "str_col": pl.Series([], dtype=pl.String),
+            "num_col": pl.Series([], dtype=pl.Int64),
+            "bool_col": pl.Series([], dtype=pl.Boolean),
+        }
+    )
+
+    dxf.register_table("empty_pd", empty_pd)
+    dxf.register_table("empty_pl", empty_pl)
+
+    # Test null count for each column type on both pandas and polars
+    for table_name in ["empty_pd", "empty_pl"]:
+        results = dxf.get_column_profiles(
+            table_name,
+            [
+                _get_null_count(0),  # str_col
+                _get_null_count(1),  # num_col
+                _get_null_count(2),  # bool_col
+            ],
+        )
+
+        # All null counts should be 0 for zero-row table
+        expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
+        assert results == expected
+
+
 EPSILON = 1e-7
 
 
@@ -4068,59 +4107,3 @@ def test_ibis_supported_features(dxf: DataExplorerFixture):
         assert tp in column_profiles["supported_types"]
 
     assert features["convert_to_code"]["support_status"] == SupportStatus.Unsupported
-
-
-def test_pandas_zero_row_null_count(dxf: DataExplorerFixture):
-    """Test null count for zero-row DataFrames."""
-    # Create empty DataFrame
-    empty_df = pd.DataFrame(
-        {
-            "str_col": pd.Series([], dtype=str),
-            "num_col": pd.Series([], dtype=int),
-            "bool_col": pd.Series([], dtype=bool),
-        }
-    )
-
-    dxf.register_table("empty", empty_df)
-
-    # Test null count for each column type
-    results = dxf.get_column_profiles(
-        "empty",
-        [
-            _get_null_count(0),  # str_col
-            _get_null_count(1),  # num_col
-            _get_null_count(2),  # bool_col
-        ],
-    )
-
-    # All null counts should be 0 for zero-row table
-    expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
-    assert results == expected
-
-
-def test_polars_zero_row_null_count(dxf: DataExplorerFixture):
-    """Test null count for zero-row Polars DataFrames."""
-    # Create empty DataFrame
-    empty_df = pl.DataFrame(
-        {
-            "str_col": pl.Series([], dtype=pl.String),
-            "num_col": pl.Series([], dtype=pl.Int64),
-            "bool_col": pl.Series([], dtype=pl.Boolean),
-        }
-    )
-
-    dxf.register_table("empty_pl", empty_df)
-
-    # Test null count for each column type
-    results = dxf.get_column_profiles(
-        "empty_pl",
-        [
-            _get_null_count(0),  # str_col
-            _get_null_count(1),  # num_col
-            _get_null_count(2),  # bool_col
-        ],
-    )
-
-    # All null counts should be 0 for zero-row table
-    expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
-    assert results == expected

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -4030,6 +4030,7 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
 
         stats = results[0]["summary_stats"]
         assert_summary_stats_equal(stats["type_display"], stats, ex_result)
+<<<<<<< HEAD
 
 
 def test_ibis_supported_features(dxf: DataExplorerFixture):
@@ -4068,3 +4069,53 @@ def test_ibis_supported_features(dxf: DataExplorerFixture):
         assert tp in column_profiles["supported_types"]
 
     assert features["convert_to_code"]["support_status"] == SupportStatus.Unsupported
+||||||| parent of 4e0e9ba97 (Add tests, try to fix problem)
+=======
+
+
+
+def test_pandas_zero_row_null_count(dxf: DataExplorerFixture):
+    """Test null count for zero-row DataFrames."""
+    # Create empty DataFrame
+    empty_df = pd.DataFrame({
+        "str_col": pd.Series([], dtype=str),
+        "num_col": pd.Series([], dtype=int),
+        "bool_col": pd.Series([], dtype=bool),
+    })
+
+    dxf.register_table("empty", empty_df)
+
+    # Test null count for each column type
+    results = dxf.get_column_profiles("empty", [
+        _get_null_count(0),  # str_col
+        _get_null_count(1),  # num_col
+        _get_null_count(2),  # bool_col
+    ])
+
+    # All null counts should be 0 for zero-row table
+    expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
+    assert results == expected
+
+
+def test_polars_zero_row_null_count(dxf: DataExplorerFixture):
+    """Test null count for zero-row Polars DataFrames."""
+    # Create empty DataFrame
+    empty_df = pl.DataFrame({
+        "str_col": pl.Series([], dtype=pl.String),
+        "num_col": pl.Series([], dtype=pl.Int64),
+        "bool_col": pl.Series([], dtype=pl.Boolean),
+    })
+
+    dxf.register_table("empty_pl", empty_df)
+
+    # Test null count for each column type
+    results = dxf.get_column_profiles("empty_pl", [
+        _get_null_count(0),  # str_col
+        _get_null_count(1),  # num_col
+        _get_null_count(2),  # bool_col
+    ])
+
+    # All null counts should be 0 for zero-row table
+    expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
+    assert results == expected
+>>>>>>> 4e0e9ba97 (Add tests, try to fix problem)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -4030,7 +4030,6 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
 
         stats = results[0]["summary_stats"]
         assert_summary_stats_equal(stats["type_display"], stats, ex_result)
-<<<<<<< HEAD
 
 
 def test_ibis_supported_features(dxf: DataExplorerFixture):
@@ -4069,28 +4068,30 @@ def test_ibis_supported_features(dxf: DataExplorerFixture):
         assert tp in column_profiles["supported_types"]
 
     assert features["convert_to_code"]["support_status"] == SupportStatus.Unsupported
-||||||| parent of 4e0e9ba97 (Add tests, try to fix problem)
-=======
-
 
 
 def test_pandas_zero_row_null_count(dxf: DataExplorerFixture):
     """Test null count for zero-row DataFrames."""
     # Create empty DataFrame
-    empty_df = pd.DataFrame({
-        "str_col": pd.Series([], dtype=str),
-        "num_col": pd.Series([], dtype=int),
-        "bool_col": pd.Series([], dtype=bool),
-    })
+    empty_df = pd.DataFrame(
+        {
+            "str_col": pd.Series([], dtype=str),
+            "num_col": pd.Series([], dtype=int),
+            "bool_col": pd.Series([], dtype=bool),
+        }
+    )
 
     dxf.register_table("empty", empty_df)
 
     # Test null count for each column type
-    results = dxf.get_column_profiles("empty", [
-        _get_null_count(0),  # str_col
-        _get_null_count(1),  # num_col
-        _get_null_count(2),  # bool_col
-    ])
+    results = dxf.get_column_profiles(
+        "empty",
+        [
+            _get_null_count(0),  # str_col
+            _get_null_count(1),  # num_col
+            _get_null_count(2),  # bool_col
+        ],
+    )
 
     # All null counts should be 0 for zero-row table
     expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
@@ -4100,22 +4101,26 @@ def test_pandas_zero_row_null_count(dxf: DataExplorerFixture):
 def test_polars_zero_row_null_count(dxf: DataExplorerFixture):
     """Test null count for zero-row Polars DataFrames."""
     # Create empty DataFrame
-    empty_df = pl.DataFrame({
-        "str_col": pl.Series([], dtype=pl.String),
-        "num_col": pl.Series([], dtype=pl.Int64),
-        "bool_col": pl.Series([], dtype=pl.Boolean),
-    })
+    empty_df = pl.DataFrame(
+        {
+            "str_col": pl.Series([], dtype=pl.String),
+            "num_col": pl.Series([], dtype=pl.Int64),
+            "bool_col": pl.Series([], dtype=pl.Boolean),
+        }
+    )
 
     dxf.register_table("empty_pl", empty_df)
 
     # Test null count for each column type
-    results = dxf.get_column_profiles("empty_pl", [
-        _get_null_count(0),  # str_col
-        _get_null_count(1),  # num_col
-        _get_null_count(2),  # bool_col
-    ])
+    results = dxf.get_column_profiles(
+        "empty_pl",
+        [
+            _get_null_count(0),  # str_col
+            _get_null_count(1),  # num_col
+            _get_null_count(2),  # bool_col
+        ],
+    )
 
     # All null counts should be 0 for zero-row table
     expected = [ColumnProfileResult(null_count=0) for _ in range(3)]
     assert results == expected
->>>>>>> 4e0e9ba97 (Add tests, try to fix problem)

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -418,17 +418,17 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @returns The column profile null percent for the specified column index
 	 */
 	getColumnProfileNullPercent(columnIndex: number) {
-		// If the table has no rows, it's meaningless to calculate the column null percent. Return
-		// undefined in this case.
 		const rows = this._tableSummaryCache.rows;
-		if (!rows) {
-			return undefined;
-		}
 
 		// Get the null count. If it hasn't been loaded yet, return undefined.
 		const nullCount = this._tableSummaryCache.getColumnProfile(columnIndex)?.null_count;
 		if (nullCount === undefined) {
 			return undefined;
+		}
+
+		// If the table has no rows, the null percent is 0% (0 nulls out of 0 total).
+		if (!rows) {
+			return 0;
 		}
 
 		// Calculate and return the column null percent.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -420,15 +420,15 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	getColumnProfileNullPercent(columnIndex: number) {
 		const rows = this._tableSummaryCache.rows;
 
+		// If the table has no rows, the null percent is 0% (0 nulls out of 0 total).
+		if (!rows) {
+			return 0;
+		}
+
 		// Get the null count. If it hasn't been loaded yet, return undefined.
 		const nullCount = this._tableSummaryCache.getColumnProfile(columnIndex)?.null_count;
 		if (nullCount === undefined) {
 			return undefined;
-		}
-
-		// If the table has no rows, the null percent is 0% (0 nulls out of 0 total).
-		if (!rows) {
-			return 0;
 		}
 
 		// Calculate and return the column null percent.


### PR DESCRIPTION
Addresses #9526. This turned out to be a UI / display problem rather than a backend computation bug. I have added unit tests in any case to validate the behavior in the 0-row case for tables.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix bug in data explorer where missing value count would still show "Calculating..." for a 0-row table.

### QA Notes

Open a dataset via file explorer or Python/R and then add a filter which causes all the rows to be excluded (so there are 0 rows displayed).

@:data-explorer
