### PR TITLE
Fix Anthropic model metadata (#9825)

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -333,7 +333,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 					version: model.created_at,
 					maxInputTokens: maxInputTokens,
 					maxOutputTokens: maxOutputTokens,
-					capabilities: {},
+					capabilities: this.capabilities,
 					isDefault: isFirst,
 					isUserSelectable: true,
 				});


### PR DESCRIPTION
Cherry pick fix to `main`