### PR TITLE
E2E test: allow one or two instances of "started" in console after reticulate restart

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 
 test.use({
@@ -40,7 +41,19 @@ test.describe('Reticulate', {
 
 		await app.code.driver.page.locator('.positron-modal-dialog-box').getByRole('button', { name: 'Yes' }).click();
 
-		await app.workbench.console.waitForReadyAndStarted('>>>', 30000, 2);
+		// doesn't support 2 or 1 instance of started:
+		// await app.workbench.console.waitForReadyAndStarted('>>>', 30000, 2);
+
+		await test.step('Wait for console to be ready and started', async () => {
+			await app.workbench.console.waitForReady('>>>', 30000);
+
+			const matchingLines = app.code.driver.page.locator('.console-instance[style*="z-index: auto"]  div span').getByText('started');
+
+			await Promise.any([
+				expect(matchingLines).toHaveCount(1, { timeout: 30_000 }),
+				expect(matchingLines).toHaveCount(2, { timeout: 30_000 }),
+			]);
+		});
 
 	});
 });


### PR DESCRIPTION
Depending on the execution environment, the number of "started" instances in console can vary,

### QA Notes

@:reticulate @:web
