### PR TITLE
Assistant: Improves tool cooperation with Copilot

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -479,10 +479,10 @@
         "name": "inspectVariables",
         "displayName": "Inspect Variables",
         "modelDescription": "List the children of an array of variables in a session. For example, the columns in a dataframe, items in a column or array, or elements of a list. If `accessKeys` is empty, lists all root-level variables in the session.\n\nIf the user references a variable by name, first determine the `access_key` from the user context or a previous inspect variables result.",
-        "icon": "$(list)",
+        "icon": "$(positron-variables-view)",
         "toolReferenceName": "inspectVariables",
         "userDescription": "Inspect data and variables in the current session",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -520,7 +520,7 @@
         "icon": "$(graph)",
         "toolReferenceName": "getPlot",
         "userDescription": "View the current active plot.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-session"
@@ -568,7 +568,10 @@
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
         "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree.",
-        "canBeReferencedInPrompt": false,
+        "icon": "$(file-directory)",
+        "toolReferenceName": "projectTree",
+        "userDescription": "Get the project tree of the current workspace.",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-workspace",
@@ -641,7 +644,10 @@
         "name": "installPythonPackage",
         "displayName": "Install Python Package",
         "modelDescription": "Install Python packages using pip. Provide an array of package names to install.",
-        "canBeReferencedInPrompt": false,
+        "icon": "$(package)",
+        "toolReferenceName": "installPythonPackage",
+        "userDescription": "Install Python packages in the current environment",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant"
         ],

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -273,7 +273,7 @@ export function getEnabledTools(
 		}
 
 		// Check that the request is using a Copilot model.
-		const usingCopilotModel = request.model.family === 'copilot';
+		const usingCopilotModel = request.model.vendor === 'copilot';
 		// Check if the user has opted-in to always include Copilot tools.
 		const alwaysIncludeCopilotTools = vscode.workspace.getConfiguration('positron.assistant').get('alwaysIncludeCopilotTools', false);
 		// Check if the tool is provided by Copilot.

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1896,7 +1896,10 @@
                 "name": "getAttachedPythonPackages",
                 "displayName": "Get attached Python packages",
                 "modelDescription": "Gets a list of Python packages that are loaded in the current Python session.",
-                "canBeReferencedInPrompt": false,
+                "toolReferenceName": "getAttachedPythonPackages",
+                "icon": "$(package)",
+                "userDescription": "Gets a list of Python packages that are loaded in the current Python session.",
+                "canBeReferencedInPrompt": true,
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1915,7 +1918,10 @@
                 "name": "getInstalledPythonPackageVersion",
                 "displayName": "Get installed Python package version",
                 "modelDescription": "Given the name of a Python package, returns the version of the package that's installed in the current Python session, or NULL if the package is not installed.",
-                "canBeReferencedInPrompt": false,
+                "toolReferenceName": "getInstalledPythonPackageVersion",
+                "icon": "$(package)",
+                "userDescription": "Gets the version of an installed Python package in the current session.",
+                "canBeReferencedInPrompt": true,
                 "inputSchema": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Fixes issue with Copilot models missing critical tools. 

### Assistant-supplied tools
Updates Assistant tool definitions to allow reference from prompt, which is a prerequisite for inclusion in Copilot's tool filtering logic. 

Fixed tools:
- `inspectVariables`
- `getPlot`
- `getProjectTree`
- `installPythonPackage`
- `getAttachedPythonPackages`
- `getInstalledPythonPackageVersion`

### Copilot-supplied tools
Upstream changes broke the logic Assistant uses to filter Copilot tools, which in turn hid tools that Copilot contributed from itself. This updates the logic to appropriately pass Copilot tools to Copilot models.

Addresses #10007

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Copilot's access to tools has been fixed


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

See linked issue for reprex. Confirm tools listed above are included in the output from the linked prompt.


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
