### PR TITLE
e2e: unskip & fix pinning with sorted data test

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -210,7 +210,7 @@ export class Filters {
 export class DataGrid {
 	grid: Locator;
 	private statusBar: Locator;
-	private rowHeaders = this.code.driver.page.locator('.data-grid-row-headers');
+	private rowHeader = this.code.driver.page.locator('.data-grid-row-header');
 	private columnHeaders = this.code.driver.page.locator(HEADER_TITLES);
 	private rows = this.code.driver.page.locator(`${DATA_GRID_ROWS} ${DATA_GRID_ROW}`);
 	private cellByPosition = (rowIndex: number, columnIndex: number) => this.code.driver.page.locator(
@@ -326,10 +326,7 @@ export class DataGrid {
 	 */
 	async pinRow(rowPosition: number) {
 		await test.step(`Pin row at 0-based position: ${rowPosition}`, async () => {
-			await this.code.driver.page
-				// rowPosition is 0-based, nth-child is 1-based
-				.locator(`.data-grid-row-headers > div:nth-child(${rowPosition + 1})`)
-				.click({ button: 'right' });
+			await this.rowHeader.nth(rowPosition).click({ button: 'right' });
 			await this.code.driver.page.getByRole('button', { name: 'Pin Row' }).click();
 		});
 	}
@@ -371,12 +368,12 @@ export class DataGrid {
 	}
 
 	/**
-	 * Click a row header by its visual position
+	 * Click a row header by its position
 	 * Index is 1-based to match UI
 	 **/
 	async clickRowHeader(rowIndex: number) {
 		await test.step(`Click row header: ${rowIndex}`, async () => {
-			await this.rowHeaders.getByText(rowIndex.toString(), { exact: true }).click();
+			await this.rowHeader.nth(rowIndex).click();
 		});
 	}
 

--- a/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
@@ -37,7 +37,6 @@ test.use({
 for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of testCases) {
 	test.describe('Data Explorer: Copy/Paste', { tag: [tags.WEB, tags.DATA_EXPLORER, ...testTags] }, () => {
 
-
 		test.beforeEach(async function ({ app, openDataFile, hotKeys }) {
 			const { dataExplorer, console, sessions, variables } = app.workbench;
 
@@ -68,7 +67,7 @@ for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of te
 			await clipboard.expectClipboardTextToBe(expectedData['col3'], '\n');
 
 			// verify copy and paste on rows
-			await dataExplorer.grid.clickRowHeader(9 + indexOffset);
+			await dataExplorer.grid.clickRowHeader(9);
 			await clipboard.copy();
 			await clipboard.expectClipboardTextToBe(expectedData['row9'], '\n');
 
@@ -83,21 +82,19 @@ for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of te
 			await clipboard.expectClipboardTextToBe(expectedData['col0_col1'], '\n');
 		});
 
-		test.skip(`${env} - Copy and paste works on cells, rows, columns, and ranges of sorted data`, {
-			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9344' }]
-		}, async function ({ app }) {
+		test(`${env} - Copy and paste works on cells, rows, columns, and ranges of sorted data`, async function ({ app }) {
 			const { dataExplorer, clipboard } = app.workbench;
 
 			// verify copy and paste on columns
 			await dataExplorer.grid.selectColumnAction(4, 'Sort Descending');
 			await dataExplorer.grid.clickColumnHeader('column3');
 			await clipboard.copy();
-			await clipboard.expectClipboardTextToBe(expectedData['col3']);
+			await clipboard.expectClipboardTextToBe(expectedData['col3_sorted_desc'], '\n');
 
-			// verify copy and paste on rows - issue 9344
-			await dataExplorer.grid.clickRowHeader(4 + indexOffset);
+			// verify copy and paste on rows
+			await dataExplorer.grid.clickRowHeader(4);
 			await clipboard.copy();
-			await clipboard.expectClipboardTextToBe(expectedData['row4']);
+			await clipboard.expectClipboardTextToBe(expectedData['row4'], '\n');
 
 			// verify copy and paste on cell
 			await dataExplorer.grid.clickCell(6, 4);
@@ -107,7 +104,7 @@ for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of te
 			// verify copy and paste on range
 			await dataExplorer.grid.selectRange({ start: { row: 0, col: 2 }, end: { row: 1, col: 3 } });
 			await clipboard.copy();
-			await clipboard.expectClipboardTextToBe('column2\tcolumn3\n47\t99\n8\t89');
+			await clipboard.expectClipboardTextToBe('column2\tcolumn3\n47\t99\n8\t89', '\n');
 		});
 
 		test(`${env} - Copy and paste of ranges works with pinned data`, async function ({ app }) {


### PR DESCRIPTION
### Summary
Re-enabling the e2e test for verifying behavior of copy/paste on sorted data.

### QA Notes

@:data-explorer @:web
