### PR TITLE
Add command to insert markdown cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -163,6 +163,15 @@ export interface IPositronNotebookInstance {
 	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
 
 	/**
+	 * Inserts a new markdown cell either above or below the current selection
+	 * and focuses the container.
+	 *
+	 * @param aboveOrBelow Whether to insert the cell above or below the current selection
+	 * @param referenceCell Optional cell to insert relative to. If not provided, uses the currently selected cell
+	 */
+	insertMarkdownCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
+
+	/**
 	 * Removes a cell from the notebook.
 	 *
 	 * @param cell Optional cell to delete. If not provided, deletes the currently selected cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -99,6 +99,16 @@ export interface IPositronNotebookCell extends Disposable {
 	insertCodeCellBelow(): void;
 
 	/**
+	 * Insert a new markdown cell above this cell
+	 */
+	insertMarkdownCellAbove(): void;
+
+	/**
+	 * Insert a new markdown cell below this cell
+	 */
+	insertMarkdownCellBelow(): void;
+
+	/**
 	 * Type guard for checking if cell is a markdown cell
 	 */
 	isMarkdownCell(): this is IPositronNotebookMarkdownCell;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -222,7 +222,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		this._instance.insertCodeCellAndFocusContainer('below', this);
 	}
 
+	insertMarkdownCellAbove(): void {
+		this._instance.insertMarkdownCellAndFocusContainer('above', this);
+	}
+
+	insertMarkdownCellBelow(): void {
+		this._instance.insertMarkdownCellAndFocusContainer('below', this);
+	}
 }
-
-
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -523,12 +523,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._onDidChangeContent.fire();
 	}
 
-	/**
-	 * Inserts a new code cell above or below the reference cell (or selected cell if no reference is provided).
-	 * @param aboveOrBelow Whether to insert the cell above or below the reference
-	 * @param referenceCell Optional reference cell. If not provided, uses the currently selected cell
-	 */
-	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+	private _insertCellAndFocusContainer(type: CellKind, aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
 		let index: number | undefined;
 
 		this._assertTextModel();
@@ -544,7 +539,20 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this.addCell(CellKind.Code, index + (aboveOrBelow === 'above' ? 0 : 1));
+		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1));
+	}
+
+	/**
+	 * Inserts a new code cell above or below the reference cell (or selected cell if no reference is provided).
+	 * @param aboveOrBelow Whether to insert the cell above or below the reference
+	 * @param referenceCell Optional reference cell. If not provided, uses the currently selected cell
+	 */
+	insertCodeCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+		this._insertCellAndFocusContainer(CellKind.Code, aboveOrBelow, referenceCell);
+	}
+
+	insertMarkdownCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+		this._insertCellAndFocusContainer(CellKind.Markup, aboveOrBelow, referenceCell);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -423,7 +423,7 @@ registerCellCommand({
 		category: 'Cell'
 	},
 	metadata: {
-		description: localize('positronNotebook.cell.insertAbove', "Insert code cell above")
+		description: localize('positronNotebook.codeCell.insertAbove', "Insert code cell above")
 	}
 });
 
@@ -440,7 +440,35 @@ registerCellCommand({
 		category: 'Cell'
 	},
 	metadata: {
-		description: localize('positronNotebook.cell.insertBelow', "Insert code cell below")
+		description: localize('positronNotebook.codeCell.insertBelow', "Insert code cell below")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertMarkdownCellAboveAndFocusContainer',
+	handler: (cell) => cell.insertMarkdownCellAbove(),
+	actionBar: {
+		icon: 'codicon-arrow-up',
+		position: 'menu',
+		order: 100,
+		category: 'Cell'
+	},
+	metadata: {
+		description: localize('positronNotebook.markdownCell.insertAbove', "Insert markdown cell above")
+	}
+});
+
+registerCellCommand({
+	commandId: 'positronNotebook.cell.insertMarkdownCellBelowAndFocusContainer',
+	handler: (cell) => cell.insertMarkdownCellBelow(),
+	actionBar: {
+		icon: 'codicon-arrow-down',
+		position: 'menu',
+		order: 100,
+		category: 'Cell'
+	},
+	metadata: {
+		description: localize('positronNotebook.markdownCell.insertBelow', "Insert markdown cell below")
 	}
 });
 
@@ -462,8 +490,7 @@ registerCellCommand({
 	metadata: {
 		description: localize('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),
 	}
-}
-);
+});
 
 // Make sure the run and stop commands are in the same place so they replace one another.
 const CELL_EXECUTION_POSITION = 10;


### PR DESCRIPTION
Addresses #9713

The cell editor action bar now has buttons to insert markdown cells above or below the currently selected cell.


https://github.com/user-attachments/assets/6405589d-b79e-493b-961d-c4c691ec7370


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:positron-notebooks