### PR TITLE
Fix OpenAI provider id

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -349,7 +349,7 @@
         "managementCommand": "positron-assistant.configureModels"
       },
       {
-        "vendor": "openai",
+        "vendor": "openai-api",
         "displayName": "OpenAI",
         "managementCommand": "positron-assistant.configureModels"
       },

--- a/extensions/positron-assistant/src/completion.ts
+++ b/extensions/positron-assistant/src/completion.ts
@@ -462,7 +462,7 @@ class OpenAICompletion extends FimPromptCompletion {
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Completion,
 		provider: {
-			id: 'openai',
+			id: 'openai-api',
 			displayName: 'OpenAI'
 		},
 		supportedOptions: ['apiKey', 'baseUrl'],
@@ -691,7 +691,7 @@ export function newCompletionProvider(config: ModelConfig): vscode.InlineComplet
 		'google': GoogleCompletion,
 		'mistral': MistralCompletion,
 		'ollama': OllamaCompletion,
-		'openai': OpenAICompletion,
+		'openai-api': OpenAICompletion,
 		'openai-compatible': OpenAICompatibleCompletion,
 		'openai-legacy': OpenAILegacyCompletion,
 		'openrouter': OpenRouterCompletion,

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -658,7 +658,7 @@ class OpenAILanguageModel extends AILanguageModel implements positron.ai.Languag
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Chat,
 		provider: {
-			id: 'openai',
+			id: 'openai-api',
 			displayName: 'OpenAI'
 		},
 		supportedOptions: ['apiKey', 'baseUrl', 'toolCalls'],

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -55,9 +55,8 @@ export const LanguageModelIcon = (props: { provider: string }) => {
 			case 'copilot':
 				return <GithubCopilot className='language-model icon' />;
 			case 'amazon-bedrock': // Vercel API uses this as an id
-			case 'bedrock':
 				return <Bedrock className='language-model icon' />;
-			case 'openai':
+			case 'openai-api':
 				return <OpenAI className='language-model icon' />;
 			case 'error':
 				return <div className={`language-model icon button-icon codicon codicon-error`} />;


### PR DESCRIPTION
Address #9979 

Change the provider id so it doesn't conflict with Copilot Chat. `openai-api` follows the pattern used with Anthropic. I've communicated with Tom on this with his write-up on using OpenAI and compatible providers.

I've also cleaned up the old Bedrock id in the icon component.

I don't think it's necessary to do any migration update handling since this is still hidden by default. Any users will have to update their settings and re-register their provider if they happen to have used the `openai` id.