### PR TITLE
e2e: expand data explorer clipboard to include copy column data via context menu

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -321,6 +321,17 @@ export class DataGrid {
 	}
 
 	/**
+	 * Copy a column by its position
+	 * @param colPosition (position is 0-based)
+	 */
+	async copyColumn(colPosition: number) {
+		await test.step(`Copy column at 0-based position: ${colPosition}`, async () => {
+			await this.jumpToStart(); // make sure we are at the start so our index is accurate
+			await this.selectColumnAction(colPosition + 1, 'Copy Column'); // selectColumnAction is 1-based
+		});
+	}
+
+	/**
 	 * Pin a row by its position
 	 * @param rowPosition (position is 0-based)
 	 */
@@ -360,10 +371,11 @@ export class DataGrid {
 	/**
 	 * Click a column header by its title
 	 * @param columnTitle The exact title of the column to click
+	 * @param options Optional parameters (e.g., right-click)
 	 */
-	async clickColumnHeader(columnTitle: string) {
+	async clickColumnHeader(columnTitle: string, options?: { button: 'left' | 'right' }) {
 		await test.step(`Click column header: ${columnTitle}`, async () => {
-			await this.columnHeaders.getByText(columnTitle).click();
+			await this.columnHeaders.getByText(columnTitle).click({ button: options?.button ?? 'left' });
 		});
 	}
 
@@ -961,4 +973,4 @@ export interface ColumnProfile {
 
 export type CellPosition = { row: number; col: number };
 
-export type ColumnRightMenuOption = 'Copy' | 'Select Column' | 'Pin Column' | 'Unpin Column' | 'Sort Ascending' | 'Sort Descending' | 'Clear Sorting' | 'Add Filter';
+export type ColumnRightMenuOption = 'Copy Column' | 'Select Column' | 'Pin Column' | 'Unpin Column' | 'Sort Ascending' | 'Sort Descending' | 'Clear Sorting' | 'Add Filter';

--- a/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
@@ -61,7 +61,7 @@ for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of te
 		test(`${env} - Copy and paste works on cells, rows, columns, and ranges of unsorted data`, async function ({ app }) {
 			const { dataExplorer, clipboard } = app.workbench;
 
-			// verify copy and paste on columns
+			// verify copy and paste on column (via shortcut)
 			await dataExplorer.grid.clickColumnHeader('column3');
 			await clipboard.copy();
 			await clipboard.expectClipboardTextToBe(expectedData['col3'], '\n');
@@ -80,6 +80,12 @@ for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of te
 			await dataExplorer.grid.selectRange({ start: { row: 0, col: 0 }, end: { row: 1, col: 1 } });
 			await clipboard.copy();
 			await clipboard.expectClipboardTextToBe(expectedData['col0_col1'], '\n');
+
+			// verify copy and paste on column (via context menu)
+			await dataExplorer.grid.clickCell(0, 0);
+			await dataExplorer.grid.copyColumn(3)
+			await clipboard.copy();
+			await clipboard.expectClipboardTextToBe(expectedData['col3'], '\n');
 		});
 
 		test(`${env} - Copy and paste works on cells, rows, columns, and ranges of sorted data`, async function ({ app }) {


### PR DESCRIPTION
### Summary

Updating the `data-explorer-clipboard.test.ts` to include a test case that verifies the correct behavior of copying a column using the context menu. Refer to the related issue: https://github.com/posit-dev/positron/issues/9315


### QA Notes

@:data-explorer @:web @:win
