### PR TITLE
Fix Anthropic model metadata

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -333,7 +333,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 					version: model.created_at,
 					maxInputTokens: maxInputTokens,
 					maxOutputTokens: maxOutputTokens,
-					capabilities: {},
+					capabilities: this.capabilities,
 					isDefault: isFirst,
 					isUserSelectable: true,
 				});


### PR DESCRIPTION
Address #9785 

The model's metadata is used to determine whether it's allowed for selection in the chat input. Anthropic doesn't return any data on model capabilities so we've been hard-coding them. This is a regression when building the model metadata after fetching the model listing where it omits setting the capabilities.

Agent and Edit modes need the model to support `agentMode` and `toolCalling` to display in the list.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
This only affected Anthropic. Bedrock and the other Vercel backed providers use the proper values.