### PR TITLE
Add Jupyter-style keybindings for undo, redo, and cell commands

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -39,12 +39,13 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
 import { SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { KernelStatusBadge } from './KernelStatusBadge.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 
@@ -404,6 +405,30 @@ registerNotebookAction({
 	}
 });
 
+// Z key: Undo in command mode (Jupyter-style)
+// Adds keybinding to existing 'undo' command that's handled by contrib/undoRedo/positronNotebookUndoRedo.ts
+KeybindingsRegistry.registerKeybindingRule({
+	id: 'undo',
+	weight: KeybindingWeight.EditorContrib,
+	when: ContextKeyExpr.and(
+		POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
+		POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+	),
+	primary: KeyCode.KeyZ
+});
+
+// Shift+Z key: Redo in command mode (Jupyter-style)
+// Adds keybinding to existing 'redo' command that's handled by contrib/undoRedo/positronNotebookUndoRedo.ts
+KeybindingsRegistry.registerKeybindingRule({
+	id: 'redo',
+	weight: KeybindingWeight.EditorContrib,
+	when: ContextKeyExpr.and(
+		POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
+		POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+	),
+	primary: KeyMod.Shift | KeyCode.KeyZ
+});
+
 //#endregion Notebook Commands
 
 //#region Cell Commands
@@ -743,16 +768,13 @@ registerCellCommand({
 	}
 });
 
-// Copy cells command - Cmd/Ctrl+C
+// Copy cells command - C (Jupyter-style)
 registerCellCommand({
 	commandId: 'positronNotebook.copyCells',
 	handler: (cell, notebook) => notebook.copyCells(),
 	multiSelect: true,  // Copy all selected cells
 	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyCode.KeyC,
-		mac: {
-			primary: KeyMod.CtrlCmd | KeyCode.KeyC,
-		},
+		primary: KeyCode.KeyC
 	},
 	actionBar: {
 		icon: 'codicon-copy',
@@ -765,13 +787,13 @@ registerCellCommand({
 	}
 });
 
-// Cut cells command - Cmd/Ctrl+X
+// Cut cells command - X (Jupyter-style)
 registerCellCommand({
 	commandId: 'positronNotebook.cutCells',
 	handler: (cell, notebook) => notebook.cutCells(),
 	multiSelect: true,  // Cut all selected cells
 	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyCode.KeyX,
+		primary: KeyCode.KeyX
 	},
 	actionBar: {
 		position: 'menu',
@@ -783,14 +805,12 @@ registerCellCommand({
 	}
 });
 
-// Paste cells command - Cmd/Ctrl+V
+// Paste cells command - V (Jupyter-style)
 registerCellCommand({
 	commandId: 'positronNotebook.pasteCells',
 	handler: (cell, notebook) => notebook.pasteCells(),
 	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyCode.KeyV,
-		win: { primary: KeyMod.CtrlCmd | KeyCode.KeyV, secondary: [KeyMod.Shift | KeyCode.Insert] },
-		linux: { primary: KeyMod.CtrlCmd | KeyCode.KeyV, secondary: [KeyMod.Shift | KeyCode.Insert] },
+		primary: KeyCode.KeyV
 	},
 	actionBar: {
 		position: 'menu',
@@ -802,12 +822,12 @@ registerCellCommand({
 	}
 });
 
-// Paste cells above command - Cmd/Ctrl+Shift+V
+// Paste cells above command - Shift+V (Jupyter-style)
 registerCellCommand({
 	commandId: 'positronNotebook.pasteCellsAbove',
 	handler: (cell, notebook) => notebook.pasteCellsAbove(),
 	keybinding: {
-		primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV,
+		primary: KeyMod.Shift | KeyCode.KeyV
 	},
 	actionBar: {
 		position: 'menu',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -119,7 +119,7 @@ export class Workbench {
 		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console, this.contextMenu);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess, this.hotKeys);
 		this.notebooksVscode = new VsCodeNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys);
-		this.notebooksPositron = new PositronNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys, this.clipboard, this.contextMenu);
+		this.notebooksPositron = new PositronNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys, this.contextMenu);
 		this.welcome = new Welcome(code);
 		this.terminal = new Terminal(code, this.quickaccess, this.clipboard);
 		this.viewer = new Viewer(code);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -7,7 +7,6 @@ import { Notebooks } from './notebooks';
 import { Code } from '../infra/code';
 import { QuickInput } from './quickInput';
 import { QuickAccess } from './quickaccess';
-import { Clipboard } from './clipboard.js';
 import test, { expect, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
 import { ContextMenu } from './dialog-contextMenu.js';
@@ -36,7 +35,7 @@ export class PositronNotebooks extends Notebooks {
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /more actions/i });
 	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
 
-	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys, private clipboard: Clipboard, private contextMenu: ContextMenu) {
+	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys, private contextMenu: ContextMenu) {
 		super(code, quickinput, quickaccess, hotKeys);
 	}
 
@@ -291,21 +290,24 @@ export class PositronNotebooks extends Notebooks {
 			// Press escape to ensure focus is out of the cell editor
 			await this.code.driver.page.keyboard.press('Escape');
 
+			// Note: We use direct keyboard shortcuts instead of hotKeys/clipboard helpers
+			// because Positron Notebooks uses Jupyter-style single-key shortcuts (C/X/V/Z)
+			// in command mode, not the standard Cmd+C/X/V/Z shortcuts
 			switch (action) {
 				case 'copy':
-					await this.clipboard.copy();
+					await this.code.driver.page.keyboard.press('KeyC');
 					break;
 				case 'cut':
-					await this.clipboard.cut();
+					await this.code.driver.page.keyboard.press('KeyX');
 					break;
 				case 'paste':
-					await this.clipboard.paste();
+					await this.code.driver.page.keyboard.press('KeyV');
 					break;
 				case 'undo':
-					await this.hotKeys.undo();
+					await this.code.driver.page.keyboard.press('KeyZ');
 					break;
 				case 'redo':
-					await this.hotKeys.redo();
+					await this.code.driver.page.keyboard.press('Shift+KeyZ');
 					break;
 				case 'delete':
 					await this.code.driver.page.keyboard.press('Backspace');


### PR DESCRIPTION
Addresses #3014.

This PR implements Jupyter-style keyboard shortcuts for cell-level undo, redo, copy, cut, and paste operations in Positron Notebooks. These shortcuts match standard Jupyter behavior and work when in command mode (notebook focused but not editing a cell).

Followup to #2357.

### Implemented shortcuts:
- <kbd>Z</kbd> - Undo last cell operation
- <kbd>Shift</kbd>+<kbd>Z</kbd> - Redo cell operation
- <kbd>C</kbd> - Copy selected cell(s)
- <kbd>X</kbd> - Cut selected cell(s)
- <kbd>V</kbd> - Paste cell(s) below
- <kbd>Shift</kbd>+<kbd>V</kbd> - Paste cell(s) above

These shortcuts only activate when the notebook container is focused but no cell editor is focused (command mode), ensuring they don't interfere with normal text editing.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks

1. Open a notebook in Positron
2. Add several cells with content
3. Press <kbd>Esc</kbd> to enter command mode (cell should have blue border, not green)
4. Test each shortcut:
   - Select a cell and press <kbd>C</kbd> to copy
   - Press <kbd>V</kbd> to paste below, or <kbd>Shift</kbd>+<kbd>V</kbd> to paste above
   - Press <kbd>X</kbd> to cut a cell
   - Press <kbd>Z</kbd> to undo the operation
   - Press <kbd>Shift</kbd>+<kbd>Z</kbd> to redo
5. Verify shortcuts only work in command mode (when no cell editor is focused)
6. Press <kbd>Enter</kbd> to enter edit mode and verify <kbd>C</kbd>, <kbd>X</kbd>, <kbd>V</kbd>, <kbd>Z</kbd> work as normal text editing keys
