### PR TITLE
PositroNB: Support HTML outputs

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -270,6 +270,10 @@ export type ParsedOutput = ParsedTextOutput |
 	trace: string;
 } |
 {
+	type: 'html';
+	content: string;
+} |
+{
 	type: 'unknown';
 	content: string;
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -12,6 +12,7 @@ import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEdito
 import { CellRevealType, INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { CellSelectionType } from '../selectionMachine.js';
+import { IOutputItemDto } from '../../../notebook/common/notebookCommon.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
@@ -270,13 +271,13 @@ export type ParsedOutput = ParsedTextOutput |
 } |
 {
 	type: 'unknown';
-	contents: string;
+	content: string;
 };
 
 
 export interface NotebookCellOutputs {
 	readonly outputId: string;
-	readonly outputs: NotebookCellOutputItem[];
+	readonly outputs: IOutputItemDto[];
 	readonly parsed: ParsedOutput;
 	preloadMessageResult?: NotebookPreloadOutputResults | undefined;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -61,27 +61,25 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 		const parsedOutputs: NotebookCellOutputs[] = [];
 
 		this.cellModel.outputs.forEach((output) => {
-			const outputs = output.outputs || [];
-			const preferredOutput = pickPreferredOutputItem(outputs);
-			if (!preferredOutput) {
+			const outputItems = output.outputs || [];
+			const preferredOutputItem = pickPreferredOutputItem(outputItems);
+			if (!preferredOutputItem) {
 				return;
 			}
 
 			const parsedOutput: NotebookCellOutputs = {
-				...output,
-				// For some reason the outputs don't make it across the spread operator sometimes,
-				// so we'll just set them explicitly.
-				outputs,
-				parsed: parseOutputData(preferredOutput),
+				outputId: output.outputId,
+				outputs: outputItems,
+				parsed: parseOutputData(preferredOutputItem),
 			};
 
-			const preloadMessageType = getWebviewMessageType(outputs);
+			const preloadMessageType = getWebviewMessageType(outputItems);
 
 			if (preloadMessageType) {
 				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
 					instance: this.instance,
 					outputId: output.outputId,
-					outputs,
+					outputs: outputItems,
 				});
 			}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -3,9 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from '../../../../nls.js';
 import { NotebookCellOutputTextModel } from '../../notebook/common/model/notebookCellOutputTextModel.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
-import { ICellOutput } from '../../notebook/common/notebookCommon.js';
+import { ICellOutput, IOutputItemDto } from '../../notebook/common/notebookCommon.js';
 import { ParsedOutput, ParsedTextOutput } from './PositronNotebookCells/IPositronNotebookCell.js';
 
 type CellOutputInfo = { id: string; content: string };
@@ -84,11 +85,11 @@ export function isParsedTextOutput(output: ParsedOutput): output is ParsedTextOu
 
 /**
  * Parse cell output into standard serializable js objects.
- * @param output Contents of a cells output
+ * @param outputItem Contents of a cells output
  * @returns The output parsed to the known types.
  */
-export function parseOutputData(output: ICellOutput['outputs'][number]): ParsedOutput {
-	const { data, mime } = output;
+export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
+	const { data, mime } = outputItem;
 	const message = data.toString();
 
 	try {
@@ -128,7 +129,10 @@ export function parseOutputData(output: ICellOutput['outputs'][number]): ParsedO
 		};
 	}
 
-	return { type: 'unknown', contents: message };
+	return {
+		type: 'unknown',
+		content: localize('cellExecutionUnknownMimeType', 'Can\'t handle mime type "{0}" yet', mime)
+	};
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -122,6 +122,10 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 		return { type: 'text', content: message };
 	}
 
+	if (mime === 'text/html') {
+		return { type: 'html', content: message };
+	}
+
 	if (mime === 'image/png') {
 		return {
 			type: 'image',

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -17,5 +17,23 @@
 			/* Dont show empty outputs at all */
 			display: none;
 		}
+
+		/*
+		Provide style hints for dataframes rendered as tables,
+		similar to styling in the console
+		*/
+		.dataframe {
+			font-size: 12px;
+			border: 1px solid var(--vscode-tab-border);
+			border-collapse: collapse;
+
+			td, th {
+				border: 1px solid var(--vscode-tab-border);
+				padding-top: 3px;
+				padding-bottom: 3px;
+				padding-left: 5px;
+				padding-right: 5px;
+			}
+		}
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -59,7 +59,7 @@ function CellOutput(output: NotebookCellOutputs) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}
 
-	const { parsed, outputs } = output;
+	const { parsed } = output;
 
 	if (isParsedTextOutput(parsed)) {
 		return <CellTextOutput {...parsed} />;
@@ -74,7 +74,7 @@ function CellOutput(output: NotebookCellOutputs) {
 			return <img alt='output image' src={parsed.dataUrl} />;
 		case 'unknown':
 			return <div className='unknown-mime-type'>
-				{localize('cellExecutionUnknownMimeType', 'Can\'t handle mime types "{0}" yet', outputs.map(o => o.mime).join(','))}
+				{parsed.content}
 			</div>;
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -20,6 +20,7 @@ import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellLeftActionMenu } from './CellLeftActionMenu.js';
+import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 
 
 interface CellOutputsSectionProps {
@@ -72,6 +73,8 @@ function CellOutput(output: NotebookCellOutputs) {
 			</div>;
 		case 'image':
 			return <img alt='output image' src={parsed.dataUrl} />;
+		case 'html':
+			return renderHtml(parsed.content);
 		case 'unknown':
 			return <div className='unknown-mime-type'>
 				{parsed.content}


### PR DESCRIPTION
Support HTML outputs in Positron notebooks, addresses #9723.

---

Also made the error message for unknown mime types more accurate, so it will show as:

```
Can't handle mime type "text/html" yet
```

instead of:

```
Can't handle mime types "text/html,text/plain" yet
```

### Images

#### Dataframe default

I've just matched how dataframes render in the console for now. We might want to update both notebooks and console styling though, input would be appreciated!

<img width="385" height="308" alt="image" src="https://github.com/user-attachments/assets/6beeb3cd-b8ac-48ad-acb5-9a69a7febc4c" />

#### Custom styled dataframe

<img width="474" height="430" alt="image" src="https://github.com/user-attachments/assets/c41040eb-4e26-49d8-8b70-0bbe4158f713" />

#### HTML magic

<img width="594" height="179" alt="image" src="https://github.com/user-attachments/assets/6df7418c-9b1e-4bc2-aa6e-b6038ccfb394" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

See the very helpful repros in #9723.