### PR TITLE
e2e: fix flake in notebook reload variables test

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -99,7 +99,7 @@ export class Workbench {
 		this.toasts = new Toasts(code);
 		this.popups = new Popups(code);
 		this.contextMenu = new ContextMenu(code);
-		this.variables = new Variables(code, this.hotKeys);
+		this.variables = new Variables(code, this.hotKeys, this.contextMenu);
 		this.dataExplorer = new DataExplorer(code, this);
 		this.sideBar = new SideBar(code);
 		this.plots = new Plots(code, this.contextMenu);

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -157,6 +157,10 @@ export class Variables {
 		return group;
 	}
 
+	/**
+	 * Select a session in the variables pane.
+	 * @param name the name of the session to select
+	 */
 	async selectSession(name: string) {
 		await this.contextMenu.triggerAndClick({
 			menuTrigger: this.code.driver.page.locator('.positron-variables .positron-action-bar').nth(1).locator('button'),
@@ -238,9 +242,4 @@ export class Variables {
 			await expect(this.interpreterLocator).toHaveText(sessionName);
 		});
 	}
-
-	async waitForVariableNotebookConnection() {
-		await expect(this.code.driver.page.getByText('No variables have been created')).toBeVisible();
-	}
-
 }

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -220,4 +220,8 @@ export class Variables {
 		});
 	}
 
+	async waitForVariableNotebookConnection() {
+		await expect(this.code.driver.page.getByText('No variables have been created')).toBeVisible();
+	}
+
 }

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -7,6 +7,7 @@
 import { Code } from '../infra/code';
 import test, { expect, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
+import { ContextMenu } from './dialog-contextMenu.js';
 
 interface FlatVariables {
 	value: string;
@@ -32,7 +33,7 @@ export class Variables {
 	variablesPane: Locator;
 	variablesRuntime: (name: string | RegExp) => Locator;
 
-	constructor(private code: Code, private hotKeys: HotKeys) {
+	constructor(private code: Code, private hotKeys: HotKeys, private contextMenu: ContextMenu) {
 		this.variablesPane = this.code.driver.page.locator('[id="workbench.panel.positronSession"]');
 		this.variablesRuntime = (name: string | RegExp) => this.variablesPane.getByRole('button', { name });
 	}
@@ -156,6 +157,13 @@ export class Variables {
 		return group;
 	}
 
+	async selectSession(name: string) {
+		await this.contextMenu.triggerAndClick({
+			menuTrigger: this.code.driver.page.locator('.positron-variables .positron-action-bar').nth(1).locator('button'),
+			menuItemLabel: name,
+		})
+	}
+
 	async selectVariablesGroup(name: string) {
 		await this.code.driver.page.locator(VARIABLES_GROUP_SELECTOR).click();
 		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).first().isVisible();
@@ -217,6 +225,17 @@ export class Variables {
 
 			await expect(row).toBeVisible({ timeout });
 			await expect(row.locator('.details-column .value')).toHaveText(value);
+		});
+	}
+
+	/**
+	 * Verify: Confirm the session is selected in the variables pane.
+	 * @param sessionName the name of the session to check is selected
+	 */
+	async expectSessionToBe(sessionName: string | RegExp) {
+		await test.step(`Verify session is selected in variables pane: ${sessionName}`, async () => {
+			await expect(this.interpreterLocator).toBeVisible();
+			await expect(this.interpreterLocator).toHaveText(sessionName);
 		});
 	}
 

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect, tags } from '../_test.setup';
+import { test, tags } from '../_test.setup';
+
+const FILENAME = 'Untitled-1.ipynb';
 
 test.use({
 	suiteId: __filename
@@ -16,27 +18,36 @@ test.afterEach(async function ({ app }) {
 test.describe('Variables Pane - Notebook', {
 	tag: [tags.CRITICAL, tags.WEB, tags.VARIABLES, tags.NOTEBOOKS]
 }, () => {
-	test('Python - Verify Variables pane basic function for notebook', async function ({ app, python }) {
-		await app.workbench.notebooks.createNewNotebook();
+	test('R - Verify Variables pane basic function for notebook', {
+		tag: [tags.ARK]
+	}, async function ({ app, hotKeys }) {
+		const { notebooks, variables } = app.workbench;
 
-		// workaround issue where starting multiple interpreters in quick succession can cause startup failure
-		await app.code.wait(1000);
+		// Create a variable via a notebook
+		await notebooks.createNewNotebook();
+		await notebooks.selectInterpreter('R');
+		await notebooks.addCodeToCellAtIndex('y <- c(2, 3, 4, 5)');
+		await notebooks.executeCodeInCell();
 
-		await app.workbench.notebooks.selectInterpreter('Python');
-		await app.workbench.notebooks.addCodeToCellAtIndex('y = [2, 3, 4, 5]');
-		await app.workbench.notebooks.executeCodeInCell();
+		// Verify the interpreter and var in the variable pane
+		await hotKeys.fullSizeSecondarySidebar();
+		await variables.expectSessionToBe('Untitled-1.ipynb');
+		await variables.expectVariableToBe('y', '2 3 4 5');
+	});
 
-		const filename = 'Untitled-1.ipynb';
+	test('Python - Verify Variables pane basic function for notebook', async function ({ app }) {
+		const { notebooks, variables, hotKeys } = app.workbench;
 
-		const interpreter = app.workbench.variables.interpreterLocator;
-		await expect(interpreter).toBeVisible();
-		await expect(interpreter).toHaveText(filename);
-		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+		// Create a variable via a notebook
+		await notebooks.createNewNotebook();
+		await notebooks.selectInterpreter('Python');
+		await notebooks.addCodeToCellAtIndex('y = [2, 3, 4, 5]');
+		await notebooks.executeCodeInCell();
 
-		await expect(async () => {
-			const variablesMap = await app.workbench.variables.getFlatVariables();
-			expect(variablesMap.get('y')).toStrictEqual({ value: '[2, 3, 4, 5]', type: 'list [4]' });
-		}).toPass({ timeout: 60000 });
+		// Verify the interpreter and var in the variable pane
+		await hotKeys.fullSizeSecondarySidebar();
+		await variables.expectSessionToBe(FILENAME);
+		await variables.expectVariableToBe('y', '[2, 3, 4, 5]');
 	});
 
 	test('Python - Verify Variables available after reload', async function ({ app, sessions, hotKeys }) {
@@ -45,18 +56,12 @@ test.describe('Variables Pane - Notebook', {
 		// Create a variable via a notebook
 		await notebooks.createNewNotebook();
 		await notebooks.selectInterpreter('Python');
-		await variables.waitForVariableNotebookConnection();
 		await notebooks.addCodeToCellAtIndex('dict = [{"a":1,"b":2},{"a":3,"b":4}]');
 		await notebooks.executeCodeInCell();
 
-		// Ensure the variable pane shows the notebook interpreter
-		const filename = 'Untitled-1.ipynb';
-		const interpreter = app.workbench.variables.interpreterLocator;
-		await expect(interpreter).toBeVisible();
-		await expect(interpreter).toHaveText(filename);
+		// Verify the interpreter and var in the variable pane
 		await hotKeys.fullSizeSecondarySidebar();
-
-		// Ensure the variable is present
+		await variables.expectSessionToBe(FILENAME);
 		await variables.expectVariableToBe('dict', `[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]`);
 
 		// Reload window
@@ -64,27 +69,8 @@ test.describe('Variables Pane - Notebook', {
 		await sessions.expectAllSessionsToBeReady();
 
 		// Ensure the variable is still present
+		await variables.selectSession(FILENAME);
 		await variables.expectVariableToBe('dict', `[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]`);
-	});
-
-	test('R - Verify Variables pane basic function for notebook', {
-		tag: [tags.ARK]
-	}, async function ({ app, r }) {
-		await app.workbench.notebooks.createNewNotebook();
-
-		await app.workbench.notebooks.selectInterpreter('R');
-		await app.workbench.notebooks.addCodeToCellAtIndex('y <- c(2, 3, 4, 5)');
-		await app.workbench.notebooks.executeCodeInCell();
-
-		const interpreter = app.workbench.variables.interpreterLocator;
-		await expect(interpreter).toBeVisible();
-		await expect(interpreter).toHaveText('Untitled-1.ipynb');
-		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
-
-		await expect(async () => {
-			const variablesMap = await app.workbench.variables.getFlatVariables();
-			expect(variablesMap.get('y')).toStrictEqual({ value: '2 3 4 5', type: 'dbl [4]' });
-		}).toPass({ timeout: 60000 });
 	});
 });
 


### PR DESCRIPTION
### Summary
I noticed that these 2 variables notebooks test had very high flake rates.

<img width="1288" height="154" alt="Screenshot 2025-10-03 at 9 19 18 AM" src="https://github.com/user-attachments/assets/54358a16-86dd-4834-a3b8-4f1ca898547f" />


This PR addresses the root cause of the flake by ensuring that the correct session is selected in the variables pane before verifying that the variables have been retained. Additionally, I perform some general cleanup of this entire test suite to enhance its maintainability.

### QA Notes

This test is tagged for critical, and ran on this PR and did _NOT_ flake! 🎉 