### PR TITLE
include '.' in envvar message

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -248,9 +248,9 @@ const ExternalAPIKey = (props: { provider: string, envKeyName?: { key: string; s
 			<div className='language-model-external-api-key'>
 				{
 					props.envKeyName && props.envKeyName.signedIn ?
-						<p>{localize('positron.languageModelConfig.externalApiInUse', "The {0} environment variable is currently in use", props.envKeyName?.key)}</p>
+						<p>{localize('positron.languageModelConfig.externalApiInUse', "The {0} environment variable is currently in use.", props.envKeyName?.key)}</p>
 						:
-						<p>{localize('positron.languageModelConfig.externalApiSetup', "You can also assign the {0} environment variable and restart Positron", props.envKeyName.key)}</p>
+						<p>{localize('positron.languageModelConfig.externalApiSetup', "You can also assign the {0} environment variable and restart Positron.", props.envKeyName.key)}</p>
 				}
 			</div> : null
 	);


### PR DESCRIPTION
Since `.` is used in other parts of this dialog.
<img width="615" height="419" alt="Screenshot 2025-10-07 at 3 25 25 PM" src="https://github.com/user-attachments/assets/c0965b04-1298-4a12-b98a-ebca45bc9643" />
