### PR TITLE
Fix web about dialog

### DIFF
--- a/src/vs/platform/dialogs/browser/dialog.ts
+++ b/src/vs/platform/dialogs/browser/dialog.ts
@@ -46,7 +46,12 @@ export function createWorkbenchDialogOptions(options: Partial<IDialogOptions>, k
 export function createBrowserAboutDialogDetails(productService: IProductService): { title: string; details: string; detailsToCopy: string } {
 	const detailString = (useAgo: boolean): string => {
 		return localize('aboutDetail',
-			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
+			// --- Start Positron ---
+			"{0} Version: {1} build {2}\nCode - OSS Version: {3}\nCommit: {4}\nDate: {5}\nBrowser: {6}",
+			productService.nameLong,
+			productService.positronVersion,
+			productService.positronBuildNumber,
+			// --- End Positron ---
 			productService.version || 'Unknown',
 			productService.commit || 'Unknown',
 			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -68,12 +68,12 @@ else {
 	// Running out of sources
 	if (Object.keys(product).length === 0) {
 		Object.assign(product, {
-			version: '1.104.0-dev',
+			version: '1.105.0-dev',
 			// --- Start Positron ---
 			// This only applies to dev builds where it is not possible to read the
 			// product configuration. Release builds replace the product configuration
 			// during the build. See INSERT_PRODUCT_CONFIGURATION above.
-			positronVersion: '2025.10.0',
+			positronVersion: '2025.11.0',
 			positronBuildNumber: '0',
 			nameShort: 'Positron Dev',
 			nameLong: 'Positron Dev',

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -75,6 +75,7 @@ else {
 			// during the build. See INSERT_PRODUCT_CONFIGURATION above.
 			positronVersion: '2025.11.0',
 			positronBuildNumber: '0',
+			date: new Date().toISOString(),
 			nameShort: 'Positron Dev',
 			nameLong: 'Positron Dev',
 			applicationName: 'positron',


### PR DESCRIPTION
Address #10060 

Fixing the missing Positron version introduced in an upstream merge refactoring.

Updated the dev details, which only shows for dev builds. Real builds properly populates the values from the `product.json`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix details in web About dialog


### QA Notes