### PR TITLE
Assistant: Sync quick chat configuration with main chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -211,25 +211,7 @@ class QuickChat extends Disposable {
 			this.widget.layoutDynamicChatTreeItemMode();
 		}
 		// --- Start Positron ---
-		// Update with any existing context from other chat widgets
-		// Look for a chat widget that is in a panel and is not a quick chat
-		const widget = this.chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Panel).find(w => w !== this.widget && w.location === ChatAgentLocation.Panel && (!('isQuickChat' in w.viewContext) || !w.viewContext.isQuickChat));
-		if (widget) {
-			// Update console context
-			if (this.widget.input.runtimeContext) {
-				// Set the Console context
-				this.widget.input.runtimeContext.setValue(widget.input.runtimeContext?.value);
-				// Set whether the Console context is enabled
-				this.widget.input.runtimeContext.enabled = widget.input.runtimeContext?.enabled ?? false;
-			}
-			// Update attachments
-			this.widget.attachmentModel.clearAndSetContext(...widget.attachmentModel.attachments);
-			// Update language model
-			const languageModel = widget.input.selectedLanguageModel;
-			if (languageModel) {
-				this.widget.input.setCurrentLanguageModel(languageModel);
-			}
-		}
+		this.syncWithMainChat();
 		// --- End Positron ---
 	}
 
@@ -263,6 +245,9 @@ class QuickChat extends Disposable {
 		this.updateModel();
 		this.sash = this._register(new Sash(parent, { getHorizontalSashTop: () => parent.offsetHeight }, { orientation: Orientation.HORIZONTAL }));
 		this.registerListeners(parent);
+		// --- Start Positron ---
+		this.syncWithMainChat();
+		// --- End Positron ---
 	}
 
 	private get maxHeight(): number {
@@ -385,4 +370,33 @@ class QuickChat extends Disposable {
 
 		this.widget.setModel(this.model, { inputValue: this._currentQuery });
 	}
+	// --- Start Positron ---
+	private syncWithMainChat() {
+		// Update with any existing context from other chat widgets
+		// Look for a chat widget that is in a panel and is not a quick chat
+		const widget = this.chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Panel).find(w => w !== this.widget && w.location === ChatAgentLocation.Panel && (!('isQuickChat' in w.viewContext) || !w.viewContext.isQuickChat));
+		if (widget) {
+			// Update language model
+			const languageModel = widget.input.selectedLanguageModel;
+			if (languageModel) {
+				this.widget.input.setCurrentLanguageModel(languageModel);
+			}
+			// Update implicit context
+			if (widget.input.implicitContext && this.widget.input.implicitContext) {
+				this.widget.input.implicitContext.setValue(widget.input.implicitContext.value, widget.input.implicitContext.isSelection);
+				this.widget.input.implicitContext.enabled = widget.input.implicitContext.enabled;
+			}
+			// Update attachments
+			this.widget.attachmentModel.clearAndSetContext(...widget.attachmentModel.attachments);
+			// Update console context
+			if (this.widget.input.runtimeContext) {
+				// Set the Console context
+				this.widget.input.runtimeContext.setValue(widget.input.runtimeContext?.value);
+				// Set whether the Console context is enabled
+				this.widget.input.runtimeContext.enabled = widget.input.runtimeContext?.enabled ?? false;
+			}
+
+		}
+	}
+	// --- End Positron ---
 }

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -374,26 +374,38 @@ class QuickChat extends Disposable {
 	private syncWithMainChat() {
 		// Update with any existing context from other chat widgets
 		// Look for a chat widget that is in a panel and is not a quick chat
-		const widget = this.chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Panel).find(w => w !== this.widget && w.location === ChatAgentLocation.Panel && (!('isQuickChat' in w.viewContext) || !w.viewContext.isQuickChat));
-		if (widget) {
+		const mainChatWidget = this.chatWidgetService
+			.getWidgetsByLocations(ChatAgentLocation.Panel)
+			.find(w =>
+				// Make sure it's not this quick chat widget
+				w !== this.widget &&
+				// Make sure it's in the panel
+				w.location === ChatAgentLocation.Panel &&
+				(
+					// And that it is not another quick chat
+					!('isQuickChat' in w.viewContext) ||
+					!w.viewContext.isQuickChat
+				)
+			);
+		if (mainChatWidget) {
 			// Update language model
-			const languageModel = widget.input.selectedLanguageModel;
+			const languageModel = mainChatWidget.input.selectedLanguageModel;
 			if (languageModel) {
 				this.widget.input.setCurrentLanguageModel(languageModel);
 			}
 			// Update implicit context
-			if (widget.input.implicitContext && this.widget.input.implicitContext) {
-				this.widget.input.implicitContext.setValue(widget.input.implicitContext.value, widget.input.implicitContext.isSelection);
-				this.widget.input.implicitContext.enabled = widget.input.implicitContext.enabled;
+			if (mainChatWidget.input.implicitContext && this.widget.input.implicitContext) {
+				this.widget.input.implicitContext.setValue(mainChatWidget.input.implicitContext.value, mainChatWidget.input.implicitContext.isSelection);
+				this.widget.input.implicitContext.enabled = mainChatWidget.input.implicitContext.enabled;
 			}
 			// Update attachments
-			this.widget.attachmentModel.clearAndSetContext(...widget.attachmentModel.attachments);
+			this.widget.attachmentModel.clearAndSetContext(...mainChatWidget.attachmentModel.attachments);
 			// Update console context
 			if (this.widget.input.runtimeContext) {
 				// Set the Console context
-				this.widget.input.runtimeContext.setValue(widget.input.runtimeContext?.value);
+				this.widget.input.runtimeContext.setValue(mainChatWidget.input.runtimeContext?.value);
 				// Set whether the Console context is enabled
-				this.widget.input.runtimeContext.enabled = widget.input.runtimeContext?.enabled ?? false;
+				this.widget.input.runtimeContext.enabled = mainChatWidget.input.runtimeContext?.enabled ?? false;
 			}
 
 		}


### PR DESCRIPTION
When invoking the quick chat feature, the session created reverts to defaults for both context & model selections. This can lead to large token use due to wrong files being attached, unexpected visibility of the Console session, and use of the wrong model. This is especially apparent when using Fix & Explain in Console, which launches a query in quick chat without user intervention.

This PR modifies quick chat logic to sync explicit context, implicit context, console visibility, and model selection from the main chat panel when a quick chat is toggled. This behavior syncs these options each time the quick chat is invoked. The data flow is unidirectional, from main to quick... any changes in quick persist until the quick chat is hidden.


https://github.com/user-attachments/assets/291fd252-abbc-47c5-b1a7-7c4863b1f02c

Addresses #9209


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Quick chat now sources model & context from the main chat interface

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Ensure that the quick chat mirrors expected selections made in the main chat interface.

Two separate flows occur for the quick chat widget: render (on first invocation after launch) and show (on subsequent invocations). The logic is the same, but both paths should be verified in case of upstream changes. 

e2e: @:assistant


