### PR TITLE
Update canSupportResource to not be "file" scheme specific

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -27,6 +27,7 @@ import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { checkPositronNotebookEnabled } from './positronNotebookExperimentalConfig.js';
 import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from '../../../services/workingCopy/common/workingCopyEditorService.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { isEqual } from '../../../../base/common/resources.js';
@@ -52,7 +53,8 @@ class PositronNotebookContribution extends Disposable {
 	constructor(
 		@IEditorResolverService private readonly editorResolverService: IEditorResolverService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IFileService private readonly fileService: IFileService
 	) {
 		super();
 
@@ -77,8 +79,11 @@ class PositronNotebookContribution extends Disposable {
 			{
 				singlePerResource: true,
 				canSupportResource: (resource: URI) => {
-					// Support both file:// and untitled:// schemes
-					return resource.scheme === Schemas.file || resource.scheme === Schemas.untitled;
+					// Support untitled notebooks and any file system that has a provider
+					// This handles: file://, vscode-remote://, vscode-userdata://, etc.
+					return resource.scheme === Schemas.untitled ||
+						resource.scheme === Schemas.vscodeNotebookCell ||
+						this.fileService.hasProvider(resource);
 				}
 			},
 			{


### PR DESCRIPTION
Addresses #9193.

### Summary

Fixes Positron notebooks displaying as raw JSON in web mode. The issue occurred because Positron's notebook editor registration only supported `file://` and `untitled://` URI schemes, but web mode uses `vscode-remote://` for saved files and `vscode-userdata://` for untitled notebooks.

The fix adopts VS Code's standard pattern of using `fileService.hasProvider(resource)` instead of hardcoding specific URI schemes. This automatically handles all file system providers (local files, remote files, web storage, etc.) and makes the implementation future-proof for any new schemes added by VS Code or extensions.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Positron notebook editor not opening in web mode - notebooks would display as JSON instead (#9193)

### QA Notes

@:notebooks @:web

**Web mode testing:**
1. Launch Positron in web mode
2. Open an existing `.ipynb` file from your workspace
3. Verify the Positron notebook editor opens (not JSON text editor)
4. Create a new notebook: `Cmd/Ctrl+Shift+P` ‚Üí "Create: Jupyter Notebook"
5. Verify the new untitled notebook opens in Positron notebook editor
6. Add and execute a code cell to verify functionality

**Desktop regression test:**
1. Launch Positron in desktop mode
2. Open an existing `.ipynb` file - should still work
3. Create a new untitled notebook - should still work
4. Verify no regressions in notebook functionality
