### PR TITLE
E2E test: no longer necessaary to enable reticulate

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -17,17 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true
-			}, { 'reload': 'web' });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
 
 	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', async function ({ app, sessions, logger }) {
 

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -17,17 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true
-			}, { 'reload': 'web' });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
 
 	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions, logger }) {
 

--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -16,17 +16,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true,
-			}, { 'reload': 'web' });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
 
 	test('R - Verify Reticulate Restart', {
 		tag: [tags.RETICULATE, tags.CONSOLE]

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -17,17 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true
-			}, { 'reload': 'web' });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
 
 	test('R - Verify Reticulate Stop/Start Functionality', {
 		tag: [tags.ARK]


### PR DESCRIPTION
Reticulate is now enabled by default.

### QA Notes

@:reticulate @:web