### PR TITLE
Assistant: show destructive action/code warnings

### DIFF
--- a/extensions/positron-assistant/src/commands/explain.ts
+++ b/extensions/positron-assistant/src/commands/explain.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 import { MD_DIR } from '../constants';
-import { ParticipantID, PositronAssistantChatParticipant, PositronAssistantEditorParticipant, PositronAssistantChatContext } from '../participants.js';
+import { PositronAssistantChatParticipant, PositronAssistantEditorParticipant, PositronAssistantChatContext } from '../participants.js';
 
 
 export const EXPLAIN_COMMAND = 'explain';
@@ -24,9 +24,9 @@ export async function explainHandler(
 ) {
 	const defaultPrompt = await fs.promises.readFile(`${MD_DIR}/prompts/chat/default.md`, 'utf8');
 	const explainPrompt = await fs.promises.readFile(`${MD_DIR}/prompts/chat/explain.md`, 'utf8');
+	const warningPrompt = await fs.promises.readFile(`${MD_DIR}/prompts/chat/warning.md`, 'utf8');
 
-	context.systemPrompt = defaultPrompt + '\n\n' + explainPrompt;
-
+	context.systemPrompt = defaultPrompt + '\n\n' + explainPrompt + '\n\n' + warningPrompt;
 	return handleDefault();
 }
 

--- a/extensions/positron-assistant/src/defaultTextProcessor.ts
+++ b/extensions/positron-assistant/src/defaultTextProcessor.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { StreamingTagLexer } from './streamingTagLexer.js';
+
+/**
+ * A text processor that handles warning tags and passes all other text as markdown.
+ * This is the default processor for chat contexts that don't require streaming edits.
+ */
+export class DefaultTextProcessor {
+	private readonly _lexer: StreamingTagLexer<string>;
+	private _insideWarning = false;
+	private _warningBuffer = '';
+
+	constructor(
+		private readonly _response: vscode.ChatResponseStream,
+	) {
+		this._lexer = new StreamingTagLexer({
+			tagNames: ['warning'],
+			contentHandler: (chunk) => {
+				this.processChunk(chunk);
+			}
+		});
+	}
+
+	process(text: string): void {
+		this._lexer.process(text);
+	}
+
+	flush(): void {
+		this._lexer.flush();
+
+		// If we have buffered warning content at the end, emit it
+		if (this._warningBuffer.trim()) {
+			this._response.warning(this._warningBuffer.trim());
+			this._warningBuffer = '';
+		}
+	}
+
+	private processChunk(chunk: any): void {
+		if (chunk.type === 'tag' && chunk.name === 'warning') {
+			if (chunk.kind === 'open') {
+				this._insideWarning = true;
+			} else if (chunk.kind === 'close') {
+				if (this._warningBuffer.trim()) {
+					this._response.warning(this._warningBuffer.trim());
+					this._warningBuffer = '';
+				}
+				this._insideWarning = false;
+			}
+		} else if (chunk.type === 'text') {
+			if (this._insideWarning) {
+				this._warningBuffer += chunk.text;
+			} else {
+				// All non-warning text goes to markdown
+				this._response.markdown(chunk.text);
+			}
+		}
+	}
+}

--- a/extensions/positron-assistant/src/defaultTextProcessor.ts
+++ b/extensions/positron-assistant/src/defaultTextProcessor.ts
@@ -20,18 +20,18 @@ export class DefaultTextProcessor {
 	) {
 		this._lexer = new StreamingTagLexer({
 			tagNames: ['warning'],
-			contentHandler: (chunk) => {
-				this.processChunk(chunk);
+			contentHandler: async (chunk) => {
+				await this.processChunk(chunk);
 			}
 		});
 	}
 
-	process(text: string): void {
-		this._lexer.process(text);
+	async process(text: string): Promise<void> {
+		await this._lexer.process(text);
 	}
 
-	flush(): void {
-		this._lexer.flush();
+	async flush(): Promise<void> {
+		await this._lexer.flush();
 
 		// If we have buffered warning content at the end, emit it
 		if (this._warningBuffer.trim()) {
@@ -40,7 +40,7 @@ export class DefaultTextProcessor {
 		}
 	}
 
-	private processChunk(chunk: any): void {
+	private async processChunk(chunk: any): Promise<void> {
 		if (chunk.type === 'tag' && chunk.name === 'warning') {
 			if (chunk.kind === 'open') {
 				this._insideWarning = true;
@@ -53,6 +53,7 @@ export class DefaultTextProcessor {
 			}
 		} else if (chunk.type === 'text') {
 			if (this._insideWarning) {
+				// Buffer warning text until the closing tag
 				this._warningBuffer += chunk.text;
 			} else {
 				// All non-warning text goes to markdown

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -16,7 +16,9 @@ The execute code tool runs code in the currently active session(s). You do not t
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
 
-BEFORE using the execute code tool, check if the code you are about to suggest involves destructive, dangerous, or difficult to reverse actions or code. If it does, you must include a warning in your response before the code block.
+You are EXTREMELY careful when using tools if the code or command you are about to suggest involves destructive, dangerous, or difficult to reverse actions, even if the user has previously confirmed they want you to take some action.
+
+When you are going to take destructive actions, you MUST ALWAYS include `<warning>` tags in your response BEFORE using the execute code tool.
 </tools>
 
 <communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -16,7 +16,7 @@ The execute code tool runs code in the currently active session(s). You do not t
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
 
-You are EXTREMELY careful when using tools if the code or command you are about to suggest involves destructive, dangerous, or difficult to reverse actions, even if the user has previously confirmed they want you to take some action.
+You are EXTREMELY careful when using tools if the code or command you are about to suggest involves destructive, dangerous, or difficult to reverse actions, even if the user has previously confirmed they want you to take some action. Examples of such actions include deleting/removing files or directories, modifying system files or directories, or running commands that could compromise the security or stability of the system. Removing files or directories is always considered destructive, even if there is a safe method to do so.
 
 When you are going to take destructive actions, you MUST ALWAYS include `<warning>` tags in your response BEFORE using the execute code tool.
 </tools>

--- a/extensions/positron-assistant/src/md/prompts/chat/agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/agent.md
@@ -1,6 +1,8 @@
 You will be given a task that may require editing multiple files and executing
 code to achieve.
 
+NEVER try to delete the `.git` directory or any of its contents.
+
 <tools>
 You will be provided with a tool that executes code. Use this tool to help the
 user complete tasks when the user gives you an imperative statement, or asks a
@@ -13,6 +15,8 @@ You ONLY use the execute code tool as a way to learn about the environment as a 
 The execute code tool runs code in the currently active session(s). You do not try to execute any other programming language.
 
 You NEVER try to start a Shiny app using the execute code tool, even if the user explicitly asks. You are unable to start a Shiny app in this way.
+
+BEFORE using the execute code tool, check if the code you are about to suggest involves destructive, dangerous, or difficult to reverse actions or code. If it does, you must include a warning in your response before the code block.
 </tools>
 
 <communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/terminal.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/terminal.md
@@ -3,7 +3,10 @@ You may respond in one of two ways:
 1. Answer the user's question in 1-3 brief sentences.
 2. Return ONLY a single line terminal command that addresses the user's question.
    1. If the command includes arguments, explain them in bulleted form.
-   2. If the command is destructive, include a warning.
+   2. If the command is destructive, dangerous, or difficult to reverse, such as deleting files or directories, you follow these guidelines:
+		- Start with a clear warning at the beginning of the response.
+		- Enclose the warning text in `<warning>` tags. For example: `<warning>**Warning: This command will permanently delete the current directory and all its contents. Use with caution!**</warning>`.
+		- The warning text should clearly describe the destructive or dangerous nature of the suggested action or code.
 
 <examples>
 <example>
@@ -16,15 +19,18 @@ You may respond in one of two ways:
 <example>
 <user>what folder am I in?</user>
 <response>
+
 ```sh
 pwd
 ```
+
 </response>
 </example>
 
 <example>
 <user>what files are in the current folder and when were they created?</user>
 <response>
+
 ```sh
 ls -l
 ```
@@ -32,10 +38,16 @@ ls -l
 - `-l`: List files in long format, showing details including creation time.
 </response>
 
+</example>
+
 <example>
 <user>delete the current directory</user>
 <response>
+
+````md
+<warning>
 **Warning: This command will permanently delete the current directory and all its contents. Use with caution!**
+</warning>
 
 ```sh
 rm -rf .
@@ -43,8 +55,9 @@ rm -rf .
 
 - `-r`: Recursively delete the directory and its contents.
 - `-f`: Force deletion without prompting for confirmation.
+````
+
 </response>
-</example>
 </example>
 
 </examples>

--- a/extensions/positron-assistant/src/md/prompts/chat/warning.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/warning.md
@@ -1,0 +1,29 @@
+When responding with code or instructions that are destructive, dangerous, or difficult to reverse, you follow these guidelines:
+- **Always include warnings** for these specific operations:
+  - Deleting files or directories (`rm`, `os.remove()`, `unlink()`, `fs.unlink()`, etc.)
+  - Modifying system files or directories
+- Start with a clear warning at the beginning of the response
+- Include additional warnings alongside the code or instructions where appropriate
+- Enclose the warning text in `<warning>` tags. For example: `<warning>**Warning: This code will permanently delete the current directory and all its contents. Use with caution!**</warning>`
+- The warning text should clearly describe the destructive or dangerous nature of the suggested action or code
+
+<example>
+<user>delete a directory using Python</user>
+<response>
+
+````md
+<warning>
+**Warning: This code will permanently delete the directory and all its contents. Use with caution!**
+</warning>
+
+```python
+import shutil
+
+shutil.rmtree('/path/to/directory')
+```
+
+- `shutil.rmtree()`: Recursively deletes a directory and all its contents
+````
+
+</response>
+</example>

--- a/extensions/positron-assistant/src/md/prompts/chat/warningStreaming.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/warningStreaming.md
@@ -1,0 +1,10 @@
+If the suggested edit includes destructive, dangerous, or difficult to reverse actions, you follow these guidelines:
+- **Always include warnings** for these specific operations:
+  - Deleting files or directories (`rm`, `os.remove()`, `unlink()`, `fs.unlink()`, etc.)
+  - Modifying system files or directories
+- Enclose the warning text in `<warning>` tags. For example: `<warning>**Warning: This code will permanently delete the current directory and all its contents. Use with caution!**</warning>`
+- The warning text should clearly describe the destructive or dangerous nature of the suggested action or code
+
+<warning>
+**Warning: This code will permanently delete the directory and all its contents. Use with caution!**
+</warning>

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -808,12 +808,12 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 			// If the user has not selected text, use the prompt for the whole document.
 			if (request.location2.selection.isEmpty) {
 				const editorSteaming = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'editorStreaming.md'), 'utf8');
-				return editorSteaming + '\n\n' + warningStreaming;
+				return [editorSteaming, warningStreaming].join('\n\n');
 			}
 
 			// If the user has selected text, generate a new version of the selection.
 			const selectionStreaming = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'selectionStreaming.md'), 'utf8');
-			return selectionStreaming + '\n\n' + warningStreaming;
+			return [selectionStreaming, warningStreaming].join('\n\n');
 		}
 
 		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
@@ -825,12 +825,12 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 		// If the user has not selected text, use the prompt for the whole document.
 		if (request.location2.selection.isEmpty) {
 			const editor = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'editor.md'), 'utf8');
-			return defaultSystem + '\n\n' + warning + '\n\n' + ask + '\n\n' + editor;
+			return [defaultSystem, warning, ask, editor].join('\n\n');
 		}
 
 		// If the user has selected text, generate a new version of the selection.
 		const selection = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'selection.md'), 'utf8');
-		return defaultSystem + '\n\n' + warning + '\n\n' + ask + '\n\n' + selection;
+		return [defaultSystem, warning, ask, selection].join('\n\n');
 	}
 
 	async getCustomPrompt(request: vscode.ChatRequest): Promise<string> {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -9,10 +9,10 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as xml from './xml.js';
 
-import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_ACTIVE_SESSION, TOOL_TAG_REQUIRES_WORKSPACE } from './constants';
+import { MARKDOWN_DIR } from './constants';
 import { isChatImageMimeType, isTextEditRequest, isWorkspaceOpen, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString } from './utils';
 import { ContextInfo, PositronAssistantToolName } from './types.js';
-import { StreamingTagLexer } from './streamingTagLexer.js';
+import { DefaultTextProcessor } from './defaultTextProcessor.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
 import { ReplaceSelectionProcessor } from './replaceSelectionProcessor.js';
 import { log, getRequestTokenUsage } from './extension.js';
@@ -262,9 +262,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const enabledTools = getEnabledTools(request, vscode.lm.tools, this.id);
 		const toolAvailability = new Map(
 			vscode.lm.tools.map(
-				tool => {
-					return [tool.name as PositronAssistantToolName, enabledTools.includes(tool.name as PositronAssistantToolName)]
-				})
+				tool => [tool.name as PositronAssistantToolName, enabledTools.includes(tool.name as PositronAssistantToolName)]
+			)
 		);
 
 		const participant = this;
@@ -641,15 +640,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 			if (chunk instanceof vscode.LanguageModelTextPart) {
 				textResponses.push(chunk);
-
-				if (textProcessor) {
-					// If there is a text processor, let it process the chunk
-					// and write to the chat response stream.
-					await textProcessor.process(chunk.value);
-				} else {
-					// If there is no text processor, treat the chunk as markdown.
-					response.markdown(chunk.value);
-				}
+				await textProcessor.process(chunk.value);
 			} else if (chunk instanceof vscode.LanguageModelToolCallPart) {
 				toolRequests.push(chunk);
 			}
@@ -706,38 +697,24 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 	 *
 	 * @param request The current chat request.
 	 * @param response The chat response stream to write to.
-	 * @returns A text processor that handles the request, or undefined if no
-	 *  streaming is needed for the request.
+	 * @returns The appropriate processor for the request.
 	 */
-	private createTextProcessor(request: vscode.ChatRequest, response: vscode.ChatResponseStream): TextProcessor | undefined {
-		// Currently, we only use streaming text processing in the experimental streaming edit mode.
-		if (!isStreamingEditsEnabled() || !isTextEditRequest(request)) {
-			return undefined;
-		}
+	private createTextProcessor(request: vscode.ChatRequest, response: vscode.ChatResponseStream): TextProcessor {
+		const defaultTextProcessor = new DefaultTextProcessor(response);
 
-		// If the selection is empty, stream string replacements to the document.
-		if (request.location2.selection.isEmpty) {
-			const replaceStringProcessor = new ReplaceStringProcessor(request.location2.document, response);
-			return new StreamingTagLexer({
-				tagNames: ReplaceStringProcessor.TagNames,
-				contentHandler(chunk) {
-					replaceStringProcessor.process(chunk);
-				},
-			});
-		}
-
-		// If the selection is not empty, stream edits to the selection.
-		const replaceSelectionProcessor = new ReplaceSelectionProcessor(
-			request.location2.document.uri,
-			request.location2.selection,
-			response,
-		);
-		return new StreamingTagLexer({
-			tagNames: ReplaceSelectionProcessor.TagNames,
-			contentHandler(chunk) {
-				replaceSelectionProcessor.process(chunk);
+		// Check if streaming edits are enabled and we're in an editor context
+		if (isStreamingEditsEnabled() && isTextEditRequest(request)) {
+			if (request.location2.selection.isEmpty) {
+				// Process streaming edits to the whole document
+				return new ReplaceStringProcessor(request.location2.document, response, defaultTextProcessor);
+			} else {
+				// Process streaming edits to the selected text
+				return new ReplaceSelectionProcessor(request.location2.document.uri, request.location2.selection, response, defaultTextProcessor);
 			}
-		});
+		}
+
+		// Process as default text, which may contain warning blocks
+		return defaultTextProcessor;
 	}
 
 	/** Additional language-specific prompts for active sessions */
@@ -770,7 +747,8 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
 		const ask = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'ask.md'), 'utf8');
 		const languages = await this.getActiveSessionInstructions();
-		const prompts = [defaultSystem, filepaths, ask, languages];
+		const warning = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'warning.md'), 'utf8');
+		const prompts = [defaultSystem, filepaths, warning, ask, languages];
 		return prompts.join('\n\n');
 	}
 }
@@ -784,7 +762,8 @@ class PositronAssistantEditParticipant extends PositronAssistantParticipant impl
 		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
 		const edit = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'edit.md'), 'utf8');
 		const languages = await this.getActiveSessionInstructions();
-		const prompts = [defaultSystem, filepaths, edit, languages];
+		const warning = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'warning.md'), 'utf8');
+		const prompts = [defaultSystem, filepaths, warning, edit, languages];
 		return prompts.join('\n\n');
 	}
 }
@@ -798,7 +777,8 @@ export class PositronAssistantAgentParticipant extends PositronAssistantParticip
 		const filepaths = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'filepaths.md'), 'utf8');
 		const agent = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'agent.md'), 'utf8');
 		const languages = await this.getActiveSessionInstructions();
-		const prompts = [defaultSystem, filepaths, agent, languages];
+		const warning = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'warning.md'), 'utf8');
+		const prompts = [defaultSystem, filepaths, warning, agent, languages];
 		return prompts.join('\n\n');
 	}
 }
@@ -808,6 +788,7 @@ class PositronAssistantTerminalParticipant extends PositronAssistantParticipant 
 	id = ParticipantID.Terminal;
 
 	protected override async getSystemPrompt(request: vscode.ChatRequest): Promise<string> {
+		// The terminal prompt includes how to handle warnings in the response.
 		return await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'terminal.md'), 'utf8');
 	}
 }
@@ -822,16 +803,21 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 		}
 
 		if (isStreamingEditsEnabled()) {
+			const warningStreaming = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'warningStreaming.md'), 'utf8');
+
 			// If the user has not selected text, use the prompt for the whole document.
 			if (request.location2.selection.isEmpty) {
-				return await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'editorStreaming.md'), 'utf8');
+				const editorSteaming = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'editorStreaming.md'), 'utf8');
+				return editorSteaming + '\n\n' + warningStreaming;
 			}
 
 			// If the user has selected text, generate a new version of the selection.
-			return await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'selectionStreaming.md'), 'utf8');
+			const selectionStreaming = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'selectionStreaming.md'), 'utf8');
+			return selectionStreaming + '\n\n' + warningStreaming;
 		}
 
 		const defaultSystem = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'default.md'), 'utf8');
+		const warning = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'warning.md'), 'utf8');
 
 		// Inline editor chats behave as in "Ask" mode
 		const ask = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'ask.md'), 'utf8');
@@ -839,12 +825,12 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 		// If the user has not selected text, use the prompt for the whole document.
 		if (request.location2.selection.isEmpty) {
 			const editor = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'editor.md'), 'utf8');
-			return defaultSystem + '\n\n' + ask + '\n\n' + editor;
+			return defaultSystem + '\n\n' + warning + '\n\n' + ask + '\n\n' + editor;
 		}
 
 		// If the user has selected text, generate a new version of the selection.
 		const selection = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'selection.md'), 'utf8');
-		return defaultSystem + '\n\n' + ask + '\n\n' + selection;
+		return defaultSystem + '\n\n' + warning + '\n\n' + ask + '\n\n' + selection;
 	}
 
 	async getCustomPrompt(request: vscode.ChatRequest): Promise<string> {

--- a/extensions/positron-assistant/src/replaceSelectionProcessor.ts
+++ b/extensions/positron-assistant/src/replaceSelectionProcessor.ts
@@ -33,31 +33,31 @@ export class ReplaceSelectionProcessor {
 	) {
 		this._lexer = new StreamingTagLexer({
 			tagNames: ['replaceSelection'],
-			contentHandler: (chunk) => {
-				this.processChunk(chunk);
+			contentHandler: async (chunk) => {
+				await this.processChunk(chunk);
 			}
 		});
 	}
 
-	process(text: string): void {
-		this._lexer.process(text);
+	async process(text: string): Promise<void> {
+		await this._lexer.process(text);
 	}
 
-	flush(): void {
-		this._lexer.flush();
+	async flush(): Promise<void> {
+		await this._lexer.flush();
 		// Also flush the default text processor if available
 		if (this._defaultTextProcessor) {
-			this._defaultTextProcessor.flush();
+			await this._defaultTextProcessor.flush();
 		}
 	}
 
-	private processChunk(chunk: any): void {
+	private async processChunk(chunk: any): Promise<void> {
 		// Proceed through the states in the expected order.
 		// NOTE: This does not currently handle unexpected or out-of-order tags.
 		switch (this._state) {
 			case 'pending_replaceSelection_open': {
 				if (chunk.type === 'text') {
-					this.onPlainText(chunk.text);
+					await this.onPlainText(chunk.text);
 				} else if (chunk.type === 'tag' && chunk.kind === 'open' && chunk.name === 'replaceSelection') {
 					this._state = 'pending_replaceSelection_close';
 				}
@@ -75,10 +75,10 @@ export class ReplaceSelectionProcessor {
 		}
 	}
 
-	private onPlainText(text: string): void {
+	private async onPlainText(text: string): Promise<void> {
 		// Outside of a replaceSelection tag, delegate to the default text processor if available
 		if (this._defaultTextProcessor) {
-			this._defaultTextProcessor.process(text);
+			await this._defaultTextProcessor.process(text);
 		} else {
 			// Fallback to treating it as markdown
 			this._response.markdown(text);

--- a/extensions/positron-assistant/src/replaceStringProcessor.ts
+++ b/extensions/positron-assistant/src/replaceStringProcessor.ts
@@ -38,31 +38,31 @@ export class ReplaceStringProcessor {
 	) {
 		this._lexer = new StreamingTagLexer({
 			tagNames: ['replaceString', 'old', 'new'],
-			contentHandler: (chunk) => {
-				this.processChunk(chunk);
+			contentHandler: async (chunk) => {
+				await this.processChunk(chunk);
 			}
 		});
 	}
 
-	process(text: string): void {
-		this._lexer.process(text);
+	async process(text: string): Promise<void> {
+		await this._lexer.process(text);
 	}
 
-	flush(): void {
-		this._lexer.flush();
+	async flush(): Promise<void> {
+		await this._lexer.flush();
 		// Also flush the default text processor if available
 		if (this._defaultTextProcessor) {
-			this._defaultTextProcessor.flush();
+			await this._defaultTextProcessor.flush();
 		}
 	}
 
-	private processChunk(chunk: any): void {
+	private async processChunk(chunk: any): Promise<void> {
 		// Proceed through the states in the expected order.
 		// NOTE: This does not currently handle unexpected or out-of-order tags.
 		switch (this._state) {
 			case 'pending_replaceString_open': {
 				if (chunk.type === 'text') {
-					this.onPlainText(chunk.text);
+					await this.onPlainText(chunk.text);
 				} else if (chunk.type === 'tag' && chunk.kind === 'open' && chunk.name === 'replaceString') {
 					this._state = 'pending_old_open';
 				}
@@ -106,10 +106,10 @@ export class ReplaceStringProcessor {
 		}
 	}
 
-	private onPlainText(text: string) {
+	private async onPlainText(text: string): Promise<void> {
 		// Outside of a replaceString tag, delegate to the default text processor if available
 		if (this._defaultTextProcessor) {
-			this._defaultTextProcessor.process(text);
+			await this._defaultTextProcessor.process(text);
 		} else {
 			// Fallback to treating it as markdown
 			this._response.markdown(text);

--- a/extensions/positron-assistant/src/replaceStringProcessor.ts
+++ b/extensions/positron-assistant/src/replaceStringProcessor.ts
@@ -4,16 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { Chunk } from './streamingTagLexer.js';
-
-export type ReplaceStringTag = typeof ReplaceStringProcessor.TagNames[number];
+import { StreamingTagLexer } from './streamingTagLexer.js';
+import { DefaultTextProcessor } from './defaultTextProcessor.js';
 
 /**
  * A streaming tag processor that handles string replacement operations.
  */
 export class ReplaceStringProcessor {
-	/** The names of the tags that this processor can handle. */
-	public static readonly TagNames = ['replaceString', 'old', 'new'] as const;
+	private readonly _lexer: StreamingTagLexer<string>;
 
 	/** The current state of the processor. */
 	private _state:
@@ -36,9 +34,29 @@ export class ReplaceStringProcessor {
 	constructor(
 		private readonly _document: vscode.TextDocument,
 		private readonly _response: vscode.ChatResponseStream,
-	) { }
+		private readonly _defaultTextProcessor?: DefaultTextProcessor,
+	) {
+		this._lexer = new StreamingTagLexer({
+			tagNames: ['replaceString', 'old', 'new'],
+			contentHandler: (chunk) => {
+				this.processChunk(chunk);
+			}
+		});
+	}
 
-	process(chunk: Chunk<ReplaceStringTag>) {
+	process(text: string): void {
+		this._lexer.process(text);
+	}
+
+	flush(): void {
+		this._lexer.flush();
+		// Also flush the default text processor if available
+		if (this._defaultTextProcessor) {
+			this._defaultTextProcessor.flush();
+		}
+	}
+
+	private processChunk(chunk: any): void {
 		// Proceed through the states in the expected order.
 		// NOTE: This does not currently handle unexpected or out-of-order tags.
 		switch (this._state) {
@@ -89,8 +107,13 @@ export class ReplaceStringProcessor {
 	}
 
 	private onPlainText(text: string) {
-		// Outside of a replaceString tag, just treat it as markdown.
-		this._response.markdown(text);
+		// Outside of a replaceString tag, delegate to the default text processor if available
+		if (this._defaultTextProcessor) {
+			this._defaultTextProcessor.process(text);
+		} else {
+			// Fallback to treating it as markdown
+			this._response.markdown(text);
+		}
 	}
 
 	private onOldText(text: string) {

--- a/extensions/positron-assistant/src/test/textProcessors.test.ts
+++ b/extensions/positron-assistant/src/test/textProcessors.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { DefaultTextProcessor } from '../defaultTextProcessor.js';
+import { ReplaceStringProcessor } from '../replaceStringProcessor.js';
+import { ReplaceSelectionProcessor } from '../replaceSelectionProcessor.js';
+import { mock } from './utils.js';
+
+suite('Text Processors', () => {
+	let responseParts: vscode.ExtendedChatResponsePart[];
+	let mockResponse: vscode.ChatResponseStream;
+	let mockUri: vscode.Uri;
+	let mockDocument: vscode.TextDocument;
+
+	const createMockResponse = () => mock<vscode.ChatResponseStream>({
+		markdown: (value: string | vscode.MarkdownString) => {
+			responseParts.push(new vscode.ChatResponseMarkdownPart(value));
+		},
+		warning: (value: string | vscode.MarkdownString) => {
+			responseParts.push(new vscode.ChatResponseWarningPart(value));
+		},
+		textEdit: (target: vscode.Uri, edits: vscode.TextEdit | vscode.TextEdit[] | true) => {
+			if (edits === true) {
+				responseParts.push(new vscode.ChatResponseTextEditPart(target, true));
+			} else {
+				responseParts.push(new vscode.ChatResponseTextEditPart(target, edits));
+			}
+		},
+	});
+
+	const getResponseParts = () => ({
+		markdown: responseParts.filter(p => p instanceof vscode.ChatResponseMarkdownPart) as vscode.ChatResponseMarkdownPart[],
+		warnings: responseParts.filter(p => p instanceof vscode.ChatResponseWarningPart) as vscode.ChatResponseWarningPart[],
+		textEdits: responseParts.filter(p => p instanceof vscode.ChatResponseTextEditPart) as vscode.ChatResponseTextEditPart[]
+	});
+
+	setup(() => {
+		responseParts = [];
+		mockResponse = createMockResponse();
+		mockUri = vscode.Uri.file('/test/file.ts');
+		mockDocument = mock<vscode.TextDocument>({
+			uri: mockUri,
+			getText: () => 'test content',
+			positionAt: (offset: number) => new vscode.Position(0, offset)
+		});
+	});
+
+	test('DefaultTextProcessor handles regular text and warning tags', async () => {
+		const processor = new DefaultTextProcessor(mockResponse);
+
+		await processor.process('Some text ');
+		await processor.process('<warning>This is a warning</warning>');
+		await processor.process(' more text');
+		await processor.flush();
+
+		const { markdown, warnings, textEdits } = getResponseParts();
+		const combinedMarkdown = markdown.map(p => p.value.value).join('');
+
+		assert.strictEqual(combinedMarkdown, 'Some text  more text');
+		assert.strictEqual(warnings.length, 1);
+		assert.strictEqual(textEdits.length, 0);
+	});
+
+	test('ReplaceSelectionProcessor handles text and replaceSelection tags', async () => {
+		const selection = new vscode.Selection(0, 0, 0, 5);
+		const defaultTextProcessor = new DefaultTextProcessor(mockResponse);
+		const processor = new ReplaceSelectionProcessor(mockUri, selection, mockResponse, defaultTextProcessor);
+
+		await processor.process('Some text ');
+		await processor.process('<warning>This is a warning</warning>');
+		await processor.process(' more text');
+		await processor.process('<replaceSelection>Replaced content</replaceSelection>');
+		await processor.flush();
+
+		const { markdown, warnings, textEdits } = getResponseParts();
+		const combinedMarkdown = markdown.map(p => p.value.value).join('');
+
+		assert.strictEqual(combinedMarkdown, 'Some text  more text');
+		assert.strictEqual(warnings.length, 1);
+		assert.strictEqual(warnings[0].value.value, 'This is a warning');
+		assert.strictEqual(textEdits.length, 2);
+
+		// First edit deletes selection, second edit inserts new content
+		assert.strictEqual(textEdits[0].edits[0].newText, '');
+		assert.strictEqual(textEdits[1].edits[0].newText, 'Replaced content');
+	});
+
+	test('ReplaceStringProcessor handles text and replaceString tags', async () => {
+		const defaultTextProcessor = new DefaultTextProcessor(mockResponse);
+		const processor = new ReplaceStringProcessor(mockDocument, mockResponse, defaultTextProcessor);
+
+		await processor.process('<warning>This is a warning</warning>');
+		await processor.process('Before ');
+		await processor.process('<replaceString><old>test content</old><new>new content</new></replaceString>');
+		await processor.process(' after');
+		await processor.flush();
+
+		const { markdown, warnings, textEdits } = getResponseParts();
+		const combinedMarkdown = markdown.map(p => p.value.value).join('');
+
+		assert.strictEqual(combinedMarkdown, 'Before  after');
+		assert.strictEqual(warnings.length, 1);
+		assert.strictEqual(warnings[0].value.value, 'This is a warning');
+		assert.strictEqual(textEdits.length, 2);
+
+		// First edit deletes old text, second edit inserts new text
+		assert.strictEqual(textEdits[0].edits[0].newText, '');
+		assert.strictEqual(textEdits[1].edits[0].newText, 'new content');
+	});
+});


### PR DESCRIPTION
### Summary

Handle and display warnings when destructive, dangerous, or hard-to-reverse actions, such as deleting files or directories are suggested.

- addresses https://github.com/posit-dev/positron/issues/8674

#### Prompt changes
- updated prompts to include guidance on how to format the warning tags `<warning>WARNING TEXT HERE</warning>`
    - new prompt file `warning.md`: used across all chat modes on when/how to include a warning
    - new prompt file `warningStreaming.md`: slightly different warning prompt for when we are streaming code changes, to avoid verbosity in the inline chat
    - updated `terminal.md` to have terminal-specific warning handling; it's heavily based on `warning.md`
    - updated `agent.md` prompt to never delete the .git directory and to ensure a warning is included before any executeCode tool codeblock is shown
- Ask/edit/agent and inline editor all include the warning prompt now
- Terminal inline chat and editor streaming prompts also have warning prompts
- `explain` command also has the warning prompt

#### Text Processor updates
- added new `DefaultTextProcessor` class that parses output for `<warning>` tags and routes warning messages to the chat UI as warnings, while passing all other text as markdown. This processor is now used as the default for chat contexts that do not require streaming edits.
- refactored text processing logic to always use a processor: streaming edit processors (`ReplaceStringProcessor` and `ReplaceSelectionProcessor`) now delegate to the `DefaultTextProcessor` for plain text content, so that warnings can be shown during streaming edits
- made a bunch of methods async as I was running into timing issues when creating the integration test
- added integration test

#### Preview

<img height="500" alt="image" src="https://github.com/user-attachments/assets/e6fa585b-9b46-4eb6-96d0-9486c936f5a9" />

<img width="1714" height="1077" alt="warnings" src="https://github.com/user-attachments/assets/25cf3044-7768-482b-8ff0-e6323e91b2fa" />

### Release Notes

#### New Features

- Assistant: show a warning when destructive code/actions are suggested (#8674)

### QA Notes

@:assistant

- Adds an integration test to test the text processors
- Warnings should show when destructive operations are presented for:
    - Ask mode
    - Edit mode
    - Agent mode
    - Inline Chat
    - Terminal Chat
    - when `/explain` is used
- YCMV (your comfort may vary) in terms of what prompts you're willing to test with, especially with Agent mode and in the Terminal inline chat 😄 