### PR TITLE
Improve view mode keybinding for markdown cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -32,7 +32,6 @@ export const POSITRON_NOTEBOOK_CELL_IS_LAST = new RawContextKey<boolean>('positr
 export const POSITRON_NOTEBOOK_CELL_IS_ONLY = new RawContextKey<boolean>('positronNotebookCellIsOnly', false);
 /**
  * Context key that is true when the markdown editor of a cell is open for editing.
- * This does not necessarily mean the cell is focused, just that the editor is visible.
  */
 export const POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService, IScopedContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 
 /**
-	 * Context key that is set when the Positron notebook editor container is focused. This will _not_ be true when the user is editing a cell.
+ * Context key that is set when the Positron notebook editor container is focused. This will _not_ be true when the user is editing a cell.
  */
 export const POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorContainerFocused', false);
 
@@ -21,14 +21,30 @@ export const POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED = new RawContextKey<boolean>(
 // Cell state context keys
 export const POSITRON_NOTEBOOK_CELL_IS_CODE = new RawContextKey<boolean>('positronNotebookCellIsCode', false);
 export const POSITRON_NOTEBOOK_CELL_IS_MARKDOWN = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false);
+/**
+ * A raw cell is one that contains plain text without any rendered outputs or execution capabilities.
+ */
 export const POSITRON_NOTEBOOK_CELL_IS_RAW = new RawContextKey<boolean>('positronNotebookCellIsRaw', false);
 export const POSITRON_NOTEBOOK_CELL_IS_RUNNING = new RawContextKey<boolean>('positronNotebookCellIsRunning', false);
 export const POSITRON_NOTEBOOK_CELL_IS_PENDING = new RawContextKey<boolean>('positronNotebookCellIsPending', false);
 export const POSITRON_NOTEBOOK_CELL_IS_FIRST = new RawContextKey<boolean>('positronNotebookCellIsFirst', false);
 export const POSITRON_NOTEBOOK_CELL_IS_LAST = new RawContextKey<boolean>('positronNotebookCellIsLast', false);
 export const POSITRON_NOTEBOOK_CELL_IS_ONLY = new RawContextKey<boolean>('positronNotebookCellIsOnly', false);
+/**
+ * Context key that is true when the markdown editor of a cell is open for editing.
+ * This does not necessarily mean the cell is focused, just that the editor is visible.
+ */
 export const POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
+/**
+ * Context key that is true when the cell is selected (active for selection/navigation, but not necessarily being edited).
+ * This is similar to "command mode" in Vim, allowing for cell navigation and selection without entering edit mode.
+ * Relevant for multi-cell selection scenarios.
+ */
 export const POSITRON_NOTEBOOK_CELL_IS_SELECTED = new RawContextKey<boolean>('positronNotebookCellIsSelected', false);
+/**
+ * POSITRON_NOTEBOOK_CELL_IS_EDITING looks to be a duplicate of POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.
+ * The context key value is set but never actually read anywhere in the codebase. Consider removing it if it's not needed.
+ */
 export const POSITRON_NOTEBOOK_CELL_IS_EDITING = new RawContextKey<boolean>('positronNotebookCellIsEditing', false);
 export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
 export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -22,7 +22,7 @@ export const POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED = new RawContextKey<boolean>(
 export const POSITRON_NOTEBOOK_CELL_IS_CODE = new RawContextKey<boolean>('positronNotebookCellIsCode', false);
 export const POSITRON_NOTEBOOK_CELL_IS_MARKDOWN = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false);
 /**
- * A raw cell is one that contains plain text without any rendered outputs or execution capabilities.
+ * A cell of type 'raw' i.e. one that contains plain text without any rendered outputs or execution capabilities.
  */
 export const POSITRON_NOTEBOOK_CELL_IS_RAW = new RawContextKey<boolean>('positronNotebookCellIsRaw', false);
 export const POSITRON_NOTEBOOK_CELL_IS_RUNNING = new RawContextKey<boolean>('positronNotebookCellIsRunning', false);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -93,6 +93,16 @@ export function NotebookCellWrapper({ cell, actionBarChildren, children, hasErro
 		tabIndex={0}
 		onClick={(e) => {
 			const clickTarget = e.nativeEvent.target as HTMLElement;
+
+			// Close any open markdown cell editors when clicking on a different cell
+			// This must happen before any early returns to ensure markdown cells always close
+			const cells = notebookInstance.cells.get();
+			for (const otherCell of cells) {
+				if (otherCell !== cell && otherCell.isMarkdownCell() && otherCell.editorShown.get()) {
+					otherCell.toggleEditor();
+				}
+			}
+
 			// If any of the element or its parents have the class
 			// 'positron-cell-editor-monaco-widget' then don't run the select code as the editor
 			// widget itself handles that logic

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -15,6 +15,11 @@ import { useObservedValue } from '../useObservedValue.js';
 import { Markdown } from './Markdown.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookMarkdownCell } from '../PositronNotebookCells/PositronNotebookMarkdownCell.js';
+import { localize } from '../../../../../nls.js';
+
+// Localized strings.
+const emptyMarkdownCell = localize('positron.notebooks.markdownCell.empty', "Empty markdown cell.");
+const doubleClickToEdit = localize('positron.notebooks.markdownCell.doubleClickToEdit', " Double click to edit.");
 
 export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownCell }) {
 
@@ -36,7 +41,8 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 						markdownString.length > 0 ?
 							<Markdown content={markdownString} />
 							: <div className='empty-output-msg'>
-								Empty markup cell. {editorShown ? '' : 'Double click to edit.'}
+								{emptyMarkdownCell}
+								{!editorShown && doubleClickToEdit}
 							</div>
 					}
 				</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -398,7 +398,7 @@ registerNotebookAction({
 			// get the selected cell that is being edited
 			const cell = state.selected;
 			// handle markdown cells differently
-			if (cell.isMarkdownCell() && cell.editorShown?.get()) {
+			if (cell.isMarkdownCell() && cell.editorShown.get()) {
 				// This handles updating selection state and closing the editor
 				cell.toggleEditor();
 			} else {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -388,7 +388,16 @@ registerNotebookAction({
 	}
 });
 
-// Escape key: Exit edit mode when cell editor is focused
+/**
+ * Escape key: Exit edit mode when cell editor is focused.
+ * This command handles the keybinding for all cell types.
+ *
+ * This action has a counterpart command called
+ * `positronNotebook.cell.collapseMarkdownEditor` that is
+ * used to contribute the same functionality to markdown
+ * cell action bars. We should keep both commands in sync
+ * to ensure consistent behavior.
+ */
 registerNotebookAction({
 	commandId: 'positronNotebook.cell.quitEdit',
 	handler: (notebook) => {
@@ -606,8 +615,14 @@ registerCellCommand({
 	}
 });
 
-
-// Collapse markdown editor (For action bar)
+/**
+ * Collapse markdown editor (For action bar)
+ *
+ * Handles contributing the behavior of
+ * `positronNotebook.cell.quitEdit` to markdown cell
+ * action bar. We should keep both commands in sync to
+ * ensure consistent behavior.
+ */
 registerCellCommand({
 	commandId: 'positronNotebook.cell.collapseMarkdownEditor',
 	handler: (cell) => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -392,7 +392,19 @@ registerNotebookAction({
 registerNotebookAction({
 	commandId: 'positronNotebook.cell.quitEdit',
 	handler: (notebook) => {
-		notebook.selectionStateMachine.exitEditor();
+		const state = notebook.selectionStateMachine.state.get();
+		// check if we are in editing mode
+		if (state.type === SelectionState.EditingSelection) {
+			// get the selected cell that is being edited
+			const cell = state.selected;
+			// handle markdown cells differently
+			if (cell.isMarkdownCell() && cell.editorShown?.get()) {
+				// This handles updating selection state and closing the editor
+				cell.toggleEditor();
+			} else {
+				notebook.selectionStateMachine.exitEditor();
+			}
+		}
 	},
 	keybinding: {
 		primary: KeyCode.Escape,

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -57,6 +57,7 @@ const ValidSelectionStateTransitions: Record<SelectionState, SelectionState[]> =
 	[SelectionState.MultiSelection]: [
 		SelectionState.MultiSelection,   // Modify selection
 		SelectionState.SingleSelection,  // Reduce to single cell
+		SelectionState.EditingSelection, // Enter edit mode for single cell
 		SelectionState.NoCells,          // All cells removed
 	],
 	[SelectionState.EditingSelection]: [


### PR DESCRIPTION
Related to #9713 (the ask to have a mechanism to switch between modes already exists)

This PR is a suggestion for improving the `edit` to `view` mode experience for markdown cells. 

While playing around with notebooks, I noticed that there was some inconsistency with how markdown cells behaved when using the keyboard vs the cell action bar that caused me a bit of confusion. 

When you are in edit mode for a markdown cell, the cell action bar has a chevron icon button that hides the editor for markdown cells. I assumed this action was changing the cell from `edit` to `view` mode. The notebook also has a keybinding to exit edit mode that maps to `Escape`. This command does not do the same thing as the button in the cell action bar. When you press `Escape` in a markdown cell, focus moves to the markdown cell container and leaves the editor. The markdown editor view stays around with the preview underneath it. 

It was unclear that this mismatch in behavior was intentional! I think another reason that the `edit` to `view` mode transition in markdown cells is confusing has to do with not having a great visual indicator for being in `view` mode. We show a focus indicator around the cell when a user is in `edit` mode, but there isn't anything like that for `view` mode.

I can close out this PR If we don't want to consolidate the behavior and need it to be different, but I figured I'd see what folks thought. I find the consolidation makes things less confusing.

It turns out we have 2 different commands that address exiting `edit` mode:
- `positronNotebook.cell.collapseMarkdownEditor` -> command for action that shows up in markdown cell action bars
- `positronNotebook.cell.quitEdit` -> command to exit `edit` mode for all cell types that is not contributed to any action bars

I think we still need two separate actions, one that allows us to contribute a button to a cell action bar, and a generic one that we can attach the keybinding to. I just think the behavior for both should be the same!

**BEFORE**

https://github.com/user-attachments/assets/9ac239f8-85ba-4941-9c4f-e3e6d4e89a99


**AFTER**

https://github.com/user-attachments/assets/ab87a398-1717-44de-b8f3-a927d4f18645


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:positron-notebooks