### PR TITLE
Include Quarto and Pandoc in REH builds

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -29,6 +29,7 @@ const glob = require('glob');
 // --- Start Positron ---
 const { positronBuildNumber } = require('./utils');
 const { copyExtensionBinariesTask } = require('./gulpfile.extensions');
+const { getQuartoBinaries } = require('./lib/quarto');
 // --- End Positron ---
 const { compileBuildWithManglingTask } = require('./gulpfile.compile');
 // --- Start PWB ---
@@ -415,6 +416,7 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 
 		// --- Start Positron ---
 		let all = es.merge(
+			getQuartoBinaries(),
 			// --- End Positron ---
 			packageJsonStream,
 			productJsonStream,

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -38,7 +38,7 @@ const rcedit = promisify(require('rcedit'));
 
 // --- Start Positron ---
 const fancyLog = require('fancy-log');
-const { getQuartoStream } = require('./lib/quarto');
+const { getQuartoBinaries } = require('./lib/quarto');
 const { positronBuildNumber } = require('./utils');
 const { copyExtensionBinariesTask } = require('./gulpfile.extensions');
 // --- End Positron ---
@@ -316,31 +316,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const positronApi = gulp.src('src/positron-dts/positron.d.ts')
 			.pipe(rename('out/positron-dts/positron.d.ts'));
 
-		// Bundled Quarto binaries
-		const quarto = getQuartoStream()
-			// Move the Quarto binaries into a `quarto` subdirectory
-			.pipe(rename(f => { f.dirname = path.join('quarto', f.dirname); }))
-
-			// Skip generated files that start with '._'
-			.pipe(es.mapSync(f => {
-				if (!f.basename.startsWith('._')) {
-					return f;
-				}
-			}))
-
-			// Restore the executable bit on the Quarto binaries. (It's very
-			// unfortunate that gulp doesn't preserve the executable bit when
-			// copying files.)
-			.pipe(util.setExecutableBit([
-				'**/dart',
-				'**/deno',
-				'**/esbuild',
-				'**/pandoc',
-				'**/quarto',
-				'**/sass',
-				'**/typst'
-			]));
-
 		// --- End Positron ---
 
 		const telemetry = gulp.src('.build/telemetry/**', { base: '.build/telemetry', dot: true });
@@ -380,7 +355,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 			api,
 			// --- Start Positron ---
 			positronApi,
-			quarto,
+			getQuartoBinaries(),
 			moduleSources,
 			// --- End Positron ---
 			telemetry,

--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -42,11 +42,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getQuartoStream = getQuartoStream;
 exports.getQuarto = getQuarto;
+exports.getQuartoBinaries = getQuartoBinaries;
 const fancy_log_1 = __importDefault(require("fancy-log"));
 const fetch_1 = require("./fetch");
 const es = __importStar(require("event-stream"));
 const gulp = require("gulp");
 const util = require("./util");
+const rename = require("gulp-rename");
+const path = require("path");
 /**
  * Get the base URL for the quarto download
  *
@@ -150,6 +153,35 @@ function getQuarto() {
             .on('error', reject)
             .on('end', resolve);
     });
+}
+/**
+ * Helper to package the quarto binaries into a `quarto` subdirectory with
+ * the executable bit set.
+ *
+ * @returns A stream that provides the quarto binaries
+ */
+function getQuartoBinaries() {
+    return getQuartoStream()
+        // Move the Quarto binaries into a `quarto` subdirectory
+        .pipe(rename(f => { f.dirname = path.join('quarto', f.dirname || ''); }))
+        // Skip generated files that start with '._'
+        .pipe(es.mapSync((f) => {
+        if (!f.basename.startsWith('._')) {
+            return f;
+        }
+    }))
+        // Restore the executable bit on the Quarto binaries. (It's very
+        // unfortunate that gulp doesn't preserve the executable bit when
+        // copying files.)
+        .pipe(util.setExecutableBit([
+        '**/dart',
+        '**/deno',
+        '**/esbuild',
+        '**/pandoc',
+        '**/quarto',
+        '**/sass',
+        '**/typst'
+    ]));
 }
 if (require.main === module) {
     getQuarto().then(() => process.exit(0)).catch(err => {

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -9,6 +9,8 @@ import * as es from 'event-stream';
 import { Stream } from 'stream';
 import gulp = require('gulp');
 import util = require('./util');
+import rename = require('gulp-rename');
+import path = require('path');
 
 /**
  * Get the base URL for the quarto download
@@ -124,6 +126,38 @@ export function getQuarto(): Promise<void> {
 			.on('error', reject)
 			.on('end', resolve);
 	});
+}
+
+/**
+ * Helper to package the quarto binaries into a `quarto` subdirectory with
+ * the executable bit set.
+ *
+ * @returns A stream that provides the quarto binaries
+ */
+export function getQuartoBinaries(): Stream {
+	return getQuartoStream()
+		// Move the Quarto binaries into a `quarto` subdirectory
+		.pipe(rename(f => { f.dirname = path.join('quarto', f.dirname || ''); }))
+
+		// Skip generated files that start with '._'
+		.pipe(es.mapSync((f: any) => {
+			if (!f.basename.startsWith('._')) {
+				return f;
+			}
+		}))
+
+		// Restore the executable bit on the Quarto binaries. (It's very
+		// unfortunate that gulp doesn't preserve the executable bit when
+		// copying files.)
+		.pipe(util.setExecutableBit([
+			'**/dart',
+			'**/deno',
+			'**/esbuild',
+			'**/pandoc',
+			'**/quarto',
+			'**/sass',
+			'**/typst'
+		]));
 }
 
 if (require.main === module) {


### PR DESCRIPTION
This change adds Quarto (and, by extension, Pandoc) to the Remote Extension Host builds of Positron, which include Remote SSH & Workbench.

Addresses https://github.com/posit-dev/positron/issues/9548.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Quarto and Pandoc are now included in the Remote SSH version of Positron (#9548)

#### Bug Fixes

- N/A


### QA Notes

An easy way to see if Positron knows about its built-in copy of Pandoc is to check the value of the `RSTUDIO_PANDOC` environment variable. 