### PR TITLE
assistant: restore upstream behaviour for source control commit attachments

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -28,10 +28,6 @@ import { ScmHistoryItemResolver } from '../../multiDiffEditor/browser/scmMultiDi
 import { ISCMHistoryItem } from '../common/history.js';
 import { ISCMProvider, ISCMService, ISCMViewService } from '../common/scm.js';
 
-// --- Start Positron ---
-import { isWeb } from '../../../../base/common/platform.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-// --- End Positron ---
 
 export interface SCMHistoryItemTransferData {
 	readonly name: string;
@@ -95,25 +91,12 @@ class SCMHistoryItemContext implements IChatContextPickerItem {
 	}
 
 	constructor(
-		// --- Start Positron ---
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		// --- End Positron ---
 		@ISCMViewService private readonly _scmViewService: ISCMViewService
 	) { }
 
 	isEnabled(_widget: IChatWidget): Promise<boolean> | boolean {
 		const activeRepository = this._scmViewService.activeRepository.get();
-		// --- Start Positron ---
-		// Disable SCM History Chat Context in Positron Web due to path error
-		// See https://github.com/posit-dev/positron/issues/9181
-		const schContextEnabled = this._configurationService.getValue<boolean>('positron.assistant.sourceControlHistoryContext.enable');
-		// if schContextEnabled is configured, follow the config to enable/disable scm history context
-		// if schContextEnabled is undefined, enable scm history context on desktop, but disable on web
-		return activeRepository?.provider.historyProvider.get() !== undefined && (schContextEnabled ?? !isWeb);
-		/*
 		return activeRepository?.provider.historyProvider.get() !== undefined;
-		*/
-		// --- End Positron ---
 	}
 
 	asPicker(_widget: IChatWidget) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

- Addresses https://github.com/posit-dev/positron/issues/9181
- Removes the gating that was added in https://github.com/posit-dev/positron/issues/9066, since I'm no longer seeing issues with <kbd>Add Context...</kbd> --> "Source Control..." on Workbench

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

<kbd>Add Context...</kbd> --> "Source Control..." should be available by default on Web/Workbench again