### PR TITLE
Assistant: Fix R extension llm tools

### DIFF
--- a/extensions/positron-r/src/llm-tools.ts
+++ b/extensions/positron-r/src/llm-tools.ts
@@ -142,7 +142,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 			const vignette = await session.callMethod('get_package_vignette', options.input.packageName, options.input.vignetteName);
 			if (vignette) {
 				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart(vignette.toString()),
+					new vscode.LanguageModelTextPart(JSON.stringify(vignette)),
 				]);
 			} else {
 				return new vscode.LanguageModelToolResult([
@@ -172,7 +172,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 			const helpPage = await session.callMethod('get_help_page', options.input.helpTopic, options.input.packageName);
 			if (helpPage) {
 				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart(helpPage.toString()),
+					new vscode.LanguageModelTextPart(JSON.stringify(helpPage)),
 				]);
 			} else {
 				return new vscode.LanguageModelToolResult([


### PR DESCRIPTION
* Addresses #9990.

Tweaks the R extension's LLM tools to JSON encode the returned help text and vignette objects from the R session.

# QA

1. Load up Assistant.
2. Ask it to read the help page for some R function.
3. Expand the info box.
4. Ensure the help text is emitted in the tool's output.

<img width="455" height="752" alt="Screenshot 2025-10-16 at 10 44 13" src="https://github.com/user-attachments/assets/6da8fba5-858e-4d61-85c3-84f9c3149e68" />
