### PR TITLE
update data explorer column selector to use new search

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -25,8 +25,8 @@ const OVERSCAN_FACTOR = 3
  *
  * This class is used to display a list of the column names from a dataset
  * in the column selector modal popup. The column selector modal popup is
- * a DataGridWaffle component. This instance manages the list of columns
- * and supports searching for columns by name.
+ * a DataGrid component. This instance manages the list of columns and
+ * supports searching for columns by name.
  */
 export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	//#region Private Properties
@@ -266,13 +266,13 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 			return undefined;
 		}
 
-		// Get the column schema for the data at this row index.
+		// Get the column schema for the row index from the original dataset.
 		const columnSchema = this._columnSchemaCache.getColumnSchema(rowIndex);
 		if (!columnSchema) {
 			return undefined;
 		}
 
-		// Get the visual index position for the data at this row index
+		// Get the visual position for the row index from the original dataset.
 		const visualPosition = this._rowLayoutManager.mapIndexToPosition(rowIndex);
 
 		// Return the cell.

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -232,8 +232,8 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	}
 
 	/**
-	 * Select the column schema at the specified position.
-	 * @param rowIndex The row index (positionally) of the selected item.
+	 * Select the column schema at the visual index provided.
+	 * @param rowIndex The row index (visual positional) of the selected item.
 	 */
 	selectItem(rowIndex: number): void {
 		// The row index is the visible row index, so we need to map it to the actual index.

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -214,10 +214,12 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 		if (rowDescriptor) {
 			// Get the layout indices for visible data.
 			const columnIndices = this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR);
-			await this._columnSchemaCache.update({
-				columnIndices,
-				invalidateCache: !!invalidateCache
-			});
+			if (columnIndices.length > 0 || invalidateCache) {
+				await this._columnSchemaCache.update({
+					columnIndices,
+					invalidateCache: !!invalidateCache
+				});
+			}
 		}
 	}
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -343,4 +343,38 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	}
 
 	//#endregion Private Methods
+
+	/**
+	 * Moves the cursor down.
+	 * Override to work with visual positions instead of data indices.
+	 */
+	override moveCursorDown() {
+		// Calculate the next visual position
+		const nextRowIndex = this.cursorRowIndex + 1;
+		// Check if we're at the last row
+		if (nextRowIndex >= this.rows) {
+			return;
+		}
+		// Set the cursor row index to the next visual position
+		this.setCursorRow(nextRowIndex);
+		// Scroll to the cursor
+		this.scrollToCursor();
+	}
+
+	/**
+	 * Moves the cursor up.
+	 * Override to work with visual positions instead of data indices.
+	 */
+	override moveCursorUp() {
+		// Calculate the previous visual position
+		const prevRowIndex = this.cursorRowIndex - 1;
+		// Check if we're at the first row
+		if (prevRowIndex < 0) {
+			return;
+		}
+		// Set the cursor row index to the previous visual position
+		this.setCursorRow(prevRowIndex);
+		// Scroll to the cursor
+		this.scrollToCursor();
+	}
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -130,22 +130,32 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 		this._rowLayoutManager.setEntries(backendState.table_shape.num_columns);
 
 		// Add the onDidSchemaUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () =>
-			// Update the data grid instance.
-			this.updateLayoutEntries()
-		));
+		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
+			// Update the layout entries.
+			await this.updateLayoutEntries()
+
+			// Perform a soft reset.
+			this.softReset();
+
+			// Fetch data.
+			await this.fetchData(true);
+		}));
 
 		// Add the onDidDataUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () =>
-			// Update the data grid instance.
-			this.updateLayoutEntries()
-		));
+		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
+			// Update the layout entries.
+			await this.updateLayoutEntries()
+
+			// Fetch data.
+			await this.fetchData(true);
+		}));
 
 		// Add the onDidUpdateBackendState event handler.
-		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async backendState =>
+		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async backendState => {
 			// Update the data grid instance.
-			this.updateLayoutEntries(backendState)
-		));
+			await this.updateLayoutEntries(backendState);
+			await this.fetchData(true);
+		}));
 
 		// Add the onDidUpdateCache event handler.
 		this._register(this._columnSchemaCache.onDidUpdateCache(() =>
@@ -303,6 +313,9 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 				this.showCursor();
 				this.setCursorRow(0);
 			}
+
+			// Force a re-render when the search changes
+			this.fireOnDidUpdateEvent();
 		}
 	}
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -255,7 +255,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	/**
 	 * Gets a cell.
 	 * @param columnIndex The column index.
-	 * @param rowIndex The row index.
+	 * @param rowIndex The row index from the original dataset.
 	 * @returns The cell.
 	 */
 	cell(columnIndex: number, rowIndex: number): JSX.Element | undefined {
@@ -264,16 +264,19 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 			return undefined;
 		}
 
-		// Get the column schema for the row index.
+		// Get the column schema for the data at this row index.
 		const columnSchema = this._columnSchemaCache.getColumnSchema(rowIndex);
 		if (!columnSchema) {
 			return undefined;
 		}
 
+		// Get the visual index position for the data at this row index
+		const visualPosition = this._rowLayoutManager.mapIndexToPosition(rowIndex);
+
 		// Return the cell.
 		return (
 			<ColumnSelectorCell
-				columnIndex={rowIndex}
+				columnIndex={visualPosition ?? -1}
 				columnSchema={columnSchema}
 				instance={this}
 				onPressed={() => this._onDidSelectColumnEmitter.fire(columnSchema)}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -278,7 +278,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 			await this.updateLayoutEntries()
 			await this.fetchData();
 
-			// select the first available row after fetching so that users cat hit "enter"
+			// select the first available row after fetching so that users can hit "enter"
 			// to make an immediate confirmation on what they were searching for
 			if (this.rows > 0) {
 				this.showCursor();

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -21,6 +21,11 @@ const ROW_HEIGHT = 26;
 
 /**
  * ColumnSelectorDataGridInstance class.
+ *
+ * This class is used to display a list of the column names from a dataset
+ * in the column selector modal popup. The column selector modal popup is
+ * a DataGridWaffle component. This instance manages the list of columns
+ * and supports searching for columns by name.
  */
 export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	//#region Private Properties

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -113,7 +113,7 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 							initialSearchText={props.searchInput}
 							onConfirmSearch={() => {
 								props.columnSelectorDataGridInstance.selectItem(
-									props.columnSelectorDataGridInstance.cursorColumnIndex
+									props.columnSelectorDataGridInstance.cursorRowIndex
 								);
 							}}
 							onNavigateOut={() => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -31,6 +31,10 @@ const OVERSCAN_FACTOR = 3
 
 /**
  * TableSummaryDataGridInstance class.
+ *
+ * This class is used to display a summary of each column in the dataset.
+ * This instance manages represents a column from the dataset and displays
+ * summary information such as data type, null count, and summary statistics.
  */
 export class TableSummaryDataGridInstance extends DataGridInstance {
 	//#region Private Properties

--- a/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
@@ -76,6 +76,17 @@ export class ColumnSchemaCache extends Disposable {
 		));
 	}
 
+	/**
+	 * Dispose method
+	 */
+	override dispose(): void {
+		// Clear the pending trim cache timeout
+		this.clearTrimCacheTimeout();
+
+		// Call the base class's dispose method.
+		super.dispose();
+	}
+
 	//#endregion Constructor & Dispose
 
 	//#region Public Properties

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -260,16 +260,22 @@ export class TableSummaryCache extends Disposable {
 			return this.update(pendingUpdateDescriptor);
 		}
 
-		// Schedule trimming the cache if we have actual column indices to preserve.
-		// This prevents accidentally clearing all cached data when columnIndices is an empty array
-		// which happens during UI state transitions (e.g. during resizing when layoutHeight is 0).
-		if (!updateDescriptor.invalidateCache && columnIndices.length) {
+		// Schedule trimming the cache if we didn't already invalidate the cache and we have
+		// column indices to keep. We don't want to schedule a trim if columnIndices is empty
+		// which can happen during UI rendering transitions (e.g.during resizing when layoutHeight
+		// is 0) because that would clear all cached data.
+		if (!updateDescriptor.invalidateCache && updateDescriptor.columnIndices.length) {
+			// Clear previously scheduled trim calls before scheduling a new one
+			// to prevent previously scheduled trim calls from clearing data that
+			// is now visible and should be in the cache. This can happen when a
+			// user is scrolling rapidly.
+			this.clearTrimCacheTimeout();
 			// Set the trim cache timeout.
 			this._trimCacheTimeout = setTimeout(() => {
 				// Release the trim cache timeout.
 				this._trimCacheTimeout = undefined;
 				// Trim the cache.
-				this.trimCache(new Set(columnIndices));
+				this.trimCache(new Set(updateDescriptor.columnIndices));
 			}, TRIM_CACHE_TIMEOUT);
 		}
 	}


### PR DESCRIPTION
Addresses #9847

Updates the column selector modal popup (which is a data grid under the hood) to use the new backend search functionality we added to the data explorer. 

This should address the issue we were seeing where column names weren't rendering in the drop down when the number of columns was greater than a few hundred. Instead of trying to fetch and render all columns, only the columns that are visible are shown and cached. When the user scrolls or searches, we go out and fetch the column data that should be in view. This is the same behavior we have in the other data grids, like the summary panel. 

Note: The RPC timeout issue described in #9846 is now also present in the column selector modal popup when searching if there are a large number of columns present. Searching will silently fail if it takes longer than 5 seconds. Depsite this, the behavior is much improved than what it was previously. 

For keyboard functionality testing, I want to point out the focus and keyboard behavior when using the search in the filter column selector dropdown is slightly different than a traditional dropdown because of some of the custom cursor selection behavior we have. The biggest thing to be aware of is: the focus/selected styling in the dropdown is always visible (and set to the first item in the dropdown) when a search is active. This is a bit odd when searching because the _actual_ focus indicator is in the search box. Pressing `Arrow Down` or `Tab` will move the actual focus indicator into the dropdown but its not obvious that is where focus went since the selected/focused state for the dropdown is always present and there is no difference between focus and selection. Everything works, its just a bit odd visually. This is how its always worked and hasn't been changed in this PR! Just be aware when testing.

Here's an example of an accessible combobox pattern in case you are curious what the differences are: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both/

**BEFORE - 5 million columns**

https://github.com/user-attachments/assets/db44403c-a0b6-43d1-9c0b-93da5fe51d51

**AFTER - Dropdown without search (6 columns)**

https://github.com/user-attachments/assets/aee88785-06bd-4cc1-8a71-f2766c5644cc

**AFTER - Dropdown with search (1000 columns)**

https://github.com/user-attachments/assets/4b323f7e-03bb-4783-b92c-b2e20a2a2d12

**AFTER - Dropdown with search (5 million columns)**

https://github.com/user-attachments/assets/6dfde728-1efc-42f7-8814-75fb15e845c9



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Update data explorer column selector to use new search (#9847)

#### Bug Fixes

- N/A


### QA Notes
@:data-explorer
@:web
@:win
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
