### PR TITLE
Fix how we track foreground session

### DIFF
--- a/extensions/positron-zed/src/extension.ts
+++ b/extensions/positron-zed/src/extension.ts
@@ -18,4 +18,21 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register some dummy commands.
 	registerCommands(context);
+
+	const checkForLanguageSession = async () => {
+		const session = await positron.runtime.getForegroundSession();
+		console.log(
+			"Foreground session language:",
+			session?.runtimeMetadata.runtimeName
+		);
+	};
+
+	context.subscriptions.push(
+		positron.runtime.onDidChangeForegroundSession(async (event) => {
+			console.log("onDidChangeForegroundSession: ", event);
+			await checkForLanguageSession();
+		})
+	);
+
+	checkForLanguageSession();
 }

--- a/extensions/positron-zed/src/extension.ts
+++ b/extensions/positron-zed/src/extension.ts
@@ -18,21 +18,4 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register some dummy commands.
 	registerCommands(context);
-
-	const checkForLanguageSession = async () => {
-		const session = await positron.runtime.getForegroundSession();
-		console.log(
-			"Foreground session language:",
-			session?.runtimeMetadata.runtimeName
-		);
-	};
-
-	context.subscriptions.push(
-		positron.runtime.onDidChangeForegroundSession(async (event) => {
-			console.log("onDidChangeForegroundSession: ", event);
-			await checkForLanguageSession();
-		})
-	);
-
-	checkForLanguageSession();
 }

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1753,7 +1753,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			//       (which would already happen if we remove this block)?
 			// Make the newly-started runtime the foreground runtime if it's a console session.
 			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
-				this._foregroundSession = session;
+				this.foregroundSession = session;
 			}
 		} catch (reason) {
 			this.clearStartingSessionMaps(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -854,6 +854,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			return;
 		}
 
+		// Check if the session is already the foreground session
+		if (session && this._foregroundSession && session.sessionId === this._foregroundSession.sessionId) {
+			return; // No change, don't update or fire events
+		}
+
 		this._foregroundSession = session;
 
 		if (session) {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1746,9 +1746,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// TODO: Should this fire onDidChangeForegroundSession?
 			//       If so, should it fire immediately or once the session is ready
 			//       (which would already happen if we remove this block)?
-			// Make the newly-started runtime the foreground runtime if it's a console session.
-			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
-				this._foregroundSession = session;
+			// Make the newly-started runtime the foreground runtime if it's a console session
+			// and activate is true.
+			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console && activate) {
+				this.foregroundSession = session;
 			}
 		} catch (reason) {
 			this.clearStartingSessionMaps(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1748,9 +1748,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// Fire the onDidStartRuntime event.
 			this._onDidStartRuntimeEmitter.fire(session);
 
-			// TODO: Should this fire onDidChangeForegroundSession?
-			//       If so, should it fire immediately or once the session is ready
-			//       (which would already happen if we remove this block)?
 			// Make the newly-started runtime the foreground runtime if it's a console session.
 			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 				this.foregroundSession = session;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1751,10 +1751,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// TODO: Should this fire onDidChangeForegroundSession?
 			//       If so, should it fire immediately or once the session is ready
 			//       (which would already happen if we remove this block)?
-			// Make the newly-started runtime the foreground runtime if it's a console session
-			// and activate is true.
-			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console && activate) {
-				this.foregroundSession = session;
+			// Make the newly-started runtime the foreground runtime if it's a console session.
+			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
+				this._foregroundSession = session;
 			}
 		} catch (reason) {
 			this.clearStartingSessionMaps(

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -377,10 +377,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 					await waitForRuntimeState(session, RuntimeState.Ready);
 
-					// TODO: Feels a bit surprising that this isn't fired. It's because we set the private
-					//       _foregroundSession property instead of the setter. When the 'ready' state is
-					//       entered, we skip setting foregroundSession because it already matches the session.
-					sinon.assert.notCalled(onDidChangeForegroundSessionSpy);
+					sinon.assert.called(onDidChangeForegroundSessionSpy);
 				});
 			}
 

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -110,7 +110,9 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 			await verifyROutline(outline);
 		});
 
-		test('Verify outline after reload with R in foreground and Python in background',
+		test.skip('Verify outline after reload with R in foreground and Python in background', {
+			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7052' }],
+		},
 			async function ({ app, runCommand, sessions }) {
 				const { outline, editor } = app.workbench;
 


### PR DESCRIPTION
Addresses #7861

This PR makes two changes:

- Updates the `foregroundSession` setter to not reset the foreground session if we have the same session. This is to address how @wch points out we have been firing the `onDidChangeForegroundSession` callback every time you click on the tab list title.
- Switches `doStartRuntimeSession()` to use the `foregroundSession` setter and not to update the private `_foregroundSession`. I believe this is the main source of the bad behavior that @wch observed.

This PR DOES NOT address https://github.com/posit-dev/positron/issues/7052; if you reload the window with an R session as the foreground session and another session (like a Python session), you will not necessarily get that foreground session back on top after the reload. What this PR fixes is what you get when an extension calls `positron.runtime.getForegroundSession()`; it will now report the right thing.

@:sessions

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed what Positron reports to extensions in `positron.runtime.getForegroundSession()`


### QA Notes

I put some debug logging in the zed extension in 0a653de8097cf2da82497dc1f425309ef2d37a1f and you can use that in a dev build to see what we're reporting, but I imagine I'll revert that commit after we confirm this is doing the right thing. Probably the easiest way to confirm what's going on in a release build is to look at what Positron Assistant reports as the current session as @wch points out in https://github.com/posit-dev/positron/issues/7052#issuecomment-3099599576:

- Start an R session and Python session
- Select the R session
- Reload Positron
- Look at the Positron Assistant chat; it should always report the correct foreground session (maybe you'll see R as foreground briefly before Python takes over)
- Select the Python session
- Reload Positron
- Look at the Assistant chat and confirm it reports the correct foreground session as sessions start up

Do be aware of #7052; we do not persist the R foreground session correctly across a reload.
