### PR TITLE
Update Positron Notebook Change Kernel Command

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -13,7 +13,6 @@ import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNot
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { IPositronNotebookActionBarContext } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernelActions.js';
 
 export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
@@ -36,9 +35,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, context?: IPositronNotebookActionBarContext): Promise<boolean> {
-		// Force the dropdown if the action was invoked by the user in the UI
-		const forceDropdown = context?.ui ?? false;
+	async run(accessor: ServicesAccessor): Promise<boolean> {
 		const notebookKernelService = accessor.get(INotebookKernelService);
 		const activeNotebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
 		const quickInputService = accessor.get(IQuickInputService);
@@ -50,13 +47,6 @@ class SelectPositronNotebookKernelAction extends Action2 {
 		const notebook = activeNotebook.textModel;
 		if (!notebook) {
 			return false;
-		}
-
-		const kernelMatches = notebookKernelService.getMatchingKernel(notebook);
-
-		if (!forceDropdown && kernelMatches.selected) {
-			// current kernel is wanted kernel -> done
-			return true;
 		}
 
 		// Show quick-pick with all kernels that match notebook, aka positronKernels


### PR DESCRIPTION
Addresses #10125

I removed the check from the `positronNotebook.selectKernel` action that only allowed the action to run if it was launched from the action bar. 

Now the command will run from the command palette!

**AFTER**

https://github.com/user-attachments/assets/3d720279-5ce8-4b3f-aac4-838c9ebfcb34


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
@:positron-notebooks