### PR TITLE
Fire the onDidChangeProviders event in language model provider registration and disposal

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -194,6 +194,11 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 			});
 		}
 
+		// --- Start Positron ---
+		// Fire the onDidChangeProviders so that extensions can refresh their model lists.
+		this._onDidChangeProviders.fire();
+		// --- End Positron ---
+
 		// FIX provider name is no longer available because metadata is no longer passed
 		// this._proxy.$registerLanguageModelProvider(handle, `${ExtensionIdentifier.toKey(extension.identifier)}/${identifier}`, {
 		// 	extension: extension.identifier,
@@ -224,6 +229,10 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 		return toDisposable(() => {
 			this._languageModelProviders.delete(vendor);
 			this._clearModelCache(vendor);
+			// --- Start Positron ---
+			// Fire the onDidChangeProviders so that extensions can refresh their model lists.
+			this._onDidChangeProviders.fire();
+			// --- End Positron ---
 			providerChangeEventDisposable?.dispose();
 			this._proxy.$unregisterProvider(vendor);
 		});


### PR DESCRIPTION
## Description

This PR addresses a regression bug with Databot (see https://github.com/posit-dev/databot/issues/63).

The fix was to fire the `onDidChangeProviders` event in `registerLanguageModelProvider` in `/positron/src/vs/workbench/api/common/extHostLanguageModels.ts`. This results in the `onDidChangeChatModels` event being fired by this code:

```TypeScript
onDidChangeChatModels: (listener, thisArgs?, disposables?) => {
	return extHostLanguageModels.onDidChangeProviders(listener, thisArgs, disposables);
},
```

In `/positron/src/vs/workbench/api/common/extHost.api.impl.ts`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Prior to this fix, the steps to reproduce this bug are:

- Launch Positron
- Open Databot and select a model.
- Close Positron
- Relaunch Positron
- Databot will indicate (No models available) in the model selector

<img width="3338" height="2260" alt="image" src="https://github.com/user-attachments/assets/000c4790-1376-45f4-9ae1-05b2bb07b2db" />

After this fix, Databot will load with models correctly:

<img width="3338" height="2260" alt="image" src="https://github.com/user-attachments/assets/b9d74b1a-0276-45f4-ba2e-3ac3fdd2f16f" />

