### PR TITLE
Use forward slash (`/`) when reporting working directory in Console header

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
@@ -11,6 +11,8 @@ import React, { MouseEvent, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { toSlashes } from '../../../../../base/common/extpath.js';
+import { isWindows } from '../../../../../base/common/platform.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { usePositronActionBarContext } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
@@ -113,7 +115,7 @@ export const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => 
 		>
 			<span className='codicon codicon-folder' role='presentation' />
 			<span className='label'>
-				{props.directoryLabel}
+				{isWindows ? toSlashes(props.directoryLabel) : props.directoryLabel}
 			</span>
 		</div>
 	);


### PR DESCRIPTION
Addresses #6161

Use `toSlashes()` on Windows to normalize the path separator in reported working directory of the Console.

I used Claude to look around the codebase at how this tends to be done elsewhere. While there is admittedly a _lot_ of `replace(/\\/g, '/')`, there is also plenty of precedent for using `toSlashes()`, which seems like the more correct solution:

https://github.com/posit-dev/positron/blob/37920eead2833c6f48d4f764a5f7fb18db4e7049/src/vs/base/common/extpath.ts#L16-L23

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Must be on Windows. In either the R or Python console, confirm that the working directory reported in the Console header uses `/` and not `\`. Here's what I'm seeing with this PR:

<img width="374" height="273" alt="Screenshot 2025-10-06 174926" src="https://github.com/user-attachments/assets/3d5bd3d4-b29d-4fca-93f2-77958237bbe1" />
<img width="428" height="322" alt="Screenshot 2025-10-06 175200" src="https://github.com/user-attachments/assets/a8b49b1e-8ff3-441f-8864-5e6cbda9fde0" />
