### PR TITLE
Assistant: place instruction from the user very last

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -317,19 +317,15 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			...toLanguageModelChatMessage(context.history),
 		];
 
-		// Add the user's prompt.
-		const userPromptPart = new vscode.LanguageModelTextPart(request.prompt);
-		messages.push(vscode.LanguageModelChatMessage.User([userPromptPart]));
-
 		// Add cache breakpoints to at-most the last 2 user messages.
 		addCacheControlBreakpointPartsToLastUserMessages(messages, 2);
 
 		// Add a user message containing context about the request, workspace, running sessions, etc.
-		// NOTE: We add the context message after the user prompt so that the context message is
-		// not cached. Since the context message is transiently added to each request, caching it
-		// will write a prompt prefix to the cache that will never be read. We will want to keep
-		// an eye on whether the order of user prompt and context message affects model responses.
 		const contextInfo = await attachContextInfo(messages);
+
+		// Add the user's prompt.
+		const userPromptPart = new vscode.LanguageModelTextPart(request.prompt);
+		messages.push(vscode.LanguageModelChatMessage.User([userPromptPart]));
 
 		// Send the request to the language model.
 		const tokenUsage = await this.sendLanguageModelRequest(request, response, token, messages, tools);

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -321,9 +321,12 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		addCacheControlBreakpointPartsToLastUserMessages(messages, 2);
 
 		// Add a user message containing context about the request, workspace, running sessions, etc.
+		// The context message is the second-last message in the chat messages.
 		const contextInfo = await attachContextInfo(messages);
 
 		// Add the user's prompt.
+		// The user's prompt is the last message in the chat messages.
+		// If this ordering changes, also update getUserPrompt for the EchoLanguageModel in extensions/positron-assistant/src/models.ts.
 		const userPromptPart = new vscode.LanguageModelTextPart(request.prompt);
 		messages.push(vscode.LanguageModelChatMessage.User([userPromptPart]));
 

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -149,7 +149,7 @@ suite('PositronAssistantParticipant', () => {
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const c = positronChatContext;
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<context>
 <shell description="Current active shell">
 ${c.shell}
@@ -192,7 +192,7 @@ Today's date is: Wednesday 11 June 2025 at 13:30:00 BST
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Full contents of the file" language="${document.languageId}">
@@ -223,7 +223,7 @@ ${document.getText()}
 		const filePath = vscode.workspace.asRelativePath(folderReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Contents of the directory">
@@ -258,7 +258,7 @@ subfolder/
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<attachments>
 ${attachmentsText}
 <attachment filePath="${filePath}" description="Visible region of the active file" language="${document.languageId}" startLine="${range.start.line + 1}" endLine="${range.end.line + 1}">
@@ -294,7 +294,7 @@ ${document.getText()}
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		const attachmentsText = await readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'attachments.md'), 'utf8');
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<attachments>
 ${attachmentsText}
 <img src="${reference.name}" />
@@ -325,7 +325,7 @@ It should be included in the chat message.`;
 			sinon.assert.calledOnce(sendRequestSpy);
 			const [messages,] = sendRequestSpy.getCall(0).args;
 			assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
-			assertContextMessage(messages.at(-1)!,
+			assertContextMessage(messages.at(-2)!,
 				`<instructions>
 ${llmsTxtContent}
 </instructions>`);
@@ -354,7 +354,7 @@ ${llmsTxtContent}
 		const [messages,] = sendRequestSpy.getCall(0).args;
 		assert.strictEqual(messages.length, DEFAULT_EXPECTED_MESSAGE_COUNT, `Unexpected messages: ${JSON.stringify(messages)}`);
 		const filePath = vscode.workspace.asRelativePath(fileReferenceUri);
-		assertContextMessage(messages.at(-1)!,
+		assertContextMessage(messages.at(-2)!,
 			`<editor description="Current active editor" filePath="${filePath}" language="${document.languageId}" line="${selection.active.line + 1}" column="${selection.active.character + 1}" documentOffset="${document.offsetAt(selection.active)}">
 <document description="Full contents of the active file">
 ${document.getText()}


### PR DESCRIPTION
Addresses #9973.

Here's an example log from this PR with context _before_ the user's instruction: [hi_with_context_before_user_message.log](https://github.com/user-attachments/files/22933950/hi_with_context_before_user_message.log)

Notably, the context is before the most recent user message, and neither have cache breakpoints:

```json
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "<sessions>\nThe user has attached information about their interactive interpreter session below. This session is running alongside the conversation with you in the Positron IDE.\n\n<session>\n{\n  \"identifier\": \"r-9d7cf837\",\n  \"language\": \"R\",\n  \"languageId\": \"r\",\n  \"version\": \"4.5.0\",\n  \"mode\": \"console\",\n  \"executions\": []\n}\n<variables description=\"Variables defined in the current session, in a pipe-delimited format, where each line is `name|kind|display_type|access_key`.\">\nconvert_to_quarto_headers|function|function|convert_to_quarto_headers\nopen_project|function|function|open_project\nprint.data.frame|function|function|print.data.frame\n</variables>\n</session>\n</sessions>\n\n<context>\n<version>\nPositron version: 2025.11.0-0\n</version>\n\n<date>\nToday's date is: Wednesday, October 15, 2025 at 12:57:07 PM CDT\n</date>\n</context>"
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Hi!"
        }
      ]
    }
  ]
```

The system prompt does have `cache_control` set.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

@:assistant

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

* A large majority of tokens in Chat sessions should still be cache reads and writes; only `userPromptPart` is newly uncached.
* For multi-turn conversations, the context shouldn't "accumulate" in the `"messages"` object, and the previous user message should then be written to the cache. e.g.

```json
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Hi!",
          "cache_control": {
            "type": "ephemeral"
          }
        }
      ]
    },
    {
      "role": "assistant",
      "content": [
        {
          "type": "text",
          "text": "Hi! How can I help you with your data science work today?"
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "<sessions>\nThe user has attached information about their interactive interpreter session below. This session is running alongside the conversation with you in the Positron IDE.\n\n<session>\n{\n  \"identifier\": \"r-9d7cf837\",\n  \"language\": \"R\",\n  \"languageId\": \"r\",\n  \"version\": \"4.5.0\",\n  \"mode\": \"console\",\n  \"executions\": []\n}\n<variables description=\"Variables defined in the current session, in a pipe-delimited format, where each line is `name|kind|display_type|access_key`.\">\nconvert_to_quarto_headers|function|function|convert_to_quarto_headers\nopen_project|function|function|open_project\nprint.data.frame|function|function|print.data.frame\n</variables>\n</session>\n</sessions>\n\n<context>\n<version>\nPositron version: 2025.11.0-0\n</version>\n\n<date>\nToday's date is: Wednesday, October 15, 2025 at 01:42:32 PM CDT\n</date>\n</context>"
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Just checking in."
        }
      ]
    }
  ]
```

Noting that "Hi! How can I..." doesn't have a `cache_control`. This is also the case on `main`.