### PR TITLE
2437 undo redo for cell level changes

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -10,6 +10,7 @@ import { SelectionStateMachine } from './selectionMachine.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { PositronNotebookContextKeyManager } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
 /**
  * Represents the possible states of a notebook's kernel connection
  */
@@ -103,6 +104,12 @@ export interface IPositronNotebookInstance {
 	 * Indicates whether this notebook is read-only and cannot be edited.
 	 */
 	readonly isReadOnly: boolean;
+
+	/**
+	 * Context key manager for this notebook instance. Used to manage notebook-specific
+	 * context keys that are scoped to the notebook's DOM container.
+	 */
+	readonly contextManager: PositronNotebookContextKeyManager;
 
 	/**
 	 * Event that fires when the cells container is scrolled

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../common/contributions.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { UndoCommand, RedoCommand } from '../../../../../../editor/browser/editorExtensions.js';
+import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
+import { PositronNotebookEditorInput } from '../../PositronNotebookEditorInput.js';
+import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
+import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+
+class PositronNotebookUndoRedoContribution extends Disposable {
+
+	static readonly ID = 'workbench.contrib.positronNotebookUndoRedo';
+
+	constructor(
+		@IEditorService private readonly editorService: IEditorService,
+		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
+		@IPositronNotebookService private readonly positronNotebookService: IPositronNotebookService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
+	) {
+		super();
+
+		const PRIORITY = 105;
+
+		this._register(UndoCommand.addImplementation(PRIORITY, 'positron-notebook-undo-redo', () => this.handleUndo()));
+		this._register(RedoCommand.addImplementation(PRIORITY, 'positron-notebook-undo-redo', () => this.handleRedo()));
+	}
+
+	private shouldHandleUndoRedo(): boolean {
+		const activeEditor = this.editorService.activeEditor;
+		if (!(activeEditor instanceof PositronNotebookEditorInput)) {
+			return false;
+		}
+
+		// Get the active notebook instance to access its scoped context key service
+		const instance = this.positronNotebookService.getActiveInstance();
+		if (!instance) {
+			return false;
+		}
+
+		// Use the notebook-specific scoped context key service instead of the global one
+		const scopedContextKeyService = instance.contextManager.getScopedContextKeyService();
+		if (!scopedContextKeyService) {
+			// Fallback to global context service if scoped service is not available
+			// This shouldn't happen in normal operation, but provides a safety net
+			const containerFocused = this.contextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED.key) ?? false;
+			const cellEditorFocused = this.contextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.key) ?? false;
+			// Handle undo/redo if either the container is focused OR a cell editor is focused
+			// This matches VS Code's behavior where notebook undo works regardless of specific focus location
+			return containerFocused || cellEditorFocused;
+		}
+
+		// Read context keys from the scoped context service that actually has these keys bound
+		const containerFocused = scopedContextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED.key) ?? false;
+		const cellEditorFocused = scopedContextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.key) ?? false;
+
+		// Handle undo/redo if either the container is focused OR a cell editor is focused
+		// This allows undo to work even when typing in a cell (common after adding a new cell)
+		return containerFocused || cellEditorFocused;
+	}
+
+	private handleUndo(): boolean | Promise<void> {
+		if (!this.shouldHandleUndoRedo()) {
+			return false;
+		}
+
+		const instance = this.positronNotebookService.getActiveInstance();
+		if (!instance) {
+			return false;
+		}
+
+		if (!this.undoRedoService.canUndo(instance.uri)) {
+			return false;
+		}
+
+		const result = this.undoRedoService.undo(instance.uri);
+		return result ?? true;
+	}
+
+	private handleRedo(): boolean | Promise<void> {
+		if (!this.shouldHandleUndoRedo()) {
+			return false;
+		}
+
+		const instance = this.positronNotebookService.getActiveInstance();
+		if (!instance) {
+			return false;
+		}
+
+		if (!this.undoRedoService.canRedo(instance.uri)) {
+			return false;
+		}
+
+		const result = this.undoRedoService.redo(instance.uri);
+		return result ?? true;
+	}
+}
+
+registerWorkbenchContribution2(
+	PositronNotebookUndoRedoContribution.ID,
+	PositronNotebookUndoRedoContribution,
+	WorkbenchPhase.BlockRestore
+);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -5,10 +5,8 @@
 
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../common/contributions.js';
-import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { UndoCommand, RedoCommand } from '../../../../../../editor/browser/editorExtensions.js';
 import { IPositronNotebookService } from '../../../../../services/positronNotebook/browser/positronNotebookService.js';
-import { PositronNotebookEditorInput } from '../../PositronNotebookEditorInput.js';
 import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../../../../services/positronNotebook/browser/ContextKeysManager.js';
 import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
@@ -18,7 +16,6 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 	static readonly ID = 'workbench.contrib.positronNotebookUndoRedo';
 
 	constructor(
-		@IEditorService private readonly editorService: IEditorService,
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
 		@IPositronNotebookService private readonly positronNotebookService: IPositronNotebookService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService
@@ -32,11 +29,6 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 	}
 
 	private shouldHandleUndoRedo(): boolean {
-		const activeEditor = this.editorService.activeEditor;
-		if (!(activeEditor instanceof PositronNotebookEditorInput)) {
-			return false;
-		}
-
 		// Get the active notebook instance to access its scoped context key service
 		const instance = this.positronNotebookService.getActiveInstance();
 		if (!instance) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -128,11 +128,11 @@ export function registerCellCommand({
 	if (keybinding) {
 		// Determine the when condition based on edit mode
 		const defaultCondition = editMode ?
-			POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED :
-			ContextKeyExpr.and( // When the command is not an "editMode" command, don't let it run when the cell editor is focused
+			ContextKeyExpr.or(
 				POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
-				POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
-			);
+				POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED
+			) :
+			POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED;
 
 		// Combine top-level `when` with keybinding.when (or default) using AND when both exist
 		const combinedKbWhen = when ? ContextKeyExpr.and(when, defaultCondition) : defaultCondition;

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -38,6 +38,7 @@ import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.j
 import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 import { SelectionState } from './selectionMachine.js';
 import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS } from '../../../services/positronNotebook/browser/ContextKeysManager.js';
+import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 
@@ -281,26 +282,26 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 //#region Notebook Commands
 registerNotebookCommand({
-	commandId: 'positronNotebook.focusUp',
+	commandId: 'positronNotebook.selectUp',
 	handler: (notebook) => notebook.selectionStateMachine.moveUp(false),
 	keybinding: {
 		primary: KeyCode.UpArrow,
 		secondary: [KeyCode.KeyK]
 	},
 	metadata: {
-		description: localize('positronNotebook.focusUp', "Move focus up")
+		description: localize('positronNotebook. selectUp', "Move focus up")
 	}
 });
 
 registerNotebookCommand({
-	commandId: 'positronNotebook.focusDown',
+	commandId: 'positronNotebook.selectDown',
 	handler: (notebook) => notebook.selectionStateMachine.moveDown(false),
 	keybinding: {
 		primary: KeyCode.DownArrow,
 		secondary: [KeyCode.KeyJ]
 	},
 	metadata: {
-		description: localize('positronNotebook.focusDown', "Move focus down")
+		description: localize('positronNotebook. selectDown', "Move focus down")
 	}
 });
 
@@ -594,10 +595,12 @@ registerCellCommand({
 		// If this is the last cell, insert a new cell below of the same type
 		if (cell.isLastCell()) {
 			notebook.addCell(cell.kind, cell.index + 1);
+			// Don't call moveDown - addCell triggers SelectionStateMachine._setCells()
+			// which already handles selection and focus of the new cell in Edit mode
+		} else {
+			// Only move down if we didn't add a cell
+			notebook.selectionStateMachine.moveDown(false);
 		}
-
-		// Move to the next cell
-		notebook.selectionStateMachine.moveDown(false);
 	},
 	editMode: true,  // Allow execution from edit mode
 	keybinding: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -289,7 +289,7 @@ registerNotebookCommand({
 		secondary: [KeyCode.KeyK]
 	},
 	metadata: {
-		description: localize('positronNotebook. selectUp', "Move focus up")
+		description: localize('positronNotebook.selectUp', "Move focus up")
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -15,6 +15,20 @@ export enum SelectionState {
 	EditingSelection = 'EditingSelection'
 }
 
+export enum OperationSource {
+	User = 'user',
+	UndoRedo = 'undoRedo',
+	Unknown = 'unknown'
+}
+
+export enum OperationType {
+	Add = 'add',
+	Delete = 'delete',
+	Cut = 'cut',
+	Paste = 'paste',
+	Unknown = 'unknown'
+}
+
 type SelectionStates =
 	| {
 		type: SelectionState.NoSelection;
@@ -108,6 +122,13 @@ export class SelectionStateMachine extends Disposable {
 		equalsFn: isSelectionStateEqual
 	}, { type: SelectionState.NoSelection });
 
+	/**
+	 * Tracks the context of the next operation to determine selection behavior
+	 */
+	private _operationContext?: {
+		type: OperationType;
+		source: OperationSource;
+	};
 
 	//#endregion Private Properties
 
@@ -255,6 +276,16 @@ export class SelectionStateMachine extends Disposable {
 		if (state.type !== SelectionState.EditingSelection) { return; }
 		state.selectedCell.defocusEditor();
 		this._setState({ type: SelectionState.SingleSelection, selected: [state.selectedCell] });
+	}
+
+	/**
+	 * Sets the context for the next operation to determine selection behavior.
+	 * This should be called before operations that will change cells.
+	 * @param type The type of operation being performed
+	 * @param source Whether this is user-initiated or from undo/redo
+	 */
+	setOperationContext(type: OperationType, source: OperationSource): void {
+		this._operationContext = { type, source };
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -2,11 +2,12 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-import { autorun, autorunDelta, IObservable, observableValueOpts } from '../../../../base/common/observable.js';
+import { autorunDelta, IObservable, observableValueOpts } from '../../../../base/common/observable.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 export enum SelectionState {
 	NoSelection = 'NoSelection',
@@ -145,9 +146,8 @@ export class SelectionStateMachine extends Disposable {
 		}));
 
 		// Update the selection state when cells change
-		this._register(autorun(reader => {
-			const cells = this._cells.read(reader);
-			this._setCells(cells);
+		this._register(autorunDelta(this._cells, ({ lastValue, newValue }) => {
+			this._setCells(newValue, lastValue);
 		}));
 	}
 	//#endregion Constructor & Dispose
@@ -173,11 +173,15 @@ export class SelectionStateMachine extends Disposable {
 	selectCell(cell: IPositronNotebookCell, selectType: CellSelectionType = CellSelectionType.Normal): void {
 		if (selectType === CellSelectionType.Normal) {
 			this._setState({ type: SelectionState.SingleSelection, selected: [cell] });
+			// Make sure to focus the cell
+			cell.focus();
 			return;
 		}
 
 		if (selectType === CellSelectionType.Edit) {
 			this._setState({ type: SelectionState.EditingSelection, selectedCell: cell });
+			// Make sure to focus the cell
+			cell.focus();
 			return;
 		}
 
@@ -292,35 +296,120 @@ export class SelectionStateMachine extends Disposable {
 
 
 	//#region Private Methods
+
+	/**
+	 * Handles selection or entering of editor for a cell.
+	 * Because these operations work on the dom, we need to wait for the dom to be updated before performing the operation.
+	 * @param cell The cell to handle.
+	 * @param operation The operation to perform.
+	 */
+	private _handleCellOperation(cell: IPositronNotebookCell, operation: 'focus' | 'enterEditor'): void {
+		this._register(disposableTimeout(() => {
+			// Use requestAnimationFrame to ensure DOM is fully rendered before focusing
+			mainWindow.requestAnimationFrame(() => {
+				if (operation === 'focus') {
+					cell.focus();
+				} else if (operation === 'enterEditor') {
+					// First focus the cell, then enter the editor
+					cell.focus();
+					this.enterEditor();
+				}
+			});
+		}, 0));
+	}
+
 	/**
 	 * Updates the selection state when cells change.
 	 *
 	 * @param cells The new cells to set.
+	 * @param previousCells The previous cells array (undefined on initial call).
 	 */
-	private _setCells(cells: IPositronNotebookCell[]): void {
+	private _setCells(cells: IPositronNotebookCell[], previousCells?: IPositronNotebookCell[]): void {
+		// Handle initial case where there are no previous cells
+		if (!previousCells) {
+			return;
+		}
+
+		// Early exit if no changes
+		if (cells.length === previousCells.length && cells.every((cell, i) => cell === previousCells[i])) {
+			return;
+		}
+
+		// Determine the source of the operation
+		const operationSource = this._operationContext?.source ?? OperationSource.Unknown;
+		// Note: operationType is available via this._operationContext?.type if needed in the future
+
+		// Clear the operation context after reading it
+		this._operationContext = undefined;
+
 		const state = this._state.get();
+		const hasSelection = state.type !== SelectionState.NoSelection;
 
-		if (state.type === SelectionState.NoSelection) {
+		// Detect changes
+		const newlyAddedCells = cells.filter(cell => !previousCells.includes(cell));
+		const deletedCells = previousCells.filter(cell => !cells.includes(cell));
+
+		const singleCellAdded = newlyAddedCells.length === 1;
+		const cellsWereDeleted = hasSelection && deletedCells.length > 0;
+
+		// Early exit if no selection and no cells added to handle
+		if (!hasSelection && newlyAddedCells.length === 0) {
 			return;
 		}
 
-		// If we're editing a cell when setCells is called. We need to check if the cell is still in the new cells.
-		// If it isn't we need to reset the selection.
-		if (state.type === SelectionState.EditingSelection) {
-			if (!cells.includes(state.selectedCell)) {
-				this._setState({ type: SelectionState.NoSelection });
-				return;
+		// Determine if we should use aggressive selection (auto-edit) based on source
+		const useAggressiveSelection = operationSource === OperationSource.User;
+
+		// Handle cell additions
+		if (newlyAddedCells.length > 0) {
+			if (singleCellAdded) {
+				// For single cell addition, decide between edit mode or normal selection
+				if (useAggressiveSelection) {
+					// First select the cell (SingleSelection state), then transition to edit mode
+					// This must be SingleSelection for enterEditor() to work correctly
+					this._setState({ type: SelectionState.SingleSelection, selected: [newlyAddedCells[0]] });
+					// Defer focus and entering the editor until DOM is ready
+					this._handleCellOperation(newlyAddedCells[0], 'enterEditor');
+				} else {
+					// Conservative selection for undo/redo - just select, don't edit
+					// Set state immediately but defer focus until DOM is ready
+					this._setState({ type: SelectionState.SingleSelection, selected: [newlyAddedCells[0]] });
+					this._handleCellOperation(newlyAddedCells[0], 'focus');
+				}
+			} else {
+				// Multiple cells added - select the first one
+				// Set state immediately but defer focus until DOM is ready
+				this._setState({ type: SelectionState.SingleSelection, selected: [newlyAddedCells[0]] });
+				this._handleCellOperation(newlyAddedCells[0], 'focus');
 			}
-			return;
+		} else if (cellsWereDeleted) {
+			// Handle deletions the same way regardless of source
+			const deletedCellsIndices = deletedCells.map(c => previousCells.indexOf(c));
+			this._handleCellDeletion(deletedCells, deletedCellsIndices, previousCells.length);
+		} else {
+			// Maintain existing selection, filtering out cells that no longer exist
+			this._maintainSelectionAfterChange(cells);
 		}
+	}
 
-		const newSelection = state.selected.filter(c => cells.includes(c));
-		if (newSelection.length === 0) {
-			this._setState({ type: SelectionState.NoSelection });
-			return;
+	/**
+	 * Maintains selection after cells change, filtering out cells that no longer exist
+	 */
+	private _maintainSelectionAfterChange(cells: IPositronNotebookCell[]): void {
+		const currentState = this._state.get();
+		if (currentState.type !== SelectionState.NoSelection) {
+			const selectedCells = currentState.type === SelectionState.EditingSelection
+				? [currentState.selectedCell]
+				: currentState.selected;
+			const newSelection = selectedCells.filter(c => cells.includes(c));
+
+			if (newSelection.length > 0) {
+				this._setState({
+					type: newSelection.length === 1 ? SelectionState.SingleSelection : SelectionState.MultiSelection,
+					selected: newSelection
+				});
+			}
 		}
-
-		this._setState({ type: newSelection.length === 1 ? SelectionState.SingleSelection : SelectionState.MultiSelection, selected: newSelection });
 	}
 
 	private _setState(state: SelectionStates) {
@@ -441,6 +530,79 @@ export class SelectionStateMachine extends Disposable {
 
 		nextCell.focus();
 	}
+
+	/**
+	 * Handles the deletion of cells from the notebook.
+	 * Manages selection state when selected cells are deleted.
+	 *
+	 * @param deletedCells Array of cells that were deleted
+	 * @param startingCellCount The number of cells before deletion
+	 */
+	private _handleCellDeletion(deletedCells: IPositronNotebookCell[], deletedCellIndices: number[], startingCellCount: number): void {
+		if (deletedCells.length === 0) {
+			return;
+		}
+
+		const selectedCells = getSelectedCells(this._state.get());
+		const deletedSelectedCells = deletedCells.filter(deletedCell =>
+			selectedCells.some(selectedCell => selectedCell === deletedCell)
+		);
+
+		if (deletedSelectedCells.length === 0) {
+			// No selected cells were deleted, nothing to do
+			return;
+		}
+
+		// Check if there will be no selected cells left after deletion
+		const remainingSelectedCells = selectedCells.filter(selectedCell =>
+			!deletedCells.includes(selectedCell)
+		);
+
+		if (remainingSelectedCells.length === 0) {
+			// Use the helper method to determine where selection should be placed
+			const suggestedFocusIndex = this._determineFocusAfterDeletion(deletedCellIndices, startingCellCount);
+
+			// Set focus on the suggested cell after sync completes
+			if (suggestedFocusIndex !== null && suggestedFocusIndex < this._cells.get().length) {
+				const cellToFocus = this._cells.get()[suggestedFocusIndex];
+				if (cellToFocus) {
+					this.selectCell(cellToFocus, CellSelectionType.Normal);
+					this._handleCellOperation(cellToFocus, 'focus');
+				}
+			} else {
+				// No cells remain, clear selection
+				this._setState({ type: SelectionState.NoSelection });
+			}
+		}
+		// If some selected cells remain, the existing _setCells logic will handle updating the selection
+	}
+
+	/**
+	 * Determines which cell should receive focus after deleting the specified cell indices.
+	 * @param cellIndices Array of cell indices being deleted (assumed to be sorted)
+	 * @param originalCellCount Total number of cells before deletion
+	 * @returns The index of the cell that should receive focus, or null if no cells remain
+	 */
+	private _determineFocusAfterDeletion(cellIndices: number[], originalCellCount: number): number | null {
+		const lowestDeletedIndex = Math.min(...cellIndices);
+		const totalCellsToDelete = cellIndices.length;
+		const newCellCount = originalCellCount - totalCellsToDelete;
+
+		// Determine the index of the cell that should receive focus after deletion
+		let targetFocusIndex: number | null = null;
+		if (newCellCount > 0) {
+			if (lowestDeletedIndex < newCellCount) {
+				// Focus on the cell that takes the place of the first deleted cell
+				targetFocusIndex = lowestDeletedIndex;
+			} else {
+				// We deleted from the end, focus on the last remaining cell
+				targetFocusIndex = newCellCount - 1;
+			}
+		}
+
+		return targetFocusIndex;
+	}
+
 	//#endregion Private Methods
 
 }

--- a/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
@@ -132,5 +132,25 @@ export class PositronNotebookContextKeyManager extends Disposable {
 		}));
 	}
 
+	/**
+	 * Gets the scoped context key service for this notebook editor.
+	 * This is the context service that has access to notebook-specific context keys.
+	 * @returns The scoped context key service, or undefined if no container has been set
+	 */
+	getScopedContextKeyService(): IContextKeyService | undefined {
+		return this._scopedContextKeyService;
+	}
+
+	/**
+	 * Manually set the container focused state.
+	 * This is needed because DOM.trackFocus doesn't fire blur events when a child element
+	 * (like a Monaco editor) gets focus. We need to manually coordinate this with the
+	 * cell editing state to ensure the context key is accurate.
+	 * @param focused - Whether the container should be considered focused
+	 */
+	setContainerFocused(focused: boolean): void {
+		this.positronEditorFocus?.set(focused);
+	}
+
 	//#endregion Public Methods
 }

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -393,7 +393,8 @@ export class PositronNotebooks extends Notebooks {
 	async getCellContent(cellIndex: number): Promise<string> {
 		const cell = this.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
 		const editor = cell.locator('.positron-cell-editor-monaco-widget .view-lines');
-		const content = await editor.textContent();
-		return content ?? '';
+		const content = await editor.textContent() ?? '';
+		// Replace the weird ascii space with a proper space
+		return content.replace(/\u00a0/g, ' ');
 	}
 }

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -53,7 +53,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(2);
 
 		// Verify cell 2 has correct content before deletion
-		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
 
 		// Delete the selected cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(2);
@@ -62,7 +62,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(5);
 
 		// Verify what was cell 3 is now at index 2
-		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 2: Delete another cell (cell 3, originally cell 4)
@@ -71,7 +71,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(3);
 
 		// Verify cell 3 has correct content before deletion
-		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 4');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 4');
 
 		// Delete the selected cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(3);
@@ -80,16 +80,16 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(4);
 
 		// Verify the remaining cells are correct
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
-		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
-		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
-		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 5');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 5');
 
 		// ========================================
 		// Test 3: Delete last cell (cell 3, contains '# Cell 5')
 		// ========================================
 		// Verify we're at the last cell with correct content
-		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 5');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 5');
 
 		// Delete the last cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(3);
@@ -98,15 +98,15 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(3);
 
 		// Verify remaining cells
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
-		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
-		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 4: Delete first cell (cell 0)
 		// ========================================
 		// Verify we're at the first cell with correct content
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
 
 		// Delete the first cell using action bar
 		await app.workbench.notebooksPositron.deleteCellWithActionBar(0);
@@ -115,8 +115,8 @@ test.describe('Cell Deletion Action Bar Behavior', {
 		expect(await getCellCount(app)).toBe(2);
 
 		// Verify what was cell 1 is now at index 0
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 1');
-		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 3');
 
 		// ========================================
 		// Test 5: Delete remaining cells
@@ -132,7 +132,7 @@ test.describe('Cell Deletion Action Bar Behavior', {
 
 		// Verify we have exactly one cell remaining with the correct content
 		expect(await getCellCount(app)).toBe(1);
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 3');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 3');
 
 		// ========================================
 		// Cleanup

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -107,7 +107,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify cell 2 is selected and has correct content
 		expect(await getFocusedCellIndex(app)).toBe(2);
-		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell 2');
 
 		// Copy the cell
 		await copyCellsWithKeyboard(app);
@@ -123,7 +123,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		expect(await getCellCount(app)).toBe(6);
 
 		// Verify the pasted cell has the correct content (should be at index 5)
-		expect(await app.workbench.notebooksPositron.getCellContent(5)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(5)).toBe('# Cell 2');
 
 		// Focus should be on the pasted cell
 		expect(await getFocusedCellIndex(app)).toBe(5);
@@ -134,7 +134,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(1);
 
 		// Verify we're at cell 1 with correct content
-		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 1');
 
 		// Cut the cell
 		await cutCellsWithKeyboard(app);
@@ -144,7 +144,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Focus should move to what was cell 2 (now at index 1)
 		expect(await getFocusedCellIndex(app)).toBe(1);
-		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 2');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell 2');
 
 		// Move to index 3 and paste
 		await app.workbench.notebooksPositron.selectCellAtIndex(3);
@@ -154,7 +154,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		expect(await getCellCount(app)).toBe(6);
 
 		// Verify the pasted cell has correct content at index 4
-		expect(await app.workbench.notebooksPositron.getCellContent(4)).toBe('# Cell 1');
+		expect(await app.workbench.notebooksPositron.getCellContent(4)).toBe('# Cell 1');
 
 		// Focus should be on the pasted cell
 		expect(await getFocusedCellIndex(app)).toBe(4);
@@ -165,7 +165,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 		await app.workbench.notebooksPositron.selectCellAtIndex(0);
 
 		// Copy cell 0
-		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Cell 0');
 		await copyCellsWithKeyboard(app);
 
 		// Paste at position 2
@@ -174,7 +174,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify first paste
 		expect(await getCellCount(app)).toBe(7);
-		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(3)).toBe('# Cell 0');
 
 		// Paste again at position 5
 		await app.workbench.notebooksPositron.selectCellAtIndex(5);
@@ -182,7 +182,7 @@ test.describe('Notebook Cell Copy-Paste Behavior', {
 
 		// Verify second paste
 		expect(await getCellCount(app)).toBe(8);
-		expect(await app.workbench.notebooksPositron.getCellContent(6)).toBe('# Cell 0');
+		expect(await app.workbench.notebooksPositron.getCellContent(6)).toBe('# Cell 0');
 
 		// ========================================
 		// Test 4: Cut and paste at beginning of notebook

--- a/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra/index.js';
+import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * Helper function to get cell count
+ */
+async function getCellCount(app: Application): Promise<number> {
+	return await app.code.driver.page.locator('[data-testid="notebook-cell"]').count();
+}
+
+/**
+ * Helper function to perform undo using keyboard shortcut
+ */
+async function undoWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+	await app.code.driver.page.keyboard.press(`${modifierKey}+KeyZ`);
+}
+
+/**
+ * Helper function to perform redo using keyboard shortcut
+ */
+async function redoWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+	await app.code.driver.page.keyboard.press(`${modifierKey}+Shift+KeyZ`);
+}
+
+/**
+ * Helper function to delete a cell using keyboard shortcut
+ */
+async function deleteCellWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	await app.code.driver.page.keyboard.press('Backspace');
+}
+
+/**
+ * Helper function to add a code cell below using keyboard shortcut
+ */
+async function addCodeCellBelowWithKeyboard(app: Application): Promise<void> {
+	// We need to press escape to get the focus out of the cell editor itself
+	await app.code.driver.page.keyboard.press('Escape');
+	await app.code.driver.page.keyboard.press('KeyB');
+}
+
+// Not running on web due to https://github.com/posit-dev/positron/issues/9193
+test.describe('Notebook Cell Undo-Redo Behavior', {
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+		// Configure Positron as the notebook editor
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+	});
+
+	test('Cell undo-redo behavior - comprehensive test', async function ({ app }) {
+		// Setup: Create notebook
+		await app.workbench.notebooks.createNewNotebook();
+		await app.workbench.notebooksPositron.expectToBeVisible();
+
+		// ========================================
+		// Test 1: Basic add cell and undo/redo
+		// ========================================
+		// Start with initial cell
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Initial Cell', 0);
+		expect(await getCellCount(app)).toBe(1);
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Initial Cell');
+
+		// Add a second cell
+		await app.workbench.notebooksPositron.selectCellAtIndex(0);
+		await addCodeCellBelowWithKeyboard(app);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Second Cell', 1);
+		expect(await getCellCount(app)).toBe(2);
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Second Cell');
+
+		// Undo the add cell operation
+		await undoWithKeyboard(app);
+		expect(await getCellCount(app)).toBe(1);
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Initial Cell');
+
+		// Redo the add cell operation
+		await redoWithKeyboard(app);
+		expect(await getCellCount(app)).toBe(2);
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Second Cell');
+
+		// ========================================
+		// Test 2: Delete cell and undo/redo
+		// ========================================
+		// Add a third cell for deletion test
+		await app.workbench.notebooksPositron.selectCellAtIndex(1);
+		await addCodeCellBelowWithKeyboard(app);
+		await app.workbench.notebooksPositron.addCodeToCellAtIndex('# Cell to Delete', 2);
+		expect(await getCellCount(app)).toBe(3);
+
+		// Delete the middle cell
+		await app.workbench.notebooksPositron.selectCellAtIndex(1);
+		await deleteCellWithKeyboard(app);
+		expect(await getCellCount(app)).toBe(2);
+		expect(await app.workbench.notebooksPositron.getCellContent(0)).toBe('# Initial Cell');
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell to Delete');
+
+		// Undo the delete
+		await undoWithKeyboard(app);
+		expect(await getCellCount(app)).toBe(3);
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Second Cell');
+		expect(await app.workbench.notebooksPositron.getCellContent(2)).toBe('# Cell to Delete');
+
+		// Redo the delete
+		await redoWithKeyboard(app);
+		expect(await getCellCount(app)).toBe(2);
+		expect(await app.workbench.notebooksPositron.getCellContent(1)).toBe('# Cell to Delete');
+
+		// ========================================
+		// Cleanup
+		// ========================================
+		// Close the notebook without saving
+		await app.workbench.notebooks.closeNotebookWithoutSaving();
+	});
+});


### PR DESCRIPTION
Addresses #2437.

### Summary

This PR implements cell-level undo/redo functionality for Positron notebooks. Previously, undo/redo only worked within cell editors (text editing). Now users can undo/redo structural operations like adding cells, deleting cells, cutting, and pasting.

The implementation uses an operation tracking system to distinguish between user-initiated actions and undo/redo operations. This enables intelligent selection behavior where user actions auto-enter edit mode for new cells, while undo/redo operations only select cells without editing.

**Key technical changes:**
- Added operation context tracking (user vs undo/redo, operation type)
- Refactored selection state machine to handle cell changes based on operation context
- Implemented custom undo/redo command handler for notebook operations
- Fixed readonly checks and removed obsolete manual selection code

This PR also addresses a regression introduced in the context keys PR where we were over-eager to run some keyboard shortcuts when editing a cell. 

### Release Notes

#### New Features

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:critical

**Manual Testing:**

Test basic undo/redo operations:

1. Create a new notebook (Python or R)
2. Add initial content to the first cell: `# Initial Cell`
3. Press <kbd>Escape</kbd> to exit edit mode
4. Press <kbd>B</kbd> to add a cell below
5. Type `# Second Cell` in the new cell
6. Press <kbd>Escape</kbd> then <kbd>Cmd/Ctrl+Z</kbd> to undo
   - **Expected:** Second cell is removed, focus returns to first cell
7. Press <kbd>Cmd/Ctrl+Shift+Z</kbd> to redo
   - **Expected:** Second cell reappears and is selected (not in edit mode)
8. Select the second cell and press <kbd>Backspace</kbd> to delete it
9. Press <kbd>Cmd/Ctrl+Z</kbd> to undo deletion
   - **Expected:** Cell reappears
10. Select a cell, press <kbd>Cmd/Ctrl+X</kbd> to cut it
11. Select another position, press <kbd>Cmd/Ctrl+V</kbd> to paste
12. Press <kbd>Cmd/Ctrl+Z</kbd> twice to undo paste and cut
    - **Expected:** Cells return to original positions

**Automated Testing:**

The PR includes a simple E2E test scaffold in `test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts` 
This can be used as a starting point to create more robust and comprehensive e2e tests. 

Run the notebook undo/redo tests specifically:
```bash
npx playwright test positron-notebook-undo-redo --project e2e-electron
```
