### PR TITLE
E2E test: fix clipboard test flake

### DIFF
--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -137,13 +137,15 @@ export class Terminal {
 	 * @param action Which action to perform on the context menu
 	 */
 	async handleContextMenu(locator: Locator, action: 'Select All' | 'Copy' | 'Paste') {
-		await locator.click({ button: 'right' });
+		try {
+			await locator.click({ button: 'right', timeout: 2000 });
+		} catch { }
 		const menu = this.code.driver.page.locator('.monaco-menu');
 
 		// dismissing dialog can be erratic, allow retries
 		for (let i = 0; i < 4; i++) {
 			try {
-				await menu.locator(`[aria-label="${action}"]`).click();
+				await menu.locator(`[aria-label="${action}"]`).click({ timeout: 2000 });
 				await expect(menu).toBeHidden({ timeout: 2000 });
 				break;
 			} catch {

--- a/test/e2e/tests/console/console-clipboard.test.ts
+++ b/test/e2e/tests/console/console-clipboard.test.ts
@@ -75,7 +75,7 @@ async function testConsoleClipboardWithContextMenu(app: Application, prompt: str
 		const clipboardText = await app.workbench.clipboard.getClipboardText();
 
 		expect(clipboardText).toMatch(regex);
-	}).toPass({ timeout: 60000 });
+	}).toPass({ timeout: 30000 });
 
 }
 

--- a/test/e2e/tests/console/console-clipboard.test.ts
+++ b/test/e2e/tests/console/console-clipboard.test.ts
@@ -75,7 +75,7 @@ async function testConsoleClipboardWithContextMenu(app: Application, prompt: str
 		const clipboardText = await app.workbench.clipboard.getClipboardText();
 
 		expect(clipboardText).toMatch(regex);
-	}).toPass({ timeout: 30000 });
+	}).toPass({ timeout: 60000 });
 
 }
 


### PR DESCRIPTION
Sometimes the right click menu in the console doesn't have Copy enabled even though a Select All just took place. This flake fix is to enable running past that and retrying.

### QA Notes

@:web @:console
