### PR TITLE
assistant: handle empty input_schema for vercel providers flow

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -589,11 +589,12 @@ function toAnthropicTools(tools: readonly vscode.LanguageModelChatTool[]): Anthr
 }
 
 function toAnthropicTool(tool: vscode.LanguageModelChatTool): Anthropic.ToolUnion {
+	// Anthropic requires a type for all tools; default to 'object' if not provided.
+	// See similar handling for the vercel SDK in AILanguageModel provideLanguageModelChatResponse in extensions/positron-assistant/src/models.ts
 	const input_schema = tool.inputSchema as Anthropic.Tool.InputSchema ?? {
 		type: 'object',
 		properties: {},
 	};
-	// Anthropic requires a type for all tools; default to 'object' if not provided.
 	if (!input_schema.type) {
 		log.warn(`[anthropic] Tool '${tool.name}' is missing input schema type; defaulting to 'object'`);
 		input_schema.type = 'object';

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -449,7 +449,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 					properties: {},
 				};
 				if (!input_schema.type) {
-					log.warn(`Tool ${tool.name} input schema missing 'type' property; defaulting to 'object'`);
+					log.warn(`Tool '${tool.name}' is missing input schema type; defaulting to 'object'`);
 					input_schema.type = 'object';
 				}
 				acc[tool.name] = ai.tool({


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/9438
- takes the same approach as the equivalent code in the Anthropic provider flow to default the input schema type to 'object'

### Release Notes

#### Bug Fixes

- Assistant: Bedrock models no longer error in Agent mode when using Copilot tools (#9438)

### QA Notes

1. auth to and select Amazon Bedrock as the provider
2. ensure `positron.assistant.alwaysIncludeCopilotTools` is enabled
3. send a message in the chat

Instead of this:

<img width="446" height="570" alt="image" src="https://github.com/user-attachments/assets/fe250050-4e95-4eaa-9d72-af037bc7f26f" />

You should see:

<img width="444" height="574" alt="image" src="https://github.com/user-attachments/assets/ddddbea8-a8bf-431c-a42d-65903967db37" />

and the Assistant Output channel should have a message like

```
[warning] Tool 'copilot_testFailure' is missing input schema type; defaulting to 'object'
```