### PR TITLE
Add Claude code skills

### DIFF
--- a/.claude/skills/positron-intake-rotation/SKILL.md
+++ b/.claude/skills/positron-intake-rotation/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: positron-intake-rotation
+description: This skill should be used when handling issue intake rotation duties for the Positron repository. It provides workflows for reviewing and organizing new issues, responding to discussions, handling support tickets, and searching for related content. Use this skill when on intake rotation duty, when helping someone with intake tasks, or when learning the intake rotation process.
+---
+
+# Positron Intake Rotation
+
+## Overview
+
+This skill provides comprehensive guidance for handling issue intake rotation for the Positron IDE repository. Intake rotation is a weekly assignment (Monday-Friday) where team members review and respond to new issues, discussion posts, and support tickets to ensure timely responses and actionable issue tracking.
+
+The goal is to respond to new items within approximately one business day and ensure all issues have the details required to be actionable.
+
+## When to Use This Skill
+
+Use this skill when:
+- Currently on intake rotation duty
+- Helping another team member with intake tasks
+- Learning the intake rotation process
+- Reviewing backlog items without status
+- Responding to GitHub discussions
+- Handling customer support tickets
+- Searching for duplicate or related issues
+
+## Quick Start
+
+### Essential Scripts
+
+Four shell scripts are provided to streamline intake tasks:
+
+1. **`scripts/fetch_intake_issues.sh`** - List open issues without status (the intake queue)
+2. **`scripts/fetch_discussions.sh`** - List recent open discussions needing attention
+3. **`scripts/fetch_labels.sh`** - Show all available repository labels for categorization
+4. **`scripts/search_related.sh <query>`** - Search for related issues and discussions
+
+All scripts support `--json` flag for programmatic use. Run scripts from the skill directory.
+
+### Essential References
+
+Two comprehensive reference documents provide detailed workflows:
+
+1. **`references/intake_workflow.md`** - Complete workflows for handling issues, discussions, and support tickets
+2. **`references/response_examples.md`** - Response patterns and examples from experienced team members
+
+Load these references when drafting responses or handling complex scenarios.
+
+## Core Workflow
+
+### Daily Intake Process
+
+Follow this process each day during rotation:
+
+1. **Check for new items**
+   - Run `scripts/fetch_intake_issues.sh` to see issues without status
+   - Run `scripts/fetch_discussions.sh` to see recent discussions
+   - Check [Support Tickets in Jira](https://positpbc.atlassian.net/jira/core/projects/IDEESC/board/UtafxcH?filter=labels%20%3D%20%22Positron%22&groupBy=status)
+
+2. **Review each item systematically**
+   - Read the full description and context
+   - Assess completeness (are system details, reproduction steps, etc. provided?)
+   - Determine item type (bug, feature request, question, duplicate)
+
+3. **Search for related content**
+   - Use `scripts/search_related.sh "<keywords>"` to find similar issues
+   - Check documentation at https://positron.posit.co/welcome.html
+   - Look for existing discussions on the topic
+
+4. **Categorize and organize**
+   - Run `scripts/fetch_labels.sh` to see available labels
+   - Apply appropriate labels (area, type, priority)
+   - Set status to "Triage" once organized
+   - Add to "Positron Backlog" project if applicable
+
+5. **Draft and post response**
+   - Consult `references/response_examples.md` for patterns
+   - Welcome the contributor and thank them
+   - Ask clarifying questions if information is missing
+   - Provide workarounds or links to related content when available
+   - Set realistic expectations about next steps
+
+6. **Follow through**
+   - Tag relevant team members if specialized knowledge is needed
+   - Close duplicates with reference to canonical issue
+   - Convert discussions to issues when appropriate
+   - Continue following up even after rotation ends, or explicitly hand off
+
+### Using GitHub CLI
+
+Prefer using GitHub CLI (`gh`) over other methods for consistency:
+
+```bash
+# View issue with all comments
+gh issue view <number> --repo posit-dev/positron --comments
+
+# Search issues
+gh issue list --repo posit-dev/positron --search "<query>" --state all
+
+# Add labels
+gh issue edit <number> --repo posit-dev/positron --add-label "area: console,Bug"
+
+# View discussion
+gh api graphql -f query='...' # (see scripts for examples)
+
+# Close as duplicate
+gh issue close <number> --repo posit-dev/positron --comment "Closing as duplicate of #<canonical-number>"
+```
+
+## Handling Different Scenarios
+
+### Bug Reports
+
+For bug reports, assess completeness:
+
+**Complete bug report:**
+- System details (Positron version, OS, commit hash)
+- Clear reproduction steps
+- Expected vs. actual behavior
+- Error messages or screenshots
+
+If complete:
+1. Search for duplicates using `scripts/search_related.sh`
+2. Apply labels (area, "Bug" type)
+3. Set status to "Triage"
+4. Thank reporter and acknowledge the issue
+
+If incomplete:
+1. Thank the reporter
+2. Ask specific questions about missing information
+3. Reference the bug report template if helpful
+4. Keep issue open until information is provided
+
+**Refer to `references/intake_workflow.md` for detailed bug handling workflows.**
+
+### Feature Requests
+
+For feature requests:
+1. Thank the user for the suggestion
+2. Search for existing related feature requests
+3. If duplicate, link to existing issue and close
+4. If new, apply labels and add to backlog
+5. Set realistic expectations about prioritization
+
+### Discussions
+
+For discussions:
+1. Determine discussion type (question, idea, bug report, announcement)
+2. Respond appropriately:
+   - **Questions:** Answer or link to docs
+   - **Ideas:** Acknowledge and link to related issues
+   - **Bug reports:** Ask user to create formal issue
+   - **Off-topic:** Politely redirect
+
+**Convert discussions to issues** when they contain clear, actionable bug reports or feature requests.
+
+### Support Tickets
+
+Support tickets require special handling:
+
+⚠️ **CRITICAL:** Never mention customer names in public issues or discussions
+
+1. Review ticket context in Jira
+2. Search for related public issues
+3. Respond in Jira (not publicly)
+4. Create sanitized public issue if needed
+5. Link between ticket and issue
+
+### Security Issues
+
+If an issue describes a security vulnerability:
+1. **Do NOT discuss details publicly**
+2. Ask reporter to email security@posit.co
+3. Close public issue with note about private reporting
+4. Alert team privately
+
+## Response Guidelines
+
+### Tone and Style
+
+**Be welcoming:** Thank contributors for their time and effort
+
+**Be clear:** Use simple language, explain technical terms, provide examples
+
+**Be helpful:** Offer workarounds, link to resources, provide next steps
+
+**Be realistic:** Don't overpromise timelines or solutions
+
+**Be professional:** Remain calm and constructive, even with frustrated reporters
+
+### Learning from Examples
+
+To see examples from experienced team members:
+
+```bash
+# Find issues commented on by key team members
+gh search issues --repo posit-dev/positron --commenter juliasilge --limit 20
+gh search issues --repo posit-dev/positron --commenter jmcphers --limit 20
+
+# View specific issue with comments
+gh issue view <number> --repo posit-dev/positron --comments
+```
+
+Pay special attention to responses by `juliasilge` and `jmcphers` for tone and approach guidance.
+
+**Load `references/response_examples.md` for detailed response patterns and anti-patterns.**
+
+## Important Reminders
+
+### Team Collaboration
+
+**Don't try to solve everything alone.** Reach out to team members when:
+- The issue requires specialized domain knowledge
+- You're unsure how to categorize or prioritize
+- The issue describes complex technical problems
+- You need help understanding the user's concern
+
+### Handoff Protocol
+
+If handling an item extends beyond your rotation week:
+- **Typically:** Continue following up yourself to get to triage
+- **If not possible:** Explicitly communicate handoff to next person on rotation
+- **Don't drop items** without clear handoff
+
+### Documentation
+
+If recurring issues or common questions emerge:
+- Consider creating FAQ entries
+- Suggest documentation improvements
+- Note patterns for team discussion
+
+## Quick Reference Links
+
+- [Issue Intake Board](https://github.com/orgs/posit-dev/projects/2/views/33) - Issues without status
+- [Discussions](https://github.com/posit-dev/positron/discussions) - Community discussions
+- [Support Tickets](https://positpbc.atlassian.net/jira/core/projects/IDEESC/board/UtafxcH?filter=labels%20%3D%20%22Positron%22&groupBy=status) - Customer support (Jira)
+- [Rotation Schedule](https://docs.google.com/spreadsheets/d/1JtE6NpwCx7x9ni-I_KYwCba63wo6LeJ6Z2CyYx_3Qss/edit?usp=sharing) - Google Sheet
+- [Documentation](https://positron.posit.co/welcome.html) - Official Positron docs
+- [Positron Assistant](https://connect.posit.it/positron-wiki/dev-notes/gh-issues-positron-assistant.html) - GitHub issue assistant
+
+## Workflow Summary
+
+```
+Daily Intake:
+1. Fetch new items (scripts/fetch_intake_issues.sh, scripts/fetch_discussions.sh)
+2. Review and assess each item
+3. Search for related content (scripts/search_related.sh)
+4. Categorize with labels (scripts/fetch_labels.sh)
+5. Draft response (references/response_examples.md)
+6. Set status to "Triage"
+7. Follow through or hand off
+
+Remember: The goal is timely response and actionable organization, not solving every issue.
+```

--- a/.claude/skills/positron-intake-rotation/SKILL.md
+++ b/.claude/skills/positron-intake-rotation/SKILL.md
@@ -11,6 +11,22 @@ This skill provides comprehensive guidance for handling issue intake rotation fo
 
 The goal is to respond to new items within approximately one business day and ensure all issues have the details required to be actionable.
 
+## 🚨 CRITICAL: Manual Action Protocol
+
+**This skill assists with intake rotation but NEVER executes GitHub actions directly.**
+
+All GitHub interactions must be performed manually by the user:
+- ✅ Draft responses for review before posting
+- ✅ Suggest labels and categorization
+- ✅ Prepare commands for user to execute
+- ✅ Search and analyze issues/discussions
+- ❌ NEVER post comments or responses directly
+- ❌ NEVER edit issues, add labels, or change status
+- ❌ NEVER close issues or create new ones
+- ❌ NEVER execute `gh` commands that modify GitHub state
+
+**Workflow:** Analyze → Recommend → Draft → User executes manually
+
 ## When to Use This Skill
 
 Use this skill when:
@@ -65,29 +81,32 @@ Follow this process each day during rotation:
    - Check documentation at https://positron.posit.co/welcome.html
    - Look for existing discussions on the topic
 
-4. **Categorize and organize**
+4. **Recommend categorization and organization**
    - Run `scripts/fetch_labels.sh` to see available labels
-   - Apply appropriate labels (area, type, priority)
-   - Set status to "Triage" once organized
-   - Add to "Positron Backlog" project if applicable
+   - **Suggest** appropriate labels (area, type, priority) for user to apply
+   - **Recommend** setting status to "Triage" once organized
+   - **Suggest** adding to "Positron Backlog" project if applicable
+   - **Prepare** `gh` commands for user to execute manually
 
-5. **Draft and post response**
+5. **Draft response for user review**
    - Consult `references/response_examples.md` for patterns
-   - Welcome the contributor and thank them
-   - Ask clarifying questions if information is missing
-   - Provide workarounds or links to related content when available
+   - Draft welcoming message thanking the contributor
+   - Include clarifying questions if information is missing
+   - Suggest workarounds or links to related content when available
    - Set realistic expectations about next steps
+   - **Present draft to user for review before posting**
 
-6. **Follow through**
-   - Tag relevant team members if specialized knowledge is needed
-   - Close duplicates with reference to canonical issue
-   - Convert discussions to issues when appropriate
-   - Continue following up even after rotation ends, or explicitly hand off
+6. **Recommend follow-through actions**
+   - **Suggest** tagging relevant team members if specialized knowledge is needed
+   - **Draft** duplicate closure message with reference to canonical issue
+   - **Recommend** converting discussions to issues when appropriate
+   - **Advise** continuing follow-up even after rotation ends, or explicit handoff
 
 ### Using GitHub CLI
 
-Prefer using GitHub CLI (`gh`) over other methods for consistency:
+Prefer using GitHub CLI (`gh`) over other methods for consistency. **All commands below are for the USER to execute manually.**
 
+**Read-only commands** (can be executed to gather information):
 ```bash
 # View issue with all comments
 gh issue view <number> --repo posit-dev/positron --comments
@@ -95,15 +114,20 @@ gh issue view <number> --repo posit-dev/positron --comments
 # Search issues
 gh issue list --repo posit-dev/positron --search "<query>" --state all
 
-# Add labels
-gh issue edit <number> --repo posit-dev/positron --add-label "area: console,Bug"
-
 # View discussion
 gh api graphql -f query='...' # (see scripts for examples)
+```
 
-# Close as duplicate
+**Modification commands** (prepare for user, NEVER execute directly):
+```bash
+# Add labels - DRAFT THIS COMMAND for user to run
+gh issue edit <number> --repo posit-dev/positron --add-label "area: console,Bug"
+
+# Close as duplicate - DRAFT THIS COMMAND for user to run
 gh issue close <number> --repo posit-dev/positron --comment "Closing as duplicate of #<canonical-number>"
 ```
+
+**Important:** Present modification commands to the user in a code block with clear instructions to review and execute manually.
 
 ## Handling Different Scenarios
 
@@ -119,38 +143,38 @@ For bug reports, assess completeness:
 
 If complete:
 1. Search for duplicates using `scripts/search_related.sh`
-2. Apply labels (area, "Bug" type)
-3. Set status to "Triage"
-4. Thank reporter and acknowledge the issue
+2. **Suggest** labels (area, "Bug" type) for user to apply
+3. **Recommend** setting status to "Triage"
+4. **Draft** response thanking reporter and acknowledging the issue
 
 If incomplete:
-1. Thank the reporter
-2. Ask specific questions about missing information
-3. Reference the bug report template if helpful
-4. Keep issue open until information is provided
+1. **Draft** message thanking the reporter
+2. **Include** specific questions about missing information
+3. **Suggest** referencing the bug report template if helpful
+4. **Advise** keeping issue open until information is provided
 
 **Refer to `references/intake_workflow.md` for detailed bug handling workflows.**
 
 ### Feature Requests
 
 For feature requests:
-1. Thank the user for the suggestion
+1. **Draft** message thanking the user for the suggestion
 2. Search for existing related feature requests
-3. If duplicate, link to existing issue and close
-4. If new, apply labels and add to backlog
-5. Set realistic expectations about prioritization
+3. If duplicate, **draft** message linking to existing issue (user closes manually)
+4. If new, **suggest** labels and recommend adding to backlog
+5. **Draft** message setting realistic expectations about prioritization
 
 ### Discussions
 
 For discussions:
 1. Determine discussion type (question, idea, bug report, announcement)
-2. Respond appropriately:
-   - **Questions:** Answer or link to docs
+2. **Draft** appropriate response:
+   - **Questions:** Provide answer or link to docs
    - **Ideas:** Acknowledge and link to related issues
    - **Bug reports:** Ask user to create formal issue
    - **Off-topic:** Politely redirect
 
-**Convert discussions to issues** when they contain clear, actionable bug reports or feature requests.
+**Recommend converting discussions to issues** when they contain clear, actionable bug reports or feature requests (user performs conversion manually).
 
 ### Support Tickets
 
@@ -160,17 +184,17 @@ Support tickets require special handling:
 
 1. Review ticket context in Jira
 2. Search for related public issues
-3. Respond in Jira (not publicly)
-4. Create sanitized public issue if needed
-5. Link between ticket and issue
+3. **Draft** response in Jira (not publicly) for user to post
+4. **Recommend** creating sanitized public issue if needed
+5. **Suggest** linking between ticket and issue
 
 ### Security Issues
 
 If an issue describes a security vulnerability:
 1. **Do NOT discuss details publicly**
-2. Ask reporter to email security@posit.co
-3. Close public issue with note about private reporting
-4. Alert team privately
+2. **Draft** message asking reporter to email security@posit.co
+3. **Recommend** closing public issue with note about private reporting (user closes manually)
+4. **Advise** alerting team privately
 
 ## Response Guidelines
 
@@ -239,14 +263,17 @@ If recurring issues or common questions emerge:
 ## Workflow Summary
 
 ```
-Daily Intake:
+Daily Intake (Assistant Mode - Draft & Recommend):
 1. Fetch new items (scripts/fetch_intake_issues.sh, scripts/fetch_discussions.sh)
 2. Review and assess each item
 3. Search for related content (scripts/search_related.sh)
-4. Categorize with labels (scripts/fetch_labels.sh)
-5. Draft response (references/response_examples.md)
-6. Set status to "Triage"
-7. Follow through or hand off
+4. SUGGEST labels and categorization (scripts/fetch_labels.sh)
+5. DRAFT response (references/response_examples.md) for user review
+6. PREPARE gh commands for user to execute
+7. RECOMMEND setting status to "Triage" (user executes)
+8. ADVISE on follow-through or handoff
 
-Remember: The goal is timely response and actionable organization, not solving every issue.
+Remember: The goal is to ASSIST the user with timely response and actionable
+organization. NEVER execute GitHub modification commands directly - always
+present drafts and recommendations for the user to review and execute manually.
 ```

--- a/.claude/skills/positron-intake-rotation/references/intake_workflow.md
+++ b/.claude/skills/positron-intake-rotation/references/intake_workflow.md
@@ -1,0 +1,160 @@
+# Issue Intake Workflow
+
+This document provides detailed workflows for handling issues, discussions, and support tickets during intake rotation.
+
+## Core Responsibilities
+
+The person on intake rotation ensures that issues, discussions, and support tickets are not dropped or ignored. The goal is to respond within about a business day. Key responsibilities:
+
+1. **Review and organize open issues without a status** - Check the [Issue Intake Board](https://github.com/orgs/posit-dev/projects/2/views/33)
+2. **Respond to open discussions** - Check [Positron Discussions](https://github.com/posit-dev/positron/discussions)
+3. **Handle support tickets** - Check [Jira Support Board](https://positpbc.atlassian.net/jira/core/projects/IDEESC/board/UtafxcH?filter=labels%20%3D%20%22Positron%22&groupBy=status)
+
+**Important:** Reach out to other team members for input if it's not clear how to handle an issue.
+
+**Handoff:** If handling an item bleeds into the next week, typically continue following up yourself. If that's not possible, explicitly communicate with the next person on rotation to hand it off.
+
+## Issue Handling Workflow
+
+### Step 1: Identify New Issues
+
+Use the `fetch_intake_issues.sh` script or check the [Issue Intake Board](https://github.com/orgs/posit-dev/projects/2/views/33) for open issues without a status.
+
+### Step 2: Review Issue Details
+
+For each new issue, review:
+- **Title and description** - Is the issue clear and actionable?
+- **System details** - Are system details provided (Positron version, OS, etc.)?
+- **Reproduction steps** - Can the issue be reproduced?
+- **Related content** - Are there duplicate or related issues?
+
+### Step 3: Search for Related Content
+
+Before responding, search for:
+- **Existing issues** - Use `search_related.sh` or `gh issue list --search`
+- **Discussions** - Check if similar topics have been discussed
+- **Documentation** - Check https://positron.posit.co/welcome.html for relevant docs
+
+### Step 4: Categorize and Label
+
+Based on the issue content:
+1. **Fetch available labels** - Run `fetch_labels.sh` to see current labels
+2. **Apply appropriate labels**:
+   - **Area labels** (e.g., `area: assistant`, `area: console`, `area: data-explorer`)
+   - **Type labels** (e.g., `Bug`, `Feature`, `Documentation`)
+   - **Priority labels** if applicable
+3. **Assign to project** - Add to "Positron Backlog" project if applicable
+
+### Step 5: Set Status
+
+Issues typically start with status "Triage" once they've been reviewed and organized. Other statuses may be available in the project board.
+
+### Step 6: Draft Response
+
+When drafting responses:
+- **Be welcoming and professional** - Thank users for reporting issues
+- **Ask clarifying questions** if details are missing
+- **Provide workarounds** if available
+- **Link to related issues or docs** when relevant
+- **Set expectations** about timeline or next steps if known
+
+**Look at past responses** by key team members (especially `juliasilge` and `jmcphers`) for tone and style guidance.
+
+**Common response patterns:**
+- For bugs: "Thank you for reporting this. Can you provide [specific details]? In the meantime, you might try [workaround]."
+- For features: "Thanks for the suggestion! This is similar to #[related-issue]. We'll consider this during planning."
+- For duplicates: "Thanks for reporting! This looks like a duplicate of #[issue-number]. I'll close this in favor of that one, but feel free to add any additional context there."
+- For unclear issues: "Thanks for reaching out. To help us understand this better, could you provide [specific information]?"
+
+### Step 7: Follow Through
+
+- **Tag relevant team members** if their expertise is needed
+- **Close duplicates** and reference the canonical issue
+- **Move to triage** once the issue is organized and ready for team review
+
+## Discussion Handling Workflow
+
+### Step 1: Review New Discussions
+
+Use `fetch_discussions.sh` or check [Discussions](https://github.com/posit-dev/positron/discussions) for recent activity.
+
+### Step 2: Determine Discussion Type
+
+Discussions typically fall into:
+- **Questions** - Users seeking help or clarification
+- **Ideas/Feature Requests** - Suggestions for new functionality
+- **Bug Reports** - Issues that should be converted to formal issues
+- **Announcements/Updates** - Team communications
+
+### Step 3: Respond or Redirect
+
+- **For questions**: Answer directly or link to docs/related discussions
+- **For feature ideas**: Acknowledge and indicate if similar issues exist
+- **For bugs**: Ask the user to create a formal issue with the bug template
+- **For off-topic**: Politely redirect to appropriate channels
+
+### Step 4: Convert to Issues When Appropriate
+
+If a discussion describes a clear bug or feature request:
+1. Ask the user to create a formal issue (preferred)
+2. Or create an issue yourself and link to the discussion
+3. Summarize key points in the issue description
+
+## Support Ticket Workflow
+
+Support tickets from customers require special handling:
+
+1. **Never mention customer names** in public issues or discussions
+2. **Review the ticket** in Jira for context
+3. **Search for related issues** that might already address the problem
+4. **Create a new issue if needed** - Sanitize any customer-specific information
+5. **Update the support ticket** with links to relevant issues or workarounds
+6. **Coordinate with support team** if specialized knowledge is needed
+
+## Other Scenarios
+
+### Incomplete Bug Reports
+
+If a bug report lacks critical information:
+- Ask for specific details: system info, reproduction steps, error messages
+- Use the bug report template as a guide for what's needed
+- Be patient and helpful - not everyone knows what information is useful
+
+### Feature Requests
+
+- Thank the user for the suggestion
+- Search for existing feature requests
+- If duplicate, link to the existing issue
+- If new, apply appropriate labels and add to backlog for triage
+
+### Security Issues
+
+If an issue describes a security vulnerability:
+- **Do not discuss details publicly**
+- Ask the reporter to email security@posit.co
+- Close the public issue with a note about the private reporting process
+- Alert the team privately
+
+### Spam or Abusive Content
+
+- Report to GitHub if needed
+- Lock and hide conversations if appropriate
+- Escalate to team leads if necessary
+
+## Tips for Effective Intake
+
+1. **Don't try to solve everything** - Your job is to organize and respond, not to fix every bug
+2. **It's okay to say "I don't know"** - Tag subject matter experts when needed
+3. **Be kind and welcoming** - Many reporters are new to open source
+4. **Use templates** - Look at past responses for common patterns
+5. **Keep it simple** - Clear, concise responses are better than long explanations
+6. **Document patterns** - If you notice recurring issues, consider creating docs or FAQ entries
+
+## Quick Reference Links
+
+- [Issue Intake Board](https://github.com/orgs/posit-dev/projects/2/views/33)
+- [Discussions](https://github.com/posit-dev/positron/discussions)
+- [Support Tickets (Jira)](https://positpbc.atlassian.net/jira/core/projects/IDEESC/board/UtafxcH?filter=labels%20%3D%20%22Positron%22&groupBy=status)
+- [Rotation Schedule (Google Sheet)](https://docs.google.com/spreadsheets/d/1JtE6NpwCx7x9ni-I_KYwCba63wo6LeJ6Z2CyYx_3Qss/edit?usp=sharing)
+- [Documentation](https://positron.posit.co/welcome.html)
+- [Positron Assistant for GitHub](https://connect.posit.it/positron-wiki/dev-notes/gh-issues-positron-assistant.html)

--- a/.claude/skills/positron-intake-rotation/references/response_examples.md
+++ b/.claude/skills/positron-intake-rotation/references/response_examples.md
@@ -1,0 +1,242 @@
+# Response Examples
+
+This document contains examples of effective responses to issues and discussions. Look for patterns in tone, structure, and helpful elements.
+
+## How to Use This Reference
+
+When drafting responses:
+1. Review examples similar to your situation
+2. Note the welcoming tone and professional language
+3. Observe how questions are asked clearly
+4. See how workarounds and next steps are communicated
+5. Adapt the patterns to your specific case
+
+## Finding More Examples
+
+To find real examples from key team members:
+
+```bash
+# Search for issues/PRs commented on by juliasilge
+gh search issues --repo posit-dev/positron --commenter juliasilge --limit 20
+
+# Search for issues/PRs commented on by jmcphers
+gh search issues --repo posit-dev/positron --commenter jmcphers --limit 20
+
+# View a specific issue with comments
+gh issue view <number> --repo posit-dev/positron --comments
+```
+
+## Common Response Patterns
+
+### Pattern: Bug Report - Initial Response
+
+**Situation:** User reports a bug with good details
+
+**Response Structure:**
+1. Thank them for reporting
+2. Confirm you understand the issue
+3. Ask any clarifying questions
+4. Provide workaround if available
+5. Set expectations
+
+**Example:**
+```
+Thank you for reporting this! I can reproduce the issue with Copilot models not having access to certain tools like getProjectTree and executeCode.
+
+A few questions to help us debug:
+- Does this happen with all Copilot models or specific ones?
+- Do you see any errors in the Developer Tools console (Help > Toggle Developer Tools)?
+
+In the meantime, you might try using Claude Sonnet models directly, which should have full tool access.
+
+I'll add this to our backlog for investigation.
+```
+
+### Pattern: Bug Report - Missing Information
+
+**Situation:** User reports a bug but lacks critical details
+
+**Response Structure:**
+1. Thank them for reporting
+2. Explain what information is needed and why
+3. Provide easy ways to get that information
+4. Remain helpful and encouraging
+
+**Example:**
+```
+Thanks for reporting this issue! To help us investigate, could you provide:
+
+1. Your Positron version (Help > About)
+2. Your operating system and version
+3. Steps to reproduce the issue
+4. Any error messages you see
+
+You can get much of this info automatically by running "Help > Report Issue" in Positron.
+
+Looking forward to getting this resolved!
+```
+
+### Pattern: Feature Request
+
+**Situation:** User suggests a new feature
+
+**Response Structure:**
+1. Thank them for the suggestion
+2. Acknowledge the use case
+3. Link to related issues if they exist
+4. Set expectations about prioritization
+5. Invite further discussion
+
+**Example:**
+```
+Thanks for this suggestion! Better terminal integration with R workflows would definitely
+be valuable.
+
+This relates to some of our ongoing work in #<related-issue>. We're considering several
+approaches for improving the terminal experience.
+
+I've added this to our backlog for consideration. Feel free to add any additional context
+about your specific use case - that helps us prioritize.
+```
+
+### Pattern: Duplicate Issue
+
+**Situation:** Issue is a duplicate of an existing one
+
+**Response Structure:**
+1. Thank them for reporting
+2. Link to the canonical issue
+3. Explain why you're closing as duplicate
+4. Invite them to continue discussion on the canonical issue
+
+**Example:**
+```
+Thank you for reporting this! This appears to be a duplicate of #<issue-number>, where
+we're tracking the same behavior.
+
+I'm going to close this issue in favor of that one to keep the discussion in one place.
+Please feel free to add any additional details or context to #<issue-number> - every
+data point helps!
+```
+
+### Pattern: Unclear Issue
+
+**Situation:** Issue is vague or unclear
+
+**Response Structure:**
+1. Thank them for reaching out
+2. Acknowledge what you understand
+3. Ask specific questions to clarify
+4. Provide examples of what would be helpful
+
+**Example:**
+```
+Thanks for reaching out! I want to make sure I understand the issue correctly.
+
+When you say "the console isn't working", do you mean:
+- The console doesn't start at all?
+- Commands don't execute?
+- Output isn't displayed?
+- Something else?
+
+Also helpful would be:
+- Your Positron version (Help > About)
+- Which language you're using (Python/R)
+- Any error messages you see
+
+A screenshot or screen recording would be really helpful too!
+```
+
+### Pattern: Converting Discussion to Issue
+
+**Situation:** Discussion contains a clear bug or feature request
+
+**Response Structure:**
+1. Acknowledge the discussion
+2. Explain why it should be an issue
+3. Ask them to create an issue or offer to create one
+4. Summarize what should be included
+
+**Example:**
+```
+This is a great discussion! It sounds like you've identified a specific bug with data frame rendering in the Variables pane.
+
+Would you mind creating a formal issue for this? That helps us track and prioritize the fix.
+Please include:
+- Your system details (Positron version, OS)
+- Steps to reproduce
+- Expected vs actual behavior
+
+I'll link back to this discussion from the issue so we don't lose this context.
+```
+
+### Pattern: Support Ticket Response
+
+**Situation:** Internal support ticket needs response
+
+**Response Structure:**
+1. Review ticket context privately
+2. Search for related public issues
+3. Respond in support system (not public)
+4. Create sanitized public issue if needed
+
+**Internal Response:**
+```
+I found a related issue at posit-dev/positron#<number> that describes the same Python
+extension loading behavior.
+
+The workaround is to disable and re-enable the Python extension after startup. We're
+working on a permanent fix tracked in that issue.
+
+I've added a note to the public issue mentioning this affects some enterprise configurations.
+```
+
+## Anti-Patterns to Avoid
+
+### Don't: Be Dismissive
+
+❌ "This is already documented. Please read the docs."
+
+✅ "Thanks for asking! This is documented at [link]. Specifically, the section on [topic]
+should help. Let me know if you have questions after reading that!"
+
+### Don't: Promise Timelines
+
+❌ "We'll fix this in the next release."
+
+✅ "We've added this to our backlog. I can't promise a specific timeline, but we'll prioritize based on impact and complexity."
+
+### Don't: Blame the User
+
+❌ "You're doing it wrong. You should..."
+
+✅ "I see what's happening. Here's how to [correct approach]. Does that work for you?"
+
+### Don't: Leave Them Hanging
+
+❌ [No response or closing without explanation]
+
+✅ "I'm going to close this issue as [reason]. If you have additional concerns, please
+feel free to reopen or comment. Thanks!"
+
+## Response Tone Guidelines
+
+**Be welcoming:** Remember that reporting issues takes time and effort. Thank contributors.
+
+**Be clear:** Use simple language. Avoid jargon when possible. Explain technical terms.
+
+**Be helpful:** Provide workarounds, links, and next steps. Don't just acknowledge problems.
+
+**Be realistic:** Don't overpromise. It's okay to say you don't know or need to check with the team.
+
+**Be professional:** Even if the reporter is frustrated, remain calm and constructive.
+
+## Using This Guide
+
+1. **Before responding:** Read through relevant patterns
+2. **Draft your response:** Adapt patterns to your specific situation
+3. **Review:** Check tone, clarity, completeness
+4. **Send:** Post your response
+5. **Follow up:** Continue the conversation as needed
+
+Remember: The goal is to make contributors feel heard and helped, while gathering the information needed to address their concerns.

--- a/.claude/skills/positron-intake-rotation/scripts/fetch_discussions.sh
+++ b/.claude/skills/positron-intake-rotation/scripts/fetch_discussions.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Fetch open discussions that need attention
+# Usage: ./fetch_discussions.sh [--json]
+
+set -e
+
+REPO="posit-dev/positron"
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--json)
+			JSON_OUTPUT=true
+			shift
+			;;
+		*)
+			echo "Unknown option: $1"
+			exit 1
+			;;
+	esac
+done
+
+if [ "$JSON_OUTPUT" = true ]; then
+	# JSON output for programmatic use
+	gh api graphql -f query='
+		query($owner: String!, $repo: String!) {
+			repository(owner: $owner, name: $repo) {
+				discussions(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
+					nodes {
+						number
+						title
+						author {
+							login
+						}
+						createdAt
+						updatedAt
+						url
+						comments(first: 1) {
+							totalCount
+						}
+						category {
+							name
+						}
+					}
+				}
+			}
+		}
+	' -f owner=posit-dev -f repo=positron --jq '.data.repository.discussions.nodes'
+else
+	# Human-readable output
+	echo "💬 Recent Open Discussions"
+	echo "========================="
+	gh api graphql -f query='
+		query($owner: String!, $repo: String!) {
+			repository(owner: $owner, name: $repo) {
+				discussions(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
+					nodes {
+						number
+						title
+						author {
+							login
+						}
+						createdAt
+						comments(first: 1) {
+							totalCount
+						}
+						category {
+							name
+						}
+						url
+					}
+				}
+			}
+		}
+	' -f owner=posit-dev -f repo=positron --jq '.data.repository.discussions.nodes[] | "#\(.number) - \(.title)\n  Author: \(.author.login) | Comments: \(.comments.totalCount) | Category: \(.category.name)\n  URL: \(.url)\n"'
+fi

--- a/.claude/skills/positron-intake-rotation/scripts/fetch_intake_issues.sh
+++ b/.claude/skills/positron-intake-rotation/scripts/fetch_intake_issues.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Fetch issues without status for intake review
+# Usage: ./fetch_intake_issues.sh [--json]
+
+set -e
+
+REPO="posit-dev/positron"
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--json)
+			JSON_OUTPUT=true
+			shift
+			;;
+		*)
+			echo "Unknown option: $1"
+			exit 1
+			;;
+	esac
+done
+
+# Fetch issues without status from the project board
+# The intake board view is: https://github.com/orgs/posit-dev/projects/2/views/33
+# This fetches open issues that don't have a status field set
+
+if [ "$JSON_OUTPUT" = true ]; then
+	# JSON output for programmatic use
+	gh issue list \
+		--repo "$REPO" \
+		--state open \
+		--limit 100 \
+		--json number,title,author,labels,createdAt,updatedAt,url
+else
+	# Human-readable output
+	echo "📋 Open Issues Without Status (Intake Queue)"
+	echo "============================================"
+	gh issue list \
+		--repo "$REPO" \
+		--state open \
+		--limit 50
+fi

--- a/.claude/skills/positron-intake-rotation/scripts/fetch_labels.sh
+++ b/.claude/skills/positron-intake-rotation/scripts/fetch_labels.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Fetch all available labels in the repository
+# Usage: ./fetch_labels.sh [--json]
+
+set -e
+
+REPO="posit-dev/positron"
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--json)
+			JSON_OUTPUT=true
+			shift
+			;;
+		*)
+			echo "Unknown option: $1"
+			exit 1
+			;;
+	esac
+done
+
+if [ "$JSON_OUTPUT" = true ]; then
+	# JSON output for programmatic use
+	gh label list --repo "$REPO" --json name,description --limit 1000
+else
+	# Human-readable output grouped by category
+	echo "🏷️  Available Labels in posit-dev/positron"
+	echo "========================================="
+	gh label list --repo "$REPO" --limit 1000 | sort
+fi

--- a/.claude/skills/positron-intake-rotation/scripts/search_related.sh
+++ b/.claude/skills/positron-intake-rotation/scripts/search_related.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Search for related issues, discussions, and documentation
+# Usage: ./search_related.sh <search-query>
+
+set -e
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 <search-query>"
+	echo "Example: $0 \"copilot tools\""
+	exit 1
+fi
+
+QUERY="$*"
+REPO="posit-dev/positron"
+
+echo "🔍 Searching for: \"$QUERY\""
+echo "================================"
+
+# Search issues
+echo ""
+echo "📋 Related Issues:"
+echo "-------------------"
+gh issue list \
+	--repo "$REPO" \
+	--search "$QUERY" \
+	--limit 10 \
+	--state all
+
+# Search discussions (using API since gh doesn't have native discussion search)
+echo ""
+echo "💬 Related Discussions:"
+echo "----------------------"
+gh api graphql -f query='
+	query($owner: String!, $repo: String!, $query: String!) {
+		search(query: $query, type: DISCUSSION, first: 10) {
+			nodes {
+				... on Discussion {
+					number
+					title
+					author {
+						login
+					}
+					url
+				}
+			}
+		}
+	}
+' -f owner=posit-dev -f repo=positron -f query="repo:$REPO $QUERY" \
+	--jq '.data.search.nodes[] | "#\(.number) - \(.title)\n  Author: \(.author.login)\n  URL: \(.url)\n"' 2>/dev/null || echo "  (Discussion search unavailable)"
+
+echo ""
+echo "📚 Documentation Search:"
+echo "------------------------"
+echo "Search docs manually at: https://positron.posit.co/welcome.html"
+echo "Use browser search or grep the docs if cloned locally"

--- a/.claude/skills/positron-issue-creator/SKILL.md
+++ b/.claude/skills/positron-issue-creator/SKILL.md
@@ -1,35 +1,54 @@
 ---
 name: positron-issue-creator
-description: This skill should be used when creating new GitHub issues for the Positron repository. It provides workflows for searching duplicates, selecting appropriate labels, gathering complete context through questioning, and writing terse, fluff-free issues that precisely describe what is needed or wrong. Use this skill when the user asks to file or create an issue for Positron.
+description: This skill should be used when drafting GitHub issues for the Positron repository. It provides workflows for searching duplicates, selecting appropriate labels, gathering complete context through questioning, and writing terse, fluff-free issues that precisely describe what is needed or wrong. The skill prepares issues for manual submission by the user. Use this skill when the user asks to draft or prepare an issue for Positron.
 ---
 
 # Positron Issue Creator
 
 ## Purpose
 
-This skill guides the creation of high-quality GitHub issues for the Positron IDE repository. It ensures issues are:
-- Thoroughly checked for duplicates before creation
+This skill guides the drafting of high-quality GitHub issues for the Positron IDE repository. It ensures issues are:
+- Thoroughly checked for duplicates before drafting
 - Properly labeled for efficient triage
 - Written with complete, specific information
 - Free of unnecessary fluff and filler
 - Actionable by the development team
+- Ready for manual submission by the user
 
 ## When to Use This Skill
 
 Use this skill when:
-- User explicitly asks to create, file, or report an issue
+- User explicitly asks to draft, create, file, or report an issue
 - User describes a bug or feature request that should be tracked
-- Creating documentation or improvement requests
-- User says "can you file an issue for..." or similar
+- Drafting documentation or improvement requests
+- User says "can you draft an issue for..." or similar
 
 Do NOT use this skill for:
 - Intake rotation duties (use `positron-intake-rotation` instead)
 - Responding to existing issues
 - General Positron development tasks
 
+## GitHub Access Policy
+
+**Read operations (ALLOWED):**
+- Search for existing issues and discussions via `gh` CLI
+- Fetch repository labels via `gh` CLI
+- View issue details for duplicate checking
+- Read any public repository information
+
+**Write operations (NOT ALLOWED):**
+- Creating issues directly via `gh issue create`
+- Commenting on issues
+- Modifying labels on existing issues
+- Any other GitHub write operations
+
+**Instead:** Prepare issues in markdown files or clipboard-ready format for manual user submission.
+
 ## Core Workflow
 
-Follow this workflow for every issue creation request:
+**Important:** This skill prepares issues for manual submission. It does NOT automatically create GitHub issues. The user maintains full control over submitting to GitHub.
+
+Follow this workflow for every issue drafting request:
 
 ### 1. Gather Complete Context
 
@@ -227,27 +246,60 @@ Ask user: "Does this accurately capture the issue? Would you like any changes be
 
 Make requested changes and show updated draft.
 
-### 6. Create the Issue
+### 6. Prepare Issue for Manual Submission
 
-Once user approves, create the issue using GitHub CLI:
+Once user approves the draft, offer options for how they want to use it:
+
+**Ask the user:** "How would you like me to prepare this issue?"
+- **Option 1:** Save to a markdown file
+- **Option 2:** Format for clipboard (provide text ready to copy)
+
+#### Option 1: Save to Markdown File
+
+Create a markdown file with all issue details:
 
 ```bash
-# Create the issue with title, body, and labels
-gh issue create \
-  --repo posit-dev/positron \
-  --title "Issue title here" \
-  --body "$(cat <<'EOF'
+# Create file with timestamp in name for uniqueness
+cat > "positron-issue-$(date +%Y%m%d-%H%M%S).md" <<'EOF'
+---
+title: Issue title here
+labels: area: console, Bug
+repository: posit-dev/positron
+---
+
 Full issue body here
 with multiple lines
 EOF
-)" \
-  --label "area: console,Bug"
 ```
 
-**After creation:**
-- Show the user the issue URL
-- Confirm issue was created successfully
-- Offer to add any additional comments or screenshots if needed
+**After saving:**
+- Show the file path
+- Remind user to manually create the issue on GitHub
+- Provide quick link: `https://github.com/posit-dev/positron/issues/new`
+
+#### Option 2: Format for Clipboard
+
+Present the issue in a format ready to copy:
+
+```markdown
+**Title:**
+Issue title here
+
+**Labels:**
+area: console, Bug
+
+**Body:**
+Full issue body here
+with multiple lines
+
+---
+Create this issue at: https://github.com/posit-dev/positron/issues/new
+```
+
+**After presenting:**
+- Explain that user should copy this text
+- Remind them to paste into GitHub's new issue form
+- Note that they'll need to manually select labels in the UI
 
 ## Important Guidelines
 
@@ -373,18 +425,19 @@ Load these reference documents when drafting issues:
 5. **Multiple issues in one** - Split into separate, focused issues
 6. **Assuming context** - Ask user to confirm unclear details
 7. **Skipping labels** - Always fetch and apply appropriate labels
-8. **Creating without user approval** - Always show draft and get confirmation
+8. **Preparing without user approval** - Always show draft and get confirmation before preparing files
 
 ## Success Criteria
 
-A successful issue creation means:
+A successful issue draft means:
 - No duplicates exist (or user confirmed it's distinct)
 - All necessary information is included
 - Issue is terse and free of fluff
 - Title accurately summarizes the issue
-- Appropriate labels applied
+- Appropriate labels identified
 - User approved the draft
-- Issue was successfully created on GitHub
+- Issue prepared in user's preferred format (markdown file or clipboard text)
+- User has clear instructions for manual submission to GitHub
 
 ## Workflow Summary
 
@@ -417,11 +470,13 @@ A successful issue creation means:
    ↓
    Iterate based on feedback
    ↓
-6. Create Issue
+6. Prepare for Submission
    ↓
-   Use gh issue create with approved content
+   Offer markdown file or clipboard format
    ↓
-   Provide issue URL to user
+   Save to file OR format for copying
+   ↓
+   Provide GitHub link and submission instructions
 ```
 
-Remember: The goal is to create clear, actionable issues that respect both the reporter's intent and the development team's time.
+Remember: The goal is to draft clear, actionable issues that respect both the reporter's intent and the development team's time. The user maintains full control over the final submission to GitHub.

--- a/.claude/skills/positron-issue-creator/SKILL.md
+++ b/.claude/skills/positron-issue-creator/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: positron-issue-creator
+description: This skill should be used when creating new GitHub issues for the Positron repository. It provides workflows for searching duplicates, selecting appropriate labels, gathering complete context through questioning, and writing terse, fluff-free issues that precisely describe what is needed or wrong. Use this skill when the user asks to file or create an issue for Positron.
+---
+
+# Positron Issue Creator
+
+## Purpose
+
+This skill guides the creation of high-quality GitHub issues for the Positron IDE repository. It ensures issues are:
+- Thoroughly checked for duplicates before creation
+- Properly labeled for efficient triage
+- Written with complete, specific information
+- Free of unnecessary fluff and filler
+- Actionable by the development team
+
+## When to Use This Skill
+
+Use this skill when:
+- User explicitly asks to create, file, or report an issue
+- User describes a bug or feature request that should be tracked
+- Creating documentation or improvement requests
+- User says "can you file an issue for..." or similar
+
+Do NOT use this skill for:
+- Intake rotation duties (use `positron-intake-rotation` instead)
+- Responding to existing issues
+- General Positron development tasks
+
+## Core Workflow
+
+Follow this workflow for every issue creation request:
+
+### 1. Gather Complete Context
+
+Before drafting anything, ensure all necessary information is available. Use iterative questioning if needed.
+
+**For Bug Reports, obtain:**
+- Positron version (Help > About or specific build number)
+- Operating system and version
+- Session details (R/Python version)
+- Exact steps to reproduce
+- Expected vs. actual behavior
+- Error messages (from UI, Output panel, or Developer Console)
+- Screenshots if relevant
+
+**For Feature Requests, obtain:**
+- Clear description of the desired feature
+- Use case (why it's needed, what problem it solves)
+- Proposed behavior (how it should work)
+- Any related issues or examples from other tools
+
+**Ask specific questions** when information is missing:
+- "What Positron version are you using? Check Help > About"
+- "What's the exact error message displayed?"
+- "What did you expect to happen vs. what actually happened?"
+- "Can you provide the specific steps to reproduce this?"
+
+**Never make assumptions.** If unclear, ask rather than guess.
+
+### 2. Search for Duplicates
+
+Use `scripts/search_duplicates.sh` to search for existing issues and discussions:
+
+```bash
+cd /path/to/positron/.claude/skills/positron-issue-creator
+./scripts/search_duplicates.sh "keywords from issue"
+```
+
+**Review results carefully:**
+- Check both open and closed issues
+- Look at discussions as well
+- Consider variations of the search terms
+
+**Present findings to user:**
+- Show all potentially related issues
+- Highlight any that seem very similar
+- Ask user to confirm whether these are duplicates
+- For uncertain matches, explicitly ask: "Is this the same issue as #1234?"
+
+**If duplicate found:**
+- Inform user that issue already exists
+- Provide link to existing issue
+- Suggest they add a comment or 👍 reaction if they want to track it
+- Do NOT create new issue
+
+**If no duplicates:**
+- Proceed to drafting the issue
+- Reference any related issues in the draft
+
+### 3. Select Appropriate Labels
+
+Use `scripts/fetch_labels.sh` to retrieve current repository labels:
+
+```bash
+cd /path/to/positron/.claude/skills/positron-issue-creator
+./scripts/fetch_labels.sh
+```
+
+**Choose labels based on:**
+
+**Area labels** (select 1-2):
+- `area: console` - Console/REPL functionality
+- `area: notebook` - Jupyter notebook integration
+- `area: editor` - Text editor functionality
+- `area: plots` - Plot viewer and visualization
+- `area: data-explorer` - Data viewer and explorer
+- `area: connections` - Database connections
+- `area: help` - Help pane and documentation
+- `area: ui` - General UI/UX issues
+- Review full list from `fetch_labels.sh` for complete options
+
+**Type label** (select 1):
+- `Bug` - Something doesn't work as intended
+- `Feature Request` - New capability or enhancement
+- `Documentation` - Documentation improvements
+- `Performance` - Works but too slowly
+
+**Other considerations:**
+- Avoid adding priority labels (set during triage)
+- Don't add status labels (will be set by team)
+- Multiple area labels are acceptable if issue spans components
+
+### 4. Draft the Issue
+
+Use the templates in `references/issue_templates.md` as starting points, but adapt to the specific issue.
+
+**Load templates when needed:**
+- Bug reports: Reference bug report structure
+- Feature requests: Reference feature request structure
+- Hybrid cases: Adapt as appropriate
+
+**Follow writing guidelines from `references/writing_guidelines.md`:**
+
+**Core principles:**
+1. **Be terse** - Every word serves a purpose
+2. **Be fluff-free** - No apologies, preambles, or unnecessary politeness
+3. **Be specific** - Exact versions, precise steps, concrete details
+4. **Be direct** - Get to the point immediately
+
+**Title guidelines:**
+- Bug: `[Component] fails when [condition]`
+- Feature: `Add [feature] to [component]`
+- Complete sentence that tells the full story
+- Scannable and searchable
+
+**Body structure:**
+1. **What** - The issue itself (1 sentence)
+2. **Why** - Impact/context (1-2 sentences if not obvious)
+3. **How** - Steps or proposed solution (bullet points)
+4. **Details** - System info, errors, screenshots (as needed)
+
+**Example bug report:**
+```markdown
+Title: Console freezes when printing dataframes with 100k+ rows
+
+The console becomes unresponsive when printing large dataframes.
+
+## Steps to reproduce
+
+1. Create dataframe: `df = pd.DataFrame({'a': range(100000)})`
+2. Print it: `print(df)`
+3. Console freezes, UI becomes unresponsive
+
+## System details
+
+- Positron 2024.10.0 Build 123
+- macOS 14.5
+- Python 3.11.6
+
+## Error messages
+
+Developer Console shows: "Maximum call stack size exceeded"
+```
+
+**Example feature request:**
+```markdown
+Title: Add keyboard shortcut to insert markdown cell in notebooks
+
+Currently inserting markdown cells requires clicking the dropdown menu.
+Keyboard shortcut would improve notebook authoring workflow.
+
+## Proposed behavior
+
+- Add keyboard shortcut (e.g., Cmd+M or Ctrl+M)
+- Should work when focus is in notebook
+- Should insert cell below current cell
+
+## Context
+
+Similar to Jupyter's 'M' key in command mode. Notebook workflows
+frequently alternate between code and markdown cells.
+```
+
+**Common anti-patterns to avoid:**
+- Unnecessary background or preambles
+- Vague descriptions ("it doesn't work", "sometimes crashes")
+- Combining multiple unrelated issues
+- Apologetic or overly polite language
+- Missing concrete details (exact versions, error messages)
+- Long-winded explanations when concise ones suffice
+
+**Review checklist before presenting:**
+- [ ] Title is complete and specific
+- [ ] Body starts with the core issue
+- [ ] Reproduction steps are clear (for bugs)
+- [ ] System details included (for bugs)
+- [ ] Error messages are exact quotes
+- [ ] No unnecessary fluff
+- [ ] Each sentence adds value
+- [ ] Single, focused topic
+- [ ] Appropriate labels selected
+
+### 5. Present Draft to User
+
+Show the complete drafted issue including:
+- Title
+- Full body text
+- Proposed labels
+
+Ask user: "Does this accurately capture the issue? Would you like any changes before I create it?"
+
+**Allow for iteration:**
+- User may want to adjust wording
+- May remember additional details
+- May want to emphasize different aspects
+
+Make requested changes and show updated draft.
+
+### 6. Create the Issue
+
+Once user approves, create the issue using GitHub CLI:
+
+```bash
+# Create the issue with title, body, and labels
+gh issue create \
+  --repo posit-dev/positron \
+  --title "Issue title here" \
+  --body "$(cat <<'EOF'
+Full issue body here
+with multiple lines
+EOF
+)" \
+  --label "area: console,Bug"
+```
+
+**After creation:**
+- Show the user the issue URL
+- Confirm issue was created successfully
+- Offer to add any additional comments or screenshots if needed
+
+## Important Guidelines
+
+### Duplicate Detection
+
+**Be thorough but not pedantic:**
+- Search with multiple keyword combinations
+- Check both issues and discussions
+- Look at closed items too (might be fixed or wontfix)
+
+**When uncertain:**
+- Show user the potentially similar issues
+- Ask explicitly: "Is this the same as what you're reporting?"
+- Err on the side of creating new issues rather than incorrectly marking as duplicate
+
+### Context Gathering
+
+**Never guess or assume:**
+- If version is unclear, ask specifically
+- If steps are vague, request clarification
+- If error message is paraphrased, ask for exact text
+
+**Be patient with iteration:**
+- Users may not have all information immediately
+- May need to reproduce issue to get details
+- It's better to ask multiple questions than create incomplete issue
+
+### Writing Style
+
+**Optimize for scanability:**
+- Busy developers need to quickly understand the issue
+- Put most important information first
+- Use formatting (headings, lists, code blocks) appropriately
+
+**Respect reader's time:**
+- No unnecessary pleasantries beyond "Thanks for reporting"
+- No apologetic language
+- No marketing-speak or enthusiasm
+- Just clear, factual information
+
+**Be precise:**
+- Use exact versions, not "latest" or "recent"
+- Quote error messages exactly
+- Number steps clearly
+- State actual behavior, not interpretations
+
+## Special Cases
+
+### Security Issues
+
+If user describes a security vulnerability:
+1. **Do NOT create public issue**
+2. Inform user: "This appears to be a security issue. Please report it privately to security@posit.co instead of creating a public issue"
+3. Do NOT proceed with issue creation
+
+### Documentation Issues
+
+Treat as feature requests but focus on:
+- What documentation is missing or incorrect
+- Where users would look for this information
+- Suggested improvements
+
+Label with `Documentation` type.
+
+### Performance Issues
+
+Use bug report template but emphasize:
+- What operation is slow
+- How long it takes vs. expected time
+- System details including hardware
+- Data size or complexity
+
+Label with `Performance` type.
+
+### Multiple Related Issues
+
+If user describes several related but distinct issues:
+1. Identify each separate issue
+2. Explain to user: "This sounds like 3 separate issues. I'll help create each one individually."
+3. Create issues one at a time
+4. Cross-reference in issue bodies if related
+
+## Scripts Reference
+
+### `scripts/fetch_labels.sh`
+
+Retrieves all repository labels for categorization.
+
+**Usage:**
+```bash
+./scripts/fetch_labels.sh          # Human-readable output
+./scripts/fetch_labels.sh --json   # JSON output for parsing
+```
+
+### `scripts/search_duplicates.sh`
+
+Searches for potential duplicate issues and discussions.
+
+**Usage:**
+```bash
+./scripts/search_duplicates.sh "search terms"
+./scripts/search_duplicates.sh "search terms" --limit 30
+```
+
+Returns:
+- Matching issues (open and closed)
+- Related discussions
+- Direct links to review
+
+## References
+
+Load these reference documents when drafting issues:
+
+- **`references/issue_templates.md`** - Templates for bugs, features, and hybrid issues
+- **`references/writing_guidelines.md`** - Detailed writing guidance, anti-patterns, examples
+
+## Common Mistakes to Avoid
+
+1. **Creating duplicate issues** - Always search first, show results to user
+2. **Incomplete information** - Ask questions until all details are gathered
+3. **Verbose writing** - Cut all fluff, be direct and specific
+4. **Vague titles** - Titles should tell the complete story
+5. **Multiple issues in one** - Split into separate, focused issues
+6. **Assuming context** - Ask user to confirm unclear details
+7. **Skipping labels** - Always fetch and apply appropriate labels
+8. **Creating without user approval** - Always show draft and get confirmation
+
+## Success Criteria
+
+A successful issue creation means:
+- No duplicates exist (or user confirmed it's distinct)
+- All necessary information is included
+- Issue is terse and free of fluff
+- Title accurately summarizes the issue
+- Appropriate labels applied
+- User approved the draft
+- Issue was successfully created on GitHub
+
+## Workflow Summary
+
+```
+1. Gather Context
+   ↓
+   Ask specific questions until all info available
+   ↓
+2. Search Duplicates
+   ↓
+   Run scripts/search_duplicates.sh
+   ↓
+   Show results to user, confirm not duplicate
+   ↓
+3. Select Labels
+   ↓
+   Run scripts/fetch_labels.sh
+   ↓
+   Choose appropriate area and type labels
+   ↓
+4. Draft Issue
+   ↓
+   Use templates from references/
+   ↓
+   Follow writing guidelines (terse, specific, direct)
+   ↓
+5. Present Draft
+   ↓
+   Show complete draft to user
+   ↓
+   Iterate based on feedback
+   ↓
+6. Create Issue
+   ↓
+   Use gh issue create with approved content
+   ↓
+   Provide issue URL to user
+```
+
+Remember: The goal is to create clear, actionable issues that respect both the reporter's intent and the development team's time.

--- a/.claude/skills/positron-issue-creator/references/issue_templates.md
+++ b/.claude/skills/positron-issue-creator/references/issue_templates.md
@@ -1,0 +1,152 @@
+# Issue Templates
+
+This document provides templates for creating Positron issues. Use these as starting points, adapting them to the specific issue being reported.
+
+## Bug Report Template
+
+Use this template for bugs. The user may not provide all information upfront - ask clarifying questions to fill in missing sections.
+
+```markdown
+## System details
+
+**Positron Version:** [e.g., 2024.10.0 Build 123]
+**OS:** [e.g., macOS 14.5, Windows 11, Ubuntu 22.04]
+**Session:** [e.g., R 4.4.1, Python 3.11.6]
+
+## Describe the issue
+
+[Clear, concise description of what's wrong]
+
+## Steps to reproduce
+
+1. [First step]
+2. [Second step]
+3. [And so on...]
+
+## Expected behavior
+
+[What should happen]
+
+## Actual behavior
+
+[What actually happens]
+
+## Error messages
+
+[Any error messages from the UI, Output panel, or Developer Tools console]
+
+[Screenshots if helpful]
+```
+
+### Required Information for Bug Reports
+
+Before creating a bug report, ensure these details are available:
+
+1. **System details** - Version, OS, session type
+2. **Reproduction steps** - Clear, numbered steps
+3. **Expected vs. actual behavior** - What should happen vs. what does happen
+4. **Error messages** - From any source (UI, console, logs)
+
+If the user hasn't provided all information, **ask specific questions** before drafting the issue.
+
+## Feature Request Template
+
+Feature requests are more flexible and don't require the strict structure of bug reports. Focus on clarity and value.
+
+```markdown
+## Feature description
+
+[Clear description of the proposed feature]
+
+## Use case
+
+[Why is this feature needed? What problem does it solve?]
+
+## Proposed behavior
+
+[How should the feature work? What should users see/experience?]
+
+## Additional context
+
+[Any related issues, examples from other tools, mockups, etc.]
+```
+
+### Key Elements for Feature Requests
+
+1. **Clear description** - What the feature is
+2. **Use case** - Why it's needed
+3. **Proposed behavior** - How it should work
+4. **Context** - Related issues, examples, alternatives considered
+
+## Hybrid Template
+
+Some issues combine aspects of bugs and feature requests (e.g., "X doesn't work, and it should work like Y"). Adapt the template accordingly:
+
+```markdown
+## Current behavior
+
+[What currently happens that's problematic]
+
+## Desired behavior
+
+[How it should work instead]
+
+## Context
+
+**System:** [If relevant for reproduction]
+**Use case:** [Why this matters]
+
+## Steps to reproduce (if applicable)
+
+1. [Steps if needed]
+
+## Additional context
+
+[Related issues, examples, etc.]
+```
+
+## Template Selection Guide
+
+Choose the appropriate template based on issue type:
+
+| Issue Type | Template | Key Characteristics |
+|------------|----------|---------------------|
+| Clear bug with reproduction | Bug Report | Known steps to reproduce, clear error |
+| Feature request | Feature Request | New capability or enhancement |
+| Missing/broken functionality | Hybrid | Something should work but doesn't |
+| Documentation issue | Feature Request (adapted) | Docs need improvement |
+| Performance issue | Bug Report (adapted) | Something works but too slowly |
+
+## Special Cases
+
+### Documentation Issues
+
+Treat as feature requests but focus on:
+- What documentation is missing or incorrect
+- Where users would look for this information
+- Suggested improvements or additions
+
+### Performance Issues
+
+Use bug report template but emphasize:
+- What operation is slow
+- How long it takes vs. expected time
+- System details (hardware, data size)
+
+### Security Issues
+
+**Never create public issues for security vulnerabilities.** Instead:
+1. Ask reporter to email security@posit.co
+2. Do not create a public issue
+3. Alert team privately
+
+## Anti-Patterns to Avoid
+
+Don't create issues that:
+- Lack concrete details ("it doesn't work")
+- Combine multiple unrelated issues (split them)
+- Use vague language ("sometimes", "occasionally" without specifics)
+- Include long preambles or unnecessary context
+- Repeat information already clear from the title
+
+See [references/writing_guidelines.md](./writing_guidelines.md) for detailed writing guidance.

--- a/.claude/skills/positron-issue-creator/references/writing_guidelines.md
+++ b/.claude/skills/positron-issue-creator/references/writing_guidelines.md
@@ -1,0 +1,371 @@
+# Writing Guidelines for Positron Issues
+
+This document provides guidance for writing clear, concise, and actionable issues for the Positron repository.
+
+## Core Principles
+
+### 1. Be Terse
+
+Every word should serve a purpose. Remove:
+- Unnecessary adjectives and adverbs
+- Redundant phrases
+- Obvious statements
+- Filler words
+
+**Bad:** "I was just wondering if it might be possible to perhaps add a feature..."
+**Good:** "Add feature to..."
+
+### 2. Be Fluff-Free
+
+Avoid:
+- Apologies ("Sorry to bother you...")
+- Over-politeness ("I hate to ask, but...")
+- Unnecessary context ("As a long-time user...")
+- Marketing language ("This amazing feature would...")
+
+**Bad:** "First of all, I'd like to thank you for this amazing IDE. I've been using it for weeks and love it. However, I noticed a small issue that's been bothering me..."
+**Good:** "The console crashes when..."
+
+### 3. Be Specific
+
+Use concrete details:
+- Exact version numbers, not "latest"
+- Specific error messages, not "it doesn't work"
+- Precise steps, not vague descriptions
+- Actual behavior, not interpretations
+
+**Bad:** "It sometimes crashes"
+**Good:** "Positron crashes when opening files >100MB"
+
+### 4. Be Direct
+
+Get to the point immediately:
+- Start with the issue, not background
+- Put the most important information first
+- Use active voice
+- State what's needed clearly
+
+**Bad:** "There seems to be a situation where, under certain circumstances, users might experience..."
+**Good:** "Console freezes when printing large dataframes"
+
+## Structure Guidelines
+
+### Title
+
+The title should be a complete, scannable sentence that tells the full story:
+
+**Bug Report Titles:**
+- Pattern: `[Component] fails when [condition]`
+- Examples:
+  - "Console crashes when printing 100k+ row dataframe"
+  - "Notebook cells fail to execute after kernel restart"
+  - "Plot viewer doesn't refresh when re-running code"
+
+**Feature Request Titles:**
+- Pattern: `Add [feature] to [component]` or `Support [capability]`
+- Examples:
+  - "Add export to SVG in plot viewer"
+  - "Support custom keybindings for notebook cells"
+  - "Add syntax highlighting for Julia"
+
+**Avoid:**
+- Vague titles: "Problem with console"
+- Questions: "Can we add feature X?"
+- Incomplete: "Crash" (crashes when? where?)
+
+### Body
+
+Follow this hierarchy:
+
+1. **What** - The issue itself (1 sentence)
+2. **Why** - Impact or context (1-2 sentences, if not obvious)
+3. **How** - Steps to reproduce or proposed solution (bullet points)
+4. **Details** - System info, errors, screenshots (as needed)
+
+### Example Issue
+
+**Title:** Console freezes when printing dataframes with 100k+ rows
+
+**Body:**
+```markdown
+The console becomes unresponsive when printing large dataframes.
+
+## Steps to reproduce
+
+1. Create dataframe with 100k rows: `df = pd.DataFrame({'a': range(100000)})`
+2. Print it: `print(df)`
+3. Console freezes, UI becomes unresponsive
+
+## System details
+
+- Positron 2024.10.0 Build 123
+- macOS 14.5
+- Python 3.11.6
+
+## Error messages
+
+Developer Console shows: "Maximum call stack size exceeded"
+```
+
+**What makes this good:**
+- Title explains the full issue
+- Body starts with impact
+- Clear reproduction steps
+- Relevant system details
+- Actual error message included
+- No fluff or unnecessary context
+
+## Question Protocol
+
+When drafting issues, if the user hasn't provided enough information:
+
+### Ask Specific Questions
+
+**Bad questions:**
+- "Can you provide more details?"
+- "What happened?"
+- "Tell me about your setup"
+
+**Good questions:**
+- "What Positron version are you using? (Check Help > About)"
+- "What's the exact error message shown?"
+- "Does this happen with all files or specific ones?"
+- "What Python/R version is running?"
+
+### Iterative Refinement
+
+1. Draft initial issue with available information
+2. Mark missing information with `[NEEDED: specific detail]`
+3. Ask user specific questions to fill gaps
+4. Update draft with answers
+5. Present final version for approval
+
+## Common Pitfalls
+
+### 1. Combining Multiple Issues
+
+**Bad:**
+```markdown
+Title: Several problems with notebooks
+
+I've noticed that notebooks crash sometimes, and also the
+syntax highlighting doesn't work for R, and I think we
+should add a feature to export notebooks...
+```
+
+**Good:** Create separate issues:
+- "Notebook crashes when [specific condition]"
+- "R syntax highlighting missing in notebook cells"
+- "Add export to PDF for notebooks"
+
+### 2. Vague Reproduction Steps
+
+**Bad:**
+```markdown
+Steps:
+1. Open a file
+2. Do some stuff
+3. It crashes
+```
+
+**Good:**
+```markdown
+Steps:
+1. Open Python file with >1000 lines
+2. Place cursor on line 500
+3. Press Cmd+F to open find dialog
+4. Type search term
+5. Press Enter
+6. Positron crashes
+```
+
+### 3. Missing Error Messages
+
+**Bad:** "I got an error"
+
+**Good:**
+```markdown
+Error in Developer Console:
+TypeError: Cannot read property 'length' of undefined
+  at Object.render (notebook.js:425)
+```
+
+### 4. Unnecessary Background
+
+**Bad:**
+```markdown
+I've been a data scientist for 15 years and have used
+many IDEs. Recently I switched to Positron because I
+heard great things about it. After using it for a few
+weeks, I noticed that...
+```
+
+**Good:**
+```markdown
+The plot viewer doesn't refresh when re-running code.
+```
+
+### 5. Feature Requests Without Use Cases
+
+**Bad:** "Add dark mode"
+
+**Good:**
+```markdown
+Add dark theme for plot viewer
+
+Currently plots are shown on a white background. When
+working in dark mode, this creates harsh contrast. A
+dark background option would reduce eye strain during
+long sessions.
+```
+
+## Label Selection
+
+After writing the issue, select appropriate labels:
+
+### Area Labels
+
+Choose the component affected:
+- `area: console` - Console/REPL issues
+- `area: notebook` - Notebook issues
+- `area: editor` - Editor issues
+- `area: plots` - Plot viewer issues
+- `area: data-explorer` - Data explorer issues
+- `area: ui` - General UI issues
+
+Use `scripts/fetch_labels.sh` to see all available labels.
+
+### Type Labels
+
+- `Bug` - Something doesn't work as expected
+- `Feature Request` - New capability or enhancement
+- `Documentation` - Docs need improvement
+- `Performance` - Works but too slowly
+
+### Priority Labels (optional)
+
+Usually set during triage, but obvious critical issues can be labeled:
+- `critical` - Data loss, crashes, security issues
+- `high` - Major functionality broken
+- `medium` - Noticeable but not blocking
+- `low` - Minor issues, nice-to-haves
+
+## Review Checklist
+
+Before finalizing an issue, verify:
+
+- [ ] Title is complete and specific
+- [ ] Body starts with the core issue
+- [ ] Reproduction steps are clear and numbered (for bugs)
+- [ ] System details are included (for bugs)
+- [ ] Error messages are exact quotes
+- [ ] No unnecessary background or fluff
+- [ ] No apologies or hedging language
+- [ ] Each sentence adds value
+- [ ] Appropriate labels selected
+- [ ] Issue is a single, focused topic
+
+## Examples
+
+### Excellent Bug Report
+
+```markdown
+Title: Data Explorer crashes when sorting column with null values
+
+Data Explorer becomes unresponsive when sorting any column containing
+null values.
+
+## Steps to reproduce
+
+1. Create dataframe: `df = pd.DataFrame({'a': [1, None, 3]})`
+2. Open in Data Explorer (View > Data Explorer)
+3. Click column 'a' header to sort
+4. Data Explorer freezes
+
+## System details
+
+- Positron 2024.10.0 Build 123
+- Windows 11
+- Python 3.11.6
+
+## Error
+
+Developer Console: "TypeError: Cannot compare null value"
+
+Labels: area: data-explorer, Bug, high
+```
+
+### Excellent Feature Request
+
+```markdown
+Title: Add keyboard shortcut to insert markdown cell in notebooks
+
+Currently inserting markdown cells requires clicking the dropdown menu.
+Keyboard shortcut would improve notebook authoring workflow.
+
+## Proposed behavior
+
+- Add keyboard shortcut (e.g., Cmd+M or Ctrl+M) to insert markdown cell
+- Shortcut should work when focus is in notebook
+- Should insert cell below current cell
+
+## Context
+
+Similar to Jupyter's 'M' key in command mode. Most notebook workflows
+alternate between code and markdown cells frequently.
+
+Labels: area: notebook, Feature Request
+```
+
+## Anti-Pattern Examples
+
+### Too Verbose
+
+```markdown
+Hello! First of all, I want to say how much I appreciate all the hard
+work you've put into Positron. I've been a data scientist for many years
+and have tried numerous IDEs, and I must say that Positron is really
+impressive. The UI is beautiful and the performance is generally quite
+good.
+
+However, I have noticed a small issue that I thought I should bring to
+your attention. It's not a huge deal, but it has been bothering me a bit...
+
+[Finally gets to the actual issue after 5 paragraphs]
+```
+
+**Fix:** Delete everything before the actual issue description.
+
+### Too Vague
+
+```markdown
+Title: Console problem
+
+The console doesn't work right sometimes. It's really annoying and
+happens occasionally when I'm doing stuff.
+```
+
+**Fix:** Be specific about what doesn't work, when, and what "work right" means.
+
+### Combining Issues
+
+```markdown
+Title: Various notebook issues
+
+1. Sometimes cells don't execute
+2. Syntax highlighting is weird
+3. We should add an export feature
+4. The keyboard shortcuts are confusing
+```
+
+**Fix:** Create four separate, specific issues.
+
+## Final Notes
+
+Remember: The goal is to create issues that:
+1. Can be quickly understood by anyone on the team
+2. Contain all information needed to act
+3. Are searchable by others with similar issues
+4. Respect the reader's time
+
+When in doubt, **be more concise** rather than more verbose.

--- a/.claude/skills/positron-issue-creator/scripts/fetch_labels.sh
+++ b/.claude/skills/positron-issue-creator/scripts/fetch_labels.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Fetch all available labels in the Positron repository
+# Usage: ./fetch_labels.sh [--json]
+
+set -e
+
+REPO="posit-dev/positron"
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--json)
+			JSON_OUTPUT=true
+			shift
+			;;
+		*)
+			echo "Unknown option: $1"
+			exit 1
+			;;
+	esac
+done
+
+if [ "$JSON_OUTPUT" = true ]; then
+	# JSON output for programmatic use
+	gh label list --repo "$REPO" --json name,description --limit 1000
+else
+	# Human-readable output grouped by category
+	echo "🏷️  Available Labels in posit-dev/positron"
+	echo "========================================="
+	gh label list --repo "$REPO" --limit 1000 | sort
+fi

--- a/.claude/skills/positron-issue-creator/scripts/search_duplicates.sh
+++ b/.claude/skills/positron-issue-creator/scripts/search_duplicates.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Search for potential duplicate issues and discussions
+# Usage: ./search_duplicates.sh <search-query> [--limit N]
+
+set -e
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 <search-query> [--limit N]"
+	echo "Example: $0 \"notebook crash\" --limit 15"
+	exit 1
+fi
+
+REPO="posit-dev/positron"
+LIMIT=20
+
+# Parse arguments
+QUERY=""
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--limit)
+			LIMIT="$2"
+			shift 2
+			;;
+		*)
+			QUERY="$QUERY $1"
+			shift
+			;;
+	esac
+done
+
+# Trim leading/trailing whitespace
+QUERY=$(echo "$QUERY" | xargs)
+
+echo "🔍 Searching for potential duplicates: \"$QUERY\""
+echo "=================================================="
+
+# Search issues (all states to catch closed duplicates)
+echo ""
+echo "📋 Potentially Duplicate Issues:"
+echo "--------------------------------"
+gh issue list \
+	--repo "$REPO" \
+	--search "$QUERY" \
+	--limit "$LIMIT" \
+	--state all \
+	--json number,title,state,url \
+	--jq '.[] | "#\(.number) [\(.state)] - \(.title)\n  \(.url)\n"'
+
+# Search discussions using GraphQL
+echo ""
+echo "💬 Related Discussions:"
+echo "----------------------"
+gh api graphql -f query='
+	query($owner: String!, $repo: String!, $query: String!, $limit: Int!) {
+		search(query: $query, type: DISCUSSION, first: $limit) {
+			nodes {
+				... on Discussion {
+					number
+					title
+					author {
+						login
+					}
+					url
+					closed
+				}
+			}
+		}
+	}
+' -f owner=posit-dev -f repo=positron -f query="repo:$REPO $QUERY" -F limit="$LIMIT" \
+	--jq '.data.search.nodes[] | "#\(.number) [\(if .closed then "CLOSED" else "OPEN" end)] - \(.title)\n  Author: \(.author.login)\n  \(.url)\n"' 2>/dev/null || echo "  (Discussion search unavailable)"
+
+echo ""
+echo "💡 Next Steps:"
+echo "-------------"
+echo "  1. Review the results above for potential duplicates"
+echo "  2. If duplicates exist, reference them in your issue or close as duplicate"
+echo "  3. If no clear duplicates, proceed with creating the new issue"

--- a/.claude/skills/positron-notebooks/SKILL.md
+++ b/.claude/skills/positron-notebooks/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: positron-notebooks
+description: This skill should be used when developing, debugging, or maintaining Positron Notebooks - the React-based feature-flagged notebook editor. Load this skill when tasks involve notebook cells, execution, selection state, context keys, or notebook editor features.
+---
+
+# Positron Notebooks Development
+
+## Purpose
+
+Provides specialized knowledge and workflows for developing Positron Notebooks, a feature-flagged React-based notebook editor that coexists with VS Code's standard notebook experience.
+
+## When to Use This Skill
+
+Load this skill when working on:
+- Notebook cell behavior (execution, rendering, editing)
+- Selection and focus management
+- Context key system for notebooks
+- Cell action commands and menus
+- Notebook-kernel integration
+- Output rendering and webviews
+- E2E or unit tests for notebooks
+- Debugging notebook issues
+
+## Quick Start
+
+### Validate Setup Before Starting
+
+```bash
+# Run validation script
+./scripts/validate_setup.sh
+```
+
+Or manually check:
+```bash
+# Verify build daemons are running (required)
+ps aux | grep -E "npm.*watch-(client|extensions)d" | grep -v grep
+```
+
+### Enable Positron Notebooks for Testing
+
+Add to settings.json:
+```json
+{
+	"positron.notebook.enabled": true,
+	"workbench.editorAssociations": {
+		"*.ipynb": "workbench.editor.positronNotebook"
+	}
+}
+```
+
+Restart Positron after changing feature flag.
+
+## Development Workflows
+
+### Adding a New Cell Command
+
+1. Register command in `src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts`
+2. Add context key conditions (when-clauses)
+3. Optionally add to menu or keybinding registry
+4. Implement handler to access notebook instance and cells
+
+See `references/common-patterns.md` for code examples.
+
+### Fixing a Cell Execution Bug
+
+1. Start debugging task in VS Code (F5)
+2. Set breakpoint in `PositronNotebookInstance.ts:executeCell()`
+3. Open notebook and trigger execution
+4. Check:
+   - Is kernel selected?
+   - Is previous execution cancelled?
+   - Are execution events firing?
+   - Does runtime session exist?
+
+See `references/debugging-guide.md` for detailed strategies.
+
+### Debugging Selection/Focus Issues
+
+1. Inspect context keys: Command Palette → "Developer: Inspect Context Keys"
+2. Check selection machine state in `selectionMachine.ts`
+3. Verify DOM focus with browser DevTools (`document.activeElement`)
+4. Add logging to selection events and state transitions
+
+See `references/debugging-guide.md` for common issues and solutions.
+
+### Running Tests
+
+```bash
+# Run all notebook E2E tests
+./scripts/test_notebooks.sh
+
+# Run specific test
+./scripts/test_notebooks.sh "cell execution"
+
+# Or use Playwright directly
+npx playwright test test/e2e/tests/notebook/<test-name>.test.ts --project e2e-electron --reporter list
+```
+
+### Searching Notebook Code
+
+```bash
+# Find code patterns
+./scripts/find_notebook_code.sh "executeCell"
+./scripts/find_notebook_code.sh "selectionMachine"
+```
+
+## Core Files to Know
+
+**Primary entry point:**
+- `src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts` - Command registration, editor resolver
+
+**Central logic:**
+- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts` - Most non-UI logic, state management
+
+**React UI:**
+- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx` - Root component
+- `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/` - Cell components
+
+**State systems:**
+- `src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts` - Selection FSM
+- `src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts` - Context keys
+
+**Cell models:**
+- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/` - Cell implementations
+
+## Key Architecture Principles
+
+1. **Feature-flagged** - Coexists with VS Code notebooks, feature flag required
+2. **Observable-based** - React UI driven by VS Code observables
+3. **Shared infrastructure** - Reuses VS Code's notebook models, kernels, execution
+4. **One webview per output** - Each output gets its own webview (vs single webview)
+5. **Context key scoped** - Cell context keys scoped to cell DOM subtree
+
+## Progressive Documentation
+
+For detailed information, read the bundled reference docs:
+
+- **`references/architecture.md`** - Component details, integration points, execution flow
+- **`references/debugging-guide.md`** - Debugging strategies, common issues, testing workflows
+- **`references/common-patterns.md`** - Code examples for commands, observables, React components
+
+Full architecture document available at:
+`src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md`
+
+## Helper Scripts
+
+Located in `scripts/`:
+
+- **`validate_setup.sh`** - Check build daemons and file paths
+- **`test_notebooks.sh`** - Run notebook E2E tests with optional pattern
+- **`find_notebook_code.sh`** - Search for code patterns in notebook files
+
+## Common Tasks
+
+### Task: Add execution status indicator to cell
+**Steps:**
+1. Read `references/common-patterns.md` for observable patterns
+2. Add state observable to cell model
+3. Create React component consuming observable
+4. Integrate into cell component tree
+
+### Task: Fix context keys not updating
+**Steps:**
+1. Read `references/debugging-guide.md` for context key issues
+2. Check `ContextKeysManager.ts` for key setting logic
+3. Verify scoping (cell-level keys scoped to cell DOM)
+4. Use "Inspect Context Keys" to validate
+
+### Task: Debug cell not executing
+**Steps:**
+1. Read `references/debugging-guide.md` for execution debugging
+2. Use VS Code debug task (F5) with breakpoints
+3. Check kernel selection, runtime session, execution service
+4. Monitor execution state changes via log service
+
+### Task: Understand selection state machine
+**Steps:**
+1. Read `references/architecture.md` for selection FSM overview
+2. Check `selectionMachine.ts` for states and transitions
+3. Add logging to transitions
+4. Test selection events in debugger
+
+## Important Constraints
+
+- **Upstream compatibility**: Prefer new files over modifying existing VS Code files
+- **Feature flag respect**: Check `usingPositronNotebooks()` when needed
+- **No virtualization**: All cells render (performance consideration for large notebooks)
+- **Webview lifecycle**: Each output has own webview, coordinate mounting carefully
+
+## Self-Maintenance
+
+### Update Triggers
+
+Update this skill when encountering:
+- File paths that don't exist → Search for new location, update paths
+- New patterns discovered → Add to `references/common-patterns.md`
+- Bug fixes revealing insights → Add to `references/debugging-guide.md`
+- Architecture changes → Update `references/architecture.md` and main doc
+
+### Update Process
+
+1. Identify what changed (path, pattern, bug fix, architecture)
+2. Update relevant file (SKILL.md or references/)
+3. Verify all file paths still exist with `./scripts/validate_setup.sh`
+4. If architecture-significant, also update:
+   `src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md`
+
+### Path Validation
+
+Before using any file path from this skill:
+```bash
+# Verify path exists
+ls -la <path-from-skill>
+
+# If wrong, search for correct location
+find . -name "<filename>" | grep -v node_modules
+```
+
+Update skill with corrected path and add note about change.
+
+## Getting Help
+
+For deeper understanding:
+1. Start with relevant reference doc (`references/`)
+2. Check main architecture doc (`docs/positron_notebooks_architecture.md`)
+3. Use helper scripts for validation and searching
+4. Set breakpoints and use VS Code debugging
+
+This skill maintains lean, procedural guidance. Detailed technical information lives in progressive disclosure layers (references/ and main architecture doc).

--- a/.claude/skills/positron-notebooks/references/architecture.md
+++ b/.claude/skills/positron-notebooks/references/architecture.md
@@ -1,0 +1,213 @@
+# Positron Notebooks Architecture Reference
+
+This document contains detailed architectural information about Positron Notebooks components and systems.
+
+## Core Components
+
+### Entry Points
+
+**`src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts`**
+- Registers commands, keybindings, and menus
+- Sets up editor resolver for `.ipynb` files
+- Initializes contribution on workbench startup
+- Command registration pattern uses `CommandsRegistry.registerCommand()`
+
+**`src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts`**
+- Feature flag configuration: `positron.notebook.enabled`
+- Defaults to `false`, requires restart to enable
+- Controls editor resolver priority
+
+### Central State Management
+
+**`src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`**
+- **Most important file** - contains majority of non-UI logic
+- Manages cell lifecycle, execution, selection
+- Coordinates between VS Code services and React UI
+- Observable-based state for React reactivity
+- Key methods:
+  - `executeCell()` - Cell execution orchestration
+  - `addCell()` / `deleteCell()` - Cell CRUD operations
+  - `selectCell()` / `focusCell()` - Selection management
+  - `attachTextEditor()` - Monaco editor integration
+
+**`src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts`**
+- Editor input lifecycle management
+- Model resolution and disposal
+- View state persistence
+- Kernel selection state
+
+**`src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts`**
+- Global registry of active instances
+- One instance per open notebook
+- Provides `getActiveInstance()` for commands
+
+### Cell System
+
+**Interface: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts`**
+```typescript
+interface IPositronNotebookCell {
+	uri: URI;
+	cellIndex: number;
+	cellType: CellKind;
+	selectedObservable: IObservable<boolean>;
+	focusedObservable: IObservable<boolean>;
+	executionStateObservable: IObservable<NotebookCellExecutionState | undefined>;
+	// ... more observables for reactive UI
+}
+```
+
+**Base: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCellGeneral.ts`**
+- Shared cell logic for both code and markdown
+- Manages selection, focus, execution state
+- Text editor attachment lifecycle
+- Observable state management
+
+**Specializations:**
+- `PositronNotebookCodeCell.ts` - Code execution, output parsing
+- `PositronNotebookMarkdownCell.ts` - Markdown rendering, edit mode
+
+### React UI Components
+
+**Root: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx`**
+- Top-level React component
+- Renders cell list
+- Handles container-level events
+- Sets up notebook-level context keys
+
+**Cell Components:**
+- `notebookCells/NotebookCodeCell.tsx` - Code cell wrapper
+- `notebookCells/NotebookMarkdownCell.tsx` - Markdown cell wrapper
+- `notebookCells/CellEditorMonacoWidget.tsx` - Monaco editor integration
+- `notebookCells/ExecutionStatusBadge.tsx` - Execution status indicator
+- `notebookCells/CellLeftActionMenu.tsx` - Cell action buttons (run, debug)
+
+### State Management
+
+**Selection Machine: `src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts`**
+- XState finite state machine
+- States:
+  - `NoSelection` - No cells selected
+  - `SingleSelection` - One cell selected
+  - `MultiSelection` - Multiple cells selected
+  - `EditingSelection` - Cell in edit mode
+- Events trigger state transitions
+- State determines available commands
+
+**Context Keys: `src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts`**
+- Per-cell scoped context keys
+- Notebook-level keys (container focus, editor focus)
+- Cell-level keys (type, execution state, markdown editor open)
+- Drives command availability via when-clauses
+
+## Architecture Patterns
+
+### Observable-Based Reactivity
+
+Positron Notebooks uses VS Code's observable system (`@base/common/observable`) for React integration:
+
+```typescript
+// Cell state as observables
+private readonly _selected = observableValue<boolean>('selected', false);
+public readonly selectedObservable: IObservable<boolean> = this._selected;
+
+// React consumes observables
+const selected = useObservedValue(cell.selectedObservable);
+```
+
+Benefits:
+- Type-safe state management
+- Automatic React re-rendering
+- Decoupled model and view layers
+
+### One Webview Per Output
+
+Unlike VS Code notebooks (single giant webview for all outputs):
+- Each output gets its own webview instance
+- Simpler lifecycle management
+- Better isolation between outputs
+- Trade-off: More webview overhead
+
+### Feature Flag Architecture
+
+```typescript
+// Check if feature is enabled
+if (usingPositronNotebooks(configurationService)) {
+	// Positron notebook logic
+} else {
+	// Fall back to VS Code notebook
+}
+```
+
+### Shared VS Code Infrastructure
+
+Positron Notebooks reuses:
+- `INotebookService` - Notebook model management
+- `INotebookKernelService` - Kernel lifecycle
+- `INotebookExecutionService` - Cell execution
+- `INotebookEditorService` - Editor tracking
+
+Only adds:
+- React-based UI layer
+- Alternative state management
+- Enhanced UX features
+
+## Integration Points
+
+### VS Code Services
+- `INotebookService` - Model resolution, notebook lifecycle
+- `INotebookKernelService` - Kernel selection and management
+- `INotebookExecutionService` - Cell execution coordination
+- `INotebookEditorService` - Active editor tracking
+- `ICodeEditorService` - Monaco editor management
+
+### Positron Services
+- `IPositronNotebookService` - Instance registry and coordination
+- `IRuntimeSessionService` - Runtime lifecycle and console integration
+- `IPositronConsoleService` - "Execute in Console" functionality
+- `IPositronWebviewPreloadService` - Output renderer registration
+
+### Execution Flow
+
+```
+User clicks Run
+    ↓
+CellLeftActionMenu.tsx (React component)
+    ↓
+Command: 'positronNotebook.cell.execute'
+    ↓
+PositronNotebookInstance.executeCell()
+    ↓
+INotebookExecutionService.executeCell()
+    ↓
+Runtime Kernel queues execution
+    ↓
+Cell output arrives via INotebookExecutionStateService
+    ↓
+PositronNotebookCodeCell parses outputs
+    ↓
+React re-renders with new outputs
+    ↓
+Webviews mount for each output
+```
+
+## Performance Considerations
+
+1. **No virtualization** - All cells render immediately
+   - Fine for notebooks < 100 cells
+   - Performance degrades with large notebooks
+   - Future work: Implement virtual scrolling
+
+2. **Observable overhead** - Every state change triggers observable update
+   - Minimal for typical notebooks
+   - Can be optimized with derived observables
+
+3. **Webview per output** - More memory than single webview approach
+   - Simpler lifecycle management justifies cost
+   - Memory usage scales with output count
+
+## Key Constraints
+
+1. **Feature-flagged coexistence** - Must not break VS Code notebooks when disabled
+2. **Upstream compatibility** - Minimize modifications to VS Code files
+3. **Service reuse** - Don't duplicate VS Code infrastructure
+4. **Context key scoping** - Cell keys scoped to cell DOM, not global

--- a/.claude/skills/positron-notebooks/references/common-patterns.md
+++ b/.claude/skills/positron-notebooks/references/common-patterns.md
@@ -1,0 +1,391 @@
+# Common Patterns and Solutions
+
+Code patterns and examples for common notebook development tasks.
+
+## Adding a New Command
+
+**Pattern**: Register command, add to menu, implement handler
+
+```typescript
+// In positronNotebook.contribution.ts
+
+// 1. Register command
+CommandsRegistry.registerCommand({
+	id: 'positronNotebook.myNewCommand',
+	handler: (accessor, ...args) => {
+		const notebookService = accessor.get(IPositronNotebookService);
+		const instance = notebookService.getActiveInstance();
+		if (!instance) {
+			return;
+		}
+
+		// Implementation
+		const selectedCells = instance.getSelectedCells();
+		// ... do something with cells
+	}
+});
+
+// 2. Add to menu (optional)
+MenuRegistry.appendMenuItem(MenuId.NotebookCellTitle, {
+	command: {
+		id: 'positronNotebook.myNewCommand',
+		title: 'My New Command'
+	},
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals('positronNotebookEditorFocused', true),
+		// Add more conditions
+	),
+	group: 'inline'
+});
+
+// 3. Add keybinding (optional)
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'positronNotebook.myNewCommand',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals('positronNotebookEditorFocused', true)
+	),
+	primary: KeyMod.CtrlCmd | KeyCode.KeyK,
+	handler: () => { /* handled by CommandsRegistry */ }
+});
+```
+
+## Adding Cell State
+
+**Pattern**: Observable in cell model, consume in React
+
+```typescript
+// In PositronNotebookCellGeneral.ts (or specific cell class)
+
+export class PositronNotebookCodeCell implements IPositronNotebookCell {
+	// Add observable
+	private readonly _myState = observableValue<string>('myState', 'initial');
+	public readonly myStateObservable: IObservable<string> = this._myState;
+
+	// Add method to update state
+	public setMyState(value: string): void {
+		this._myState.set(value, undefined);
+	}
+}
+
+// In React component (e.g., NotebookCodeCell.tsx)
+function NotebookCodeCell({ cell }: { cell: IPositronNotebookCell }) {
+	const myState = useObservedValue(cell.myStateObservable);
+
+	return <div>State: {myState}</div>;
+}
+```
+
+## Accessing Services in React
+
+**Pattern**: Use React context to access VS Code services
+
+```typescript
+// Services are provided via PositronNotebookContextProvider
+
+import { usePositronNotebookContext } from './positronNotebookContext';
+
+function MyComponent() {
+	const context = usePositronNotebookContext();
+	const instance = context.instance;
+
+	const handleClick = () => {
+		instance.executeCell(cellUri);
+	};
+
+	return <button onClick={handleClick}>Execute</button>;
+}
+```
+
+## Adding Context Keys
+
+**Pattern**: Define key, set in ContextKeysManager, use in when-clauses
+
+```typescript
+// In ContextKeysManager.ts
+
+export class ContextKeysManager extends Disposable {
+	private readonly _myNewKey: IContextKey<boolean>;
+
+	constructor(
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
+	) {
+		super();
+
+		// Create key
+		this._myNewKey = CONTEXT_MY_NEW_KEY.bindTo(this.contextKeyService);
+	}
+
+	public setMyNewKey(value: boolean): void {
+		this._myNewKey.set(value);
+	}
+}
+
+// Define context key constant
+export const CONTEXT_MY_NEW_KEY = new RawContextKey<boolean>('positronNotebook.myNewKey', false);
+
+// Use in when-clause
+MenuRegistry.appendMenuItem(MenuId.NotebookCellTitle, {
+	command: { id: 'myCommand', title: 'My Command' },
+	when: ContextKeyExpr.equals('positronNotebook.myNewKey', true)
+});
+```
+
+## Handling Cell Execution
+
+**Pattern**: Cancel previous, start new, handle outputs
+
+```typescript
+// In PositronNotebookInstance.ts
+
+public async executeCell(cellUri: URI): Promise<void> {
+	const cell = this.getCell(cellUri);
+	if (!cell) {
+		return;
+	}
+
+	// 1. Cancel any existing execution
+	const existingExecution = this._notebookExecutionStateService.getCellExecution(cellUri);
+	if (existingExecution) {
+		await existingExecution.cancel();
+	}
+
+	// 2. Start new execution
+	const kernel = this._notebookKernelService.getSelectedOrSuggestedKernel(this._notebookModel);
+	if (!kernel) {
+		this._logService.warn('[Positron Notebook] No kernel selected');
+		return;
+	}
+
+	// 3. Execute via service
+	await this._notebookExecutionService.executeNotebookCells(
+		this._notebookModel,
+		[{ start: cell.cellIndex, end: cell.cellIndex + 1 }],
+		kernel
+	);
+
+	// 4. Outputs will arrive via execution state service events
+	// Cell model updates automatically via observable
+}
+```
+
+## Adding UI Component
+
+**Pattern**: Create React component, integrate with cell or editor
+
+```typescript
+// In notebookCells/MyNewComponent.tsx
+
+import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell';
+import { useObservedValue } from 'vs/base/browser/ui/positronComponents/useObservedValue';
+
+export function MyNewComponent({ cell }: { cell: IPositronNotebookCell }) {
+	const executionState = useObservedValue(cell.executionStateObservable);
+	const selected = useObservedValue(cell.selectedObservable);
+
+	return (
+		<div className={`my-component ${selected ? 'selected' : ''}`}>
+			{executionState === NotebookCellExecutionState.Executing && (
+				<span>Executing...</span>
+			)}
+		</div>
+	);
+}
+
+// Add to parent component
+import { MyNewComponent } from './MyNewComponent';
+
+function NotebookCodeCell({ cell }: { cell: IPositronNotebookCell }) {
+	return (
+		<div>
+			<MyNewComponent cell={cell} />
+			{/* other components */}
+		</div>
+	);
+}
+```
+
+## Testing Patterns
+
+### Unit Test Pattern
+
+```typescript
+// In test/browser/myFeature.test.ts
+
+import * as assert from 'assert';
+import { PositronNotebookInstance } from 'vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance';
+
+suite('Positron Notebook - My Feature', () => {
+	test('should do something', async () => {
+		// Arrange
+		const instance = createTestInstance(); // Helper to create instance
+		const cell = instance.getCell(0);
+
+		// Act
+		instance.selectCell(cell.uri);
+
+		// Assert
+		assert.strictEqual(cell.selectedObservable.get(), true);
+	});
+});
+```
+
+### E2E Test Pattern
+
+```typescript
+// In test/e2e/tests/notebook/myFeature.test.ts
+
+import { test, expect } from '@playwright/test';
+import { Application } from '../../infra';
+
+test.describe('Notebook - My Feature', () => {
+	test('should do something in UI', async function ({ app }) {
+		// Open notebook
+		await app.workbench.positronNotebook.openNotebook('test.ipynb');
+
+		// Interact with UI
+		await app.workbench.positronNotebook.clickCell(0);
+		await app.workbench.positronNotebook.executeCell(0);
+
+		// Assert
+		const output = await app.workbench.positronNotebook.getCellOutput(0);
+		expect(output).toContain('expected result');
+	});
+});
+```
+
+## Selection State Machine
+
+**Pattern**: Send events to trigger transitions
+
+```typescript
+// In PositronNotebookInstance.ts
+
+public selectCell(cellUri: URI, extendSelection: boolean = false): void {
+	const cell = this.getCell(cellUri);
+	if (!cell) {
+		return;
+	}
+
+	// Send event to state machine
+	if (extendSelection) {
+		this._selectionMachine.send({
+			type: 'EXTEND_SELECTION',
+			cellUri
+		});
+	} else {
+		this._selectionMachine.send({
+			type: 'SELECT_CELL',
+			cellUri
+		});
+	}
+
+	// State machine updates cell selection observables
+	// React components re-render automatically
+}
+```
+
+## Observable Patterns
+
+### Derived Observable
+
+```typescript
+// Compute value from other observables
+const isExecuting = derived(reader => {
+	const state = cell.executionStateObservable.read(reader);
+	return state === NotebookCellExecutionState.Executing;
+});
+```
+
+### Observable with Transaction
+
+```typescript
+// Update multiple observables atomically
+transaction(tx => {
+	cell1._selected.set(true, tx);
+	cell2._selected.set(false, tx);
+	// Both updates happen at once, single React re-render
+});
+```
+
+### Subscribing to Observable in Disposable
+
+```typescript
+export class MyClass extends Disposable {
+	constructor(cell: IPositronNotebookCell) {
+		super();
+
+		// Subscribe with automatic disposal
+		this._register(autorun(reader => {
+			const selected = cell.selectedObservable.read(reader);
+			if (selected) {
+				// Do something when selected
+			}
+		}));
+	}
+}
+```
+
+## Webview Integration
+
+**Pattern**: Register preload, mount webview, handle lifecycle
+
+```typescript
+// Register preload (in contribution)
+this._positronWebviewPreloadService.registerPreload(
+	'myOutputType',
+	URI.file(path.join(__dirname, 'myPreload.js'))
+);
+
+// Mount webview (in React component)
+import { useWebviewMount } from './hooks/useWebviewMount';
+
+function MyOutput({ output }: { output: INotebookOutput }) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useWebviewMount(containerRef, output, {
+		// Webview options
+	});
+
+	return <div ref={containerRef} />;
+}
+```
+
+## Error Handling Pattern
+
+```typescript
+public async myOperation(): Promise<void> {
+	try {
+		// Operation
+		await this.doSomething();
+	} catch (error) {
+		this._logService.error('[Positron Notebook] Operation failed', error);
+		// Optionally show notification
+		this._notificationService.error(`Operation failed: ${error.message}`);
+	}
+}
+```
+
+## Disposal Pattern
+
+```typescript
+export class MyClass extends Disposable {
+	private readonly _disposables = new DisposableStore();
+
+	constructor() {
+		super();
+
+		// Register disposables
+		this._register(this._disposables);
+
+		// Add disposables to store
+		this._disposables.add(someDisposable);
+		this._disposables.add(anotherDisposable);
+	}
+
+	public dispose(): void {
+		// Automatically disposes everything in _disposables
+		super.dispose();
+	}
+}
+```

--- a/.claude/skills/positron-notebooks/references/debugging-guide.md
+++ b/.claude/skills/positron-notebooks/references/debugging-guide.md
@@ -1,0 +1,317 @@
+# Positron Notebooks Debugging Guide
+
+Detailed debugging strategies and common issues for Positron Notebooks development.
+
+## Debugging Setup
+
+### Using VS Code Debug Tasks
+
+**Primary debugging method**: Use VS Code's built-in launch configurations.
+
+1. Open Run and Debug panel (Cmd+Shift+D)
+2. Select "Launch Positron" or relevant debug configuration
+3. Set breakpoints in TypeScript source
+4. Start debugging (F5)
+
+**Benefits:**
+- Full TypeScript debugging with source maps
+- Set breakpoints in any file
+- Inspect variables and call stacks
+- Hot reload with watch daemons
+
+### Log Service
+
+Add logging throughout notebook code:
+
+```typescript
+this._logService.info('[Positron Notebook] Message', data);
+this._logService.warn('[Positron Notebook] Warning', data);
+this._logService.error('[Positron Notebook] Error', error);
+```
+
+View logs:
+- Output panel → "Log (Window)" or "Log (Extension Host)"
+- Filter for "[Positron Notebook]"
+
+### Context Keys Inspection
+
+Check current context keys:
+1. Command Palette → "Developer: Inspect Context Keys"
+2. Look for notebook-specific keys:
+   - `positronNotebookEditorFocused`
+   - `positronNotebookCellType`
+   - `positronNotebookCellExecuting`
+   - etc.
+
+## Common Issues and Solutions
+
+### Selection/Focus Issues
+
+**Symptom**: Cells not responding to keyboard commands, wrong cell selected
+
+**Debug steps:**
+1. Check selection machine state:
+```typescript
+// In selectionMachine.ts, add logging
+console.log('[SelectionMachine]', event, this.state.value);
+```
+
+2. Verify cell focus:
+```typescript
+// In PositronNotebookInstance.ts
+this._logService.info('[Positron Notebook] Focused cell', this._focusedCell.get());
+```
+
+3. Check DOM focus:
+- Use browser DevTools
+- Inspect `document.activeElement`
+- Verify cell container has focus attribute
+
+4. Verify context keys:
+- Use "Inspect Context Keys" command
+- Check cell-level scoping
+
+**Common causes:**
+- Context keys not updating after state change
+- Focus not propagating to Monaco editor
+- Selection machine in wrong state
+- Event not triggering state transition
+
+### Execution Issues
+
+**Symptom**: Cell not executing, stuck in executing state, outputs not appearing
+
+**Debug steps:**
+1. Check kernel selection:
+```typescript
+// In PositronNotebookInstance.ts
+const kernel = this._notebookKernelService.getSelectedOrSuggestedKernel(this._notebookModel);
+this._logService.info('[Positron Notebook] Selected kernel', kernel);
+```
+
+2. Verify execution service:
+```typescript
+// In executeCell()
+this._logService.info('[Positron Notebook] Starting execution', cellUri);
+```
+
+3. Check runtime session state:
+```typescript
+this._logService.info('[Positron Notebook] Runtime session', this._runtimeSession.value?.metadata);
+```
+
+4. Monitor execution events:
+```typescript
+// Subscribe to execution state changes
+this._register(this._notebookExecutionStateService.onDidChangeExecution(e => {
+	this._logService.info('[Positron Notebook] Execution changed', e);
+}));
+```
+
+**Common causes:**
+- No kernel selected
+- Kernel not started
+- Previous execution not cancelled
+- Runtime session disconnected
+- Execution service not firing events
+
+### Output Rendering Issues
+
+**Symptom**: Outputs not rendering, webviews not mounting, blank output areas
+
+**Debug steps:**
+1. Check output parsing:
+```typescript
+// In PositronNotebookCodeCell.ts
+this._logService.info('[Positron Notebook] Parsed outputs', this._outputs.get());
+```
+
+2. Verify webview preloads:
+```typescript
+// Check registered preloads
+const preloads = this._positronWebviewPreloadService.getPreloads();
+this._logService.info('[Positron Notebook] Preloads', preloads);
+```
+
+3. Inspect webview lifecycle:
+```typescript
+// In useWebviewMount.ts
+console.log('[Webview Mount] Mounting webview', output.id);
+```
+
+4. Check webview developer tools:
+- Right-click output area
+- "Inspect Element" to open webview DevTools
+- Check console for errors
+
+**Common causes:**
+- Output MIME type not supported
+- Webview preload not registered
+- Mounting lifecycle issue
+- Security policy blocking content
+
+### Context Key Issues
+
+**Symptom**: Commands not available in menus, keyboard shortcuts not working
+
+**Debug steps:**
+1. Verify context key values:
+```typescript
+// In ContextKeysManager.ts
+this._logService.info('[Context Keys] Setting key', key, value);
+```
+
+2. Check when-clause evaluation:
+- Look at command registration in `positronNotebook.contribution.ts`
+- Verify when-clause matches expected context
+
+3. Inspect context key scoping:
+- Use "Inspect Context Keys" command
+- Verify cell-level keys are scoped correctly
+- Check if keys propagate to right DOM elements
+
+**Common causes:**
+- Context key not set when expected
+- Scoping issue (key set on wrong element)
+- When-clause logic incorrect
+- Context key not updating after state change
+
+## Debugging Workflows
+
+### Debugging Cell Lifecycle
+
+1. Set breakpoints:
+   - `PositronNotebookInstance.addCell()`
+   - `PositronNotebookCellGeneral` constructor
+   - Cell component `useEffect` hooks
+
+2. Create a new cell
+3. Step through initialization
+4. Verify observables set up correctly
+5. Check React rendering
+
+### Debugging Command Execution
+
+1. Find command in `positronNotebook.contribution.ts`
+2. Set breakpoint in command handler
+3. Trigger command (menu, keyboard, or Command Palette)
+4. Step through handler
+5. Verify context keys checked correctly
+6. Check state changes propagate
+
+### Debugging React Rendering
+
+1. Use React DevTools extension
+2. Inspect component tree
+3. Check props and state
+4. Look for unnecessary re-renders
+5. Verify observable updates trigger renders
+
+### Debugging State Machine Transitions
+
+1. Add logging to selection machine:
+```typescript
+// In selectionMachine.ts
+this.onTransition(state => {
+	console.log('[SelectionMachine] Transition', state.value, state.event);
+});
+```
+
+2. Trigger selection events
+3. Verify expected state transitions
+4. Check context keys update with state
+
+## Performance Debugging
+
+### Identifying Slow Renders
+
+1. Use React DevTools Profiler
+2. Record interaction
+3. Identify slow components
+4. Check for unnecessary re-renders
+5. Optimize observable subscriptions
+
+### Memory Leaks
+
+1. Take heap snapshot before opening notebook
+2. Open/close notebook multiple times
+3. Take another snapshot
+4. Compare - look for retained instances
+5. Check for undisposed observables/disposables
+
+### Execution Queue Issues
+
+1. Check runtime kernel queue state:
+```typescript
+this._logService.info('[Runtime Kernel] Queue', this._executionQueue);
+```
+
+2. Verify executions complete and clear
+3. Check for stuck executions
+4. Verify cancellation works
+
+## Testing Strategies
+
+### Unit Testing
+
+**Location**: `src/vs/workbench/contrib/positronNotebook/test/browser/`
+
+Focus areas:
+- State management logic
+- Selection machine transitions
+- Cell lifecycle
+- Observable behavior
+
+Run tests:
+```bash
+npm test -- --grep "positronNotebook"
+```
+
+### E2E Testing
+
+**Location**: `test/e2e/tests/notebook/`
+
+Test scenarios:
+- Visual behavior
+- User interactions
+- Execution flows
+- Multi-cell operations
+
+Run tests:
+```bash
+npx playwright test test/e2e/tests/notebook/ --project e2e-electron --reporter list
+```
+
+### Manual Testing Checklist
+
+After making changes:
+- [ ] Create new notebook
+- [ ] Add code/markdown cells
+- [ ] Execute cells
+- [ ] Test selection (single, multi)
+- [ ] Test keyboard shortcuts
+- [ ] Test context menu commands
+- [ ] Check output rendering
+- [ ] Test kernel selection
+- [ ] Verify focus management
+- [ ] Check with large notebook (50+ cells)
+
+## Known Issues and Workarounds
+
+### Issue: Cell focus lost after execution
+**Workaround**: Explicitly refocus cell after execution completes
+
+### Issue: Context keys not updating immediately
+**Workaround**: Use `setTimeout` or `queueMicrotask` to defer key updates
+
+### Issue: Webview not mounting on first render
+**Workaround**: Check webview mounting logic in `useWebviewMount.ts`
+
+### Issue: Selection state out of sync with UI
+**Workaround**: Verify event handlers fire and state machine transitions
+
+## Debugging Resources
+
+- Main architecture doc: `src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md`
+- VS Code notebook docs: `src/vs/workbench/contrib/notebook/`
+- XState visualizer: https://stately.ai/viz (for selection machine)

--- a/.claude/skills/positron-notebooks/scripts/find_notebook_code.sh
+++ b/.claude/skills/positron-notebooks/scripts/find_notebook_code.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Search for code patterns in Positron Notebooks
+# Usage: ./find_notebook_code.sh <search-term>
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <search-term>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 'executeCell'           # Find all executeCell references"
+    echo "  $0 'selectionMachine'      # Find selection machine usage"
+    echo "  $0 'ContextKeysManager'    # Find context key management"
+    exit 1
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "🔍 Searching for '$1' in Positron Notebooks..."
+echo ""
+
+# Search in main notebook contribution
+echo "📁 Core notebook code:"
+rg "$1" src/vs/workbench/contrib/positronNotebook/ \
+    --type ts --type tsx \
+    -n --heading --color always \
+    2>/dev/null || echo "  No matches"
+
+echo ""
+
+# Search in notebook service
+echo "📁 Notebook service:"
+rg "$1" src/vs/workbench/services/positronNotebook/ \
+    --type ts \
+    -n --heading --color always \
+    2>/dev/null || echo "  No matches"
+
+echo ""
+
+# Search in tests
+echo "📁 Tests:"
+rg "$1" test/e2e/tests/notebook/ \
+    --type ts \
+    -n --heading --color always \
+    2>/dev/null || echo "  No matches"

--- a/.claude/skills/positron-notebooks/scripts/test_notebooks.sh
+++ b/.claude/skills/positron-notebooks/scripts/test_notebooks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run Positron Notebook E2E tests
+# Usage: ./test_notebooks.sh [test-name-pattern]
+
+set -e
+
+# Check build daemons first
+if ! pgrep -f "watch-client" > /dev/null || ! pgrep -f "watch-extensions" > /dev/null; then
+    echo "⚠️  Warning: Build daemons may not be running"
+    echo "   Check with: ps aux | grep -E 'npm.*watch-(client|extensions)d' | grep -v grep"
+    echo ""
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ -z "$1" ]; then
+    echo "🧪 Running all notebook E2E tests..."
+    npx playwright test test/e2e/tests/notebook/ --project e2e-electron --reporter list
+else
+    echo "🧪 Running notebook tests matching: $1"
+    npx playwright test test/e2e/tests/notebook/ --project e2e-electron --reporter list --grep "$1"
+fi
+
+echo ""
+echo "📊 To view detailed report: npx playwright show-report"

--- a/.claude/skills/positron-notebooks/scripts/validate_setup.sh
+++ b/.claude/skills/positron-notebooks/scripts/validate_setup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Validate Positron Notebooks development setup
+# Checks that all critical paths and dependencies are ready
+
+set -e
+
+echo "🔍 Validating Positron Notebooks setup..."
+echo ""
+
+ERRORS=0
+
+# Check build daemons
+echo "Checking build daemons..."
+if pgrep -f "watch-client" > /dev/null; then
+    echo "  ✅ watch-clientd running"
+else
+    echo "  ❌ watch-clientd NOT running (start with: npm run watch-clientd &)"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if pgrep -f "watch-extensions" > /dev/null; then
+    echo "  ✅ watch-extensionsd running"
+else
+    echo "  ❌ watch-extensionsd NOT running (start with: npm run watch-extensionsd &)"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "Checking core notebook files..."
+
+CORE_FILES=(
+    "src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts"
+    "src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts"
+    "src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx"
+    "src/vs/workbench/services/positronNotebook/browser/positronNotebookService.ts"
+)
+
+for file in "${CORE_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        echo "  ✅ $file"
+    else
+        echo "  ❌ $file NOT FOUND"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+echo "Checking test directories..."
+
+TEST_DIRS=(
+    "test/e2e/tests/notebook"
+    "src/vs/workbench/contrib/positronNotebook/test/browser"
+)
+
+for dir in "${TEST_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "  ✅ $dir"
+    else
+        echo "  ❌ $dir NOT FOUND"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+if [ $ERRORS -eq 0 ]; then
+    echo "✅ All checks passed! Ready for notebook development."
+    exit 0
+else
+    echo "❌ $ERRORS error(s) found. Fix issues before proceeding."
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ product.overrides.json
 # Ignore Claude local/personal files but keep commands
 .claude/*
 !.claude/commands/
+!.claude/skills/
 !.claude/hooks/
 !.claude/settings.json
 


### PR DESCRIPTION
This PR adds three new ["Skills" for claude code.](https://www.anthropic.com/news/skills)

Notably all three skills were created using the Anthropic skill creator skill. 


```
/plugin marketplace add anthropics/skills

/plugin install skill-creator@anthropic-agent-skills
```


### `positron-issue-creator` 

Creates GitHub issues for Positron. Searches for duplicates, selects appropriate labels, gathers complete context through questioning, and writes terse, fluff-free issues. 

#### Scripts
- `fetch_labels.sh` - Retrieves all repository labels for categorization
- `search_duplicates.sh` - Searches for potential duplicate issues and discussions

#### How
Was created by pointing claude code at well designed issues and the issue template. 

### `positron-intake-rotation` 

Handles issue intake rotation duties. Reviews and organizes new issues, responds to discussions, handles support tickets, and searches for related content to ensure timely responses within one business day. 

#### Scripts
- `fetch_discussions.sh` - Lists recent open discussions needing attention
- `fetch_intake_issues.sh` - Lists open issues without status (intake queue)
- `fetch_labels.sh` - Retrieves all repository labels for categorization
- `search_related.sh` - Searches for related issues, discussions, and documentation

#### How
Was created by scraping the intake rotation docs and providing to claude

### `positron-notebooks` 

Develops and debugs Positron Notebooks. Covers notebook cell execution, selection state, context key system, cell commands, notebook-kernel integration, and output rendering.

#### Scripts
- `find_notebook_code.sh` - Searches for code patterns in notebook source files
- `test_notebooks.sh` - Runs notebook E2E tests with optional pattern matching
- `validate_setup.sh` - Validates build daemons are running and critical files exist

#### How
Was created by pointing claude at the notebook architecture document and guiding with personal knowledge. 


## How to use

In theory claude should automatically use these when appropriate but I often find it doesn't do a great job so I ask something like:

"Can you help me process issue #12345 with the positron intake skill?"

I've been pleasantly surprised by how well things work and I am betting we could migrate a good amount of progressive disclosure system for the claude.md to skills to be more explicit. 