### PR TITLE
Keep empty files when bundling Quarto in our builds

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -73,7 +73,7 @@ function getQuartoWindows(version) {
         verbose: true,
         timeoutSeconds: 90,
     })
-        .pipe(unzip());
+        .pipe(unzip({ keepEmpty: true }));
 }
 /**
  * Gets a stream that downloads and unpacks the quarto executable for macOS

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -36,7 +36,7 @@ function getQuartoWindows(version: string): Stream {
 		verbose: true,
 		timeoutSeconds: 90,
 	})
-		.pipe(unzip());
+		.pipe(unzip({ keepEmpty: true }));
 }
 
 /**

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -36,15 +36,7 @@ function getQuartoWindows(version: string): Stream {
 		verbose: true,
 		timeoutSeconds: 90,
 	})
-		.pipe(unzip({ keepEmpty: true }))
-		// Add a debug step to log all files, including empty ones
-		.pipe(es.through(function (file) {
-			const size = file.contents ? file.contents.length : 0;
-			if (size === 0) {
-				fancyLog(`Empty file detected: ${file.path}`);
-			}
-			this.emit('data', file);
-		}));
+		.pipe(unzip({ keepEmpty: true }));
 }
 
 /**

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -11,6 +11,8 @@ import gulp = require('gulp');
 import util = require('./util');
 import rename = require('gulp-rename');
 import path = require('path');
+import fs = require('fs');
+import os = require('os');
 
 /**
  * Get the base URL for the quarto download
@@ -28,21 +30,118 @@ function getBaseUrl(version: string): string {
  * @param version The version of quarto to download
  * @returns A stream
  */
+/**
+ * Check if specific files exist in a ZIP buffer directly without using gulp-unzip
+ *
+ * @param zipBuffer The ZIP file as a Buffer
+ * @param filesToCheck Array of file paths to check for
+ */
+function checkZipContents(zipBuffer: Buffer, filesToCheck: string[]): void {
+	// Use the yauzl module for unzipping
+	const yauzl = require('yauzl');
+
+	const tempPath = path.join(os.tmpdir(), `quarto-check-${Date.now()}.zip`);
+
+	try {
+		// Write the buffer to a temp file
+		fs.writeFileSync(tempPath, zipBuffer);
+
+		// Open the ZIP file
+		yauzl.open(tempPath, { lazyEntries: true }, (err: Error | null, zipfile: any) => {
+			if (err) {
+				fancyLog(`Error checking ZIP contents: ${err}`);
+				return;
+			}
+
+			fancyLog(`Checking ZIP file contents directly (bypassing gulp-unzip)`);
+
+			// Track files we find
+			const foundFiles = new Set<string>();
+
+			zipfile.on('entry', (entry: any) => {
+				const fileName = entry.fileName;
+				const fileSize = entry.uncompressedSize;
+
+				// Check if this is one of our tracked files
+				for (const fileToCheck of filesToCheck) {
+					if (fileName.endsWith(fileToCheck)) {
+						fancyLog(`DIRECT ZIP CHECK - FOUND: ${fileName}, size: ${fileSize} bytes`);
+						foundFiles.add(fileToCheck);
+					}
+				}
+
+				// Continue reading entries
+				zipfile.readEntry();
+			});
+
+			zipfile.on('end', () => {
+				// Check for files that weren't found
+				for (const fileToCheck of filesToCheck) {
+					if (!foundFiles.has(fileToCheck)) {
+						fancyLog(`DIRECT ZIP CHECK - NOT FOUND: ${fileToCheck}`);
+					}
+				}
+
+				// Clean up
+				try {
+					fs.unlinkSync(tempPath);
+				} catch (e) {
+					// Ignore errors during cleanup
+				}
+			});
+
+			// Start reading entries
+			zipfile.readEntry();
+		});
+	} catch (err) {
+		fancyLog(`Error in checkZipContents: ${err}`);
+	}
+}
+
 function getQuartoWindows(version: string): Stream {
 	const unzip = require('gulp-unzip');
 	const basename = `quarto-${version}-win`;
-	return fetchUrls([`${basename}.zip`], {
+
+	// Files we want to track
+	const filesToTrack = [
+		'share/formats/pdf/pandoc/after-body.tex',
+		'share/formats/pdf/pandoc/before-bib.tex',
+		'share/formats/pdf/pandoc/before-title.tex'
+	];
+
+	// Get the fetch stream
+	const fetchStream = fetchUrls([`${basename}.zip`], {
 		base: getBaseUrl(version),
 		verbose: true,
 		timeoutSeconds: 90,
-	})
+	});
+
+	// Add logging to check raw ZIP content before unzipping
+	const preUnzipStream = fetchStream.pipe(es.through(function (file) {
+		fancyLog(`Received ZIP file: ${file.path}, size: ${file.contents ? file.contents.length : 0} bytes`);
+
+		// Check ZIP contents directly if we have file contents
+		if (file.contents) {
+			checkZipContents(file.contents, filesToTrack);
+		}
+
+		this.emit('data', file);
+	}));
+
+	// Unzip with keepEmpty option and add detailed logging
+	return preUnzipStream
 		.pipe(unzip({ keepEmpty: true }))
-		// Add a debug step to log all files, including empty ones
 		.pipe(es.through(function (file) {
-			const size = file.contents ? file.contents.length : 0;
-			if (size === 0) {
-				fancyLog(`Empty file detected: ${file.path}`);
+			// Log all files
+			fancyLog(`Extracted file: ${file.path}, size: ${file.contents ? file.contents.length : 0} bytes`);
+
+			// Check specifically for our tracked files
+			for (const trackFile of filesToTrack) {
+				if (file.path.endsWith(trackFile)) {
+					fancyLog(`FOUND TRACKED FILE: ${file.path}, size: ${file.contents ? file.contents.length : 0} bytes`);
+				}
 			}
+
 			this.emit('data', file);
 		}));
 }

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -36,7 +36,15 @@ function getQuartoWindows(version: string): Stream {
 		verbose: true,
 		timeoutSeconds: 90,
 	})
-		.pipe(unzip({ keepEmpty: true }));
+		.pipe(unzip({ keepEmpty: true }))
+		// Add a debug step to log all files, including empty ones
+		.pipe(es.through(function (file) {
+			const size = file.contents ? file.contents.length : 0;
+			if (size === 0) {
+				fancyLog(`Empty file detected: ${file.path}`);
+			}
+			this.emit('data', file);
+		}));
 }
 
 /**


### PR DESCRIPTION
I _hope_ that this addresses problems that folks are experiencing like:

- https://github.com/posit-dev/positron/issues/5553
- https://github.com/posit-dev/positron/discussions/9081
- https://github.com/quarto-dev/quarto-r/issues/283

We originally thought what needed to happen was to bundle tinytex or another PDF engine, but that may not be the source of the error folks are experiencing. Instead, as @cderv explains, these empty but required files are missing, leading to errors like:

> NotFound: The system cannot find the file specified. (os error 2): lstat 'C:\Users\JonVanausdeln\AppData\Local\Programs\Positron\resources\app\quarto\share\formats\pdf\pandoc\before-bib.tex'

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed Quarto bundling on Windows


### QA Notes

We need to get a Windows release build here, and then try to use `quarto::quarto_render()` for a small example file to render to PDF, something like this:

````
---
title: "Diamond sizes"
format: pdf
---

```{r}
#| label: setup
#| include: false

library(tidyverse)
library(diamonds)

smaller <- diamonds |>
  filter(carat <= 2.5)
```

We have data about `r nrow(diamonds)` diamonds. Only `r nrow(diamonds) - nrow(smaller)` are larger than 2.5 carats. The distribution of the remainder is shown below:

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

```{r}
#| label: plot-smaller-diamonds
#| echo: false

smaller |> 
  ggplot(aes(x = carat)) +
  geom_freqpoly(binwidth = 0.03)
```

````

After this change, you'll get an error about not having tinytex instead of a missing `before-bib.tex`.
