### PR TITLE
Skip extension test on windows

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -220,14 +220,14 @@ jobs:
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
 
-      - name: Run Extensions Test
-        id: extensions
-        continue-on-error: true
-        shell: bash
-        run: |
-          set +e
-          npm run test-extension -- -l positron-r
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
+      # - name: Run Extensions Test
+      #   id: extensions
+      #   continue-on-error: true
+      #   shell: bash
+      #   run: |
+      #     set +e
+      #     npm run test-extension -- -l positron-r
+      #     echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Run Bootstrap Extensions Test
         if: ${{ inputs.skip_extension_test != true }}
@@ -307,12 +307,12 @@ jobs:
           path: test-logs
           if-no-files-found: ignore
 
-      - name: Fail workflow if extension tests failed
-        if: |
-          steps.extensions.outputs.exit_code != '0'
-        run: |
-          echo "Extension tests failed."
-          exit 1
+      # - name: Fail workflow if extension tests failed
+      #   if: |
+      #     steps.extensions.outputs.exit_code != '0'
+      #   run: |
+      #     echo "Extension tests failed."
+      #     exit 1
 
       - name: Upload inspect-ai JSON Responses
         if: ${{ always() && inputs.project == 'inspect-ai' }}


### PR DESCRIPTION
Due to https://github.com/posit-dev/positron/issues/10121, I'm skipping the extensions tests on windows for now.

### QA Notes
See run where they are skipped https://github.com/posit-dev/positron/actions/runs/18758569817

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
