### PR TITLE
Data Explorer: [Backport] Revert formatting of integer medians to previous behavior to allow a decimal part to display

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
@@ -91,7 +91,8 @@ export const ColumnProfileInteger = (props: ColumnProfileIntegerProps) => {
 				<div className='values'>
 					<ColumnProfileNullCountValue {...props} />
 					<IntegerStatsValue stats={stats} value={stats?.min_value} />
-					<IntegerStatsValue stats={stats} value={stats?.median} />
+					{/* Use StatsValue for median since it can be a decimal for even-length sequences */}
+					<StatsValue stats={stats} value={stats?.median} />
 					{/* Use StatsValue for mean to handle cases where mean is not an integer */}
 					<StatsValue stats={stats} value={stats?.mean} />
 					<IntegerStatsValue stats={stats} value={stats?.max_value} />

--- a/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-polars.test.ts
@@ -71,10 +71,10 @@ test.describe('Data Explorer - Python Polars', {
 
 		// Verify all column profile data
 		await dataExplorer.summaryPanel.verifyColumnData([
-			{ column: 1, expected: { 'Missing': '0', 'Min': '1', 'Median': '2', 'Mean': '2.00', 'Max': '3', 'SD': '1.00' } },
+			{ column: 1, expected: { 'Missing': '0', 'Min': '1', 'Median': '2.00', 'Mean': '2.00', 'Max': '3', 'SD': '1.00' } },
 			{ column: 2, expected: { 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' } },
 			{ column: 3, expected: { 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' } },
-			{ column: 4, expected: { 'Missing': '1', 'Min': '2', 'Median': '3', 'Mean': '2.50', 'Max': '3', 'SD': '0.7071' } },
+			{ column: 4, expected: { 'Missing': '1', 'Min': '2', 'Median': '2.50', 'Mean': '2.50', 'Max': '3', 'SD': '0.7071' } },
 			{ column: 5, expected: { 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' } },
 			{ column: 6, expected: { 'Missing': '1', 'True': '1', 'False': '1' } }
 		]);

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -35,7 +35,7 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 			{ column: 2, expected: { 'Missing': '0', 'Empty': '0', 'Unique': '100' } },
 			{ column: 3, expected: { 'Missing': '0', 'True': '46', 'False': '54' } },
 			{ column: 4, expected: { 'Missing': '0', 'Min': '-125', 'Median': '-11', 'Mean': '-2.71', 'Max': '126', 'SD': '75.02' } },
-			{ column: 5, expected: { 'Missing': '0', 'Min': '-32403', 'Median': '-1357', 'Mean': '2138.13', 'Max': '32721', 'SD': '18186.19' } }
+			{ column: 5, expected: { 'Missing': '0', 'Min': '-32403', 'Median': '-1357.50', 'Mean': '2138.13', 'Max': '32721', 'SD': '18186.19' } }
 		]);
 		await summaryPanel.verifySparklineHeights([
 			{ column: 1, expected: ['50.0'] },


### PR DESCRIPTION
Backport of #9736 

@:data-explorer