### PR TITLE
Data Explorer: Remove now unneeded "number" display type

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -759,8 +759,8 @@ function getNumericDisplayType(duckdbName: string): ColumnDisplayType {
 	} else if (duckdbName.startsWith('DECIMAL')) {
 		return ColumnDisplayType.Decimal;
 	} else {
-		// Fallback to Number for any other numeric type
-		return ColumnDisplayType.Number;
+		// Fallback to Floating for any other numeric type
+		return ColumnDisplayType.Floating;
 	}
 }
 

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -1362,7 +1362,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'id',
 				type: 'INTEGER',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Integer,
 				values: ['1', '2', '3', '4', '5']
 			},
 			{
@@ -1374,7 +1374,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'value',
 				type: 'DOUBLE',
-				display_type: ColumnDisplayType.Number,
+				display_type: ColumnDisplayType.Floating,
 				values: ['10.5', '20.75', '30.25', '40.5', '50.0']
 			}
 		]);

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -855,7 +855,7 @@ class DataExplorerTableView:
 
 
 def _box_number_stats(
-    min_val, max_val, mean_val, median_val, std_val, display_type=ColumnDisplayType.Number
+    min_val, max_val, mean_val, median_val, std_val, display_type=ColumnDisplayType.Floating
 ):
     return ColumnSummaryStats(
         type_display=display_type,
@@ -1066,7 +1066,6 @@ def _get_float_formatter(options: FormatOptions) -> Callable:
 
 
 _FILTER_RANGE_COMPARE_SUPPORTED = {
-    ColumnDisplayType.Number,
     ColumnDisplayType.Floating,
     ColumnDisplayType.Integer,
     ColumnDisplayType.Decimal,
@@ -1085,7 +1084,7 @@ def _pandas_temporal_mapper(type_name):
 
 
 def _pandas_summarize_number(
-    col: pd.Series, options: FormatOptions, display_type=ColumnDisplayType.Number
+    col: pd.Series, options: FormatOptions, display_type=ColumnDisplayType.Floating
 ):
     import numpy as np
 
@@ -1876,7 +1875,6 @@ class PandasView(DataExplorerTableView):
     _SUMMARIZERS = MappingProxyType(
         {
             ColumnDisplayType.Boolean: _pandas_summarize_boolean,
-            ColumnDisplayType.Number: _pandas_summarize_number,
             ColumnDisplayType.Floating: _pandas_summarize_floating,
             ColumnDisplayType.Integer: _pandas_summarize_integer,
             ColumnDisplayType.Decimal: _pandas_summarize_number,
@@ -2701,7 +2699,6 @@ class PolarsView(DataExplorerTableView):
     _SUMMARIZERS = MappingProxyType(
         {
             ColumnDisplayType.Boolean: _polars_summarize_boolean,
-            ColumnDisplayType.Number: _polars_summarize_number,
             ColumnDisplayType.Floating: _polars_summarize_number,
             ColumnDisplayType.Integer: _polars_summarize_number,
             ColumnDisplayType.Decimal: _polars_summarize_number,
@@ -2822,7 +2819,6 @@ def _polars_dtype_from_display(display_type):
     import polars as pl
 
     return {
-        ColumnDisplayType.Number: pl.Float64,
         ColumnDisplayType.Floating: pl.Float64,
         ColumnDisplayType.Integer: pl.Int64,
         ColumnDisplayType.Decimal: pl.Float64,  # Polars doesn't have a separate decimal type

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -41,8 +41,6 @@ class ColumnDisplayType(str, enum.Enum):
     Possible values for ColumnDisplayType
     """
 
-    Number = "number"
-
     Boolean = "boolean"
 
     String = "string"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2782,7 +2782,7 @@ def _assert_close(expected, actual):
 
 
 def assert_summary_stats_equal(display_type, result, ex_result):
-    if display_type == ColumnDisplayType.Number:
+    if display_type == ColumnDisplayType.Floating:
         _assert_numeric_stats_equal(ex_result, result["number_stats"])
     elif display_type == ColumnDisplayType.String:
         _assert_string_stats_equal(ex_result, result["string_stats"])

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -2782,7 +2782,11 @@ def _assert_close(expected, actual):
 
 
 def assert_summary_stats_equal(display_type, result, ex_result):
-    if display_type == ColumnDisplayType.Floating:
+    if display_type in (
+        ColumnDisplayType.Floating,
+        ColumnDisplayType.Integer,
+        ColumnDisplayType.Decimal,
+    ):
         _assert_numeric_stats_equal(ex_result, result["number_stats"])
     elif display_type == ColumnDisplayType.String:
         _assert_string_stats_equal(ex_result, result["string_stats"])

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -494,7 +494,6 @@
 				"type": "string",
 				"description": "Canonical Positron display name of data type",
 				"enum": [
-					"number",
 					"boolean",
 					"string",
 					"date",

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -51,7 +51,6 @@ const validateRowFilterValue = (columnSchema: ColumnSchema, value: string) => {
 	// Validate the row filter value that was supplied based on the column schema type.
 	switch (columnSchema.type_display) {
 		// Number (including all numeric subtypes).
-		case ColumnDisplayType.Number:
 		case ColumnDisplayType.Floating:
 		case ColumnDisplayType.Integer:
 		case ColumnDisplayType.Decimal:
@@ -302,7 +301,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 		// Add is less than / is greater than conditions.
 		switch (selectedColumnSchema.type_display) {
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:
@@ -346,7 +344,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 		// Add is equal to, is not equal to conditions.
 		switch (selectedColumnSchema.type_display) {
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:
@@ -396,7 +393,6 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 		// Add is between / is not between conditions.
 		switch (selectedColumnSchema.type_display) {
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/utility/columnSchemaUtilities.ts
@@ -17,7 +17,6 @@ export const columnSchemaDataTypeIcon = (columnSchema?: ColumnSchema) => {
 
 	// Determine the alignment based on type.
 	switch (columnSchema.type_display) {
-		case ColumnDisplayType.Number:
 		case ColumnDisplayType.Floating:
 		case ColumnDisplayType.Integer:
 		case ColumnDisplayType.Decimal:

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1150,7 +1150,6 @@ export enum SearchSchemaSortOrder {
  * Possible values for ColumnDisplayType
  */
 export enum ColumnDisplayType {
-	Number = 'number',
 	Boolean = 'boolean',
 	String = 'string',
 	Date = 'date',

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -60,7 +60,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		// Determines whether a sparkline is expected for this column type
 		const shouldShowSparkline = () => {
 			switch (props.columnSchema.type_display) {
-				case ColumnDisplayType.Number:
 				case ColumnDisplayType.Floating:
 				case ColumnDisplayType.Integer:
 				case ColumnDisplayType.Decimal:
@@ -113,7 +112,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		// Render.
 		switch (props.columnSchema.type_display) {
 			// Column display types that render a histogram sparkline.
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal: {
@@ -376,7 +374,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				return <ColumnProfileInteger columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Other numeric types
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal:
 				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
@@ -422,7 +419,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
 			// Number (including all numeric subtypes).
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -66,7 +66,6 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 	get alignment() {
 		// Determine the alignment based on type.
 		switch (this.columnSchema.type_display) {
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -352,7 +352,6 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 		let summaryStatsSupported;
 		switch (columnSchema.type_display) {
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:
@@ -644,7 +643,6 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Return the row height.
 		switch (columnSchema.type_display) {
 			// Number (including all numeric subtypes).
-			case ColumnDisplayType.Number:
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Integer:
 			case ColumnDisplayType.Decimal:

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -18,10 +18,10 @@ import {
 } from '../../languageRuntime/common/positronDataExplorerComm.js';
 
 const exampleTypes: [string, ColumnDisplayType, object][] = [
-	['int64', ColumnDisplayType.Number, {}],
+	['int64', ColumnDisplayType.Integer, {}],
 	['string', ColumnDisplayType.String, {}],
 	['boolean', ColumnDisplayType.Boolean, {}],
-	['double', ColumnDisplayType.Number, {}],
+	['double', ColumnDisplayType.Floating, {}],
 	['timestamp', ColumnDisplayType.Datetime, { timezone: 'America/New_York' }]
 ];
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -340,7 +340,6 @@ export class TableSummaryCache extends Disposable {
 			// Determine whether to load the histogram or the frequency table for the column.
 			switch (columnSchema?.type_display) {
 				// Number (including all numeric subtypes).
-				case ColumnDisplayType.Number:
 				case ColumnDisplayType.Floating:
 				case ColumnDisplayType.Integer:
 				case ColumnDisplayType.Decimal: {

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableSummaryDataGridInstance.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableSummaryDataGridInstance.test.ts
@@ -171,13 +171,13 @@ suite('TableSummaryDataGridInstance', () => {
 	});
 
 	test('canToggleColumnExpansion should return true for supported column types when feature is enabled', () => {
-		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Number);
+		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Floating);
 		getColumnSchemaStub.returns(supportedColumnSchema);
 		assert.strictEqual(instance.canToggleColumnExpansion(0), true);
 	});
 
 	test('toggleExpandColumn should update row layout manager', async () => {
-		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Number);
+		const supportedColumnSchema = getColumnSchema('test', 0, 'number', ColumnDisplayType.Floating);
 		getColumnSchemaStub.returns(supportedColumnSchema);
 		await instance.toggleExpandColumn(0);
 		assert(toggleExpandColumnStub.calledWith(0));


### PR DESCRIPTION
This PR is internal cleanup after https://github.com/posit-dev/positron/pull/9715 which introduced specific numeric display types for the data explorer. Now that support for this has been landed in Ark, the legacy "number" display type can be removed.

This change does **not** need to be backported for 2025.10.

@:data-explorer