### PR TITLE
Assistant: Allow setting default model by provider

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -302,6 +302,14 @@
             "type": "string",
             "default": "",
             "markdownDescription": "%configuration.preferredModel.description%"
+          },
+          "positron.assistant.defaultModels": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "markdownDescription": "%configuration.defaultModels.description%"
           }
         }
       }

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -36,5 +36,6 @@
 	"configuration.providerTimeout.description": "Specifies the timeout in seconds when signing in to a provider.",
 	"configuration.alwaysIncludeCopilotTools.description": "Allow any model in Positron Assistant to use tools provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider**.\n\nSee also: `#chat.useCopilotParticipantsWithOtherProviders#`",
 	"configuration.filterModels.description": "A list of [glob patterns](https://aka.ms/vscode-glob-patterns) to filter available LLM models in Positron Assistant.\n\nAllows only language models with ID or name matching at least one of the patterns to be used. Defaults to allowing all models.",
-	"configuration.preferredModel.description": "A preferred model ID or name (partial match supported) to use if available in Positron Assistant."
+	"configuration.preferredModel.description": "A preferred model ID or name (partial match supported) to use if available in Positron Assistant.",
+	"configuration.defaultModels.description": "A mapping of provider IDs to default model IDs or names (partial match supported) to use for that provider in Positron Assistant."
 }

--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -13,6 +13,9 @@ import { log, recordTokenUsage, recordRequestTokenUsage } from './extension.js';
 import { TokenUsage } from './tokens.js';
 import { availableModels } from './models.js';
 
+export const DEFAULT_ANTHROPIC_MODEL_NAME = 'Claude Sonnet 4.5';
+export const DEFAULT_ANTHROPIC_MODEL_MATCH = 'claude-sonnet-4-5';
+
 /**
  * Options for controlling cache behavior in the Anthropic language model.
  */
@@ -59,8 +62,8 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		},
 		supportedOptions: ['apiKey', 'apiKeyEnvVar'],
 		defaults: {
-			name: 'Claude 3.5 Sonnet v2',
-			model: 'claude-3-5-sonnet-latest',
+			name: DEFAULT_ANTHROPIC_MODEL_NAME,
+			model: DEFAULT_ANTHROPIC_MODEL_MATCH + '-latest',
 			toolCalls: true,
 			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
 		},
@@ -239,6 +242,17 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		return AnthropicLanguageModel.source.provider.displayName;
 	}
 
+	private isDefaultUserModel(id: string, name?: string): boolean {
+		const config = vscode.workspace.getConfiguration('positron.assistant');
+		const defaultModels = config.get<Record<string, string>>('defaultModels') || {};
+		if ('anthropic-api' in defaultModels) {
+			if (id.includes(defaultModels['anthropic-api']) || name?.includes(defaultModels['anthropic-api'])) {
+				return true;
+			}
+		}
+		return id.includes(DEFAULT_ANTHROPIC_MODEL_MATCH);
+	}
+
 	private onContentBlock(block: Anthropic.ContentBlock, progress: vscode.Progress<vscode.ChatResponseFragment2>): void {
 		switch (block.type) {
 			case 'tool_use':
@@ -308,7 +322,6 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 		const userSetMaxOutputTokens: Record<string, number> = vscode.workspace.getConfiguration('positron.assistant').get('maxOutputTokens', {});
 		let hasMore = true;
 		let nextPageToken: string | undefined;
-		let isFirst = true;
 
 		log.trace(`Fetching models from Anthropic API for provider ${this.provider}`);
 
@@ -334,16 +347,23 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 					maxInputTokens: maxInputTokens,
 					maxOutputTokens: maxOutputTokens,
 					capabilities: {},
-					isDefault: isFirst,
+					isDefault: this.isDefaultUserModel(model.id, model.display_name),
 					isUserSelectable: true,
 				});
-				isFirst = false;
 			});
 
 			hasMore = modelsPage.has_more;
 			if (hasMore && modelsPage.data.length > 0) {
 				nextPageToken = modelsPage.data[modelsPage.data.length - 1].id;
 			}
+		}
+
+		// If no models match the default ID, make the first model the default.
+		if (modelListing.length > 0 && !modelListing.some(m => m.isDefault)) {
+			modelListing[0] = {
+				...modelListing[0],
+				isDefault: true,
+			};
 		}
 
 		this.modelListing = modelListing;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -535,10 +535,13 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// }));
 
 		this._register(this.languageModelsService.onDidChangeCurrentProvider((provider) => {
-			// if the current provider is not the same as the current model's provider, change the current model to the first model of the new provider
+			// if the current provider is not the same as the current model's provider, change the current model to a model of the new provider
 			if (this._currentLanguageModel && provider && this._currentLanguageModel.metadata.vendor !== provider) {
 				const models = this.getModels();
-				if (models.length > 0) {
+				const defaultModel = models.find(m => m.metadata.isDefault);
+				if (defaultModel) {
+					this.setCurrentLanguageModel(defaultModel);
+				} else if (models.length > 0) {
 					this.setCurrentLanguageModel(models[0]);
 				}
 			}
@@ -1300,7 +1303,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					// --- Start Positron ---
 					const models = this.getModels();
 					if (!this._currentLanguageModel && models.length > 0) {
-						this.setCurrentLanguageModel(models[0]);
+						const defaultModel = models.find(m => m.metadata.isDefault);
+						if (defaultModel) {
+							this.setCurrentLanguageModel(defaultModel);
+						} else if (models.length > 0) {
+							this.setCurrentLanguageModel(models[0]);
+						}
 					}
 					// --- End Positron ---
 


### PR DESCRIPTION
Followup to #9799, based on a discussion with @sharon-wang, so that PR should be merged first.

* Addreses #9388.

I have also added a little code to the AWS provider so that stale configurations pointing to older model IDs that are no longer available will get updated to the latest defaults as the provider is started.

### QA Notes

1. Sign into multiple providers, at least Anthropic and AWS Bedrock.
2. Try switching between them, confirm that the defaults we want by default are selected.
3. Set the following settings,
```
  "positron.assistant.defaultModels": { "anthropic-api": "Opus", "amazon-bedrock": "Opus" },
```
4. Reload the window, confirm that switching between the models now selects Opus models by default.

Note 1: Upstream has code to remember your last selection, so after the reload window you have to change providers to see the default kick in.

Note 2: Sometimes Assistant gets stuck in a state showing "Pick Model..." in the selector. Switching providers does nothing to clear that, but selecting a model first, and then switching providers, gets things working again. I don't know if this is related to this commit, or the changes in #9799.
