### PR TITLE
Data Explorer: Fix value parsing issues with thousands separator when formatting histogram tooltips

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -284,6 +284,13 @@ export class DataExplorerClientInstance extends Disposable {
 		return this._backendClient.clientId;
 	}
 
+	/**
+	 * Gets the profile format options.
+	 */
+	get profileFormatOptions(): FormatOptions {
+		return this._profileFormatOptions;
+	}
+
 	//#endregion Public Properties
 
 	//#region Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileInteger.tsx
@@ -76,6 +76,7 @@ export const ColumnProfileInteger = (props: ColumnProfileIntegerProps) => {
 				<ColumnProfileSparklineHistogram
 					columnHistogram={columnHistogram}
 					displayType={columnSchema?.type_display}
+					formatOptions={props.instance.profileFormatOptions}
 					hoverManager={props.instance.hoverManager}
 				/>
 			}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileNumber.tsx
@@ -45,6 +45,7 @@ export const ColumnProfileNumber = (props: ColumnProfileNumberProps) => {
 				<ColumnProfileSparklineHistogram
 					columnHistogram={columnHistogram}
 					displayType={columnSchema?.type_display}
+					formatOptions={props.instance.profileFormatOptions}
 					hoverManager={props.instance.hoverManager}
 				/>
 			}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 // Other dependencies.
 import { VectorHistogram } from './vectorHistogram.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
-import { ColumnFrequencyTable, ColumnHistogram, ColumnDisplayType } from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { ColumnFrequencyTable, ColumnHistogram, ColumnDisplayType, FormatOptions } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 
 /**
@@ -29,6 +29,7 @@ interface ColumnProfileSparklineHistogramProps {
 	readonly columnHistogram: ColumnHistogram;
 	readonly hoverManager: IHoverManager;
 	readonly displayType?: ColumnDisplayType;
+	readonly formatOptions: FormatOptions;
 }
 
 /**
@@ -39,7 +40,8 @@ interface ColumnProfileSparklineHistogramProps {
 export const ColumnProfileSparklineHistogram = ({
 	columnHistogram,
 	hoverManager,
-	displayType
+	displayType,
+	formatOptions
 }: ColumnProfileSparklineHistogramProps) => {
 	// Render.
 	return (
@@ -53,6 +55,7 @@ export const ColumnProfileSparklineHistogram = ({
 			<VectorHistogram
 				columnHistogram={columnHistogram}
 				displayType={displayType}
+				formatOptions={formatOptions}
 				graphHeight={GRAPH_HEIGHT}
 				graphWidth={GRAPH_WIDTH}
 				hoverManager={hoverManager}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -133,6 +133,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 						<VectorHistogram
 							columnHistogram={columnHistogram}
 							displayType={props.columnSchema.type_display}
+							formatOptions={props.instance.profileFormatOptions}
 							graphHeight={SPARKLINE_HEIGHT}
 							graphWidth={SPARKLINE_WIDTH}
 							hoverManager={props.instance.hoverManager}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -382,6 +382,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Gets the profile format options.
+	 */
+	get profileFormatOptions() {
+		return this._dataExplorerClientInstance.profileFormatOptions;
+	}
+
+	/**
 	 * Gets a data cell.
 	 * @param columnIndex The column index.
 	 * @param rowIndex The row index.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -297,6 +297,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		return this._hoverManager;
 	}
 
+	/**
+	 * Gets the profile format options.
+	 */
+	get profileFormatOptions() {
+		return this._dataExplorerClientInstance.profileFormatOptions;
+	}
+
 	//#endregion Public Properties
 
 	//#region Public Methods


### PR DESCRIPTION
Addresses #9798. For values 1000 or higher, the histogram bins were being formatted using the cell formatter in the backend, introducing a thousands separator which would foul up `parseFloat` which was used later to reformat the tooltip (or handle the conversion to whole numbers for integers).

This now displays the bins as formatted by the backend for floating point data

<img width="367" height="119" alt="image" src="https://github.com/user-attachments/assets/05f678f7-e24d-46cd-afef-d644485afe21" />

Integers over 1000 are fixed, too

<img width="348" height="105" alt="image" src="https://github.com/user-attachments/assets/36768222-afe8-4ac1-9cbe-b62151d04074" />

There are some other refinements as described in #9801 but since this issue is critical it would be better to get this fix in ASAP and address those in a follow up PR. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:data-explorer
