### PR TITLE
Set JUPYTER_PREFER_ENV_PATH in Positron terminals/consoles

### DIFF
--- a/extensions/positron-environment/package.json
+++ b/extensions/positron-environment/package.json
@@ -33,7 +33,8 @@
             },
             "default": {
               "SF_PARTNER": "posit_positron",
-              "SPARK_CONNECT_USER_AGENT": "posit-positron"
+              "SPARK_CONNECT_USER_AGENT": "posit-positron",
+              "JUPYTER_PREFER_ENV_PATH": "1"
             },
             "description": "%environment.configuration.variables.set.description%",
             "order": 2


### PR DESCRIPTION
This change attempts to work around a venv precedence issue. Very briefly, the problem is that in some circumstances Quarto doesn't use your project's venv but uses some _other_ venv on your system, but does so in a way that makes it very unclear that's what's happening. 

The core issue is that Jupyter will actually choose user-level config _over_ project-level/virtual environment config by default. Sometimes this is what you want, but in a Python project with a venv, it is very confusing. You can read more about this here:

https://discourse.jupyter.org/t/jupyter-paths-priority-order/7771

There are a few different ways we can address this, each with their own tradeoffs. What I've chosen to do here is just set `JUPYTER_PREFER_ENV_PATH=1` by default in Positron, so that the behavior out of the box is that project venvs are preferred.

We'll have to see if this makes things more predictable for people; I can't think of any Positron use cases where you wouldn't want to prefer the project venv, but in case there are any, I've added this variable using a configurable setting, so users can change it to 0 in the field if it winds up causing any trouble.

Addresses https://github.com/posit-dev/positron/issues/9579. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Set `JUPYTER_PREFER_ENV_PATH=1` in Positron terminals and consoles so that Python virtual environments are used consistently for Quarto rendering. (#9579)

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
