### PR TITLE
e2e: reduce # of tests tagged with @:critical

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Autocomplete', {
-	tag: [tags.WEB, tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.EDITOR, tags.CRITICAL]
+	tag: [tags.WEB, tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.EDITOR]
 }, () => {
 
 	test.afterEach(async function ({ hotKeys }) {

--- a/test/e2e/tests/data-explorer/data-explorer-performance.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-performance.test.ts
@@ -63,7 +63,7 @@ test.describe('Data Explorer: Performance', { tag: [] }, () => {
 
 	testCases.forEach(testCase => {
 		test(`${testCase.varType} - Record data load, basic filtering and sorting [${testCase.preFilterSummary.source} rows]`,
-			{ tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.DATA_EXPLORER, tags.PERFORMANCE] },
+			{ tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER, tags.PERFORMANCE] },
 			async function ({ app, openFile, runCommand, metric, sessions }) {
 				const { dataExplorer, variables, editors } = app.workbench;
 				await sessions.start(testCase.env === 'Python' ? 'python' : 'r');

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -14,7 +14,7 @@ test.afterEach(async function ({ hotKeys }) {
 });
 
 test.describe('Data Explorer - DuckDB Column Summary', {
-	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER, tags.DUCK_DB]
+	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER, tags.DUCK_DB]
 }, () => {
 	test('Verify basic duckdb column summary functionality', async function ({ app, openDataFile, hotKeys }) {
 		const { summaryPanel } = app.workbench.dataExplorer;

--- a/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
+++ b/test/e2e/tests/notebook/cell-deletion-action-bar.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Cell Deletion Action Bar Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/cell-execution-info.test.ts
+++ b/test/e2e/tests/notebook/cell-execution-info.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Cell Execution Tooltip', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebook/notebook-focus-and-selection.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 // Not running on web due to Positron notebooks being desktop-only
 test.describe('Notebook Focus and Selection', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-cell-reordering.test.ts
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Notebook Cell Reordering', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.WIN, tags.NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-copy-paste.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
 test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async ({ app, settings }) => {

--- a/test/e2e/tests/notebook/positron-notebook-editor.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-editor.test.ts
@@ -14,7 +14,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Open & Save', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);

--- a/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-undo-redo.test.ts
@@ -10,8 +10,8 @@ test.use({
 });
 
 // Not running on web due to https://github.com/posit-dev/positron/issues/9193
-test.describe('Postiron Notebooks: Cell Undo-Redo Behavior', {
-	tag: [tags.CRITICAL, tags.WIN, tags.NOTEBOOKS, tags.POSITRON_NOTEBOOKS]
+test.describe('Positron Notebooks: Cell Undo-Redo Behavior', {
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -14,7 +14,7 @@ test.use({
 test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () => {
 
 	test('Python - Matplotlib Interact Test', {
-		tag: [tags.CRITICAL, tags.WEB, tags.WIN],
+		tag: [tags.WEB, tags.WIN],
 	}, async function ({ app, hotKeys, python }) {
 		const { notebooks, quickaccess } = app.workbench;
 

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -392,7 +392,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await verifyPlotInNewWindow(app, 'R', rBasicPlot);
 		});
 
-		test('R - Verify saving an R plot', { tag: [tags.WIN, tags.CRITICAL, tags.CRITICAL] }, async function ({ app }) {
+		test('R - Verify saving an R plot', { tag: [tags.WIN, tags.CRITICAL] }, async function ({ app }) {
 			await test.step('Sending code to console to create plot', async () => {
 				await app.workbench.console.executeCode('R', rSavePlot);
 				await app.workbench.plots.waitForCurrentPlot();

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -35,7 +35,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('Python - Verify basic plot functionality - Dynamic Plot', {
-			tag: [tags.CRITICAL, tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN]
 		}, async function ({ app, logger, headless }, testInfo) {
 			// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
 			logger.log('Sending code to console');
@@ -77,7 +77,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('Python - Verify basic plot functionality - Static Plot', {
-			tag: [tags.CRITICAL, tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN]
 		}, async function ({ app, logger }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('Python', pythonStaticPlot);
@@ -348,7 +348,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('R - Verify basic plot functionality', {
-			tag: [tags.CRITICAL, tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN]
 		}, async function ({ app, logger, headless }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('R', rBasicPlot);

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -35,7 +35,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('Python - Verify basic plot functionality - Dynamic Plot', {
-			tag: [tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN, tags.CRITICAL]
 		}, async function ({ app, logger, headless }, testInfo) {
 			// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
 			logger.log('Sending code to console');
@@ -77,7 +77,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('Python - Verify basic plot functionality - Static Plot', {
-			tag: [tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN, tags.CRITICAL]
 		}, async function ({ app, logger }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('Python', pythonStaticPlot);
@@ -153,7 +153,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await verifyPlotInNewWindow(app, 'Python', pythonDynamicPlot);
 		});
 
-		test('Python - Verify saving a Python plot', { tag: [tags.WIN] }, async function ({ app }) {
+		test('Python - Verify saving a Python plot', { tag: [tags.WIN, tags.CRITICAL] }, async function ({ app }) {
 			await test.step('Sending code to console to create plot', async () => {
 				await app.workbench.console.executeCode('Python', pythonDynamicPlot);
 				await app.workbench.plots.waitForCurrentPlot();
@@ -348,7 +348,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('R - Verify basic plot functionality', {
-			tag: [tags.WEB, tags.WIN]
+			tag: [tags.WEB, tags.WIN, tags.CRITICAL]
 		}, async function ({ app, logger, headless }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('R', rBasicPlot);
@@ -388,11 +388,11 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.plots.waitForNoPlots();
 		});
 
-		test('R - Verify opening plot in new window', { tag: [tags.WEB, tags.WIN, tags.PLOTS] }, async function ({ app }) {
+		test('R - Verify opening plot in new window', { tag: [tags.WEB, tags.WIN, tags.PLOTS, tags.CRITICAL] }, async function ({ app }) {
 			await verifyPlotInNewWindow(app, 'R', rBasicPlot);
 		});
 
-		test('R - Verify saving an R plot', { tag: [tags.WIN] }, async function ({ app }) {
+		test('R - Verify saving an R plot', { tag: [tags.WIN, tags.CRITICAL, tags.CRITICAL] }, async function ({ app }) {
 			await test.step('Sending code to console to create plot', async () => {
 				await app.workbench.console.executeCode('R', rSavePlot);
 				await app.workbench.plots.waitForCurrentPlot();

--- a/test/e2e/tests/sessions/session-delete.test.ts
+++ b/test/e2e/tests/sessions/session-delete.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Sessions: Delete', {
-	tag: [tags.WEB, tags.CRITICAL, tags.WIN, tags.SESSIONS, tags.CRITICAL]
+	tag: [tags.WEB, tags.WIN, tags.SESSIONS]
 }, () => {
 
 	test('Python - Validate can delete a single session', async function ({ sessions }) {


### PR DESCRIPTION
### Summary
Reducing our `@:critical` test suite.
@jonvanausdeln , I wasn't sure what to do about assistant. Just let me know!


### QA Notes

These are the currently tagged tests, I can happily remove more, I didn't want to get too aggressive 😏 on first pass:
```
  [e2e-electron] › tests/apps/python-apps.test.ts:25:6 › Python Applications › Python - Verify Basic Dash App
  [e2e-electron] › tests/apps/python-apps.test.ts:51:6 › Python Applications › Python - Verify Basic FastAPI App
  [e2e-electron] › tests/apps/python-apps.test.ts:77:6 › Python Applications › Python - Verify Basic Gradio App
  [e2e-electron] › tests/apps/python-apps.test.ts:106:6 › Python Applications › Python - Verify Basic Streamlit App
  [e2e-electron] › tests/apps/python-apps.test.ts:139:6 › Python Applications › Python - Verify Basic Flask App
  [e2e-electron] › tests/connections/connections-sqlite.test.ts:22:6 › SQLite DB Connection › Python - Can establish a SQLite connection, disconnect & reconnect
  [e2e-electron] › tests/connections/connections-sqlite.test.ts:60:6 › SQLite DB Connection › R - Can establish a SQLite connection, disconnect & reconnect
  [e2e-electron] › tests/connections/connections-sqlite.test.ts:89:6 › SQLite DB Connection › R - Ensure SQLite connections are updated after adding a database
  [e2e-electron] › tests/console/console-input.test.ts:21:6 › Console Input › Python - Can get input string via console
  [e2e-electron] › tests/console/console-input.test.ts:35:6 › Console Input › R - Can get input string via console
  [e2e-electron] › tests/console/console-input.test.ts:51:6 › Console Input › R - Can use `menu` to select alternatives
  [e2e-electron] › tests/console/console-input.test.ts:69:6 › Console Input › R - Verify ESC dismisses autocomplete without deleting typed text
  [e2e-electron] › tests/data-explorer/data-explorer-python-pandas.test.ts:23:6 › Data Explorer - Python Pandas › Python Pandas - Verify table data, copy to clipboard, sparkline hover, null percentage hover
  [e2e-electron] › tests/data-explorer/data-explorer-python-pandas.test.ts:53:6 › Data Explorer - Python Pandas › Python Pandas - Verify data explorer functionality with empty fields
  [e2e-electron] › tests/data-explorer/data-explorer-python-pandas.test.ts:92:6 › Data Explorer - Python Pandas › Python Pandas - Verify can execute cell, open data grid, and data present
  [e2e-electron] › tests/data-explorer/data-explorer-python-pandas.test.ts:125:6 › Data Explorer - Python Pandas › Python Pandas - Verify opening Data Explorer for the second time brings focus back
  [e2e-electron] › tests/data-explorer/data-explorer-python-pandas.test.ts:141:6 › Data Explorer - Python Pandas › Python Pandas - Verify blank spaces in data explorer and disconnect behavior
  [e2e-electron] › tests/data-explorer/data-explorer-python-polars.test.ts:34:6 › Data Explorer - Python Polars › Python Polars - Verify table data, copy to clipboard, sparkline hover, null percentage hover
  [e2e-electron] › tests/data-explorer/data-explorer-python-polars.test.ts:58:6 › Data Explorer - Python Polars › Python Polars - Verify column info functionality: missing %s, profile data
  [e2e-electron] › tests/data-explorer/data-explorer-python-polars.test.ts:83:6 › Data Explorer - Python Polars › Python Polars - Verify can filter column
  [e2e-electron] › tests/data-explorer/data-explorer-python-polars.test.ts:94:6 › Data Explorer - Python Polars › Python Polars - Verify can sort column
  [e2e-electron] › tests/data-explorer/data-explorer-r.test.ts:24:6 › Data Explorer - R  › R - Verify basic data explorer functionality
  [e2e-electron] › tests/diagnostics/diagnostics.test.ts:20:6 › Diagnostics › Python - Verify diagnostics isolation between sessions in the editor and problems view
  [e2e-electron] › tests/diagnostics/diagnostics.test.ts:59:6 › Diagnostics › R - Verify diagnostics isolation between sessions in the editor and problems view
  [e2e-electron] › tests/interpreters/session-picker.test.ts:17:6 › Session Picker › Python - Start and verify session via session picker
  [e2e-electron] › tests/interpreters/session-picker.test.ts:24:6 › Session Picker › R - Start and verify session via session picker
  [e2e-electron] › tests/interpreters/session-picker.test.ts:33:6 › Session Picker › Verify Session Picker updates correctly across multiple active sessions
  [e2e-electron] › tests/interpreters/session-picker.test.ts:55:6 › Session Picker › Verify Session Quickpick ranks sessions by last used
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-empty.test.ts:17:6 › New Folder Flow: Empty Project › Verify empty folder defaults
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-jupyter.test.ts:25:6 › New Folder Flow: Jupyter Project › Jupyter Folder Defaults
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-python.test.ts:44:6 › New Folder Flow: Python Project › New env: Git initialized
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-python.test.ts:83:6 › New Folder Flow: Python Project › New env: Venv environment
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-python.test.ts:100:6 › New Folder Flow: Python Project › New env: uv environment
  [e2e-electron] › tests/new-folder-flow/new-folder-flow-r.test.ts:27:6 › New Folder Flow: R Project › R - Folder Defaults
  [e2e-electron] › tests/notebook/notebook-create.test.ts:42:7 › Notebooks › Python Notebooks › Python - Verify code cell execution and markdown formatting in notebook
  [e2e-electron] › tests/notebook/notebook-create.test.ts:61:7 › Notebooks › Python Notebooks › Python - Save untitled notebook and preserve session
  [e2e-electron] › tests/notebook/notebook-create.test.ts:117:7 › Notebooks › Python Notebooks › Python - Ensure LSP works across cells
  [e2e-electron] › tests/notebook/notebook-create.test.ts:152:7 › Notebooks › R Notebooks › R - Verify code cell execution and markdown formatting in notebook
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:24:6 › Positron Assistant Setup › Verify Positron Assistant enabled
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:35:6 › Positron Assistant Setup › Anthropic: Verify Bad API key results in error
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:52:6 › Positron Assistant Setup › Echo: Verify Successful API Key Sign in and Sign Out
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:70:6 › Positron Assistant Setup › Verify Inline Chat opens
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:89:6 › Positron Assistant Setup › Verify Authentication Type When Switching Providers
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:130:6 › Positron Assistant Chat Editing › Python: Verify running code in console from chat markdown response
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:145:6 › Positron Assistant Chat Editing › R: Verify running code in console from chat markdown response
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:154:7 › Positron Assistant Chat Editing › Verify Manage Models is available
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:183:6 › Positron Assistant Chat Tokens › Token usage is displayed in chat response
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:194:6 › Positron Assistant Chat Tokens › Token usage is not displayed when setting is disabled
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:201:6 › Positron Assistant Chat Tokens › Token usage is not displayed for non-supported providers
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:208:6 › Positron Assistant Chat Tokens › Token usage updates when settings change
  [e2e-electron] › tests/positron-assistant/positron-assistant.test.ts:226:6 › Positron Assistant Chat Tokens › Total token usage is displayed in chat header
  [e2e-electron] › tests/sessions/session-mgmt.test.ts:25:6 › Sessions: Management › Validate active session list in console matches active session list in session picker
  [e2e-electron] › tests/sessions/session-mgmt.test.ts:52:7 › Sessions: Management › Validate session, console, variables, and plots persist after reload
  [e2e-electron] › tests/sessions/session-rename.test.ts:24:6 › Sessions: Rename › Validate can rename sessions and name persists
  [e2e-electron] › tests/sessions/session-state.test.ts:22:6 › Sessions: State › Validate session states during start, restart, and shutdown
  [e2e-electron] › tests/sessions/session-state.test.ts:76:6 › Sessions: State › Validate state displays as active when executing code
  [e2e-electron] › tests/sessions/session-state.test.ts:98:6 › Sessions: State › Validate metadata between sessions
  [e2e-electron] › tests/variables/variables-notebook.test.ts:21:6 › Variables Pane - Notebook › R - Verify Variables pane basic function for notebook
  [e2e-electron] › tests/variables/variables-notebook.test.ts:38:6 › Variables Pane - Notebook › Python - Verify Variables pane basic function for notebook
  [e2e-electron] › tests/variables/variables-notebook.test.ts:53:6 › Variables Pane - Notebook › Python - Verify Variables available after reload
  [e2e-electron] › tests/variables/variables-notebook.test.ts:76:6 › Variables Pane - Notebook › Python - Verify variables persist across cells
  [e2e-electron] › tests/variables/variables-sessions.test.ts:24:6 › Variables: Sessions › Validate variables are isolated between sessions
  ```