### PR TITLE
Lints on an external PR I merged

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -331,8 +331,8 @@ function getRHomePathLinux(binpath: string): string | undefined {
 		LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
 		return undefined;
 	}
-	const testPath = testPathMatch[1]
-	if (testPath != R_HOME_DIR) {
+	const testPath = testPathMatch[1];
+	if (testPath !== R_HOME_DIR) {
 		return homepath;
 	}
 	const prefixMatch = testPath.match('(.*)\/.*\/R');
@@ -340,23 +340,23 @@ function getRHomePathLinux(binpath: string): string | undefined {
 		LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
 		return undefined;
 	}
-	const prefix = prefixMatch[1]
-    // Replicating special linux logic in R's official shell script
-    // https://github.com/wch/r-source/blob/8898619c430a383ceb401dee3e492ba386ea5967/src/scripts/R.sh.in#L5C1-L27C3
-    const is64BitArch = [
-        // Actual values returned by Node.js process.arch
-        'x64',      // Node.js equivalent of x86_64
-        'arm64',    // not in official shell script (but maybe should be?)
-        'ppc64',    // PowerPC 64-bit
-        's390x',    // IBM System z
-        // Remaining values from official script values, just to be safe
-        'x86_64', 'mips64', 'powerpc64', 'sparc64'
-].includes(process.arch);
+	const prefix = prefixMatch[1];
+	// Replicating special linux logic in R's official shell script
+	// https://github.com/wch/r-source/blob/8898619c430a383ceb401dee3e492ba386ea5967/src/scripts/R.sh.in#L5C1-L27C3
+	const is64BitArch = [
+		// Actual values returned by Node.js process.arch
+		'x64',      // Node.js equivalent of x86_64
+		'arm64',    // not in official shell script (but maybe should be?)
+		'ppc64',    // PowerPC 64-bit
+		's390x',    // IBM System z
+		// Remaining values from official script values, just to be safe
+		'x86_64', 'mips64', 'powerpc64', 'sparc64'
+	].includes(process.arch);
 
-    const libnn = is64BitArch ? 'lib64' : 'lib';
-    const libnnFallback = is64BitArch ? 'lib' : 'lib64';
-	const libnnPath = path.join(prefix, libnn, 'R/bin/exec/R')
-	const libnnFallbackPath = path.join(prefix, libnnFallback, 'R/bin/exec/R')
+	const libnn = is64BitArch ? 'lib64' : 'lib';
+	const libnnFallback = is64BitArch ? 'lib' : 'lib64';
+	const libnnPath = path.join(prefix, libnn, 'R/bin/exec/R');
+	const libnnFallbackPath = path.join(prefix, libnnFallback, 'R/bin/exec/R');
 	if (isExecutable(libnnPath)) {
 		return path.join(prefix, libnn, "R");
 	}


### PR DESCRIPTION
Related to #9945. These revealed themselves to me once I visited this file myself, locally.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
