### PR TITLE
Add support for Databricks-style code cells in both Python and R

### DIFF
--- a/extensions/positron-code-cells/package.json
+++ b/extensions/positron-code-cells/package.json
@@ -202,6 +202,11 @@
             "%positron.codeCells.configuration.cellStyle.both%"
           ],
           "markdownDescription": "%positron.codeCells.configuration.cellStyle%"
+        },
+        "codeCells.additionalCellDelimiter": {
+          "type": "string",
+          "default": "# COMMAND ----------",
+          "markdownDescription": "%positron.codeCells.configuration.additionalCellDelimiter%"
         }
       }
     }

--- a/extensions/positron-code-cells/package.nls.json
+++ b/extensions/positron-code-cells/package.nls.json
@@ -16,5 +16,6 @@
 	"positron.codeCells.configuration.cellStyle": "Controls the style of code cell decorations. Colors are configurable with the `notebook.selectedCellBackground` and `interactive.activeCodeBorder` theme colors. See https://code.visualstudio.com/api/references/theme-color for more information about the available theme colors and how to override them.",
 	"positron.codeCells.configuration.cellStyle.border": "Highlight the active cell's border.",
 	"positron.codeCells.configuration.cellStyle.background": "Highlight the active cell's background.",
-	"positron.codeCells.configuration.cellStyle.both": "Highlight the active cell's border and background."
+	"positron.codeCells.configuration.cellStyle.both": "Highlight the active cell's border and background.",
+	"positron.codeCells.configuration.additionalCellDelimiter": "Additional text that marks the start of a new cell (e.g., for Databricks notebooks)"
 }

--- a/extensions/positron-code-cells/src/documentManager.ts
+++ b/extensions/positron-code-cells/src/documentManager.ts
@@ -12,6 +12,13 @@ import { IGNORED_SCHEMES } from './extension';
 // export const documentManagers: DocumentManager[] = [];
 const documentManagers: Map<vscode.Uri, DocumentManager> = new Map();
 
+// Function to reparse document cells
+export function reparseOpenDocuments(): void {
+	documentManagers.forEach(manager => {
+		manager.parseCells();
+	});
+}
+
 // Creates a cached document that handles parsing code cells for supported languages
 export class DocumentManager implements vscode.Disposable {
 	private cells: Cell[] = [];

--- a/extensions/positron-code-cells/src/extension.ts
+++ b/extensions/positron-code-cells/src/extension.ts
@@ -8,7 +8,7 @@ import { initializeLogging } from './logging';
 import { CellCodeLensProvider } from './codeLenses';
 import { activateDecorations } from './decorations';
 import { activateContextKeys } from './context';
-import { activateDocumentManagers } from './documentManager';
+import { activateDocumentManagers, reparseOpenDocuments } from './documentManager';
 import { registerCommands } from './commands';
 
 export const IGNORED_SCHEMES = ['vscode-notebook-cell', 'vscode-interactive-input'];
@@ -26,17 +26,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		// Adds 'Run Cell' | 'Run Above' | 'Run Below' code lens for cells
 		vscode.languages.registerCodeLensProvider('*', new CellCodeLensProvider()),
 
-		// Listen for configuration changes and prompt to restart
+		// Listen for configuration changes and reparse the open documents
 		vscode.workspace.onDidChangeConfiguration(event => {
 			if (event.affectsConfiguration('codeCells.additionalCellDelimiter')) {
-				void vscode.window.showInformationMessage(
-					vscode.l10n.t('Code cell delimiter configuration changed. Please restart Positron for changes to take effect.'),
-					vscode.l10n.t('Reload Window')
-				).then(selection => {
-					if (selection === vscode.l10n.t('Reload Window')) {
-						void vscode.commands.executeCommand('workbench.action.reloadWindow');
-					}
-				});
+				reparseOpenDocuments();
 			}
 		}),
 

--- a/extensions/positron-code-cells/src/extension.ts
+++ b/extensions/positron-code-cells/src/extension.ts
@@ -26,6 +26,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		// Adds 'Run Cell' | 'Run Above' | 'Run Below' code lens for cells
 		vscode.languages.registerCodeLensProvider('*', new CellCodeLensProvider()),
 
+		// Listen for configuration changes and prompt to restart
+		vscode.workspace.onDidChangeConfiguration(event => {
+			if (event.affectsConfiguration('codeCells.additionalCellDelimiter')) {
+				void vscode.window.showInformationMessage(
+					vscode.l10n.t('Code cell delimiter configuration changed. Please restart Positron for changes to take effect.'),
+					vscode.l10n.t('Reload Window')
+				).then(selection => {
+					if (selection === vscode.l10n.t('Reload Window')) {
+						void vscode.commands.executeCommand('workbench.action.reloadWindow');
+					}
+				});
+			}
+		}),
+
 		// Temporarily disabled because registering this provider causes it to
 		// become the *only* folding range provider for R and Python files,
 		// suppressing the built-in folding range provider.

--- a/extensions/positron-code-cells/src/extension.ts
+++ b/extensions/positron-code-cells/src/extension.ts
@@ -8,7 +8,7 @@ import { initializeLogging } from './logging';
 import { CellCodeLensProvider } from './codeLenses';
 import { activateDecorations } from './decorations';
 import { activateContextKeys } from './context';
-import { activateDocumentManagers, reparseOpenDocuments } from './documentManager';
+import { activateDocumentManagers } from './documentManager';
 import { registerCommands } from './commands';
 
 export const IGNORED_SCHEMES = ['vscode-notebook-cell', 'vscode-interactive-input'];
@@ -25,13 +25,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		// Adds 'Run Cell' | 'Run Above' | 'Run Below' code lens for cells
 		vscode.languages.registerCodeLensProvider('*', new CellCodeLensProvider()),
-
-		// Listen for configuration changes and reparse the open documents
-		vscode.workspace.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration('codeCells.additionalCellDelimiter')) {
-				reparseOpenDocuments();
-			}
-		}),
 
 		// Temporarily disabled because registering this provider causes it to
 		// become the *only* folding range provider for R and Python files,

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -63,11 +63,14 @@ const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
 const rIsSectionHeaderRegExp = new RegExp(/^#+.*[-=]{4,}\s*$/);
-const databricksIsCellStartRegExp = new RegExp(/^# COMMAND ----------$/);
+
+function getAdditionalCellDelimiter(): string {
+	return vscode.workspace.getConfiguration('codeCells').get('additionalCellDelimiter', '# COMMAND ----------');
+}
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
-	isCellStart: (line) => pythonIsCellStartRegExp.test(line) || databricksIsCellStartRegExp.test(line),
+	isCellStart: (line) => pythonIsCellStartRegExp.test(line) || line === getAdditionalCellDelimiter(),
 	isCellEnd: (_line) => false,
 	getCellType: (line) => pythonMarkdownRegExp.test(line) ? CellType.Markdown : CellType.Code,
 	getCellText: (cell, document) =>
@@ -78,8 +81,8 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line) || databricksIsCellStartRegExp.test(line),
-	isCellEnd: (_line) => !databricksIsCellStartRegExp.test(_line) && rIsSectionHeaderRegExp.test(_line),
+	isCellStart: (line) => rIsCellStartRegExp.test(line) || line === getAdditionalCellDelimiter(),
+	isCellEnd: (_line) => _line !== getAdditionalCellDelimiter() && rIsSectionHeaderRegExp.test(_line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
 	newCell: () => '\n# %%\n'

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -63,10 +63,11 @@ const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
 const rIsSectionHeaderRegExp = new RegExp(/^#+.*[-=]{4,}\s*$/);
+const databricksIsCellStartRegExp = new RegExp(/^# COMMAND ----------$/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
-	isCellStart: (line) => pythonIsCellStartRegExp.test(line),
+	isCellStart: (line) => pythonIsCellStartRegExp.test(line) || databricksIsCellStartRegExp.test(line),
 	isCellEnd: (_line) => false,
 	getCellType: (line) => pythonMarkdownRegExp.test(line) ? CellType.Markdown : CellType.Code,
 	getCellText: (cell, document) =>
@@ -77,8 +78,8 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line),
-	isCellEnd: (_line) => rIsSectionHeaderRegExp.test(_line),
+	isCellStart: (line) => rIsCellStartRegExp.test(line) || databricksIsCellStartRegExp.test(line),
+	isCellEnd: (_line) => !databricksIsCellStartRegExp.test(_line) && rIsSectionHeaderRegExp.test(_line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
 	newCell: () => '\n# %%\n'

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -27,6 +27,7 @@ suite('Parsers', () => {
 		const language = 'python';
 		const codeCellBody = '123\n456';
 		const codeCell = `# %%\n${codeCellBody}`;
+		const databricksCodeCell = `# COMMAND ----------\n${codeCellBody}`;
 		const markdownBody = `# H1
 ## H2
 
@@ -45,6 +46,7 @@ And a [link](target)`;
 		const singleCellTests: [string, string, CellType][] = [
 			['Parses a single code cell', codeCell, CellType.Code],
 			['Parses a single markdown cell', commentedMarkdownCell, CellType.Markdown],
+			['Parses a Databricks-style code cell', databricksCodeCell, CellType.Code],
 		];
 		singleCellTests.forEach(([title, content, expectedType]) => {
 			test(title, async () => {
@@ -62,9 +64,19 @@ And a [link](target)`;
 			]);
 		});
 
+		test('Parses mixed cell types (standard and Databricks-style)', async () => {
+			const content = [codeCell, databricksCodeCell].join('\n');
+			const document = await vscode.workspace.openTextDocument({ language, content });
+			assert.deepStrictEqual(parseCells(document), [
+				{ range: new vscode.Range(0, 0, 2, 3), type: CellType.Code },
+				{ range: new vscode.Range(3, 0, 5, 3), type: CellType.Code }
+			]);
+		});
+
 		const getCellTypeTests: [string, string, CellType][] = [
 			['Get the cell type for a code cell', codeCell, CellType.Code],
 			['Get the cell type for a markdown cell', commentedMarkdownCell, CellType.Markdown],
+			['Get the cell type for a Databricks-style code cell', databricksCodeCell, CellType.Code],
 		];
 		getCellTypeTests.forEach(([title, content, expectedType]) => {
 			test(title, () => {
@@ -99,6 +111,7 @@ And a [link](target)`;
 		const codeCell1 = `#+\n${codeCellBody}`;
 		const codeCell2 = `# %%\n789\n\n012`;
 		const codeCell3 = `# Header ----\n\n123\n456`;
+		const databricksCodeCell = `# COMMAND ----------\n${codeCellBody}`;
 
 		const parser = getParser(language);
 
@@ -108,6 +121,7 @@ And a [link](target)`;
 
 		const singleCellTests: [string, string, CellType][] = [
 			['Parses a single code cell', codeCell1, CellType.Code],
+			['Parses a Databricks-style code cell', databricksCodeCell, CellType.Code],
 		];
 		singleCellTests.forEach(([title, content, expectedType]) => {
 			test(title, async () => {
@@ -137,6 +151,7 @@ And a [link](target)`;
 
 		const getCellTextTests: [string, string, CellType, string][] = [
 			['Get the cell text for a code cell', codeCell1, CellType.Code, codeCellBody],
+			['Get the cell text for a Databricks-style code cell', databricksCodeCell, CellType.Code, codeCellBody],
 		];
 		getCellTextTests.forEach(([title, content, expectedType, expectedText]) => {
 			test(title, async () => {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9554

I made this work for an _exact_ match for the text as shown here, for both R and Python: https://docs.databricks.com/aws/en/notebooks/notebook-export-import?language=Python

We do have to make such a delimiter _not_ also end a code cell in `.R`, or else it can't count up the lines correctly. What this means is that if an R user has _exactly_ `# COMMAND ----------` they get a code cell when they might not want to.

I also set this up as a setting that the user can adjust if they like:

<img width="753" height="593" alt="Screenshot 2025-10-11 at 12 09 44 PM" src="https://github.com/user-attachments/assets/a679b204-4557-443c-8c87-e2b0b191d616" />


### Release Notes

#### New Features

- Added support for Databricks-style `# COMMAND ----------` code cells in `.py` and `.R` files. You can customize this behavior by changing the new `codeCells.additionalCellDelimiter` setting.

#### Bug Fixes

- N/A


### QA Notes

If you have an `.R` file like this:

```r
# A section but not a code cell ----
1

## A subsection but not a code cell ----
2

# COMMAND ----------
3 ## this one is a code cell

# A new section but not a code cell ----
4

#+ A new code cell
5

# Another new section but not a code cell ----
6
```

you should see the correct decorations and be able to run the code cells. Also, all that should also show up in the Outline.

Similarly, for a Python file, you should get three code cells here:

```python
# COMMAND ----------
1

# %% potato!
2

# COMMAND ----------
3 
```

If you change the new `codeCells.additionalCellDelimiter` to something else reasonable, that should also work. Things like emoji and such work well, but it is just doing straight string checking, so very strange strings or encodings may not work as expected.