### PR TITLE
Data Explorer: Fix Python histogram inconsistencies for 0-row data frames (or 0 rows after filtering)

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
@@ -104,7 +104,7 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
     # Handle single value case - return single bin consistent with Polars implementation
     unique_values = np.unique(data)
     if len(unique_values) == 1:
-        return [len(data)], np.array([unique_values[0], unique_values[0]])
+        return [len(data)], [unique_values[0], unique_values[0]]
 
     # We optimistically compute the histogram once, and then do extra
     # work in the special cases where the binning method produces a
@@ -162,7 +162,7 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
             # All values are the same, set bin edges to [value, value]
             bin_edges = np.array([unique_values[0], unique_values[0]])
 
-    return bin_counts, bin_edges
+    return bin_counts.tolist(), bin_edges.tolist()
 
 
 def _get_histogram_polars(

--- a/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
+++ b/extensions/positron-python/python_files/posit/positron/_data_explorer_internal.py
@@ -97,6 +97,15 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
         # For decimals, we convert to float which is lossy but works for now
         return _get_histogram_numpy(data.astype(float), num_bins, method=method)
 
+    # Handle empty data case - return empty histogram consistent with Polars implementation
+    if len(data) == 0:
+        return _EMPTY_HISTOGRAM
+
+    # Handle single value case - return single bin consistent with Polars implementation
+    unique_values = np.unique(data)
+    if len(unique_values) == 1:
+        return [len(data)], np.array([unique_values[0], unique_values[0]])
+
     # We optimistically compute the histogram once, and then do extra
     # work in the special cases where the binning method produces a
     # finer-grained histogram than the maximum number of bins that we
@@ -117,6 +126,9 @@ def _get_histogram_numpy(data, num_bins, method="fd", *, to_numpy=False):
         # raised. We catch it and try again to avoid paying the
         # filtering cost every time
         data = data[np.isfinite(data)]
+        # Check if filtering removed all data
+        if len(data) == 0:
+            return _EMPTY_HISTOGRAM
         bin_counts, bin_edges = np.histogram(data, **hist_params)
 
     need_recompute = False

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -4251,7 +4251,6 @@ def test_ibis_supported_features(dxf: DataExplorerFixture):
 
 def test_histogram_edge_cases_empty_and_single_row(dxf: DataExplorerFixture):
     """Test histogram behavior for 0-row and 1-row DataFrames."""
-
     # Test 0-row DataFrames
     empty_pd = pd.DataFrame(
         {

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -3413,7 +3413,7 @@ def test_profile_histogram_windows_int32_bug():
     )
     result = _get_histogram_numpy(arr, 10, method="fd")[0]
     expected = _get_histogram_numpy(arr.astype(np.float64), 10, method="fd")[0]
-    assert (result == expected).all()  # type: ignore
+    assert result == expected
 
 
 def test_histogram_single_value_special_case():

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -3413,7 +3413,7 @@ def test_profile_histogram_windows_int32_bug():
     )
     result = _get_histogram_numpy(arr, 10, method="fd")[0]
     expected = _get_histogram_numpy(arr.astype(np.float64), 10, method="fd")[0]
-    assert (result == expected).all()
+    assert (result == expected).all()  # type: ignore
 
 
 def test_histogram_single_value_special_case():
@@ -4253,27 +4253,35 @@ def test_histogram_edge_cases_empty_and_single_row(dxf: DataExplorerFixture):
     """Test histogram behavior for 0-row and 1-row DataFrames."""
 
     # Test 0-row DataFrames
-    empty_pd = pd.DataFrame({
-        "numbers": pd.Series([], dtype='float64'),
-        "integers": pd.Series([], dtype='int64'),
-    })
-    empty_pl = pl.DataFrame({
-        "numbers": pl.Series([], dtype=pl.Float64),
-        "integers": pl.Series([], dtype=pl.Int64),
-    })
+    empty_pd = pd.DataFrame(
+        {
+            "numbers": pd.Series([], dtype="float64"),
+            "integers": pd.Series([], dtype="int64"),
+        }
+    )
+    empty_pl = pl.DataFrame(
+        {
+            "numbers": pl.Series([], dtype=pl.Float64),
+            "integers": pl.Series([], dtype=pl.Int64),
+        }
+    )
 
     dxf.register_table("empty_pd", empty_pd)
     dxf.register_table("empty_pl", empty_pl)
 
     # Test 1-row DataFrames
-    single_pd = pd.DataFrame({
-        "numbers": pd.Series([42.5], dtype='float64'),
-        "integers": pd.Series([7], dtype='int64'),
-    })
-    single_pl = pl.DataFrame({
-        "numbers": pl.Series([42.5], dtype=pl.Float64),
-        "integers": pl.Series([7], dtype=pl.Int64),
-    })
+    single_pd = pd.DataFrame(
+        {
+            "numbers": pd.Series([42.5], dtype="float64"),
+            "integers": pd.Series([7], dtype="int64"),
+        }
+    )
+    single_pl = pl.DataFrame(
+        {
+            "numbers": pl.Series([42.5], dtype=pl.Float64),
+            "integers": pl.Series([7], dtype=pl.Int64),
+        }
+    )
 
     dxf.register_table("single_pd", single_pd)
     dxf.register_table("single_pl", single_pl)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -4247,3 +4247,78 @@ def test_ibis_supported_features(dxf: DataExplorerFixture):
         assert tp in column_profiles["supported_types"]
 
     assert features["convert_to_code"]["support_status"] == SupportStatus.Unsupported
+
+
+def test_histogram_edge_cases_empty_and_single_row(dxf: DataExplorerFixture):
+    """Test histogram behavior for 0-row and 1-row DataFrames."""
+
+    # Test 0-row DataFrames
+    empty_pd = pd.DataFrame({
+        "numbers": pd.Series([], dtype='float64'),
+        "integers": pd.Series([], dtype='int64'),
+    })
+    empty_pl = pl.DataFrame({
+        "numbers": pl.Series([], dtype=pl.Float64),
+        "integers": pl.Series([], dtype=pl.Int64),
+    })
+
+    dxf.register_table("empty_pd", empty_pd)
+    dxf.register_table("empty_pl", empty_pl)
+
+    # Test 1-row DataFrames
+    single_pd = pd.DataFrame({
+        "numbers": pd.Series([42.5], dtype='float64'),
+        "integers": pd.Series([7], dtype='int64'),
+    })
+    single_pl = pl.DataFrame({
+        "numbers": pl.Series([42.5], dtype=pl.Float64),
+        "integers": pl.Series([7], dtype=pl.Int64),
+    })
+
+    dxf.register_table("single_pd", single_pd)
+    dxf.register_table("single_pl", single_pl)
+
+    # Test histogram profiles for empty DataFrames
+    for table_name in ["empty_pd", "empty_pl"]:
+        # Test numeric column histogram
+        hist_profiles = [_get_histogram(0, bins=10, method="fixed")]  # numbers column
+        results = dxf.get_column_profiles(table_name, hist_profiles)
+
+        histogram_result = results[0]["small_histogram"]
+        assert histogram_result["bin_counts"] == []
+        assert histogram_result["bin_edges"] == ["0.00", "1.00"]  # Default empty histogram range
+
+        # Test different histogram methods with empty data
+        for method in ["sturges", "freedman_diaconis", "scott"]:
+            hist_profiles = [_get_histogram(0, bins=10, method=method)]
+            results = dxf.get_column_profiles(table_name, hist_profiles)
+            histogram_result = results[0]["small_histogram"]
+            assert histogram_result["bin_counts"] == []
+            assert histogram_result["bin_edges"] == ["0.00", "1.00"]
+
+    # Test histogram profiles for single-row DataFrames
+    for table_name in ["single_pd", "single_pl"]:
+        # Test numeric column histogram - should create single bin with same min/max
+        hist_profiles = [_get_histogram(0, bins=10, method="fixed")]  # numbers column
+        results = dxf.get_column_profiles(table_name, hist_profiles)
+
+        histogram_result = results[0]["small_histogram"]
+        # For single values, should create single bin with identical edges
+        assert histogram_result["bin_counts"] == [1]
+        assert histogram_result["bin_edges"] == ["42.50", "42.50"]
+
+        # Test integer column histogram
+        hist_profiles = [_get_histogram(1, bins=10, method="fixed")]  # integers column
+        results = dxf.get_column_profiles(table_name, hist_profiles)
+
+        histogram_result = results[0]["small_histogram"]
+        assert histogram_result["bin_counts"] == [1]
+        assert histogram_result["bin_edges"] == ["7", "7"]
+
+        # Test different histogram methods with single values
+        for method in ["sturges", "freedman_diaconis", "scott"]:
+            hist_profiles = [_get_histogram(0, bins=10, method=method)]
+            results = dxf.get_column_profiles(table_name, hist_profiles)
+            histogram_result = results[0]["small_histogram"]
+            assert histogram_result["bin_counts"] == [1]
+            assert histogram_result["bin_edges"] == ["42.50", "42.50"]


### PR DESCRIPTION
Addresses #9527. https://github.com/posit-dev/ark/pull/932 adds fixes for 1-row and 0-row data frames in R which addresses #9528.

I had noticed that histograms would fail to compute for pandas data frames with zero rows. This normalizes and tests the behavior to make sure it is consistent (and works) for both polars and pandas.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix errors computing summary sparklines for 0-row and 1-row data frames from Python and R in the data explorer.

### QA Notes

The sparkline panel should not show any stuck loading indicators for 0-row or 1-row data frames.

@:data-explorer