### PR TITLE
Positron nb focus on open

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -227,12 +227,7 @@ export class SelectionStateMachine extends Disposable {
 		if (state.type === SelectionState.MultiSelection) {
 			const updatedSelection = state.selected.filter(c => c !== cell);
 			if (updatedSelection.length === 0) {
-				// All cells deselected - let invariant enforcement handle transition to NoCells
-				// If cells still exist, select the first one
-				const cells = this._cells.get();
-				if (cells.length > 0) {
-					this._setState({ type: SelectionState.SingleSelection, selected: cells[0] });
-				}
+				// All cells deselected - let invariant enforcement handle transition
 				return;
 			}
 			const verifiedSelection = verifyNonEmptyArray(updatedSelection);
@@ -304,12 +299,6 @@ export class SelectionStateMachine extends Disposable {
 
 	/**
 	 * Selects a cell for editing - enters edit mode with the specified cell.
-	 *
-	 * Note: This method supports the NoCells → EditingSelection transition for cases where
-	 * a cell is created in an empty notebook and immediately entered for editing (e.g., notebook
-	 * initialization, or adding a cell after deleting all cells). This avoids forcing a two-step
-	 * transition (NoCells → SingleSelection → EditingSelection) which would trigger unnecessary
-	 * intermediate state updates and side effects.
 	 *
 	 * @param cell The cell to select and edit.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -14,109 +14,7 @@ import { IEnvironmentService } from '../../../../platform/environment/common/env
  *
  * This file implements a selection state machine for Positron notebooks.
  *
- * STATES:
- * -------
- * - NoCells: No cells exist in the notebook
- * - SingleSelection: Exactly one cell is selected (not editing)
- * - MultiSelection: Multiple cells are selected
- * - EditingSelection: One cell is selected and its editor is focused
- *
- * STATE TRANSITIONS:
- * ------------------
- * Valid transitions between states:
- *
- * 1. NoCells → SingleSelection
- *    Trigger: Cells appear in notebook (automatic via _enforceInvariant)
- *    Guard: cells.length > 0
- *    Result: First cell is automatically selected
- *
- * 2. SingleSelection → NoCells
- *    Trigger: All cells removed (automatic via _enforceInvariant)
- *    Guard: cells.length === 0
- *    Result: Selection cleared
- *
- * 3. NoCells → EditingSelection
- *    Trigger: selectCell(cell, CellSelectionType.Edit) when a cell is created in an empty notebook
- *    Guard: None (valid whenever transitioning from empty notebook to editing)
- *    Result: Cell is created and immediately enters edit mode without intermediate selection state
- *
- * 4. SingleSelection → EditingSelection
- *    Trigger: enterEditor() called or selectCell(cell, CellSelectionType.Edit)
- *    Guard: Must be in SingleSelection state
- *    Result: Cell editor is shown and focused
- *
- * 5. SingleSelection → MultiSelection
- *    Trigger: selectCell(cell, CellSelectionType.Add) or moveUp/moveDown(addMode: true)
- *    Guard: Must have at least one cell already selected
- *    Result: Additional cell added to selection
- *
- * 6. SingleSelection → SingleSelection
- *    Trigger: selectCell(cell, CellSelectionType.Normal) or moveUp/moveDown(addMode: false)
- *    Guard: None
- *    Result: New cell becomes the only selected cell
- *
- * 7. EditingSelection → SingleSelection
- *    Trigger: exitEditor() called
- *    Guard: Must be in EditingSelection state
- *    Result: Editor focus removed, cell remains selected
- *
- * 8. EditingSelection → NoCells
- *    Trigger: Cell being edited is removed (automatic via _setCells)
- *    Guard: cells.length === 0
- *    Result: Selection cleared
- *
- * 9. MultiSelection → SingleSelection
- *    Trigger: deselectCell() reduces to 1 cell, or selectCell(cell, CellSelectionType.Normal)
- *    Guard: None
- *    Result: Single cell selected
- *
- * 10. MultiSelection → MultiSelection
- *     Trigger: selectCell(cell, CellSelectionType.Add), deselectCell(), or moveUp/moveDown(addMode: true)
- *     Guard: Result must have >= 2 cells selected
- *     Result: Selection modified but remains multi-cell
- *
- * 11. MultiSelection → NoCells
- *     Trigger: All selected cells removed (automatic via _setCells)
- *     Guard: cells.length === 0
- *     Result: Selection cleared
- *
- * INVARIANTS:
- * -----------
- * 1. NoCells ↔ cells.length === 0
- *    Enforced by: _enforceInvariant() called on every cell array change
- *
- * 2. If cells exist, something must be selected
- *    Enforced by: Automatic transition to SingleSelection when cells appear
- *
- * 3. EditingSelection requires exactly one cell
- *    Enforced by: enterEditor() guard and type system
- *
- * 4. SingleSelection.selected and MultiSelection.selected arrays are never empty
- *    Enforced by: Type system and transition logic
- *
- * STATE GUARDS (conditions that must be true for transitions):
- * -------------------------------------------------------------
- * - enterEditor(): Current state must be SingleSelection
- * - exitEditor(): Current state must be EditingSelection
- * - selectCell(Add): Current state must not be NoCells
- * - moveUp/moveDown: Current state must not be EditingSelection or NoCells
- *
- * AUTOMATIC TRANSITIONS:
- * ----------------------
- * Some transitions happen automatically without explicit method calls:
- * - Any state → NoCells: When cells array becomes empty
- * - NoCells → SingleSelection: When cells array becomes non-empty
- * - Any state → SingleSelection: When selected cells are removed, selects neighboring cell
- *
- * METHODS BY STATE:
- * -----------------
- * Available operations depend on current state:
- * - NoCells: No operations available (guards prevent all actions)
- * - SingleSelection: selectCell, deselectCell, moveUp, moveDown, enterEditor
- * - MultiSelection: selectCell, deselectCell, moveUp, moveDown
- * - EditingSelection: exitEditor (movement and selection operations blocked by guards)
- */
-
+ **/
 export enum SelectionState {
 	NoCells = 'NoCells',
 	SingleSelection = 'SingleSelection',
@@ -163,7 +61,6 @@ export function getSelectedCells(state: SelectionStates): IPositronNotebookCell[
 			return [state.selectedCell];
 	}
 }
-
 
 /**
  * Get the selected cell if there is exactly one selected.
@@ -213,7 +110,6 @@ export class SelectionStateMachine extends Disposable {
 		debugName: 'selectionState',
 		equalsFn: isSelectionStateEqual
 	}, { type: SelectionState.NoCells });
-
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -41,6 +41,7 @@ export enum TestTags {
 	MODAL = '@:modal',
 	NEW_FOLDER_FLOW = '@:new-folder-flow',
 	NOTEBOOKS = '@:notebooks',
+	POSITRON_NOTEBOOKS = '@:positron-notebooks',
 	OUTLINE = '@:outline',
 	OUTPUT = '@:output',
 	PLOTS = '@:plots',

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -22,7 +22,7 @@ async function getCellCount(app: Application): Promise<number> {
 
 
 test.describe('Cell Deletion Action Bar Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test('Cell deletion using action bar', async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -32,7 +32,7 @@ async function activateInfoPopup({ app, icon }: { app: Application; icon: Locato
 }
 
 test.describe('Cell Execution Info Popup', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -387,11 +387,8 @@ test.describe('Notebook Focus and Selection', {
 		expect(normalizedContent).toContain('new cell content');
 	});
 
-	// NEW TESTS: Initial focus behavior (should fail with current implementation)
-	test('First cell is automatically selected when notebook loads', async function ({ app, hotKeys }) {
-		// Close the notebook from beforeEach to avoid focus contamination
-		await hotKeys.closeAllEditors();
-
+	// Initial focus behavior (should fail with current implementation)
+	test('First cell is automatically selected when notebook loads', async function ({ app }) {
 		// Open a real notebook file to test initial load behavior
 		const notebookPath = path.join('workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');
 		await app.workbench.notebooks.openNotebook(notebookPath, false);

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -52,6 +52,16 @@ async function getCellCount(app: Application): Promise<number> {
 }
 
 /**
+ * Wait for at least one cell to exist in the DOM
+ */
+async function waitForCellsInDOM(app: Application, timeoutMs: number = 2000): Promise<void> {
+	await app.code.driver.page.locator('[data-testid="notebook-cell"]').first().waitFor({
+		state: 'visible',
+		timeout: timeoutMs
+	});
+}
+
+/**
  * Wait for focus to settle (useful after DOM changes)
  * Waits until any notebook cell has focus (or until timeout)
  */
@@ -59,10 +69,7 @@ async function waitForFocusSettle(app: Application, timeoutMs: number = 2000): P
 	const page = app.code.driver.page;
 
 	// First, ensure at least one cell exists in the DOM
-	await page.locator('[data-testid="notebook-cell"]').first().waitFor({
-		state: 'attached',
-		timeout: timeoutMs
-	});
+	await waitForCellsInDOM(app, timeoutMs);
 
 	// Now wait for one of them to have focus
 	await page.waitForFunction(() => {
@@ -359,7 +366,7 @@ test.describe('Notebook Focus and Selection', {
 		await app.workbench.notebooksPositron.expectToBeVisible();
 
 		// Wait for cells to be in DOM and for initial focus to settle
-		await app.code.driver.page.locator('[data-testid="notebook-cell"]').first().waitFor({ state: 'visible', timeout: 5000 });
+		await waitForCellsInDOM(app, 5000);
 		await waitForFocusSettle(app);
 
 		// EXPECTED: First cell should be automatically selected without any user interaction

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -13,7 +13,7 @@ test.use({
 });
 
 /**
- * Helper function to get the currently focused cell index
+ * Get the currently focused cell index
  * Checks if the cell or any of its children contain the active element
  */
 async function getFocusedCellIndex(app: Application): Promise<number | null> {
@@ -36,7 +36,7 @@ async function getFocusedCellIndex(app: Application): Promise<number | null> {
 }
 
 /**
- * Helper function to check if a cell is selected (has selection styling)
+ * Check if a cell is selected (has selection styling)
  */
 async function isCellSelected(app: Application, index: number): Promise<boolean> {
 	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(index);
@@ -45,14 +45,14 @@ async function isCellSelected(app: Application, index: number): Promise<boolean>
 }
 
 /**
- * Helper function to get cell count
+ * Get cell count
  */
 async function getCellCount(app: Application): Promise<number> {
 	return await app.code.driver.page.locator('[data-testid="notebook-cell"]').count();
 }
 
 /**
- * Helper function to wait for focus to settle (useful after DOM changes)
+ * Wait for focus to settle (useful after DOM changes)
  * Waits until any notebook cell has focus (or until timeout)
  */
 async function waitForFocusSettle(app: Application, timeoutMs: number = 2000): Promise<void> {
@@ -74,7 +74,7 @@ async function waitForFocusSettle(app: Application, timeoutMs: number = 2000): P
 }
 
 /**
- * Helper function to check if the Monaco editor in a cell is focused
+ * Check if the Monaco editor in a cell is focused
  */
 async function isEditorFocused(app: Application, cellIndex: number): Promise<boolean> {
 	const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(cellIndex);
@@ -87,7 +87,7 @@ async function isEditorFocused(app: Application, cellIndex: number): Promise<boo
 }
 
 /**
- * Helper function to normalize cell content by replacing non-breaking spaces with regular spaces
+ * Normalize cell content by replacing non-breaking spaces with regular spaces
  */
 function normalizeCellContent(content: string): string {
 	// Replace non-breaking spaces (U+00A0) with regular spaces
@@ -95,7 +95,7 @@ function normalizeCellContent(content: string): string {
 }
 
 /**
- * Helper function to create a fresh notebook with 5 pre-populated cells
+ * Create a fresh notebook with 5 pre-populated cells
  * Call this in tests that need a notebook with existing cells
  */
 async function createNotebookWith5Cells(app: Application): Promise<void> {
@@ -147,10 +147,6 @@ test.describe('Notebook Focus and Selection', {
 		expect(await isCellSelected(app, 0)).toBe(false);
 		expect(await isCellSelected(app, 1)).toBe(false);
 	});
-
-	// NOTE: Clicking a selected cell currently does NOT deselect it in the current implementation
-	// This test is commented out as the behavior may change during refactoring
-	// test('Clicking a selected cell deselects it', async function ({ app }) { ... });
 
 	test('Arrow Down navigation moves focus to next cell', async function ({ app }) {
 		await createNotebookWith5Cells(app);
@@ -283,37 +279,6 @@ test.describe('Notebook Focus and Selection', {
 		expect(await getFocusedCellIndex(app)).toBe(2);
 	});
 
-	test('Sanity check: clicking editor focuses it (validates isEditorFocused helper)', async function ({ app }) {
-		await createNotebookWith5Cells(app);
-
-		// Select cell 1
-		await app.workbench.notebooksPositron.selectCellAtIndex(1);
-		await waitForFocusSettle(app, 200);
-
-		// Press Escape to exit edit mode (selectCellAtIndex may enter edit mode)
-		await app.code.driver.page.keyboard.press('Escape');
-		await waitForFocusSettle(app, 200);
-
-		// Editor should not be focused after pressing Escape
-		expect(await isEditorFocused(app, 1)).toBe(false);
-
-		// Click directly into the Monaco editor
-		const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(1);
-		const editor = cell.locator('.monaco-editor');
-		await editor.click();
-		await waitForFocusSettle(app, 200);
-
-		// Now editor should be focused
-		expect(await isEditorFocused(app, 1)).toBe(true);
-
-		// Type some text to confirm editor is really focused
-		await app.code.driver.page.keyboard.type('# editor good');
-		const cellContent = await app.workbench.notebooksPositron.getCellContent(1);
-		// Normalize content to handle non-breaking spaces
-		const normalizedContent = normalizeCellContent(cellContent);
-		expect(normalizedContent).toContain('# editor good');
-	});
-
 	test('Enter key on selected cell enters edit mode', async function ({ app }) {
 		await createNotebookWith5Cells(app);
 
@@ -387,7 +352,6 @@ test.describe('Notebook Focus and Selection', {
 		expect(normalizedContent).toContain('new cell content');
 	});
 
-	// Initial focus behavior (should fail with current implementation)
 	test('First cell is automatically selected when notebook loads', async function ({ app }) {
 		// Open a real notebook file to test initial load behavior
 		const notebookPath = path.join('workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -87,7 +87,7 @@ function normalizeCellContent(content: string): string {
 
 // Not running on web due to Positron notebooks being desktop-only
 test.describe('Notebook Focus and Selection', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -50,7 +50,7 @@ async function pasteCellsWithKeyboard(app: Application): Promise<void> {
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Notebook Cell Copy-Paste Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -14,7 +14,7 @@ test.use({
 
 
 test.describe('Positron notebook opening and saving', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
@@ -58,7 +58,7 @@ async function addCodeCellBelowWithKeyboard(app: Application): Promise<void> {
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Notebook Cell Undo-Redo Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);


### PR DESCRIPTION
Addresses #9707.

When opening a Positron notebook, the editor was not properly focusing a cell, requiring users to click a cell before keyboard shortcuts like `j` and `k` for navigation would work. This PR fixes the issue by replacing the `no selection` state with a `no-cells` state in the selection state machine and adding an invariant to ensure at least one cell is always selected when the notebook contains cells.

I took this opportunity to refactor the selection state machine too as it had fallen out of good state-machine form after piecemeal edits for a while. Docs have been added at the top and we now verify transition correctness and throw errors in dev mode to hopefully catch bugs (It already caught one while making this PR.)


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Positron notebooks not focusing a cell on open, requiring click before keyboard navigation works (#9707)

### QA Notes

@:positron-notebooks

The test suite includes comprehensive coverage of the fix:

1. **Basic focus on open**: Open a notebook file (e.g., via <kbd>Cmd</kbd>+<kbd>P</kbd>) and verify the first cell is automatically selected
2. **Immediate keyboard navigation**: Without clicking any cell, press <kbd>J</kbd> or <kbd>K</kbd> to verify navigation works immediately
3. **Selection persistence**: Switch between editors and verify cell selection is maintained when returning to the notebook

To manually test:
1. Open any notebook file using <kbd>Cmd</kbd>+<kbd>P</kbd> (or <kbd>Ctrl</kbd>+<kbd>P</kbd> on Windows/Linux)
2. Without clicking anywhere, press <kbd>J</kbd> or <kbd>K</kbd>
3. Expected: Cell selection moves down/up immediately
4. Previously: Nothing happened until clicking a cell
