### PR TITLE
Data Explorer: Do not generate invalid SVG with NaN values when there are zero histogram bins

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -150,6 +150,11 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 		const binCounts = props.columnHistogram.bin_counts;
 		const numBins = binCounts.length;
 
+		// Return empty path if no bins or maxBinCount is 0
+		if (numBins === 0 || maxBinCount === 0) {
+			return path;
+		}
+
 		for (let i = 0; i < numBins; i++) {
 			const binHeight = (binCounts[i] / maxBinCount) * props.graphHeight;
 			const x = (i / numBins) * props.graphWidth;
@@ -193,7 +198,7 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 					d={buildHistogramPath()}
 					fill='var(--vscode-positronDataExplorer-sparklineFill)'
 				/>
-				{props.columnHistogram.bin_counts.map((binCount, binCountIndex) => {
+				{maxBinCount > 0 && props.columnHistogram.bin_counts.map((binCount, binCountIndex) => {
 					const binCountHeight = (binCount / maxBinCount) * props.graphHeight;
 					const binMin = props.columnHistogram.bin_edges[binCountIndex];
 					const binMax = props.columnHistogram.bin_edges[binCountIndex + 1];


### PR DESCRIPTION
Observed when investigating https://github.com/posit-dev/positron/issues/9617, but it does not resolve this issue so can be merged separately.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Avoids generating invalid SVG for data explorer sparklines for tables with zero rows.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Console errors for zero-row tables no longer present. 

@:data-explorer