### PR TITLE
Fix enter key bug in positron notebook cell editors

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -860,12 +860,16 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const onKeyDown = (event: KeyboardEvent) => {
 			const { key, shiftKey, ctrlKey, metaKey } = event;
 			if (key === 'Enter' && !(ctrlKey || metaKey || shiftKey)) {
-				// Prevent the Enter key from being processed by the editor
-				event.preventDefault();
-				event.stopPropagation();
-				this.selectionStateMachine.enterEditor().catch(err => {
-					this._logService.error(this.id, 'Error entering editor:', err);
-				});
+				// Only intercept Enter if we're NOT already in edit mode
+				// When already editing, let the event pass through to Monaco
+				const currentState = this.selectionStateMachine.state.get();
+				if (currentState.type !== SelectionState.EditingSelection) {
+					event.preventDefault();
+					event.stopPropagation();
+					this.selectionStateMachine.enterEditor().catch(err => {
+						this._logService.error(this.id, 'Error entering editor:', err);
+					});
+				}
 			} else if (key === 'Escape') {
 				this.selectionStateMachine.exitEditor();
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -118,11 +118,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private readonly _cellsContainerListeners = this._register(new DisposableStore());
 
 	/**
-	 * Callback to clear the keyboard navigation listeners. Set when listeners are attached.
-	 */
-	private _clearKeyboardNavigation: (() => void) | undefined = undefined;
-
-	/**
 	 * Key-value map of language to base cell editor options for cells of that language.
 	 */
 	private _baseCellEditorOptions: Map<string, IBaseCellEditorOptions> = new Map();
@@ -672,7 +667,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._container = container;
 		this.contextManager.setContainer(container, scopedContextKeyService);
 
-		this._setupKeyboardNavigation(container);
 		this._logService.info(this.id, 'attachView');
 	}
 
@@ -720,7 +714,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	detachView(): void {
 		this._container = undefined;
 		this._logService.info(this.id, 'detachView');
-		this._clearKeyboardNavigation?.();
 		this._notebookOptions?.dispose();
 		this._notebookOptions = undefined;
 	}
@@ -848,39 +841,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		await this.notebookExecutionService.executeNotebookCells(this.textModel, Array.from(cells).map(c => c.cellModel as NotebookCellTextModel), this._contextKeyService);
 	}
 
-
-	/**
-	 * Setup keyboard navigation for the current notebook.
-	 * @param container The main containing node the notebook is rendered into
-	 */
-	private _setupKeyboardNavigation(container: HTMLElement) {
-		// Add some keyboard navigation for cases not covered by the keybindings. I'm not sure if
-		// there's a way to do this directly with keybindings but this feels acceptable due to the
-		// ubiquity of the enter key and escape keys for these types of actions.
-		const onKeyDown = (event: KeyboardEvent) => {
-			const { key, shiftKey, ctrlKey, metaKey } = event;
-			if (key === 'Enter' && !(ctrlKey || metaKey || shiftKey)) {
-				// Only intercept Enter if we're NOT already in edit mode
-				// When already editing, let the event pass through to Monaco
-				const currentState = this.selectionStateMachine.state.get();
-				if (currentState.type !== SelectionState.EditingSelection) {
-					event.preventDefault();
-					event.stopPropagation();
-					this.selectionStateMachine.enterEditor().catch(err => {
-						this._logService.error(this.id, 'Error entering editor:', err);
-					});
-				}
-			} else if (key === 'Escape') {
-				this.selectionStateMachine.exitEditor();
-			}
-		};
-
-		this._container?.addEventListener('keydown', onKeyDown);
-
-		this._clearKeyboardNavigation = () => {
-			this._container?.removeEventListener('keydown', onKeyDown);
-		};
-	}
 
 	/**
 	 * Clears the output of a specific cell in the notebook.

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -39,7 +39,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 import { SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -366,6 +366,41 @@ registerNotebookCommand({
 	},
 	metadata: {
 		description: localize('positronNotebook.addSelectionUp', "Extend selection up")
+	}
+});
+
+// Enter key: Enter edit mode when cell is selected but NOT editing
+registerNotebookCommand({
+	commandId: 'positronNotebook.cell.edit',
+	handler: (notebook) => {
+		notebook.selectionStateMachine.enterEditor().catch(err => {
+			console.error('Error entering editor:', err);
+		});
+	},
+	keybinding: {
+		primary: KeyCode.Enter,
+		when: ContextKeyExpr.and(
+			POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
+			POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+		)
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.edit', "Enter cell edit mode")
+	}
+});
+
+// Escape key: Exit edit mode when cell editor is focused
+registerNotebookCommand({
+	commandId: 'positronNotebook.cell.quitEdit',
+	handler: (notebook) => {
+		notebook.selectionStateMachine.exitEditor();
+	},
+	keybinding: {
+		primary: KeyCode.Escape,
+		when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.quitEdit', "Exit cell edit mode")
 	}
 });
 

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -350,4 +350,51 @@ test.describe('Notebook Focus and Selection', {
 		expect(normalizedContent).toContain('new cell content');
 	});
 
+	test('Enter key in edit mode adds newline within cell', async function ({ app }) {
+		// Select cell 1 and enter edit mode
+		await app.workbench.notebooksPositron.selectCellAtIndex(1);
+		await waitForFocusSettle(app, 200);
+		await app.code.driver.page.keyboard.press('Enter');
+		await waitForFocusSettle(app, 300);
+		expect(await isEditorFocused(app, 1)).toBe(true);
+
+		// Get initial content
+		const initialContent = await app.workbench.notebooksPositron.getCellContent(1);
+		const normalizedInitial = normalizeCellContent(initialContent);
+		expect(normalizedInitial).toBe('print("Cell 1")');
+
+		// Get cell and editor locators for line counting
+		const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(1);
+		const editor = cell.locator('.positron-cell-editor-monaco-widget');
+		const viewLines = editor.locator('.view-line');
+
+		// Position cursor in the MIDDLE of the text (after "print(")
+		// This avoids any trailing newline trimming issues
+		await app.code.driver.page.keyboard.press('Home');
+		for (let i = 0; i < 6; i++) { // Move past "print("
+			await app.code.driver.page.keyboard.press('ArrowRight');
+		}
+		await waitForFocusSettle(app, 100);
+
+		// Sanity check: Get initial line count before pressing Enter
+		const initialLineCount = await viewLines.count();
+
+		// Press Enter to split the line in the middle
+		await app.code.driver.page.keyboard.press('Enter');
+		await waitForFocusSettle(app, 200);
+
+		// Verify the line count increased by counting Monaco's .view-line elements
+		// Note: getCellContent uses .textContent() which strips newlines, so we count line elements directly
+		const lineCount = await viewLines.count();
+
+		// Line count should have increased by 1 after pressing Enter
+		expect(lineCount).toBe(initialLineCount + 1);
+
+		// Verify we're still in the same cell (cell count unchanged)
+		expect(await getCellCount(app)).toBe(5);
+
+		// Verify we're still in edit mode in cell 1
+		expect(await isEditorFocused(app, 1)).toBe(true);
+	});
+
 });

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -361,7 +361,8 @@ test.describe('Notebook Focus and Selection', {
 		// Get initial content
 		const initialContent = await app.workbench.notebooksPositron.getCellContent(1);
 		const normalizedInitial = normalizeCellContent(initialContent);
-		expect(normalizedInitial).toBe('print("Cell 1")');
+		const lineText = 'print("Cell 1")';
+		expect(normalizedInitial).toBe(lineText);
 
 		// Get cell and editor locators for line counting
 		const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(1);
@@ -371,7 +372,8 @@ test.describe('Notebook Focus and Selection', {
 		// Position cursor in the MIDDLE of the text (after "print(")
 		// This avoids any trailing newline trimming issues
 		await app.code.driver.page.keyboard.press('Home');
-		for (let i = 0; i < 6; i++) { // Move past "print("
+		const middleIndex = Math.floor(lineText.length / 2);
+		for (let i = 0; i < middleIndex; i++) { // move to middle of line
 			await app.code.driver.page.keyboard.press('ArrowRight');
 		}
 		await waitForFocusSettle(app, 100);


### PR DESCRIPTION
Addresses #9769.

This PR fixes the Enter key not working in Positron notebook cells. The issue was introduced in #9685 when implementing logic to prevent Enter from bleeding through when transitioning into edit mode. The original approach used manual DOM event interception which couldn't distinguish between "entering edit mode" vs "already editing."

### Solution

Rather than patching the manual event handling, this PR replaces the brittle DOM interception approach with proper context-aware keybindings that follow VS Code patterns:

- **Enter key**: Registered with context `positronNotebookEditorContainerFocused && !positronNotebookCellEditorFocused` - only fires when cell is selected but NOT editing
- **Escape key**: Registered with context `positronNotebookCellEditorFocused` - only fires when Monaco editor has focus

This eliminates the manual state checking, makes keybindings user-customizable, and aligns with how upstream VS Code notebooks handle keyboard navigation.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Enter key not adding newlines in notebook cell editors (#9769)

### QA Notes

@:notebooks @:critical

Test the Enter key behavior in notebook cells:

1. Open a notebook and create a cell with content: `print("Cell 1")`
2. Press <kbd>Escape</kbd> to exit edit mode
3. Press <kbd>Enter</kbd> to re-enter edit mode - verify the editor gains focus without adding a newline
4. While editing, move cursor to the middle of the text (e.g., after `print(`)
5. Press <kbd>Enter</kbd> - verify a newline is inserted, splitting the line
6. Press <kbd>Escape</kbd> - verify you exit edit mode and return to cell selection

Both the "Enter to edit" test (step 3) and "Enter in edit mode" test (step 5) are covered by automated E2E tests in `notebook-focus-and-selection.test.ts`.
