### PR TITLE
e2e: nb more actions helper

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -13,6 +13,8 @@ import { HotKeys } from './hotKeys.js';
 
 const DEFAULT_TIMEOUT = 10000;
 
+type moreActionsMenuItems = 'Copy cell' | 'Cut cell' | 'Paste Cell Above' | 'Paste cell below' | 'Move cell down' | 'Move cell up' | 'Insert code cell above' | 'Insert code cell below';
+
 /**
  * Notebooks functionality exclusive to Positron notebooks.
  */
@@ -30,6 +32,8 @@ export class PositronNotebooks extends Notebooks {
 	private kernelStatusBadge = this.code.driver.page.getByTestId('notebook-kernel-status');
 	private deleteCellButton = this.cell.getByRole('button', { name: /delete the selected cell/i });
 	private cellInfoToolTip = this.code.driver.page.getByRole('tooltip', { name: /cell execution details/i });
+	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /more actions/i });
+	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
 
 	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys, private clipboard: Clipboard) {
 		super(code, quickinput, quickaccess, hotKeys);
@@ -165,6 +169,18 @@ export class PositronNotebooks extends Notebooks {
 					}, 'should NOT be in edit mode').toPass({ timeout: 15000 });
 				});
 			}
+		});
+	}
+
+	/**
+	 * Action: Select an action from the More Actions menu for a specific cell.
+	 * @param cellIndex - The index of the cell to act on
+	 * @param action - The action to perform from the More Actions menu
+	 */
+	async selectFromMoreActionsMenu(cellIndex: number, action: moreActionsMenuItems): Promise<void> {
+		await test.step(`Select action from More Actions menu: ${action}`, async () => {
+			await this.moreActionsButtonAtIndex(cellIndex).click();
+			await this.moreActionsOption(action).click();
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -421,6 +421,16 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
+	 * Verify: Cell contents match expected contents.
+	 * @param expectedContents - Array of expected cell contents in order.
+	 */
+	async expectCellContentsToBe(expectedContents: string[]): Promise<void> {
+		for (let i = 0; i < expectedContents.length; i++) {
+			await this.expectCellContentAtIndexToBe(i, expectedContents[i]);
+		}
+	}
+
+	/**
 	 * Verify: Cell content at specified index matches expected content.
 	 * @param cellIndex - The index of the cell to check.
 	 * @param expectedContent - The expected content of the cell.

--- a/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
@@ -22,7 +22,7 @@ test.describe('Notebook Cell Reordering', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Move first cell down using action bar button - should swap with second cell', async function ({ app }) {
+	test('Move first cell down - should swap with second cell (via Action Bar)', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Open an existing notebook to match manual testing scenario
@@ -38,19 +38,8 @@ test.describe('Notebook Cell Reordering', {
 		const cell1Content = await notebooksPositron.getCellContent(1);
 		const cell2Content = await notebooksPositron.getCellContent(2);
 
-		// Select first cell
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-
-		// Find and click the "More Actions" button in the action bar
-		const cell = app.code.driver.page.locator('[data-testid="notebook-cell"]').nth(0);
-		const moreActionsButton = cell.getByRole('button', { name: /more actions/i });
-		await expect(moreActionsButton).toBeVisible({ timeout: 5000 });
-		await moreActionsButton.click();
-
-		// Wait for the menu to open and find "Move cell down" option
-		const moveDownOption = app.code.driver.page.locator('button.custom-context-menu-item', { hasText: /move cell down/i });
-		await expect(moveDownOption).toBeVisible({ timeout: 5000 });
-		await moveDownOption.click();
+		// Select "Move cell down"
+		await notebooksPositron.selectFromMoreActionsMenu(0, 'Move cell down');
 
 		// Verify cell moved down by EXACTLY ONE position
 		await notebooksPositron.expectCellContentAtIndexToBe(0, cell1Content); // Former cell 1 is now at position 0
@@ -61,7 +50,7 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectCellCountToBe(initialCount);
 	});
 
-	test('Move first cell down - should swap with second cell', async function ({ app }) {
+	test('Move first cell down - should swap with second cell (via Keyboard)', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Setup: Create notebook with 3 cells

--- a/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
@@ -22,7 +22,7 @@ test.describe('Notebook Cell Reordering', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Move first cell down - should swap with second cell (via Action Bar)', async function ({ app }) {
+	test('Action Bar: swap 1st and 2nd cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Open an existing notebook to match manual testing scenario
@@ -50,213 +50,89 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectCellCountToBe(initialCount);
 	});
 
-	test('Move first cell down - should swap with second cell (via Keyboard)', async function ({ app }) {
+	test('Keyboard: swap 1st and 2nd cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 3 cells
 		await notebooksPositron.newNotebook(3);
 
 		// Verify initial order
 		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// Select first cell and move down
 		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+		await keyboard.press('Alt+ArrowDown');
 
 		// Verify cell moved down by exactly one position
 		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0', '# Cell 2']);
 	});
 
-	test('Move cell up - basic operation', async function ({ app }) {
+	test('Boundaries: first-up and last-down are no-ops', async ({ app }) => {
 		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
-		// Setup: Create notebook with 3 cells
 		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-
-		// Select second cell and move up
-		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
-
-		// Verify cell moved up
-		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-	});
-
-	test('Move cell down - basic operation', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-
-		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-
-		// Select first cell and move down
+		// First cell up -> no change
 		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
+		await keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
-		// Verify cell moved down
-		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-	});
-
-	test('Move last cell up', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-
-		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-
-		// Select last cell and move up
+		// Last cell down -> no change
 		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
-		// Verify cell moved up
 		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 1');
 	});
 
-	test('Boundary: Cannot move first cell up', async function ({ app }) {
+	test('Multi-move: move first to end then one up', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
-
-		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-
-		// Select first cell and try to move up (should be no-op)
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
-
-		// Verify order hasn't changed
-		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-	});
-
-	test('Boundary: Cannot move last cell down', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-
-		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-
-		// Select last cell and try to move down (should be no-op)
-		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
-
-		// Verify order hasn't changed
-		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-	});
-
-	test('Move cell multiple times', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 4 cells
 		await notebooksPositron.newNotebook(4);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2', '# Cell 3']);
 
 		// Move Cell 0 down three times to end
 		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0', '# Cell 2', '# Cell 3']);
 
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 2', '# Cell 0', '# Cell 3']);
 
-		await app.code.driver.page.keyboard.press('Alt+ArrowDown');
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 3');
-		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 0');
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 2', '# Cell 3', '# Cell 0']);
 
 		// Now move it back up
-		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 3');
+		await keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 2', '# Cell 0', '# Cell 3']);
 	});
 
 	test('Undo/redo cell move operation', async function ({ app, hotKeys }) {
 		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 3 cells
 		await notebooksPositron.newNotebook(3);
-
-		// Verify initial order
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// Move cell 1 up
 		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
-		await app.code.driver.page.keyboard.press('Alt+ArrowUp');
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0', '# Cell 2']);
 
 		// Undo the move
-		await hotKeys.undo();
-		await app.code.driver.page.waitForTimeout(500);
-
-		// Verify order is restored
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.performCellAction('undo');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// Redo the move
-		await hotKeys.redo();
-		await app.code.driver.page.waitForTimeout(500);
-
-		// Verify order is changed again
-		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
-		await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 0');
-		await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
+		await notebooksPositron.performCellAction('redo');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0', '# Cell 2']);
 	});
 });


### PR DESCRIPTION
### Summary

Small modifications to the cell order test for new notebooks focusing on keeping our suite lean while maintaining coverage:
* Retained the same test coverage but consolidated it.
    * Merged boundary tests (2) into one.
    * Eliminated the basic cell tests (2) since the multi-directional movement of a cell indirectly covers those.
* Introduced a helper to utilize the “more options” menu.
* Added a helper for verifying multiple cell values.

### QA Notes

@:positron-notebooks

