### PR TITLE
e2e: fix logs & screenshots on app fixture failures

### DIFF
--- a/test/e2e/fixtures/test-setup/app-external.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-external.fixtures.ts
@@ -40,11 +40,9 @@ export async function startExternalPositronServerApp(fixtureOptions: AppFixtureO
 		error = err;
 	}
 
-	// Return the app, but also throw the error asynchronously
-	// so that the test runner sees the failure
 	if (error) {
-		// Throw after returning, so the test runner sees the error
-		setTimeout(() => { throw error; }, 0);
+		// Throw after returning, so we have time to capture screenshot and trace
+		setTimeout(() => { throw error; }, 1000);
 	}
 
 	return app;

--- a/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
@@ -26,11 +26,9 @@ export async function startManagedApp(fixtureOptions: AppFixtureOptions): Promis
 		error = err;
 	}
 
-	// Return the app, but also throw the error asynchronously
-	// so that the test runner sees the failure
 	if (error) {
-		// Throw after returning, so the test runner sees the error
-		setTimeout(() => { throw error; }, 0);
+		// Throw after returning, so we have time to capture screenshot and trace
+		setTimeout(() => { throw error; }, 1000);
 	}
 
 	return app;

--- a/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
@@ -12,9 +12,9 @@ import { AppFixtureOptions } from './app.fixtures';
  */
 export async function startManagedApp(fixtureOptions: AppFixtureOptions): Promise<Application> {
 	const { options } = fixtureOptions;
-	const app = createApp(options);
-
 	let error: unknown = undefined;
+
+	const app = createApp(options);
 
 	try {
 		await app.start();

--- a/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-managed.fixtures.ts
@@ -7,29 +7,24 @@ import { Application, createApp } from '../../infra';
 import { AppFixtureOptions } from './app.fixtures';
 
 /**
- * Start a managed Positron app (Electron or browser-based)
+ * Managed Positron app (Electron or browser-based)
  * Projects: e2e-electron, e2e-chromium/firefox/webkit/edge (port 9000)
  */
-export async function startManagedApp(fixtureOptions: AppFixtureOptions): Promise<Application> {
+export async function ManagedApp(
+	fixtureOptions: AppFixtureOptions
+): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
 	const { options } = fixtureOptions;
-	let error: unknown = undefined;
 
 	const app = createApp(options);
 
-	try {
+	const start = async () => {
 		await app.start();
-		throw new Error('OOPS!');
 		await app.workbench.sessions.expectNoStartUpMessaging();
-	}
-	catch (err) {
-		console.error('Error during app start or session check:', err);
-		error = err;
+	};
+
+	const stop = async () => {
+		await app.stop();
 	}
 
-	if (error) {
-		// Throw after returning, so we have time to capture screenshot and trace
-		setTimeout(() => { throw error; }, 1000);
-	}
-
-	return app;
+	return { app, start, stop };
 }

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -27,16 +27,28 @@ export async function WorkbenchApp(
 
 	const start = async () => {
 		await app.connectToExternalServer();
+
+		// Workbench: Login to Posit Workbench
 		await app.positWorkbench.auth.signIn();
 		await app.positWorkbench.dashboard.expectHeaderToBeVisible();
 		await app.positWorkbench.dashboard.openSession('qa-example-content');
-		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60_000 });
+
+		// Wait for Positron to be ready
+		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 		await app.workbench.sessions.expectNoStartUpMessaging();
 		await app.workbench.sessions.deleteAll();
 		await app.workbench.hotKeys.closeAllEditors();
 	};
 
 	const stop = async () => {
+		// Exit Posit Workbench session
+		try {
+			await app.positWorkbench.dashboard.goTo();
+			await app.positWorkbench.dashboard.quitSession('qa-example-content');
+		} catch (error) {
+			console.warn('Failed to quit workbench session:', error);
+		}
+
 		await app.stopExternalServer();
 	}
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -44,8 +44,8 @@ export async function startWorkbenchApp(fixtureOptions: AppFixtureOptions): Prom
 	// Return the app, but also throw the error asynchronously
 	// so that the test runner sees the failure
 	if (error) {
-		// Throw after returning, so the test runner sees the error
-		setTimeout(() => { throw error; }, 0);
+		// Throw after returning, so we have time to capture screenshot and trace
+		setTimeout(() => { throw error; }, 1000);
 	}
 
 	return app;

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -5,9 +5,9 @@
 
 import * as playwright from '@playwright/test';
 import { Application, ApplicationOptions, MultiLogger } from '../../infra';
-import { startManagedApp } from './app-managed.fixtures';
-import { startExternalPositronServerApp } from './app-external.fixtures';
-import { startWorkbenchApp } from './app-workbench.fixtures';
+import { ManagedApp } from './app-managed.fixtures';
+import { ExternalPositronServerApp } from './app-external.fixtures';
+import { WorkbenchApp } from './app-workbench.fixtures';
 
 export interface AppFixtureOptions {
 	options: ApplicationOptions;
@@ -19,19 +19,19 @@ export interface AppFixtureOptions {
 /**
  * Main app fixture that routes to the appropriate implementation based on configuration
  */
-export async function AppFixture(fixtureOptions: AppFixtureOptions): Promise<Application> {
+export async function AppFixture(fixtureOptions: AppFixtureOptions): Promise<{
+	app: Application;
+	start: () => Promise<void>;
+	stop: () => Promise<void>;
+}> {
 	const project = fixtureOptions.workerInfo.project.name;
 
-	// Start the appropriate app based on the project name
-	// e2e-workbench -> Workbench (Docker)
-	// e2e-server -> External Positron server
-	// All others -> Managed (Electron or browser-based)
 	if (project === 'e2e-workbench') {
-		return await startWorkbenchApp(fixtureOptions);
+		return await WorkbenchApp(fixtureOptions);
 	} else if (project.includes('server')) {
-		return await startExternalPositronServerApp(fixtureOptions);
+		return await ExternalPositronServerApp(fixtureOptions);
 	} else {
-		return await startManagedApp(fixtureOptions);
+		return await ManagedApp(fixtureOptions);
 	}
 }
 

--- a/test/e2e/fixtures/test-setup/index.ts
+++ b/test/e2e/fixtures/test-setup/index.ts
@@ -5,3 +5,4 @@ export * from './reporting.fixtures';
 export * from './settings.fixtures';
 export * from './app.fixtures';
 export * from './file-ops.fixtures';
+export * from './shared-utils.js';

--- a/test/e2e/fixtures/test-setup/shared-utils.ts
+++ b/test/e2e/fixtures/test-setup/shared-utils.ts
@@ -73,14 +73,14 @@ export async function copyUserSettings(userDir: string): Promise<string> {
  * @param workerInfo Information about the worker process.
  * @returns A promise that resolves when the operation is complete.
  */
-export async function renameTempLogsDir(logger: MultiLogger, logsPath: string, workerInfo: any) {
+export async function renameTempLogsDir(logger: MultiLogger, logsPath: string, workerInfo: any): Promise<string> {
 	const specLogsPath = path.join(path.dirname(logsPath), SPEC_NAME || `worker-${workerInfo.workerIndex}`);
 
 	try {
 		await access(logsPath, constants.F_OK);
 	} catch {
 		console.error(`moveAndOverwrite: source path does not exist: ${logsPath}`);
-		return;
+		return 'unable to rename temp logs dir';
 	}
 
 	// check if the destination exists and delete it if so
@@ -101,4 +101,5 @@ export async function renameTempLogsDir(logger: MultiLogger, logsPath: string, w
 	} catch (err) {
 		logger.log(`moveAndOverwrite: failed to move ${logsPath} to ${specLogsPath}:`, err);
 	}
+	return specLogsPath
 }

--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -55,6 +55,7 @@ export class DashboardPage {
 		await this.sessionNameInput.fill(folderToOpen);
 		await this.launchButton.click();
 		await this.code.driver.page.getByRole('button', { name: 'Open Folder', exact: true }).click();
+		await this.quickInput.waitForQuickInputOpened()
 		await this.quickInput.selectQuickInputElementContaining(folderToOpen);
 		await this.quickInput.clickOkButton();
 	}

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -8,7 +8,7 @@ import * as playwright from '@playwright/test';
 const { test: base, expect: playwrightExpect } = playwright;
 
 // Node.js built-in modules
-import path, { join } from 'path';
+import { join } from 'path';
 
 // Local imports
 import { Application, createLogger, TestTags, Sessions, HotKeys, TestTeardown, ApplicationOptions, MultiLogger, VscodeSettings } from '../infra';

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -31,8 +31,6 @@ import {
 	// eslint-disable-next-line local/code-import-patterns
 } from '@currents/playwright';
 
-let SPEC_NAME = '';
-
 // Test fixtures
 export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures & CurrentsWorkerFixtures>({
 	...currentsFixtures.baseFixtures,
@@ -118,8 +116,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 			}
 
 			// rename the temp logs dir to the spec name (if available)
-			const specLogsPath = path.join(path.dirname(logsPath), SPEC_NAME || `worker-${workerInfo.workerIndex}`);
-			await renameTempLogsDir(logger, logsPath, specLogsPath);
+			await renameTempLogsDir(logger, logsPath, workerInfo);
 		}
 	}, { scope: 'worker', auto: true, timeout: 80000 }],
 
@@ -228,7 +225,6 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 	}, { auto: true }],
 
 	attachLogsToReport: [async ({ suiteId, logsPath }, use, testInfo) => {
-		console.log('!!!! attachLogs')
 		const attachLogsFixture = AttachLogsToReportFixture();
 		await attachLogsFixture({ suiteId, logsPath, testInfo }, use);
 	}, { auto: true }],

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -25,7 +25,7 @@ import { runDockerCommand } from '../fixtures/test-setup/app-workbench.fixtures.
 
 // used specifically for app fixture error handling in test.afterAll
 let appFixtureFailed = false;
-let fixtureScreenshot: Buffer | undefined;
+let appFixtureScreenshot: Buffer | undefined;
 let renamedLogsPath = 'not-set';
 
 // Currents fixtures
@@ -119,7 +119,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 			try {
 				const page = app.code?.driver?.page;
 				if (page) {
-					fixtureScreenshot = await page.screenshot({ path: screenshotPath });
+					appFixtureScreenshot = await page.screenshot({ path: screenshotPath });
 				}
 			} catch {
 				// ignore
@@ -309,9 +309,9 @@ test.afterAll(async function ({ logger, suiteId, }, testInfo) {
 
 	if (appFixtureFailed) {
 		try {
-			if (fixtureScreenshot) {
+			if (appFixtureScreenshot) {
 				await testInfo.attach('app-start-failure', {
-					body: fixtureScreenshot,
+					body: appFixtureScreenshot,
 					contentType: 'image/png',
 				});
 			}
@@ -327,7 +327,7 @@ test.afterAll(async function ({ logger, suiteId, }, testInfo) {
 		}
 
 		appFixtureFailed = false;
-		fixtureScreenshot = undefined;
+		appFixtureScreenshot = undefined;
 	}
 });
 


### PR DESCRIPTION
### Summary
Updated app fixture to properly capture screenshots and logs on html reports when/if the app fixture fails.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
