### PR TITLE
Column profiles not updating alongside row filters

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -130,18 +130,17 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 		// Add the onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async state => {
-			// If search/sort is in progress, we need to be more careful about cache invalidation
-			if (!this.hasNoSearchOrSort()) {
-				// During search operations, update layout but preserve cache when possible
-				// This prevents search results from being wiped out by backend updates
-				await this.updateLayoutEntries(state);
-				// Only invalidate cache if we have no visible search/sort state
-				await this.fetchData(false);
-
-			} else {
+			if (this.hasNoSearchOrSort()) {
 				// No active search/sort, safe to do full update
 				await this.updateLayoutEntries(state);
 				await this.fetchData(true);
+			} else {
+				// During search operations, update layout but preserve cache when possible
+				// This prevents search results from being wiped out by backend updates
+				await this.updateLayoutEntries(state);
+				// If search/sort is in progress, we need to be more careful about cache invalidation
+				// Only invalidate cache if we have no visible search/sort state
+				await this.fetchData(false);
 			}
 		}));
 
@@ -497,14 +496,14 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Now update the pinned indexes in the row layout manager.
 		this._rowLayoutManager.setPinnedIndexes(pinnedColumnIndices);
 
-		// If there's an active search or sort, we need to refresh the layout entries
-		// to ensure the new pinned columns are included in the combined entry map
-		if (!this.hasNoSearchOrSort()) {
+		if (this.hasNoSearchOrSort()) {
+			this.fetchData(false);
+		} else {
+			// If there's an active search or sort, we need to refresh the layout entries
+			// to ensure the new pinned columns are included in the combined entry map
 			await this.updateLayoutEntries();
 			// Invalidate the cache when pinned columns change with active search/sort
 			await this.fetchData(true);
-		} else {
-			this.fetchData(false);
 		}
 
 		// Force a re-render when the pinned columns change

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -130,18 +130,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 		// Add the onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async state => {
-			if (this.hasNoSearchOrSort()) {
-				// No active search/sort, safe to do full update
-				await this.updateLayoutEntries(state);
-				await this.fetchData(true);
-			} else {
-				// During search operations, update layout but preserve cache when possible
-				// This prevents search results from being wiped out by backend updates
-				await this.updateLayoutEntries(state);
-				// If search/sort is in progress, we need to be more careful about cache invalidation
-				// Only invalidate cache if we have no visible search/sort state
-				await this.fetchData(false);
-			}
+			// Always update layout entries and invalidate cache when backend state changes
+			// Backend state changes represent changes to the underlying data (like row filters)
+			// so column profiles need to be recalculated regardless of search/sort state
+			await this.updateLayoutEntries(state);
+			await this.fetchData(true);
 		}));
 
 		// Add the table summary cache onDidUpdate event handler.


### PR DESCRIPTION
Addresses #9617

This PR addresses the issue where column profiles were not being recalculated when a row filter was added IF there was already a search or sort filter for the summary panel. 

All I've done to fix the issue is revert this change: https://github.com/posit-dev/positron/pull/9220/commits/328fe127dfa96dbf02f4a9d3ec5545606bc07649 from https://github.com/posit-dev/positron/pull/9220.  I haven't noticed any issues with the column profiles "disappearing" which is what this change was originally trying to fix. I think the issue with "disappearing" column profiles was resolved with a different code change.


https://github.com/user-attachments/assets/5029008c-49ad-4d01-98d6-6d8ef42d1372


https://github.com/user-attachments/assets/31c99379-59c1-4827-9a30-3c356cb84c43


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:data-explorer