### PR TITLE
fix open-remote-ssh whitespace

### DIFF
--- a/extensions/open-remote-ssh/.eslintrc.json
+++ b/extensions/open-remote-ssh/.eslintrc.json
@@ -1,65 +1,65 @@
 {
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
-  },
-  "plugins": [
-    "@typescript-eslint/eslint-plugin",
-    "jsdoc"
-  ],
-  "rules": {
-    "constructor-super": "warn",
-    "curly": "warn",
-    "eqeqeq": "warn",
-    "no-buffer-constructor": "warn",
-    "no-caller": "warn",
-    "no-case-declarations": "warn",
-    "no-debugger": "warn",
-    "no-duplicate-case": "warn",
-    "no-duplicate-imports": "warn",
-    "no-eval": "warn",
-    "no-async-promise-executor": "warn",
-    "no-extra-semi": "warn",
-    "no-new-wrappers": "warn",
-    "no-redeclare": "off",
-    "no-sparse-arrays": "warn",
-    "no-throw-literal": "warn",
-    "no-unsafe-finally": "warn",
-    "no-unused-labels": "warn",
-    "no-restricted-globals": [
-      "warn",
-      "name",
-      "length",
-      "event",
-      "closed",
-      "external",
-      "status",
-      "origin",
-      "orientation",
-      "context"
-    ], // non-complete list of globals that are easy to access unintentionally
-    "no-var": "warn",
-    "jsdoc/no-types": "warn",
-    "semi": "off",
-    "@typescript-eslint/semi": "warn",
-    "@typescript-eslint/member-delimiter-style": "warn",
-    "@typescript-eslint/naming-convention": [
-      "warn",
-      {
-        "selector": "class",
-        "format": [
-          "PascalCase"
-        ]
-      }
-    ],
-    "quotes": "off",
-    "@typescript-eslint/quotes": [
-      "warn",
-      "single",
-      {
-        "allowTemplateLiterals": true
-      }
-    ]
-  }
+	"parser": "@typescript-eslint/parser",
+	"parserOptions": {
+		"ecmaVersion": 6,
+		"sourceType": "module"
+	},
+	"plugins": [
+		"@typescript-eslint/eslint-plugin",
+		"jsdoc"
+	],
+	"rules": {
+		"constructor-super": "warn",
+		"curly": "warn",
+		"eqeqeq": "warn",
+		"no-buffer-constructor": "warn",
+		"no-caller": "warn",
+		"no-case-declarations": "warn",
+		"no-debugger": "warn",
+		"no-duplicate-case": "warn",
+		"no-duplicate-imports": "warn",
+		"no-eval": "warn",
+		"no-async-promise-executor": "warn",
+		"no-extra-semi": "warn",
+		"no-new-wrappers": "warn",
+		"no-redeclare": "off",
+		"no-sparse-arrays": "warn",
+		"no-throw-literal": "warn",
+		"no-unsafe-finally": "warn",
+		"no-unused-labels": "warn",
+		"no-restricted-globals": [
+			"warn",
+			"name",
+			"length",
+			"event",
+			"closed",
+			"external",
+			"status",
+			"origin",
+			"orientation",
+			"context"
+		], // non-complete list of globals that are easy to access unintentionally
+		"no-var": "warn",
+		"jsdoc/no-types": "warn",
+		"semi": "off",
+		"@typescript-eslint/semi": "warn",
+		"@typescript-eslint/member-delimiter-style": "warn",
+		"@typescript-eslint/naming-convention": [
+			"warn",
+			{
+				"selector": "class",
+				"format": [
+					"PascalCase"
+				]
+			}
+		],
+		"quotes": "off",
+		"@typescript-eslint/quotes": [
+			"warn",
+			"single",
+			{
+				"allowTemplateLiterals": true
+			}
+		]
+	}
 }

--- a/extensions/open-remote-ssh/.vscode/launch.json
+++ b/extensions/open-remote-ssh/.vscode/launch.json
@@ -1,18 +1,18 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
-        }
-    ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: watch"
+		}
+	]
 }

--- a/extensions/open-remote-ssh/package.json
+++ b/extensions/open-remote-ssh/package.json
@@ -1,364 +1,364 @@
 {
-  "name": "open-remote-ssh",
-  "displayName": "Open Remote - SSH",
-  "description": "Use any remote machine with a SSH server as your development environment.",
-  "version": "0.0.49",
-  "publisher": "jeanp413",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jeanp413/open-remote-ssh.git"
-  },
-  "bugs": {
-    "url": "https://github.com/jeanp413/open-remote-ssh/issues"
-  },
-  "engines": {
-    "vscode": "^1.70.2"
-  },
-  "extensionKind": [
-    "ui"
-  ],
-  "enabledApiProposals": [
-    "resolvers",
-    "contribViewsRemote"
-  ],
-  "keywords": [
-    "remote development",
-    "remote",
-    "ssh"
-  ],
-  "api": "none",
-  "activationEvents": [
-    "onCommand:openremotessh.openEmptyWindow",
-    "onCommand:openremotessh.openEmptyWindowInCurrentWindow",
-    "onCommand:openremotessh.openConfigFile",
-    "onCommand:openremotessh.showLog",
-    "onResolveRemoteAuthority:ssh-remote",
-    "onView:sshHosts"
-  ],
-  "main": "./out/extension.js",
-  "contributes": {
-    "configuration": {
-      "title": "Remote SSH",
-      "properties": {
-        "remoteSSH.configFile": {
-          "type": "string",
-          "description": "The absolute file path to a custom SSH config file.",
-          "default": "",
-          "scope": "application"
-        },
-        "remoteSSH.connectTimeout": {
-          "type": "number",
-          "description": "Specifies the timeout in seconds used for the SSH command that connects to the remote.",
-          "default": 60,
-          "scope": "application",
-          "minimum": 1
-        },
-        "remoteSSH.defaultExtensions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "List of extensions that should be installed automatically on all SSH hosts.",
-          "scope": "application"
-        },
-        "remoteSSH.enableDynamicForwarding": {
-          "type": "boolean",
-          "description": "Whether to use SSH dynamic forwarding to allow setting up new port tunnels over an existing SSH connection.",
-          "scope": "application",
-          "default": true
-        },
-        "remoteSSH.enableAgentForwarding": {
-          "type": "boolean",
-          "markdownDescription": "Enable fixing the remote environment so that the SSH config option `ForwardAgent` will take effect as expected from VS Code's remote extension host.",
-          "scope": "application",
-          "default": true
-        },
-        "remoteSSH.serverDownloadUrlTemplate": {
-          "type": "string",
-          "description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
-          "scope": "application",
-          "default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
-        },
-        "remoteSSH.remotePlatform": {
-          "type": "object",
-          "description": "A map of the remote hostname to the platform for that remote. Valid values: linux, macos, windows.",
-          "scope": "application",
-          "default": {},
-          "additionalProperties": {
-            "type": "string",
-            "enum": [
-              "linux",
-              "macos",
-              "windows"
-            ]
-          }
-        },
-        "remoteSSH.remoteServerListenOnSocket": {
-          "type": "boolean",
-          "description": "When true, the remote vscode server will listen on a socket path instead of opening a port. Only valid for Linux and macOS remotes. Requires `AllowStreamLocalForwarding` to be enabled for the SSH server.",
-          "default": false
-        },
-        "remoteSSH.experimental.serverBinaryName": {
-          "type": "string",
-          "description": "**Experimental:** The name of the server binary, use this **only if** you are using a client without a corresponding server release",
-          "scope": "application",
-          "default": ""
-        }
-      }
-    },
-    "views": {
-      "remote": [
-        {
-          "id": "sshHosts",
-          "name": "SSH Targets",
-          "group": "targets@1",
-          "remoteName": "ssh-remote"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "openremotessh.openEmptyWindow",
-        "title": "Connect to Host...",
-        "category": "Remote-SSH"
-      },
-      {
-        "command": "openremotessh.openEmptyWindowInCurrentWindow",
-        "title": "Connect Current Window to Host...",
-        "category": "Remote-SSH"
-      },
-      {
-        "command": "openremotessh.openConfigFile",
-        "title": "Open SSH Configuration File...",
-        "category": "Remote-SSH"
-      },
-      {
-        "command": "openremotessh.showLog",
-        "title": "Show Log",
-        "category": "Remote-SSH"
-      },
-      {
-        "command": "openremotessh.explorer.emptyWindowInNewWindow",
-        "title": "Connect to Host in New Window",
-        "icon": "$(empty-window)"
-      },
-      {
-        "command": "openremotessh.explorer.emptyWindowInCurrentWindow",
-        "title": "Connect to Host in Current Window"
-      },
-      {
-        "command": "openremotessh.explorer.reopenFolderInCurrentWindow",
-        "title": "Open on SSH Host in Current Window"
-      },
-      {
-        "command": "openremotessh.explorer.reopenFolderInNewWindow",
-        "title": "Open on SSH Host in New Window",
-        "icon": "$(folder-opened)"
-      },
-      {
-        "command": "openremotessh.explorer.deleteFolderHistoryItem",
-        "title": "Remove From Recent List",
-        "icon": "$(x)"
-      },
-      {
-        "command": "openremotessh.explorer.refresh",
-        "title": "Refresh",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "openremotessh.explorer.configure",
-        "title": "Configure",
-        "icon": "$(gear)"
-      },
-      {
-        "command": "openremotessh.explorer.add",
-        "title": "Add New",
-        "icon": "$(plus)"
-      }
-    ],
-    "resourceLabelFormatters": [
-      {
-        "scheme": "vscode-remote",
-        "authority": "ssh-remote+*",
-        "formatting": {
-          "label": "${path}",
-          "separator": "/",
-          "tildify": true,
-          "workspaceSuffix": "SSH"
-        }
-      }
-    ],
-    "menus": {
-      "statusBar/remoteIndicator": [
-        {
-          "command": "openremotessh.openEmptyWindow",
-          "when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
-          "group": "remote_20_ssh_1general@1"
-        },
-        {
-          "command": "openremotessh.openEmptyWindowInCurrentWindow",
-          "when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
-          "group": "remote_20_ssh_1general@2"
-        },
-        {
-          "command": "openremotessh.openConfigFile",
-          "when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
-          "group": "remote_20_ssh_1general@3"
-        },
-        {
-          "command": "openremotessh.showLog",
-          "when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
-          "group": "remote_20_ssh_1general@4"
-        },
-        {
-          "command": "openremotessh.openEmptyWindow",
-          "when": "remoteConnectionState == disconnected",
-          "group": "remote_20_ssh_3local@1"
-        },
-        {
-          "command": "openremotessh.openEmptyWindowInCurrentWindow",
-          "when": "remoteConnectionState == disconnected",
-          "group": "remote_20_ssh_3local@2"
-        },
-        {
-          "command": "openremotessh.openConfigFile",
-          "when": "remoteConnectionState == disconnected",
-          "group": "remote_20_ssh_3local@3"
-        },
-        {
-          "command": "openremotessh.openEmptyWindow",
-          "when": "!remoteName && !virtualWorkspace",
-          "group": "remote_20_ssh_3local@5"
-        },
-        {
-          "command": "openremotessh.openEmptyWindowInCurrentWindow",
-          "when": "!remoteName && !virtualWorkspace",
-          "group": "remote_20_ssh_3local@6"
-        },
-        {
-          "command": "openremotessh.openConfigFile",
-          "when": "!remoteName && !virtualWorkspace",
-          "group": "remote_20_ssh_3local@7"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "openremotessh.explorer.refresh",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.configure",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.add",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.emptyWindowInNewWindow",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.emptyWindowInCurrentWindow",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.reopenFolderInCurrentWindow",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.reopenFolderInNewWindow",
-          "when": "false"
-        },
-        {
-          "command": "openremotessh.explorer.deleteFolderHistoryItem",
-          "when": "false"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "openremotessh.explorer.add",
-          "when": "view == sshHosts",
-          "group": "navigation"
-        },
-        {
-          "command": "openremotessh.explorer.configure",
-          "when": "view == sshHosts",
-          "group": "navigation"
-        },
-        {
-          "command": "openremotessh.explorer.refresh",
-          "when": "view == sshHosts",
-          "group": "navigation"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "openremotessh.explorer.emptyWindowInNewWindow",
-          "when": "viewItem =~ /^openremotessh.explorer.host$/",
-          "group": "inline@1"
-        },
-        {
-          "command": "openremotessh.explorer.emptyWindowInNewWindow",
-          "when": "viewItem =~ /^openremotessh.explorer.host$/",
-          "group": "navigation@2"
-        },
-        {
-          "command": "openremotessh.explorer.emptyWindowInCurrentWindow",
-          "when": "viewItem =~ /^openremotessh.explorer.host$/",
-          "group": "navigation@1"
-        },
-        {
-          "command": "openremotessh.explorer.reopenFolderInNewWindow",
-          "when": "viewItem == openremotessh.explorer.folder",
-          "group": "inline@1"
-        },
-        {
-          "command": "openremotessh.explorer.reopenFolderInNewWindow",
-          "when": "viewItem == openremotessh.explorer.folder",
-          "group": "navigation@2"
-        },
-        {
-          "command": "openremotessh.explorer.reopenFolderInCurrentWindow",
-          "when": "viewItem == openremotessh.explorer.folder",
-          "group": "navigation@1"
-        },
-        {
-          "command": "openremotessh.explorer.deleteFolderHistoryItem",
-          "when": "viewItem =~ /^openremotessh.explorer.folder/",
-          "group": "navigation@3"
-        },
-        {
-          "command": "openremotessh.explorer.deleteFolderHistoryItem",
-          "when": "viewItem =~ /^openremotessh.explorer.folder/",
-          "group": "inline@2"
-        }
-      ]
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
-  },
-  "devDependencies": {
-    "@types/node": "^16.11.0",
-    "@types/ssh2": "^0.5.52",
-    "@types/ssh2-streams": "0.1.12",
-    "@typescript-eslint/eslint-plugin": "^5.19.0",
-    "@typescript-eslint/parser": "^5.19.0",
-    "node-loader": "^1.0.2",
-    "ts-loader": "^9.2.7",
-    "typescript": "^4.6.3"
-  },
-  "dependencies": {
-    "@jeanp413/ssh-config": "^4.3.1",
-    "glob": "^9.3.1",
-    "simple-socks": "git+https://github.com/jeanp413/simple-socks#main",
-    "socks": "^2.5.0",
-    "ssh2": "git+https://github.com/jmcphers/ssh2#master"
-  }
+	"name": "open-remote-ssh",
+	"displayName": "Open Remote - SSH",
+	"description": "Use any remote machine with a SSH server as your development environment.",
+	"version": "0.0.49",
+	"publisher": "jeanp413",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jeanp413/open-remote-ssh.git"
+	},
+	"bugs": {
+		"url": "https://github.com/jeanp413/open-remote-ssh/issues"
+	},
+	"engines": {
+		"vscode": "^1.70.2"
+	},
+	"extensionKind": [
+		"ui"
+	],
+	"enabledApiProposals": [
+		"resolvers",
+		"contribViewsRemote"
+	],
+	"keywords": [
+		"remote development",
+		"remote",
+		"ssh"
+	],
+	"api": "none",
+	"activationEvents": [
+		"onCommand:openremotessh.openEmptyWindow",
+		"onCommand:openremotessh.openEmptyWindowInCurrentWindow",
+		"onCommand:openremotessh.openConfigFile",
+		"onCommand:openremotessh.showLog",
+		"onResolveRemoteAuthority:ssh-remote",
+		"onView:sshHosts"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"configuration": {
+			"title": "Remote SSH",
+			"properties": {
+				"remoteSSH.configFile": {
+					"type": "string",
+					"description": "The absolute file path to a custom SSH config file.",
+					"default": "",
+					"scope": "application"
+				},
+				"remoteSSH.connectTimeout": {
+					"type": "number",
+					"description": "Specifies the timeout in seconds used for the SSH command that connects to the remote.",
+					"default": 60,
+					"scope": "application",
+					"minimum": 1
+				},
+				"remoteSSH.defaultExtensions": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "List of extensions that should be installed automatically on all SSH hosts.",
+					"scope": "application"
+				},
+				"remoteSSH.enableDynamicForwarding": {
+					"type": "boolean",
+					"description": "Whether to use SSH dynamic forwarding to allow setting up new port tunnels over an existing SSH connection.",
+					"scope": "application",
+					"default": true
+				},
+				"remoteSSH.enableAgentForwarding": {
+					"type": "boolean",
+					"markdownDescription": "Enable fixing the remote environment so that the SSH config option `ForwardAgent` will take effect as expected from VS Code's remote extension host.",
+					"scope": "application",
+					"default": true
+				},
+				"remoteSSH.serverDownloadUrlTemplate": {
+					"type": "string",
+					"description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
+					"scope": "application",
+					"default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
+				},
+				"remoteSSH.remotePlatform": {
+					"type": "object",
+					"description": "A map of the remote hostname to the platform for that remote. Valid values: linux, macos, windows.",
+					"scope": "application",
+					"default": {},
+					"additionalProperties": {
+						"type": "string",
+						"enum": [
+							"linux",
+							"macos",
+							"windows"
+						]
+					}
+				},
+				"remoteSSH.remoteServerListenOnSocket": {
+					"type": "boolean",
+					"description": "When true, the remote vscode server will listen on a socket path instead of opening a port. Only valid for Linux and macOS remotes. Requires `AllowStreamLocalForwarding` to be enabled for the SSH server.",
+					"default": false
+				},
+				"remoteSSH.experimental.serverBinaryName": {
+					"type": "string",
+					"description": "**Experimental:** The name of the server binary, use this **only if** you are using a client without a corresponding server release",
+					"scope": "application",
+					"default": ""
+				}
+			}
+		},
+		"views": {
+			"remote": [
+				{
+					"id": "sshHosts",
+					"name": "SSH Targets",
+					"group": "targets@1",
+					"remoteName": "ssh-remote"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "openremotessh.openEmptyWindow",
+				"title": "Connect to Host...",
+				"category": "Remote-SSH"
+			},
+			{
+				"command": "openremotessh.openEmptyWindowInCurrentWindow",
+				"title": "Connect Current Window to Host...",
+				"category": "Remote-SSH"
+			},
+			{
+				"command": "openremotessh.openConfigFile",
+				"title": "Open SSH Configuration File...",
+				"category": "Remote-SSH"
+			},
+			{
+				"command": "openremotessh.showLog",
+				"title": "Show Log",
+				"category": "Remote-SSH"
+			},
+			{
+				"command": "openremotessh.explorer.emptyWindowInNewWindow",
+				"title": "Connect to Host in New Window",
+				"icon": "$(empty-window)"
+			},
+			{
+				"command": "openremotessh.explorer.emptyWindowInCurrentWindow",
+				"title": "Connect to Host in Current Window"
+			},
+			{
+				"command": "openremotessh.explorer.reopenFolderInCurrentWindow",
+				"title": "Open on SSH Host in Current Window"
+			},
+			{
+				"command": "openremotessh.explorer.reopenFolderInNewWindow",
+				"title": "Open on SSH Host in New Window",
+				"icon": "$(folder-opened)"
+			},
+			{
+				"command": "openremotessh.explorer.deleteFolderHistoryItem",
+				"title": "Remove From Recent List",
+				"icon": "$(x)"
+			},
+			{
+				"command": "openremotessh.explorer.refresh",
+				"title": "Refresh",
+				"icon": "$(refresh)"
+			},
+			{
+				"command": "openremotessh.explorer.configure",
+				"title": "Configure",
+				"icon": "$(gear)"
+			},
+			{
+				"command": "openremotessh.explorer.add",
+				"title": "Add New",
+				"icon": "$(plus)"
+			}
+		],
+		"resourceLabelFormatters": [
+			{
+				"scheme": "vscode-remote",
+				"authority": "ssh-remote+*",
+				"formatting": {
+					"label": "${path}",
+					"separator": "/",
+					"tildify": true,
+					"workspaceSuffix": "SSH"
+				}
+			}
+		],
+		"menus": {
+			"statusBar/remoteIndicator": [
+				{
+					"command": "openremotessh.openEmptyWindow",
+					"when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
+					"group": "remote_20_ssh_1general@1"
+				},
+				{
+					"command": "openremotessh.openEmptyWindowInCurrentWindow",
+					"when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
+					"group": "remote_20_ssh_1general@2"
+				},
+				{
+					"command": "openremotessh.openConfigFile",
+					"when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
+					"group": "remote_20_ssh_1general@3"
+				},
+				{
+					"command": "openremotessh.showLog",
+					"when": "remoteName =~ /^ssh-remote$/ && remoteConnectionState == connected",
+					"group": "remote_20_ssh_1general@4"
+				},
+				{
+					"command": "openremotessh.openEmptyWindow",
+					"when": "remoteConnectionState == disconnected",
+					"group": "remote_20_ssh_3local@1"
+				},
+				{
+					"command": "openremotessh.openEmptyWindowInCurrentWindow",
+					"when": "remoteConnectionState == disconnected",
+					"group": "remote_20_ssh_3local@2"
+				},
+				{
+					"command": "openremotessh.openConfigFile",
+					"when": "remoteConnectionState == disconnected",
+					"group": "remote_20_ssh_3local@3"
+				},
+				{
+					"command": "openremotessh.openEmptyWindow",
+					"when": "!remoteName && !virtualWorkspace",
+					"group": "remote_20_ssh_3local@5"
+				},
+				{
+					"command": "openremotessh.openEmptyWindowInCurrentWindow",
+					"when": "!remoteName && !virtualWorkspace",
+					"group": "remote_20_ssh_3local@6"
+				},
+				{
+					"command": "openremotessh.openConfigFile",
+					"when": "!remoteName && !virtualWorkspace",
+					"group": "remote_20_ssh_3local@7"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "openremotessh.explorer.refresh",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.configure",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.add",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.emptyWindowInNewWindow",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.emptyWindowInCurrentWindow",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.reopenFolderInCurrentWindow",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.reopenFolderInNewWindow",
+					"when": "false"
+				},
+				{
+					"command": "openremotessh.explorer.deleteFolderHistoryItem",
+					"when": "false"
+				}
+			],
+			"view/title": [
+				{
+					"command": "openremotessh.explorer.add",
+					"when": "view == sshHosts",
+					"group": "navigation"
+				},
+				{
+					"command": "openremotessh.explorer.configure",
+					"when": "view == sshHosts",
+					"group": "navigation"
+				},
+				{
+					"command": "openremotessh.explorer.refresh",
+					"when": "view == sshHosts",
+					"group": "navigation"
+				}
+			],
+			"view/item/context": [
+				{
+					"command": "openremotessh.explorer.emptyWindowInNewWindow",
+					"when": "viewItem =~ /^openremotessh.explorer.host$/",
+					"group": "inline@1"
+				},
+				{
+					"command": "openremotessh.explorer.emptyWindowInNewWindow",
+					"when": "viewItem =~ /^openremotessh.explorer.host$/",
+					"group": "navigation@2"
+				},
+				{
+					"command": "openremotessh.explorer.emptyWindowInCurrentWindow",
+					"when": "viewItem =~ /^openremotessh.explorer.host$/",
+					"group": "navigation@1"
+				},
+				{
+					"command": "openremotessh.explorer.reopenFolderInNewWindow",
+					"when": "viewItem == openremotessh.explorer.folder",
+					"group": "inline@1"
+				},
+				{
+					"command": "openremotessh.explorer.reopenFolderInNewWindow",
+					"when": "viewItem == openremotessh.explorer.folder",
+					"group": "navigation@2"
+				},
+				{
+					"command": "openremotessh.explorer.reopenFolderInCurrentWindow",
+					"when": "viewItem == openremotessh.explorer.folder",
+					"group": "navigation@1"
+				},
+				{
+					"command": "openremotessh.explorer.deleteFolderHistoryItem",
+					"when": "viewItem =~ /^openremotessh.explorer.folder/",
+					"group": "navigation@3"
+				},
+				{
+					"command": "openremotessh.explorer.deleteFolderHistoryItem",
+					"when": "viewItem =~ /^openremotessh.explorer.folder/",
+					"group": "inline@2"
+				}
+			]
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"pretest": "npm run compile && npm run lint",
+		"lint": "eslint src --ext ts",
+		"test": "node ./out/test/runTest.js"
+	},
+	"devDependencies": {
+		"@types/node": "^16.11.0",
+		"@types/ssh2": "^0.5.52",
+		"@types/ssh2-streams": "0.1.12",
+		"@typescript-eslint/eslint-plugin": "^5.19.0",
+		"@typescript-eslint/parser": "^5.19.0",
+		"node-loader": "^1.0.2",
+		"ts-loader": "^9.2.7",
+		"typescript": "^4.6.3"
+	},
+	"dependencies": {
+		"@jeanp413/ssh-config": "^4.3.1",
+		"glob": "^9.3.1",
+		"simple-socks": "git+https://github.com/jeanp413/simple-socks#main",
+		"socks": "^2.5.0",
+		"ssh2": "git+https://github.com/jmcphers/ssh2#master"
+	}
 }

--- a/extensions/open-remote-ssh/src/commands.ts
+++ b/extensions/open-remote-ssh/src/commands.ts
@@ -6,59 +6,59 @@ import { exists as fileExists } from './common/files';
 import SSHDestination from './ssh/sshDestination';
 
 export async function promptOpenRemoteSSHWindow(reuseWindow: boolean) {
-    const host = await vscode.window.showInputBox({
-        title: 'Enter [user@]hostname[:port]'
-    });
+	const host = await vscode.window.showInputBox({
+		title: 'Enter [user@]hostname[:port]'
+	});
 
-    if (!host) {
-        return;
-    }
+	if (!host) {
+		return;
+	}
 
-    const sshDest = new SSHDestination(host);
-    openRemoteSSHWindow(sshDest.toEncodedString(), reuseWindow);
+	const sshDest = new SSHDestination(host);
+	openRemoteSSHWindow(sshDest.toEncodedString(), reuseWindow);
 }
 
 export function openRemoteSSHWindow(host: string, reuseWindow: boolean) {
-    vscode.commands.executeCommand('vscode.newWindow', { remoteAuthority: getRemoteAuthority(host), reuseWindow });
+	vscode.commands.executeCommand('vscode.newWindow', { remoteAuthority: getRemoteAuthority(host), reuseWindow });
 }
 
 export function openRemoteSSHLocationWindow(host: string, path: string, reuseWindow: boolean) {
-    vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.from({ scheme: 'vscode-remote', authority: getRemoteAuthority(host), path }), { forceNewWindow: !reuseWindow });
+	vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.from({ scheme: 'vscode-remote', authority: getRemoteAuthority(host), path }), { forceNewWindow: !reuseWindow });
 }
 
 export async function addNewHost() {
-    const sshConfigPath = getSSHConfigPath();
-    if (!await fileExists(sshConfigPath)) {
-        await fs.promises.appendFile(sshConfigPath, '');
-    }
+	const sshConfigPath = getSSHConfigPath();
+	if (!await fileExists(sshConfigPath)) {
+		await fs.promises.appendFile(sshConfigPath, '');
+	}
 
-    await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(sshConfigPath), { preview: false });
+	await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(sshConfigPath), { preview: false });
 
-    const textEditor = vscode.window.activeTextEditor;
-    if (textEditor?.document.uri.fsPath !== sshConfigPath) {
-        return;
-    }
+	const textEditor = vscode.window.activeTextEditor;
+	if (textEditor?.document.uri.fsPath !== sshConfigPath) {
+		return;
+	}
 
-    const textDocument = textEditor.document;
-    const lastLine = textDocument.lineAt(textDocument.lineCount - 1);
+	const textDocument = textEditor.document;
+	const lastLine = textDocument.lineAt(textDocument.lineCount - 1);
 
-    if (!lastLine.isEmptyOrWhitespace) {
-        await textEditor.edit((editBuilder: vscode.TextEditorEdit) => {
-            editBuilder.insert(lastLine.range.end, '\n');
-        });
-    }
+	if (!lastLine.isEmptyOrWhitespace) {
+		await textEditor.edit((editBuilder: vscode.TextEditorEdit) => {
+			editBuilder.insert(lastLine.range.end, '\n');
+		});
+	}
 
-    let snippet = '\nHost ${1:dev}\n\tHostName ${2:dev.example.com}\n\tUser ${3:john}';
-    await textEditor.insertSnippet(
-        new vscode.SnippetString(snippet),
-        new vscode.Position(textDocument.lineCount, 0)
-    );
+	let snippet = '\nHost ${1:dev}\n\tHostName ${2:dev.example.com}\n\tUser ${3:john}';
+	await textEditor.insertSnippet(
+		new vscode.SnippetString(snippet),
+		new vscode.Position(textDocument.lineCount, 0)
+	);
 }
 
 export async function openSSHConfigFile() {
-    const sshConfigPath = getSSHConfigPath();
-    if (!await fileExists(sshConfigPath)) {
-        await fs.promises.appendFile(sshConfigPath, '');
-    }
-    vscode.commands.executeCommand('vscode.open', vscode.Uri.file(sshConfigPath));
+	const sshConfigPath = getSSHConfigPath();
+	if (!await fileExists(sshConfigPath)) {
+		await fs.promises.appendFile(sshConfigPath, '');
+	}
+	vscode.commands.executeCommand('vscode.open', vscode.Uri.file(sshConfigPath));
 }

--- a/extensions/open-remote-ssh/src/common/files.ts
+++ b/extensions/open-remote-ssh/src/common/files.ts
@@ -4,18 +4,18 @@ import * as os from 'os';
 const homeDir = os.homedir();
 
 export async function exists(path: string) {
-    try {
-        await fs.promises.access(path);
-        return true;
-    } catch {
-        return false;
-    }
+	try {
+		await fs.promises.access(path);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
-export function untildify(path: string){
+export function untildify(path: string) {
 	return path.replace(/^~(?=$|\/|\\)/, homeDir);
 }
 
 export function normalizeToSlash(path: string) {
-    return path.replace(/\\/g, '/');
+	return path.replace(/\\/g, '/');
 }

--- a/extensions/open-remote-ssh/src/extension.ts
+++ b/extensions/open-remote-ssh/src/extension.ts
@@ -6,27 +6,27 @@ import { HostTreeDataProvider } from './hostTreeView';
 import { getRemoteWorkspaceLocationData, RemoteLocationHistory } from './remoteLocationHistory';
 
 export async function activate(context: vscode.ExtensionContext) {
-    const logger = new Log('Remote - SSH');
-    context.subscriptions.push(logger);
+	const logger = new Log('Remote - SSH');
+	context.subscriptions.push(logger);
 
-    const remoteSSHResolver = new RemoteSSHResolver(context, logger);
-    context.subscriptions.push(vscode.workspace.registerRemoteAuthorityResolver(REMOTE_SSH_AUTHORITY, remoteSSHResolver));
-    context.subscriptions.push(remoteSSHResolver);
+	const remoteSSHResolver = new RemoteSSHResolver(context, logger);
+	context.subscriptions.push(vscode.workspace.registerRemoteAuthorityResolver(REMOTE_SSH_AUTHORITY, remoteSSHResolver));
+	context.subscriptions.push(remoteSSHResolver);
 
-    const locationHistory = new RemoteLocationHistory(context);
-    const locationData = getRemoteWorkspaceLocationData();
-    if (locationData) {
-        await locationHistory.addLocation(locationData[0], locationData[1]);
-    }
+	const locationHistory = new RemoteLocationHistory(context);
+	const locationData = getRemoteWorkspaceLocationData();
+	if (locationData) {
+		await locationHistory.addLocation(locationData[0], locationData[1]);
+	}
 
-    const hostTreeDataProvider = new HostTreeDataProvider(locationHistory);
-    context.subscriptions.push(vscode.window.createTreeView('sshHosts', { treeDataProvider: hostTreeDataProvider }));
-    context.subscriptions.push(hostTreeDataProvider);
+	const hostTreeDataProvider = new HostTreeDataProvider(locationHistory);
+	context.subscriptions.push(vscode.window.createTreeView('sshHosts', { treeDataProvider: hostTreeDataProvider }));
+	context.subscriptions.push(hostTreeDataProvider);
 
-    context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openEmptyWindow', () => promptOpenRemoteSSHWindow(false)));
-    context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openEmptyWindowInCurrentWindow', () => promptOpenRemoteSSHWindow(true)));
-    context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openConfigFile', () => openSSHConfigFile()));
-    context.subscriptions.push(vscode.commands.registerCommand('openremotessh.showLog', () => logger.show()));
+	context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openEmptyWindow', () => promptOpenRemoteSSHWindow(false)));
+	context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openEmptyWindowInCurrentWindow', () => promptOpenRemoteSSHWindow(true)));
+	context.subscriptions.push(vscode.commands.registerCommand('openremotessh.openConfigFile', () => openSSHConfigFile()));
+	context.subscriptions.push(vscode.commands.registerCommand('openremotessh.showLog', () => logger.show()));
 }
 
 export function deactivate() {

--- a/extensions/open-remote-ssh/src/remoteLocationHistory.ts
+++ b/extensions/open-remote-ssh/src/remoteLocationHistory.ts
@@ -3,52 +3,52 @@ import { REMOTE_SSH_AUTHORITY } from './authResolver';
 import SSHDestination from './ssh/sshDestination';
 
 export class RemoteLocationHistory {
-    private static STORAGE_KEY = 'remoteLocationHistory_v0';
+	private static STORAGE_KEY = 'remoteLocationHistory_v0';
 
-    private remoteLocationHistory: Record<string, string[]> = {};
+	private remoteLocationHistory: Record<string, string[]> = {};
 
-    constructor(private context: vscode.ExtensionContext) {
-        // context.globalState.update(RemoteLocationHistory.STORAGE_KEY, undefined);
-        this.remoteLocationHistory = context.globalState.get(RemoteLocationHistory.STORAGE_KEY) || {};
-    }
+	constructor(private context: vscode.ExtensionContext) {
+		// context.globalState.update(RemoteLocationHistory.STORAGE_KEY, undefined);
+		this.remoteLocationHistory = context.globalState.get(RemoteLocationHistory.STORAGE_KEY) || {};
+	}
 
-    getHistory(host: string): string[] {
-        return this.remoteLocationHistory[host] || [];
-    }
+	getHistory(host: string): string[] {
+		return this.remoteLocationHistory[host] || [];
+	}
 
-    async addLocation(host: string, path: string) {
-        let hostLocations = this.remoteLocationHistory[host] || [];
-        if (!hostLocations.includes(path)) {
-            hostLocations.unshift(path);
-            this.remoteLocationHistory[host] = hostLocations;
+	async addLocation(host: string, path: string) {
+		let hostLocations = this.remoteLocationHistory[host] || [];
+		if (!hostLocations.includes(path)) {
+			hostLocations.unshift(path);
+			this.remoteLocationHistory[host] = hostLocations;
 
-            await this.context.globalState.update(RemoteLocationHistory.STORAGE_KEY, this.remoteLocationHistory);
-        }
-    }
+			await this.context.globalState.update(RemoteLocationHistory.STORAGE_KEY, this.remoteLocationHistory);
+		}
+	}
 
-    async removeLocation(host: string, path: string) {
-        let hostLocations = this.remoteLocationHistory[host] || [];
-        hostLocations = hostLocations.filter(l => l !== path);
-        this.remoteLocationHistory[host] = hostLocations;
+	async removeLocation(host: string, path: string) {
+		let hostLocations = this.remoteLocationHistory[host] || [];
+		hostLocations = hostLocations.filter(l => l !== path);
+		this.remoteLocationHistory[host] = hostLocations;
 
-        await this.context.globalState.update(RemoteLocationHistory.STORAGE_KEY, this.remoteLocationHistory);
-    }
+		await this.context.globalState.update(RemoteLocationHistory.STORAGE_KEY, this.remoteLocationHistory);
+	}
 }
 
 export function getRemoteWorkspaceLocationData(): [string, string] | undefined {
-    let location = vscode.workspace.workspaceFile;
-    if (location && location.scheme === 'vscode-remote' && location.authority.startsWith(REMOTE_SSH_AUTHORITY) && location.path.endsWith('.code-workspace')) {
-        const [, host] = location.authority.split('+');
-        const sshDest = SSHDestination.parseEncoded(host);
-        return [sshDest.hostname, location.path];
-    }
+	let location = vscode.workspace.workspaceFile;
+	if (location && location.scheme === 'vscode-remote' && location.authority.startsWith(REMOTE_SSH_AUTHORITY) && location.path.endsWith('.code-workspace')) {
+		const [, host] = location.authority.split('+');
+		const sshDest = SSHDestination.parseEncoded(host);
+		return [sshDest.hostname, location.path];
+	}
 
-    location = vscode.workspace.workspaceFolders?.[0].uri;
-    if (location && location.scheme === 'vscode-remote' && location.authority.startsWith(REMOTE_SSH_AUTHORITY)) {
-        const [, host] = location.authority.split('+');
-        const sshDest = SSHDestination.parseEncoded(host);
-        return [sshDest.hostname, location.path];
-    }
+	location = vscode.workspace.workspaceFolders?.[0].uri;
+	if (location && location.scheme === 'vscode-remote' && location.authority.startsWith(REMOTE_SSH_AUTHORITY)) {
+		const [, host] = location.authority.split('+');
+		const sshDest = SSHDestination.parseEncoded(host);
+		return [sshDest.hostname, location.path];
+	}
 
-    return undefined;
+	return undefined;
 }

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -4,208 +4,208 @@ import { getVSCodeServerConfig } from './serverConfig';
 import SSHConnection from './ssh/sshConnection';
 
 export interface ServerInstallOptions {
-    id: string;
-    quality: string;
-    commit: string;
-    version: string;
-    release?: string; // vscodium specific
-    extensionIds: string[];
-    envVariables: string[];
-    useSocketPath: boolean;
-    serverApplicationName: string;
-    serverDataFolderName: string;
-    serverDownloadUrlTemplate: string;
+	id: string;
+	quality: string;
+	commit: string;
+	version: string;
+	release?: string; // vscodium specific
+	extensionIds: string[];
+	envVariables: string[];
+	useSocketPath: boolean;
+	serverApplicationName: string;
+	serverDataFolderName: string;
+	serverDownloadUrlTemplate: string;
 }
 
 export interface ServerInstallResult {
-    exitCode: number;
-    listeningOn: number | string;
-    connectionToken: string;
-    logFile: string;
-    osReleaseId: string;
-    arch: string;
-    platform: string;
-    tmpDir: string;
-    [key: string]: any;
+	exitCode: number;
+	listeningOn: number | string;
+	connectionToken: string;
+	logFile: string;
+	osReleaseId: string;
+	arch: string;
+	platform: string;
+	tmpDir: string;
+	[key: string]: any;
 }
 
 export class ServerInstallError extends Error {
-    constructor(message: string) {
-        super(message);
-    }
+	constructor(message: string) {
+		super(message);
+	}
 }
 
 const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
-    let shell = 'powershell';
+	let shell = 'powershell';
 
-    // detect platform and shell for windows
-    if (!platform || platform === 'windows') {
-        const result = await conn.exec('uname -s');
+	// detect platform and shell for windows
+	if (!platform || platform === 'windows') {
+		const result = await conn.exec('uname -s');
 
-        if (result.stdout) {
-            if (result.stdout.includes('windows32')) {
-                platform = 'windows';
-            } else if (result.stdout.includes('MINGW64')) {
-                platform = 'windows';
-                shell = 'bash';
-            }
-        } else if (result.stderr) {
-            if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
-                platform = 'windows';
-            }
+		if (result.stdout) {
+			if (result.stdout.includes('windows32')) {
+				platform = 'windows';
+			} else if (result.stdout.includes('MINGW64')) {
+				platform = 'windows';
+				shell = 'bash';
+			}
+		} else if (result.stderr) {
+			if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
+				platform = 'windows';
+			}
 
-            if (result.stderr.includes('is not recognized as an internal or external command')) {
-                platform = 'windows';
-                shell = 'cmd';
-            }
-        }
+			if (result.stderr.includes('is not recognized as an internal or external command')) {
+				platform = 'windows';
+				shell = 'cmd';
+			}
+		}
 
-        if (platform) {
-            logger.trace(`Detected platform: ${platform}, ${shell}`);
-        }
-    }
+		if (platform) {
+			logger.trace(`Detected platform: ${platform}, ${shell}`);
+		}
+	}
 
-    const scriptId = crypto.randomBytes(12).toString('hex');
+	const scriptId = crypto.randomBytes(12).toString('hex');
 
-    const vscodeServerConfig = await getVSCodeServerConfig();
-    const installOptions: ServerInstallOptions = {
-        id: scriptId,
-        version: vscodeServerConfig.version,
-        commit: vscodeServerConfig.commit,
-        quality: vscodeServerConfig.quality,
-        release: vscodeServerConfig.release,
-        extensionIds,
-        envVariables,
-        useSocketPath,
-        serverApplicationName: vscodeServerConfig.serverApplicationName,
-        serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-        serverDownloadUrlTemplate: serverDownloadUrlTemplate || vscodeServerConfig.serverDownloadUrlTemplate || DEFAULT_DOWNLOAD_URL_TEMPLATE,
-    };
+	const vscodeServerConfig = await getVSCodeServerConfig();
+	const installOptions: ServerInstallOptions = {
+		id: scriptId,
+		version: vscodeServerConfig.version,
+		commit: vscodeServerConfig.commit,
+		quality: vscodeServerConfig.quality,
+		release: vscodeServerConfig.release,
+		extensionIds,
+		envVariables,
+		useSocketPath,
+		serverApplicationName: vscodeServerConfig.serverApplicationName,
+		serverDataFolderName: vscodeServerConfig.serverDataFolderName,
+		serverDownloadUrlTemplate: serverDownloadUrlTemplate || vscodeServerConfig.serverDownloadUrlTemplate || DEFAULT_DOWNLOAD_URL_TEMPLATE,
+	};
 
-    let commandOutput: { stdout: string; stderr: string };
-    if (platform === 'windows') {
-        const installServerScript = generatePowerShellInstallScript(installOptions);
+	let commandOutput: { stdout: string; stderr: string };
+	if (platform === 'windows') {
+		const installServerScript = generatePowerShellInstallScript(installOptions);
 
-        logger.trace('Server install command:', installServerScript);
+		logger.trace('Server install command:', installServerScript);
 
-        const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
-        const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
-        const endRegex = new RegExp(`${scriptId}: end`);
-        // investigate if it's possible to use `-EncodedCommand` flag
-        // https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
-        let command = '';
-        if (shell === 'powershell') {
-            command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-        } else if (shell === 'bash') {
-            command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-        } else if (shell === 'cmd') {
-            const script = installServerScript.trim()
-                // remove comments
-                .replace(/^#.*$/gm, '')
-                // remove empty lines
-                .replace(/\n{2,}/gm, '\n')
-                // remove leading spaces
-                .replace(/^\s*/gm, '')
-                // escape double quotes (from powershell/cmd)
-                .replace(/"/g, '"""')
-                // escape single quotes (from cmd)
-                .replace(/'/g, `''`)
-                // escape redirect (from cmd)
-                .replace(/>/g, `^>`)
-                // escape new lines (from powershell/cmd)
-                .replace(/\n/g, '\'`n\'');
+		const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
+		const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
+		const endRegex = new RegExp(`${scriptId}: end`);
+		// investigate if it's possible to use `-EncodedCommand` flag
+		// https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
+		let command = '';
+		if (shell === 'powershell') {
+			command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+		} else if (shell === 'bash') {
+			command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+		} else if (shell === 'cmd') {
+			const script = installServerScript.trim()
+				// remove comments
+				.replace(/^#.*$/gm, '')
+				// remove empty lines
+				.replace(/\n{2,}/gm, '\n')
+				// remove leading spaces
+				.replace(/^\s*/gm, '')
+				// escape double quotes (from powershell/cmd)
+				.replace(/"/g, '"""')
+				// escape single quotes (from cmd)
+				.replace(/'/g, `''`)
+				// escape redirect (from cmd)
+				.replace(/>/g, `^>`)
+				// escape new lines (from powershell/cmd)
+				.replace(/\n/g, '\'`n\'');
 
-            command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
+			command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
 
-            logger.trace('Command length (8191 max):', command.length);
+			logger.trace('Command length (8191 max):', command.length);
 
-            if (command.length > 8191) {
-                throw new ServerInstallError(`Command line too long`);
-            }
-        } else {
-            throw new ServerInstallError(`Not supported shell: ${shell}`);
-        }
+			if (command.length > 8191) {
+				throw new ServerInstallError(`Command line too long`);
+			}
+		} else {
+			throw new ServerInstallError(`Not supported shell: ${shell}`);
+		}
 
-        commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
-    } else {
-        const installServerScript = generateBashInstallScript(installOptions);
+		commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
+	} else {
+		const installServerScript = generateBashInstallScript(installOptions);
 
-        logger.trace('Server install command:', installServerScript);
-        // Fish shell does not support heredoc so let's workaround it using -c option,
-        // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
-        commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
-    }
+		logger.trace('Server install command:', installServerScript);
+		// Fish shell does not support heredoc so let's workaround it using -c option,
+		// also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
+		commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
+	}
 
-    if (commandOutput.stderr) {
-        logger.trace('Server install command stderr:', commandOutput.stderr);
-    }
-    logger.trace('Server install command stdout:', commandOutput.stdout);
+	if (commandOutput.stderr) {
+		logger.trace('Server install command stderr:', commandOutput.stderr);
+	}
+	logger.trace('Server install command stdout:', commandOutput.stdout);
 
-    const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
-    if (!resultMap) {
-        throw new ServerInstallError(`Failed parsing install script output`);
-    }
+	const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
+	if (!resultMap) {
+		throw new ServerInstallError(`Failed parsing install script output`);
+	}
 
-    const exitCode = parseInt(resultMap.exitCode, 10);
-    if (exitCode === 66) {
-        throw new ServerInstallError(
-            `There is no available Positron server with version ${installOptions.version} for ${resultMap.platform} ${resultMap.arch}.`
-            + `\nPlease check the [system requirements](https://positron.posit.co/remote-ssh.html#system-requirements) and [troubleshooting guides](https://positron.posit.co/remote-ssh.html#how-it-works-troubleshooting).`
-        );
-    } else if (exitCode !== 0) {
-        throw new ServerInstallError(`Couldn't install Positron server on remote server, install script returned non-zero exit status`);
-    }
+	const exitCode = parseInt(resultMap.exitCode, 10);
+	if (exitCode === 66) {
+		throw new ServerInstallError(
+			`There is no available Positron server with version ${installOptions.version} for ${resultMap.platform} ${resultMap.arch}.`
+			+ `\nPlease check the [system requirements](https://positron.posit.co/remote-ssh.html#system-requirements) and [troubleshooting guides](https://positron.posit.co/remote-ssh.html#how-it-works-troubleshooting).`
+		);
+	} else if (exitCode !== 0) {
+		throw new ServerInstallError(`Couldn't install Positron server on remote server, install script returned non-zero exit status`);
+	}
 
-    const listeningOn = resultMap.listeningOn.match(/^\d+$/)
-        ? parseInt(resultMap.listeningOn, 10)
-        : resultMap.listeningOn;
+	const listeningOn = resultMap.listeningOn.match(/^\d+$/)
+		? parseInt(resultMap.listeningOn, 10)
+		: resultMap.listeningOn;
 
-    const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
+	const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
 
-    return {
-        exitCode,
-        listeningOn,
-        connectionToken: resultMap.connectionToken,
-        logFile: resultMap.logFile,
-        osReleaseId: resultMap.osReleaseId,
-        arch: resultMap.arch,
-        platform: resultMap.platform,
-        tmpDir: resultMap.tmpDir,
-        ...remoteEnvVars
-    };
+	return {
+		exitCode,
+		listeningOn,
+		connectionToken: resultMap.connectionToken,
+		logFile: resultMap.logFile,
+		osReleaseId: resultMap.osReleaseId,
+		arch: resultMap.arch,
+		platform: resultMap.platform,
+		tmpDir: resultMap.tmpDir,
+		...remoteEnvVars
+	};
 }
 
 function parseServerInstallOutput(str: string, scriptId: string): { [k: string]: string } | undefined {
-    const startResultStr = `${scriptId}: start`;
-    const endResultStr = `${scriptId}: end`;
+	const startResultStr = `${scriptId}: start`;
+	const endResultStr = `${scriptId}: end`;
 
-    const startResultIdx = str.indexOf(startResultStr);
-    if (startResultIdx < 0) {
-        return undefined;
-    }
+	const startResultIdx = str.indexOf(startResultStr);
+	if (startResultIdx < 0) {
+		return undefined;
+	}
 
-    const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
-    if (endResultIdx < 0) {
-        return undefined;
-    }
+	const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
+	if (endResultIdx < 0) {
+		return undefined;
+	}
 
-    const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
+	const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
 
-    const resultMap: { [k: string]: string } = {};
-    const resultArr = installResult.split(/\r?\n/);
-    for (const line of resultArr) {
-        const [key, value] = line.split('==');
-        resultMap[key] = value;
-    }
+	const resultMap: { [k: string]: string } = {};
+	const resultArr = installResult.split(/\r?\n/);
+	for (const line of resultArr) {
+		const [key, value] = line.split('==');
+		resultMap[key] = value;
+	}
 
-    return resultMap;
+	return resultMap;
 }
 
 function generateBashInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-    return `
+	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+	return `
 # Server installation script
 
 TMP_DIR="\${XDG_RUNTIME_DIR:-"/tmp"}"
@@ -435,17 +435,17 @@ print_install_results_and_exit 0
 }
 
 function generatePowerShellInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-    const downloadUrl = serverDownloadUrlTemplate
-        .replace(/\$\{quality\}/g, quality)
-        .replace(/\$\{version\}/g, version)
-        .replace(/\$\{commit\}/g, commit)
-        .replace(/\$\{os\}/g, 'win32')
-        .replace(/\$\{arch\}/g, 'x64')
-        .replace(/\$\{arch-long}/g, 'x86_64')
-        .replace(/\$\{release\}/g, release ?? '');
+	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+	const downloadUrl = serverDownloadUrlTemplate
+		.replace(/\$\{quality\}/g, quality)
+		.replace(/\$\{version\}/g, version)
+		.replace(/\$\{commit\}/g, commit)
+		.replace(/\$\{os\}/g, 'win32')
+		.replace(/\$\{arch\}/g, 'x64')
+		.replace(/\$\{arch-long}/g, 'x86_64')
+		.replace(/\$\{release\}/g, release ?? '');
 
-    return `
+	return `
 # Server installation script
 
 $TMP_DIR="$env:TEMP\\$([System.IO.Path]::GetRandomFileName())"

--- a/extensions/open-remote-ssh/src/ssh/hostfile.ts
+++ b/extensions/open-remote-ssh/src/ssh/hostfile.ts
@@ -11,33 +11,33 @@ const HASH_MAGIC = '|1|';
 const HASH_DELIM = '|';
 
 export async function checkNewHostInHostkeys(host: string): Promise<boolean> {
-    const fileContent = await fs.promises.readFile(KNOW_HOST_FILE, { encoding: 'utf8' });
-    const lines = fileContent.split(/\r?\n/);
-    for (let line of lines) {
-        line = line.trim();
-        if (!line.startsWith(HASH_MAGIC)) {
-            continue;
-        }
+	const fileContent = await fs.promises.readFile(KNOW_HOST_FILE, { encoding: 'utf8' });
+	const lines = fileContent.split(/\r?\n/);
+	for (let line of lines) {
+		line = line.trim();
+		if (!line.startsWith(HASH_MAGIC)) {
+			continue;
+		}
 
-        const [hostEncripted_] = line.split(' ');
-        const [salt_, hostHash_] = hostEncripted_.substring(HASH_MAGIC.length).split(HASH_DELIM);
-        const hostHash = crypto.createHmac('sha1', Buffer.from(salt_, 'base64') as BinaryLike).update(host).digest();
-        if (hostHash.toString('base64') === hostHash_) {
-            return false;
-        }
-    }
+		const [hostEncripted_] = line.split(' ');
+		const [salt_, hostHash_] = hostEncripted_.substring(HASH_MAGIC.length).split(HASH_DELIM);
+		const hostHash = crypto.createHmac('sha1', Buffer.from(salt_, 'base64') as BinaryLike).update(host).digest();
+		if (hostHash.toString('base64') === hostHash_) {
+			return false;
+		}
+	}
 
-    return true;
+	return true;
 }
 
 export async function addHostToHostFile(host: string, hostKey: Buffer, type: string): Promise<void> {
-    if (!folderExists(PATH_SSH_USER_DIR)) {
-        await fs.promises.mkdir(PATH_SSH_USER_DIR, 0o700);
-    }
+	if (!folderExists(PATH_SSH_USER_DIR)) {
+		await fs.promises.mkdir(PATH_SSH_USER_DIR, 0o700);
+	}
 
-    const salt = crypto.randomBytes(20);
-    const hostHash = crypto.createHmac('sha1', salt as BinaryLike).update(host).digest();
+	const salt = crypto.randomBytes(20);
+	const hostHash = crypto.createHmac('sha1', salt as BinaryLike).update(host).digest();
 
-    const entry = `${HASH_MAGIC}${salt.toString('base64')}${HASH_DELIM}${hostHash.toString('base64')} ${type} ${hostKey.toString('base64')}\n`;
-    await fs.promises.appendFile(KNOW_HOST_FILE, entry);
+	const entry = `${HASH_MAGIC}${salt.toString('base64')}${HASH_DELIM}${hostHash.toString('base64')} ${type} ${hostKey.toString('base64')}\n`;
+	await fs.promises.appendFile(KNOW_HOST_FILE, entry);
 }

--- a/extensions/open-remote-ssh/src/ssh/identityFiles.ts
+++ b/extensions/open-remote-ssh/src/ssh/identityFiles.ts
@@ -17,100 +17,100 @@ const PATH_SSH_CLIENT_ID_ECDSA_SK = path.join(homeDir, '.ssh', '/id_ecdsa_sk');
 const PATH_SSH_CLIENT_ID_ED25519_SK = path.join(homeDir, '.ssh', '/id_ed25519_sk');
 
 const DEFAULT_IDENTITY_FILES: string[] = [
-    PATH_SSH_CLIENT_ID_RSA,
-    PATH_SSH_CLIENT_ID_ECDSA,
-    PATH_SSH_CLIENT_ID_ECDSA_SK,
-    PATH_SSH_CLIENT_ID_ED25519,
-    PATH_SSH_CLIENT_ID_ED25519_SK,
-    PATH_SSH_CLIENT_ID_XMSS,
-    PATH_SSH_CLIENT_ID_DSA,
+	PATH_SSH_CLIENT_ID_RSA,
+	PATH_SSH_CLIENT_ID_ECDSA,
+	PATH_SSH_CLIENT_ID_ECDSA_SK,
+	PATH_SSH_CLIENT_ID_ED25519,
+	PATH_SSH_CLIENT_ID_ED25519_SK,
+	PATH_SSH_CLIENT_ID_XMSS,
+	PATH_SSH_CLIENT_ID_DSA,
 ];
 
 export interface SSHKey {
-    filename: string;
-    parsedKey: ParsedKey;
-    fingerprint: string;
-    agentSupport?: boolean;
-    isPrivate?: boolean;
+	filename: string;
+	parsedKey: ParsedKey;
+	fingerprint: string;
+	agentSupport?: boolean;
+	isPrivate?: boolean;
 }
 
 // From https://github.com/openssh/openssh-portable/blob/acb2059febaddd71ee06c2ebf63dcf211d9ab9f2/sshconnect2.c#L1689-L1690
 export async function gatherIdentityFiles(identityFiles: string[], sshAgentSock: string | undefined, identitiesOnly: boolean, logger: Log) {
-    identityFiles = identityFiles.map(untildify).map(i => i.replace(/\.pub$/, ''));
-    if (identityFiles.length === 0) {
-        identityFiles.push(...DEFAULT_IDENTITY_FILES);
-    }
+	identityFiles = identityFiles.map(untildify).map(i => i.replace(/\.pub$/, ''));
+	if (identityFiles.length === 0) {
+		identityFiles.push(...DEFAULT_IDENTITY_FILES);
+	}
 
-    const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async keyPath => {
-        keyPath = await fileExists(keyPath + '.pub') ? keyPath + '.pub' : keyPath;
-        return fs.promises.readFile(keyPath);
-    }));
-    const fileKeys: SSHKey[] = identityFileContentsResult.map((result, i) => {
-        if (result.status === 'rejected') {
-            return undefined;
-        }
+	const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async keyPath => {
+		keyPath = await fileExists(keyPath + '.pub') ? keyPath + '.pub' : keyPath;
+		return fs.promises.readFile(keyPath);
+	}));
+	const fileKeys: SSHKey[] = identityFileContentsResult.map((result, i) => {
+		if (result.status === 'rejected') {
+			return undefined;
+		}
 
-        const parsedResult = ssh2.utils.parseKey(result.value);
-        if (parsedResult instanceof Error || !parsedResult) {
-            logger.error(`Error while parsing SSH public key ${identityFiles[i]}:`, parsedResult);
-            return undefined;
-        }
+		const parsedResult = ssh2.utils.parseKey(result.value);
+		if (parsedResult instanceof Error || !parsedResult) {
+			logger.error(`Error while parsing SSH public key ${identityFiles[i]}:`, parsedResult);
+			return undefined;
+		}
 
-        const parsedKey = Array.isArray(parsedResult) ? parsedResult[0] : parsedResult;
-        const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
+		const parsedKey = Array.isArray(parsedResult) ? parsedResult[0] : parsedResult;
+		const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
 
-        return {
-            filename: identityFiles[i],
-            parsedKey,
-            fingerprint
-        };
-    }).filter(<T>(v: T | undefined): v is T => !!v);
+		return {
+			filename: identityFiles[i],
+			parsedKey,
+			fingerprint
+		};
+	}).filter(<T>(v: T | undefined): v is T => !!v);
 
-    let sshAgentParsedKeys: ParsedKey[] = [];
-    try {
-        if (!sshAgentSock) {
-            throw new Error(`SSH_AUTH_SOCK environment variable not defined`);
-        }
+	let sshAgentParsedKeys: ParsedKey[] = [];
+	try {
+		if (!sshAgentSock) {
+			throw new Error(`SSH_AUTH_SOCK environment variable not defined`);
+		}
 
-        sshAgentParsedKeys = await new Promise<ParsedKey[]>((resolve, reject) => {
-            const sshAgent = new ssh2.OpenSSHAgent(sshAgentSock);
-            sshAgent.getIdentities((err, publicKeys) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(publicKeys || []);
-                }
-            });
-        });
-    } catch (e) {
-        logger.error(`Couldn't get identities from OpenSSH agent`, e);
-    }
+		sshAgentParsedKeys = await new Promise<ParsedKey[]>((resolve, reject) => {
+			const sshAgent = new ssh2.OpenSSHAgent(sshAgentSock);
+			sshAgent.getIdentities((err, publicKeys) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(publicKeys || []);
+				}
+			});
+		});
+	} catch (e) {
+		logger.error(`Couldn't get identities from OpenSSH agent`, e);
+	}
 
-    const sshAgentKeys: SSHKey[] = sshAgentParsedKeys.map(parsedKey => {
-        const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
-        return {
-            filename: parsedKey.comment,
-            parsedKey,
-            fingerprint,
-            agentSupport: true
-        };
-    });
+	const sshAgentKeys: SSHKey[] = sshAgentParsedKeys.map(parsedKey => {
+		const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
+		return {
+			filename: parsedKey.comment,
+			parsedKey,
+			fingerprint,
+			agentSupport: true
+		};
+	});
 
-    const agentKeys: SSHKey[] = [];
-    const preferredIdentityKeys: SSHKey[] = [];
-    for (const agentKey of sshAgentKeys) {
-        const foundIdx = fileKeys.findIndex(k => agentKey.parsedKey.type === k.parsedKey.type && agentKey.fingerprint === k.fingerprint);
-        if (foundIdx >= 0) {
-            preferredIdentityKeys.push({ ...fileKeys[foundIdx], agentSupport: true });
-            fileKeys.splice(foundIdx, 1);
-        } else if (!identitiesOnly) {
-            agentKeys.push(agentKey);
-        }
-    }
-    preferredIdentityKeys.push(...agentKeys);
-    preferredIdentityKeys.push(...fileKeys);
+	const agentKeys: SSHKey[] = [];
+	const preferredIdentityKeys: SSHKey[] = [];
+	for (const agentKey of sshAgentKeys) {
+		const foundIdx = fileKeys.findIndex(k => agentKey.parsedKey.type === k.parsedKey.type && agentKey.fingerprint === k.fingerprint);
+		if (foundIdx >= 0) {
+			preferredIdentityKeys.push({ ...fileKeys[foundIdx], agentSupport: true });
+			fileKeys.splice(foundIdx, 1);
+		} else if (!identitiesOnly) {
+			agentKeys.push(agentKey);
+		}
+	}
+	preferredIdentityKeys.push(...agentKeys);
+	preferredIdentityKeys.push(...fileKeys);
 
-    logger.trace(`Identity keys:`, preferredIdentityKeys.length ? preferredIdentityKeys.map(k => `${k.filename} ${k.parsedKey.type} SHA256:${k.fingerprint}`).join('\n') : 'None');
+	logger.trace(`Identity keys:`, preferredIdentityKeys.length ? preferredIdentityKeys.map(k => `${k.filename} ${k.parsedKey.type} SHA256:${k.fingerprint}`).join('\n') : 'None');
 
-    return preferredIdentityKeys;
+	return preferredIdentityKeys;
 }

--- a/extensions/open-remote-ssh/src/ssh/sshConnection.ts
+++ b/extensions/open-remote-ssh/src/ssh/sshConnection.ts
@@ -9,356 +9,356 @@ import { Server } from 'net';
 import { SocksConnectionInfo, createServer as createSocksServer } from 'simple-socks';
 
 export interface SSHConnectConfig extends ConnectConfig {
-    /** Optional Unique ID attached to ssh connection. */
-    uniqueId?: string;
-    /** Automatic retry to connect, after disconnect. Default true */
-    reconnect?: boolean;
-    /** Number of reconnect retry, after disconnect. Default 10 */
-    reconnectTries?: number;
-    /** Delay after which reconnect should be done. Default 5000ms */
-    reconnectDelay?: number;
-    /** Path to private key */
-    identity?: string | Buffer;
+	/** Optional Unique ID attached to ssh connection. */
+	uniqueId?: string;
+	/** Automatic retry to connect, after disconnect. Default true */
+	reconnect?: boolean;
+	/** Number of reconnect retry, after disconnect. Default 10 */
+	reconnectTries?: number;
+	/** Delay after which reconnect should be done. Default 5000ms */
+	reconnectDelay?: number;
+	/** Path to private key */
+	identity?: string | Buffer;
 }
 
 export interface SSHTunnelConfig {
-    /** Remote Address to connect */
-    remoteAddr?: string;
-    /** Local port to bind to. By default, it will bind to a random port, if not passed */
-    localPort?: number;
-    /** Remote Port to connect */
-    remotePort?: number;
-    /** Remote socket path to connect */
-    remoteSocketPath?: string;
-    socks?: boolean;
-    /**  Unique name */
-    name?: string;
+	/** Remote Address to connect */
+	remoteAddr?: string;
+	/** Local port to bind to. By default, it will bind to a random port, if not passed */
+	localPort?: number;
+	/** Remote Port to connect */
+	remotePort?: number;
+	/** Remote socket path to connect */
+	remoteSocketPath?: string;
+	socks?: boolean;
+	/**  Unique name */
+	name?: string;
 }
 
 const defaultOptions: Partial<SSHConnectConfig> = {
-    reconnect: false,
-    port: 22,
-    reconnectTries: 3,
-    reconnectDelay: 5000
+	reconnect: false,
+	port: 22,
+	reconnectTries: 3,
+	reconnectDelay: 5000
 };
 
 const SSHConstants = {
-    'CHANNEL': {
-        SSH: 'ssh',
-        TUNNEL: 'tunnel',
-        X11: 'x11'
-    },
-    'STATUS': {
-        BEFORECONNECT: 'beforeconnect',
-        CONNECT: 'connect',
-        BEFOREDISCONNECT: 'beforedisconnect',
-        DISCONNECT: 'disconnect'
-    }
+	'CHANNEL': {
+		SSH: 'ssh',
+		TUNNEL: 'tunnel',
+		X11: 'x11'
+	},
+	'STATUS': {
+		BEFORECONNECT: 'beforeconnect',
+		CONNECT: 'connect',
+		BEFOREDISCONNECT: 'beforedisconnect',
+		DISCONNECT: 'disconnect'
+	}
 };
 
 export default class SSHConnection extends EventEmitter {
-    public config: SSHConnectConfig;
+	public config: SSHConnectConfig;
 
-    private activeTunnels: { [index: string]: SSHTunnelConfig & { server: Server } } = {};
-    private __$connectPromise: Promise<SSHConnection> | null = null;
-    private __retries: number = 0;
-    private __err: Error & ClientErrorExtensions & { code?: string } | null = null;
-    private sshConnection: Client | null = null;
+	private activeTunnels: { [index: string]: SSHTunnelConfig & { server: Server } } = {};
+	private __$connectPromise: Promise<SSHConnection> | null = null;
+	private __retries: number = 0;
+	private __err: Error & ClientErrorExtensions & { code?: string } | null = null;
+	private sshConnection: Client | null = null;
 
-    constructor(options: SSHConnectConfig) {
-        super();
-        this.config = Object.assign({}, defaultOptions, options);
-        this.config.uniqueId = this.config.uniqueId || `${this.config.username}@${this.config.host}`;
-    }
+	constructor(options: SSHConnectConfig) {
+		super();
+		this.config = Object.assign({}, defaultOptions, options);
+		this.config.uniqueId = this.config.uniqueId || `${this.config.username}@${this.config.host}`;
+	}
 
-    /**
-      * Emit message on this channel
-      */
-    override emit(channel: string, status: string, payload?: any): boolean {
-        super.emit(channel, status, this, payload);
-        return super.emit(`${channel}:${status}`, this, payload);
-    }
+	/**
+	  * Emit message on this channel
+	  */
+	override emit(channel: string, status: string, payload?: any): boolean {
+		super.emit(channel, status, this, payload);
+		return super.emit(`${channel}:${status}`, this, payload);
+	}
 
-    /**
-     * Get shell socket
-     */
-    shell(options: ShellOptions = {}): Promise<ClientChannel> {
-        return this.connect().then(() => {
-            return new Promise<ClientChannel>((resolve, reject) => {
-                this.sshConnection!.shell(options, (err, stream) => err ? reject(err) : resolve(stream));
-            });
-        });
-    }
+	/**
+	 * Get shell socket
+	 */
+	shell(options: ShellOptions = {}): Promise<ClientChannel> {
+		return this.connect().then(() => {
+			return new Promise<ClientChannel>((resolve, reject) => {
+				this.sshConnection!.shell(options, (err, stream) => err ? reject(err) : resolve(stream));
+			});
+		});
+	}
 
-    /**
-     * Exec a command
-     */
-    exec(cmd: string, params?: Array<string>, options: ExecOptions = {}): Promise<{ stdout: string; stderr: string }> {
-        cmd += (Array.isArray(params) ? (' ' + params.join(' ')) : '');
-        return this.connect().then(() => {
-            return new Promise((resolve, reject) => {
-                this.sshConnection!.exec(cmd, options, (err, stream) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    let stdout = '';
-                    let stderr = '';
-                    stream.on('close', function () {
-                        return resolve({ stdout, stderr });
-                    }).on('data', function (data: Buffer | string) {
-                        stdout += data.toString();
-                    }).stderr.on('data', function (data: Buffer | string) {
-                        stderr += data.toString();
-                    });
-                });
-            });
-        });
-    }
-    
-    /**
-     * Exec a command
-     */
-    execPartial(cmd: string, tester: (stdout: string, stderr: string) => boolean, params?: Array<string>, options: ExecOptions = {}): Promise<{ stdout: string; stderr: string }> {
-        cmd += (Array.isArray(params) ? (' ' + params.join(' ')) : '');
-        return this.connect().then(() => {
-            return new Promise((resolve, reject) => {
-                this.sshConnection!.exec(cmd, options, (err, stream) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    let stdout = '';
-                    let stderr = '';
-                    let resolved = false;
-                    stream.on('close', function () {
-                        if (!resolved) {
-                            return resolve({ stdout, stderr });
-                        }
-                    }).on('data', function (data: Buffer | string) {
-                        stdout += data.toString();
-                        
-                        if (tester(stdout, stderr)) {
-                            resolved = true;
-                            
-                            return resolve({ stdout, stderr });
-                        }
-                    }).stderr.on('data', function (data: Buffer | string) {
-                        stderr += data.toString();
-                        
-                        if (tester(stdout, stderr)) {
-                            resolved = true;
-                        
-                            return resolve({ stdout, stderr });
-                        }
-                    });
-                });
-            });
-        });
-    }
+	/**
+	 * Exec a command
+	 */
+	exec(cmd: string, params?: Array<string>, options: ExecOptions = {}): Promise<{ stdout: string; stderr: string }> {
+		cmd += (Array.isArray(params) ? (' ' + params.join(' ')) : '');
+		return this.connect().then(() => {
+			return new Promise((resolve, reject) => {
+				this.sshConnection!.exec(cmd, options, (err, stream) => {
+					if (err) {
+						return reject(err);
+					}
+					let stdout = '';
+					let stderr = '';
+					stream.on('close', function () {
+						return resolve({ stdout, stderr });
+					}).on('data', function (data: Buffer | string) {
+						stdout += data.toString();
+					}).stderr.on('data', function (data: Buffer | string) {
+						stderr += data.toString();
+					});
+				});
+			});
+		});
+	}
 
-    /**
-     * Forward out
-     */
-    forwardOut(srcIP: string, srcPort: number, destIP: string, destPort: number): Promise<ClientChannel> {
-        return this.connect().then(() => {
-            return new Promise((resolve, reject) => {
-                this.sshConnection!.forwardOut(srcIP, srcPort, destIP, destPort, (err, stream) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    resolve(stream);
-                });
-            });
-        });
-    }
+	/**
+	 * Exec a command
+	 */
+	execPartial(cmd: string, tester: (stdout: string, stderr: string) => boolean, params?: Array<string>, options: ExecOptions = {}): Promise<{ stdout: string; stderr: string }> {
+		cmd += (Array.isArray(params) ? (' ' + params.join(' ')) : '');
+		return this.connect().then(() => {
+			return new Promise((resolve, reject) => {
+				this.sshConnection!.exec(cmd, options, (err, stream) => {
+					if (err) {
+						return reject(err);
+					}
+					let stdout = '';
+					let stderr = '';
+					let resolved = false;
+					stream.on('close', function () {
+						if (!resolved) {
+							return resolve({ stdout, stderr });
+						}
+					}).on('data', function (data: Buffer | string) {
+						stdout += data.toString();
 
-    /**
-     * Get a Socks Port
-     */
-    getSocksPort(localPort: number): Promise<number> {
-        return this.addTunnel({ name: '__socksServer', socks: true, localPort: localPort }).then((tunnel) => {
-            return tunnel.localPort!;
-        });
-    }
+						if (tester(stdout, stderr)) {
+							resolved = true;
 
-    /**
-     * Close SSH Connection
-     */
-    close(): Promise<void> {
-        this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.BEFOREDISCONNECT);
-        return this.closeTunnel().then(() => {
-            if (this.sshConnection) {
-                this.sshConnection.end();
-                this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT);
-            }
-        });
-    }
+							return resolve({ stdout, stderr });
+						}
+					}).stderr.on('data', function (data: Buffer | string) {
+						stderr += data.toString();
 
-    /**
-     * Connect the SSH Connection
-     */
-    connect(c?: SSHConnectConfig): Promise<SSHConnection> {
-        this.config = Object.assign(this.config, c);
-        ++this.__retries;
+						if (tester(stdout, stderr)) {
+							resolved = true;
 
-        if (this.__$connectPromise) {
-            return this.__$connectPromise;
-        }
+							return resolve({ stdout, stderr });
+						}
+					});
+				});
+			});
+		});
+	}
 
-        this.__$connectPromise = new Promise((resolve, reject) => {
-            this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.BEFORECONNECT);
-            if (!this.config || typeof this.config === 'function' || !(this.config.host || this.config.sock) || !this.config.username) {
-                reject(`Invalid SSH connection configuration host/username can't be empty`);
-                this.__$connectPromise = null;
-                return;
-            }
+	/**
+	 * Forward out
+	 */
+	forwardOut(srcIP: string, srcPort: number, destIP: string, destPort: number): Promise<ClientChannel> {
+		return this.connect().then(() => {
+			return new Promise((resolve, reject) => {
+				this.sshConnection!.forwardOut(srcIP, srcPort, destIP, destPort, (err, stream) => {
+					if (err) {
+						return reject(err);
+					}
+					resolve(stream);
+				});
+			});
+		});
+	}
 
-            if (this.config.identity) {
-                if (fs.existsSync(this.config.identity)) {
-                    this.config.privateKey = fs.readFileSync(this.config.identity);
-                }
-                delete this.config.identity;
-            }
+	/**
+	 * Get a Socks Port
+	 */
+	getSocksPort(localPort: number): Promise<number> {
+		return this.addTunnel({ name: '__socksServer', socks: true, localPort: localPort }).then((tunnel) => {
+			return tunnel.localPort!;
+		});
+	}
 
-            //Start ssh server connection
-            this.sshConnection = new Client();
-            this.sshConnection.on('ready', (err: Error & ClientErrorExtensions) => {
-                if (err) {
-                    this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: err });
-                    this.__$connectPromise = null;
-                    return reject(err);
-                }
-                this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.CONNECT);
-                this.__retries = 0;
-                this.__err = null;
-                resolve(this);
-            }).on('error', (err) => {
-                this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: err });
-                this.__err = err;
-            }).on('close', () => {
-                this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: this.__err });
-                if (this.config.reconnect && this.__retries <= this.config.reconnectTries! && this.__err && this.__err.level !== 'client-authentication' && this.__err.code !== 'ENOTFOUND') {
-                    setTimeout(() => {
-                        this.__$connectPromise = null;
-                        resolve(this.connect());
-                    }, this.config.reconnectDelay);
-                } else {
-                    reject(this.__err);
-                }
-            }).connect(this.config);
-        });
-        return this.__$connectPromise;
-    }
+	/**
+	 * Close SSH Connection
+	 */
+	close(): Promise<void> {
+		this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.BEFOREDISCONNECT);
+		return this.closeTunnel().then(() => {
+			if (this.sshConnection) {
+				this.sshConnection.end();
+				this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT);
+			}
+		});
+	}
 
-    /**
-     * Get existing tunnel by name
-     */
-    getTunnel(name: string) {
-        return this.activeTunnels[name];
-    }
+	/**
+	 * Connect the SSH Connection
+	 */
+	connect(c?: SSHConnectConfig): Promise<SSHConnection> {
+		this.config = Object.assign(this.config, c);
+		++this.__retries;
 
-    /**
-     * Add new tunnel if not exist
-     */
-    addTunnel(SSHTunnelConfig: SSHTunnelConfig): Promise<SSHTunnelConfig & { server: Server }> {
-        SSHTunnelConfig.name = SSHTunnelConfig.name || `${SSHTunnelConfig.remoteAddr}@${SSHTunnelConfig.remotePort || SSHTunnelConfig.remoteSocketPath}`;
-        this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.BEFORECONNECT, { SSHTunnelConfig: SSHTunnelConfig });
-        if (this.getTunnel(SSHTunnelConfig.name)) {
-            this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.CONNECT, { SSHTunnelConfig: SSHTunnelConfig });
-            return Promise.resolve(this.getTunnel(SSHTunnelConfig.name));
-        } else {
-            return new Promise((resolve, reject) => {
-                let server: net.Server;
-                if (SSHTunnelConfig.socks) {
-                    server = createSocksServer({
-                        connectionFilter: (destination: SocksConnectionInfo, origin: SocksConnectionInfo, callback: (err?: any, dest?: stream.Duplex) => void) => {
-                            this.connect().then(() => {
-                                this.sshConnection!.forwardOut(
-                                    origin.address,
-                                    origin.port,
-                                    destination.address,
-                                    destination.port,
-                                    (err, stream) => {
-                                        if (err) {
-                                            this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                                            return callback(err);
-                                        }
-                                        return callback(null, stream);
-                                    });
-                            });
-                        }
-                    }).on('proxyError', (err: any) => {
-                        this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                    });
-                } else {
-                    server = net.createServer()
-                        .on('connection', (socket) => {
-                            this.connect().then(() => {
-                                if (SSHTunnelConfig.remotePort) {
-                                    this.sshConnection!.forwardOut('127.0.0.1', 0, SSHTunnelConfig.remoteAddr!, SSHTunnelConfig.remotePort!, (err, stream) => {
-                                        if (err) {
-                                            this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                                            return;
-                                        }
-                                        stream.pipe(socket);
-                                        socket.pipe(stream);
-                                    });
-                                } else {
-                                    this.sshConnection!.openssh_forwardOutStreamLocal(SSHTunnelConfig.remoteSocketPath!, (err, stream) => {
-                                        if (err) {
-                                            this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                                            return;
-                                        }
-                                        stream.pipe(socket);
-                                        socket.pipe(stream);
-                                    });
-                                }
-                            });
-                        });
-                }
+		if (this.__$connectPromise) {
+			return this.__$connectPromise;
+		}
 
-                SSHTunnelConfig.localPort = SSHTunnelConfig.localPort || 0;
-                server.on('listening', () => {
-                    SSHTunnelConfig.localPort = (server.address() as net.AddressInfo).port;
-                    this.activeTunnels[SSHTunnelConfig.name!] = Object.assign({}, { server }, SSHTunnelConfig);
-                    this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.CONNECT, { SSHTunnelConfig: SSHTunnelConfig });
-                    resolve(this.activeTunnels[SSHTunnelConfig.name!]);
-                }).on('error', (err: any) => {
-                    this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                    server.close();
-                    reject(err);
-                    delete this.activeTunnels[SSHTunnelConfig.name!];
-                }).listen(SSHTunnelConfig.localPort);
-            });
-        }
-    }
+		this.__$connectPromise = new Promise((resolve, reject) => {
+			this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.BEFORECONNECT);
+			if (!this.config || typeof this.config === 'function' || !(this.config.host || this.config.sock) || !this.config.username) {
+				reject(`Invalid SSH connection configuration host/username can't be empty`);
+				this.__$connectPromise = null;
+				return;
+			}
 
-    /**
-     * Close the tunnel
-     */
-    closeTunnel(name?: string): Promise<void> {
-        if (name && this.activeTunnels[name]) {
-            return new Promise((resolve) => {
-                const tunnel = this.activeTunnels[name];
-                this.emit(
-                    SSHConstants.CHANNEL.TUNNEL,
-                    SSHConstants.STATUS.BEFOREDISCONNECT,
-                    { SSHTunnelConfig: tunnel }
-                );
-                tunnel.server.close(() => {
-                    this.emit(
-                        SSHConstants.CHANNEL.TUNNEL,
-                        SSHConstants.STATUS.DISCONNECT,
-                        { SSHTunnelConfig: this.activeTunnels[name] }
-                    );
-                    delete this.activeTunnels[name];
-                    resolve();
-                });
-            });
-        } else if (!name) {
-            const tunnels = Object.keys(this.activeTunnels).map((key) => this.closeTunnel(key));
-            return Promise.all(tunnels).then(() => { });
-        }
+			if (this.config.identity) {
+				if (fs.existsSync(this.config.identity)) {
+					this.config.privateKey = fs.readFileSync(this.config.identity);
+				}
+				delete this.config.identity;
+			}
 
-        return Promise.resolve();
-    }
+			//Start ssh server connection
+			this.sshConnection = new Client();
+			this.sshConnection.on('ready', (err: Error & ClientErrorExtensions) => {
+				if (err) {
+					this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: err });
+					this.__$connectPromise = null;
+					return reject(err);
+				}
+				this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.CONNECT);
+				this.__retries = 0;
+				this.__err = null;
+				resolve(this);
+			}).on('error', (err) => {
+				this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: err });
+				this.__err = err;
+			}).on('close', () => {
+				this.emit(SSHConstants.CHANNEL.SSH, SSHConstants.STATUS.DISCONNECT, { err: this.__err });
+				if (this.config.reconnect && this.__retries <= this.config.reconnectTries! && this.__err && this.__err.level !== 'client-authentication' && this.__err.code !== 'ENOTFOUND') {
+					setTimeout(() => {
+						this.__$connectPromise = null;
+						resolve(this.connect());
+					}, this.config.reconnectDelay);
+				} else {
+					reject(this.__err);
+				}
+			}).connect(this.config);
+		});
+		return this.__$connectPromise;
+	}
+
+	/**
+	 * Get existing tunnel by name
+	 */
+	getTunnel(name: string) {
+		return this.activeTunnels[name];
+	}
+
+	/**
+	 * Add new tunnel if not exist
+	 */
+	addTunnel(SSHTunnelConfig: SSHTunnelConfig): Promise<SSHTunnelConfig & { server: Server }> {
+		SSHTunnelConfig.name = SSHTunnelConfig.name || `${SSHTunnelConfig.remoteAddr}@${SSHTunnelConfig.remotePort || SSHTunnelConfig.remoteSocketPath}`;
+		this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.BEFORECONNECT, { SSHTunnelConfig: SSHTunnelConfig });
+		if (this.getTunnel(SSHTunnelConfig.name)) {
+			this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.CONNECT, { SSHTunnelConfig: SSHTunnelConfig });
+			return Promise.resolve(this.getTunnel(SSHTunnelConfig.name));
+		} else {
+			return new Promise((resolve, reject) => {
+				let server: net.Server;
+				if (SSHTunnelConfig.socks) {
+					server = createSocksServer({
+						connectionFilter: (destination: SocksConnectionInfo, origin: SocksConnectionInfo, callback: (err?: any, dest?: stream.Duplex) => void) => {
+							this.connect().then(() => {
+								this.sshConnection!.forwardOut(
+									origin.address,
+									origin.port,
+									destination.address,
+									destination.port,
+									(err, stream) => {
+										if (err) {
+											this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+											return callback(err);
+										}
+										return callback(null, stream);
+									});
+							});
+						}
+					}).on('proxyError', (err: any) => {
+						this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+					});
+				} else {
+					server = net.createServer()
+						.on('connection', (socket) => {
+							this.connect().then(() => {
+								if (SSHTunnelConfig.remotePort) {
+									this.sshConnection!.forwardOut('127.0.0.1', 0, SSHTunnelConfig.remoteAddr!, SSHTunnelConfig.remotePort!, (err, stream) => {
+										if (err) {
+											this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+											return;
+										}
+										stream.pipe(socket);
+										socket.pipe(stream);
+									});
+								} else {
+									this.sshConnection!.openssh_forwardOutStreamLocal(SSHTunnelConfig.remoteSocketPath!, (err, stream) => {
+										if (err) {
+											this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+											return;
+										}
+										stream.pipe(socket);
+										socket.pipe(stream);
+									});
+								}
+							});
+						});
+				}
+
+				SSHTunnelConfig.localPort = SSHTunnelConfig.localPort || 0;
+				server.on('listening', () => {
+					SSHTunnelConfig.localPort = (server.address() as net.AddressInfo).port;
+					this.activeTunnels[SSHTunnelConfig.name!] = Object.assign({}, { server }, SSHTunnelConfig);
+					this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.CONNECT, { SSHTunnelConfig: SSHTunnelConfig });
+					resolve(this.activeTunnels[SSHTunnelConfig.name!]);
+				}).on('error', (err: any) => {
+					this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+					server.close();
+					reject(err);
+					delete this.activeTunnels[SSHTunnelConfig.name!];
+				}).listen(SSHTunnelConfig.localPort);
+			});
+		}
+	}
+
+	/**
+	 * Close the tunnel
+	 */
+	closeTunnel(name?: string): Promise<void> {
+		if (name && this.activeTunnels[name]) {
+			return new Promise((resolve) => {
+				const tunnel = this.activeTunnels[name];
+				this.emit(
+					SSHConstants.CHANNEL.TUNNEL,
+					SSHConstants.STATUS.BEFOREDISCONNECT,
+					{ SSHTunnelConfig: tunnel }
+				);
+				tunnel.server.close(() => {
+					this.emit(
+						SSHConstants.CHANNEL.TUNNEL,
+						SSHConstants.STATUS.DISCONNECT,
+						{ SSHTunnelConfig: this.activeTunnels[name] }
+					);
+					delete this.activeTunnels[name];
+					resolve();
+				});
+			});
+		} else if (!name) {
+			const tunnels = Object.keys(this.activeTunnels).map((key) => this.closeTunnel(key));
+			return Promise.all(tunnels).then(() => { });
+		}
+
+		return Promise.resolve();
+	}
 }

--- a/extensions/open-remote-ssh/src/ssh/sshDestination.ts
+++ b/extensions/open-remote-ssh/src/ssh/sshDestination.ts
@@ -1,54 +1,54 @@
 export default class SSHDestination {
-    constructor(
-        public readonly hostname: string,
-        public readonly user?: string,
-        public readonly port?: number
-    ) {
-    }
+	constructor(
+		public readonly hostname: string,
+		public readonly user?: string,
+		public readonly port?: number
+	) {
+	}
 
-    static parse(dest: string): SSHDestination {
-        let user: string | undefined;
-        const atPos = dest.lastIndexOf('@');
-        if (atPos !== -1) {
-            user = dest.substring(0, atPos);
-        }
+	static parse(dest: string): SSHDestination {
+		let user: string | undefined;
+		const atPos = dest.lastIndexOf('@');
+		if (atPos !== -1) {
+			user = dest.substring(0, atPos);
+		}
 
-        let port: number | undefined;
-        const colonPos = dest.lastIndexOf(':');
-        if (colonPos !== -1) {
-            port = parseInt(dest.substring(colonPos + 1), 10);
-        }
+		let port: number | undefined;
+		const colonPos = dest.lastIndexOf(':');
+		if (colonPos !== -1) {
+			port = parseInt(dest.substring(colonPos + 1), 10);
+		}
 
-        const start = atPos !== -1 ? atPos + 1 : 0;
-        const end = colonPos !== -1 ? colonPos : dest.length;
-        const hostname = dest.substring(start, end);
+		const start = atPos !== -1 ? atPos + 1 : 0;
+		const end = colonPos !== -1 ? colonPos : dest.length;
+		const hostname = dest.substring(start, end);
 
-        return new SSHDestination(hostname, user, port);
-    }
+		return new SSHDestination(hostname, user, port);
+	}
 
-    toString(): string {
-        let result = this.hostname;
-        if (this.user) {
-            result = `${this.user}@` + result;
-        }
-        if (this.port) {
-            result = result + `:${this.port}`;
-        }
-        return result;
-    }
+	toString(): string {
+		let result = this.hostname;
+		if (this.user) {
+			result = `${this.user}@` + result;
+		}
+		if (this.port) {
+			result = result + `:${this.port}`;
+		}
+		return result;
+	}
 
-    // vscode.uri implementation lowercases the authority, so when reopen or restore
-    // a remote session from the recently openend list the connection fails
-    static parseEncoded(dest: string): SSHDestination {
-        try {
-            const data = JSON.parse(Buffer.from(dest, 'hex').toString());
-            return new SSHDestination(data.hostName, data.user, data.port);
-        } catch {
-        }
-        return SSHDestination.parse(dest.replace(/\\x([0-9a-f]{2})/g, (_, charCode) => String.fromCharCode(parseInt(charCode, 16))));
-    }
+	// vscode.uri implementation lowercases the authority, so when reopen or restore
+	// a remote session from the recently openend list the connection fails
+	static parseEncoded(dest: string): SSHDestination {
+		try {
+			const data = JSON.parse(Buffer.from(dest, 'hex').toString());
+			return new SSHDestination(data.hostName, data.user, data.port);
+		} catch {
+		}
+		return SSHDestination.parse(dest.replace(/\\x([0-9a-f]{2})/g, (_, charCode) => String.fromCharCode(parseInt(charCode, 16))));
+	}
 
-    toEncodedString(): string {
-        return this.toString().replace(/[A-Z]/g, (ch) => `\\x${ch.charCodeAt(0).toString(16).toLowerCase()}`);
-    }
+	toEncodedString(): string {
+		return this.toString().replace(/[A-Z]/g, (ch) => `\\x${ch.charCodeAt(0).toString(16).toLowerCase()}`);
+	}
 }


### PR DESCRIPTION
Our hard fork of the open-remote-ssh extension has a nice mixture of files with tabs and files with spaces. This PR changes everything to tabs, in order to align with our top-level [settings.json](https://github.com/posit-dev/positron/blob/main/.vscode/settings.json#L6) file, so that I don't have to keep worrying about temporarily disabling formatting every time I need to work in this extension.