### PR TITLE
Bump to ark 0.1.213

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -974,7 +974,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.212"
+      "ark": "0.1.213"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Bumps ark to pick up "convert to code" (for dplyr) and the more granular display types for numeric columns.

@wesm and I are coordinating on this, ~so it's not ready to merge. Waiting for #9715 to land.~ We're going to merge both and handle any fallout in subsequent PRs.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The data explorer can convert current data frame filters and sorts to the equivalent dplyr code: https://github.com/posit-dev/positron/issues/9030

#### Bug Fixes



### QA Notes

#### Convert to code

Open an R data frame in the data explorer. Add one or more filters and/or one or more sorts.

* The "convert to code" button should be available.
* If you click it, you should get dplyr code to replicate the explorer's manipulations (dplyr is the only supported syntax right now).
* If you run the code provided, it should work! And give the same result as what you're staring at in the explorer.

`@:data-explorer`