### PR TITLE
PositroNB extension API integration and debugging

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -13,8 +13,15 @@ import { NotebookDto } from './mainThreadNotebookDto.js';
 import { MainThreadNotebookEditors } from './mainThreadNotebookEditors.js';
 import { extHostCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { editorGroupToColumn } from '../../services/editor/common/editorGroupColumn.js';
+// --- Start Positron ---
+/* Swap out implementations for proxies that include Positron notebooks as well
 import { getNotebookEditorFromEditorPane, IActiveNotebookEditor, INotebookEditor } from '../../contrib/notebook/browser/notebookBrowser.js';
 import { INotebookEditorService } from '../../contrib/notebook/browser/services/notebookEditorService.js';
+*/
+import { IActiveNotebookEditor, INotebookEditor } from '../../contrib/notebook/browser/notebookBrowser.js';
+import { getNotebookEditorFromEditorPane } from '../../contrib/positronNotebook/browser/NotebookEditorProxyService.js';
+import { INotebookEditorProxyService } from '../../contrib/positronNotebook/browser/INotebookEditorProxyService.js';
+// --- End Positron ---
 import { NotebookTextModel } from '../../contrib/notebook/common/model/notebookTextModel.js';
 import { INotebookService } from '../../contrib/notebook/common/notebookService.js';
 import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
@@ -97,7 +104,11 @@ export class MainThreadNotebooksAndEditors {
 		extHostContext: IExtHostContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@INotebookService private readonly _notebookService: INotebookService,
-		@INotebookEditorService private readonly _notebookEditorService: INotebookEditorService,
+		// --- Start Positron ---
+		// Swap out the notebook editor service for a proxy that includes Positron notebooks as well
+		// @INotebookEditorService private readonly _notebookEditorService: INotebookEditorService,
+		@INotebookEditorProxyService private readonly _notebookEditorService: INotebookEditorProxyService,
+		// --- End Positron ---
 		@IEditorService private readonly _editorService: IEditorService,
 		@IEditorGroupsService private readonly _editorGroupService: IEditorGroupsService,
 		@ILogService private readonly _logService: ILogService,

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -3,16 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// --- Start Positron ---
-import { POSITRON_NOTEBOOK_EDITOR_ID, usingPositronNotebooks } from '../../contrib/positronNotebook/common/positronNotebookCommon.js';
-import { checkPositronNotebookEnabled } from '../../contrib/positronNotebook/browser/positronNotebookExperimentalConfig.js';
-// --- End Positron ---
 import { DisposableStore, dispose } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { EditorActivation } from '../../../platform/editor/common/editor.js';
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_EDITOR_ID, usingPositronNotebooks } from '../../contrib/positronNotebook/common/positronNotebookCommon.js';
+import { checkPositronNotebookEnabled } from '../../contrib/positronNotebook/browser/positronNotebookExperimentalConfig.js';
+/* Swap out implementations for proxies that include Positron notebooks as well
 import { getNotebookEditorFromEditorPane, INotebookEditor, INotebookEditorOptions } from '../../contrib/notebook/browser/notebookBrowser.js';
+*/
+import { INotebookEditor, INotebookEditorOptions } from '../../contrib/notebook/browser/notebookBrowser.js';
+import { getNotebookEditorFromEditorPane } from '../../contrib/positronNotebook/browser/NotebookEditorProxyService.js';
+// --- End Positron ---
 import { INotebookEditorService } from '../../contrib/notebook/browser/services/notebookEditorService.js';
 import { ICellRange } from '../../contrib/notebook/common/notebookRange.js';
 import { columnToEditorGroup, editorGroupToColumn } from '../../services/editor/common/editorGroupColumn.js';
@@ -122,15 +126,6 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 		// --- End Positron ---
 
 		const editorPane = await this._editorService.openEditor({ resource: URI.revive(resource), options: editorOptions }, columnToEditorGroup(this._editorGroupService, this._configurationService, options.position));
-		// --- Start Positron ---
-		if (editorPane?.getId() === POSITRON_NOTEBOOK_EDITOR_ID) {
-			// Positron notebook is already open, just return a synthetic ID
-			// We can't return the actual notebook editor ID because Positron notebooks
-			// don't implement INotebookEditor interface yet (https://github.com/posit-dev/positron/issues/9440)
-			const uri = URI.revive(resource);
-			return `positron-notebook-${uri.toString()}`;
-		}
-		// --- End Positron ---
 		const notebookEditor = getNotebookEditorFromEditorPane(editorPane);
 
 		if (notebookEditor) {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatNotebook.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatNotebook.ts
@@ -69,7 +69,7 @@ export class InlineChatNotebookContribution {
 				// To support inline chat in Positron notebooks:
 				// construct a session comparison key from the corresponding notebook
 				for (const positronInstance of positronNotebookService.listInstances(data.notebook)) {
-					const candidate = `<positron-notebook>${positronInstance.id}#${uri}`;
+					const candidate = `<positron-notebook>${positronInstance.getId()}#${uri}`;
 					if (!fallback) {
 						fallback = candidate;
 					}

--- a/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start Positron ---
+import { getNotebookInstanceFromActiveEditorPane } from '../../../positronNotebook/browser/notebookUtils.js';
+import { toPositronNotebookCommand } from '../../../positronNotebook/browser/toPositronNotebookCommand.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+// --- End Positron ---
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, IAction2Options, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
@@ -247,6 +252,16 @@ export abstract class NotebookMultiCellAction extends Action2 {
 				selectedCells: cellRangeToViewCells(editor, selectedCellRange)
 			});
 		}
+		// --- Start Positron ---
+		// If the active editor is a Positron notebook, reroute to the corresponding Positron command.
+		const notebookInstance = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
+		if (notebookInstance) {
+			const id = toPositronNotebookCommand(this.desc.id);
+			if (id) {
+				return accessor.get(ICommandService).executeCommand(id);
+			}
+		}
+		// --- End Positron ---
 	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/INotebookEditorProxyService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/INotebookEditorProxyService.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
+
+export const INotebookEditorProxyService = createDecorator<INotebookEditorProxyService>('INotebookEditorProxyService');
+
+/**
+ * Proxy that combines Positron and VSCode notebook editors behind the INotebookEditorService interface.
+ */
+export type INotebookEditorProxyService = Pick<
+	INotebookEditorService,
+	'_serviceBrand' |
+	'listNotebookEditors' |
+	'onDidAddNotebookEditor' |
+	'onDidRemoveNotebookEditor'
+>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -41,13 +41,13 @@ export enum KernelStatus {
  * - Controls cell selection and editing states
  * - Provides methods for common notebook operations
  */
-export interface IPositronNotebookInstance extends Pick<INotebookEditor, 'getId'> {
+export interface IPositronNotebookInstance extends Pick<INotebookEditor, 'getId' | 'textModel' | 'getSelections'> {
 	// ===== Properties =====
 	/**
 	 * URI of the notebook file being edited. This serves as the unique identifier
 	 * for the notebook's content on disk.
 	 */
-	get uri(): URI;
+	readonly uri: URI;
 
 	readonly scopedContextKeyService: IScopedContextKeyService | undefined;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -31,6 +31,36 @@ export enum KernelStatus {
 }
 
 /**
+ * Subset of INotebookEditor required to integrate with the extension API,
+ * so we don't have to implement the entire INotebookEditor interface (...yet)
+ * See mainThreadNotebookDocumentsAndEditors.ts and mainThreadNotebookEditors.ts.
+ */
+type INotebookEditorForExtensionApi = Pick<
+	INotebookEditor,
+	// Basic
+	| 'getId'
+	// Text/view model
+	| 'textModel'  // only used for .uri
+	| 'hasModel'
+	| 'getViewModel'  // only used for .viewType
+	// Selected cells: vscode.NotebookEditor.selections
+	| 'getSelections'
+	| 'setSelections'
+	| 'onDidChangeSelection'
+	// Visible cells: vscode.NotebookEditor.visibleRanges
+	| 'visibleRanges'
+	| 'onDidChangeVisibleRanges'
+	// Cell structure: to retrieve a cell to be revealed and to ensure the revealed range is within the notebook length
+	| 'getLength'
+	| 'cellAt'  // returned ICellViewModel is only used by passing to a reveal method below
+	// Reveal: to reveal a cell
+	| 'revealInCenter'
+	| 'revealCellRangeInView'
+	| 'revealInCenterIfOutsideViewport'
+	| 'revealInViewAtTop'
+>;
+
+/**
  * Interface defining the public API for interacting with a Positron notebook instance.
  * This interface abstracts away the complexity of notebook management and provides
  * a clean contract for the React UI layer to interact with notebook functionality.
@@ -41,7 +71,7 @@ export enum KernelStatus {
  * - Controls cell selection and editing states
  * - Provides methods for common notebook operations
  */
-export interface IPositronNotebookInstance extends Pick<INotebookEditor, 'getId' | 'textModel' | 'getSelections'> {
+export interface IPositronNotebookInstance extends INotebookEditorForExtensionApi {
 	// ===== Properties =====
 	/**
 	 * URI of the notebook file being edited. This serves as the unique identifier

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -10,7 +10,7 @@ import { SelectionStateMachine } from './selectionMachine.js';
 import { INotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
-import { IBaseCellEditorOptions } from '../../notebook/browser/notebookBrowser.js';
+import { IBaseCellEditorOptions, INotebookEditor } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -41,14 +41,8 @@ export enum KernelStatus {
  * - Controls cell selection and editing states
  * - Provides methods for common notebook operations
  */
-export interface IPositronNotebookInstance {
+export interface IPositronNotebookInstance extends Pick<INotebookEditor, 'getId'> {
 	// ===== Properties =====
-	/**
-	 * Unique identifier for the notebook instance. Used for debugging and claiming
-	 * ownership of various resources.
-	 */
-	readonly id: string;
-
 	/**
 	 * URI of the notebook file being edited. This serves as the unique identifier
 	 * for the notebook's content on disk.

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookEditorProxyService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookEditorProxyService.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
+import { getNotebookEditorFromEditorPane as getVscodeNotebookEditorFromEditorPane, INotebookEditor } from '../../notebook/browser/notebookBrowser.js';
+import { IPositronNotebookService } from './positronNotebookService.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { INotebookEditorProxyService } from './INotebookEditorProxyService.js';
+import { getNotebookInstanceFromEditorPane } from './notebookUtils.js';
+import { IEditorPane } from '../../../common/editor.js';
+import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+
+/**
+ * Proxy that combines Positron and VSCode notebook editors behind the INotebookEditorService interface.
+ */
+export class NotebookEditorProxyService extends Disposable implements INotebookEditorProxyService {
+	readonly _serviceBrand: undefined;
+
+	private readonly _onDidAddNotebookEditorEmitter = this._register(new Emitter<INotebookEditor>());
+	private readonly _onDidRemoveNotebookEditorEmitter = this._register(new Emitter<INotebookEditor>());
+
+	public readonly onDidAddNotebookEditor = this._onDidAddNotebookEditorEmitter.event;
+	public readonly onDidRemoveNotebookEditor = this._onDidRemoveNotebookEditorEmitter.event;
+
+	constructor(
+		@INotebookEditorService private readonly _notebookEditorService: INotebookEditorService,
+		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService
+	) {
+		super();
+
+		// Forward events from the notebook editor service
+		this._register(this._notebookEditorService.onDidAddNotebookEditor((editor) => {
+			this._onDidAddNotebookEditorEmitter.fire(editor);
+		}));
+		this._register(this._notebookEditorService.onDidRemoveNotebookEditor((editor) => {
+			this._onDidRemoveNotebookEditorEmitter.fire(editor);
+		}));
+
+		// Forward events from the Positron notebook service
+		this._register(this._positronNotebookService.onDidAddNotebookInstance(instance => {
+			this._onDidAddNotebookEditorEmitter.fire(asNotebookEditor(instance));
+		}));
+		this._register(this._positronNotebookService.onDidRemoveNotebookInstance(instance => {
+			this._onDidRemoveNotebookEditorEmitter.fire(asNotebookEditor(instance));
+		}));
+	}
+
+	listNotebookEditors(): readonly INotebookEditor[] {
+		return [
+			...this._notebookEditorService.listNotebookEditors(),
+			...this._positronNotebookService.listInstances().map(asNotebookEditor),
+		];
+	}
+}
+
+registerSingleton(INotebookEditorProxyService, NotebookEditorProxyService, InstantiationType.Delayed);
+
+export function getNotebookEditorFromEditorPane(editorPane?: IEditorPane): INotebookEditor | undefined {
+	const notebookInstance = getNotebookInstanceFromEditorPane(editorPane);
+	if (notebookInstance) {
+		return asNotebookEditor(notebookInstance);
+	}
+	return getVscodeNotebookEditorFromEditorPane(editorPane);
+}
+
+function asNotebookEditor(notebookInstance: IPositronNotebookInstance): INotebookEditor {
+	return notebookInstance as unknown as INotebookEditor;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -433,7 +433,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this.textModel !== undefined;
 	}
 
-	getViewModel(): INotebookViewModel | undefined {
+	getViewModel(): INotebookViewModel {
 		// Only implementing parts needed by the extension API, see the note in IPositronNotebookInstance.ts
 		return {
 			viewType: 'jupyter-notebook',
@@ -449,9 +449,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	cellAt(index: number): ICellViewModel | undefined {
-		// Implement ICellViewModel as needed. Not currently needed since the extension API
-		// only uses the returned value in calls to our own reveal* methods
-		return this.cells.get()[index] as unknown as ICellViewModel;
+		const cell = this.cells.get().at(index);
+		if (cell) {
+			assertNotebookCellIsCellViewModel(cell);
+			return cell;
+		}
+		return undefined;
 	}
 
 	/**
@@ -1353,4 +1356,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	// #endregion
+}
+
+function assertNotebookCellIsCellViewModel(cell: IPositronNotebookCell): asserts cell is IPositronNotebookCell & ICellViewModel {
+	// No-op; used for type assertion.
+	// Implement ICellViewModel as needed. Not currently needed since the extension API
+	// only uses the returned value in calls to our own reveal* methods
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine, toCellRanges } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IPositronNotebookService } from './positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from './IPositronNotebookInstance.js';
@@ -41,6 +41,7 @@ import { cellToCellDto2, serializeCellsToClipboard } from './cellClipboardUtils.
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { isNotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSession.js';
+import { ICellRange } from '../../notebook/common/notebookRange.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
 	textModel: NotebookTextModel;
@@ -836,6 +837,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return options;
 	}
 
+	/**
+	 * Gets the current selected cells.
+	 * @returns An array of cell ranges, where each range represents a group of consecutive selected cells.
+	 */
+	getSelections(): ICellRange[] {
+		return toCellRanges(this.selectionStateMachine.state.get());
+	}
 
 	/**
 	 * Gets the current state of the editor. This should

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -305,15 +305,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (this._notebookOptions) {
 			return this._notebookOptions;
 		}
-		this._logService.info(this.id, 'Generating new notebook options');
+		this._logService.info(this._id, 'Generating new notebook options');
 
 		this._notebookOptions = this._instantiationService.createInstance(NotebookOptions, DOM.getActiveWindow(), this.isReadOnly, undefined);
 
 		return this._notebookOptions;
-	}
-
-	get id(): string {
-		return this._id;
 	}
 
 	get isDisposed(): boolean {
@@ -412,7 +408,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._webviewPreloadService.attachNotebookInstance(this);
 
-		this._logService.info(this.id, 'constructor');
+		this._logService.info(this._id, 'constructor');
 
 		// Add listener for content changes to sync cells
 		this._register(this.onDidChangeContent(() => {
@@ -422,7 +418,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	override dispose() {
 
-		this._logService.info(this.id, 'dispose');
+		this._logService.info(this._id, 'dispose');
 		this._positronNotebookService.unregisterInstance(this);
 		// Remove from the instance map
 		PositronNotebookInstance._instanceMap.delete(this.uri);
@@ -435,6 +431,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	// =============================================================================================
 	// #region Public Methods
+
+	getId(): string {
+		return this._id;
+	}
 
 	/**
 	 * Handle logic associated with the text model for notebook. This
@@ -811,7 +811,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._scopedContextKeyService = scopedContextKeyService;
 		this.contextManager.setContainer(container, scopedContextKeyService);
 
-		this._logService.info(this.id, 'attachView');
+		this._logService.info(this._id, 'attachView');
 	}
 
 	/**
@@ -859,7 +859,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	detachView(): void {
 		this._container = undefined;
-		this._logService.info(this.id, 'detachView');
+		this._logService.info(this._id, 'detachView');
 		this._notebookOptions?.dispose();
 		this._notebookOptions = undefined;
 	}
@@ -868,7 +868,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Closes the notebook instance and disposes of all resources.
 	 */
 	close(): void {
-		this._logService.info(this.id, 'Closing a notebook instance');
+		this._logService.info(this._id, 'Closing a notebook instance');
 		this.dispose();
 	}
 
@@ -960,13 +960,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @returns
 	 */
 	private async _runCells(cells: IPositronNotebookCell[]): Promise<void> {
-		this._logService.info(this.id, '_runCells');
+		this._logService.info(this._id, '_runCells');
 
 		this._assertTextModel();
 
 		// Make sure we have a kernel to run the cells.
 		if (this.kernelStatus.get() !== KernelStatus.Connected) {
-			this._logService.info(this.id, 'No kernel connected, attempting to connect');
+			this._logService.info(this._id, 'No kernel connected, attempting to connect');
 			// Attempt to connect to the kernel
 			await this._commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -12,7 +12,7 @@ import { INotebookKernelService, INotebookKernel } from '../../notebook/common/n
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromEditorPane } from './notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IPositronNotebookActionBarContext } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernelActions.js';
 
@@ -41,7 +41,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 		// Force the dropdown if the action was invoked by the user in the UI
 		const forceDropdown = context?.ui ?? false;
 		const notebookKernelService = accessor.get(INotebookKernelService);
-		const activeNotebook = getNotebookInstanceFromEditorPane(accessor.get(IEditorService));
+		const activeNotebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
 		const quickInputService = accessor.get(IQuickInputService);
 
 		if (!activeNotebook) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -9,7 +9,6 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { INotebookKernelService, INotebookKernel } from '../../notebook/common/notebookKernelService.js';
-import { PositronNotebookInstance } from './PositronNotebookInstance.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
@@ -48,7 +47,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 			return false;
 		}
 
-		const notebook = (activeNotebook as PositronNotebookInstance).textModel;
+		const notebook = activeNotebook.textModel;
 		if (!notebook) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -10,7 +10,7 @@ import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED, POSITRON_NOTEBOOK_CELL_EDIT
 import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromEditorPane } from '../../notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
 
 class PositronNotebookUndoRedoContribution extends Disposable {
 
@@ -31,7 +31,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 
 	private shouldHandleUndoRedo(): boolean {
 		// Get the active notebook instance to access its scoped context key service
-		const instance = getNotebookInstanceFromEditorPane(this.editorService);
+		const instance = getNotebookInstanceFromActiveEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -62,7 +62,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = getNotebookInstanceFromEditorPane(this.editorService);
+		const instance = getNotebookInstanceFromActiveEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -80,7 +80,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = getNotebookInstanceFromEditorPane(this.editorService);
+		const instance = getNotebookInstanceFromActiveEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -43,6 +43,12 @@
 			aspect-ratio: 1;
 		}
 
+		/* The debug codicon (the icon itself) is misaligned with run above / run below icons by 1 pixel */
+		&.codicon-debug-alt-small {
+			position: relative;
+			top: -1px;
+		}
+
 		&.disabled {
 			color: var(--vscode-positronActionBar-disabledForeground);
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -15,7 +15,7 @@ import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { getSelectedCell, getSelectedCells, getEditingCell } from '../../selectionMachine.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromEditorPane } from '../../notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
 
 /**
  * Options for registering a cell command.
@@ -82,7 +82,7 @@ export function registerCellCommand({
 		id: commandId,
 		handler: (accessor: ServicesAccessor) => {
 			const editorService = accessor.get(IEditorService);
-			const activeNotebook = getNotebookInstanceFromEditorPane(editorService);
+			const activeNotebook = getNotebookInstanceFromActiveEditorPane(editorService);
 			if (!activeNotebook) {
 				return;
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
@@ -7,6 +7,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { IEditorPane } from '../../../common/editor.js';
 
 /**
  * Retrieves the active Positron notebook instance from the editor service.
@@ -14,15 +15,23 @@ import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js
  * @param editorService The editor service
  * @returns The active notebook instance, or undefined if no Positron notebook is active
  */
-export function getNotebookInstanceFromEditorPane(editorService: IEditorService): IPositronNotebookInstance | undefined {
-	const activeEditorPane = editorService.activeEditorPane;
+export function getNotebookInstanceFromActiveEditorPane(editorService: IEditorService): IPositronNotebookInstance | undefined {
+	return getNotebookInstanceFromEditorPane(editorService.activeEditorPane);
+}
 
+/**
+ * Retrieves the Positron notebook instance from an editor pane.
+ *
+ * @param editorPane The editor pane
+ * @returns The active notebook instance, or undefined if the editor pane is not a Positron notebook
+ */
+export function getNotebookInstanceFromEditorPane(editorPane?: IEditorPane): IPositronNotebookInstance | undefined {
 	// Check if the active editor is a Positron Notebook Editor
-	if (!activeEditorPane || activeEditorPane.getId() !== POSITRON_NOTEBOOK_EDITOR_ID) {
+	if (!editorPane || editorPane.getId() !== POSITRON_NOTEBOOK_EDITOR_ID) {
 		return undefined;
 	}
 
 	// Extract the notebook instance from the editor
-	const activeNotebook = (activeEditorPane as PositronNotebookEditor).notebookInstance;
+	const activeNotebook = (editorPane as PositronNotebookEditor).notebookInstance;
 	return activeNotebook;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -37,7 +37,7 @@ import { registerCellCommand } from './notebookCells/actionBar/registerCellComma
 import { registerNotebookAction } from './registerNotebookAction.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
-import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
+import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 import { SelectionState } from './selectionMachine.js';
 import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
@@ -45,6 +45,7 @@ import { registerAction2, MenuId } from '../../../../platform/actions/common/act
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { KernelStatusBadge } from './KernelStatusBadge.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 
 /**
@@ -495,7 +496,7 @@ registerCellCommand({
 // Make sure the run and stop commands are in the same place so they replace one another.
 const CELL_EXECUTION_POSITION = 10;
 registerCellCommand({
-	commandId: 'positronNotebook.cell.execute',
+	commandId: POSITRON_EXECUTE_CELL_COMMAND_ID,
 	handler: (cell) => {
 		cell.run();
 	},
@@ -533,6 +534,36 @@ registerCellCommand({
 	},
 	metadata: {
 		description: localize('positronNotebook.cell.stopExecution', "Stop cell execution")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.debug',
+	handler: async (cell, notebook, accessor) => {
+		await accessor.get(ICommandService).executeCommand('notebook.debugCell', {
+			// Args expected by the notebook.debugCell command,
+			// a subset of vscode.NotebookCell
+			notebook: {
+				uri: notebook.uri,
+			},
+			document: {
+				uri: cell.uri,
+			},
+		});
+	},
+	editMode: true,
+	keybinding: {
+		primary: KeyMod.Alt | KeyMod.Shift | KeyCode.Enter
+	},
+	when: CELL_CONTEXT_KEYS.isCode,
+	actionBar: {
+		icon: 'codicon-debug-alt-small',
+		position: 'main',
+		order: 10,
+		category: 'Execution',
+	},
+	metadata: {
+		description: localize('positronNotebook.cell.debug', "Debug cell"),
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
@@ -105,6 +105,7 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 	public registerInstance(instance: IPositronNotebookInstance): void {
 		if (!this._instanceById.has(instance.getId())) {
 			this._instanceById.set(instance.getId(), instance);
+			this._onDidAddNotebookInstance.fire(instance);
 		}
 		this._activeInstance = instance;
 	}
@@ -114,6 +115,7 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 			if (this._activeInstance === instance) {
 				this._activeInstance = null;
 			}
+			this._onDidRemoveNotebookInstance.fire(instance);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
@@ -18,7 +18,7 @@ import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromEditorPane } from './notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 
 /**
  * Keybinding configuration for notebook actions.
@@ -262,7 +262,7 @@ function registerNotebookCommandInternal(options: INotebookCommandOptions): IDis
 		id: options.commandId,
 		handler: (accessor: ServicesAccessor) => {
 			const editorService = accessor.get(IEditorService);
-			const activeNotebook = getNotebookInstanceFromEditorPane(editorService);
+			const activeNotebook = getNotebookInstanceFromActiveEditorPane(editorService);
 			if (!activeNotebook) {
 				return;
 			}
@@ -357,7 +357,7 @@ function registerNotebookWidgetInternal(options: INotebookWidgetOptions): IDispo
 			return () => {
 				// Get the active notebook using the VS Code pattern
 				const editorService = accessor.get(IEditorService);
-				const notebook = getNotebookInstanceFromEditorPane(editorService);
+				const notebook = getNotebookInstanceFromActiveEditorPane(editorService);
 				if (!notebook) {
 					return null;
 				}

--- a/src/vs/workbench/contrib/positronNotebook/browser/toPositronNotebookCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/toPositronNotebookCommand.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { EXECUTE_CELL_COMMAND_ID } from '../../notebook/browser/notebookBrowser.js';
+import { POSITRON_EXECUTE_CELL_COMMAND_ID } from '../common/positronNotebookCommon.js';
+
+
+const _code2PositronCommandId: Record<string, string> = {
+	[EXECUTE_CELL_COMMAND_ID]: POSITRON_EXECUTE_CELL_COMMAND_ID,
+};
+
+export function toPositronNotebookCommand(commandId: string): string | undefined {
+	try {
+		return _code2PositronCommandId[commandId];
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -8,6 +8,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 export const POSITRON_NOTEBOOK_EDITOR_ID = 'workbench.editor.positronNotebook';
 export const POSITRON_NOTEBOOK_EDITOR_INPUT_ID = 'workbench.input.positronNotebook';
 
+export const POSITRON_EXECUTE_CELL_COMMAND_ID = 'positronNotebook.cell.execute';
+
 /**
  * Check if Positron notebooks are configured as the default editor for .ipynb files
  * @param configurationService Configuration service
@@ -16,5 +18,5 @@ export const POSITRON_NOTEBOOK_EDITOR_INPUT_ID = 'workbench.input.positronNotebo
 
 export function usingPositronNotebooks(configurationService: IConfigurationService): boolean {
 	const editorAssociations = configurationService.getValue<Record<string, string>>('workbench.editorAssociations') || {};
-	return editorAssociations['*.ipynb'] === 'workbench.editor.positronNotebook';
+	return editorAssociations['*.ipynb'] === POSITRON_NOTEBOOK_EDITOR_ID;
 }

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -113,7 +113,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 
 	public attachNotebookInstance(instance: IPositronNotebookInstance): void {
 		console.log('Adding notebook instance to webview preloads knowledge', instance);
-		const notebookId = instance.id;
+		const notebookId = instance.getId();
 		if (this._notebookToDisposablesMap.has(notebookId)) {
 			// Clear existing disposables
 			this._notebookToDisposablesMap.get(notebookId)?.dispose();
@@ -139,6 +139,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			data: message.outputs.reduce((acc, output) => {
 				acc[output.mime] = output.data.toString();
 				return acc;
+				// eslint-disable-next-line local/code-no-dangerous-type-assertions
 			}, {} as Record<string, any>)
 		};
 	}
@@ -159,10 +160,10 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		outputId: NotebookOutput['outputId'];
 		outputs: NotebookOutput['outputs'];
 	}): NotebookPreloadOutputResults | undefined {
-		const notebookMessages = this._messagesByNotebookId.get(instance.id);
+		const notebookMessages = this._messagesByNotebookId.get(instance.getId());
 
 		if (!notebookMessages) {
-			throw new Error(`PositronWebviewPreloadService: Notebook ${instance.id} not found in messagesByNotebookId map.`);
+			throw new Error(`PositronWebviewPreloadService: Notebook ${instance.getId()} not found in messagesByNotebookId map.`);
 		}
 
 		// Check if this output contains any mime types that require webview handling
@@ -202,15 +203,15 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		displayMessage: ILanguageRuntimeMessageWebOutput,
 	): Promise<INotebookOutputWebview> {
 		// Grab disposables for this session
-		const disposables = this._notebookToDisposablesMap.get(instance.id);
+		const disposables = this._notebookToDisposablesMap.get(instance.getId());
 		if (!disposables) {
-			throw new Error(`PositronWebviewPreloadService: Could not find disposables for notebook ${instance.id}`);
+			throw new Error(`PositronWebviewPreloadService: Could not find disposables for notebook ${instance.getId()}`);
 		}
 
 		// Create a plot client and fire event letting plots pane know it's good to go.
-		const storedMessages = this._messagesByNotebookId.get(instance.id) ?? [];
+		const storedMessages = this._messagesByNotebookId.get(instance.getId()) ?? [];
 		const webview = await this._notebookOutputWebviewService.createMultiMessageWebview({
-			runtimeId: instance.id,
+			runtimeId: instance.getId(),
 			preReqMessages: storedMessages,
 			displayMessage: displayMessage,
 			viewType: 'jupyter-notebook'
@@ -218,7 +219,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 
 		// Assert that we have a webview
 		if (!webview) {
-			throw new Error(`PositronWebviewPreloadService: Failed to create webview for notebook ${instance.id}`);
+			throw new Error(`PositronWebviewPreloadService: Failed to create webview for notebook ${instance.getId()}`);
 		}
 
 		return webview;


### PR DESCRIPTION
This PR integrates Positron notebook editors with the extension API (addresses #9440) and hooks up the notebook runtime debugging extension (#9251).

This is a rework of #9843. It turned out to be simplest to manage Positron notebook state in the same place as upstream state, otherwise we have to restore to more complicated state merging and conflicts. 

Debug cell button position:

<img width="131" height="68" alt="image" src="https://github.com/user-attachments/assets/8365c291-747c-4df4-a532-895e86419378" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Nothing should break. You should be able to debug a cell in a Positro notebook editor.

@:notebooks