### PR TITLE
Positron nb fix cell focus bug

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -195,13 +195,6 @@ export interface IPositronNotebookInstance {
 	moveCells(cells: IPositronNotebookCell[], targetIndex: number): void;
 
 	/**
-	 * Updates the currently editing cell state.
-	 *
-	 * @param cell The cell to set as editing, or undefined to clear editing state
-	 */
-	setEditingCell(cell: IPositronNotebookCell | undefined): void;
-
-	/**
 	 * Checks if the notebook instance contains a code editor.
 	 *
 	 * @param editor The code editor to check for.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -22,7 +22,7 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType, getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IPositronNotebookService } from './positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus } from './IPositronNotebookInstance.js';
@@ -897,13 +897,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		});
 
 		if (newlyAddedCells.length === 1) {
-			// If we've only added one cell, we can set it as the selected cell in edit mode.
-			this.selectionStateMachine.selectCell(newlyAddedCells[0], CellSelectionType.Edit);
-			// Defer focus request to next tick to allow React to mount the editor component.
-			// Without this, requestEditorFocus() fires before the editor exists, and the
-			// autorun in CellEditorMonacoWidget won't be able to focus a non-existent editor.
+			// Defer to next tick to allow React to mount the editor component.
+			// enterEditor() handles both state update and focus management.
 			setTimeout(() => {
-				newlyAddedCells[0].requestEditorFocus();
+				this.selectionStateMachine.enterEditor(newlyAddedCells[0]);
 			}, 0);
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -747,17 +747,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 
 	/**
-	 * Sets the cell that is currently being edited.
-	 * @param cell The cell to set as editing, or undefined to clear editing state
-	 */
-	setEditingCell(cell: IPositronNotebookCell | undefined): void {
-		if (cell === undefined) {
-			return;
-		}
-		this.selectionStateMachine.selectCell(cell, CellSelectionType.Edit);
-	}
-
-	/**
 	 * Checks if the notebook contains a specific code editor.
 	 * @param editor The code editor to check for
 	 * @returns True if the editor belongs to one of the notebook's cells, false otherwise

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -23,6 +23,7 @@ import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNo
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../ContextKeysManager.js';
+import { CellSelectionType } from '../selectionMachine.js';
 
 /**
  *
@@ -81,7 +82,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editorContextKeyService);
 
 		disposables.add(editor.onDidFocusEditorWidget(() => {
-			instance.setEditingCell(cell);
+			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Edit);
 			cellEditorFocusedKey.set(true);
 		}));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -23,7 +23,6 @@ import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNo
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../ContextKeysManager.js';
-import { CellSelectionType } from '../selectionMachine.js';
 
 /**
  *
@@ -82,7 +81,8 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editorContextKeyService);
 
 		disposables.add(editor.onDidFocusEditorWidget(() => {
-			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Edit);
+			// enterEditor() automatically detects that editor has focus and skips focus management
+			instance.selectionStateMachine.enterEditor(cell);
 			cellEditorFocusedKey.set(true);
 		}));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -87,6 +87,9 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 		disposables.add(editor.onDidBlurEditorWidget(() => {
 			cellEditorFocusedKey.set(false);
+			// Pass the cell so we only exit if THIS specific cell is being edited (not a different one)
+			// This handles the race condition where a user clicks from one cell editor into another.
+			instance.selectionStateMachine.exitEditor(cell);
 		}));
 
 		/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -175,7 +175,6 @@ export class SelectionStateMachine extends Disposable {
 	) {
 		super();
 		this._register(autorunDelta(this.state, ({ lastValue, newValue }) => {
-			console.log('SelectionStateMachine: state changed', newValue);
 			if (lastValue !== undefined) {
 				this._updateCellSelectionStatus(lastValue, newValue);
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -299,10 +299,13 @@ export class SelectionStateMachine extends Disposable {
 
 	/**
 	 * Reset the selection to the cell so user can navigate between cells
+	 * @param cell Optional - if provided, only exit if this specific cell is being edited
 	 */
-	exitEditor(): void {
+	exitEditor(cell?: IPositronNotebookCell): void {
 		const state = this._state.get();
 		if (state.type !== SelectionState.EditingSelection) { return; }
+		// If a specific cell is provided, only exit if THAT cell is being edited
+		if (cell && state.selected !== cell) { return; }
 		this._setState({ type: SelectionState.SingleSelection, selected: state.selected });
 	}
 
@@ -461,7 +464,7 @@ export class SelectionStateMachine extends Disposable {
 		} else {
 			this._setState({ type: SelectionState.NoCells });
 		}
-	};
+	}
 
 	/**
 	 * Validates and corrects state to maintain invariants.

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -376,10 +376,11 @@ export class PositronNotebooks extends Notebooks {
 			try {
 				// Click on kernel status badge to open selection
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
-				await this.kernelStatusBadge.click();
-
-				// Wait for kernel selection UI to appear
-				await this.quickinput.waitForQuickInputOpened();
+				await expect(async () => {
+					// we shouldn't need to retry this, but the input closes immediately sometimes
+					await this.kernelStatusBadge.click();
+					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
+				}).toPass({ timeout: 10000 });
 
 				// Select the desired kernel
 				await this.quickinput.selectQuickInputElementContaining(desiredKernel);

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -14,6 +14,9 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {
+		if (process.env.CI) {
+			test.skip();
+		}
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 	});
 

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -14,9 +14,6 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {
-		if (process.env.CI) {
-			test.skip();
-		}
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 	});
 

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -73,8 +73,7 @@ test.describe('Notebook Focus and Selection', {
 		});
 
 
-		// BUG: https://github.com/posit-dev/positron/issues/9876
-		await test.step.skip('Test 6: Cell regains edit mode when clicking away and back', async () => {
+		await test.step('Test 6: Cell regains edit mode when clicking away and back', async () => {
 			// verify we are starting with 5 cells
 			await notebooksPositron.expectCellCountToBe(5);
 			await notebooksPositron.selectCellAtIndex(1);


### PR DESCRIPTION
Addresses #9876 and #9904

This PR fixes a bug in Positron Notebooks where clicking outside a cell and then clicking back inside would cause the notebook to lose cursor context. This resulted in keyboard shortcuts (like `d` for delete cell) being triggered when the user was trying to type normally inside the cell.

The fix updates the cell editor widget to properly notify the selection state machine when the editor loses focus. This ensures that when users click back into a cell, the notebook correctly recognizes that the editor context should be active, allowing normal typing to work as expected.

We also take advantage of being in the selection machine to simplify the API in an attempt to avoid confusion like this in the future. 

The e2e test from #9895 has been re-enabled and passes. 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:critical

1. Create a new notebook
2. Add a code cell and type some content (e.g., "test code")
3. Click outside the cell (somewhere in the notebook UI but not in another cell)
4. Click back inside the cell - verify the cursor is blinking
5. Type `d` - verify it types the letter "d" instead of showing "(D) was pressed. Waiting for a second key of..."
6. Type `dd` or `backspace` - verify these type normally instead of deleting the cell
7. Repeat steps 2-6 with multiple cells to ensure consistent behavior
