### PR TITLE
Bump axios version used by supervisor

### DIFF
--- a/extensions/positron-supervisor/package-lock.json
+++ b/extensions/positron-supervisor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "axios": "1.11.0",
+        "axios": "^1.12.0",
         "tail": "^2.2.6",
         "ws": "^8.18.0"
       },
@@ -249,9 +249,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -177,7 +177,7 @@
   "dependencies": {
     "tail": "^2.2.6",
     "ws": "^8.18.0",
-    "axios": "1.11.0"
+    "axios": "^1.12.0"
   },
   "overrides": {
 	"request": {


### PR DESCRIPTION
Supersedes https://github.com/posit-dev/positron/pull/9549; see there for notes. This is a minor version bump that shouldn't affect any of our own usage. 