### PR TITLE
Skipping integration tetst for now

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -179,8 +179,10 @@ const apiTestSerializer: vscode.NotebookSerializer = {
 		assert.strictEqual(firstNotebookEditor?.notebook, secondNotebookEditor?.notebook, 'split notebook editors share the same document');
 	});
 
+	// --- Start Positron ---
+	// Skipping due to https://github.com/posit-dev/positron/issues/10114
 	test.skip('#106657. Opening a notebook from markers view is broken ', async function () {
-
+	// --- End Positron ---
 		const document = await openRandomNotebookDocument();
 		const [cell] = document.getCells();
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -179,7 +179,7 @@ const apiTestSerializer: vscode.NotebookSerializer = {
 		assert.strictEqual(firstNotebookEditor?.notebook, secondNotebookEditor?.notebook, 'split notebook editors share the same document');
 	});
 
-	test('#106657. Opening a notebook from markers view is broken ', async function () {
+	test.skip('#106657. Opening a notebook from markers view is broken ', async function () {
 
 		const document = await openRandomNotebookDocument();
 		const [cell] = document.getCells();


### PR DESCRIPTION
To mitigate https://github.com/posit-dev/positron/issues/10114, this skips that integration test for now.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
