### PR TITLE
More quoting and normalization around R binpaths, for Windows

### DIFF
--- a/extensions/positron-r/src/interpreter-settings.ts
+++ b/extensions/positron-r/src/interpreter-settings.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { LOGGER } from './extension';
-import { arePathsSame, isParentPath, untildify } from './path-utils';
+import { arePathsSame, isParentPath, normalizeUserPath } from './path-utils';
 
 /**
  * Directory(ies) where this user keeps R installations.
@@ -21,7 +21,7 @@ export function userRHeadquarters(): string[] {
 		return [];
 	}
 	const userHqDirs = customRootFolders
-		.map((item) => path.normalize(untildify(item)))
+		.map((item) => normalizeUserPath(item))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -46,7 +46,7 @@ export function userRBinaries(): string[] {
 		return [];
 	}
 	const userBinaries = customBinaries
-		.map((item) => path.normalize(untildify(item)))
+		.map((item) => normalizeUserPath(item))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -72,7 +72,7 @@ function getExcludedInstallations(): string[] {
 		return [];
 	}
 	const excludedPaths = interpretersExclude
-		.map((item) => path.normalize(untildify(item)))
+		.map((item) => normalizeUserPath(item))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -100,7 +100,7 @@ export function getInterpreterOverridePaths(): string[] {
 		return [];
 	}
 	const overridePaths = interpretersOverride
-		.map((item) => path.normalize(untildify(item)))
+		.map((item) => normalizeUserPath(item))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -149,7 +149,7 @@ export function getDefaultInterpreterPath(): string | undefined {
 	const config = vscode.workspace.getConfiguration('positron.r');
 	let defaultInterpreterPath = config.get<string>('interpreters.default');
 	if (defaultInterpreterPath) {
-		defaultInterpreterPath = path.normalize(untildify(defaultInterpreterPath));
+		defaultInterpreterPath = normalizeUserPath(defaultInterpreterPath);
 		if (path.isAbsolute(defaultInterpreterPath)) {
 			LOGGER.info(`Default R interpreter path specified in 'positron.r.interpreters.default': ${defaultInterpreterPath}`);
 			return defaultInterpreterPath;

--- a/extensions/positron-r/src/interpreter-settings.ts
+++ b/extensions/positron-r/src/interpreter-settings.ts
@@ -21,7 +21,7 @@ export function userRHeadquarters(): string[] {
 		return [];
 	}
 	const userHqDirs = customRootFolders
-		.map((item) => untildify(item))
+		.map((item) => path.normalize(untildify(item)))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -46,7 +46,7 @@ export function userRBinaries(): string[] {
 		return [];
 	}
 	const userBinaries = customBinaries
-		.map((item) => untildify(item))
+		.map((item) => path.normalize(untildify(item)))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -72,7 +72,7 @@ function getExcludedInstallations(): string[] {
 		return [];
 	}
 	const excludedPaths = interpretersExclude
-		.map((item) => untildify(item))
+		.map((item) => path.normalize(untildify(item)))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -100,7 +100,7 @@ export function getInterpreterOverridePaths(): string[] {
 		return [];
 	}
 	const overridePaths = interpretersOverride
-		.map((item) => untildify(item))
+		.map((item) => path.normalize(untildify(item)))
 		.filter((item) => {
 			if (path.isAbsolute(item)) {
 				return true;
@@ -149,7 +149,7 @@ export function getDefaultInterpreterPath(): string | undefined {
 	const config = vscode.workspace.getConfiguration('positron.r');
 	let defaultInterpreterPath = config.get<string>('interpreters.default');
 	if (defaultInterpreterPath) {
-		defaultInterpreterPath = untildify(defaultInterpreterPath);
+		defaultInterpreterPath = path.normalize(untildify(defaultInterpreterPath));
 		if (path.isAbsolute(defaultInterpreterPath)) {
 			LOGGER.info(`Default R interpreter path specified in 'positron.r.interpreters.default': ${defaultInterpreterPath}`);
 			return defaultInterpreterPath;

--- a/extensions/positron-r/src/path-utils.ts
+++ b/extensions/positron-r/src/path-utils.ts
@@ -39,9 +39,22 @@ export function arePathsSame(path1: string, path2: string): boolean {
 
 /**
  * Copied from the function of the same name in extensions/positron-python/src/client/common/helpers.ts.
+ * NOTE: We do not export this since in all known cases, normalizeUserPath()
+ * is the better choice.
  */
-export function untildify(path: string): string {
+function untildify(path: string): string {
 	return path.replace(/^~($|\/|\\)/, `${os.homedir()}$1`);
+}
+
+/**
+ * Normalizes a user-provided path (e.g., from settings) by expanding tilde (~) to the home
+ * directory, normalizing path separators, and resolving `.` and `..`. This leaves us with
+ * more robust and predictable paths in, e.g., the R installation metadata.
+ * @param filepath The user-provided path to normalize
+ * @returns The normalized, tilde-expanded, absolute path
+ */
+export function normalizeUserPath(filepath: string): string {
+	return path.normalize(untildify(filepath));
 }
 
 /**

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -146,10 +146,6 @@ export class RInstallation {
 		current: boolean = false,
 		reasonDiscovered: ReasonDiscovered[] | null = null
 	) {
-		// Normalize path separators on Windows to insulate us against path
-		// separator choices made by users/admins
-		// Avoids issues with possible downstream shell execution using this path
-		// https://github.com/posit-dev/positron/issues/9216
 		pth = path.normalize(pth);
 
 		LOGGER.info(`Candidate R binary at ${pth}`);

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -146,6 +146,12 @@ export class RInstallation {
 		current: boolean = false,
 		reasonDiscovered: ReasonDiscovered[] | null = null
 	) {
+		// Normalize path separators on Windows to insulate us against path
+		// separator choices made by users/admins
+		// Avoids issues with possible downstream shell execution using this path
+		// https://github.com/posit-dev/positron/issues/9216
+		pth = path.normalize(pth);
+
 		LOGGER.info(`Candidate R binary at ${pth}`);
 
 		this.binpath = pth;

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -88,10 +88,12 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 				{ env: taskEnv }
 			);
 		} else {
-			// The explicit quoting treatment here is also motivated by PowerShell, so make sure to
-			// test any changes on Windows.
+			// The explicit quoting treatment here is motivated by problems on
+			// both bash and PowerShell, on Windows, so make sure to test any
+			// changes on Windows.
+			// https://github.com/posit-dev/positron/issues/9216
 			exec = new vscode.ShellExecution(
-				binpath,
+				{ value: binpath, quoting: vscode.ShellQuoting.Strong },
 				['--quiet', '--no-restore', '--no-save', '-e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
 				{ env: taskEnv }
 			);


### PR DESCRIPTION
Addresses #9216 

My initial hunch was that this had to do with path separators, which lead to me adding path normalization in many places. I still think this is a good idea, so I've kept that.

But the real problem was that the R binpath wasn't *necessarily* quoted when firing the `vscode.ShellExecution`s that back R package tasks. And that is necessary for robustness on Windows.

It turns out, because most people have R installed below `C:\Program Files`, that pesky space was causing the binpath to be quoted, which is good and necessary. But if you have R installed somewhere else and you cause it to be discovered by Positron and that somewhere else *doesn't* have spaces or other challenging characters, the binpath won't be quoted. And the task falls over.

Here's the quoting for R installed in the usual place (note the single quotes around the binpath):

```
*  Executing task: 'C:\Program Files\R\R-4.5.1\bin\x64\R.exe' --quiet --no-restore --no-save -e 'devtools::check()' 

> devtools::check()
══ Documenting ═════════════════════════════════════════════════════════════════════════════════
ℹ Updating stringr documentation
ℹ Loading stringr
...  blah blah
```

Here's the **lack** of quoting for R installed in a more creative place:

```
Executing task: C:\quirkyRLocation\R-4.3.3\bin\x64\R.exe --quiet --no-restore --no-save -e 'devtools::check()' 

bash: C:quirkyRLocationR-4.3.3binx64R.exe: command not found

 *  The terminal process "C:\Program Files\Git\bin\bash.exe '--login', '-i', '-c', 'C:\quirkyRLocation\R-4.3.3\bin\x64\R.exe --quiet --no-restore --no-save -e 'devtools::check()''" terminated with exit code: 127.
```

With this PR, we force the binpath to be quoted unconditionally, which gets R package tasks working again:

```
Executing task: & 'C:\quirkyRLocation\R-4.3.3\bin\x64\R.exe' --quiet --no-restore --no-save -e 'devtools::check()' 

> devtools::check()
══ Documenting ═══════════════════════════════════════════════════════════════
ℹ Updating stringr documentation
... blah blah
```

### QA Notes

Must be on Windows.

You must have R installed to a path that contains no spaces or other quote-worthy characters and ensure that Positron discovers it. I used a [CRAN installer for R 4.3](https://cran.r-project.org/bin/windows/base/old/) and installed it to `C:\quirkyRLocation\R-4.3.3`. I then informed Positron about that by specifying a custom root folder:

```
...
"positron.r.customRootFolders": [
  "C:/quirkyRLocation"
]
...
```

Prior to this PR, checking or testing an R package will fail with the error shown above and in #9216.

With this PR, those package tests will succeed. I tested this with Positron using both Git Bash and PowerShell, i.e. I played with this setting:

```
...
//"terminal.integrated.defaultProfile.windows": "Git Bash",
"terminal.integrated.defaultProfile.windows": "PowerShell",
...
```

`@:ark` `@:win`