### PR TITLE
Do not invert deltaX / deltaY in wheelHandler when the shift key is down

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -541,11 +541,6 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			}
 		}
 
-		// When the user is holding the shift key, invert delta X and delta Y.
-		if (e.shiftKey) {
-			[deltaX, deltaY] = [deltaY, deltaX];
-		}
-
 		// If the alt key is pressed, scroll by 10 times the delta X and delta Y.
 		if (e.altKey) {
 			deltaX *= 10;


### PR DESCRIPTION
## Description

This PR addresses https://github.com/posit-dev/positron/issues/3755. The fix was to remove the code in Data Grid that inverted `deltaX` and `deltaY` when the shift key is pressed during wheel events. It is unnecessary code.

Trackpads already have gestures for scrolling vertically and scrolling horizontally, so shift key inversion isn't necessary for wheel events that come from a trackpad.

By the time a React onWheel handler runs, the `deltaX` and `deltaY` values are already inverted by the browser engine when the event comes from a mouse and the shift key is down.

So this code:

```TypeScript
// When the user is holding the shift key, invert delta X and delta Y.
if (e.shiftKey) {
	[deltaX, deltaY] = [deltaY, deltaX];
}
```

was causing a _double inversion_ of `deltaX` and `deltaY` for mouse-initiated wheel events.

(*And, there is no way in a React `onWheel` event handler to tell whether the event came from a trackpad or a mouse.)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #3755 Fix mouse wheel handling in Data Explorer so that holding the shift key down will invert the scroll direction from vertical to horizontal.

### QA Notes

- None