### PR TITLE
Assistant: Clarifies vebiage in model configuration affordances

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -525,7 +525,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 			if (!model) {
 				// --- Start Positron ---
 				// TODO: make this more generic once we support more model providers https://github.com/posit-dev/positron/issues/8301
-				throw new Error('No language models available for chat. Please ensure you have logged into Anthropic as a language model provider by clicking `Add Model Provider...` or running the command `Positron Assistant: Configure Language Model Providers` and authenticating with Anthropic.');
+				throw new Error('No language models available for chat. Please ensure you have logged into Anthropic as a language model provider by clicking `Configure Model Providers...` or running the command `Positron Assistant: Configure Language Model Providers` and authenticating with Anthropic.');
 				/*
 				throw new Error('Language model unavailable');
 				*/

--- a/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
+++ b/src/vs/workbench/contrib/chat/browser/positron/chatActionBar.tsx
@@ -19,8 +19,8 @@ interface ChatActionBarProps {
 	onModelSelect: (newLanguageModel: IPositronChatProvider | undefined) => void;
 }
 
-const addModelProviderLabel = () => localize('positronChatSelector.addModelProvider', 'Add Model Provider...');
-const addModelProviderTooltip = () => localize('positronChatSelector.addModelProviderTooltip', 'Add a Language Model Provider');
+const addModelProviderLabel = () => localize('positronChatSelector.addModelProvider', 'Configure Model Providers...');
+const addModelProviderTooltip = () => localize('positronChatSelector.addModelProviderTooltip', 'Add and Configure Language Model Providers');
 
 export const ChatActionBar: React.FC<ChatActionBarProps> = ((props) => {
 	const services = usePositronReactServicesContext();

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -11,7 +11,7 @@ import { Toasts } from './dialog-toasts';
 
 const CHAT_BUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
 const CONFIGURE_MODELS_LINK = 'a[data-href="command:positron-assistant.configureModels"]';
-const ADD_MODEL_BUTTON = '[id="workbench.panel.chat"] button[aria-label="Add Model Provider..."]';
+const ADD_MODEL_BUTTON = '[id="workbench.panel.chat"] button[aria-label="Configure Model Providers..."]';
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
 const CLOSE_BUTTON = 'button.positron-button.action-bar-button.default:has-text("Close")';
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
@@ -80,7 +80,7 @@ export class Assistant {
 
 	async verifyAddModelButtonVisible() {
 		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toBeVisible();
-		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toHaveText('Add Model Provider...');
+		await expect(this.code.driver.page.locator(ADD_MODEL_BUTTON)).toHaveText('Configure Model Providers...');
 	}
 
 	async verifyInlineChatInputsVisible() {


### PR DESCRIPTION
Updates the model provider selector to match verbiage used in existing command:
<img width="1345" height="437" alt="Screenshot 2025-10-16 at 9 26 55 AM" src="https://github.com/user-attachments/assets/0072e6e5-5702-4724-8ba5-1215b6a80700" />

Omitted "Language" for brevity in menu option.

Addresses #9888

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant model picker now reads "Configure Model Providers" to reflect functionality


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
