### PR TITLE
Restore manage models action

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/manageModelsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/manageModelsActions.ts
@@ -10,12 +10,17 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize2 } from '../../../../../nls.js';
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { ContextKeyExpr, ContextKeyTrueExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../common/languageModels.js';
 import { CHAT_CATEGORY } from './chatActions.js';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { ContextKeyTrueExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+// --- End Positron ---
 
 interface IVendorQuickPickItem extends IQuickPickItem {
 	managementCommand?: string;

--- a/src/vs/workbench/contrib/chat/browser/actions/manageModelsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/manageModelsActions.ts
@@ -10,7 +10,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize2 } from '../../../../../nls.js';
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, ContextKeyTrueExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
@@ -36,6 +36,9 @@ export class ManageModelsAction extends Action2 {
 			title: localize2('manageLanguageModels', 'Manage Language Models...'),
 			category: CHAT_CATEGORY,
 			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.or(
+				// --- Start Positron ---
+				ContextKeyTrueExpr.INSTANCE,
+				// --- End Positron ---
 				ChatContextKeys.Entitlement.planFree,
 				ChatContextKeys.Entitlement.planPro,
 				ChatContextKeys.Entitlement.planProPlus,

--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -56,7 +56,12 @@ function getModelPickerActionBarActionProvider(commandService: ICommandService, 
 	const actionProvider: IActionProvider = {
 		getActions: () => {
 			const additionalActions: IAction[] = [];
+			// --- Start Positron ---
+			// override the entitlement check to always show manage models option
+			const useManageModelsAction = true;
 			if (
+				useManageModelsAction ||
+				// --- End Positron ---
 				chatEntitlementService.entitlement === ChatEntitlement.Free ||
 				chatEntitlementService.entitlement === ChatEntitlement.Pro ||
 				chatEntitlementService.entitlement === ChatEntitlement.ProPlus ||

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -38,6 +38,7 @@ const MODE_DROPDOWN = 'a.action-label[aria-label^="Set Mode"]';
 const MODE_DROPDOWN_ITEM = '.monaco-list-row[role="menuitemcheckbox"]';
 const MODEL_PICKER_DROPDOWN = '.action-item.chat-modelPicker-item .monaco-dropdown .dropdown-label a.action-label[aria-label*="Pick Model"]';
 const MODEL_DROPDOWN_ITEM = '.monaco-list-row[role="menuitemcheckbox"]';
+const MANAGE_MODELS_ITEM = '.action-widget a.action-label[aria-label="Manage language models"]';
 /*
  *  Reuseable Positron Assistant functionality for tests to leverage.
  */
@@ -94,6 +95,11 @@ export class Assistant {
 		await expect(this.code.driver.page.locator(INSERT_AT_CURSOR_BUTTON)).toHaveCount(1);
 		await expect(this.code.driver.page.locator(COPY_BUTTON)).toHaveCount(1);
 		await expect(this.code.driver.page.locator(INSERT_NEW_FILE_BUTTON)).toHaveCount(1);
+	}
+
+	async verifyManageModelsOptionVisible() {
+		await this.code.driver.page.locator(MODEL_PICKER_DROPDOWN).click();
+		await expect(this.code.driver.page.locator(MANAGE_MODELS_ITEM)).toBeVisible();
 	}
 
 	async selectModelProvider(provider: string) {

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -96,11 +96,6 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickCloseButton();
 	});
 
-	test('Verify Manage Models is available', async function ({ app }) {
-		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.verifyManageModelsOptionVisible();
-	});
-
 });
 /**
  * Test suite Positron Assistant actions from the chat interface.
@@ -153,6 +148,10 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 		await app.workbench.assistant.clickChatCodeRunButton('foo <- 200');
 		await app.workbench.console.waitForConsoleContents('foo <- 200');
 		await app.workbench.variables.expectVariableToBe('foo', '200');
+	});
+
+	test('Verify Manage Models is available', async function ({ app }) {
+		await app.workbench.assistant.verifyManageModelsOptionVisible();
 	});
 });
 

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -96,6 +96,11 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 		await app.workbench.assistant.clickCloseButton();
 	});
 
+	test('Verify Manage Models is available', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.verifyManageModelsOptionVisible();
+	});
+
 });
 /**
  * Test suite Positron Assistant actions from the chat interface.


### PR DESCRIPTION
Address #10013

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix missing "Manage Models..." action from Assistant model picker


### QA Notes
An automated test was added to check that the "Manage Models..." action exists.