### PR TITLE
Add operation tracking to avoid undesired edit mode entering

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -35,7 +35,7 @@ export function AddCodeCellButton({ notebookInstance, index, bordered }: { noteb
 		codicon='code'
 		fullLabel={fullLabel}
 		label={label}
-		onClick={() => notebookInstance.addCell(CellKind.Code, index)}
+		onClick={() => notebookInstance.addCell(CellKind.Code, index, true)}
 	/>;
 
 }
@@ -50,7 +50,7 @@ export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { n
 		codicon='markdown'
 		fullLabel={fullLabel}
 		label={label}
-		onClick={() => notebookInstance.addCell(CellKind.Markup, index)}
+		onClick={() => notebookInstance.addCell(CellKind.Markup, index, true)}
 	/>;
 
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -37,7 +37,7 @@ export enum KernelStatus {
  */
 export enum NotebookOperationType {
 	/** Normal cell insertion via UI or command */
-	Insert = 'Insert',
+	InsertAndEdit = 'InsertAndEdit',
 	/** Cells added via paste operation */
 	Paste = 'Paste',
 	/** Cells restored via undo operation */
@@ -193,8 +193,9 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 *
 	 * @param type The kind of cell to create (e.g., code, markdown)
 	 * @param index The position at which to insert the new cell
+	 * @param enterEditMode Whether to put the new cell into edit mode immediately
 	 */
-	addCell(type: CellKind, index: number): void;
+	addCell(type: CellKind, index: number, enterEditMode: boolean): void;
 
 	/**
 	 * Inserts a new code cell either above or below the current selection

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -31,6 +31,22 @@ export enum KernelStatus {
 }
 
 /**
+ * Represents the types of operations that can be performed on a notebook.
+ * Used to track the context of cell additions and modifications to control
+ * automatic behavior like entering edit mode.
+ */
+export enum NotebookOperationType {
+	/** Normal cell insertion via UI or command */
+	Insert = 'Insert',
+	/** Cells added via paste operation */
+	Paste = 'Paste',
+	/** Cells restored via undo operation */
+	Undo = 'Undo',
+	/** Cells restored via redo operation */
+	Redo = 'Redo'
+}
+
+/**
  * Subset of INotebookEditor required to integrate with the extension API,
  * so we don't have to implement the entire INotebookEditor interface (...yet)
  * See mainThreadNotebookDocumentsAndEditors.ts and mainThreadNotebookEditors.ts.
@@ -272,6 +288,31 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 * Returns whether there are cells available to paste from the clipboard.
 	 */
 	canPaste(): boolean;
+
+	/**
+	 * Gets the current notebook operation type that is in progress, if any.
+	 * This is used to track the context of cell additions and modifications to
+	 * control automatic behavior like entering edit mode. Operation is cleared
+	 * after being retrieved to ensure it only applies to the immediate next
+	 * action.
+	 * @returns The current operation type, or undefined if no operation is in
+	 * progress
+	 */
+	getAndResetCurrentOperation(): NotebookOperationType | undefined;
+
+	/**
+	 * Sets the current notebook operation type.
+	 * This should be called at the beginning of operations like paste, undo, or redo
+	 * to provide context for subsequent cell additions.
+	 * @param type The operation type to set
+	 */
+	setCurrentOperation(type: NotebookOperationType): void;
+
+	/**
+	 * Clears the current notebook operation type.
+	 * This should be called after the operation context is no longer needed.
+	 */
+	clearCurrentOperation(): void;
 
 	/**
 	 * Shows or focuses the notebook console for this notebook instance.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -22,10 +22,10 @@ import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine, toCellRanges } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { CellSelectionType, getSelectedCell, getSelectedCells, SelectionState, SelectionStateMachine, toCellRanges } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IPositronNotebookService } from './positronNotebookService.js';
-import { IPositronNotebookInstance, KernelStatus } from './IPositronNotebookInstance.js';
+import { IPositronNotebookInstance, KernelStatus, NotebookOperationType } from './IPositronNotebookInstance.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { SELECT_KERNEL_ID_POSITRON } from './SelectPositronNotebookKernelAction.js';
@@ -197,6 +197,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	private readonly _onDidScrollCellsContainer = this._register(new Emitter<void>());
 	readonly onDidScrollCellsContainer = this._onDidScrollCellsContainer.event;
+
+	/**
+	 * Tracks the current operation type (paste, undo, redo, etc.) to provide
+	 * context for automatic behaviors like entering edit mode on cell addition.
+	 */
+	private _currentOperation: NotebookOperationType | undefined = undefined;
 
 	// =============================================================================================
 	// #region Public Properties
@@ -612,6 +618,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (!this.language) {
 			throw new Error(localize('noLanguage', "No language for notebook"));
 		}
+
+		// Set operation type to enable automatic edit mode entry for normal inserts
+		this.setCurrentOperation(NotebookOperationType.Insert);
 
 		const textModel = this.textModel;
 		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
@@ -1043,11 +1052,21 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return newCell;
 		});
 
+		const currentOp = this.getAndResetCurrentOperation();
+
 		if (newlyAddedCells.length === 1) {
-			// Defer to next tick to allow React to mount the editor component.
-			// enterEditor() handles both state update and focus management.
+			// We don't auto-enter edit mode for paste, undo, or redo operations
+			const shouldAutoEdit = shouldAutoEditOnCellAdd(currentOp);
+
+			// Defer to next tick to allow React to mount the cell component
 			setTimeout(() => {
-				this.selectionStateMachine.enterEditor(newlyAddedCells[0]);
+				if (shouldAutoEdit) {
+					// Enter edit mode (which also selects the cell)
+					this.selectionStateMachine.enterEditor(newlyAddedCells[0]);
+				} else {
+					// Just select the cell without entering edit mode
+					this.selectionStateMachine.selectCell(newlyAddedCells[0], CellSelectionType.Normal);
+				}
 			}, 0);
 		}
 
@@ -1278,49 +1297,59 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this._assertTextModel();
+		// Set operation type to prevent automatic edit mode entry
+		this.setCurrentOperation(NotebookOperationType.Paste);
 
-		const textModel = this.textModel;
-		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
-		const pasteIndex = index ?? this.getInsertionIndex();
-		const cellCount = this._clipboardCells.length;
+		try {
+			this._assertTextModel();
 
-		// Use textModel.applyEdits to properly create and register cells
-		const synchronous = true;
-		const endSelections: ISelectionState = {
-			kind: SelectionStateType.Index,
-			focus: { start: pasteIndex, end: pasteIndex + cellCount },
-			selections: [{ start: pasteIndex, end: pasteIndex + cellCount }]
-		};
-		const focusAfterInsertion = {
-			start: pasteIndex,
-			end: pasteIndex + cellCount
-		};
+			const textModel = this.textModel;
+			const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
+			const pasteIndex = index ?? this.getInsertionIndex();
+			const cellCount = this._clipboardCells.length;
 
-		textModel.applyEdits([
-			{
-				editType: CellEditType.Replace,
-				index: pasteIndex,
-				count: 0,
-				cells: this._clipboardCells
-			}
-		],
-			synchronous,
-			{
+			// Use textModel.applyEdits to properly create and register cells
+			const synchronous = true;
+			const endSelections: ISelectionState = {
 				kind: SelectionStateType.Index,
-				focus: focusAfterInsertion,
-				selections: [focusAfterInsertion]
-			},
-			() => endSelections, undefined, computeUndoRedo
-		);
+				focus: { start: pasteIndex, end: pasteIndex + cellCount },
+				selections: [{ start: pasteIndex, end: pasteIndex + cellCount }]
+			};
+			const focusAfterInsertion = {
+				start: pasteIndex,
+				end: pasteIndex + cellCount
+			};
 
-		// If this was a cut operation, clear the clipboard
-		if (this._isClipboardCut) {
-			this._clipboardCells = [];
-			this._isClipboardCut = false;
+			textModel.applyEdits([
+				{
+					editType: CellEditType.Replace,
+					index: pasteIndex,
+					count: 0,
+					cells: this._clipboardCells
+				}
+			],
+				synchronous,
+				{
+					kind: SelectionStateType.Index,
+					focus: focusAfterInsertion,
+					selections: [focusAfterInsertion]
+				},
+				() => endSelections, undefined, computeUndoRedo
+			);
+
+			// If this was a cut operation, clear the clipboard
+			if (this._isClipboardCut) {
+				this._clipboardCells = [];
+				this._isClipboardCut = false;
+			}
+
+			this._onDidChangeContent.fire();
+			// If successful, _syncCells() will have cleared the flag
+		} catch (error) {
+			// Clear flag on exception since _syncCells() won't run
+			this.clearCurrentOperation();
+			throw error;
 		}
-
-		this._onDidChangeContent.fire();
 	}
 
 	/**
@@ -1344,6 +1373,30 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this._clipboardCells.length > 0;
 	}
 
+	/**
+	 * Gets the current notebook operation type that is in progress, if any.
+	 * @returns The current operation type, or undefined if no operation is in progress
+	 */
+	getAndResetCurrentOperation(): NotebookOperationType | undefined {
+		const currentOp = this._currentOperation;
+		this.clearCurrentOperation();
+		return currentOp;
+	}
+
+	/**
+	 * Sets the current notebook operation type.
+	 * @param type The operation type to set
+	 */
+	setCurrentOperation(type: NotebookOperationType): void {
+		this._currentOperation = type;
+	}
+
+	/**
+	 * Clears the current notebook operation type.
+	 */
+	clearCurrentOperation(): void {
+		this._currentOperation = undefined;
+	}
 
 	// Helper method to get insertion index
 	private getInsertionIndex(): number {
@@ -1362,4 +1415,9 @@ function assertNotebookCellIsCellViewModel(cell: IPositronNotebookCell): asserts
 	// No-op; used for type assertion.
 	// Implement ICellViewModel as needed. Not currently needed since the extension API
 	// only uses the returned value in calls to our own reveal* methods
+}
+
+function shouldAutoEditOnCellAdd(currentOp: NotebookOperationType | undefined): boolean {
+	// Don't auto-enter edit mode for paste, undo, or redo operations
+	return currentOp === NotebookOperationType.Insert;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1242,11 +1242,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private _clipboardCells: ICellDto2[] = [];
 
 	/**
-	 * Flag to track if the clipboard contains cut cells (vs copied cells)
-	 */
-	private _isClipboardCut: boolean = false;
-
-	/**
 	 * Copies the specified cells to the clipboard.
 	 * @param cells The cells to copy. If not provided, copies the currently selected cells
 	 */
@@ -1259,7 +1254,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		// Store internally for full-fidelity paste
 		this._clipboardCells = cellsToCopy.map(cell => cellToCellDto2(cell));
-		this._isClipboardCut = false;
 
 		// Also write to system clipboard as text
 		const clipboardText = serializeCellsToClipboard(cellsToCopy);
@@ -1282,7 +1276,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		// Copy cells first
 		this.copyCells(cellsToCut);
-		this._isClipboardCut = true;
 
 		// Delete the cells (this handles selection and focus automatically)
 		this.deleteCells(cellsToCut);
@@ -1336,12 +1329,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				},
 				() => endSelections, undefined, computeUndoRedo
 			);
-
-			// If this was a cut operation, clear the clipboard
-			if (this._isClipboardCut) {
-				this._clipboardCells = [];
-				this._isClipboardCut = false;
-			}
 
 			this._onDidChangeContent.fire();
 			// If successful, _syncCells() will have cleared the flag

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -612,15 +612,17 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param index The position where the cell should be inserted
 	 * @throws Error if no language is set for the notebook
 	 */
-	addCell(type: CellKind, index: number): void {
+	addCell(type: CellKind, index: number, enterEditMode: boolean): void {
 		this._assertTextModel();
 
 		if (!this.language) {
 			throw new Error(localize('noLanguage', "No language for notebook"));
 		}
 
-		// Set operation type to enable automatic edit mode entry for normal inserts
-		this.setCurrentOperation(NotebookOperationType.Insert);
+		if (enterEditMode) {
+			// Set operation type to enable automatic edit mode entry for normal inserts
+			this.setCurrentOperation(NotebookOperationType.InsertAndEdit);
+		}
 
 		const textModel = this.textModel;
 		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
@@ -677,7 +679,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1));
+		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), false);
 	}
 
 	/**
@@ -1406,5 +1408,5 @@ function assertNotebookCellIsCellViewModel(cell: IPositronNotebookCell): asserts
 
 function shouldAutoEditOnCellAdd(currentOp: NotebookOperationType | undefined): boolean {
 	// Don't auto-enter edit mode for paste, undo, or redo operations
-	return currentOp === NotebookOperationType.Insert;
+	return currentOp === NotebookOperationType.InsertAndEdit;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -11,6 +11,7 @@ import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/und
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
+import { NotebookOperationType } from '../../IPositronNotebookInstance.js';
 
 class PositronNotebookUndoRedoContribution extends Disposable {
 
@@ -71,8 +72,16 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const result = this.undoRedoService.undo(instance.uri);
-		return result ?? true;
+		instance.setCurrentOperation(NotebookOperationType.Undo);
+
+		try {
+			const result = this.undoRedoService.undo(instance.uri);
+			// If successful, _syncCells() will clear the flag
+			return result ?? true;
+		} catch (error) {
+			instance.clearCurrentOperation();
+			throw error;
+		}
 	}
 
 	private handleRedo(): boolean | Promise<void> {
@@ -89,8 +98,16 @@ class PositronNotebookUndoRedoContribution extends Disposable {
 			return false;
 		}
 
-		const result = this.undoRedoService.redo(instance.uri);
-		return result ?? true;
+		instance.setCurrentOperation(NotebookOperationType.Redo);
+
+		try {
+			const result = this.undoRedoService.redo(instance.uri);
+			// If successful, _syncCells() will clear the flag
+			return result ?? true;
+		} catch (error) {
+			instance.clearCurrentOperation();
+			throw error;
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -751,7 +751,7 @@ registerCellCommand({
 
 		// If this is the last cell, insert a new cell below of the same type
 		if (cell.isLastCell()) {
-			notebook.addCell(cell.kind, cell.index + 1);
+			notebook.addCell(cell.kind, cell.index + 1, true);
 			// Don't call moveDown - addCell triggers SelectionStateMachine._setCells()
 			// which already handles selection and focus of the new cell in Edit mode
 		} else {
@@ -948,7 +948,7 @@ registerNotebookAction({
 	commandId: 'positronNotebook.addCodeCellAtEnd',
 	handler: (notebook) => {
 		const cellCount = notebook.cells.get().length;
-		notebook.addCell(CellKind.Code, cellCount);
+		notebook.addCell(CellKind.Code, cellCount, true);
 	},
 	menu: {
 		id: MenuId.EditorActionsLeft,
@@ -968,7 +968,7 @@ registerNotebookAction({
 	commandId: 'positronNotebook.addMarkdownCellAtEnd',
 	handler: (notebook) => {
 		const cellCount = notebook.cells.get().length;
-		notebook.addCell(CellKind.Markup, cellCount);
+		notebook.addCell(CellKind.Markup, cellCount, true);
 	},
 	menu: {
 		id: MenuId.EditorActionsLeft,

--- a/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
+++ b/src/vs/workbench/contrib/positronNotebook/docs/positron_notebooks_architecture.md
@@ -181,6 +181,15 @@ The test suite includes more end-to-end tests than unit tests due to the visual 
 - **End-to-end tests** in `test/e2e/tests/notebook`
 - **Unit tests** in `src/vs/workbench/contrib/positronNotebook/test/browser`
 
+### Running tests
+
+To run all Positron Notebooks end-to-end tests tagged with `@:positron-notebooks`:
+
+```bash
+npx playwright test --project e2e-electron --grep "@:positron-notebooks" --reporter list
+```
+
+
 ### Debugging strategies
 
 - Use log service messages to trace lifecycle events throughout the editor, instance, and kernel components.


### PR DESCRIPTION
Addresses #10118.

This PR fixes notebook cells incorrectly entering edit mode during paste, undo, and redo operations. The issue was caused by the notebook instance not distinguishing between user-initiated cell creation (which should enter edit mode) and programmatic cell operations like paste/undo/redo (which should stay in command mode). The fix adds operation tracking to identify and exclude these programmatic operations from automatically entering edit mode.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open a notebook in Positron
2. Test paste behavior:
   - Copy a cell (<kbd>Cmd/Ctrl+C</kbd>)
   - Paste it (<kbd>Cmd/Ctrl+V</kbd>)
   - Verify the pasted cell is selected but **not** in edit mode (cursor not blinking in cell)
3. Test undo behavior:
   - Delete a cell
   - Undo the deletion (<kbd>Cmd/Ctrl+Z</kbd>)
   - Verify the restored cell is selected but **not** in edit mode
4. Test redo behavior:
   - Add a cell, then undo the addition
   - Redo the addition (<kbd>Cmd/Ctrl+Shift+Z</kbd>)
   - Verify the cell is selected but **not** in edit mode
5. Verify edit mode still works correctly:
   - Click the "+ Code" button to add a new cell
   - Verify the new cell **does** enter edit mode (cursor blinking)
   - Press <kbd>Shift+Enter</kbd> at the end of the notebook
   - Verify the new cell **does** enter edit mode
