### PR TITLE
Assistant: Switch to using `languageModelSystem` API for system prompts

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1073,7 +1073,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 884,
+        "line_number": 893,
         "is_secret": false
       }
     ],
@@ -1756,5 +1756,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-25T13:52:12Z"
+  "generated_at": "2025-09-26T11:10:38Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1073,7 +1073,7 @@
         "filename": "extensions/positron-assistant/src/models.ts",
         "hashed_secret": "ba10d824a2c4c13ce293171d14843c0f0043d039",
         "is_verified": false,
-        "line_number": 901,
+        "line_number": 884,
         "is_secret": false
       }
     ],
@@ -1756,5 +1756,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-25T14:30:28Z"
+  "generated_at": "2025-09-25T13:52:12Z"
 }

--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -586,6 +586,8 @@ function toAnthropicSystemParts(message: vscode.LanguageModelChatMessage2, sourc
 		const part = message.content[i];
 		if (part instanceof vscode.LanguageModelTextPart) {
 			content.push(toAnthropicTextBlock(part, source));
+		} else if (part instanceof vscode.LanguageModelPromptTsxPart) {
+			content.push(languageModelPromptTsxPartToAnthropicBlock(part, source));
 		} else {
 			throw new Error('Unsupported part type on system message');
 		}

--- a/extensions/positron-assistant/src/commands/quarto.ts
+++ b/extensions/positron-assistant/src/commands/quarto.ts
@@ -31,15 +31,14 @@ export async function quartoHandler(
 	});
 	const editor = await vscode.window.showTextDocument(document);
 
-	const messages = toLanguageModelChatMessage(context.history);
-	messages.push(...[
+	const messages = [
+		new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
+		...toLanguageModelChatMessage(context.history),
 		vscode.LanguageModelChatMessage.User(vscode.l10n.t('Convert to Qmd.')),
-	]);
+	];
 
 	response.progress(vscode.l10n.t('Writing Quarto document...'));
-	const modelResponse = await request.model.sendRequest(messages, {
-		modelOptions: { system },
-	}, token);
+	const modelResponse = await request.model.sendRequest(messages, {}, token);
 
 	for await (const chunk of modelResponse.text) {
 		if (token.isCancellationRequested) {

--- a/extensions/positron-assistant/src/edits.ts
+++ b/extensions/positron-assistant/src/edits.ts
@@ -138,10 +138,11 @@ async function* mapEdit(
 
 	// Send a request to the language model with the document and code block
 	const response = await model.sendRequest([
+		new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
 		vscode.LanguageModelChatMessage.User(
 			JSON.stringify({ document, block })
 		)
-	], { modelOptions: { system } }, token);
+	], {}, token);
 
 	let hasCodeFence = false; // Tracks if a code fence has been detected
 	let buffer = ''; // Buffer for accumulating streamed text

--- a/extensions/positron-assistant/src/git.ts
+++ b/extensions/positron-assistant/src/git.ts
@@ -160,8 +160,9 @@ export async function generateCommitMessage(
 		await Promise.all(gitChanges.map(async ({ repo, changes }) => {
 			if (changes.length > 0) {
 				const response = await model.sendRequest([
+					new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
 					vscode.LanguageModelChatMessage.User(changes.map(change => change.summary).join('\n')),
-				], { modelOptions: { system } }, tokenSource.token);
+				], {}, tokenSource.token);
 
 				repo.inputBox.value = '';
 				for await (const delta of response.text) {

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -370,29 +370,14 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 
 		const aiMessages: ai.CoreMessage[] = [];
 
-		// The system message we will send to the model.
-		let systemMessage: string | undefined = modelOptions.system;
-
-		if (bedrockCacheBreakpoint && systemMessage) {
-			// Add the system prompt as the first message if we have a system
-			// prompt and cache breakpoints are enabled.
-			//
-			// This must be done in order to set a cache breakpoint for the
-			// system message. In general we prefer to send the system message
-			// using the 'system' option in streamText; see the
-			// CoreSystemMessage documentation for a detailed explanation.
-			const aiSystemMessage: ai.CoreSystemMessage = {
-				role: 'system',
-				content: systemMessage,
-			};
-			markBedrockCacheBreakpoint(aiSystemMessage);
-			aiMessages.push(aiSystemMessage);
-
-			// Consume the system message so it doesn't get sent a second time
-			systemMessage = undefined;
+		// Add system prompt from `modelOptions.system`, if provided.
+		// TODO: Once extensions such as databot no longer use `modelOptions.system`,
+		// we can remove the `system` parameter and use the given system messages only.
+		if (modelOptions.system) {
+			aiMessages.push({ role: 'system', content: modelOptions.system });
 		}
 
-		// Convert all other messages to the Vercel AI format.
+		// Convert all messages to the Vercel AI format.
 		aiMessages.push(...toAIMessage(processedMessages, toolResultExperimentalContent,
 			bedrockCacheBreakpoint));
 
@@ -414,13 +399,16 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 		if (modelTools) {
 			log.trace(`tools: ${modelTools ? Object.keys(modelTools).join(', ') : '(none)'}`);
 		}
+
+		const systemMessage = aiMessages.find(m => m.role === 'system');
 		if (systemMessage) {
-			log.trace(`system: ${systemMessage.length > 100 ? `${systemMessage.substring(0, 100)}...` : systemMessage} (${systemMessage.length} chars)`);
+			const content = systemMessage.content;
+			log.trace(`system: ${content.length > 100 ? `${content.substring(0, 100)}...` : content} (${content.length} chars)`);
 		}
+
 		log.trace(`messages: ${JSON.stringify(aiMessages, null, 2)}`);
 		const result = ai.streamText({
 			model: aiModel,
-			system: systemMessage,
 			messages: aiMessages,
 			maxSteps: modelOptions.maxSteps ?? 50,
 			tools: modelTools,

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -368,18 +368,22 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider2
 		const bedrockCacheBreakpoint = this.provider === 'amazon-bedrock' &&
 			!aiModel.modelId.startsWith('us.anthropic.claude-3-5');
 
-		const aiMessages: ai.CoreMessage[] = [];
-
 		// Add system prompt from `modelOptions.system`, if provided.
 		// TODO: Once extensions such as databot no longer use `modelOptions.system`,
 		// we can remove the `system` parameter and use the given system messages only.
 		if (modelOptions.system) {
-			aiMessages.push({ role: 'system', content: modelOptions.system });
+			processedMessages.unshift(new vscode.LanguageModelChatMessage(
+				vscode.LanguageModelChatMessageRole.System,
+				modelOptions.system
+			));
 		}
 
 		// Convert all messages to the Vercel AI format.
-		aiMessages.push(...toAIMessage(processedMessages, toolResultExperimentalContent,
-			bedrockCacheBreakpoint));
+		const aiMessages: ai.CoreMessage[] = toAIMessage(
+			processedMessages,
+			toolResultExperimentalContent,
+			bedrockCacheBreakpoint
+		);
 
 		if (options.tools && options.tools.length > 0) {
 			tools = options.tools.reduce((acc: Record<string, ai.Tool>, tool: vscode.LanguageModelChatTool) => {

--- a/extensions/positron-assistant/src/participantDetection.ts
+++ b/extensions/positron-assistant/src/participantDetection.ts
@@ -44,14 +44,16 @@ class PositronAssistantParticipantDetector implements vscode.ChatParticipantDete
 			// Serialize participants to JSON for the model
 			const participantJson = JSON.stringify(participants);
 
+			// System prompt instructs the model to return a JSON object or null
+			const system = await fs.promises.readFile(`${MD_DIR}/prompts/chat/participantDetection.md`, 'utf8');
+
 			// Send a request to the language model with participants and user prompt
 			const result = await chatRequest.model.sendRequest([
+				new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
 				vscode.LanguageModelChatMessage.User(participantJson),
 				vscode.LanguageModelChatMessage.User(userPrompt),
 			], {
 				modelOptions: {
-					// System prompt instructs the model to return a JSON object or null
-					system: await fs.promises.readFile(`${MD_DIR}/prompts/chat/participantDetection.md`, 'utf8'),
 					// Pass the request ID through modelOptions for token usage tracking
 					requestId: chatRequest.id,
 				}

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -338,13 +338,14 @@ suite('AnthropicLanguageModel', () => {
 			// Call the method under test.
 			const { body } = await provideLanguageModelResponse(
 				[
+					new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
 					vscode.LanguageModelChatMessage.User('Hi'),
 					vscode.LanguageModelChatMessage.User('Bye'),
 				],
 				{
 					// Define the request tools, not sorted by name, so we can test sorting behavior.
 					tools: [toolB, toolA],
-					modelOptions: { system },
+					modelOptions: {},
 				},
 			);
 
@@ -391,6 +392,7 @@ suite('AnthropicLanguageModel', () => {
 			// Call the method under test with no cacheControl options to test default behavior.
 			const { body } = await provideLanguageModelResponse(
 				[
+					new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
 					vscode.LanguageModelChatMessage.User('Hi'),
 					vscode.LanguageModelChatMessage.User('Bye'),
 				],
@@ -398,7 +400,6 @@ suite('AnthropicLanguageModel', () => {
 					// Define the request tools, not sorted by name, so we can test sorting behavior.
 					tools: [toolB, toolA],
 					modelOptions: {
-						system,
 						cacheControl: {
 							system: false,
 						} satisfies CacheControlOptions,

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -13,8 +13,8 @@ import { readFile } from 'fs/promises';
 import { MARKDOWN_DIR } from '../constants.js';
 import path = require('path');
 
-/** We expect 2 messages by default: 1 for the user's prompt, and 1 containing at least the default context */
-const DEFAULT_EXPECTED_MESSAGE_COUNT = 2;
+/** We expect 3 messages by default: 1 for the system prompt, 1 for the user's prompt, and 1 containing at least the default context */
+const DEFAULT_EXPECTED_MESSAGE_COUNT = 3;
 
 class TestLanguageModelChatResponse implements vscode.LanguageModelChatResponse {
 	stream: AsyncIterable<string> = {

--- a/extensions/positron-assistant/tsconfig.json
+++ b/extensions/positron-assistant/tsconfig.json
@@ -19,6 +19,7 @@
 		"../../src/vscode-dts/vscode.proposed.languageModelSystem.d.ts",
 		"../../src/vscode-dts/vscode.proposed.defaultChat*.d.ts",
 		"../../src/vscode-dts/vscode.proposed.inlineCompletions*.d.ts",
+		"../../src/vscode-dts/vscode.proposed.languageModelSystem*.d.ts",
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/positron-dts/positron.d.ts",
 	],


### PR DESCRIPTION
In this PR we remove the use of the `modelOptions.system` mechanism for setting system prompts, and instead switch to using the `languageModelSystem` API (which involves sending messages with the `System` role) as used by Copilot Chat.

With these changes, the mechanism is properly supported for both the Anthropic and Vercel AI SDK:
 - For Anthropic we convert System messages into a `system` property to be passed to the API.
 - For Vercel we convert the System messages into a single system message prepended to the messages array.

The option to provide a `modelOptions.system` parameter remains for now, but we can remove it once extensions such as Databot have also migrated to use the newer mechanism.

This is a follow on to #9553, and cherry-picks a commit from there. So it should be merged before this PR.

Addresses #9434, by enabling Databot to send its system prompt to both Assistant and Copilot models without special casing once it has migrated to the new `languageModelSystem` API.

### QA Notes

This is an internal implementation detail, so there should be no user facing changes.

Chatting to both Assistant and Copilot registered models should be as normal, including with the Positron system prompt attached. This can be confirmed by watching the Assistant and GitHub Copilot Chat output panels in trace mode. For Copilot registered models, the Copilot and Assistant system prompts should be concatenated.

<img width="1607" height="224" alt="Screenshot 2025-09-25 at 16 56 35" src="https://github.com/user-attachments/assets/8e2053d6-0906-4c5e-bf1b-a3041008922c" />
