### PR TITLE
notebooks: fix modal language; e2e test

### DIFF
--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -225,7 +225,7 @@ export class TestDirectoryFileService implements IFileService {
 	canDelete(): Promise<true | Error> { return Promise.resolve(true); }
 	exists(): Promise<boolean> { return Promise.resolve(true); }
 	resolve(): Promise<IFileStatWithMetadata> { return this.stat(URI.file('/')); }
-	realpath(): Promise<URI> { return Promise.resolve(URI.file('/')); }
+	realpath(resource: URI): Promise<URI> { return Promise.resolve(resource); }
 	resolveAll(): Promise<any[]> { return Promise.resolve([]); }
 	readFile(): Promise<any> { throw new Error('Not implemented'); }
 	readFileStream(): Promise<any> { throw new Error('Not implemented'); }

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -90,6 +90,9 @@ test.describe('Notebooks', {
 			await quickInput.type(path.join(app.workspacePathOrFolder, newFileName));
 			await quickInput.clickOkButton();
 
+			// Click 'Update' on the modal that popped up
+			await app.code.driver.page.getByRole('button', { name: 'Update' }).click();
+
 			// Verify the variables pane shows the correct notebook name
 			await variables.expectRuntimeToBe('visible', newFileName);
 
@@ -163,5 +166,3 @@ test.describe('Notebooks', {
 		});
 	});
 });
-
-

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -90,9 +90,6 @@ test.describe('Notebooks', {
 			await quickInput.type(path.join(app.workspacePathOrFolder, newFileName));
 			await quickInput.clickOkButton();
 
-			// Click 'Update' on the modal that popped up
-			await app.code.driver.page.getByRole('button', { name: 'Update' }).click();
-
 			// Verify the variables pane shows the correct notebook name
 			await variables.expectRuntimeToBe('visible', newFileName);
 


### PR DESCRIPTION
Addresses #9673. 

Fixes the paths displayed in the "update working directory?" modal so they don't display as relative if they're outside the workspace. 

Also resolves symlinks for them when checking for equality. This fixes the e2e test that was failing due to the modal popping up where it shouldn't have been because it was in a symlinked folder on MacOS.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:notebooks @:win @:web

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
Should I kick off a nightly run?