### PR TITLE
e2e: fix notebook flake to expect ms or s

### DIFF
--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -43,7 +43,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			await notebooksPositron.addCodeToCell(0, 'print("hello world")', { run: true });
 			await notebooksPositron.expectToolTipToContain({
 				order: 1,
-				duration: /\d+ms/,
+				duration: /\d+(ms|s)/,
 				status: 'Success'
 			}, 30000);
 
@@ -62,7 +62,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			});
 			await notebooksPositron.expectToolTipToContain({
 				order: 2,
-				duration: /\d+ms/,
+				duration: /\d+(ms|s)/,
 				status: 'Failed'
 			});
 


### PR DESCRIPTION
### Summary

Noticed a test flake due to tooltip assuming time in `ms`, when in fact it could also be in `s`.

### QA Notes

@:positron-notebooks
