### PR TITLE
Data Explorer: Add Integer, Floating, Decimal display types and use whole number formatting for integer sparkline tooltips

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -151,21 +151,20 @@ const SENTINEL_INF = 10;
 const SENTINEL_NEGINF = 11;
 
 // TODO
-// - Decimal
 // - Nested types
 // - JSON
 const SCHEMA_TYPE_MAPPING = new Map<string, ColumnDisplayType>([
 	['BOOLEAN', ColumnDisplayType.Boolean],
-	['UTINYINT', ColumnDisplayType.Number],
-	['TINYINT', ColumnDisplayType.Number],
-	['USMALLINT', ColumnDisplayType.Number],
-	['SMALLINT', ColumnDisplayType.Number],
-	['UINTEGER', ColumnDisplayType.Number],
-	['INTEGER', ColumnDisplayType.Number],
-	['UBIGINT', ColumnDisplayType.Number],
-	['BIGINT', ColumnDisplayType.Number],
-	['FLOAT', ColumnDisplayType.Number],
-	['DOUBLE', ColumnDisplayType.Number],
+	['UTINYINT', ColumnDisplayType.Integer],
+	['TINYINT', ColumnDisplayType.Integer],
+	['USMALLINT', ColumnDisplayType.Integer],
+	['SMALLINT', ColumnDisplayType.Integer],
+	['UINTEGER', ColumnDisplayType.Integer],
+	['INTEGER', ColumnDisplayType.Integer],
+	['UBIGINT', ColumnDisplayType.Integer],
+	['BIGINT', ColumnDisplayType.Integer],
+	['FLOAT', ColumnDisplayType.Floating],
+	['DOUBLE', ColumnDisplayType.Floating],
 	['VARCHAR', ColumnDisplayType.String],
 	['UUID', ColumnDisplayType.String],
 	['DATE', ColumnDisplayType.Date],
@@ -175,7 +174,7 @@ const SCHEMA_TYPE_MAPPING = new Map<string, ColumnDisplayType>([
 	['TIMESTAMP_NS WITH TIME ZONE', ColumnDisplayType.Datetime],
 	['TIME', ColumnDisplayType.Time],
 	['INTERVAL', ColumnDisplayType.Interval],
-	['DECIMAL', ColumnDisplayType.Number]
+	['DECIMAL', ColumnDisplayType.Decimal]
 ]);
 
 function formatLiteral(value: string, schema: ColumnSchema) {
@@ -613,7 +612,7 @@ class ColumnProfileEvaluator {
 
 		if (isNumeric(columnSchema.column_type)) {
 			return {
-				type_display: ColumnDisplayType.Number,
+				type_display: getNumericDisplayType(columnSchema.column_type),
 				number_stats: {
 					min_value: formatNumber(getStat('min')),
 					max_value: formatNumber(getStat('max')),
@@ -624,7 +623,7 @@ class ColumnProfileEvaluator {
 			};
 		} else if (columnSchema.column_type.startsWith('DECIMAL')) {
 			return {
-				type_display: ColumnDisplayType.Number,
+				type_display: ColumnDisplayType.Decimal,
 				number_stats: {
 					min_value: getStat('string_min'),
 					max_value: getStat('string_max'),
@@ -727,9 +726,13 @@ class ColumnProfileEvaluator {
 
 function isInteger(duckdbName: string) {
 	switch (duckdbName) {
+		case 'UTINYINT':
 		case 'TINYINT':
+		case 'USMALLINT':
 		case 'SMALLINT':
+		case 'UINTEGER':
 		case 'INTEGER':
+		case 'UBIGINT':
 		case 'BIGINT':
 			return true;
 		default:
@@ -737,12 +740,28 @@ function isInteger(duckdbName: string) {
 	}
 }
 
+function isFloating(duckdbName: string) {
+	return duckdbName === 'FLOAT' || duckdbName === 'DOUBLE';
+}
+
 function isNumeric(duckdbName: string) {
 	return (
 		isInteger(duckdbName) ||
-		duckdbName === 'FLOAT' ||
-		duckdbName === 'DOUBLE'
+		isFloating(duckdbName)
 	);
+}
+
+function getNumericDisplayType(duckdbName: string): ColumnDisplayType {
+	if (isInteger(duckdbName)) {
+		return ColumnDisplayType.Integer;
+	} else if (isFloating(duckdbName)) {
+		return ColumnDisplayType.Floating;
+	} else if (duckdbName.startsWith('DECIMAL')) {
+		return ColumnDisplayType.Decimal;
+	} else {
+		// Fallback to Number for any other numeric type
+		return ColumnDisplayType.Number;
+	}
 }
 
 /**
@@ -811,9 +830,9 @@ export class DuckDBTableView {
 					type_display = ColumnDisplayType.Unknown;
 				}
 
-				// If entry.column_type is like DECIMAL($p,$s), set type_display to Number
+				// If entry.column_type is like DECIMAL($p,$s), set type_display to Decimal
 				if (entry.column_type.startsWith('DECIMAL')) {
-					type_display = ColumnDisplayType.Number;
+					type_display = ColumnDisplayType.Decimal;
 				}
 
 				return {
@@ -849,7 +868,7 @@ export class DuckDBTableView {
 					displayType = ColumnDisplayType.Unknown;
 				}
 				if (columnType.startsWith('DECIMAL')) {
-					displayType = ColumnDisplayType.Number;
+					displayType = ColumnDisplayType.Decimal;
 				}
 
 				// Apply each filter
@@ -1348,8 +1367,11 @@ END`;
 	 */
 	private createEmptySummaryStats(columnSchema: SchemaEntry): ColumnSummaryStats {
 		if (isNumeric(columnSchema.column_type) || columnSchema.column_type.startsWith('DECIMAL')) {
+			const displayType = columnSchema.column_type.startsWith('DECIMAL')
+				? ColumnDisplayType.Decimal
+				: getNumericDisplayType(columnSchema.column_type);
 			return {
-				type_display: ColumnDisplayType.Number,
+				type_display: displayType,
 				number_stats: {}
 			};
 		} else if (columnSchema.column_type === 'VARCHAR') {

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -1104,8 +1104,8 @@ export interface DataSelectionCellRange {
 }
 
 /**
- * A selection that for a rectangle of data cells defined by arrays of
- * row and column indices
+ * A rectangular cell selection defined by arrays of row and column
+ * indices
  */
 export interface DataSelectionCellIndices {
 	/**
@@ -1206,7 +1206,10 @@ export enum ColumnDisplayType {
 	Object = 'object',
 	Array = 'array',
 	Struct = 'struct',
-	Unknown = 'unknown'
+	Unknown = 'unknown',
+	Floating = 'floating',
+	Integer = 'integer',
+	Decimal = 'decimal'
 }
 
 /**

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -303,24 +303,24 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		});
 
 		const schemaEntries: Array<[string, string, ColumnDisplayType]> = [
-			['year', 'SMALLINT', ColumnDisplayType.Number],
-			['month', 'TINYINT', ColumnDisplayType.Number],
-			['day', 'TINYINT', ColumnDisplayType.Number],
-			['dep_time', 'SMALLINT', ColumnDisplayType.Number],
-			['sched_dep_time', 'SMALLINT', ColumnDisplayType.Number],
-			['dep_delay', 'SMALLINT', ColumnDisplayType.Number],
-			['arr_time', 'SMALLINT', ColumnDisplayType.Number],
-			['sched_arr_time', 'SMALLINT', ColumnDisplayType.Number],
-			['arr_delay', 'SMALLINT', ColumnDisplayType.Number],
+			['year', 'SMALLINT', ColumnDisplayType.Integer],
+			['month', 'TINYINT', ColumnDisplayType.Integer],
+			['day', 'TINYINT', ColumnDisplayType.Integer],
+			['dep_time', 'SMALLINT', ColumnDisplayType.Integer],
+			['sched_dep_time', 'SMALLINT', ColumnDisplayType.Integer],
+			['dep_delay', 'SMALLINT', ColumnDisplayType.Integer],
+			['arr_time', 'SMALLINT', ColumnDisplayType.Integer],
+			['sched_arr_time', 'SMALLINT', ColumnDisplayType.Integer],
+			['arr_delay', 'SMALLINT', ColumnDisplayType.Integer],
 			['carrier', 'VARCHAR', ColumnDisplayType.String],
-			['flight', 'SMALLINT', ColumnDisplayType.Number],
+			['flight', 'SMALLINT', ColumnDisplayType.Integer],
 			['tailnum', 'VARCHAR', ColumnDisplayType.String],
 			['origin', 'VARCHAR', ColumnDisplayType.String],
 			['dest', 'VARCHAR', ColumnDisplayType.String],
-			['air_time', 'SMALLINT', ColumnDisplayType.Number],
-			['distance', 'SMALLINT', ColumnDisplayType.Number],
-			['hour', 'TINYINT', ColumnDisplayType.Number],
-			['minute', 'TINYINT', ColumnDisplayType.Number],
+			['air_time', 'SMALLINT', ColumnDisplayType.Integer],
+			['distance', 'SMALLINT', ColumnDisplayType.Integer],
+			['hour', 'TINYINT', ColumnDisplayType.Integer],
+			['minute', 'TINYINT', ColumnDisplayType.Integer],
 			['time_hour', 'TIMESTAMP_NS', ColumnDisplayType.Datetime],
 		];
 
@@ -437,25 +437,25 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"a"',
 						type: 'TINYINT',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Integer,
 						values: ['127', '-128', '0', 'NULL']
 					},
 					{
 						name: '"b"',
 						type: 'SMALLINT',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Integer,
 						values: ['32767', '-32768', '0', 'NULL']
 					},
 					{
 						name: '"c"',
 						type: 'INTEGER',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Integer,
 						values: ['2147483647', '-2147483648', '0', 'NULL']
 					},
 					{
 						name: '"d"',
 						type: 'BIGINT',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Integer,
 						values: ['9223372036854775807', '-9223372036854775808', '0', 'NULL']
 					},
 				],
@@ -483,7 +483,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"a"',
 						type: 'DOUBLE',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Floating,
 						values: [
 							'0', '1.125', '0.12345', 'NULL', '\'NaN\'',
 							'\'Infinity\'', '\'-Infinity\'',
@@ -492,7 +492,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"b"',
 						type: 'FLOAT',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Floating,
 						values: [
 							'0', '1.115', '0.12366', 'NULL', '\'NaN\'',
 							'\'Infinity\'', '\'-Infinity\'',
@@ -511,7 +511,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"a"',
 						type: 'DOUBLE',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Floating,
 						values: [
 							'123456789.78', '456789.78'
 						]
@@ -535,7 +535,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"a"',
 						type: 'DOUBLE',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Floating,
 						values: [
 							'155500', '150000', '15000'
 						]
@@ -608,19 +608,19 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					{
 						name: '"decimal_default"',
 						type: 'DECIMAL',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Decimal,
 						values: ['1.23', '45.67', '89.01', 'NULL']
 					},
 					{
 						name: '"decimal_precision"',
 						type: 'DECIMAL(10)', // same as DECIMAL(10,0)
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Decimal,
 						values: ['123456', '987654', '555555', 'NULL']
 					},
 					{
 						name: '"decimal_precision_scale"',
 						type: 'DECIMAL(10,2)',
-						display_type: ColumnDisplayType.Number,
+						display_type: ColumnDisplayType.Decimal,
 						values: ['123.456', '789.012', '345.678', 'NULL']
 					}
 				],
@@ -1987,7 +1987,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		const tableName = await createSummaryStatsTestTable(
 			'"numeric_column"', // Quoted field name
 			'DOUBLE',
-			ColumnDisplayType.Number,
+			ColumnDisplayType.Floating,
 			(i) => `${i * 2.5}`, // Values 0, 2.5, 5.0, 7.5, ... 247.5
 			100
 		);
@@ -2001,7 +2001,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 		// Verify the summary stats
 		assert.ok(summaryStats, 'Summary stats should be returned');
-		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Number, 'Type display should be Number');
+		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Floating, 'Type display should be Floating');
 		assert.ok(summaryStats.number_stats, 'Number stats should be present');
 
 		const numberStats = summaryStats.number_stats!;
@@ -2147,7 +2147,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		const tableName = await createSummaryStatsTestTable(
 			'"null_column"', // Quoted field name
 			'INTEGER',
-			ColumnDisplayType.Number,
+			ColumnDisplayType.Integer,
 			() => 'NULL', // All NULL values
 			20
 		);
@@ -2161,7 +2161,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 		// Verify the summary stats for all null values
 		assert.ok(summaryStats, 'Summary stats should be returned');
-		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Number, 'Type display should be Number');
+		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Integer, 'Type display should be Integer');
 		assert.ok(summaryStats.number_stats, 'Number stats should be present even for all null values');
 
 		const numberStats = summaryStats.number_stats!;
@@ -2180,13 +2180,13 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'id',
 				type: 'INTEGER',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Integer,
 				values: ['1', '2', '3'],
 			},
 			{
 				name: 'user_id',
 				type: 'INTEGER',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Integer,
 				values: ['101', '102', '103'],
 			},
 			{
@@ -2210,7 +2210,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'age',
 				type: 'INTEGER',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Integer,
 				values: ['25', '30', '35'],
 			},
 			{
@@ -2260,7 +2260,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'salary',
 				type: 'DOUBLE',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Floating,
 				values: ['50000.0', '60000.0', '70000.0'],
 			},
 		]);
@@ -2375,10 +2375,22 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 				// Type filter tests
 				{
-					filters: [typeFilter(ColumnDisplayType.Number)],
+					filters: [typeFilter(ColumnDisplayType.Integer)],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [0, 1, 5],
+					description: 'Integer columns',
+				},
+				{
+					filters: [typeFilter(ColumnDisplayType.Floating)],
+					sortOrder: SearchSchemaSortOrder.Original,
+					expected: [12],
+					description: 'Floating columns',
+				},
+				{
+					filters: [typeFilter(ColumnDisplayType.Integer, ColumnDisplayType.Floating)],
 					sortOrder: SearchSchemaSortOrder.Original,
 					expected: [0, 1, 5, 12],
-					description: 'Number columns',
+					description: 'Integer and Floating columns',
 				},
 				{
 					filters: [typeFilter(ColumnDisplayType.String)],
@@ -2408,11 +2420,11 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				{
 					filters: [
 						textFilter(TextSearchType.Contains, 'a'),
-						typeFilter(ColumnDisplayType.Number),
+						typeFilter(ColumnDisplayType.Integer, ColumnDisplayType.Floating),
 					],
 					sortOrder: SearchSchemaSortOrder.Original,
 					expected: [5, 12],
-					description: 'Contains "a" AND Number type',
+					description: 'Contains "a" AND Integer/Floating type',
 				},
 
 				// Sort order tests - by name
@@ -2449,10 +2461,10 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					description: 'Descending by type',
 				},
 				{
-					filters: [typeFilter(ColumnDisplayType.Number)],
+					filters: [typeFilter(ColumnDisplayType.Integer, ColumnDisplayType.Floating)],
 					sortOrder: SearchSchemaSortOrder.AscendingType,
 					expected: [12, 0, 1, 5],
-					description: 'Number columns by type',
+					description: 'Integer/Floating columns by type',
 				},
 
 				// Case sensitivity tests
@@ -2486,7 +2498,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		const tableName = await createSummaryStatsTestTable(
 			'"single_value_column"', // Quoted field name
 			'INTEGER',
-			ColumnDisplayType.Number,
+			ColumnDisplayType.Integer,
 			() => '42', // All values are 42
 			15
 		);
@@ -2500,7 +2512,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 		// Verify the summary stats for a single value
 		assert.ok(summaryStats, 'Summary stats should be returned');
-		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Number, 'Type display should be Number');
+		assert.strictEqual(summaryStats.type_display, ColumnDisplayType.Integer, 'Type display should be Integer');
 		assert.ok(summaryStats.number_stats, 'Number stats should be present');
 
 		const numberStats = summaryStats.number_stats!;

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -854,9 +854,11 @@ class DataExplorerTableView:
     )
 
 
-def _box_number_stats(min_val, max_val, mean_val, median_val, std_val):
+def _box_number_stats(
+    min_val, max_val, mean_val, median_val, std_val, display_type=ColumnDisplayType.Number
+):
     return ColumnSummaryStats(
-        type_display=ColumnDisplayType.Number,
+        type_display=display_type,
         number_stats=SummaryStatsNumber(
             min_value=min_val,
             max_value=max_val,
@@ -1065,6 +1067,9 @@ def _get_float_formatter(options: FormatOptions) -> Callable:
 
 _FILTER_RANGE_COMPARE_SUPPORTED = {
     ColumnDisplayType.Number,
+    ColumnDisplayType.Floating,
+    ColumnDisplayType.Integer,
+    ColumnDisplayType.Decimal,
     ColumnDisplayType.Date,
     ColumnDisplayType.Datetime,
     ColumnDisplayType.Time,
@@ -1485,27 +1490,27 @@ class PandasView(DataExplorerTableView):
 
     TYPE_DISPLAY_MAPPING = MappingProxyType(
         {
-            "integer": "number",
-            "int8": "number",
-            "int16": "number",
-            "int32": "number",
-            "int64": "number",
-            "uint8": "number",
-            "uint16": "number",
-            "uint32": "number",
-            "uint64": "number",
-            "floating": "number",
-            "float16": "number",
-            "float32": "number",
-            "float64": "number",
-            "complex64": "number",
-            "complex128": "number",
-            "complex256": "number",
+            "integer": "integer",
+            "int8": "integer",
+            "int16": "integer",
+            "int32": "integer",
+            "int64": "integer",
+            "uint8": "integer",
+            "uint16": "integer",
+            "uint32": "integer",
+            "uint64": "integer",
+            "floating": "floating",
+            "float16": "floating",
+            "float32": "floating",
+            "float64": "floating",
+            "complex64": "floating",
+            "complex128": "floating",
+            "complex256": "floating",
             "mixed-integer": "object",
             "mixed-integer-float": "object",
             "mixed": "object",
-            "decimal": "number",
-            "complex": "number",
+            "decimal": "decimal",
+            "complex": "floating",
             "bool": "boolean",
             "datetime64": "datetime",
             "datetime64[ns]": "datetime",
@@ -1517,16 +1522,16 @@ class PandasView(DataExplorerTableView):
             "bytes": "string",
             "empty": "unknown",
             # NA-enabled numeric data types
-            "Int8": "number",
-            "Int16": "number",
-            "Int32": "number",
-            "Int64": "number",
-            "UInt8": "number",
-            "UInt16": "number",
-            "UInt32": "number",
-            "UInt64": "number",
-            "Float32": "number",
-            "Float64": "number",
+            "Int8": "integer",
+            "Int16": "integer",
+            "Int32": "integer",
+            "Int64": "integer",
+            "UInt8": "integer",
+            "UInt16": "integer",
+            "UInt32": "integer",
+            "UInt64": "integer",
+            "Float32": "floating",
+            "Float64": "floating",
             # NA-enabled bool
             "boolean": "boolean",
             # NA-enabled string
@@ -1862,6 +1867,9 @@ class PandasView(DataExplorerTableView):
         {
             ColumnDisplayType.Boolean: _pandas_summarize_boolean,
             ColumnDisplayType.Number: _pandas_summarize_number,
+            ColumnDisplayType.Floating: _pandas_summarize_number,
+            ColumnDisplayType.Integer: _pandas_summarize_number,
+            ColumnDisplayType.Decimal: _pandas_summarize_number,
             ColumnDisplayType.String: _pandas_summarize_string,
             ColumnDisplayType.Date: _pandas_summarize_date,
             ColumnDisplayType.Datetime: _pandas_summarize_datetime,
@@ -2348,23 +2356,23 @@ class PolarsView(DataExplorerTableView):
     TYPE_DISPLAY_MAPPING = MappingProxyType(
         {
             "Boolean": "boolean",
-            "Int8": "number",
-            "Int16": "number",
-            "Int32": "number",
-            "Int64": "number",
-            "UInt8": "number",
-            "UInt16": "number",
-            "UInt32": "number",
-            "UInt64": "number",
-            "Float32": "number",
-            "Float64": "number",
+            "Int8": "integer",
+            "Int16": "integer",
+            "Int32": "integer",
+            "Int64": "integer",
+            "UInt8": "integer",
+            "UInt16": "integer",
+            "UInt32": "integer",
+            "UInt64": "integer",
+            "Float32": "floating",
+            "Float64": "floating",
             "Binary": "string",
             "String": "string",
             "Date": "date",
             "Datetime": "datetime",
             "Time": "time",
             "Duration": "interval",
-            "Decimal": "number",
+            "Decimal": "decimal",
             "Object": "object",
             "List": "array",
             "Struct": "struct",
@@ -2684,6 +2692,9 @@ class PolarsView(DataExplorerTableView):
         {
             ColumnDisplayType.Boolean: _polars_summarize_boolean,
             ColumnDisplayType.Number: _polars_summarize_number,
+            ColumnDisplayType.Floating: _polars_summarize_number,
+            ColumnDisplayType.Integer: _polars_summarize_number,
+            ColumnDisplayType.Decimal: _polars_summarize_number,
             ColumnDisplayType.String: _polars_summarize_string,
             ColumnDisplayType.Object: _polars_summarize_object,
             ColumnDisplayType.Date: _polars_summarize_date,
@@ -2800,7 +2811,12 @@ class PolarsView(DataExplorerTableView):
 def _polars_dtype_from_display(display_type):
     import polars as pl
 
-    return {ColumnDisplayType.Number: pl.Float64}.get(display_type)
+    return {
+        ColumnDisplayType.Number: pl.Float64,
+        ColumnDisplayType.Floating: pl.Float64,
+        ColumnDisplayType.Integer: pl.Int64,
+        ColumnDisplayType.Decimal: pl.Float64,  # Polars doesn't have a separate decimal type
+    }.get(display_type)
 
 
 class PyArrowView(DataExplorerTableView):

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -1084,7 +1084,9 @@ def _pandas_temporal_mapper(type_name):
     return None
 
 
-def _pandas_summarize_number(col: pd.Series, options: FormatOptions):
+def _pandas_summarize_number(
+    col: pd.Series, options: FormatOptions, display_type=ColumnDisplayType.Number
+):
     import numpy as np
 
     math_helper = NumPyMathHelper()
@@ -1112,16 +1114,24 @@ def _pandas_summarize_number(col: pd.Series, options: FormatOptions):
                 median_val = float_format(np.median(non_null_values))
                 std_val = float_format(non_null_values.std(ddof=1))
 
-            min_val = float_format(min_val)
-            max_val = float_format(max_val)
+            if display_type == ColumnDisplayType.Floating:
+                min_val = float_format(min_val)
+                max_val = float_format(max_val)
+            else:
+                min_val = str(min_val)
+                max_val = str(max_val)
 
     return _box_number_stats(
-        min_val,
-        max_val,
-        mean_val,
-        median_val,
-        std_val,
+        min_val, max_val, mean_val, median_val, std_val, display_type=display_type
     )
+
+
+def _pandas_summarize_floating(col: pd.Series, options: FormatOptions):
+    return _pandas_summarize_number(col, options, display_type=ColumnDisplayType.Floating)
+
+
+def _pandas_summarize_integer(col: pd.Series, options: FormatOptions):
+    return _pandas_summarize_number(col, options, display_type=ColumnDisplayType.Integer)
 
 
 def _pandas_summarize_string(col: pd.Series, _options: FormatOptions):
@@ -1867,8 +1877,8 @@ class PandasView(DataExplorerTableView):
         {
             ColumnDisplayType.Boolean: _pandas_summarize_boolean,
             ColumnDisplayType.Number: _pandas_summarize_number,
-            ColumnDisplayType.Floating: _pandas_summarize_number,
-            ColumnDisplayType.Integer: _pandas_summarize_number,
+            ColumnDisplayType.Floating: _pandas_summarize_floating,
+            ColumnDisplayType.Integer: _pandas_summarize_integer,
             ColumnDisplayType.Decimal: _pandas_summarize_number,
             ColumnDisplayType.String: _pandas_summarize_string,
             ColumnDisplayType.Date: _pandas_summarize_date,

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -63,6 +63,12 @@ class ColumnDisplayType(str, enum.Enum):
 
     Unknown = "unknown"
 
+    Floating = "floating"
+
+    Integer = "integer"
+
+    Decimal = "decimal"
+
 
 @enum.unique
 class RowFilterCondition(str, enum.Enum):

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -764,7 +764,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
                     dtype="complex256",
                 ),
                 "complex256",
-                "number",
+                "floating",
                 None,
             )
         )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -657,12 +657,12 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
 
 def test_pandas_get_schema(dxf: DataExplorerFixture):
     cases = [
-        ([1, 2, 3, 4, 5], "int64", "number", None),
+        ([1, 2, 3, 4, 5], "int64", "integer", None),
         ([True, False, True, None, True], "bool", "boolean", None),
         (["foo", "bar", None, "bar", "None"], "string", "string", None),
-        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16), "float16", "number", None),
-        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32), "float32", "number", None),
-        ([0, 1.2, -4.5, 6, np.nan], "float64", "number", None),
+        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16), "float16", "floating", None),
+        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32), "float32", "floating", None),
+        ([0, 1.2, -4.5, 6, np.nan], "float64", "floating", None),
         (
             pd.to_datetime(
                 [
@@ -683,22 +683,22 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         (
             np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"),
             "complex64",
-            "number",
+            "floating",
             None,
         ),
-        ([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], "complex128", "number", None),
+        ([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], "complex128", "floating", None),
         ([None] * 5, "empty", "unknown", None),
         # NA-enabled numbers
-        (pd.Series([1, 2, None, 3, 4], dtype="Int8"), "Int8", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="Int16"), "Int16", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="Int32"), "Int32", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="Int64"), "Int64", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="UInt8"), "UInt8", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="UInt16"), "UInt16", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="UInt32"), "UInt32", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="UInt64"), "UInt64", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="Float32"), "Float32", "number", None),
-        (pd.Series([1, 2, None, 3, 4], dtype="Float64"), "Float64", "number", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Int8"), "Int8", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Int16"), "Int16", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Int32"), "Int32", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Int64"), "Int64", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="UInt8"), "UInt8", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="UInt16"), "UInt16", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="UInt32"), "UInt32", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="UInt64"), "UInt64", "integer", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Float32"), "Float32", "floating", None),
+        (pd.Series([1, 2, None, 3, 4], dtype="Float64"), "Float64", "floating", None),
         # NA boolean
         (pd.Series([True, False, None, None, True], dtype="boolean"), "boolean", "boolean", None),
         # NA string
@@ -752,7 +752,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
             "string",
             None,
         ),
-        (pd.Series([0, 1, 0, 1, 0], dtype="category"), "category", "number", None),
+        (pd.Series([0, 1, 0, 1, 0], dtype="category"), "category", "integer", None),
     ]
 
     if hasattr(np, "complex256"):
@@ -844,7 +844,7 @@ def test_pandas_series(dxf: DataExplorerFixture):
                 "column_name": "a",
                 "column_index": 0,
                 "type_name": "int64",
-                "type_display": "number",
+                "type_display": "integer",
             },
         ],
     )
@@ -863,7 +863,7 @@ def test_pandas_series(dxf: DataExplorerFixture):
                 "column_name": "unnamed",
                 "column_index": 0,
                 "type_name": "int64",
-                "type_display": "number",
+                "type_display": "integer",
             },
         ],
     )
@@ -1060,12 +1060,24 @@ def test_search_schema_sort_by_type(dxf: DataExplorerFixture):
 
     # Test ascending type sort
     result = dxf.search_schema("type_sort_test_df", [], "ascending_type")
-    # is_active(6), birth_date(7), created_at(5), id(0), user_id(1), age(4), salary(8), name(2), full_name(3)
-    expected_ascending_type = [6, 7, 5, 0, 1, 4, 8, 2, 3]  # boolean, date, datetime, number, string
+    # With new types: boolean, date, datetime, floating, integer, string
+    # is_active(6), birth_date(7), created_at(5), salary(8), id(0), user_id(1), age(4), name(2), full_name(3)
+    expected_ascending_type = [
+        6,
+        7,
+        5,
+        8,
+        0,
+        1,
+        4,
+        2,
+        3,
+    ]  # boolean, date, datetime, floating, integer, string
     assert result["matches"] == expected_ascending_type
 
     # Test descending type sort
     result = dxf.search_schema("type_sort_test_df", [], "descending_type")
+    # With new types reversed: string, integer, floating, datetime, date, boolean
     # name(2), full_name(3), id(0), user_id(1), age(4), salary(8), created_at(5), birth_date(7), is_active(6)
     expected_descending_type = [
         2,
@@ -1077,13 +1089,15 @@ def test_search_schema_sort_by_type(dxf: DataExplorerFixture):
         5,
         7,
         6,
-    ]  # string, number, datetime, date, boolean
+    ]  # string, integer, floating, datetime, date, boolean
     assert result["matches"] == expected_descending_type
 
-    # Test type sort with filters
-    number_filter = _match_types_filter([ColumnDisplayType.Number])
+    # Test type sort with filters - test for both integer and floating types
+    number_filter = _match_types_filter([ColumnDisplayType.Integer, ColumnDisplayType.Floating])
     result = dxf.search_schema("type_sort_test_df", [number_filter], "ascending_type")
-    expected_number_columns = [0, 1, 4, 8]
+    # With ascending type sort: floating comes before integer
+    # salary (8) is floating, id (0), user_id (1), age (4) are integer
+    expected_number_columns = [8, 0, 1, 4]  # floating first, then integers
     assert result["matches"] == expected_number_columns
 
 
@@ -3470,16 +3484,16 @@ def test_histogram_single_value_special_case():
 POLARS_TYPE_EXAMPLES = [
     (pl.Null, [None, None, None, None], "Null", "unknown", None),
     (pl.Boolean, [False, None, True, False], "Boolean", "boolean", None),
-    (pl.Int8, [-1, 2, 3, None], "Int8", "number", None),
-    (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number", None),
-    (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number", None),
-    (pl.Int64, [-10000000000, 20000000000, 30000000000, None], "Int64", "number", None),
-    (pl.UInt8, [0, 2, 3, None], "UInt8", "number", None),
-    (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number", None),
-    (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number", None),
-    (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number", None),
-    (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number", None),
-    (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number", None),
+    (pl.Int8, [-1, 2, 3, None], "Int8", "integer", None),
+    (pl.Int16, [-10000, 20000, 30000, None], "Int16", "integer", None),
+    (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "integer", None),
+    (pl.Int64, [-10000000000, 20000000000, 30000000000, None], "Int64", "integer", None),
+    (pl.UInt8, [0, 2, 3, None], "UInt8", "integer", None),
+    (pl.UInt16, [0, 2000, 3000, None], "UInt16", "integer", None),
+    (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "integer", None),
+    (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "integer", None),
+    (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "floating", None),
+    (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "floating", None),
     (pl.Binary, [b"testing", b"some", b"strings", None], "Binary", "string", None),
     (pl.String, ["tésting", "söme", "strîngs", None], "String", "string", None),
     (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time", None),
@@ -3508,7 +3522,7 @@ POLARS_TYPE_EXAMPLES = [
             None,
         ],
         "Decimal(precision=12, scale=4)",
-        "number",
+        "decimal",
         None,
     ),
     (pl.List(pl.Int32), [[], [1, None, 3], [0], None], "List(Int32)", "array", None),
@@ -3937,9 +3951,10 @@ def test_polars_filter_set_membership(dxf: DataExplorerFixture):
         # TODO(wesm): improve this test once
         # https://github.com/pola-rs/polars/issues/17771 has a
         # resolution.
+        # Note: column 'a' is Int64, so we use integer values for filtering
         (
-            [_set_member_filter(schema[0], [2, 3.5, 4.0, 5, 6.5])],
-            test_df.filter(test_df["a"].is_in(pl.Series([2, 3.5, 4.0, 5, 6.5], dtype=pl.Float64))),
+            [_set_member_filter(schema[0], [2, 3, 4, 5, 6])],
+            test_df.filter(test_df["a"].is_in(pl.Series([2, 3, 4, 5, 6], dtype=pl.Int64))),
         ),
         (
             [_set_member_filter(schema[0], [2, 4])],

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -965,11 +965,11 @@ def test_query_table_summary(shell: PositronShell, variables_comm: DummyComm):
                 "num_rows": 5,
                 "num_columns": 2,
                 "column_schemas": [
-                    '{"column_name": "a", "column_label": null, "column_index": 0, "type_name": "int64", "type_display": "number", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
+                    '{"column_name": "a", "column_label": null, "column_index": 0, "type_name": "int64", "type_display": "integer", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
                     '{"column_name": "b", "column_label": null, "column_index": 1, "type_name": "bool", "type_display": "boolean", "description": null, "children": null, "precision": null, "scale": null, "timezone": null, "type_size": null}',
                 ],
                 "column_profiles": [
-                    '{"column_name": "a", "type_display": "number", "summary_stats": {"type_display": "number", "number_stats": {"min_value": "1.0000", "max_value": "5.0000", "mean": "3.0000", "median": "3.0000", "stdev": "1.5811"}, "string_stats": null, "boolean_stats": null, "date_stats": null, "datetime_stats": null, "other_stats": null}}',
+                    '{"column_name": "a", "type_display": "integer", "summary_stats": {"type_display": "integer", "number_stats": {"min_value": "1", "max_value": "5", "mean": "3.0000", "median": "3.0000", "stdev": "1.5811"}, "string_stats": null, "boolean_stats": null, "date_stats": null, "datetime_stats": null, "other_stats": null}}',
                     '{"column_name": "b", "type_display": "boolean", "summary_stats": {"type_display": "boolean", "number_stats": null, "string_stats": null, "boolean_stats": {"true_count": 3, "false_count": 1}, "date_stats": null, "datetime_stats": null, "other_stats": null}}',
                 ],
             }

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -504,7 +504,10 @@
 					"object",
 					"array",
 					"struct",
-					"unknown"
+					"unknown",
+					"floating",
+					"integer",
+					"decimal"
 				]
 			},
 			"column_schema": {

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -41,10 +41,11 @@ const commsFiles = comms.map(comm => comm + '.json');
 /// The directory to write the generated Typescript files to
 const tsOutputDir = `${__dirname}/../../src/vs/workbench/services/languageRuntime/common`;
 
-/// The directory to write the generated Rust files to (note that this presumes
-/// that the ark repo is cloned into the same parent directory as the
-/// positron repo)
-const rustOutputDir = `${__dirname}/../../../ark/crates/amalthea/src/comm`;
+/// The directory to write the generated Rust files to
+/// By default, presumes that the ark repo is cloned into the same parent directory as the
+/// positron repo. Can be overridden with the ARK_DIRECTORY environment variable.
+const arkDirectory = process.env.ARK_DIRECTORY || `${__dirname}/../../../ark`;
+const rustOutputDir = `${arkDirectory}/crates/amalthea/src/comm`;
 
 /// The directory to write the generated Python files to
 const pythonOutputDir = `${__dirname}/../../extensions/positron-python/python_files/posit/positron`;
@@ -1756,7 +1757,9 @@ async function createCommInterface() {
 // Check that the ark repo is cloned
 if (!existsSync(rustOutputDir)) {
 	console.error('The ark repo must be cloned into the same parent directory as the ' +
-		'Positron rep, so that Rust output types can be written.');
+		'Positron repo, or the ARK_DIRECTORY environment variable must be set to the path ' +
+		'of the ark repo, so that Rust output types can be written.\n' +
+		`Expected Rust output directory: ${rustOutputDir}`);
 	process.exit(1);
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -50,8 +50,11 @@ const validateRowFilterValue = (columnSchema: ColumnSchema, value: string) => {
 
 	// Validate the row filter value that was supplied based on the column schema type.
 	switch (columnSchema.type_display) {
-		// Number.
+		// Number (including all numeric subtypes).
 		case ColumnDisplayType.Number:
+		case ColumnDisplayType.Floating:
+		case ColumnDisplayType.Integer:
+		case ColumnDisplayType.Decimal:
 			return isNumber();
 
 		// Boolean.
@@ -300,6 +303,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		// Add is less than / is greater than conditions.
 		switch (selectedColumnSchema.type_display) {
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 			case ColumnDisplayType.Date:
 			case ColumnDisplayType.Datetime:
 			case ColumnDisplayType.Time:
@@ -341,6 +347,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		// Add is equal to, is not equal to conditions.
 		switch (selectedColumnSchema.type_display) {
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 			case ColumnDisplayType.String:
 			case ColumnDisplayType.Date:
 			case ColumnDisplayType.Datetime:
@@ -388,6 +397,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		// Add is between / is not between conditions.
 		switch (selectedColumnSchema.type_display) {
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 			case ColumnDisplayType.Date:
 			case ColumnDisplayType.Datetime:
 			case ColumnDisplayType.Time:

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
@@ -18,6 +18,9 @@ export const columnSchemaDataTypeIcon = (columnSchema?: ColumnSchema) => {
 	// Determine the alignment based on type.
 	switch (columnSchema.type_display) {
 		case ColumnDisplayType.Number:
+		case ColumnDisplayType.Floating:
+		case ColumnDisplayType.Integer:
+		case ColumnDisplayType.Decimal:
 			return 'codicon-positron-data-type-number';
 
 		case ColumnDisplayType.Boolean:

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1160,7 +1160,10 @@ export enum ColumnDisplayType {
 	Object = 'object',
 	Array = 'array',
 	Struct = 'struct',
-	Unknown = 'unknown'
+	Unknown = 'unknown',
+	Floating = 'floating',
+	Integer = 'integer',
+	Decimal = 'decimal'
 }
 
 /**

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
@@ -92,8 +92,10 @@ export const ColumnProfileInteger = (props: ColumnProfileIntegerProps) => {
 					<ColumnProfileNullCountValue {...props} />
 					<IntegerStatsValue stats={stats} value={stats?.min_value} />
 					<IntegerStatsValue stats={stats} value={stats?.median} />
+					{/* Use StatsValue for mean to handle cases where mean is not an integer */}
 					<StatsValue stats={stats} value={stats?.mean} />
 					<IntegerStatsValue stats={stats} value={stats?.max_value} />
+					{/* Use StatsValue for stdev to handle cases where stdev is not an integer */}
 					<StatsValue stats={stats} value={stats?.stdev} />
 				</div>
 			</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
@@ -14,31 +14,62 @@ import { StatsValue } from './statsValue.js';
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
 import { ColumnProfileSparklineHistogram } from './columnProfileSparklines.js';
-import { positronMax, positronMean, positronMedian, positronMin, positronMissing, positronSD } from '../../common/constants.js';
+import { positronMax, positronMean, positronMedian, positronMin, positronMissing, positronNA, positronSD } from '../../common/constants.js';
 
 /**
  * Constants.
  */
-export const COLUMN_PROFILE_NUMBER_LINE_COUNT = 6;
+export const COLUMN_PROFILE_INTEGER_LINE_COUNT = 6;
 
 /**
- * ColumnProfileNumberProps interface.
+ * IntegerStatsValue component for formatting integer values.
  */
-interface ColumnProfileNumberProps {
+const IntegerStatsValue = ({ stats, value }: { stats?: any; value?: number | string }) => {
+	// Render placeholder.
+	if (stats === undefined) {
+		return (
+			<div className='value-placeholder'>&#x22ef;</div>
+		);
+	}
+
+	// Format value as integer if it's a number
+	let displayValue: string;
+	if (value === undefined || value === null) {
+		displayValue = positronNA;
+	} else if (typeof value === 'number') {
+		// Round to nearest integer and format with locale-aware thousands separators
+		displayValue = Math.round(value).toLocaleString();
+	} else {
+		// Already a string, try to parse and format as integer
+		const num = parseFloat(value);
+		displayValue = isNaN(num) ? value : Math.round(num).toLocaleString();
+	}
+
+	// Render value.
+	return (
+		<div className='value'>{displayValue}</div>
+	);
+};
+
+/**
+ * ColumnProfileIntegerProps interface.
+ */
+interface ColumnProfileIntegerProps {
 	instance: TableSummaryDataGridInstance;
 	columnIndex: number;
 }
 
 /**
- * ColumnProfileNumber component.
- * @param props A ColumnProfileNumberProps that contains the component properties.
+ * ColumnProfileInteger component.
+ * @param props A ColumnProfileIntegerProps that contains the component properties.
  * @returns The rendered component.
  */
-export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
+export const ColumnProfileInteger = (props: ColumnProfileIntegerProps) => {
 	// Render.
 	const columnHistogram = props.instance.getColumnProfileLargeHistogram(props.columnIndex);
 	const stats = props.instance.getColumnProfileSummaryStats(props.columnIndex)?.number_stats;
 	const columnSchema = props.instance.getColumnSchema(props.columnIndex);
+
 	return (
 		<div className='column-profile-info'>
 			{columnHistogram &&
@@ -59,10 +90,10 @@ export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
 				</div>
 				<div className='values'>
 					<ColumnProfileNullCountValue {...props} />
-					<StatsValue stats={stats} value={stats?.min_value} />
-					<StatsValue stats={stats} value={stats?.median} />
+					<IntegerStatsValue stats={stats} value={stats?.min_value} />
+					<IntegerStatsValue stats={stats} value={stats?.median} />
 					<StatsValue stats={stats} value={stats?.mean} />
-					<StatsValue stats={stats} value={stats?.max_value} />
+					<IntegerStatsValue stats={stats} value={stats?.max_value} />
 					<StatsValue stats={stats} value={stats?.stdev} />
 				</div>
 			</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
@@ -37,12 +37,12 @@ const IntegerStatsValue = ({ stats, value }: { stats?: any; value?: number | str
 	if (value === undefined || value === null) {
 		displayValue = positronNA;
 	} else if (typeof value === 'number') {
-		// Round to nearest integer and format with locale-aware thousands separators
-		displayValue = Math.round(value).toLocaleString();
+		// Round to nearest integer and format without thousands separator
+		displayValue = Math.round(value).toString();
 	} else {
 		// Already a string, try to parse and format as integer
 		const num = parseFloat(value);
-		displayValue = isNaN(num) ? value : Math.round(num).toLocaleString();
+		displayValue = isNaN(num) ? value : Math.round(num).toString();
 	}
 
 	// Render value.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 // Other dependencies.
 import { VectorHistogram } from './vectorHistogram.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
-import { ColumnFrequencyTable, ColumnHistogram } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { ColumnFrequencyTable, ColumnHistogram, ColumnDisplayType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
@@ -28,6 +28,7 @@ const X_AXIS_HEIGHT = 0.5;
 interface ColumnProfileSparklineHistogramProps {
 	readonly columnHistogram: ColumnHistogram;
 	readonly hoverManager: IHoverManager;
+	readonly displayType?: ColumnDisplayType;
 }
 
 /**
@@ -37,7 +38,8 @@ interface ColumnProfileSparklineHistogramProps {
  */
 export const ColumnProfileSparklineHistogram = ({
 	columnHistogram,
-	hoverManager
+	hoverManager,
+	displayType
 }: ColumnProfileSparklineHistogramProps) => {
 	// Render.
 	return (
@@ -50,6 +52,7 @@ export const ColumnProfileSparklineHistogram = ({
 		>
 			<VectorHistogram
 				columnHistogram={columnHistogram}
+				displayType={displayType}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
 				hoverManager={hoverManager}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -15,6 +15,7 @@ import { positronClassNames } from '../../../../../base/common/positronUtilities
 import { VectorHistogram } from './vectorHistogram.js';
 import { ColumnProfileDate } from './columnProfileDate.js';
 import { ColumnProfileNumber } from './columnProfileNumber.js';
+import { ColumnProfileInteger } from './columnProfileInteger.js';
 import { ColumnProfileObject } from './columnProfileObject.js';
 import { ColumnProfileString } from './columnProfileString.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
@@ -369,10 +370,13 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	const ColumnProfile = () => {
 		// Return the profile for the display type.
 		switch (props.columnSchema.type_display) {
-			// Number (including all numeric subtypes).
+			// Integer - use dedicated integer formatter
+			case ColumnDisplayType.Integer:
+				return <ColumnProfileInteger columnIndex={props.columnIndex} instance={props.instance} />;
+
+			// Other numeric types
 			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
-			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:
 				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -60,6 +60,9 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		const shouldShowSparkline = () => {
 			switch (props.columnSchema.type_display) {
 				case ColumnDisplayType.Number:
+				case ColumnDisplayType.Floating:
+				case ColumnDisplayType.Integer:
+				case ColumnDisplayType.Decimal:
 				case ColumnDisplayType.Boolean:
 				case ColumnDisplayType.String:
 					return true;
@@ -109,7 +112,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		// Render.
 		switch (props.columnSchema.type_display) {
 			// Column display types that render a histogram sparkline.
-			case ColumnDisplayType.Number: {
+			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal: {
 				// Get the column histogram.
 				const columnHistogram = props.instance.getColumnProfileSmallHistogram(props.columnIndex);
 				if (!columnHistogram) {
@@ -363,8 +369,11 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	const ColumnProfile = () => {
 		// Return the profile for the display type.
 		switch (props.columnSchema.type_display) {
-			// Number.
+			// Number (including all numeric subtypes).
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Boolean.
@@ -407,8 +416,11 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	const dataTypeIcon = (() => {
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
-			// Number.
+			// Number (including all numeric subtypes).
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 				return 'codicon-positron-data-type-number';
 
 			// Boolean.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -134,6 +134,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					>
 						<VectorHistogram
 							columnHistogram={columnHistogram}
+							displayType={props.columnSchema.type_display}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
 							hoverManager={props.instance.hoverManager}

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -67,6 +67,9 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 		// Determine the alignment based on type.
 		switch (this.columnSchema.type_display) {
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 				return DataColumnAlignment.Right;
 
 			case ColumnDisplayType.Boolean:

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -353,6 +353,9 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		let summaryStatsSupported;
 		switch (columnSchema.type_display) {
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 			case ColumnDisplayType.Boolean:
 			case ColumnDisplayType.String:
 			case ColumnDisplayType.Date:
@@ -631,8 +634,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 		// Return the row height.
 		switch (columnSchema.type_display) {
-			// Number.
+			// Number (including all numeric subtypes).
 			case ColumnDisplayType.Number:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Decimal:
 				return rowHeight(true, COLUMN_PROFILE_NUMBER_LINE_COUNT);
 
 			// Boolean.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -394,6 +394,15 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Gets the column schema for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column schema for the specified column index
+	 */
+	getColumnSchema(columnIndex: number) {
+		return this._tableSummaryCache.getColumnSchema(columnIndex);
+	}
+
+	/**
 	 * Gets the column profile null count for the specified column index.
 	 * @param columnIndex The column index.
 	 * @returns The column profile null count for the specified column index

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -339,8 +339,11 @@ export class TableSummaryCache extends Disposable {
 
 			// Determine whether to load the histogram or the frequency table for the column.
 			switch (columnSchema?.type_display) {
-				// Number.
-				case ColumnDisplayType.Number: {
+				// Number (including all numeric subtypes).
+				case ColumnDisplayType.Number:
+				case ColumnDisplayType.Floating:
+				case ColumnDisplayType.Integer:
+				case ColumnDisplayType.Decimal: {
 					// If histograms are supported, load them.
 					if (histogramSupported) {
 						// Load the small histogram.

--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -71,10 +71,10 @@ test.describe('Data Explorer - Python Polars', {
 
 		// Verify all column profile data
 		await dataExplorer.summaryPanel.verifyColumnData([
-			{ column: 1, expected: { 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' } },
+			{ column: 1, expected: { 'Missing': '0', 'Min': '1', 'Median': '2', 'Mean': '2.00', 'Max': '3', 'SD': '1.00' } },
 			{ column: 2, expected: { 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' } },
 			{ column: 3, expected: { 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' } },
-			{ column: 4, expected: { 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' } },
+			{ column: 4, expected: { 'Missing': '1', 'Min': '2', 'Median': '3', 'Mean': '2.50', 'Max': '3', 'SD': '0.7071' } },
 			{ column: 5, expected: { 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' } },
 			{ column: 6, expected: { 'Missing': '1', 'True': '1', 'False': '1' } }
 		]);

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -35,7 +35,7 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 			{ column: 2, expected: { 'Missing': '0', 'Empty': '0', 'Unique': '100' } },
 			{ column: 3, expected: { 'Missing': '0', 'True': '46', 'False': '54' } },
 			{ column: 4, expected: { 'Missing': '0', 'Min': '-125', 'Median': '-11', 'Mean': '-2.71', 'Max': '126', 'SD': '75.02' } },
-			{ column: 5, expected: { 'Missing': '0', 'Min': '-32,403', 'Median': '-1,357', 'Mean': '2138.13', 'Max': '32,721', 'SD': '18186.19' } }
+			{ column: 5, expected: { 'Missing': '0', 'Min': '-32403', 'Median': '-1357', 'Mean': '2138.13', 'Max': '32721', 'SD': '18186.19' } }
 		]);
 		await summaryPanel.verifySparklineHeights([
 			{ column: 1, expected: ['50.0'] },

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -35,7 +35,7 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 			{ column: 2, expected: { 'Missing': '0', 'Empty': '0', 'Unique': '100' } },
 			{ column: 3, expected: { 'Missing': '0', 'True': '46', 'False': '54' } },
 			{ column: 4, expected: { 'Missing': '0', 'Min': '-125', 'Median': '-11', 'Mean': '-2.71', 'Max': '126', 'SD': '75.02' } },
-			{ column: 5, expected: { 'Missing': '0', 'Min': '-32403', 'Median': '-1357.50', 'Mean': '2138.13', 'Max': '32721', 'SD': '18186.19' } }
+			{ column: 5, expected: { 'Missing': '0', 'Min': '-32,403', 'Median': '-1,357', 'Mean': '2138.13', 'Max': '32,721', 'SD': '18186.19' } }
 		]);
 		await summaryPanel.verifySparklineHeights([
 			{ column: 1, expected: ['50.0'] },


### PR DESCRIPTION
Addresses #9482 and #2614. The existing `Number` display type is maintained to ease transition. I incorporated Decimal/Integer/Floating into the DuckDB and Python backends (actually very simple, since it only involves the schema results), and will follow up with an Ark PR.

<img width="357" height="237" alt="image" src="https://github.com/user-attachments/assets/e107d9e3-242e-4efe-8442-e9386a49e678" />

(This PR was almost entirely done by Claude Code with Sonnet 4.5) 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Integer types display sparkline histogram bins as whole number intervals.

#### Bug Fixes

- N/A


### QA Notes

Statistics (aside from mean and standard deviation) and histogram tooltips for integer types should display whole numbers and make sense. Everything else should work as it did before.

@:data-explorer