### PR TITLE
Fix `positron.RuntimeCodeExecutionMode.Silent` behavior for queued code in the console

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemPendingInput.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemPendingInput.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { RuntimeCodeExecutionMode } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { IConsoleCodeAttribution } from '../../common/positronConsoleCodeExecution.js';
 import { RuntimeItemStandard } from './runtimeItem.js';
 
@@ -19,13 +20,15 @@ export class RuntimeItemPendingInput extends RuntimeItemStandard {
 	 * @param attribution The attribution for the code.
 	 * @param executionId The execution identifier for the code.
 	 * @param code The code.
+	 * @param mode The code execution mode.
 	 */
 	constructor(
 		id: string,
 		readonly inputPrompt: string,
 		readonly attribution: IConsoleCodeAttribution,
 		readonly executionId: string | undefined,
-		readonly code: string
+		readonly code: string,
+		readonly mode: RuntimeCodeExecutionMode = RuntimeCodeExecutionMode.Interactive
 	) {
 		// Call the base class's constructor.
 		super(id, code);

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2176,10 +2176,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
-			// Check if this is a silent execution. If so, skip creating the UI element
-			// and remove it from the tracking set.
+			// Check if this is a silent execution. If so, skip creating the UI element.
 			if (this._silentExecutionIds.has(languageRuntimeMessageInput.parent_id)) {
-				this._silentExecutionIds.delete(languageRuntimeMessageInput.parent_id);
 				return;
 			}
 
@@ -2234,6 +2232,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
+			// Skip prompts for silent executions
+			if (this._silentExecutionIds.has(languageRuntimeMessagePrompt.parent_id)) {
+				return;
+			}
+
 			// Set the active activity item prompt.
 			this._activeActivityItemPrompt = new ActivityItemPrompt(
 				languageRuntimeMessagePrompt.id,
@@ -2261,6 +2264,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					);
 				}
 
+				// Skip output for silent executions
+				if (this._silentExecutionIds.has(languageRuntimeMessageOutput.parent_id)) {
+					return;
+				}
+
 				// Create an activity item representing the message.
 				const activityItemOutput = this.createActivityItemOutput(languageRuntimeMessageOutput);
 				if (!activityItemOutput) {
@@ -2286,6 +2294,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					formatCallbackTrace('onDidReceiveRuntimeMessageStream', languageRuntimeMessageStream) +
 					`\nStream ${languageRuntimeMessageStream.name}: "${traceOutput}" ${formattedLength(languageRuntimeMessageStream.text.length)}`
 				);
+			}
+
+			// Skip stream output for silent executions
+			if (this._silentExecutionIds.has(languageRuntimeMessageStream.parent_id)) {
+				return;
 			}
 
 			// Handle stdout and stderr.
@@ -2326,6 +2339,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageError.message +
 						formatTraceback(languageRuntimeMessageError.traceback)
 					);
+				}
+
+				// Skip errors for silent executions
+				if (this._silentExecutionIds.has(languageRuntimeMessageError.parent_id)) {
+					return;
 				}
 
 				// Add or update the runtime item activity.
@@ -2382,6 +2400,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						this.markInputBusyState(languageRuntimeMessageState.parent_id, false);
 						// This external execution ID has completed, so we can remove it.
 						this._externalExecutionIds.delete(languageRuntimeMessageState.parent_id);
+						// This silent execution ID has completed, so we can remove it.
+						this._silentExecutionIds.delete(languageRuntimeMessageState.parent_id);
 						break;
 					}
 				}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -956,6 +956,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _externalExecutionIds: Set<string> = new Set<string>();
 
 	/**
+	 * The set of silent execution IDs. This is used to track execution
+	 * requests that should not produce UI side effects, so when the runtime
+	 * rebroadcasts the input message, we can skip creating ActivityItemInput
+	 * entries for them.
+	 */
+	private _silentExecutionIds: Set<string> = new Set<string>();
+
+	/**
 	 * Gets or sets the session, if attached.
 	 */
 	private _session: ILanguageRuntimeSession | undefined;
@@ -1485,6 +1493,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// Clear the console.
 			this._runtimeItems = [];
 			this._runtimeItemActivities.clear();
+			this._silentExecutionIds.clear();
 			this._onDidChangeRuntimeItemsEmitter.fire();
 			this._onDidClearConsoleEmitter.fire();
 		}
@@ -2167,6 +2176,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
+			// Check if this is a silent execution. If so, skip creating the UI element
+			// and remove it from the tracking set.
+			if (this._silentExecutionIds.has(languageRuntimeMessageInput.parent_id)) {
+				this._silentExecutionIds.delete(languageRuntimeMessageInput.parent_id);
+				return;
+			}
+
 			// Add or update the runtime item activity.
 			this.addOrUpdateRuntimeItemActivity(
 				languageRuntimeMessageInput.parent_id,
@@ -2551,6 +2567,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					}
 				}
 			}
+
+			// Clear tracking sets for execution IDs
+			this._silentExecutionIds.clear();
 
 			// Dispose of the runtime event handlers.
 			this._runtimeDisposableStore.clear();
@@ -2959,6 +2978,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// replaced with the real ActivityItemInput when the runtime sends it (which can take a
 			// moment or two to happen).
 			this.addOrUpdateRuntimeItemActivity(id, activityItemInput);
+		} else {
+			// Track silent executions so we can skip creating UI elements
+			// when the runtime rebroadcasts the input message.
+			this._silentExecutionIds.add(id);
 		}
 
 		// If this is an interactive submission, check to see the text we just executed is

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2204,8 +2204,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
-			// Check if this is a silent execution. If so, skip creating the UI element.
+			// Check if this is a silent execution. If so, skip creating the UI element
+			// and remove it from the tracking set.
 			if (this._silentExecutionIds.has(languageRuntimeMessageInput.parent_id)) {
+				this._silentExecutionIds.delete(languageRuntimeMessageInput.parent_id);
 				return;
 			}
 
@@ -2260,11 +2262,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
-			// Skip prompts for silent executions
-			if (this._silentExecutionIds.has(languageRuntimeMessagePrompt.parent_id)) {
-				return;
-			}
-
 			// Set the active activity item prompt.
 			this._activeActivityItemPrompt = new ActivityItemPrompt(
 				languageRuntimeMessagePrompt.id,
@@ -2292,11 +2289,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					);
 				}
 
-				// Skip output for silent executions
-				if (this._silentExecutionIds.has(languageRuntimeMessageOutput.parent_id)) {
-					return;
-				}
-
 				// Create an activity item representing the message.
 				const activityItemOutput = this.createActivityItemOutput(languageRuntimeMessageOutput);
 				if (!activityItemOutput) {
@@ -2322,11 +2314,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					formatCallbackTrace('onDidReceiveRuntimeMessageStream', languageRuntimeMessageStream) +
 					`\nStream ${languageRuntimeMessageStream.name}: "${traceOutput}" ${formattedLength(languageRuntimeMessageStream.text.length)}`
 				);
-			}
-
-			// Skip stream output for silent executions
-			if (this._silentExecutionIds.has(languageRuntimeMessageStream.parent_id)) {
-				return;
 			}
 
 			// Handle stdout and stderr.
@@ -2367,11 +2354,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageError.message +
 						formatTraceback(languageRuntimeMessageError.traceback)
 					);
-				}
-
-				// Skip errors for silent executions
-				if (this._silentExecutionIds.has(languageRuntimeMessageError.parent_id)) {
-					return;
 				}
 
 				// Add or update the runtime item activity.
@@ -2428,8 +2410,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						this.markInputBusyState(languageRuntimeMessageState.parent_id, false);
 						// This external execution ID has completed, so we can remove it.
 						this._externalExecutionIds.delete(languageRuntimeMessageState.parent_id);
-						// This silent execution ID has completed, so we can remove it.
-						this._silentExecutionIds.delete(languageRuntimeMessageState.parent_id);
 						break;
 					}
 				}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -936,8 +936,19 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 }
 
 /**
-* PositronConsoleInstance class.
-*/
+ * Pending code fragment with its execution metadata.
+ */
+interface IPendingCodeFragment {
+	code: string;
+	attribution: IConsoleCodeAttribution;
+	executionId: string | undefined;
+	mode: RuntimeCodeExecutionMode;
+	errorBehavior: RuntimeErrorBehavior;
+}
+
+/**
+ * PositronConsoleInstance class.
+ */
 class PositronConsoleInstance extends Disposable implements IPositronConsoleInstance {
 	//#region Private Properties
 
@@ -962,6 +973,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * entries for them.
 	 */
 	private _silentExecutionIds: Set<string> = new Set<string>();
+
+	/**
+	 * Queue of pending code fragments waiting to be executed.
+	 */
+	private _pendingCodeQueue: IPendingCodeFragment[] = [];
 
 	/**
 	 * Gets or sets the session, if attached.
@@ -1601,7 +1617,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// code, so add this code to it and wait for it to be processed the next time the runtime
 		// becomes idle.
 		if (this._runtimeItemPendingInput) {
-			this.addPendingInput(code, attribution, executionId, mode);
+			this.addPendingInput(
+				code,
+				attribution,
+				executionId,
+				mode ?? RuntimeCodeExecutionMode.Interactive,
+				errorBehavior ?? RuntimeErrorBehavior.Continue
+			);
 			return;
 		}
 
@@ -1610,7 +1632,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// time the runtime becomes idle.
 		const runtimeState = this.session?.getRuntimeState() || RuntimeState.Uninitialized;
 		if (!(runtimeState === RuntimeState.Idle || runtimeState === RuntimeState.Ready)) {
-			this.addPendingInput(code, attribution, executionId, mode);
+			this.addPendingInput(
+				code,
+				attribution,
+				executionId,
+				mode ?? RuntimeCodeExecutionMode.Interactive,
+				errorBehavior ?? RuntimeErrorBehavior.Continue
+			);
 			return;
 		}
 
@@ -2622,38 +2650,59 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param attribution The attribution for the pending input.
 	 * @param executionId The execution ID for the pending input.
 	 * @param mode The code execution mode.
+	 * @param errorBehavior The error behavior.
 	 */
 	private addPendingInput(code: string,
 		attribution: IConsoleCodeAttribution,
-		executionId?: string,
-		mode: RuntimeCodeExecutionMode = RuntimeCodeExecutionMode.Interactive) {
-		// If there is a pending input runtime item, remove it.
-		if (this._runtimeItemPendingInput) {
-			// Get the index of the pending input runtime item.
-			const index = this.runtimeItems.indexOf(this._runtimeItemPendingInput);
+		executionId: string | undefined,
+		mode: RuntimeCodeExecutionMode,
+		errorBehavior: RuntimeErrorBehavior) {
+		// Add to the pending code queue.
+		this._pendingCodeQueue.push({
+			code,
+			attribution,
+			executionId,
+			mode,
+			errorBehavior
+		});
 
-			// This index should always be > -1, but be defensive. Remove the pending input runtime
-			// item.
+		// If there is a pending input runtime item, we need to recreate it with the concatenated code.
+		if (this._runtimeItemPendingInput) {
+			// Remove the old pending input runtime item.
+			const index = this.runtimeItems.indexOf(this._runtimeItemPendingInput);
 			if (index > -1) {
 				this._runtimeItems.splice(index, 1);
 			}
 
-			// Set the code.
-			code = this._runtimeItemPendingInput.code + '\n' + code;
-		}
+			// Concatenate the new code with the old code.
+			const concatenatedCode = this._runtimeItemPendingInput.code + '\n' + code;
 
-		// Create the pending input runtime item.
-		this._runtimeItemPendingInput = new RuntimeItemPendingInput(
-			generateUuid(),
-			this._session?.dynState.inputPrompt ?? '',
-			attribution,
-			executionId,
-			code,
-			mode
-		);
+			// Create a new pending input runtime item with the concatenated code.
+			this._runtimeItemPendingInput = new RuntimeItemPendingInput(
+				generateUuid(),
+				this._session?.dynState.inputPrompt ?? '',
+				attribution,
+				executionId,
+				concatenatedCode,
+				mode
+			);
 
-		// Add the pending input runtime item only if it's not a silent execution.
-		if (mode !== RuntimeCodeExecutionMode.Silent) {
+			// Add it back to the runtime items (only if mode is not silent).
+			if (mode !== RuntimeCodeExecutionMode.Silent) {
+				this.addRuntimeItem(this._runtimeItemPendingInput);
+			}
+		} else if (mode !== RuntimeCodeExecutionMode.Silent) {
+			// Create the pending input runtime item for interactive mode.
+			this._runtimeItemPendingInput = new RuntimeItemPendingInput(
+				generateUuid(),
+				this._session?.dynState.inputPrompt ?? '',
+				attribution,
+				executionId,
+				code,
+				mode
+			);
+
+			// Add the pending input runtime item.
 			this.addRuntimeItem(this._runtimeItemPendingInput);
 		}
 	}
@@ -2662,6 +2711,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Clears pending input.
 	 */
 	private clearPendingInput() {
+		// Clear the pending code queue.
+		this._pendingCodeQueue = [];
+
 		// If there is a pending input runtime item, remove it.
 		if (this._runtimeItemPendingInput) {
 			// Get the index of the pending input runtime item.
@@ -2797,90 +2849,56 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	private async processPendingInputImpl(): Promise<void> {
-		// If there isn't a pending input runtime item, return.
-		if (!this._runtimeItemPendingInput) {
+		// If there isn't a pending code queue or it's empty, return.
+		if (this._pendingCodeQueue.length === 0) {
 			return;
 		}
 
-		// If there's no session, return
+		// If there's no session, return.
 		if (!this._session) {
 			return;
 		}
 
-		// Save the attribution
-		const attribution = this._runtimeItemPendingInput.attribution;
+		// Process the first item in the queue.
+		const pendingItem = this._pendingCodeQueue[0];
 
-		// Find a complete code fragment to execute.
-		let code = undefined;
-		const codeLines: string[] = [];
+		// Check if the code fragment is complete.
+		const codeFragmentStatus = await this._session.isCodeFragmentComplete(pendingItem.code);
 
-		// Get the pending input lines. We keep this up to date at every iteration so it always
-		// reflects the current state of the pending input, even after an `await`, which may have
-		// allowed the user to append more pending input code.
-		let pendingInputLines = this._runtimeItemPendingInput.code.split('\n');
-
-		for (let i = 0; i < pendingInputLines.length; i++) {
-			// Push the pending input line to the code lines.
-			codeLines.push(pendingInputLines[i]);
-
-			// Determine whether the code lines are a complete code fragment.
-			const codeFragment = codeLines.join('\n');
-			const codeFragmentStatus = await this._session.isCodeFragmentComplete(codeFragment);
-
-			// If we have been interrupted, then `clearPendingInput()` has reset
-			// `_runtimeItemPendingInput` and there is nothing for us to do.
-			if (this._pendingInputState === 'Interrupted') {
-				return;
-			}
-
-			// SAFETY: We expect that `this._runtimeItemPendingInput.code` will only ever grow.
-			// Also, the update of `pendingInputLines` must happen before we break, because we use
-			// it below.
-			pendingInputLines = this._runtimeItemPendingInput.code.split('\n');
-
-			if (codeFragmentStatus === RuntimeCodeFragmentStatus.Complete) {
-				code = codeFragment;
-				break;
-			}
+		// If we have been interrupted, then `clearPendingInput()` has cleared the queue.
+		if (this._pendingInputState === 'Interrupted') {
+			return;
 		}
 
-		// Get the index of the pending input runtime item.
-		const index = this.runtimeItems.indexOf(this._runtimeItemPendingInput);
+		// If the code fragment is not complete, wait for more input.
+		// Move the incomplete code to pending code for user editing.
+		if (codeFragmentStatus !== RuntimeCodeFragmentStatus.Complete) {
+			// Remove the item from the queue.
+			this._pendingCodeQueue.shift();
 
-		// Remove the current pending input runtime item. We are either done with it entirely, or
-		// we are going to update it with a new one if we have remaining pending lines.
-		// This index should always be > -1, but be defensive.
-		if (index > -1) {
-			this._runtimeItems.splice(index, 1);
-		}
+			// Remove the pending input visual item if it exists.
+			if (this._runtimeItemPendingInput) {
+				const index = this.runtimeItems.indexOf(this._runtimeItemPendingInput);
+				if (index > -1) {
+					this._runtimeItems.splice(index, 1);
+				}
+				this._onDidChangeRuntimeItemsEmitter.fire();
+			}
 
-		// If we didn't find a complete fragment, set the pending code to everything in the
-		// (possibly updated) pending input item and let the pending code path handle it.
-		if (code === undefined) {
-			// We removed the pending input runtime item, so emit the change.
-			this._onDidChangeRuntimeItemsEmitter.fire();
+			// Set as pending code for user to complete.
+			this.setPendingCode(pendingItem.code, pendingItem.executionId);
 
-			// The pending input line(s) now become the pending code.
-			// This fires an event allowing the `ConsoleInput` to update its code editor widget,
-			// allowing the user to keep typing to eventually generate a complete code chunk.
-			this.setPendingCode(
-				this._runtimeItemPendingInput.code,
-				this._runtimeItemPendingInput.executionId);
-
-			// And we no longer have a pending input item.
+			// Clear the pending input item.
 			this._runtimeItemPendingInput = undefined;
 
 			return;
 		}
 
-		// Create the ID for the code fragment that will be executed.
-		const id = this._runtimeItemPendingInput.executionId || this.generateExecutionId(code);
-
-		// Get the mode from the pending input item.
-		const mode = this._runtimeItemPendingInput.mode;
+		// The code is complete, so execute it.
+		const id = pendingItem.executionId || this.generateExecutionId(pendingItem.code);
 
 		// Add the provisional ActivityItemInput for the code fragment only if it's not a silent execution.
-		if (mode !== RuntimeCodeExecutionMode.Silent) {
+		if (pendingItem.mode !== RuntimeCodeExecutionMode.Silent) {
 			const runtimeItemActivity = new RuntimeItemActivity(
 				id,
 				new ActivityItemInput(
@@ -2890,7 +2908,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					ActivityItemInputState.Provisional,
 					this._session.dynState.inputPrompt,
 					this._session.dynState.continuationPrompt,
-					code
+					pendingItem.code
 				)
 			);
 			this._runtimeItems.push(runtimeItemActivity);
@@ -2901,55 +2919,58 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this._silentExecutionIds.add(id);
 		}
 
-		// If there are remaining pending input lines, add them in a new pending input
-		// runtime item so they are processed the next time the runtime becomes idle.
-		const nCodeLines = codeLines.length;
-		const nPendingLines = pendingInputLines.length;
+		// Remove the processed item from the queue.
+		this._pendingCodeQueue.shift();
 
-		if (nCodeLines < nPendingLines) {
-			// Create the new pending input runtime item, preserving the
-			// attribution, the execution ID, and the mode.
-			this._runtimeItemPendingInput = new RuntimeItemPendingInput(
-				generateUuid(),
-				this._session.dynState.inputPrompt,
-				attribution,
-				id,
-				pendingInputLines.slice(nCodeLines).join('\n'),
-				mode
-			);
-
-			// Add the pending input runtime item only if it's not a silent execution.
-			if (mode !== RuntimeCodeExecutionMode.Silent) {
-				this._runtimeItems.push(this._runtimeItemPendingInput);
+		// Remove the pending input visual item if this was the last item or update it for remaining items.
+		if (this._runtimeItemPendingInput) {
+			const index = this.runtimeItems.indexOf(this._runtimeItemPendingInput);
+			if (index > -1) {
+				this._runtimeItems.splice(index, 1);
 			}
-		} else if (nCodeLines === nPendingLines) {
-			// We are about to execute everything available, so there isn't a new pending input item.
-			this._runtimeItemPendingInput = undefined;
-		} else {
-			throw new Error('Unexpected state. Can\'t have more code lines than pending lines.');
+
+			if (this._pendingCodeQueue.length > 0) {
+				// There are more items in the queue, create a new pending input visual
+				// for the next item if it's not silent.
+				const nextItem = this._pendingCodeQueue[0];
+				if (nextItem.mode !== RuntimeCodeExecutionMode.Silent) {
+					this._runtimeItemPendingInput = new RuntimeItemPendingInput(
+						generateUuid(),
+						this._session.dynState.inputPrompt,
+						nextItem.attribution,
+						nextItem.executionId,
+						nextItem.code,
+						nextItem.mode
+					);
+					this._runtimeItems.push(this._runtimeItemPendingInput);
+				} else {
+					this._runtimeItemPendingInput = undefined;
+				}
+			} else {
+				// No more items in the queue.
+				this._runtimeItemPendingInput = undefined;
+			}
 		}
 
-		// Fire the runtime items changed event once, now, after everything is set up.
+		// Fire the runtime items changed event.
 		this._onDidChangeRuntimeItemsEmitter.fire();
 
 		// Execute the code fragment.
-		const errorBehavior = RuntimeErrorBehavior.Continue;
-
 		this._session.execute(
-			code,
+			pendingItem.code,
 			id,
-			mode,
-			errorBehavior,
+			pendingItem.mode,
+			pendingItem.errorBehavior,
 		);
 
 		// Create and fire the onDidExecuteCode event.
 		const event: ILanguageRuntimeCodeExecutedEvent = {
 			executionId: id,
 			sessionId: this._session.sessionId,
-			code,
-			mode,
-			attribution,
-			errorBehavior,
+			code: pendingItem.code,
+			mode: pendingItem.mode,
+			attribution: pendingItem.attribution,
+			errorBehavior: pendingItem.errorBehavior,
 			languageId: this._session.runtimeMetadata.languageId,
 			runtimeName: this._session.runtimeMetadata.runtimeName
 		};


### PR DESCRIPTION
- Addresses https://github.com/posit-dev/positron/issues/7205
- Closes https://github.com/posit-dev/positron/pull/9741

This is an internal, non-fork PR applying the commits from https://github.com/posit-dev/positron/pull/9741, because of the problems outlined in https://github.com/posit-dev/positron/issues/6628.

@:console @:interpreter @:sessions

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix `positron.RuntimeCodeExecutionMode.Silent` behavior for queued code in the console


### QA Notes

The motivating extension example in https://github.com/posit-dev/positron/issues/7205 is a good example to look at, and I also chose some existing tests to run here which run code in the console from an extension (like the R package dev tests).
