### PR TITLE
new python project: only display supported versions

### DIFF
--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -970,7 +970,8 @@ export class NewFolderFlowStateManager
 		// Once the runtime startup is complete, we can return the filtered list of interpreters.
 		const langId = this._getLangId();
 		let runtimesForLang = this._services.languageRuntimeService.registeredRuntimes
-			.filter(runtime => runtime.languageId === langId);
+			.filter(runtime => runtime.languageId === langId)
+			.filter(runtime => runtime.extraRuntimeData?.supported ?? true);
 
 		// If we're creating a new Python environment, only return Global runtimes.
 		if (langId === LanguageIds.Python


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #9365. Filters the New Python Project interpreters to those with supported versions.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Don't show unsupported versions in the New Python Project flow #9365


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:new-folder-flow @:web @:rhel-web

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
See reprex in the original issue.