### PR TITLE
Bump ark to 0.1.211

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -974,7 +974,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.210"
+      "ark": "0.1.211"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Bumps ark to pick up the fix to #8426. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix R Help failing to load in the Help pane in environments with system proxies (#8426)


### QA Notes

The original issue suggests using devproxy on Windows to simulate a proxy. If you're on macOS or Linux, you can also use `mitmproxy` and point the `HTTP_PROXY` env var at it to reproduce the problem. Here's an example mitmproxy script to block localhost requests:

```python
from mitmproxy import http

def request(flow: http.HTTPFlow) -> None:
    if "localhost" in flow.request.pretty_host or "127.0.0.1" in flow.request.pretty_host:
        # Make the request timeout/fail
        flow.response = http.Response.make(
            408,  # Request Timeout
            b"Localhost requests blocked by proxy",
            {"Content-Type": "text/plain"}
        )
```