### PR TITLE
Fix dependency warning in use effect

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -67,8 +67,7 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 	const inputRef = React.useRef<HTMLInputElement>(null);
 
 	// Variables
-	const sessionId = positronConsoleInstance.sessionId;
-	const isActiveTab = positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === sessionId;
+	const isActiveTab = positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId;
 
 	useEffect(() => {
 		// Create the disposable store for cleanup.
@@ -91,8 +90,8 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 		// the session, pick it up.
 		disposableStore.add(
 			services.runtimeSessionService.onDidUpdateNotebookSessionUri(e => {
-				if (e.sessionId === sessionId) {
-					const session = services.runtimeSessionService.getActiveSession(sessionId);
+				if (e.sessionId === positronConsoleInstance.sessionId) {
+					const session = services.runtimeSessionService.getActiveSession(positronConsoleInstance.sessionId);
 					if (session) {
 						setSessionName(session.session.getLabel());
 					}
@@ -251,15 +250,15 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 		try {
 			// Updated to support proper deletion of sessions that have
 			// been shutdown or exited.
-			if (services.runtimeSessionService.getSession(sessionId)) {
+			if (services.runtimeSessionService.getSession(positronConsoleInstance.sessionId)) {
 				// Attempt to delete the session from the runtime session service.
 				// This will throw an error if the session is not found.
-				await services.runtimeSessionService.deleteSession(sessionId);
+				await services.runtimeSessionService.deleteSession(positronConsoleInstance.sessionId);
 			} else {
 				// If the session is not found, it may have been deleted already
 				// or is a provisional session. In this case, we can delete the
 				// session from the Positron Console service.
-				services.positronConsoleService.deletePositronConsoleSession(sessionId);
+				services.positronConsoleService.deletePositronConsoleSession(positronConsoleInstance.sessionId);
 			}
 		} catch (error) {
 			// Show an error notification if the session could not be deleted.
@@ -370,8 +369,8 @@ const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: Console
 			ref={tabRef}
 			aria-controls={`console-panel-${positronConsoleInstance.sessionMetadata.sessionId}`}
 			aria-label={positronConsoleInstance.sessionName}
-			aria-selected={positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === sessionId}
-			className={`tab-button ${positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === sessionId && 'tab-button--active'}`}
+			aria-selected={positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId}
+			className={`tab-button ${positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId && 'tab-button--active'}`}
 			data-testid={`console-tab-${positronConsoleInstance.sessionMetadata.sessionId}`}
 			role='tab'
 			tabIndex={isActiveTab ? 0 : -1}


### PR DESCRIPTION
Noticed an issue with the dependency list in one of the `useEffects` for the `ConsoleTabList` component while I was working on a different issue. The `useEffect` has been working without issue since the error is a bit of a false positive.

I think this was a small thing that was missed during the changes for #9550. It is caused by the fact that we have a local variable for `positronConsoleInstance.sessionId` called `sessionId`. I removed the local variable and replaced all the use cases with `positronConsoleInstance.sessionId` to avoid having two references for the same value in the component.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:console
@:interpreter
@:sessions