### PR TITLE
E2E test: bump docker images post upstream merge 1.105.0

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest-8x
     container:
-      image: ghcr.io/posit-dev/positron-ubuntu24-amd64:48
+      image: ghcr.io/posit-dev/positron-ubuntu24-amd64:52
       options: --user 0:0
       # Static PAT is needed because the bot can't pass a token to the job for security reasons
       credentials:

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -274,7 +274,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.project }}-json-results
+          name: ${{ inputs.project }}-rhel-json-results
           path: test-results/rhel.json
           if-no-files-found: ignore
 

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     container:
-      image: ghcr.io/posit-dev/positron-rocky8-amd64:49
+      image: ghcr.io/posit-dev/positron-rocky8-amd64:53
       options: --user 0:0
       # Static PAT is needed because the bot can't pass a token to the job for security reasons
       credentials:
@@ -104,7 +104,7 @@ jobs:
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
     services:
       postgres:
-        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:49
+        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:53
         credentials:
           username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
           password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     container:
-      image: ghcr.io/posit-dev/positron-ubuntu24-amd64:48
+      image: ghcr.io/posit-dev/positron-ubuntu24-amd64:52
       options: --user 0:0
       # Static PAT is needed because the bot can't pass a token to the job for security reasons
       credentials:
@@ -119,7 +119,7 @@ jobs:
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
     services:
       postgres:
-        image: ghcr.io/posit-dev/positron-postgres-ubuntu24-amd64:48
+        image: ghcr.io/posit-dev/positron-postgres-ubuntu24-amd64:52
         credentials:
           username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
           password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -282,7 +282,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.project }}-json-results
+          name: ${{ inputs.project }}-ubuntu-json-results
           path: test-results/ubuntu.json
           if-no-files-found: ignore
 

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -323,7 +323,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.project }}-json-results
+          name: ${{ inputs.project }}-windows-json-results
           path: test-results/windows.json
           if-no-files-found: ignore
 

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -199,104 +199,6 @@
         "is_secret": false
       }
     ],
-    ".config/guardian/.gdnsuppress": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "85d819d560eee2c39d132c6b64d423ac0b51cb64",
-        "is_verified": false,
-        "line_number": 15,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "a51813568421e33416e9677f5abf9cbdbb78d5d2",
-        "is_verified": false,
-        "line_number": 18,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "a40a44b0fc85fdd60e348a0e81c566c21e897168",
-        "is_verified": false,
-        "line_number": 25,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "3b65278ea81525d3cb95e83ac4f2b287c3b77e80",
-        "is_verified": false,
-        "line_number": 28,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "f77aab176d7fe08dc87889cff00d1ee06cb1e247",
-        "is_verified": false,
-        "line_number": 35,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "98524b4d37c96618662a795c3e516471bd2908a2",
-        "is_verified": false,
-        "line_number": 38,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "298125dc08a723b1508182f56fbe238841ff46db",
-        "is_verified": false,
-        "line_number": 45,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "61fb69023c444bc6220b3aa5e08e5e02712b0643",
-        "is_verified": false,
-        "line_number": 48,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "28333811f5be058764c5bd255d651dd465996f8a",
-        "is_verified": false,
-        "line_number": 55,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "68d2f3c2c7491ddb01db1f712768f13bfd05dd56",
-        "is_verified": false,
-        "line_number": 58,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "f6f5c8cfc8dce686215c00ad684141405f98e7e9",
-        "is_verified": false,
-        "line_number": 65,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".config/guardian/.gdnsuppress",
-        "hashed_secret": "cc9a2f91ea8747e5fe672e077cad43e71bda3a04",
-        "is_verified": false,
-        "line_number": 68,
-        "is_secret": false
-      }
-    ],
     ".github/workflows/test-assistant-llm.yml": [
       {
         "type": "Secret Keyword",
@@ -345,13 +247,23 @@
         "is_secret": false
       }
     ],
+    "build/azure-pipelines/alpine/product-build-alpine-node-modules.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/alpine/product-build-alpine-node-modules.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 30,
+        "is_secret": false
+      }
+    ],
     "build/azure-pipelines/alpine/product-build-alpine.yml": [
       {
         "type": "Secret Keyword",
         "filename": "build/azure-pipelines/alpine/product-build-alpine.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 24,
         "is_secret": false
       }
     ],
@@ -361,7 +273,17 @@
         "filename": "build/azure-pipelines/darwin/product-build-darwin-cli-sign.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 20,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/darwin/product-build-darwin-node-modules.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/darwin/product-build-darwin-node-modules.yml",
+        "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
+        "is_verified": false,
+        "line_number": 29,
         "is_secret": false
       }
     ],
@@ -371,7 +293,7 @@
         "filename": "build/azure-pipelines/darwin/product-build-darwin-universal.yml",
         "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -381,7 +303,7 @@
         "filename": "build/azure-pipelines/darwin/product-build-darwin.yml",
         "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 34,
         "is_secret": false
       }
     ],
@@ -405,13 +327,23 @@
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/linux/product-build-linux.yml": [
+    "build/azure-pipelines/linux/product-build-linux-node-modules.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/linux/product-build-linux.yml",
+        "filename": "build/azure-pipelines/linux/product-build-linux-node-modules.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 32,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/linux/steps/product-build-linux-compile.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/linux/steps/product-build-linux-compile.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 36,
         "is_secret": false
       }
     ],
@@ -421,7 +353,7 @@
         "filename": "build/azure-pipelines/product-compile.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 30,
         "is_secret": false
       }
     ],
@@ -431,7 +363,7 @@
         "filename": "build/azure-pipelines/product-publish.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 20,
         "is_secret": false
       },
       {
@@ -439,7 +371,7 @@
         "filename": "build/azure-pipelines/product-publish.yml",
         "hashed_secret": "f38b5618311373a766cdff2e405d6cbb08cdeeb6",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 27,
         "is_secret": false
       },
       {
@@ -447,7 +379,26 @@
         "filename": "build/azure-pipelines/product-publish.yml",
         "hashed_secret": "1bf2ebe6cfdadfebbe51dd18d36f3d42a9bf2d62",
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 73,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/product-release.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/product-release.yml",
+        "hashed_secret": "1bf2ebe6cfdadfebbe51dd18d36f3d42a9bf2d62",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "build/azure-pipelines/web/product-build-web-node-modules.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/web/product-build-web-node-modules.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -457,7 +408,7 @@
         "filename": "build/azure-pipelines/web/product-build-web.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -467,17 +418,17 @@
         "filename": "build/azure-pipelines/win32/product-build-win32-cli-sign.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 43,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/win32/product-build-win32.yml": [
+    "build/azure-pipelines/win32/product-build-win32-node-modules.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/win32/product-build-win32.yml",
+        "filename": "build/azure-pipelines/win32/product-build-win32-node-modules.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 34,
         "is_secret": false
       }
     ],
@@ -487,7 +438,17 @@
         "filename": "build/azure-pipelines/win32/sdl-scan-win32.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 27,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/win32/steps/product-build-win32-compile.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/win32/steps/product-build-win32-compile.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 38,
         "is_secret": false
       }
     ],
@@ -497,7 +458,7 @@
         "filename": "build/lib/stylelint/vscode-known-variables.json",
         "hashed_secret": "bebac042cf8ae1cf5954a7f233759a1373a1bd5b",
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 768,
         "is_secret": false
       }
     ],
@@ -771,7 +732,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "package.json",
-        "hashed_secret": "9546e915208a53c27607c2cfeac8a6a0f46b94e3",
+        "hashed_secret": "6f7bf77d6f2ca0f1370bbcb2cabec503f963b17a",
         "is_verified": false,
         "line_number": 4,
         "is_secret": false
@@ -789,7 +750,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d2f95711fc96b07db8c7528b3e37d158327cfa4a",
+        "hashed_secret": "61015ea48f0526f88771d33c21ae86443b2ef8f7",
         "is_verified": false,
         "line_number": 65,
         "is_secret": false
@@ -837,7 +798,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "f571c4930ad8d580f14ef8ce9c4870f85876cb75",
+        "hashed_secret": "cc951a5b49b2427dc721d3f2b0e6ee7858e4d2a4",
         "is_verified": false,
         "line_number": 186,
         "is_secret": false
@@ -869,7 +830,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "52c8a83aa001c5eb1557d60c46ad19a56751962c",
+        "hashed_secret": "cb22aff190bc935fd234929afc0f630dca1d3c2c",
         "is_verified": false,
         "line_number": 285,
         "is_secret": false
@@ -1179,6 +1140,24 @@
         "is_secret": false
       }
     ],
+    "src/vs/platform/mcp/test/common/mcpManagementService.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/platform/mcp/test/common/mcpManagementService.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 79,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/platform/mcp/test/common/mcpManagementService.test.ts",
+        "hashed_secret": "0b4dfe8c773082cd0867ba4a680bc8c9ddbbdf2f",
+        "is_verified": false,
+        "line_number": 127,
+        "is_secret": false
+      }
+    ],
     "src/vs/platform/native/electron-main/auth.ts": [
       {
         "type": "Secret Keyword",
@@ -1424,5 +1403,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-23T20:43:04Z"
+  "generated_at": "2025-10-27T14:23:54Z"
 }

--- a/product.json
+++ b/product.json
@@ -182,8 +182,8 @@
 		},
 		{
 			"name": "ms-toolsai.jupyter",
-			"version": "2025.8.0",
-			"sha256sum": "3e0373fe1b309660e6e53189ab7ad34f7e374d3c7a76b8e4621d6a5b93d4caae",
+			"version": "2025.9.1",
+			"sha256sum": "110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f",
 			"repo": "https://github.com/Microsoft/vscode-jupyter",
 			"metadata": {
 				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
@@ -230,7 +230,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.23.15",
+			"version": "1.23.16",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",
@@ -281,8 +281,8 @@
 		},
 		{
 			"name": "GitHub.vscode-pull-request-github",
-			"version": "0.118.2",
-			"sha256": "c397647f9b4286292abb85e07ad466a968d0aa6c120e75f770a4f421b4c3d9bd",
+			"version": "0.120.1",
+			"sha256": "707ca25c651817d67cc2826cdbb08fb8664afa3520f33c8c243c0547263aad2f",
 			"repo": "https://github.com/Microsoft/vscode-pull-request-github",
 			"metadata": {
 				"publisherId": {


### PR DESCRIPTION
Bump ubuntu and rhel images post 1.105.0 merge (node 22.19 & postgres image change)

### QA Notes

@:connections @:web @:rhel-web
