### PR TITLE
python: ibis update with 11.0.0 release

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -898,7 +898,7 @@ def test_inspect_ibis_exprs() -> None:
 
     test_df = pd.DataFrame({"a": [1, 2, 1, 1, 2], "b": ["foo", "bar", "baz", "qux", None]})
     _, columns = test_df.shape
-    t = ibis.memtable(test_df, name="df")
+    t = ibis.memtable(test_df)
     table_type = "ibis.Table"
 
     verify_inspector(


### PR DESCRIPTION
Last night's [nightly Python CI](https://github.com/posit-dev/positron/actions/runs/18548439473) failed with:

```python
>       t = ibis.memtable(test_df, name="df")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: memtable() got an unexpected keyword argument 'name'
```

There's a new release of ibis 11.0.0, which no longer supports the `name` argument. This is vestigial for testing purposes, since we don't use `name` for anything. So just going to remove it.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Updated Python tests to comply with `ibis-framework==11.0.0`.


### QA Notes

Green CI in this PR and nightly. Kicked off nightly run here: https://github.com/posit-dev/positron/actions/runs/18563888998