### PR TITLE
Assistant: Fix for streaming selection edits

### DIFF
--- a/extensions/positron-assistant/src/replaceSelectionProcessor.ts
+++ b/extensions/positron-assistant/src/replaceSelectionProcessor.ts
@@ -91,8 +91,8 @@ export class ReplaceSelectionProcessor {
 			this._response.textEdit(this._uri, vscode.TextEdit.delete(this._selection));
 			this._didDeleteSelection = true;
 
-			// Update the insert position to the end of the deleted text.
-			this._insertPosition = this._selection.anchor;
+			// Update the insert position to the start of the removed text.
+			this._insertPosition = this._selection.start;
 		}
 
 		// Insert the new chunk at the start of the selection.


### PR DESCRIPTION
 * Addresses #9929.

### QA Notes

1. Ensure streaming edits are enabled:
```
 "positron.assistant.streamingEdits.enable": true,
```

2. Select a multi-line block of code where several lines of documentation can be added. I found that a TypeScript type definition was a good test.
 
4. Invoke the inline editor, and use the `/doc` command.

5. Documentation should be added cleanly via streaming edits:

<img width="1018" height="464" alt="Screenshot 2025-10-13 at 14 03 13" src="https://github.com/user-attachments/assets/2c1b877e-382f-4a42-88c5-1245d3026927" />

6. Try this twice. First by selecting the code block from the start to the end of the selection. Then again from the end to the start. i.e. test with the final cursor position at the start and end of the selected block.
