### PR TITLE
Show the Positron version in help -> about

### DIFF
--- a/src/vs/platform/dialogs/electron-browser/dialog.ts
+++ b/src/vs/platform/dialogs/electron-browser/dialog.ts
@@ -11,7 +11,11 @@ import { IProductService } from '../../product/common/productService.js';
 import { process } from '../../../base/parts/sandbox/electron-browser/globals.js';
 
 export function createNativeAboutDialogDetails(productService: IProductService, osProps: IOSProperties): { title: string; details: string; detailsToCopy: string } {
-	let version = productService.version;
+	// --- Start Positron ---
+	// Show the Positron version instead of the Code - OSS version
+	// let version = productService.version;
+	let version = productService.positronVersion;
+	// --- End Positron ---
 	if (productService.target) {
 		version = `${version} (${productService.target} setup)`;
 	} else if (productService.darwinUniversalAssetId) {


### PR DESCRIPTION
Just noticed that Help -> About no longer shows the Positron version after the 104 merge.

<img width="286" height="355" alt="image" src="https://github.com/user-attachments/assets/ff4274c8-55fa-44bb-8957-ecd714b274af" />

This change restores the Positron version in Help -> About.