### PR TITLE
Merging in upstream vscode-server for admin enforced settings

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -1289,7 +1289,7 @@
         "filename": "src/vs/server/node/webClientServer.ts",
         "hashed_secret": "66e26ed510af41f1d322d1ebda4389302f4a03c7",
         "is_verified": false,
-        "line_number": 510,
+        "line_number": 523,
         "is_secret": false
       },
       {
@@ -1297,7 +1297,7 @@
         "filename": "src/vs/server/node/webClientServer.ts",
         "hashed_secret": "93f2efffc36c6e096cdb21d6aadb7087dc0d7478",
         "is_verified": false,
-        "line_number": 516,
+        "line_number": 529,
         "is_secret": false
       }
     ],
@@ -1418,5 +1418,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-21T16:10:36Z"
+  "generated_at": "2025-10-22T15:17:54Z"
 }

--- a/src/vs/platform/configuration/common/configurationService.ts
+++ b/src/vs/platform/configuration/common/configurationService.ts
@@ -24,6 +24,10 @@ import { FileOperationError, FileOperationResult, IFileService } from '../../fil
 import { ILogService } from '../../log/common/log.js';
 import { IPolicyService, NullPolicyService } from '../../policy/common/policy.js';
 
+// --- Start PWB ---
+import { IAdminPolicyService } from '../../policy/common/adminPolicyService.js';
+// --- End PWB ---
+
 export class ConfigurationService extends Disposable implements IConfigurationService, IDisposable {
 
 	declare readonly _serviceBrand: undefined;
@@ -44,10 +48,15 @@ export class ConfigurationService extends Disposable implements IConfigurationSe
 		fileService: IFileService,
 		policyService: IPolicyService,
 		private readonly logService: ILogService,
+		// --- Start PWB ---
+		adminPolicyService?: IAdminPolicyService,
+		// --- End PWB ---
 	) {
 		super();
 		this.defaultConfiguration = this._register(new DefaultConfiguration(logService));
-		this.policyConfiguration = policyService instanceof NullPolicyService ? new NullPolicyConfiguration() : this._register(new PolicyConfiguration(this.defaultConfiguration, policyService, logService));
+		// --- Start PWB ---
+		this.policyConfiguration = policyService instanceof NullPolicyService ? new NullPolicyConfiguration() : this._register(new PolicyConfiguration(this.defaultConfiguration, policyService, logService, adminPolicyService));
+		// --- End PWB ---
 		this.userConfiguration = this._register(new UserSettings(this.settingsResource, {}, extUriBiasedIgnorePathCase, fileService, logService));
 		this.configuration = new Configuration(
 			this.defaultConfiguration.configurationModel,

--- a/src/vs/platform/policy/common/adminPolicyService.ts
+++ b/src/vs/platform/policy/common/adminPolicyService.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line header/header
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { isObject } from '../../../base/common/types.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILogService } from '../../log/common/log.js';
+
+export const IAdminPolicyService = createDecorator<IAdminPolicyService>('adminPolicyService');
+
+export interface IAdminPolicyService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Get all enforced settings
+	 */
+	getAllSettings(): ReadonlyArray<AdminPolicy>;
+}
+
+export interface AdminPolicy {
+	key: string;
+	value: any;
+}
+
+export class AdminPolicyService extends Disposable implements IAdminPolicyService {
+
+	readonly _serviceBrand: undefined;
+
+	private readonly settings: Array<AdminPolicy>;
+
+	constructor(
+		private readonly enforcedSettings: string,
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+		this.settings = this.read();
+	}
+
+	private read(): Array<AdminPolicy> {
+		const settings: Array<AdminPolicy> = [];
+
+		try {
+			this.logService.info(`[AdminPolicyService] Parsing enforced settings: ${this.enforcedSettings}`);
+			const raw = JSON.parse(this.enforcedSettings);
+
+			if (!isObject(raw)) {
+				throw new Error('Enforced settings isn\'t a JSON object');
+			}
+
+			for (const key of Object.keys(raw)) {
+				settings.push({ key, value: raw[key] });
+				this.logService.info(`[AdminPolicyService] Added policy: ${key} = ${JSON.stringify(raw[key])}`);
+			}
+
+			this.logService.info(`[AdminPolicyService] Successfully parsed ${settings.length} policies`);
+		} catch (error) {
+			this.logService.error(`[AdminPolicyService] Failed to read enforced settings ${this.enforcedSettings}`, error);
+		}
+
+		return settings;
+	}
+
+	public getAllSettings(): ReadonlyArray<AdminPolicy> {
+		this.logService.info(`[AdminPolicyService] getAllSettings() called, returning ${this.settings.length} policies`);
+		return this.settings;
+	}
+}

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -464,6 +464,9 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 
 	os: IOSConfiguration;
 	policiesData?: IStringDictionary<{ definition: PolicyDefinition; value: PolicyValue }>;
+	// --- Start PWB ---
+	adminPoliciesData?: string; // JSON string of enforced settings from POSITRON_ENFORCED_SETTINGS
+	// --- End PWB ---
 }
 
 /**

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1538,6 +1538,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			accessibilitySupport: app.accessibilitySupportEnabled,
 			colorScheme: this.themeMainService.getColorScheme(),
 			policiesData: this.policyService.serialize(),
+			// --- Start PWB ---
+			adminPoliciesData: process.env['POSITRON_ENFORCED_SETTINGS'], // Start PWB: Pass enforced settings to renderer
+			// --- End PWB ---
 			continueOn: this.environmentMainService.continueOn,
 
 			cssModules: this.cssDevelopmentService.isEnabled ? await this.cssDevelopmentService.getCssModules() : undefined

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -140,7 +140,7 @@ export class ExtensionHostConnection extends Disposable {
 
 	override dispose(): void {
 		// --- Start PWB ---
-                // cleanResources made async so it can flush the socket buffer before closing
+		// cleanResources made async so it can flush the socket buffer before closing
 		this._cleanResources().catch((error) => {
 			this._logError('Error during async cleanup:' + error.toString());
 		});
@@ -249,10 +249,10 @@ export class ExtensionHostConnection extends Disposable {
 		this._sendSocketToExtensionHost(this._extensionHostProcess, connectionData);
 	}
 
-        // --- Start PWB ---
-        // Need to make this async to flush the socket before closing
+	// --- Start PWB ---
+	// Need to make this async to flush the socket before closing
 	private async _cleanResources(): Promise<void> {
-        // --- End PWB ---
+		// --- End PWB ---
 
 		if (this._disposed) {
 			// already called
@@ -260,13 +260,13 @@ export class ExtensionHostConnection extends Disposable {
 		}
 		this._disposed = true;
 		if (this._connectionData) {
-		        // --- Start PWB ---
+			// --- Start PWB ---
 			try {
 				await this._connectionData.socketDrain();
 			} catch (error) {
 				this._logError('Failed to drain socket during cleanup: ' + error.toString());
 			}
-		        // --- End PWB ---
+			// --- End PWB ---
 			this._connectionData.socket.end();
 			this._connectionData = null;
 		}
@@ -333,22 +333,22 @@ export class ExtensionHostConnection extends Disposable {
 			this._extensionHostProcess.on('error', (err) => {
 				this._logError(`<${pid}> Extension Host Process had an error`);
 				this._logService.error(err);
-		                // --- Start PWB ---
-                                // Made async to flush buffer before closing
+				// --- Start PWB ---
+				// Made async to flush buffer before closing
 				this._cleanResources().catch((error) => {
 					this._logError('Error during async cleanup after extension host error: ' + error.toString());
 				});
-		                // --- End PWB ---
+				// --- End PWB ---
 			});
 
 			this._extensionHostProcess.on('exit', (code: number, signal: string) => {
 				this._extensionHostStatusService.setExitInfo(this._reconnectionToken, { code, signal });
 				this._log(`<${pid}> Extension Host Process exited with code: ${code}, signal: ${signal}.`);
-		                // --- Start PWB ---
+				// --- Start PWB ---
 				this._cleanResources().catch((error) => {
 					this._logError('Error during async cleanup after extension host exit ' + error.toString());
 				});
-		                // --- End PWB ---
+				// --- End PWB ---
 			});
 
 			if (extHostNamedPipeServer) {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -48,6 +48,9 @@ import { getPiiPathsFromEnvironment, isInternalTelemetry, isLoggingOnly, ITeleme
 import ErrorTelemetry from '../../platform/telemetry/node/errorTelemetry.js';
 import { IPtyService, TerminalSettingId } from '../../platform/terminal/common/terminal.js';
 import { PtyHostService } from '../../platform/terminal/node/ptyHostService.js';
+// --- Start PWB ---
+import { AdminPolicyService, IAdminPolicyService } from '../../platform/policy/common/adminPolicyService.js';
+// --- End PWB ---
 import { IUriIdentityService } from '../../platform/uriIdentity/common/uriIdentity.js';
 import { UriIdentityService } from '../../platform/uriIdentity/common/uriIdentityService.js';
 import { RemoteAgentEnvironmentChannel } from './remoteAgentEnvironmentImpl.js';
@@ -144,8 +147,23 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	const uriIdentityService = new UriIdentityService(fileService);
 	services.set(IUriIdentityService, uriIdentityService);
 
+	// --- Start PWB ---
+	// Admin Policy (enforced settings from environment variable)
+	const enforcedSettings = process.env['POSITRON_ENFORCED_SETTINGS'];
+	let adminPolicyService: IAdminPolicyService | undefined;
+	if (enforcedSettings) {
+		logService.info(`[Admin Policy] Found POSITRON_ENFORCED_SETTINGS: ${enforcedSettings}`);
+		adminPolicyService = disposables.add(new AdminPolicyService(enforcedSettings, logService));
+	} else {
+		logService.info('[Admin Policy] No POSITRON_ENFORCED_SETTINGS environment variable found');
+	}
+	// --- End PWB ---
+
 	// Configuration
-	const configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, new NullPolicyService(), logService);
+	// --- Start PWB ---
+	// Add adminPolicyService to constructor
+	const configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, new NullPolicyService(), logService, adminPolicyService);
+	// --- End PWB ---
 	services.set(IConfigurationService, configurationService);
 
 	// User Data Profiles

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -30,6 +30,7 @@ import { IExtensionManifest } from '../../platform/extensions/common/extensions.
 import { ICSSDevelopmentService } from '../../platform/cssDev/node/cssDevService.js';
 
 // --- Start PWB: Server proxy support ---
+// eslint-disable-next-line local/code-import-patterns
 import httpProxy from 'http-proxy';
 import { kProxyRegex } from './pwbConstants.js';
 // --- End PWB ---
@@ -427,6 +428,15 @@ export class WebClientServer {
 			} catch (err) {/* Ignore Error */ }
 		}
 
+		// --- Start PWB: Admin enforced settings ---
+		const enforcedSettings = process.env['POSITRON_ENFORCED_SETTINGS'];
+		if (enforcedSettings) {
+			this._logService.info(`[WebClientServer] Passing POSITRON_ENFORCED_SETTINGS to browser: ${enforcedSettings}`);
+		} else {
+			this._logService.info('[WebClientServer] No POSITRON_ENFORCED_SETTINGS environment variable found');
+		}
+		// --- End PWB ---
+
 		const workbenchWebConfiguration = {
 			remoteAuthority,
 			serverBasePath: basePath,
@@ -451,7 +461,10 @@ export class WebClientServer {
 			bootstrapExtensionsDir: this._environmentService.args['bootstrap-extensions-dir'],
 			// --- End Positron ---
 			productConfiguration,
-			callbackRoute: callbackRoute
+			callbackRoute: callbackRoute,
+			// --- Start PWB: Admin enforced settings ---
+			adminPoliciesData: enforcedSettings
+			// --- End PWB ---
 		};
 
 		const cookies = cookie.parse(req.headers.cookie || '');

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -311,7 +311,14 @@ export interface IWorkbenchConstructionOptions {
 	 */
 	readonly userDataPath?: string;
 	// --- End PWB ---
-  
+
+	// --- Start PWB: Admin enforced settings ---
+	/**
+	 * JSON string of enforced settings from POSITRON_ENFORCED_SETTINGS environment variable.
+	 */
+	readonly adminPoliciesData?: string;
+	// --- End PWB ---
+
 	// --- Start PWB: disable file downloads ---
 	/**
 	 * Whether the "Download..." option is enabled for files.


### PR DESCRIPTION
#9573 

Brings in the changes to support admin enforced settings. Setting `POSITRON_ENFORCED_SETTINGS` before starting Positron (web or desktop) with the JSON for the settings (matching the format in `settings.json`) will freeze the settings. They cannot be changed after startup and altering the environment variable will have no effect. If an admin changes the enforced settings, it will only affect new instances.

The desktop support has no use case at the moment but provides the ability for implementing a mechanism for admins to enforce settings on desktop as well. This would allow support for Linux, more complex settings (upstream only allows settings that are booleans, strings, and numbers), and for settings that aren't specifically marked as a policy (upstream only allows a short list of settings to be enforced).

The images below used this value for the environment variable: `"{\"positron.assistant.enabledProviders\": [\"amazon-bedrock\",\"openai-api\"], \"positron.assistant.enable\": true}"` This locks Assistant to enabled and sets the enabled providers to Bedrock and OpenAI (aside from the default supported Anthropic and Copilot).

<img width="823" height="842" alt="image" src="https://github.com/user-attachments/assets/114b031e-cf30-4f74-82a4-efc48181e7ba" />

The `settings.json` shows that `echo` was set but it is ignored and overridden by the admin setting. Also, the incorrect `openai` value is set there but the admin setting sets it correctly so it also shows as available in the dialog.

<img width="489" height="82" alt="image" src="https://github.com/user-attachments/assets/2b96cadf-5f40-4aff-801c-c54155f56855" />

The settings editor decorates a setting as managed by the organization. It cannot be altered. This decoration comes from upstream. The behaviour around preventing changes is based on the existing upstream policy code.

### Release Notes

#### New Features

- Admin enforced settings

#### Bug Fixes

- N/A


### QA Notes
Attempting to change an enforced setting may allow it to be changed but verify that the setting is locked even though the value changed. Often, the value reverts once the setting loses focus and the UI syncs back to the state.