### PR TITLE
Check `positron.assistant.enable` before turning on console Assistant actions

### DIFF
--- a/src/vs/base/browser/positronReactHooks.tsx
+++ b/src/vs/base/browser/positronReactHooks.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePositronReactServicesContext } from './positronReactRendererContext.js';
+import { ContextKeyValue } from '../../platform/contextkey/common/contextkey.js';
 
 
 /**
@@ -26,6 +27,30 @@ export const usePositronConfiguration = <T,>(key: string, watch: boolean = true)
 		});
 		return () => disposable.dispose();
 	}, [configurationService, key, watch]);
+
+	return value;
+}
+
+/**
+ * usePositronContextKey hook.
+ * @param key Context key to retrieve.
+ * @param watch Whether to watch for changes. Default true.
+ * @returns The context value.
+ */
+export const usePositronContextKey = <T extends ContextKeyValue,>(key: string, watch: boolean = true): T | undefined => {
+	const { contextKeyService } = usePositronReactServicesContext();
+	const [value, setValue] = useState(() => contextKeyService.getContextKeyValue<T>(key));
+
+	useEffect(() => {
+		if (!watch) {
+			return;
+		}
+		const disposable = contextKeyService.onDidChangeContext(e => {
+			const keySet = new Set([key]);
+			e.affectsSome(keySet) && setValue(contextKeyService.getContextKeyValue<T>(key));
+		});
+		return () => disposable.dispose();
+	}, [contextKeyService, key, watch]);
 
 	return value;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -35,7 +35,9 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	const [showTraceback, setShowTraceback] = useState(false);
 
 	// Configuration hooks.
-	const showAssistantActions = usePositronConfiguration<boolean>('positron.assistant.consoleActions.enable');
+	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
+	const enableAssistantActions = usePositronConfiguration<boolean>('positron.assistant.consoleActions.enable');
+	const showAssistantActions = enableAssistant && enableAssistantActions;
 
 	// Traceback useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -15,7 +15,7 @@ import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
 import { ActivityItemErrorMessage } from '../../../../services/positronConsole/browser/classes/activityItemErrorMessage.js';
 import { ConsoleQuickFix } from './activityErrorQuickFix.js';
-import { usePositronConfiguration } from '../../../../../base/browser/positronReactHooks.js';
+import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
 
 // ActivityErrorProps interface.
 export interface ActivityErrorMessageProps {
@@ -37,7 +37,8 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	// Configuration hooks.
 	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
 	const enableAssistantActions = usePositronConfiguration<boolean>('positron.assistant.consoleActions.enable');
-	const showAssistantActions = enableAssistant && enableAssistantActions;
+	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
+	const showAssistantActions = enableAssistant && hasChatModels && enableAssistantActions;
 
 	// Traceback useEffect.
 	useEffect(() => {


### PR DESCRIPTION
This PR cherry picks #9921 to the `prerelease/2025.10` branch so that we can do a patch release, if we decide we want to. This is a fairly low risk, minimal change that I think the Workbench team could take in their release.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed the behavior of Assistant’s Console actions when Assistant is not enabled at all.


### QA Notes

If you have a very fresh build of Positron with no state and you have _not_ enabled Positron Assistant, then code that errors (for example, `data[1]` in R) should return an error and traceback but _no_ Fix/Explain decorations.
