### PR TITLE
Positron nb cell reorder

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -30,6 +30,8 @@ export const POSITRON_NOTEBOOK_CELL_IS_ONLY = new RawContextKey<boolean>('positr
 export const POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
 export const POSITRON_NOTEBOOK_CELL_IS_SELECTED = new RawContextKey<boolean>('positronNotebookCellIsSelected', false);
 export const POSITRON_NOTEBOOK_CELL_IS_EDITING = new RawContextKey<boolean>('positronNotebookCellIsEditing', false);
+export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
+export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);
 
 // All cell context keys in one place so we can easily operate on them all at once
 export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
@@ -44,6 +46,8 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	markdownEditorOpen: POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN,
 	isSelected: POSITRON_NOTEBOOK_CELL_IS_SELECTED,
 	isEditing: POSITRON_NOTEBOOK_CELL_IS_EDITING,
+	canMoveUp: POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP,
+	canMoveDown: POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN,
 } as const;
 
 // Interface for the cell context keys
@@ -68,6 +72,8 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		markdownEditorOpen: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.markdownEditorOpen.bindTo(service),
 		isSelected: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isSelected.bindTo(service),
 		isEditing: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isEditing.bindTo(service),
+		canMoveUp: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveUp.bindTo(service),
+		canMoveDown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown.bindTo(service),
 	} satisfies IPositronNotebookCellContextKeys;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -170,6 +170,31 @@ export interface IPositronNotebookInstance {
 	deleteCell(cell?: IPositronNotebookCell): void;
 
 	/**
+	 * Moves a cell up by one position.
+	 * Supports multi-cell selection - moves all selected cells as a group.
+	 *
+	 * @param cell The cell to move up
+	 */
+	moveCellUp(cell: IPositronNotebookCell): void;
+
+	/**
+	 * Moves a cell down by one position.
+	 * Supports multi-cell selection - moves all selected cells as a group.
+	 *
+	 * @param cell The cell to move down
+	 */
+	moveCellDown(cell: IPositronNotebookCell): void;
+
+	/**
+	 * Moves cells to a specific index.
+	 * Used by drag-and-drop operations.
+	 *
+	 * @param cells Array of cells to move
+	 * @param targetIndex The index to move the cells to
+	 */
+	moveCells(cells: IPositronNotebookCell[], targetIndex: number): void;
+
+	/**
 	 * Updates the currently editing cell state.
 	 *
 	 * @param cell The cell to set as editing, or undefined to clear editing state

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -636,19 +636,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	moveCellUp(cell: IPositronNotebookCell): void {
 		this._assertTextModel();
 
-		// 1. Validate boundaries
 		if (cell.index <= 0) {
 			return;
 		}
 
-		// 2. Resolve contiguous selection (ignore discontiguous spans)
 		const cellsToMove = getSelectedCells(this.selectionStateMachine.state.get());
-		if (!cellsToMove) {
-			// TODO: surface lightweight feedback that only contiguous selections can move together
-			return;
-		}
-
-		// 3. Calculate move parameters
 		const firstIndex = Math.min(...cellsToMove.map(c => c.index));
 		const lastIndex = Math.max(...cellsToMove.map(c => c.index));
 		const length = lastIndex - firstIndex + 1;
@@ -658,12 +650,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		// 4. Apply edit with proper selection state management
 		const textModel = this.textModel;
 		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
 		const focusRange = { start: firstIndex, end: lastIndex + 1 };
 
 		textModel.applyEdits([{
+			// Move edits are important to maintaining cell identity
 			editType: CellEditType.Move,
 			index: firstIndex,
 			length: length,
@@ -684,7 +676,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			computeUndoRedo
 		);
 
-		// 5. Fire content change - REQUIRED for React UI sync!
 		this._onDidChangeContent.fire();
 	}
 
@@ -701,12 +692,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		// Resolve contiguous selection
 		const cellsToMove = getSelectedCells(this.selectionStateMachine.state.get());
-		if (!cellsToMove) {
-			return;
-		}
-
 		const firstIndex = Math.min(...cellsToMove.map(c => c.index));
 		const lastIndex = Math.max(...cellsToMove.map(c => c.index));
 		const length = lastIndex - firstIndex + 1;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -45,7 +45,7 @@ export function NotebookCellMoreActionsMenu({
 		}
 
 		try {
-			const entries = buildMoreActionsMenuItems(instance, commandService, cell, menuActions);
+			const entries = buildMoreActionsMenuItems(commandService, menuActions);
 
 			setIsMenuOpen(true);
 			onMenuStateChange(true);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -6,9 +6,6 @@
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { CustomContextMenuItem } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuEntry } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
-import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
-import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType } from '../../selectionMachine.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { CustomContextMenuSeparator } from '../../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 
@@ -17,9 +14,7 @@ import { CustomContextMenuSeparator } from '../../../../../browser/positronCompo
  * This provides a clean extension point for adding new actions via the registry.
  */
 export function buildMoreActionsMenuItems(
-	instance: IPositronNotebookInstance,
 	commandService: ICommandService,
-	cell: IPositronNotebookCell,
 	menuActions?: INotebookCellActionBarItem[]
 ): CustomContextMenuEntry[] {
 	// Use provided menuActions or fallback to getting all from registry
@@ -37,12 +32,7 @@ export function buildMoreActionsMenuItems(
 				label: String(action.label ?? action.commandId), // TODO: Use CommandCenter.title when available
 				icon: action.icon?.startsWith('codicon-') ? action.icon.slice(8) : action.icon,
 				onSelected: () => {
-					// IMPORTANT: Ensure the cell from this menu is selected before executing
-					// Otherwise the command would operate on whatever cell is currently selected
-					instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-
-					// Execute command - it will now operate on the correct cell
-					commandService.executeCommand(action.commandId);
+					// No op as command is executed via the commandId argument
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -78,6 +78,8 @@ export function useCellContextKeys(
 			keys.markdownEditorOpen.set(cell.isMarkdownCell() ? cell.editorShown.read(reader) : false);
 			keys.isSelected.set(selectionStatus === CellSelectionStatus.Selected);
 			keys.isEditing.set(selectionStatus === CellSelectionStatus.Editing);
+			keys.canMoveUp.set(cell.index > 0 && cells.length > 1);
+			keys.canMoveDown.set(cell.index < cells.length - 1 && cells.length > 1);
 		}));
 
 		// Set the state to let other components know that the context keys are ready

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -761,6 +761,48 @@ registerCellCommand({
 	}
 });
 
+// Move cell up command - Alt+UpArrow
+registerCellCommand({
+	commandId: 'positronNotebook.cell.moveUp',
+	handler: (cell, notebook) => notebook.moveCellUp(cell),
+	multiSelect: true,  // Moves all selected cells
+	editMode: true,     // Allow from editor focus
+	when: CELL_CONTEXT_KEYS.canMoveUp,
+	actionBar: {
+		icon: 'codicon-arrow-up',
+		position: 'menu',
+		order: 110,
+		category: 'Cell Order'
+	},
+	keybinding: {
+		primary: KeyMod.Alt | KeyCode.UpArrow
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.moveUp', "Move cell up")
+	}
+});
+
+// Move cell down command - Alt+DownArrow
+registerCellCommand({
+	commandId: 'positronNotebook.cell.moveDown',
+	handler: (cell, notebook) => notebook.moveCellDown(cell),
+	multiSelect: true,  // Moves all selected cells
+	editMode: true,     // Allow from editor focus
+	when: CELL_CONTEXT_KEYS.canMoveDown,
+	actionBar: {
+		icon: 'codicon-arrow-down',
+		position: 'menu',
+		order: 111,
+		category: 'Cell Order'
+	},
+	keybinding: {
+		primary: KeyMod.Alt | KeyCode.DownArrow
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.moveDown', "Move cell down")
+	}
+});
+
 
 //#endregion Cell Commands
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -325,7 +325,7 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 //#region Notebook Commands
 registerNotebookAction({
 	commandId: 'positronNotebook.selectUp',
-	handler: (notebook) => notebook.selectionStateMachine.moveUp(false),
+	handler: (notebook) => notebook.selectionStateMachine.moveSelectionUp(false),
 	keybinding: {
 		primary: KeyCode.UpArrow,
 		secondary: [KeyCode.KeyK]
@@ -337,7 +337,7 @@ registerNotebookAction({
 
 registerNotebookAction({
 	commandId: 'positronNotebook.selectDown',
-	handler: (notebook) => notebook.selectionStateMachine.moveDown(false),
+	handler: (notebook) => notebook.selectionStateMachine.moveSelectionDown(false),
 	keybinding: {
 		primary: KeyCode.DownArrow,
 		secondary: [KeyCode.KeyJ]
@@ -349,7 +349,7 @@ registerNotebookAction({
 
 registerNotebookAction({
 	commandId: 'positronNotebook.addSelectionDown',
-	handler: (notebook) => notebook.selectionStateMachine.moveDown(true),
+	handler: (notebook) => notebook.selectionStateMachine.moveSelectionDown(true),
 	keybinding: {
 		primary: KeyMod.Shift | KeyCode.DownArrow,
 		secondary: [KeyMod.Shift | KeyCode.KeyJ]
@@ -361,7 +361,7 @@ registerNotebookAction({
 
 registerNotebookAction({
 	commandId: 'positronNotebook.addSelectionUp',
-	handler: (notebook) => notebook.selectionStateMachine.moveUp(true),
+	handler: (notebook) => notebook.selectionStateMachine.moveSelectionUp(true),
 	keybinding: {
 		primary: KeyMod.Shift | KeyCode.UpArrow,
 		secondary: [KeyMod.Shift | KeyCode.KeyK]
@@ -673,7 +673,7 @@ registerCellCommand({
 			// which already handles selection and focus of the new cell in Edit mode
 		} else {
 			// Only move down if we didn't add a cell
-			notebook.selectionStateMachine.moveDown(false);
+			notebook.selectionStateMachine.moveSelectionDown(false);
 		}
 	},
 	editMode: true,  // Allow execution from edit mode

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -761,7 +761,7 @@ registerCellCommand({
 	}
 });
 
-// Move cell up command - Alt+UpArrow
+// Move cell up
 registerCellCommand({
 	commandId: 'positronNotebook.cell.moveUp',
 	handler: (cell, notebook) => notebook.moveCellUp(cell),
@@ -782,7 +782,7 @@ registerCellCommand({
 	}
 });
 
-// Move cell down command - Alt+DownArrow
+// Move cell down
 registerCellCommand({
 	commandId: 'positronNotebook.cell.moveDown',
 	handler: (cell, notebook) => notebook.moveCellDown(cell),

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -268,7 +268,7 @@ export class SelectionStateMachine extends Disposable {
 	 * Move the selection up.
 	 * @param addMode If true, the selection will be added to the current selection.
 	 */
-	moveUp(addMode: boolean): void {
+	moveSelectionUp(addMode: boolean): void {
 		this._moveSelection(true, addMode);
 	}
 
@@ -276,7 +276,7 @@ export class SelectionStateMachine extends Disposable {
 	 * Move the selection down.
 	 * @param addMode If true, the selection will be added to the current selection.
 	 */
-	moveDown(addMode: boolean): void {
+	moveSelectionDown(addMode: boolean): void {
 		this._moveSelection(false, addMode);
 	}
 

--- a/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
@@ -1,0 +1,273 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import { test, tags } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Cell Reordering', {
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Move first cell down using action bar button - should swap with second cell', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Open an existing notebook to match manual testing scenario
+		const notebookPath = path.join('workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');
+		await notebooksPositron.openNotebook(notebookPath);
+
+		// Get initial cell count
+		const initialCount = await notebooksPositron.getCellCount();
+		expect(initialCount).toBeGreaterThan(2); // Need at least 3 cells to test moving
+
+		// Get the content of the first three cells to verify order
+		const cell0Content = await notebooksPositron.getCellContent(0);
+		const cell1Content = await notebooksPositron.getCellContent(1);
+		const cell2Content = await notebooksPositron.getCellContent(2);
+
+		// Select first cell
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+
+		// Find and click the "More Actions" button in the action bar
+		const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(0);
+		const moreActionsButton = cell.getByRole('button', { name: /more actions/i });
+		await expect(moreActionsButton).toBeVisible({ timeout: 5000 });
+		await moreActionsButton.click();
+
+		// Wait for the menu to open and find "Move cell down" option
+		const moveDownOption = app.code.driver.page.locator('button.custom-context-menu-item', { hasText: /move cell down/i });
+		await expect(moveDownOption).toBeVisible({ timeout: 5000 });
+		await moveDownOption.click();
+
+		// Verify cell moved down by EXACTLY ONE position
+		await notebooksPositron.expectCellContentAtIndexToBe(0, cell1Content); // Former cell 1 is now at position 0
+		await notebooksPositron.expectCellContentAtIndexToBe(1, cell0Content); // Former cell 0 is now at position 1
+		await notebooksPositron.expectCellContentAtIndexToBe(2, cell2Content); // Cell 2 should be unchanged
+
+		// Verify cell count hasn't changed
+		await notebooksPositron.expectCellCountToBe(initialCount);
+	});
+
+	test('Move first cell down - should swap with second cell', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select first cell and move down
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+
+		// Verify cell moved down by exactly one position
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+
+	test('Move cell up - basic operation', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select second cell and move up
+		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+
+		// Verify cell moved up
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+
+	test('Move cell down - basic operation', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select first cell and move down
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+
+		// Verify cell moved down
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+
+	test('Move last cell up', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select last cell and move up
+		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+
+		// Verify cell moved up
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 1');
+	});
+
+	test('Boundary: Cannot move first cell up', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select first cell and try to move up (should be no-op)
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+
+		// Verify order hasn't changed
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+
+	test('Boundary: Cannot move last cell down', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Select last cell and try to move down (should be no-op)
+		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+
+		// Verify order hasn't changed
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+
+	test('Move cell multiple times', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 4 cells
+		await notebooksPositron.newNotebook(4);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+
+		// Move Cell 0 down three times to end
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+
+		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 3');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 0');
+
+		// Now move it back up
+		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+	});
+
+	test('Undo/redo cell move operation', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup: Create notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+
+		// Verify initial order
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Move cell 1 up
+		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
+		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Undo the move
+		await hotKeys.undo();
+		await app.code.driver.page.waitForTimeout(500);
+
+		// Verify order is restored
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+
+		// Redo the move
+		await hotKeys.redo();
+		await app.code.driver.page.waitForTimeout(500);
+
+		// Verify order is changed again
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+	});
+});


### PR DESCRIPTION
Addresses #2354.

### Summary

This PR adds keyboard shortcuts and action bar buttons to move cells in Positron notebooks. Users can move cells up and down using `Alt+↑` and `Alt+↓`, or a cell's action bar.

https://github.com/user-attachments/assets/959e2a90-8323-4cc1-aad5-f0a38a611d3f



_This is necessary foundation work for #9840._

The implementation includes:
- Cell movement commands with `Alt+↑/↓` keyboard shortcuts
- Action bar buttons that appear contextually (hidden at boundaries and in single-cell notebooks)
- Full undo/redo support with focus tracking
- Multi-cell selection support via keyboard shortcuts
  - Only on contiguous sections currently as that's what the selection model in positron notebooks allows. (This will change in #9848.)
- Context keys (`positron.notebook.cell.canMoveUp/Down`) to control UI element visibility

**Technical notes**: Multi-cell moves work via keyboard shortcuts but not action bar buttons, as clicking an action button resets selection to that cell only; this will change in #9848.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:positron-notebooks

**Test keyboard shortcuts:**
1. Open or create a new notebook with at few cells
2. Select a cell in the middle and press `Alt+↓` - verify cell moves down
3. Press `Alt+↑` twice - verify cell moves back up
4. Navigate to the first cell and press `Alt+↑` - verify it's a no-op
5. Navigate to the last cell and press `Alt+↓` - verify it's a no-op
6. Move a cell and press `Cmd/Ctrl+Z` - verify undo restores position
7. Press `Cmd/Ctrl+Shift+Z` - verify redo reapplies the move

**Test multi-cell selection:**
1. Select multiple contiguous cells (Shift+Click or Shift+↑/↓)
2. Press `Alt+↓` - verify all selected cells move down together
3. Verify relative order is maintained within the group

**Test action bar buttons:**
1. Hover over a cell to reveal the action bar
2. Verify up/down arrow buttons appear (except at boundaries)
3. Click buttons to verify cell movement
4. Open a notebook with only one cell - verify buttons are hidden

**Test with different cell types:**
1. Move markdown cells - verify editor state is preserved
2. Move code cells with outputs - verify outputs stay attached
3. Execute cells before/after moving - verify execution state works correctly
