### PR TITLE
e2e test: Skip flaky assistant test

### DIFF
--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -73,7 +73,10 @@ export enum TestTags {
 	WORKBENCH = '@:workbench',
 
 	// exclude tags
-	NIGHTLY_ONLY = '@:nightly-only'
+	NIGHTLY_ONLY = '@:nightly-only',
+
+	// Provisional tag for tests that won't report in PR runs yet
+	PROVISIONAL = '@:provisional'
 }
 
 

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -150,7 +150,8 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 		await app.workbench.variables.expectVariableToBe('foo', '200');
 	});
 
-	test('Verify Manage Models is available', async function ({ app }) {
+	// Skipping due to flakiness. We can re-enable as part of the PROVISIONAL tag work
+	test.skip('Verify Manage Models is available', { tag: [tags.PROVISIONAL] }, async function ({ app }) {
 		await app.workbench.assistant.verifyManageModelsOptionVisible();
 	});
 });


### PR DESCRIPTION
THe new assistant teste is flaky.

* Skip for now
* Added a PROVISIONAL tag to be used in upcoming work.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
