### PR TITLE
Prevent unnecessary fetch data calls that invalidate the cache

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -43,7 +43,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	/**
 	 * The current column name search filter text.
 	 */
-	private _searchText?: string;
+	private _searchText = '';
 
 	/**
 	 * The current sort option for the summary rows
@@ -516,12 +516,14 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @param searchText The search text used to filter column names (case insensitive).
 	 */
 	async setSearchText(searchText: string): Promise<void> {
-		this._searchText = searchText || undefined;
-		await this.updateLayoutEntries();
-		// invalidate the cache when the search and sort is removed
-		await this.fetchData(this.hasNoSearchOrSort());
-		// Force a re-render when the search or sort options change
-		this.fireOnDidUpdateEvent();
+		if (this._searchText !== searchText) {
+			this._searchText = searchText;
+			await this.updateLayoutEntries();
+			// invalidate the cache when the search and sort is removed
+			await this.fetchData(this.hasNoSearchOrSort());
+			// Force a re-render when the search or sort options change
+			this.fireOnDidUpdateEvent();
+		}
 	}
 
 	/**
@@ -529,12 +531,14 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @param sortOption The sort option used to order the rows.
 	 */
 	async setSortOption(sortOption: SearchSchemaSortOrder): Promise<void> {
-		this._sortOption = sortOption;
-		await this.updateLayoutEntries();
-		// invalidate the cache when the search and sort is removed
-		await this.fetchData(this.hasNoSearchOrSort());
-		// Force a re-render when the search or sort options change
-		this.fireOnDidUpdateEvent();
+		if (this._sortOption !== sortOption) {
+			this._sortOption = sortOption;
+			await this.updateLayoutEntries();
+			// invalidate the cache when the search and sort is removed
+			await this.fetchData(this.hasNoSearchOrSort());
+			// Force a re-render when the search or sort options change
+			this.fireOnDidUpdateEvent();
+		}
 	}
 
 	//#endregion Public Methods
@@ -547,7 +551,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @returns A value which indicates whether there is a search or sort option applied.
 	 */
 	private hasNoSearchOrSort(): boolean {
-		return this._searchText === undefined && this._sortOption === SearchSchemaSortOrder.Original;
+		return this._searchText === '' && this._sortOption === SearchSchemaSortOrder.Original;
 	}
 
 	/**


### PR DESCRIPTION
Addresses #9593

This PR addresses the sparkline double-rendering issue which was caused by:
- Incorrect initialization of `TableSummaryDataGridInstance._searchText`: `_searchText` was `undefined` when it should have been `''`
- Bad cache invalidation logic in `TableSummaryDataGridInstance.setSearchText` and `TableSummaryDataGridInstance.setSortOption`: Both functions were always calling `fetchData` and invalidating the cache every time regardless of search/sort state.

This issue wasn't noticeable for smaller datasets because column profile calculations are completed rapidly and made it so the intermittent cache invalidation wasn't noticeable during manual testing.

This issue was quite apparent when datasets had millions of rows because: we calculate column profile data in batches and in between those batched calculations we were invalidating the column profile data cache which undid all the calculation work and required us to recalculate it!

https://github.com/user-attachments/assets/09ab7294-a535-4080-9ad6-87489a3dde42


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix the column profile recalculation bug in Data Explorer (#9593)


### QA Notes
I think we should see an improvement in the performance tests for Data Explorer once this gets merged. It would be good to verify before closing the issue.

I used the `nyc-flights-data-py/flights-33million.py` file to test the changes since the issue was quite noticeable with this many rows.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer