### PR TITLE
Downgrade Workbench extension to version 1.6.12

### DIFF
--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.6.20",
+			"version": "1.6.12",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "cfc8d2b15f991047a6169c422002505cc93aa04f33e2986319ef2d168a11a49c",
+			"sha256": "8e70f88827add54bb60ea6566dab500558265abe5979d9cafd0df988f5ca759b",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Downgrade the workbench extension to version 1.6.12.

This change uses the values as defined in PR #9546.