### PR TITLE
python: windows handling for undetermined versions

### DIFF
--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -391,13 +391,13 @@ export function getPyenvVersion(workspacePath: string | undefined): string | und
 
 /**
  * Check if a version is supported (i.e. >= the minimum supported version and < the maximum).
- * Also returns true if the version could not be determined.
+ * Returns false if the version could not be determined.
  */
 export function isVersionSupported(version: PythonVersion | undefined): boolean {
     return (
-        !version ||
-        (comparePythonVersionDescending(MINIMUM_PYTHON_VERSION, version) >= 0 &&
-            comparePythonVersionDescending(MAXIMUM_PYTHON_VERSION_EXCLUSIVE, version) < 0)
+        version !== undefined &&
+        comparePythonVersionDescending(MINIMUM_PYTHON_VERSION, version) >= 0 &&
+        comparePythonVersionDescending(MAXIMUM_PYTHON_VERSION_EXCLUSIVE, version) < 0
     );
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -391,13 +391,13 @@ export function getPyenvVersion(workspacePath: string | undefined): string | und
 
 /**
  * Check if a version is supported (i.e. >= the minimum supported version and < the maximum).
- * Returns false if the version could not be determined.
+ * Also returns true if the version could not be determined.
  */
 export function isVersionSupported(version: PythonVersion | undefined): boolean {
     return (
-        version !== undefined &&
-        comparePythonVersionDescending(MINIMUM_PYTHON_VERSION, version) >= 0 &&
-        comparePythonVersionDescending(MAXIMUM_PYTHON_VERSION_EXCLUSIVE, version) < 0
+        !version ||
+        (comparePythonVersionDescending(MINIMUM_PYTHON_VERSION, version) >= 0 &&
+            comparePythonVersionDescending(MAXIMUM_PYTHON_VERSION_EXCLUSIVE, version) < 0)
     );
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -143,14 +143,23 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                 return { path: undefined, isImmediate };
             }
         } else if (await hasFiles(['.venv/**/*'])) {
-            interpreterPath = path.join(workspaceUri.fsPath, '.venv', 'bin', 'python');
+            interpreterPath =
+                os.platform() === 'win32'
+                    ? path.join(workspaceUri.fsPath, '.venv', 'Scripts', 'python.exe')
+                    : path.join(workspaceUri.fsPath, '.venv', 'bin', 'python');
             isImmediate = true;
         } else if (await hasFiles(['.conda/**/*'])) {
-            interpreterPath = path.join(workspaceUri.fsPath, '.conda', 'bin', 'python');
+            interpreterPath =
+                os.platform() === 'win32'
+                    ? path.join(workspaceUri.fsPath, '.conda', 'Scripts', 'python.exe')
+                    : path.join(workspaceUri.fsPath, '.conda', 'bin', 'python');
             isImmediate = true;
-        } else if (await hasFiles(['*/bin/python'])) {
-            // if we found */bin/python but not .venv or .conda, use the first one we find
-            const files = await vscode.workspace.findFiles('*/bin/python', '**/node_modules/**');
+        } else if (await hasFiles(['*/bin/python', '*/Scripts/python.exe'])) {
+            // if we found */bin/python or */Scripts/python.exe but not .venv or .conda, use the first one we find
+            const files = await vscode.workspace.findFiles(
+                os.platform() === 'win32' ? '*/Scripts/python.exe' : '*/bin/python',
+                '**/node_modules/**',
+            );
             if (files.length > 0) {
                 interpreterPath = files[0].fsPath;
                 isImmediate = true;

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -304,7 +304,10 @@ suite('Python runtime manager - recommendedWorkspaceRuntime', () => {
         });
         hasFilesStub.withArgs(['.venv/**/*']).resolves(true);
 
-        const venvPythonPath = path.join(workspaceUri.fsPath, '.venv', 'bin', 'python');
+        const venvPythonPath =
+            process.platform === 'win32'
+                ? path.join(workspaceUri.fsPath, '.venv', 'Scripts', 'python.exe')
+                : path.join(workspaceUri.fsPath, '.venv', 'bin', 'python');
         interpreter.setup((i) => i.path).returns(() => venvPythonPath);
         interpreterService
             .setup((i) =>
@@ -336,7 +339,10 @@ suite('Python runtime manager - recommendedWorkspaceRuntime', () => {
         hasFilesStub.withArgs(['.venv/**/*']).resolves(false);
         hasFilesStub.withArgs(['.conda/**/*']).resolves(true);
 
-        const condaPythonPath = path.join(workspaceUri.fsPath, '.conda', 'bin', 'python');
+        const condaPythonPath =
+            process.platform === 'win32'
+                ? path.join(workspaceUri.fsPath, '.conda', 'Scripts', 'python.exe')
+                : path.join(workspaceUri.fsPath, '.conda', 'bin', 'python');
         interpreter.setup((i) => i.path).returns(() => condaPythonPath);
         interpreterService
             .setup((i) =>


### PR DESCRIPTION
There was some handling that created fake paths by looking for `./.venv` and then immediately trying to start up `./.venv/bin/python`. The `js` locator is just smarter about resolving this correctly, which is why we do not see this problem there. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #9186 Fixes bug where Positron created environments show as version 0.0.1.


### QA Notes

make a new project through new project wizard. should not get 0.0.1 versioned python