### PR TITLE
Update secrets baseline for 2025.10

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1135,7 +1135,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "5b814ca57cd60fe405db9254ede91971a2e15767",
+        "hashed_secret": "ee0889627ab4af479c002f869cc459020a5cf93b",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1619,6 +1619,16 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/api/node/loopbackServer.ts": [
+      {
+        "type": "AWS Access Key",
+        "filename": "src/vs/workbench/api/node/loopbackServer.ts",
+        "hashed_secret": "094ab4147707513f945937285ac0a6ef8472a356",
+        "is_verified": false,
+        "line_number": 184,
+        "is_secret": false
+      }
+    ],
     "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1687,6 +1697,16 @@
         "is_secret": false
       }
     ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 96,
+        "is_secret": false
+      }
+    ],
     "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
@@ -1736,5 +1756,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-01T16:53:43Z"
+  "generated_at": "2025-10-14T21:13:42Z"
 }


### PR DESCRIPTION
Update secrets baseline from running the VSCode Task - detect-secrets - update and audit baseline
