### PR TITLE
Fix Positron notebook markdown cell focus bugs

### DIFF
--- a/src/vs/base/browser/positron/renderHtml.tsx
+++ b/src/vs/base/browser/positron/renderHtml.tsx
@@ -69,11 +69,12 @@ export const renderHtml = (html: string, opts: HTMLRendererOptions = {}): React.
 
 		if (node.type === 'text') {
 			// Create <span> elements to host the text content.
-			if (node.content && node.content.trim().length > 0) {
+			// Preserve all text content, including whitespace-only nodes, as they may be
+			// semantically significant (e.g., spaces between inline elements).
+			if (node.content && node.content.length > 0) {
 				return React.createElement('span', {}, node.content);
 			}
-			// Text nodes with no content (or only whitespae content) are
-			// currently ignored.
+			// Only ignore truly empty text nodes (null, undefined, or empty string).
 			return undefined;
 		} else if (node.type === 'tag' && node.children) {
 			if (node.children.length === 1 && node.children[0].type === 'text') {

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { escape } from '../../../../base/common/strings.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { tokenizeToString } from '../../../../editor/common/languages/textToHtmlTokenizer.js';
+import * as marked from '../../../../base/common/marked/marked.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+
+/**
+ * Renders markdown with theme-aware syntax highlighting for Positron notebooks.
+ * Unlike renderMarkdownDocument, this doesn't sanitize aggressively since notebook
+ * content is trusted and needs to support local image paths.
+ */
+export async function renderNotebookMarkdown(
+	content: string,
+	extensionService: IExtensionService,
+	languageService: ILanguageService
+): Promise<string> {
+	const m = new marked.Marked(
+		markedHighlight({
+			async: true,
+			async highlight(code: string, lang: string): Promise<string> {
+				if (!lang) {
+					return escape(code);
+				}
+
+				await extensionService.whenInstalledExtensionsRegistered();
+
+				const languageId = languageService.getLanguageIdByLanguageName(lang)
+					?? languageService.getLanguageIdByLanguageName(lang.split(/\s+|:|,|(?!^)\{|\?]/, 1)[0]);
+
+				return tokenizeToString(languageService, code, languageId);
+			}
+		})
+	);
+
+	return await m.parse(content, { async: true });
+}
+
+/**
+ * Helper for marked.js syntax highlighting integration.
+ *
+ * NOTE: This code is duplicated from markdownDocumentRenderer.ts (MarkedHighlight namespace)
+ * which itself copied it from https://github.com/markedjs/marked-highlight.
+ *
+ * We duplicate it here rather than modifying upstream code to avoid merge conflicts.
+ * The MarkedHighlight namespace is private in upstream, so we can't import it.
+ *
+ * If VSCode upstream exports this utility in the future, we should use that instead.
+ */
+function markedHighlight(options: marked.MarkedOptions & {
+	highlight: (code: string, lang: string) => string | Promise<string>;
+	async?: boolean;
+}): marked.MarkedExtension {
+	if (!options || typeof options.highlight !== 'function') {
+		throw new Error('Must provide highlight function');
+	}
+
+	return {
+		async: !!options.async,
+		walkTokens(token: marked.Token): Promise<void> | void {
+			if (token.type !== 'code') {
+				return;
+			}
+
+			if (options.async) {
+				return Promise.resolve(options.highlight(token.text, token.lang || '')).then(updateToken(token));
+			}
+
+			const code = options.highlight(token.text, token.lang || '');
+			if (code instanceof Promise) {
+				throw new Error('markedHighlight is not set to async but the highlight function is async.');
+			}
+			updateToken(token)(code);
+		},
+		renderer: {
+			code({ text, lang, escaped }: marked.Tokens.Code) {
+				const classAttr = lang ? ` class="language-${escape(lang)}"` : '';
+				text = text.replace(/\n$/, '');
+				return `<pre><code${classAttr}>${escaped ? text : escape(text)}\n</code></pre>`;
+			},
+		},
+	};
+}
+
+function updateToken(token: any) {
+	return (code: string) => {
+		if (typeof code === 'string' && code !== token.text) {
+			token.escaped = true;
+			token.text = code;
+		}
+	};
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
@@ -16,6 +16,8 @@ import { ExternalLink } from '../../../../../base/browser/ui/ExternalLink/Extern
 import { localize } from '../../../../../nls.js';
 import { createCancelablePromise, raceTimeout } from '../../../../../base/common/async.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { renderNotebookMarkdown } from '../markdownRenderer.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
 
 /**
  * Component that render markdown content from a string.
@@ -56,7 +58,7 @@ function useMarkdown(content: string): MarkdownRenderResults {
 	React.useEffect(() => {
 
 		const conversionCancellablePromise = createCancelablePromise(() => raceTimeout(
-			services.commandService.executeCommand('markdown.api.render', content),
+			renderNotebookMarkdown(content, services.get(IExtensionService), services.languageService),
 			5000,
 		));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -110,10 +110,11 @@ export function NotebookCellWrapper({ cell, actionBarChildren, children }: {
 				return;
 			}
 
+			// If already selected, do nothing - maintain selection invariant
 			if (selectionStatus === CellSelectionStatus.Selected) {
-				cell.deselect();
 				return;
 			}
+
 			const addMode = e.shiftKey || e.ctrlKey || e.metaKey;
 			selectionStateMachine.selectCell(cell, addMode ? CellSelectionType.Add : CellSelectionType.Normal);
 		}}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -15,9 +15,11 @@ import { useObservedValue } from '../useObservedValue.js';
 import { Markdown } from './Markdown.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookMarkdownCell } from '../PositronNotebookCells/PositronNotebookMarkdownCell.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 
 export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownCell }) {
 
+	const notebookInstance = useNotebookInstance();
 	const markdownString = useObservedValue(cell.markdownString);
 	const editorShown = useObservedValue(cell.editorShown);
 
@@ -29,14 +31,21 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 				{editorShown ? <CellEditorMonacoWidget cell={cell} /> : null}
 			</div>
 			<div className='cell-contents positron-notebook-cell-outputs'>
-				<div className='positron-notebook-markup-rendered' onDoubleClick={() => {
-					cell.toggleEditor();
-				}}>
+				<div
+					className='positron-notebook-markup-rendered'
+					onDoubleClick={(e) => {
+						// Prevent bubbling to wrapper's onClick and default browser behavior
+						e.stopPropagation();
+						e.preventDefault();
+						// Enter edit mode for this cell
+						notebookInstance.selectionStateMachine.enterEditor(cell);
+					}}
+				>
 					{
 						markdownString.length > 0 ?
 							<Markdown content={markdownString} />
 							: <div className='empty-output-msg'>
-								Empty markup cell. {editorShown ? '' : 'Double click to edit'}
+								Empty markup cell. {editorShown ? '' : 'Double click to edit.'}
 							</div>
 					}
 				</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -39,7 +39,11 @@ export function NotebookCellMoreActionsMenu({
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 	const commandService = usePositronReactServicesContext().commandService;
-	const showMoreActionsMenu = () => {
+	const showMoreActionsMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
+		// Prevent click from bubbling to cell wrapper which would deselect the cell
+		e.preventDefault();
+		e.stopPropagation();
+
 		if (!buttonRef.current) {
 			return;
 		}


### PR DESCRIPTION
Addresses #9877, #9909, and #9849.

### Summary

This is a general bug-bash pr for markdown rendering in positron notebooks. It addresses two focus-related bugs and improves markdown syntax highlighting in Positron notebooks.

1. **Double-clicking to edit markdown cells loses focus** (#9877): When double-clicking a collapsed markdown cell to enter edit mode, focus would jump to the top of the notebook instead of entering the editor. This was caused by a race condition where the Monaco editor's model wasn't fully loaded before attempting to focus.

2. **Ellipsis button click causes focus jump** (#9909): Clicking the ellipsis (more actions) button on a collapsed markdown cell would cause focus to jump to the top of the notebook. This occurred because the button's click event wasn't stopped from propagating to the cell wrapper, which triggered cell deselection logic.

3. **Markdown syntax highlighting*: Markdown code blocks in notebook cells now use VSCode's tokenization system with `.mtk*` classes that automatically match the current theme etc.. This avoids needing to call to an async command and speeds up rendering/ makes it more debugable. 

## Old
<img width="956" height="1085" alt="image" src="https://github.com/user-attachments/assets/be289fd1-f98e-4eef-b700-47a6930f8d09" />


## New look
<img width="932" height="936" alt="image" src="https://github.com/user-attachments/assets/82704ea4-290a-4c25-8761-99fdf8104b15" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

**Markdown cell focus behavior:**
- Test double-clicking and pressing Enter on collapsed markdown cells to enter edit mode
- Verify focus stays in the editor and doesn't jump to the top of the notebook
- Test rapid cell navigation while markdown editor is loading

**Markdown cell action buttons:**
- Test clicking the ellipsis (...) button and other action buttons on collapsed markdown cells
- Verify focus remains stable and menus appear correctly

**Markdown syntax highlighting:**
- Test markdown cells with code blocks in various languages (Python, R, JavaScript, etc.)
- Switch between different themes (Dark+, Light+, custom themes)
- Verify syntax highlighting colors update to match the current theme
- Compare with Monaco editor syntax highlighting to ensure colors match
- Test that local image references in markdown cells still render correctly