### PR TITLE
remove active session limit

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -35,16 +35,6 @@ import { untildify } from '../../../../base/common/labels.js';
 import { Schemas } from '../../../../base/common/network.js';
 
 /**
- * The maximum number of active sessions a user can have running at a time.
- * This value is arbitrary and a limit to use for sanity purposes for the
- * multiple console sessions feature. This should be removed in the future
- * or made a setting if limiting concurrent active sessions is required.
- *
- * Only to be used with `console.multipleConsoleSessions` feaeture flag.
- */
-const MAX_CONCURRENT_SESSIONS = 15;
-
-/**
  * Get a map key corresponding to a session.
  *
  * @returns A composite of the session mode, runtime ID, and notebook URI - assuming that there
@@ -1990,23 +1980,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 					`is already starting for the language.` +
 					(source ? ` Request source: ${source}` : ``));
 			}
-
-			// Restrict the number of console sessions that can be created to 15.
-			// This value is arbitrary and should be made a configuration setting
-			// in the future for users once this feature has stabilized!
-			if (this._activeSessionsBySessionId.size >= MAX_CONCURRENT_SESSIONS) {
-				this._notificationService.notify({
-					severity: Severity.Info,
-					message: localize('positron.console.maxError', "Cannot start console session.\
-							The maximum number of consoles ({0}) has been reached", MAX_CONCURRENT_SESSIONS)
-				});
-
-				throw new Error(`Session for language runtime ` +
-					`${formatLanguageRuntimeMetadata(languageRuntime)} ` +
-					`cannot be started because the maximum number of ` +
-					`runtime sessions has been reached.`
-				);
-			}
 		} else if (sessionMode === LanguageRuntimeSessionMode.Notebook) {
 			// If no notebook URI is provided, throw an error.
 			if (!notebookUri) {
@@ -2483,7 +2456,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 					return p;
 				}
 				return path.join(workspaceFolderName, relativePath);
-			}
+			};
 
 			const currentWorkingDirectoryDisplay = makeDisplayPath(currentWorkingDirectoryResolved);
 			const newWorkingDirectoryDisplay = makeDisplayPath(newWorkingDirectoryResolved);


### PR DESCRIPTION
Addresses #9576

This should resolve the pesky issue where you couldn't have more than 15 notebooks open due to a poorly implemented active session limit checks I added which didn't bother taking notebooks into account. 🙈 

You can now create as many interpreter sessions and open as many notebook sessions as you'd like!

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Remove active sessions limit (#9576)


### QA Notes
See  #9576 for testing steps.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:console
@:interpreter
@:sessions
@:notebooks
@:positron-notebooks