### PR TITLE
e2e: add positron nb test for clicking away and back to cell

### DIFF
--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -82,7 +82,7 @@ test.describe('Positron Notebooks: Cell Deletion Action Bar Behavior', {
 		// ========================================
 		await test.step('Test 3: Delete last cell (cell 3, contains \'# Cell 5\')', async () => {
 			// Verify we're at the last cell with correct content
-			expect(await notebooksPositron.getCellContent(3)).toBe('# Cell 5');
+			await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 5');
 
 			// Delete the last cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(3);

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -72,7 +72,33 @@ test.describe('Notebook Focus and Selection', {
 			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
 		});
 
-		await test.step('Test 6: Shift+Arrow Down adds next cell to selection', async () => {
+
+		// BUG: https://github.com/posit-dev/positron/issues/9876
+		await test.step.skip('Test 6: Cell regains edit mode when clicking away and back', async () => {
+			// verify we are starting with 5 cells
+			await notebooksPositron.expectCellCountToBe(5);
+			await notebooksPositron.selectCellAtIndex(1);
+
+			// click away to defocus cell
+			const active = notebooksPositron.cell.nth(1);
+			const box = await active.boundingBox();
+			if (box) {
+				const page = app.code.driver.page;
+				const x = box.x + box.width / 2 - 300;
+				const y = box.y + box.height + 20;
+
+				await page.mouse.click(x, y);
+			}
+
+			// click back on cell to re-focus
+			await notebooksPositron.selectCellAtIndex(1);
+
+			// verify backspace deletes cell content not cell (indicating edit mode is active)
+			await keyboard.press('Backspace');
+			await notebooksPositron.expectCellCountToBe(5);
+		});
+
+		await test.step('Test 7: Shift+Arrow Down adds next cell to selection', async () => {
 			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
 			await keyboard.press('Shift+ArrowDown');
 			await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });


### PR DESCRIPTION
### Summary
Added a new test to verify an issue with edit mode (via clicking away and back from cell) that was discovered. Currently, the test is being skipped. Once the issue is resolved, it can be unskipped.

Related: https://github.com/posit-dev/positron/issues/9876

### QA Notes

@:positron-notebooks