### PR TITLE
e2e: skip new folder flow test due to #9999

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -12,7 +12,10 @@ test.use({
 });
 
 // Not running conda test on windows because conda reeks havoc on selecting the correct python interpreter
-test.describe('New Folder Flow: Python Project', { tag: [tags.MODAL, tags.NEW_FOLDER_FLOW, tags.WEB] }, () => {
+test.describe.skip('New Folder Flow: Python Project', {
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9999' }],
+	tag: [tags.MODAL, tags.NEW_FOLDER_FLOW, tags.WEB]
+}, () => {
 	const folderTemplate = FolderTemplate.PYTHON_PROJECT;
 
 	test.beforeAll(async function ({ settings }) {


### PR DESCRIPTION
### Summary
Due to Issue #9999 the new-folder-flow test frequently fails. Skipping test until the issue is resolved.

### QA notes
n/a