### PR TITLE
9335 change default value for enable positron notebook flag

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
@@ -17,9 +17,9 @@ export const POSITRON_NOTEBOOK_ENABLED_KEY = 'positron.notebook.enabled';
 
 /**
  * Retrieves the value of the configuration setting that determines whether to enable
- * the experimental Positron Notebook editor.
+ * the Positron Notebook editor.
  * @param configurationService The configuration service
- * @returns Whether to enable the experimental Positron Notebook editor
+ * @returns Whether to enable the Positron Notebook editor
  */
 export function checkPositronNotebookEnabled(
 	configurationService: IConfigurationService
@@ -42,9 +42,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[POSITRON_NOTEBOOK_ENABLED_KEY]: {
 			type: 'boolean',
-			default: false,
-			included: false, // Hide from Settings UI - can only be set directly in JSON
-			tags: ['experimental'],
+			default: true,
 			markdownDescription: localize(
 				'positron.enablePositronNotebook',
 				'Enable the Positron Notebook editor for .ipynb files. When disabled, the default VS Code notebook editor will be used.\n\nA restart is required to take effect.'

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -15,19 +15,13 @@
 
 ## Executive Summary
 
-Positron Notebooks is a feature-flagged notebook editor that ships alongside the standard VS Code notebook experience. When `positron.notebook.enabled` is true, the editor registers as an optional handler for `.ipynb` resources while reusing VS Code's notebook models, kernel selection, execution, and working copy services. The user interface is implemented in React with observable-backed components. The implementation coexists with the built-in notebook editor: users can opt into Positron Notebooks via the `Open With…` menu or by configuring an editor association, and the feature can be disabled without impacting the standard experience.
+Positron Notebooks is an alternative notebook editor that ships enabled alongside the standard VS Code notebook experience. The feature is enabled by default (`positron.notebook.enabled: true`), making it available in the `Open With…` menu. It registers as an optional handler for `.ipynb` resources while reusing VS Code's notebook models, kernel selection, execution, and working copy services. The user interface is implemented in React with observable-backed components. Users can make Positron Notebooks the default `.ipynb` handler via editor associations, or disable the feature entirely via the `positron.notebook.enabled` setting without impacting the standard VS Code notebook editor.
 
 ## Quick Start for Contributors
 
-### Enable the editor
+### Using the editor
 
-1. Add the feature flag to your `settings.json` and restart Positron:
-```json
-{
-    "positron.notebook.enabled": true
-}
-```
-2. To make Positron the default handler for `.ipynb` files, add:
+1. Positron Notebooks is enabled by default, making it available in the `Open With…` menu. However, the VS Code notebook editor remains the default for `.ipynb` files. To make Positron Notebooks the default handler, add to your `settings.json`:
 ```json
 {
     "workbench.editorAssociations": {
@@ -37,18 +31,16 @@ Positron Notebooks is a feature-flagged notebook editor that ships alongside the
 ```
 Alternatively, you can right-click a notebook, select `Open With…` -> `Configure Default editor...` -> `Positron Notebook` to avoid editing JSON directly.
 
-Without this association, the Positron editor remains available in the `Open With…` menu.
+2. Open or create an `.ipynb` file. With editor associations configured, the Positron notebook editor will be used by default. Without editor associations, use `Open With…` to access Positron Notebooks.
 
-3. Open or create an `.ipynb` file. The editor resolver constructs the necessary editor input, resolves the backing notebook model, and instantiates the Positron notebook editor.
-
-To revert to the standard VS Code notebook editor, remove the feature flag (and association if set).
+To disable Positron Notebooks entirely, set `"positron.notebook.enabled": false` in your `settings.json` and restart Positron.
 
 ## Architecture Overview
 
 Core design principles:
 
-1. **Feature flagged** – all contributions check `positron.notebook.enabled`, allowing the editor to ship disabled by default.
-2. **Parallel implementation** – registration priority is `RegisteredEditorPriority.option`; the built-in editor remains the default unless the user opts in.
+1. **Feature flagged** – all contributions check `positron.notebook.enabled` (enabled by default), allowing the editor to be disabled if needed.
+2. **Parallel implementation** – registration priority is `RegisteredEditorPriority.option`; the VS Code notebook editor remains the default, and Positron Notebooks is available via `Open With…` unless editor associations are configured.
 3. **Shared infrastructure** – notebook models, kernel discovery, execution, diffing, and working copy management all use VS Code services.
 4. **Observable state + React view** – notebook state lives in observables, consumed by React components.
 5. **Context-key driven UX** – notebook and cell behaviors are controlled through scoped context keys that determine command availability and toolbar visibility.
@@ -59,8 +51,8 @@ Core design principles:
 
 ### Configuration layer (`browser/positronNotebookExperimentalConfig.ts`)
 
-- `positronNotebookExperimentalConfig.ts` registers the `positron.notebook.enabled` setting (machine-overridable, hidden, defaults to `false`).
-- `workbench.editorAssociations` remains the mechanism for making Positron the default `.ipynb` editor. `usingPositronNotebooks()` in `common/positronNotebookCommon.ts` encapsulates the check.
+- `positronNotebookExperimentalConfig.ts` registers the `positron.notebook.enabled` setting (machine-overridable, visible in Settings UI, defaults to `true`).
+- `workbench.editorAssociations` is the mechanism for making Positron the default `.ipynb` editor. `usingPositronNotebooks()` in `common/positronNotebookCommon.ts` encapsulates the check.
 
 ### Editor registration and resolution (`browser/positronNotebook.contribution.ts`)
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -94,16 +94,18 @@ export class PositronNotebooks extends Notebooks {
 	 * @param settings - The settings fixture
 	 * @param editor - 'positron' to use Positron notebook editor, 'default' to clear associations
 	 * @param waitMs - The number of milliseconds to wait for the settings to be applied
+	 * @param enableNotebooks - Whether to enable Positron notebooks (defaults to true, set to false to explicitly disable)
 	 */
 	async setNotebookEditor(
 		settings: {
 			set: (settings: Record<string, unknown>, options?: { reload?: boolean | 'web'; waitMs?: number; waitForReady?: boolean; keepOpen?: boolean }) => Promise<void>;
 		},
 		editor: 'positron' | 'default',
-		waitMs = 800
+		waitMs = 800,
+		enableNotebooks = true
 	) {
 		await settings.set({
-			'positron.notebook.enabled': true,
+			'positron.notebook.enabled': enableNotebooks,
 			'workbench.editorAssociations': editor === 'positron'
 				? { '*.ipynb': 'workbench.editor.positronNotebook' }
 				: {}
@@ -111,7 +113,7 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
-	 * Action: Enable Positron notebooks in settings and set to 'positron' editor.
+	 * Action: Configure editor associations to use Positron notebook editor for .ipynb files.
 	 * @param settings - The settings fixture
 	 */
 	async enablePositronNotebooks(
@@ -120,7 +122,6 @@ export class PositronNotebooks extends Notebooks {
 		},
 	) {
 		const config: Record<string, unknown> = {
-			'positron.notebook.enabled': true,
 			'workbench.editorAssociations': { '*.ipynb': 'workbench.editor.positronNotebook' }
 		};
 		await settings.set(config, { reload: true });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -124,7 +124,7 @@ export class PositronNotebooks extends Notebooks {
 		const config: Record<string, unknown> = {
 			'workbench.editorAssociations': { '*.ipynb': 'workbench.editor.positronNotebook' }
 		};
-		await settings.set(config, { reload: true });
+		await settings.set(config);
 	}
 
 	/**


### PR DESCRIPTION
Addresses #9335.

This PR enables Positron Notebooks by default. Previously, users had to manually set `positron.notebook.enabled: true` before the feature was even available in the "Open With..." menu. Now the feature is enabled by default and visible in the Settings GUI.

### Changes Made

1. **Configuration**: Changed `positron.notebook.enabled` default from `false` to `true`
2. **Settings visibility**: Removed `included: false` flag to make setting appear in Settings GUI
3. **Tests**: Updated test helpers to reflect new default

**Important**: This PR does NOT change which editor opens `.ipynb` files by default. It only makes Positron Notebooks available in the "Open With..." menu without requiring manual configuration flag changes. Users still need to configure `workbench.editorAssociations` to make Positron Notebooks the default handler.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks

1. Open Positron with no custom settings
2. Verify that `positron.notebook.enabled` is visible when searching for "positron notebook" in Settings UI
3. Right-click an `.ipynb` file and verify "Positron Notebook" appears in the "Open With..." menu without any manual configuration
4. Verify that `.ipynb` files still open with VS Code notebook editor by default
5. Optionally test setting `workbench.editorAssociations` to confirm Positron Notebooks can be made the default:

```json
{
    "workbench.editorAssociations": {
        "*.ipynb": "workbench.editor.positronNotebook"
    }
}
```
