### PR TITLE
Use CodeOSS version for extension update check

### DIFF
--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -14,6 +14,9 @@ export interface IUpdate {
 	timestamp?: number;
 	url?: string;
 	sha256hash?: string;
+	// --- Start Positron ---
+	codeoss_version?: string;
+	// --- End Positron ---
 }
 
 /**

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -2172,13 +2172,11 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			case StateType.Updating:
 			case StateType.Ready: {
 				// --- Start Positron ---
-				// Removing for now until the release update metadata populates with the CodeOSS version
-				/*
-				const version = this.updateService.state.update.productVersion;
+				// Use codeoss_version from the Positron update data
+				const version = this.updateService.state.update.codeoss_version;
 				if (version && semver.valid(version)) {
 					return { version, date: this.updateService.state.update.timestamp ? new Date(this.updateService.state.update.timestamp).toISOString() : undefined };
 				}
-				*/
 				// --- End Positron ---
 			}
 		}


### PR DESCRIPTION
Address #9533 

Re-enables using the CodeOSS version when checking for extension updates. This would reduce the amount of extension updates by updating extensions to a version that is supported by the pending Positron update.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Use CodeOSS version when checking for extension updates


### QA Notes
Testing can be done against the `dailies` update channel. Those builds are currently including `codeoss_version` in the update metadata. Release builds will include it as well on the next build published to the `releases` update channel.

For testing in dev, turn off auto-updates and set the update channel to `dailies`. Auto-updates don't work in dev and it will disable the update service if enabled.