### PR TITLE
e2e: fix for delete sessions native menu

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -116,7 +116,7 @@ export class Workbench {
 		this.console = new Console(code, this.quickInput, this.quickaccess, this.hotKeys, this.contextMenu);
 		this.modals = new Modals(code, this.toasts, this.console);
 		this.clipboard = new Clipboard(code, this.hotKeys);
-		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console);
+		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console, this.contextMenu);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess, this.hotKeys);
 		this.notebooksVscode = new VsCodeNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys);
 		this.notebooksPositron = new PositronNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys, this.clipboard);

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -28,12 +28,12 @@ export class ContextMenu {
 	 * @param menuItemLabel The label of the menu item to click
 	 * @param menuItemType The type of the menu item, either 'menuitemcheckbox' or 'menuitem'
 	 */
-	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem' }: ContextMenuClick): Promise<void> {
+	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem', menuTriggerButton = 'left' }: ContextMenuClick): Promise<void> {
 		await test.step(`Trigger context menu and click '${menuItemLabel}'`, async () => {
 			if (this.isNativeMenu) {
-				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel });
+				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
-				await menuTrigger.click();
+				await menuTrigger.click({ button: menuTriggerButton });
 
 				// Hover over the menu item
 				const menuItem = menuItemType === 'menuitemcheckbox'
@@ -157,9 +157,9 @@ export class ContextMenu {
 	 * @param menuTrigger The locator that will trigger the context menu when clicked
 	 * @param menuItemLabel The label of the menu item to click
 	 */
-	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel }: Omit<ContextMenuClick, 'menuItemType'>): Promise<void> {
+	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton = 'left' }: Omit<ContextMenuClick, 'menuItemType'> & { clickButton?: ClickButton }): Promise<void> {
 		// Show the context menu by clicking on the trigger element
-		const menuItems = await this.showContextMenu(() => menuTrigger.click());
+		const menuItems = await this.showContextMenu(() => menuTrigger.click({ button: menuTriggerButton }));
 
 		// Handle the menu interaction once it's shown
 		if (menuItems) {
@@ -195,9 +195,11 @@ export class ContextMenu {
 	}
 }
 
+type ClickButton = 'left' | 'right' | 'middle';
 
 interface ContextMenuClick {
 	menuTrigger: Locator;
 	menuItemLabel: string | RegExp;
 	menuItemType?: 'menuitemcheckbox' | 'menuitem';
+	menuTriggerButton?: ClickButton;
 }

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import test, { expect, Locator, Page } from '@playwright/test';
-import { Code, QuickAccess, Console } from '../infra';
+import { Code, QuickAccess, Console, ContextMenu } from '../infra';
 import { QuickInput } from './quickInput';
 
 // Lazy getters for environment variables - these will be evaluated when accessed, not at module load time
@@ -44,7 +44,7 @@ export class Sessions {
 	private consoleInstance = (sessionId: string) => this.page.getByTestId(`console-${sessionId}`);
 	private outputChannel = this.page.getByRole('combobox');
 
-	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput, private console: Console) { }
+	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput, private console: Console, private contextMenu: ContextMenu) { }
 
 	// -- Actions --
 
@@ -499,7 +499,7 @@ export class Sessions {
 			await this.console.focus();
 			await this.code.driver.page.mouse.move(0, 0);
 			await expect(this.page.locator('text=/^Starting up|^Starting|^Preparing|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
-		})
+		});
 	}
 
 	/**
@@ -754,11 +754,11 @@ export class Sessions {
 			await this.console.focus();
 			const sessionTab = this.getSessionTab(sessionId);
 
-			// open the context menu and select "Delete"
-			await sessionTab.click({ button: 'right' });
-			await this.deleteMenuItem.hover();
-			await this.page.waitForTimeout(500);
-			await this.deleteMenuItem.click();
+			await this.contextMenu.triggerAndClick({
+				menuTrigger: sessionTab,
+				menuTriggerButton: 'right',
+				menuItemLabel: 'Delete'
+			});
 		});
 	}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -30,7 +30,7 @@ export class Sessions {
 	currentSessionTab = this.sessionTabs.filter({ has: this.page.locator('.tab-button--active') });
 	sessionPicker = this.page.locator('[id="workbench.parts.positron-top-action-bar"]').locator('.action-bar-region-right').getByRole('button').first();
 	private renameMenuItem = this.page.getByRole('menuitem', { name: 'Rename...' });
-	private deleteMenuItem = this.page.getByRole('menuitem', { name: 'Delete' });
+	deleteMenuItem = this.page.getByRole('menuitem', { name: 'Delete' });
 
 	// Session status indicators
 	private activeStatus = (session: Locator) => session.locator(ACTIVE_STATUS_ICON);


### PR DESCRIPTION
### Summary

In our e2e tests, updating the delete session method to be able to handle native menus as well.


### QA Notes

Confirmed tests passed locally: `e2e-electron` (native menus), `e2e-chromium`.

@:sessions