### PR TITLE
e2e: add ability to override pw trace via env var

### DIFF
--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -121,7 +121,7 @@ export function TracingFixture() {
 
 			// attach the trace to the report if CI and test failed or not in CI
 			const isCI = process.env.CI === 'true';
-			if (!isCI || testInfo.status !== testInfo.expectedStatus || testInfo.retry || process.env.PW_TRACE_MODE === 'on') {
+			if (!isCI || testInfo.status !== testInfo.expectedStatus || testInfo.retry || process.env.PW_TRACE === 'on') {
 				testInfo.attachments.push({ name: 'trace', path: tracePath, contentType: 'application/zip' });
 			}
 		}

--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -121,7 +121,7 @@ export function TracingFixture() {
 
 			// attach the trace to the report if CI and test failed or not in CI
 			const isCI = process.env.CI === 'true';
-			if (!isCI || testInfo.status !== testInfo.expectedStatus || testInfo.retry) {
+			if (!isCI || testInfo.status !== testInfo.expectedStatus || testInfo.retry || process.env.PW_TRACE_MODE === 'on') {
 				testInfo.attachments.push({ name: 'trace', path: tracePath, contentType: 'application/zip' });
 			}
 		}


### PR DESCRIPTION
### Summary

Adds the ability to always attach trace to reports. By default, it only attaches if there’s a failure or retry:
```
PW_TRACE=on npx playwright test
```

### QA Notes
n/a
