### PR TITLE
e2e: quarto: use hotkey to kill all terminals

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -85,8 +85,13 @@
     {
         "key": "cmd+j y",
         "command": "workbench.action.positronDataExplorer.expandSummary" // Show the Summary Panel in DE
-    },{
+    },
+    {
         "key": "cmd+j m",
         "command": "workbench.action.positronDataExplorer.summaryOnRight" // Move the DE Summary Panel to the right side
+    },
+    {
+        "key": "cmd+j t",
+        "command": "workbench.action.terminal.killAll" // Kill all terminals
     }
 ]

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -117,6 +117,14 @@ export class HotKeys {
 	}
 
 	// ------------------------
+	// --- Terminal Actions ---
+	// ------------------------
+
+	public async killAllTerminals() {
+		await this.pressHotKeys('Cmd+J T', 'Kill all terminals');
+	}
+
+	// ------------------------
 	// --- Console & Visuals ---
 	// ------------------------
 

--- a/test/e2e/tests/quarto/quarto-r.test.ts
+++ b/test/e2e/tests/quarto/quarto-r.test.ts
@@ -18,10 +18,10 @@ test.describe('Quarto - R', { tag: [tags.WEB, tags.WIN, tags.QUARTO, tags.ARK] }
 		await app.workbench.quickaccess.openFile(path.join(app.workspacePathOrFolder, 'workspaces', 'quarto_basic', 'quarto_basic.qmd'));
 	});
 
-	test.afterEach(async function ({ app }) {
+	test.afterEach(async function ({ app, hotKeys }) {
 		// Clean up any terminals that may have been created during Quarto operations
 		try {
-			await app.workbench.quickaccess.runCommand('workbench.action.terminal.killAll');
+			await hotKeys.killAllTerminals();
 		} catch (error) {
 			// Ignore errors if no terminals exist
 		}


### PR DESCRIPTION
### Summary
Using hotkey to kill all terminals in the R quarto test. Confirmed this is the only test that was using that particular command.

### QA Notes
@:quarto