### PR TITLE
Fix empty editor bug

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -166,6 +166,11 @@ export interface IPositronNotebookCell extends Disposable {
 	attachContainer(container: HTMLElement): void;
 
 	/**
+	 * Get the container that the cell is attached to
+	 */
+	get container(): HTMLElement | undefined;
+
+	/**
 	 *
 	 * @param editor Code editor widget associated with cell.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -143,6 +143,9 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		this._container = container;
 	}
 
+	get container(): HTMLElement | undefined {
+		return this._container;
+	}
 
 	attachEditor(editor: CodeEditorWidget): void {
 		this._editor.set(editor, undefined);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -43,6 +43,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IPositronNotebookService } from './positronNotebookService.js';
 
 
 /**
@@ -91,6 +92,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
 		@IEditorService editorService: IEditorService,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
 	) {
 		// Call the base class's constructor.
 		super(
@@ -275,6 +277,20 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		const scopedContextKeyService = this._renderReact();
 
 		notebookInstance.attachView(this._parentDiv, scopedContextKeyService);
+	}
+
+	/**
+	 * Called when this composite should receive keyboard focus.
+	 */
+	override focus(): void {
+		super.focus();
+
+		// Drive focus into the notebook instance based on selection state
+		if (this.notebookInstance) {
+			// Update the active instance so cell commands target this notebook
+			this._positronNotebookService.setActiveInstance(this.notebookInstance);
+			this.notebookInstance.grabFocus();
+		}
 	}
 
 	override clearInput(): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -43,7 +43,6 @@ import { URI } from '../../../../base/common/uri.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IPositronNotebookService } from './positronNotebookService.js';
 
 
 /**
@@ -92,7 +91,6 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
 		@IEditorService editorService: IEditorService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
 	) {
 		// Call the base class's constructor.
 		super(
@@ -287,8 +285,6 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 
 		// Drive focus into the notebook instance based on selection state
 		if (this.notebookInstance) {
-			// Update the active instance so cell commands target this notebook
-			this._positronNotebookService.setActiveInstance(this.notebookInstance);
 			this.notebookInstance.grabFocus();
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -280,11 +280,6 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	override clearInput(): void {
 		this._logService.info(this._identifier, 'clearInput');
 
-		if (this.notebookInstance && this._parentDiv) {
-			this.notebookInstance.detachView();
-			console.log('isVisible', this._isVisible.get());
-		}
-
 		if (this.notebookInstance) {
 			this.notebookInstance.detachView();
 		}
@@ -353,7 +348,11 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		// Create a scoped context key service rooted at the notebook container so cell scopes inherit it.
 		const scopedContextKeyService = this._containerScopedContextKeyService = this.contextKeyService.createScoped(this._parentDiv);
 
-		const reactRenderer: PositronReactRenderer = this._positronReactRenderer ?? new PositronReactRenderer(this._parentDiv);
+		// Create renderer if it doesn't exist, otherwise reuse existing renderer
+		if (!this._positronReactRenderer) {
+			this._positronReactRenderer = new PositronReactRenderer(this._parentDiv);
+		}
+		const reactRenderer = this._positronReactRenderer;
 
 		reactRenderer.render(
 			<NotebookVisibilityProvider isVisible={this._isVisible}>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -980,6 +980,41 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
+	 * Grabs focus for this notebook based on the current selection state.
+	 * Called when the notebook editor receives focus from the workbench.
+	 *
+	 * Note: This method may be called twice during tab switches:
+	 * - First call: Early, cells may not be rendered yet (no-op via optional chaining)
+	 * - Second call: After render completes, focus succeeds
+	 */
+	grabFocus(): void {
+		const state = this.selectionStateMachine.state.get();
+
+		switch (state.type) {
+			case SelectionState.EditingSelection:
+				// Focus the editor - enterEditor() already has idempotency checks
+				this.selectionStateMachine.enterEditor(state.selected);
+				break;
+
+			case SelectionState.SingleSelection:
+			case SelectionState.MultiSelection: {
+				// Focus the first selected cell's container
+				// Optional chaining handles undefined containers gracefully
+				const cell = state.type === SelectionState.SingleSelection
+					? state.selected
+					: state.selected[0];
+				cell.container?.focus();
+				break;
+			}
+
+			case SelectionState.NoCells:
+				// Fall back to notebook container
+				this._container?.focus();
+				break;
+		}
+	}
+
+	/**
 	 * Clears the outputs of all cells in the notebook.
 	 */
 	clearAllCellOutputs(): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -11,8 +11,9 @@ import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickin
 import { selectKernelIcon } from '../../notebook/browser/notebookIcons.js';
 import { INotebookKernelService, INotebookKernel } from '../../notebook/common/notebookKernelService.js';
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
-import { IPositronNotebookService } from './positronNotebookService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { getActiveNotebook } from './notebookUtils.js';
 
 export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
@@ -38,8 +39,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 	async run(accessor: ServicesAccessor, context?: SelectPositronNotebookKernelContext): Promise<boolean> {
 		const { forceDropdown } = context || { forceDropdown: false };
 		const notebookKernelService = accessor.get(INotebookKernelService);
-		const notebookService = accessor.get(IPositronNotebookService);
-		const activeNotebook = notebookService.getActiveInstance();
+		const activeNotebook = getActiveNotebook(accessor.get(IEditorService));
 		const quickInputService = accessor.get(IQuickInputService);
 
 		if (!activeNotebook) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -13,7 +13,7 @@ import { INotebookKernelService, INotebookKernel } from '../../notebook/common/n
 import { PositronNotebookInstance } from './PositronNotebookInstance.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getActiveNotebook } from './notebookUtils.js';
+import { getNotebookInstanceFromEditorPane } from './notebookUtils.js';
 
 export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
@@ -39,7 +39,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 	async run(accessor: ServicesAccessor, context?: SelectPositronNotebookKernelContext): Promise<boolean> {
 		const { forceDropdown } = context || { forceDropdown: false };
 		const notebookKernelService = accessor.get(INotebookKernelService);
-		const activeNotebook = getActiveNotebook(accessor.get(IEditorService));
+		const activeNotebook = getNotebookInstanceFromEditorPane(accessor.get(IEditorService));
 		const quickInputService = accessor.get(IQuickInputService);
 
 		if (!activeNotebook) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -10,7 +10,7 @@ import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED, POSITRON_NOTEBOOK_CELL_EDIT
 import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { getActiveNotebook } from '../../notebookUtils.js';
+import { getNotebookInstanceFromEditorPane } from '../../notebookUtils.js';
 
 class PositronNotebookUndoRedoContribution extends Disposable {
 
@@ -31,7 +31,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 
 	private shouldHandleUndoRedo(): boolean {
 		// Get the active notebook instance to access its scoped context key service
-		const instance = getActiveNotebook(this.editorService);
+		const instance = getNotebookInstanceFromEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -62,7 +62,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = getActiveNotebook(this.editorService);
+		const instance = getNotebookInstanceFromEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -80,7 +80,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = getActiveNotebook(this.editorService);
+		const instance = getNotebookInstanceFromEditorPane(this.editorService);
 		if (!instance) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -6,10 +6,11 @@
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../common/contributions.js';
 import { UndoCommand, RedoCommand } from '../../../../../../editor/browser/editorExtensions.js';
-import { IPositronNotebookService } from '../../positronNotebookService.js';
 import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
 import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { getActiveNotebook } from '../../notebookUtils.js';
 
 class PositronNotebookUndoRedoContribution extends Disposable {
 
@@ -17,7 +18,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 
 	constructor(
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
-		@IPositronNotebookService private readonly positronNotebookService: IPositronNotebookService,
+		@IEditorService private readonly editorService: IEditorService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) {
 		super();
@@ -30,7 +31,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 
 	private shouldHandleUndoRedo(): boolean {
 		// Get the active notebook instance to access its scoped context key service
-		const instance = this.positronNotebookService.getActiveInstance();
+		const instance = getActiveNotebook(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -61,7 +62,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = this.positronNotebookService.getActiveInstance();
+		const instance = getActiveNotebook(this.editorService);
 		if (!instance) {
 			return false;
 		}
@@ -79,7 +80,7 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const instance = this.positronNotebookService.getActiveInstance();
+		const instance = getActiveNotebook(this.editorService);
 		if (!instance) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -5,7 +5,6 @@
 
 import { CommandsRegistry, ICommandMetadata } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IPositronNotebookService } from '../../positronNotebookService.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { NotebookCellActionBarRegistry, INotebookCellActionBarItem } from './actionBarRegistry.js';
 import { IDisposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
@@ -15,6 +14,8 @@ import { IPositronNotebookCommandKeybinding } from './commandUtils.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { getSelectedCell, getSelectedCells, getEditingCell } from '../../selectionMachine.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { getActiveNotebook } from '../../notebookUtils.js';
 
 /**
  * Options for registering a cell command.
@@ -80,8 +81,8 @@ export function registerCellCommand({
 	const commandDisposable = CommandsRegistry.registerCommand({
 		id: commandId,
 		handler: (accessor: ServicesAccessor) => {
-			const notebookService = accessor.get(IPositronNotebookService);
-			const activeNotebook = notebookService.getActiveInstance();
+			const editorService = accessor.get(IEditorService);
+			const activeNotebook = getActiveNotebook(editorService);
 			if (!activeNotebook) {
 				return;
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -15,7 +15,7 @@ import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { getSelectedCell, getSelectedCells, getEditingCell } from '../../selectionMachine.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { getActiveNotebook } from '../../notebookUtils.js';
+import { getNotebookInstanceFromEditorPane } from '../../notebookUtils.js';
 
 /**
  * Options for registering a cell command.
@@ -82,7 +82,7 @@ export function registerCellCommand({
 		id: commandId,
 		handler: (accessor: ServicesAccessor) => {
 			const editorService = accessor.get(IEditorService);
-			const activeNotebook = getActiveNotebook(editorService);
+			const activeNotebook = getNotebookInstanceFromEditorPane(editorService);
 			if (!activeNotebook) {
 				return;
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
@@ -14,7 +14,7 @@ import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js
  * @param editorService The editor service
  * @returns The active notebook instance, or undefined if no Positron notebook is active
  */
-export function getActiveNotebook(editorService: IEditorService): IPositronNotebookInstance | undefined {
+export function getNotebookInstanceFromEditorPane(editorService: IEditorService): IPositronNotebookInstance | undefined {
 	const activeEditorPane = editorService.activeEditorPane;
 
 	// Check if the active editor is a Positron Notebook Editor

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { PositronNotebookEditor } from './PositronNotebookEditor.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+
+/**
+ * Retrieves the active Positron notebook instance from the editor service.
+ *
+ * @param editorService The editor service
+ * @returns The active notebook instance, or undefined if no Positron notebook is active
+ */
+export function getActiveNotebook(editorService: IEditorService): IPositronNotebookInstance | undefined {
+	const activeEditorPane = editorService.activeEditorPane;
+
+	// Check if the active editor is a Positron Notebook Editor
+	if (!activeEditorPane || activeEditorPane.getId() !== POSITRON_NOTEBOOK_EDITOR_ID) {
+		return undefined;
+	}
+
+	// Extract the notebook instance from the editor
+	const activeNotebook = (activeEditorPane as PositronNotebookEditor).notebookInstance;
+	return activeNotebook;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
@@ -36,13 +36,6 @@ export interface IPositronNotebookService {
 	getActiveInstance(): IPositronNotebookInstance | null;
 
 	/**
-	 * Set the currently active notebook instance.
-	 * This should be called when a notebook editor receives focus.
-	 * @param instance The instance to set as active.
-	 */
-	setActiveInstance(instance: IPositronNotebookInstance): void;
-
-	/**
 	 * Register a new notebook instance.
 	 * @param instance The instance to register.
 	 */
@@ -99,10 +92,6 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 
 	public getActiveInstance(): IPositronNotebookInstance | null {
 		return this._activeInstance;
-	}
-
-	public setActiveInstance(instance: IPositronNotebookInstance): void {
-		this._activeInstance = instance;
 	}
 
 	public registerInstance(instance: IPositronNotebookInstance): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
@@ -36,6 +36,13 @@ export interface IPositronNotebookService {
 	getActiveInstance(): IPositronNotebookInstance | null;
 
 	/**
+	 * Set the currently active notebook instance.
+	 * This should be called when a notebook editor receives focus.
+	 * @param instance The instance to set as active.
+	 */
+	setActiveInstance(instance: IPositronNotebookInstance): void;
+
+	/**
 	 * Register a new notebook instance.
 	 * @param instance The instance to register.
 	 */
@@ -92,6 +99,10 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 
 	public getActiveInstance(): IPositronNotebookInstance | null {
 		return this._activeInstance;
+	}
+
+	public setActiveInstance(instance: IPositronNotebookInstance): void {
+		this._activeInstance = instance;
 	}
 
 	public registerInstance(instance: IPositronNotebookInstance): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
@@ -31,11 +31,6 @@ export interface IPositronNotebookService {
 	listInstances(uri?: URI): Array<IPositronNotebookInstance>;
 
 	/**
-	 * Get the currently active notebook instance, if it exists.
-	 */
-	getActiveInstance(): IPositronNotebookInstance | null;
-
-	/**
 	 * Register a new notebook instance.
 	 * @param instance The instance to register.
 	 */
@@ -68,7 +63,6 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
-		// Call the disposable constrcutor.
 		super();
 	}
 
@@ -88,10 +82,6 @@ class PositronNotebookService extends Disposable implements IPositronNotebookSer
 			instances = instances.filter(instance => isEqual(instance.uri, uri));
 		}
 		return instances;
-	}
-
-	public getActiveInstance(): IPositronNotebookInstance | null {
-		return this._activeInstance;
 	}
 
 	public registerInstance(instance: IPositronNotebookInstance): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
@@ -13,11 +13,12 @@ import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/conte
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { PositronActionBarWidgetRegistry } from '../../../../platform/positronActionBar/browser/positronActionBarWidgetRegistry.js';
-import { IPositronNotebookService } from './positronNotebookService.js';
 import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from './ContextKeysManager.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { getActiveNotebook } from './notebookUtils.js';
 
 /**
  * Keybinding configuration for notebook actions.
@@ -260,8 +261,8 @@ function registerNotebookCommandInternal(options: INotebookCommandOptions): IDis
 	const commandDisposable = CommandsRegistry.registerCommand({
 		id: options.commandId,
 		handler: (accessor: ServicesAccessor) => {
-			const notebookService = accessor.get(IPositronNotebookService);
-			const activeNotebook = notebookService.getActiveInstance();
+			const editorService = accessor.get(IEditorService);
+			const activeNotebook = getActiveNotebook(editorService);
 			if (!activeNotebook) {
 				return;
 			}
@@ -354,11 +355,9 @@ function registerNotebookWidgetInternal(options: INotebookWidgetOptions): IDispo
 		componentFactory: (accessor) => {
 			// Return a wrapper component that provides notebook context
 			return () => {
-				// Get the active notebook instance from the service
-				const notebookService = accessor.get(IPositronNotebookService);
-				const notebook = notebookService.getActiveInstance();
-
-				// If no active notebook, don't render anything
+				// Get the active notebook using the VS Code pattern
+				const editorService = accessor.get(IEditorService);
+				const notebook = getActiveNotebook(editorService);
 				if (!notebook) {
 					return null;
 				}

--- a/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookAction.tsx
@@ -18,7 +18,7 @@ import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getActiveNotebook } from './notebookUtils.js';
+import { getNotebookInstanceFromEditorPane } from './notebookUtils.js';
 
 /**
  * Keybinding configuration for notebook actions.
@@ -262,7 +262,7 @@ function registerNotebookCommandInternal(options: INotebookCommandOptions): IDis
 		id: options.commandId,
 		handler: (accessor: ServicesAccessor) => {
 			const editorService = accessor.get(IEditorService);
-			const activeNotebook = getActiveNotebook(editorService);
+			const activeNotebook = getNotebookInstanceFromEditorPane(editorService);
 			if (!activeNotebook) {
 				return;
 			}
@@ -357,7 +357,7 @@ function registerNotebookWidgetInternal(options: INotebookWidgetOptions): IDispo
 			return () => {
 				// Get the active notebook using the VS Code pattern
 				const editorService = accessor.get(IEditorService);
-				const notebook = getActiveNotebook(editorService);
+				const notebook = getNotebookInstanceFromEditorPane(editorService);
 				if (!notebook) {
 					return null;
 				}

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -216,9 +216,8 @@ test.describe('Notebook Focus and Selection', {
 			await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
 		});
 
-		// BUG: https://github.com/posit-dev/positron/issues/9849
 		// Switch between notebooks to ensure selection is preserved
-		await test.step.skip('Selection is preserved when switching between editors', async () => {
+		await test.step('Selection is preserved when switching between editors', async () => {
 			// Switch back to tab 1 and verify selection is still at cell 2
 			await clickTab(TAB_1);
 			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -191,8 +191,9 @@ test.describe('Notebook Focus and Selection', {
 		const { notebooks, notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
-		const clickTab = (name: string) => app.code.driver.page.getByRole('tab', { name }).click();
-		const TAB_1 = 'Untitled-1.ipynb';
+		const clickTab = (name: string | RegExp) => app.code.driver.page.getByRole('tab', { name }).click();
+		// Depending on when this test is run, the untitled notebook may have a different number
+		const TAB_1 = /Untitled-\d+\.ipynb/;
 		const TAB_2 = 'bitmap-notebook.ipynb';
 
 		// Start a new notebook (tab 1)


### PR DESCRIPTION
Addresses #9849 and #10011

The editor-dissapearing bug was caused by improper storage of the react renderer in the notebook editor. Because of this when navigating back to the notebook the editor would not realize it had rendered before and restart everything which ran into bugs with things like disposed objects etc.

This PR makes sure that we actually store the react renderer to prevent premature cleanup. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

You should be able to open a notebook then navigate away from the tab (make it not visible at all) and back and the notebook should still show up. 
