### PR TITLE
Assistant: gate Copilot chat participants with non-Copilot providers behind setting

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -280,7 +280,7 @@
           "positron.assistant.alwaysIncludeCopilotTools": {
             "type": "boolean",
             "default": false,
-            "description": "%configuration.alwaysIncludeCopilotTools.description%"
+            "markdownDescription": "%configuration.alwaysIncludeCopilotTools.description%"
           },
           "positron.assistant.providerTimeout": {
             "type": "number",

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -34,5 +34,5 @@
 	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses.",
 	"configuration.consoleActions.enable.description": "Enable Positron Assistant console actions, such as Fix and Explain.",
 	"configuration.providerTimeout.description": "Specifies the timeout in seconds when signing in to a provider.",
-	"configuration.alwaysIncludeCopilotTools.description": "Allow any model in Positron Assistant to use tools provided by Copilot. This requires that you are signed into Copilot, and may send data to Copilot models regardless of the selected provider."
+	"configuration.alwaysIncludeCopilotTools.description": "Allow any model in Positron Assistant to use tools provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider**.\n\nSee also: `#chat.useCopilotParticipantsWithOtherProviders#`"
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -212,6 +212,11 @@ configurationRegistry.registerConfiguration({
 			default: 8192, // 8k characters
 			minimum: 1024,
 		},
+		'chat.useCopilotParticipantsWithOtherProviders': {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.useCopilotParticipantsWithOtherProviders', "Allow any model in Positron Assistant to use chat participants provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider**.\n\n See also: `#positron.assistant.alwaysIncludeCopilotTools#`"),
+			default: false
+		},
 		// --- End Positron ---
 		'chat.editing.autoAcceptDelay': {
 			type: 'number',

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -28,7 +28,7 @@ import { ChatContextKeys } from './chatContextKeys.js';
 import { IChatAgentEditedFileEvent, IChatProgressHistoryResponseContent, IChatRequestVariableData, ISerializableChatAgentData } from './chatModel.js';
 import { IRawChatCommandContribution } from './chatParticipantContribTypes.js';
 import { IChatFollowup, IChatLocationData, IChatProgress, IChatResponseErrorDetails, IChatTaskDto } from './chatService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from './constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, COPILOT_CHAT_EXTENSION_ID } from './constants.js';
 // --- Start Positron ---
 import { ILanguageModelsService } from './languageModels.js';
 import { IPositronAssistantConfigurationService } from '../../positronAssistant/common/interfaces/positronAssistantService.js';
@@ -493,9 +493,30 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 	private _agentIsEnabled(idOrAgent: string | IChatAgentEntry): boolean {
 		const entry = typeof idOrAgent === 'string' ? this._agents.get(idOrAgent) : idOrAgent;
 		// --- Start Positron ---
-		// Disable Copilot Chat agent if Copilot is not enabled
-		if (ExtensionIdentifier.equals(entry?.data.extensionId, 'github.copilot-chat') && !this.positronAssistantConfigurationService.copilotEnabled) {
-			return false;
+		// Special handling for Copilot Chat participants
+		const isCopilotParticipant = ExtensionIdentifier.equals(entry?.data.extensionId, COPILOT_CHAT_EXTENSION_ID);
+		if (isCopilotParticipant) {
+			// Disable Copilot Chat agent if Copilot is not enabled
+			const isCopilotEnabled = this.positronAssistantConfigurationService.copilotEnabled;
+			if (!isCopilotEnabled) {
+				return false;
+			}
+
+			const currentProvider = this.languageModelsService.currentProvider;
+			const currentProviderExtensionId = currentProvider ?
+				this.languageModelsService.getExtensionIdentifierForProvider(currentProvider.id) :
+				undefined;
+			if (!currentProviderExtensionId) {
+				return false;
+			}
+			const isCurrentProviderCopilot = ExtensionIdentifier.equals(currentProviderExtensionId, COPILOT_CHAT_EXTENSION_ID);
+			if (!isCurrentProviderCopilot) {
+				// Disable Copilot Chat agent if the user has not opted into using Copilot participants for non-Copilot providers
+				const useCopilotParticipantsWithOtherProviders = this.configurationService.getValue<boolean>(ChatConfiguration.UseCopilotParticipantsWithOtherProviders);
+				if (!useCopilotParticipantsWithOtherProviders) {
+					return false;
+				}
+			}
 		}
 		// --- End Positron ---
 		return !entry?.data.when || this.contextKeyService.contextMatchesRules(ContextKeyExpr.deserialize(entry.data.when));

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 export enum ChatConfiguration {
+	// --- Start Positron ---
+	UseCopilotParticipantsWithOtherProviders = 'chat.useCopilotParticipantsWithOtherProviders',
+	// --- End Positron ---
 	UseFileStorage = 'chat.useFileStorage',
 	AgentEnabled = 'chat.agent.enabled',
 	Edits2Enabled = 'chat.edits2.enabled',
@@ -58,3 +61,5 @@ export namespace ChatAgentLocation {
 		return ChatAgentLocation.Panel;
 	}
 }
+
+export const COPILOT_CHAT_EXTENSION_ID = 'github.copilot-chat';


### PR DESCRIPTION
### Summary

- part of https://github.com/posit-dev/positron/issues/9416
- follow-up to https://github.com/posit-dev/positron/pull/9591#pullrequestreview-3286959007
- prevents Copilot chat participants from being enabled for non-Copilot providers
- adds setting to allow users to opt-in to Copilot chat participants for non-Copilot providers via `chat.useCopilotParticipantsWithOtherProviders`

### Release Notes

#### New Features

- Assistant: use `chat.useCopilotParticipantsWithOtherProviders` to enable Copilot participants with other providers (#9416)

### QA Notes

- `chat.useCopilotParticipantsWithOtherProviders` and `positron.assistant.alwaysIncludeCopilotTools` are separate settings, but link to each other

#### Copilot participants unavailable

If any of these are true:
- `chat.useCopilotParticipantsWithOtherProviders` disabled (default) + not logged into copilot
- `chat.useCopilotParticipantsWithOtherProviders` disabled (default) + logged into copilot
- `chat.useCopilotParticipantsWithOtherProviders` enabled + not logged into copilot

Steps:
1. Login to a non-GitHub Copilot provider
2. In chat, ensure you've selected a non-GitHub Copilot provider and corresponding model
3. In chat, you should not be able to use any of the participants from copilot, such a `@vscode` or `@workspace`

#### Copilot participants available

If any of these are true:
- logged into copilot and using copilot as the provider in chat
- `chat.useCopilotParticipantsWithOtherProviders` enabled + logged into copilot and using a non-copilot provider in chat

Steps:
1. Login to Anthropic or another non-GitHub Copilot provider
2. Ensure you're logged into GitHub Copilot too
3. In chat, choose any provider + model
4. In chat, you should be able to use any of the participants from copilot, such a `@vscode` or `@workspace`, or have participant detection choose a copilot participant