### PR TITLE
Update `licenseUrl` for the desktop app

### DIFF
--- a/product.json
+++ b/product.json
@@ -8,7 +8,7 @@
 	"dataFolderName": ".positron",
 	"win32MutexName": "positron",
 	"licenseName": "Software Evaluation License",
-	"licenseUrl": "https://github.com/posit-dev/positron/tree/main?tab=License-1-ov-file",
+	"licenseUrl": "https://positron.posit.co/licensing",
 	"serverLicenseUrl": "https://posit.co/about/eula/",
 	"serverGreeting": [],
 	"serverLicense": [],


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron-builds/issues/540

This PR does _not_ change `serverLicenseUrl` which points to the EULA.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

When you click "View License" from the Help menu in the desktop app, it should navigate through to <https://positron.posit.co/licensing>
