### PR TITLE
Assistant: Enable Console actions by default

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -271,10 +271,10 @@
           },
           "positron.assistant.consoleActions.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "%configuration.consoleActions.enable.description%",
             "tags": [
-              "experimental"
+              "preview"
             ]
           }
         }


### PR DESCRIPTION
Based on discussion in the Assistant sync, we've opted to enable the Console fix/explain actions by default for 2025.10. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Assistant's Console actions enabled by default (#9645)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
e2e: @:assistant
