### PR TITLE
e2e: unskip cell-execution-info test

### DIFF
--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -33,6 +33,7 @@ export class ContextMenu {
 			if (this.isNativeMenu) {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
+				await menuTrigger.hover();
 				await menuTrigger.click({ button: menuTriggerButton });
 
 				// Hover over the menu item

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -33,8 +33,8 @@ export class ContextMenu {
 			if (this.isNativeMenu) {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
-				await menuTrigger.click({ button: menuTriggerButton, force: true });
-				// await menuTrigger.click();
+				// await menuTrigger.click({ button: menuTriggerButton });
+				await menuTrigger.click();
 
 				// Hover over the menu item
 				const menuItem = menuItemType === 'menuitemcheckbox'

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -40,7 +40,7 @@ export class ContextMenu {
 				const menuItem = menuItemType === 'menuitemcheckbox'
 					? this.getContextMenuCheckboxItem(menuItemLabel)
 					: this.getContextMenuItem(menuItemLabel);
-				await menuItem.hover();
+				await menuItem.hover({ timeout: 1000 });
 				await this.page.waitForTimeout(500);
 
 				// Either selects the menu item or dismisses the tooltip

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -33,7 +33,6 @@ export class ContextMenu {
 			if (this.isNativeMenu) {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
-				await menuTrigger.hover();
 				await menuTrigger.click({ button: menuTriggerButton });
 
 				// Hover over the menu item

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -34,6 +34,7 @@ export class ContextMenu {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
 				await menuTrigger.click({ button: menuTriggerButton, force: true });
+				// await menuTrigger.click();
 
 				// Hover over the menu item
 				const menuItem = menuItemType === 'menuitemcheckbox'

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -33,7 +33,7 @@ export class ContextMenu {
 			if (this.isNativeMenu) {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
-				await menuTrigger.click({ button: menuTriggerButton });
+				await menuTrigger.click({ button: menuTriggerButton, force: true });
 
 				// Hover over the menu item
 				const menuItem = menuItemType === 'menuitemcheckbox'

--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -31,11 +31,11 @@ export class ContextMenu {
 	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem', menuTriggerButton = 'left' }: ContextMenuClick): Promise<void> {
 		await test.step(`Trigger context menu and click '${menuItemLabel}'`, async () => {
 			if (this.isNativeMenu) {
+				this.code.logger.log(`Using native menu to select: ${menuItemLabel}`);
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
-				// await menuTrigger.click({ button: menuTriggerButton });
-				await menuTrigger.click();
-
+				this.code.logger.log(`Using web menu to select: ${menuItemLabel}`);
+				await menuTrigger.click({ button: menuTriggerButton });
 				// Hover over the menu item
 				const menuItem = menuItemType === 'menuitemcheckbox'
 					? this.getContextMenuCheckboxItem(menuItemLabel)

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,7 +381,7 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					await this.kernelStatusBadge.click({ timeout: 1000 });
+					await this.kernelStatusBadge.click({ timeout: 1000, force: true });
 					await this.code.driver.page.getByText('Change Kernel').click();
 					if (false) {
 						await this.contextMenu.triggerAndClick({

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,7 +381,7 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					await this.code.driver.page.waitForTimeout(3000);
+					// await this.kernelStatusBadge.click();
 					await this.contextMenu.triggerAndClick({
 						menuTrigger: this.kernelStatusBadge,
 						menuItemLabel: /Change Kernel/

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,11 +381,12 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					// await this.kernelStatusBadge.click();
-					await this.contextMenu.triggerAndClick({
-						menuTrigger: this.kernelStatusBadge,
-						menuItemLabel: /Change Kernel/
-					});
+					await this.kernelStatusBadge.click();
+					await this.code.driver.page.getByText('Change Kernel').click();
+					// await this.contextMenu.triggerAndClick({
+					// 	menuTrigger: this.kernelStatusBadge,
+					// 	menuItemLabel: /Change Kernel/
+					// });
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
 					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,11 +381,11 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					// await this.contextMenu.triggerAndClick({
-					// 	menuTrigger: this.kernelStatusBadge,
-					// 	menuItemLabel: /Change Kernel/
-					// });
-					await this.kernelStatusBadge.click();
+					await this.code.driver.page.waitForTimeout(3000);
+					await this.contextMenu.triggerAndClick({
+						menuTrigger: this.kernelStatusBadge,
+						menuItemLabel: /Change Kernel/
+					});
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
 					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -377,31 +377,20 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log('Could not check current kernel status');
 			}
 
-			// Need to select the kernel
-			try {
-				// Click on kernel status badge to open selection
-				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
-				await expect(async () => {
-					// we shouldn't need to retry this, but the input closes immediately sometimes
-					await this.kernelStatusBadge.click({ timeout: 1000, force: true });
-					await this.code.driver.page.getByText('Change Kernel').click();
-					if (false) {
-						await this.contextMenu.triggerAndClick({
-							menuTrigger: this.kernelStatusBadge,
-							menuItemLabel: /Change Kernel/
-						});
-					}
-					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
-					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
-					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
-				}).toPass({ timeout: 10000 });
+			// Click on kernel status badge to open selection
+			await expect(async () => {
+				// we shouldn't need to retry this, but the input closes immediately sometimes
+				await this.contextMenu.triggerAndClick({
+					menuTrigger: this.kernelStatusBadge,
+					menuItemLabel: /Change Kernel/
+				});
+				// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
+				await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
+				await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
+			}).toPass({ timeout: 10000 });
 
-				await this.quickinput.waitForQuickInputClosed();
-				this.code.logger.log(`Selected kernel: ${desiredKernel}`);
-			} catch (e) {
-				this.code.logger.log(`Failed to select kernel: ${e}`);
-				throw e;
-			}
+			await this.quickinput.waitForQuickInputClosed();
+			this.code.logger.log(`Selected kernel: ${desiredKernel}`);
 
 			// Wait for the kernel status to show "Connected"
 			await expect(this.kernelStatusBadge).toContainText(desiredKernel, { timeout: 30000 });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -30,7 +30,7 @@ export class PositronNotebooks extends Notebooks {
 	private executionStatusAtIndex = (index: number) => this.cell.nth(index).locator('[data-execution-status]');
 	private detectingKernelsText = this.code.driver.page.getByText(/detecting kernels/i);
 	private cellStatusSyncIcon = this.code.driver.page.locator('.cell-status-item-has-runnable .codicon-sync');
-	private kernelStatusBadge = this.code.driver.page.getByTestId('notebook-kernel-status');
+	private kernelStatusBadge = this.code.driver.page.getByRole('button', { name: 'Kernel Actions' })
 	private deleteCellButton = this.cell.getByRole('button', { name: /delete the selected cell/i });
 	private cellInfoToolTip = this.code.driver.page.getByRole('tooltip', { name: /cell execution details/i });
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /more actions/i });
@@ -123,7 +123,8 @@ export class PositronNotebooks extends Notebooks {
 			'positron.notebook.enabled': true,
 			'workbench.editorAssociations': { '*.ipynb': 'workbench.editor.positronNotebook' }
 		};
-		await settings.set(config, { reload: true });
+		await settings.set(config, { reload: false });
+		await this.hotKeys.reloadWindow(true);
 	}
 
 	/**
@@ -381,7 +382,7 @@ export class PositronNotebooks extends Notebooks {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
 					await this.contextMenu.triggerAndClick({
 						menuTrigger: this.kernelStatusBadge,
-						menuItemLabel: /Change Kernel...|No Kernel Selected/
+						menuItemLabel: /Change Kernel/
 					});
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,10 +381,11 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					await this.contextMenu.triggerAndClick({
-						menuTrigger: this.kernelStatusBadge,
-						menuItemLabel: /Change Kernel/
-					});
+					// await this.contextMenu.triggerAndClick({
+					// 	menuTrigger: this.kernelStatusBadge,
+					// 	menuItemLabel: /Change Kernel/
+					// });
+					await this.kernelStatusBadge.click();
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
 					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,12 +381,14 @@ export class PositronNotebooks extends Notebooks {
 				this.code.logger.log(`Clicking kernel status badge to select: ${desiredKernel}`);
 				await expect(async () => {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
-					await this.kernelStatusBadge.click();
+					await this.kernelStatusBadge.click({ timeout: 1000 });
 					await this.code.driver.page.getByText('Change Kernel').click();
-					// await this.contextMenu.triggerAndClick({
-					// 	menuTrigger: this.kernelStatusBadge,
-					// 	menuItemLabel: /Change Kernel/
-					// });
+					if (false) {
+						await this.contextMenu.triggerAndClick({
+							menuTrigger: this.kernelStatusBadge,
+							menuItemLabel: /Change Kernel/
+						});
+					}
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
 					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,16 +381,14 @@ export class PositronNotebooks extends Notebooks {
 					// we shouldn't need to retry this, but the input closes immediately sometimes
 					await this.contextMenu.triggerAndClick({
 						menuTrigger: this.kernelStatusBadge,
-						menuItemLabel: `Change Kernel...`
+						menuItemLabel: /Change Kernel...|No Kernel Selected/
 					});
 					// this is a short wait because for some reason, 1st click always gets auto-closed in playwright :shrug:
 					await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
-
-					// Select the desired kernel
-					await this.quickinput.selectQuickInputElementContaining(desiredKernel);
-					await this.quickinput.waitForQuickInputClosed();
+					await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
 				}).toPass({ timeout: 10000 });
 
+				await this.quickinput.waitForQuickInputClosed();
 				this.code.logger.log(`Selected kernel: ${desiredKernel}`);
 			} catch (e) {
 				this.code.logger.log(`Failed to select kernel: ${e}`);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -123,8 +123,7 @@ export class PositronNotebooks extends Notebooks {
 		const config: Record<string, unknown> = {
 			'workbench.editorAssociations': { '*.ipynb': 'workbench.editor.positronNotebook' }
 		};
-		await settings.set(config, { reload: false });
-		await this.hotKeys.reloadWindow(true);
+		await settings.set(config, { reload: true });
 	}
 
 	/**

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -123,7 +123,7 @@ export class PositronNotebooks extends Notebooks {
 		const config: Record<string, unknown> = {
 			'workbench.editorAssociations': { '*.ipynb': 'workbench.editor.positronNotebook' }
 		};
-		await settings.set(config, { reload: true });
+		await settings.set(config, { reload: 'web' });
 	}
 
 	/**

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -92,11 +92,11 @@ export class QuickInput {
 		}
 	}
 
-	async selectQuickInputElementContaining(text: string): Promise<string> {
+	async selectQuickInputElementContaining(text: string, { timeout, force = true }: { timeout?: number; force?: boolean } = {}): Promise<string> {
 		const firstMatch = this.code.driver.page.locator(`${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`).first();
 
 		const firstMatchResult = await firstMatch.locator('.quick-input-list-row').nth(0).textContent() || '';
-		await firstMatch.click({ force: true, timeout: 10000 });
+		await firstMatch.click({ force, timeout });
 		await this.code.driver.page.mouse.move(0, 0);
 
 		return firstMatchResult.trim();

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Cell Deletion Action Bar Behavior', {
-	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS, tags.WEB]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Cell Deletion Action Bar Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS, tags.WEB]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -26,7 +26,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test.skip('Cell Execution Tooltip - Basic Functionality', async function ({ app }) {
+	test('Cell Execution Tooltip - Basic Functionality', async function ({ app }) {
 		const { notebooks, notebooksPositron } = app.workbench;
 
 		await test.step('Test Setup: Create notebook and select kernel', async () => {

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Cell Execution Tooltip', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS, tags.WEB]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 // Not running on web due to Positron notebooks being desktop-only
 test.describe('Notebook Focus and Selection', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS, tags.WEB]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS, tags.WEB]
 }, () => {
 
 	test.beforeAll(async ({ app, settings }) => {

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -58,37 +58,38 @@ test.describe('Positron Notebooks: Open & Save', {
 	});
 
 
-	test('Positron notebooks can open new untitled notebooks and saving works properly', async function ({ app, settings, runCommand, cleanup }) {
-		const { notebooks, notebooksPositron, quickInput, editors } = app.workbench;
+	test('Positron notebooks can open new untitled notebooks and saving works properly', { tag: [tags.WEB] },
+		async function ({ app, settings, runCommand, cleanup }) {
+			const { notebooks, notebooksPositron, quickInput, editors } = app.workbench;
 
-		// Configure Positron as the default notebook editor
-		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+			// Configure Positron as the default notebook editor
+			await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
 
-		// Create a new untitled notebook
-		await notebooks.createNewNotebook();
-		await notebooksPositron.expectToBeVisible();
+			// Create a new untitled notebook
+			await notebooks.createNewNotebook();
+			await notebooksPositron.expectToBeVisible();
 
-		// New notebooks should automatically be named "Untitled-1.ipynb" by default
-		await editors.waitForActiveTab('Untitled-1.ipynb', false);
+			// New notebooks should automatically be named "Untitled-1.ipynb" by default
+			await editors.waitForActiveTab('Untitled-1.ipynb', false);
 
-		// Test save dialog functionality - save with a name that doesn't include .ipynb extension
-		// The enhanced save dialog should automatically handle extension enforcement
-		await runCommand('workbench.action.files.saveAs', { keepOpen: true });
-		await quickInput.waitForQuickInputOpened();
+			// Test save dialog functionality - save with a name that doesn't include .ipynb extension
+			// The enhanced save dialog should automatically handle extension enforcement
+			await runCommand('workbench.action.files.saveAs', { keepOpen: true });
+			await quickInput.waitForQuickInputOpened();
 
-		// Type filename without extension to test automatic extension handling
-		const baseFileName = `saved-positron-notebook-${Math.random().toString(36).substring(7)}`;
-		await quickInput.type(path.join(app.workspacePathOrFolder, baseFileName));
-		await quickInput.clickOkButton();
+			// Type filename without extension to test automatic extension handling
+			const baseFileName = `saved-positron-notebook-${Math.random().toString(36).substring(7)}`;
+			await quickInput.type(path.join(app.workspacePathOrFolder, baseFileName));
+			await quickInput.clickOkButton();
 
-		// Verify the file was saved and the .ipynb extension was automatically added
-		const expectedFileName = `${baseFileName}.ipynb`;
-		await editors.waitForActiveTab(expectedFileName, false);
-		await notebooksPositron.expectToBeVisible();
+			// Verify the file was saved and the .ipynb extension was automatically added
+			const expectedFileName = `${baseFileName}.ipynb`;
+			await editors.waitForActiveTab(expectedFileName, false);
+			await notebooksPositron.expectToBeVisible();
 
-		// Keep the test workspace clean for subsequent test runs
-		await cleanup.removeTestFiles([expectedFileName]);
-	});
+			// Keep the test workspace clean for subsequent test runs
+			await cleanup.removeTestFiles([expectedFileName]);
+		});
 
 	test('Ghost editor issue: Positron notebook does not create duplicate VS Code notebook on reload with dirty notebook', async function ({ app, settings, hotKeys }) {
 		const { notebooks, notebooksPositron, editors } = app.workbench;

--- a/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
@@ -11,7 +11,7 @@ test.use({
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Postiron Notebooks: Cell Undo-Redo Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS, tags.WEB]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {


### PR DESCRIPTION
### Summary
* Fixing cell-execution info test to handle context menu kernel selection
* Tagging _most_ positron notebook tests for WEB. There were 2 that are not happy, I'm deferring those for later.

### QA Notes

@:positron-notebooks @:web

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
