### PR TITLE
Data Explorer: Always treat first row of CSV as header row

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1769,6 +1769,10 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 			// TODO: Will need to be able to pass CSV / TSV options from the
 			// UI at some point.
 			const options: Array<string> = [];
+
+			// Always treat the first row as header to avoid inference issues
+			options.push('header=true');
+
 			if (fileExt === '.tsv') {
 				options.push('delim=\'\t\'');
 			} else if (fileExt !== '.csv' && fileExt !== '.tsv') {


### PR DESCRIPTION
Addresses #8860. We won't currently have options to properly distinguish between data files that have a header row and those that don't, and DuckDB's inference logic to determine the presence of a header can fail in certain files (setting "no header" for files that do have a header). In our discussion we decided that refusing to guess/infer was a better approach, and since the "with header" option is the most common one, it should be the default behavior. We will eventually have to figure out how to allow users to look at headerless CSV files (probably with some option dropdown menu, not sure). 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Always treat the first row of CSV files as the column labels in the data explorer to address cases where DuckDB infers the presence of a header incorrectly. 


### QA Notes

See examples of incorrect header inference in #8860.

@:data-explorer