### PR TITLE
E2E test: fix for toggling bottom panel in publisher test

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -71,6 +71,10 @@
        "command": "workbench.action.minimizePanel" // View: Minimize Bottom Panel
     },
 	{
+        "key": "cmd+j v",
+        "command": "workbench.action.restorePanel" // Restore Bottom Panel
+    },
+	{
         "key": "cmd+j q",
         "command": "workbench.action.files.openFolder" // Open Folder
     },

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -7,7 +7,7 @@ import test, { expect } from '@playwright/test';
 import { Code } from '../infra/code.js';
 
 /**
- * Provides hotkey shortcuts for common operations.
+ * Provides hotkey shortcuts for common operations. References the keybindings defined in `test/e2e/fixtures/keybindings.json`.
  */
 export class HotKeys {
 	constructor(private code: Code) { }
@@ -166,6 +166,10 @@ export class HotKeys {
 
 	public async minimizeBottomPanel() {
 		await this.pressHotKeys('Cmd+J P', 'Minimize bottom panel');
+	}
+
+	public async restoreBottomPanel() {
+		await this.pressHotKeys('Cmd+J V', 'Restore bottom panel');
 	}
 
 	// -------------------------

--- a/test/e2e/tests/workbench/publisher/publisher.test.ts
+++ b/test/e2e/tests/workbench/publisher/publisher.test.ts
@@ -120,7 +120,7 @@ test.describe('Publisher - Positron', { tag: [tags.WORKBENCH, tags.PUBLISHER] },
 			await expect(deployButton).toBeVisible();
 		});
 
-		await hotKeys.toggleBottomPanel();
+		await hotKeys.minimizeBottomPanel();
 
 		await test.step('Ensure toml file is ready for update', async () => {
 			await expect(async () => {
@@ -149,7 +149,7 @@ test.describe('Publisher - Positron', { tag: [tags.WORKBENCH, tags.PUBLISHER] },
 			await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled({ timeout: 10000 });
 		});
 
-		await hotKeys.toggleBottomPanel();
+		await hotKeys.restoreBottomPanel();
 
 		let appGuid;
 		await test.step('Deploy, await completion and get appGuid', async () => {


### PR DESCRIPTION
Change to minimizeBottomPanel & restoreBottomPanel instead of toggleBottomPanel so that minimize will continue to be the current state even if already minimized.

### QA Notes


