### PR TITLE
Prefer lib64 R_HOME on 64-bit linux

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -6,7 +6,7 @@
 import * as semver from 'semver';
 import * as path from 'path';
 import * as fs from 'fs';
-import { extractValue, readLines, removeSurroundingQuotes } from './util';
+import { extractValue, readLines, isExecutable, removeSurroundingQuotes } from './util';
 import { LOGGER } from './extension';
 import { MINIMUM_R_VERSION } from './constants';
 import { arePathsSame } from './path-utils';
@@ -264,8 +264,9 @@ export class RInstallation {
 export function getRHomePath(binpath: string): string | undefined {
 	switch (process.platform) {
 		case 'darwin':
+			return getRHomePathDarwin(binpath);
 		case 'linux':
-			return getRHomePathNotWindows(binpath);
+			return getRHomePathLinux(binpath);
 		case 'win32':
 			return getRHomePathWindows(binpath);
 		default:
@@ -273,7 +274,7 @@ export function getRHomePath(binpath: string): string | undefined {
 	}
 }
 
-function getRHomePathNotWindows(binpath: string): string | undefined {
+function getRHomePathDarwin(binpath: string): string | undefined {
 	const binLines = readLines(binpath);
 	const re = new RegExp('Shell wrapper for R executable');
 	if (!binLines.some(x => re.test(x))) {
@@ -287,6 +288,27 @@ function getRHomePathNotWindows(binpath: string): string | undefined {
 	}
 	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
 	// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
+	const R_HOME_DIR = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
+	const homepath = R_HOME_DIR;
+	if (homepath === '') {
+		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
+		return undefined;
+	}
+	return homepath;
+}
+
+function getRHomePathLinux(binpath: string): string | undefined {
+	const binLines = readLines(binpath);
+	const re = new RegExp('Shell wrapper for R executable');
+	if (!binLines.some(x => re.test(x))) {
+		LOGGER.info(`Binary is not a shell script wrapping the executable: ${binpath}`);
+		return undefined;
+	}
+	const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
+	if (!targetLine) {
+		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
+		return undefined;
+	}
 	// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
 	// On linux we have seen the path surrounded with double quotes, which must be removed (#3696).
 	const R_HOME_DIR = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
@@ -294,6 +316,40 @@ function getRHomePathNotWindows(binpath: string): string | undefined {
 	if (homepath === '') {
 		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
 		return undefined;
+	}
+
+	// on linux 64bit machines, lib64 is preferred over lib
+	// "/usr/lib64/R" <-- we prefer this, if both are present
+	// "/usr/lib/R"
+	const testLine = binLines.find(line => line.match('if test "\\${R_HOME_DIR}" = ".*"; then'));
+	if (!testLine) {
+		LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
+		return undefined;
+	}
+	const testPathMatch = testLine.match('= "(.*)"; then');
+	if (!testPathMatch) {
+		LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
+		return undefined;
+	}
+	const testPath = testPathMatch[1]
+	if (testPath != R_HOME_DIR) {
+		return homepath;
+	}
+	const prefixMatch = testPath.match('(.*)\/.*\/R');
+	if (!prefixMatch) {
+		LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
+		return undefined;
+	}
+	const prefix = prefixMatch[1]
+	const libnn = ['x64', 'arm64', 'ppc64', 's390x'].includes(process.arch) ? 'lib64' : 'lib';
+	const libnnFallback = libnn === 'lib64' ? 'lib' : 'lib64';
+	const libnnPath = path.join(prefix, libnn, 'R/bin/exec/R')
+	const libnnFallbackPath = path.join(prefix, libnnFallback, 'R/bin/exec/R')
+	if (isExecutable(libnnPath)) {
+		return path.join(prefix, libnn, "R");
+	}
+	if (isExecutable(libnnFallbackPath)) {
+		return path.join(prefix, libnnFallback, "R");
 	}
 	return homepath;
 }

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -341,8 +341,20 @@ function getRHomePathLinux(binpath: string): string | undefined {
 		return undefined;
 	}
 	const prefix = prefixMatch[1]
-	const libnn = ['x64', 'arm64', 'ppc64', 's390x'].includes(process.arch) ? 'lib64' : 'lib';
-	const libnnFallback = libnn === 'lib64' ? 'lib' : 'lib64';
+    // Replicating special linux logic in R's official shell script
+    // https://github.com/wch/r-source/blob/8898619c430a383ceb401dee3e492ba386ea5967/src/scripts/R.sh.in#L5C1-L27C3
+    const is64BitArch = [
+        // Actual values returned by Node.js process.arch
+        'x64',      // Node.js equivalent of x86_64
+        'arm64',    // not in official shell script (but maybe should be?)
+        'ppc64',    // PowerPC 64-bit
+        's390x',    // IBM System z
+        // Remaining values from official script values, just to be safe
+        'x86_64', 'mips64', 'powerpc64', 'sparc64'
+].includes(process.arch);
+
+    const libnn = is64BitArch ? 'lib64' : 'lib';
+    const libnnFallback = is64BitArch ? 'lib' : 'lib64';
 	const libnnPath = path.join(prefix, libnn, 'R/bin/exec/R')
 	const libnnFallbackPath = path.join(prefix, libnnFallback, 'R/bin/exec/R')
 	if (isExecutable(libnnPath)) {

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -53,6 +53,15 @@ export function readLines(pth: string): Array<string> {
 	}
 }
 
+export function isExecutable(filePath: string): boolean {
+	try {
+		fs.accessSync(filePath, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 // extractValue('KEY=VALUE', 'KEY')      --> 'VALUE'
 // extractValue('KEY:VALUE', 'KEY', ':') --> 'VALUE'
 // extractValue('KEE:VALUE', 'KEY')      --> ''


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Addresses #8453. Positron provides information about the R binary to ark so that it can start the R kernel. Currently on linux and mac it does this by reading [this line from R binary](https://github.com/wch/r-source/blob/8898619c430a383ceb401dee3e492ba386ea5967/src/scripts/R.sh.in#L4C1-L4C32).

```bash
R_HOME_DIR="@abs_top_builddir@"
``` 

[Positron code](https://github.com/posit-dev/positron/blob/acfdbe51cd9542018985e2d17fe828c4b72013a5/extensions/positron-r/src/r-installation.ts#L276C1-L299C2):
```typescript
function getRHomePathNotWindows(binpath: string): string | undefined {
	const binLines = readLines(binpath);
	const re = new RegExp('Shell wrapper for R executable');
	if (!binLines.some(x => re.test(x))) {
		LOGGER.info(`Binary is not a shell script wrapping the executable: ${binpath}`);
		return undefined;
	}
	const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
	if (!targetLine) {
		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
		return undefined;
	}
	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
	// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
	// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
	// On linux we have seen the path surrounded with double quotes, which must be removed (#3696).
	const R_HOME_DIR = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
	const homepath = R_HOME_DIR;
	if (homepath === '') {
		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
		return undefined;
	}
	return homepath;
}
```

but if you look a little bit further, you can see there's some [additional logic](https://github.com/wch/r-source/blob/8898619c430a383ceb401dee3e492ba386ea5967/src/scripts/R.sh.in#L5C1-L27C3) to determine the R_HOME path. 

```bash
if test "${R_HOME_DIR}" = "@prefix@/@LIBnn@/R"; then
   case "@R_OS@" in
   linux*)
     run_arch=`uname -m`
     case "$run_arch" in
        x86_64|mips64|ppc64|powerpc64|sparc64|s390x)
          libnn=lib64
          libnn_fallback=lib
        ;;
        *)
          libnn=lib
          libnn_fallback=lib64
        ;;
     esac
     if [ -x "@prefix@/${libnn}/R/bin/exec/R" ]; then
        R_HOME_DIR="@prefix@/${libnn}/R"
     elif [ -x "@prefix@/${libnn_fallback}/R/bin/exec/R" ]; then
        R_HOME_DIR="@prefix@/${libnn_fallback}/R"
     ## else -- leave alone (might be a sub-arch)
     fi
     ;;
  esac
fi
```

This logic essentially says that on linux 64bit machines, R_HOME paths from "lib64" are preferred before "lib". AKA /usr/lib64/R should be checked before /usr/lib/R.

This pull request implements that logic when detecting R_HOME which addresses #8453. 

Before:
<img width="768" height="156" alt="image" src="https://github.com/user-attachments/assets/547a625b-08e9-48e3-b38c-6f112d4bd2e8" />

After:
<img width="376" height="129" alt="image" src="https://github.com/user-attachments/assets/97f11584-8178-4eb6-8414-77bc429e5099" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- On linux 64-bit distros, "lib64" R_HOME paths are detected before "lib" R_HOME paths.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
