### PR TITLE
Update `AskVSCodeCopilot` title and query to be appropriate for Positron Assistant

### DIFF
--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -345,7 +345,10 @@ class AskVSCodeCopilot extends Action2 {
 	constructor() {
 		super({
 			id: AskVSCodeCopilot.ID,
-			title: localize2('askVScode', 'Ask @vscode'),
+			// --- Start Positron ---
+			title: localize2('askVScode', 'Ask Positron Assistant'),
+			// title: localize2('askVScode', 'Ask @vscode'),
+			// --- End Positron ---
 			category: Categories.Help,
 			f1: true,
 			precondition: ContextKeyExpr.equals('chatSetupHidden', false)
@@ -354,14 +357,20 @@ class AskVSCodeCopilot extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const commandService = accessor.get(ICommandService);
-		commandService.executeCommand('workbench.action.chat.open', { mode: 'ask', query: '@vscode ', isPartialQuery: true });
+		// --- Start Positron ---
+		//commandService.executeCommand('workbench.action.chat.open', { mode: 'ask', query: '@vscode ', isPartialQuery: true });
+		commandService.executeCommand('workbench.action.chat.open', { mode: 'ask', query: '', isPartialQuery: true });
+		// --- End Positron ---
 	}
 }
 
 MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
 	command: {
 		id: AskVSCodeCopilot.ID,
-		title: localize2('askVScode', 'Ask @vscode'),
+		// --- Start Positron ---
+		title: localize2('askVScode', 'Ask Positron Assistant'),
+		// title: localize2('askVScode', 'Ask @vscode'),
+		// --- End Positron ---
 	},
 	order: 7,
 	group: '1_welcome',


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9822

This PR updates the entry in the Help menu that originally said `"Ask @vscode"`. I changed the text to say "Ask Positron Assistant" and then also changed what the command does to open chat with _no_  query instead of `@vscode`, since we don't have an equivalent chat participant (related to https://github.com/posit-dev/positron/issues/8756).

If you don't have Positron Assistant enabled, clicking this option in the Help menu behaves the same way as it does now, which is honestly not ideal but this PR is at least not introducing any regressions in this area.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

In the Help menu, you should see "Ask Positron Assistant". If you click that, it should open up your chat panel and put your cursor in the chat box.
