### PR TITLE
Fix issue where summary panel filters clear when switching tabs quickly

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -28,17 +28,22 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	// State to hold the search text typed by the user
 	const [searchText, setSearchText] = useState(instance.searchText || '');
 	// State to hold the debounced search text that we use to filter data.
-	const [debouncedSearchText, setDebouncedSearchText] = useState('');
+	const [debouncedSearchText, setDebouncedSearchText] = useState(instance.searchText || '');
 	// State to hold the current sort option
 	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(instance.sortOption || SearchSchemaSortOrder.Original);
 
 	/**
-	 * Initialize the search text input when the instance changes.
-	 * This ensures the search text is displayed correctly when switching between tabs.
+	 * Initialize the search text input and sort option when the instance changes.
+	 * This ensures the search text and sort option are displayed correctly when switching between tabs.
 	 */
 	useEffect(() => {
 		const instanceSearchText = instance.searchText || '';
+		const instanceSortOption = instance.sortOption || SearchSchemaSortOrder.Original;
+
 		setSearchText(instanceSearchText);
+		setDebouncedSearchText(instanceSearchText);
+		setSortOption(instanceSortOption);
+
 		// Update the filter input field
 		if (filterRef.current) {
 			filterRef.current.setFilterText(instanceSearchText);
@@ -55,7 +60,7 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 		}, SEARCH_DEBOUNCE_TIMEOUT);
 
 		return () => clearTimeout(debounce);
-	}, [searchText, instance]);
+	}, [searchText]);
 
 	/**
 	 * Every time the debounced search text changes (every SEARCH_DEBOUNCE_TIMEOUT milliseconds),


### PR DESCRIPTION
Addresses #9545 

When switching tabs quickly, the debounced search text from the previous tab would overwrite the debounced search text state for the current tab. This happened because the useEffect dependency array for setting the debounce text would run when the instance changed, causing issues when switching tabs quickly.



https://github.com/user-attachments/assets/d6e372fa-dbf6-4149-ad72-d44fc6650757


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:data-explorer