### PR TITLE
Limit advanced data explorer features for large data sets

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -18,6 +18,7 @@ import { positronClassNames } from '../../../../base/common/positronUtilities.js
  */
 interface ActionBarFilterProps {
 	width: number;
+	disabled?: boolean;
 	initialFilterText?: string;
 	onFilterTextChanged: (filterText: string) => void;
 }
@@ -77,6 +78,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 				<input
 					ref={inputRef}
 					className='text-input'
+					disabled={props.disabled}
 					placeholder={(() => localize('positronFilterPlaceholder', "Filter"))()}
 					type='text'
 					value={filterText}
@@ -88,6 +90,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 					<button
 						aria-label={(() => localize('positronClearFilter', "Clear filter"))()}
 						className='clear-button'
+						disabled={props.disabled}
 						onClick={buttonClearClickHandler}
 						onKeyDown={buttonClearKeyDownHandler}
 					>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -34,6 +34,7 @@ interface ActionBarMenuButtonProps {
 	readonly tooltip?: string | (() => string | undefined);
 	readonly dropdownTooltip?: string | (() => string | undefined);
 	readonly dropdownIndicator?: 'disabled' | 'enabled' | 'enabled-split';
+	readonly disabled?: boolean;
 	readonly actions: () => readonly IAction[] | Promise<readonly IAction[]>;
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
@@ -27,13 +27,18 @@
 	background-color: var(--vscode-positronDataExplorer-background);
 }
 
-.data-explorer-panel .row-filter-bar .row-filter-button:hover {
+.data-explorer-panel .row-filter-bar .row-filter-button:hover:not(.disabled) {
 	background-color: var(--vscode-positronActionBar-hoverBackground);
 }
 
+.data-explorer-panel .row-filter-bar .row-filter-button.disabled {
+	cursor: default;
+	opacity: 50%;
+}
+
 /* high contrast theme support for manage filter button */
-.hc-black .data-explorer-panel .row-filter-bar .row-filter-button:hover,
-.hc-light .data-explorer-panel .row-filter-bar .row-filter-button:hover {
+.hc-black .data-explorer-panel .row-filter-bar .row-filter-button:hover:not(.disabled),
+.hc-light .data-explorer-panel .row-filter-bar .row-filter-button:hover:not(.disabled) {
 	border: 1px dashed var(--vscode-focusBorder) !important;
 }
 
@@ -95,6 +100,7 @@
 }
 
 .data-explorer-panel .row-filter-bar .filter-entries .add-row-filter-button.disabled {
+	cursor: default;
 	opacity: 50%;
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -48,7 +48,7 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 	useEffect(() => {
 		const checkBackendState = async () => {
 			const backendState = await context.instance.dataExplorerClientInstance.getBackendState();
-			if (backendState.table_shape.num_columns >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT || backendState.table_shape.num_rows >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT) {
+			if (backendState.table_shape.num_columns >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT) {
 				setDisabled(true);
 			}
 		};

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -14,6 +14,8 @@ import { PositronActionBarContextProvider } from '../../../../../../../platform/
 import { ActionBarRegion } from '../../../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../../../platform/positronActionBar/browser/components/actionBarFilter.js';
 import { SearchSchemaSortOrder } from '../../../../../../services/languageRuntime/common/positronDataExplorerComm.js';
+import { usePositronDataExplorerContext } from '../../../../positronDataExplorerContext.js';
+import { MAX_ADVANCED_LAYOUT_ENTRY_COUNT } from '../../../../../positronDataGrid/classes/layoutManager.js';
 
 // This is the debounce time for the search input in milliseconds.
 // It allows the user to type without triggering a search on every keystroke.
@@ -24,13 +26,34 @@ export interface SummaryRowActionBarProps {
 }
 
 export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
+	const context = usePositronDataExplorerContext();
 	const filterRef = useRef<ActionBarFilterHandle>(null);
+
 	// State to hold the search text typed by the user
 	const [searchText, setSearchText] = useState(instance.searchText || '');
 	// State to hold the debounced search text that we use to filter data.
 	const [debouncedSearchText, setDebouncedSearchText] = useState(instance.searchText || '');
 	// State to hold the current sort option
 	const [sortOption, setSortOption] = useState<SearchSchemaSortOrder>(instance.sortOption || SearchSchemaSortOrder.Original);
+	// State for determining if filtering/sort should be disabled when the dataset has too many columns
+	const [disabled, setDisabled] = useState(false);
+
+	/**
+	 * useEffect to check if filtering should be disabled when the
+	 * dataset has too many columns, which causes the column selector
+	 * dropdown to be empty due to the layout manager not being unable
+	 * to create an entryMap.
+	 * See https://github.com/posit-dev/positron/issues/9265
+	 */
+	useEffect(() => {
+		const checkBackendState = async () => {
+			const backendState = await context.instance.dataExplorerClientInstance.getBackendState();
+			if (backendState.table_shape.num_columns >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT || backendState.table_shape.num_rows >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT) {
+				setDisabled(true);
+			}
+		};
+		checkBackendState();
+	}, [context.instance.dataExplorerClientInstance]);
 
 	/**
 	 * Initialize the search text input and sort option when the instance changes.
@@ -100,12 +123,14 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 					<ActionBarRegion location='left'>
 						<SummaryRowSortDropdown
 							currentSort={sortOption}
+							disabled={disabled}
 							onSortChanged={handleSortChanged}
 						/>
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarFilter
 							ref={filterRef}
+							disabled={disabled}
 							width={140}
 							onFilterTextChanged={filterText => setSearchText(filterText)} />
 					</ActionBarRegion>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowSortDropdown.tsx
@@ -58,10 +58,11 @@ const sortLabelMap = new Map(
  */
 export interface SummaryRowSortDropdownProps {
 	currentSort: SearchSchemaSortOrder;
+	disabled?: boolean;
 	onSortChanged: (sortOption: SearchSchemaSortOrder) => void;
 }
 
-export const SummaryRowSortDropdown = ({ currentSort, onSortChanged }: SummaryRowSortDropdownProps) => {
+export const SummaryRowSortDropdown = ({ currentSort, disabled, onSortChanged }: SummaryRowSortDropdownProps) => {
 	// Get the label for the current sort option
 	const currentSortLabel = sortLabelMap.get(currentSort) || positronSortByOriginal;
 
@@ -72,7 +73,7 @@ export const SummaryRowSortDropdown = ({ currentSort, onSortChanged }: SummaryRo
 			id: sortOption.id,
 			label: sortOption.label,
 			tooltip: sortOption.label,
-			enabled: true,
+			enabled: disabled ? false : true,
 			checked: currentSort === sortOption.option,
 			run: () => { onSortChanged(sortOption.option) }
 		}));
@@ -82,6 +83,7 @@ export const SummaryRowSortDropdown = ({ currentSort, onSortChanged }: SummaryRo
 		<ActionBarMenuButton
 			actions={actions}
 			ariaLabel={positronDataExplorerSummarySort}
+			disabled={disabled}
 			label={currentSortLabel}
 			tooltip={positronDataExplorerSummarySort}
 		/>

--- a/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/layoutManager.ts
@@ -270,6 +270,10 @@ export class LayoutManager {
 		this._inverseEntryMap.clear();
 
 		// Enable advanced layout capabilities, if we don't have too many entries.
+		// When we have too many entries, we fall back to a simplified layout strategy.
+		// In the case of there being too many rows, not having an entry map means row
+		// resizing will not be supported.
+		// See https://github.com/posit-dev/positron/issues/9265
 		if (this._entryCount <= MAX_ADVANCED_LAYOUT_ENTRY_COUNT) {
 			// Set the entry sizes, if they were provided and are valid (i.e., they have the correct length).
 			// This is unavoidably O(n) over entry sizes.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -387,17 +387,11 @@ export class DataExplorerClientInstance extends Disposable {
 	}
 
 	/**
-	 * This is the new search method that is used by the summary panel
-	 * as part of the enhancement work behind the  `dataExplorer.summaryPanelEnhancements`
-	 * feature flag.
+	 * This is the new search method that is used by the summary panel.
 	 *
 	 * This method utilizes the backend search_schema method and is intentionally
-	 * kept separate from the existing searchSchema method to avoid breaking the column
-	 * filtering functionality that is currently implemented.
-	 *
-	 * We will want to rename this method or the other method once unknowns for
-	 * implementing search and sort are resolved. TBD on what changes, if any,
-	 * the column filtering will need to go through.
+	 * kept separate from the existing searchSchema method to avoid changing the
+	 * column filtering functionality that is currently implemented.
 	 *
 	 * @param options The search options.
 	 * @param options.searchText The search text, if any, to filter the schema by.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -131,19 +131,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			// See https://github.com/posit-dev/positron/issues/9265
 			const exceedsLimit = await this.exceedsAdvancedLayoutLimits(state);
 			if (exceedsLimit) {
-				const exceedsColumns = state.table_shape.num_columns >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT;
-				const exceedsRows = state.table_shape.num_rows >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT;
-
 				let message: string;
-				if (exceedsColumns && exceedsRows) {
-					message = localize(
-						'positron.dataExplorer.largeDatasetNotificationColumnsAndRows',
-						"Dataset '{0}' has {1} columns and {2} rows, which exceeds the supported size for the Data Explorer. Advanced features such as filtering, sorting, and row resizing will be disabled to improve performance.",
-						state.display_name,
-						state.table_shape.num_columns.toLocaleString(),
-						state.table_shape.num_rows.toLocaleString()
-					);
-				} else if (exceedsColumns) {
+				if (state.table_shape.num_columns >= MAX_ADVANCED_LAYOUT_ENTRY_COUNT) {
 					message = localize(
 						'positron.dataExplorer.largeDatasetNotificationColumns',
 						"Dataset '{0}' has {1} columns, which exceeds the supported size for the Data Explorer. Advanced features such as filtering, sorting, and row resizing will be disabled to improve performance.",

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -65,6 +65,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _onDidChangePinnedColumns = this._register(new Emitter<number[]>());
 
+	/**
+	 * This tracks if we've already shown the exceeds dataset limit notification for this instance
+	 * which should only be shown once per instance. This notification is shown when the dataset
+	 * exceeds the limit for certain advanced features such as filtering, resizing, etc.
+	 * See https://github.com/posit-dev/positron/issues/9265
+	 */
+	private _hasShownLargeDatasetNotification: boolean = false;
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -131,7 +139,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			// See https://github.com/posit-dev/positron/issues/9265
 			const exceedsColumnLimit = await this.exceedsAdvancedColumnLayoutLimits(state);
 			const exceedsRowLimit = await this.exceedsAdvancedRowLayoutLimits(state);
-			if (exceedsColumnLimit || exceedsRowLimit) {
+			if ((exceedsColumnLimit || exceedsRowLimit) && !this._hasShownLargeDatasetNotification) {
+				this._hasShownLargeDatasetNotification = true;
+
 				let message: string;
 				if (exceedsColumnLimit) {
 					message = localize(


### PR DESCRIPTION
Addresses #9265 

When there are over 10 million columns, we disable:
- sorting and filtering in the main data grid
- sorting and filtering in the summary panel
- resizing rows in the main data grid

When there are over 10 million rows, we disable:
- resizing rows in the main data grid

https://github.com/user-attachments/assets/bbb36503-fae3-4b3f-a1cd-5147197c0c10

Note: I did notice during my testing with a dataset that had 1 million columns that the filter dropdown in the data explorer struggled to render the list of columns despite being under the limit where we skip creating an `entryMap`. This makes me think that there may be other issues contributing to how we create that filter dropdown. At 50,000 columns, the dropdown is able to render but the delay is quite visible. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Limit advanced data explorer features for large data sets (#9265)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer 