### PR TITLE
Assistant: enable file read/write tools in Agent mode

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -291,10 +291,12 @@ export function getEnabledTools(
 		// include Copilot tools.
 		const shouldIncludeCopilotTools = (usingCopilotModel || copilotEnabled && alwaysIncludeCopilotTools);
 
-		// Enable Copilot tools only if shouldIncludeCopilotTools is true; otherwise, enable if agent mode or tool is tagged 'positron-assistant'.
-		const enableTool = copilotTool
-			? shouldIncludeCopilotTools
-			: (isAgentMode || tool.tags.includes('positron-assistant'));
+		// Enable if tagged 'positron-assistant' OR a Copilot tool when shouldIncludeCopilotTools is true OR  Agent mode enabled.
+		// editFile from 'positron-assistant' will be disabled in Ask mode based on control flow above.
+		const enableTool = tool.tags.includes('positron-assistant') ||
+			(copilotTool
+				? shouldIncludeCopilotTools
+				: isAgentMode);
 
 		// If we've decided to enable the tool, add it to the list.
 		if (enableTool) {


### PR DESCRIPTION
The tools `getFileContents`, `findTextInProject`, and `editFile` were previously disabled in Agent mode. This change introduces those three tools to Agent mode without changing the set available in Ask or Edit.

Duplicate of #9873, this time from a branch rather than a fork (ty for the permissions!)—a complete description of the changes is there. Related to #9868.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
