### PR TITLE
Add R workspace autosave

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -163,6 +163,12 @@
             "default": false,
             "description": "%r.configuration.restoreWorkspace.description%"
           },
+          "positron.r.saveWorkspace": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.saveWorkspace.description%"
+          },
           "positron.r.quietMode": {
             "scope": "window",
             "type": "boolean",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -55,6 +55,7 @@
 	"r.configuration.profile.description": "Whether and how to profile Ark. Set to '*' for everything, '*>50' for all contexts taking more than 50ms, or 'foo>50' for contexts matching 'foo' taking more than 50ms (restart Positron to apply).",
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",
 	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (restart Positron to apply)",
+	"r.configuration.saveWorkspace.description": "Save the workspace to .RData on exit (restart Positron to apply)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",
 	"r.configuration.quietMode.description": "Run R in quiet mode, to suppress initial copyright and welcome messages (restart Positron to apply)",
 	"r.configuration.pipe": "String to insert as the pipe operator",

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -149,6 +149,14 @@ export function createJupyterKernelSpec(
 		kernelSpec.argv.push('--no-restore-data');
 	}
 
+	// If the user has chosen to save the workspace, pass the
+	// `--save` flag to R, otherwise, pass `--no-save`.
+	if (config.get<boolean>('saveWorkspace')) {
+		kernelSpec.argv.push('--save');
+	} else {
+		kernelSpec.argv.push('--no-save');
+	}
+
 	// If the user has supplied extra arguments to R, pass them along.
 	const extraArgs = config.get<Array<string>>('extraArguments');
 	const quietMode = config.get<boolean>('quietMode');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add workspace autosave to the `.RData` of the working directory, that can be opted-in through settings (Resolves #964)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

The PR alone does not work for Windows, as there is a problem propagating the arguments to the R runtime (#9927).