### PR TITLE
Add user-configurable setting for plot sizing policy

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -98,7 +98,7 @@ export const DarkFilterMenuButton = () => {
 			run: async () => {
 				await services.preferencesService.openUserSettings({
 					jsonEditor: false,
-					query: 'positron.plots.darkFilter'
+					query: 'plots.darkFilter,positron.plots.darkFilter'
 				});
 			}
 		});

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -101,7 +101,7 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 	}
 }
 
-// Register the configuration setting
+// Old configuration with `positron` in name
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
 		properties: {
@@ -121,32 +121,16 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('positron.plots.darkFilterSetting', "Use a color filter to make light plots appear dark."),
 				deprecationMessage: localize('positron.plots.darkFilter.deprecated', "This setting is deprecated. Please use 'plots.darkFilter' instead."),
 			},
-			'positron.plots.defaultSizingPolicy': {
-				type: 'string',
-				default: 'auto',
-				enum: [
-					'auto',
-					'fill',
-					'intrinsic',
-					'landscape',
-					'portrait',
-					'square'
-				],
-				enumDescriptions: [
-					localize('positron.plots.defaultSizingPolicyAuto', 'Automatically size the plot'),
-					localize('positron.plots.defaultSizingPolicyFill', 'Fill the entire available space with the plot'),
-					localize('positron.plots.defaultSizingPolicyIntrinsic', 'Use the plot\'s intrinsic size when available'),
-					localize('positron.plots.defaultSizingPolicyLandscape', 'Use 4:3 landscape aspect ratio'),
-					localize('positron.plots.defaultSizingPolicyPortrait', 'Use 3:4 portrait aspect ratio'),
-					localize('positron.plots.defaultSizingPolicySquare', 'Use 1:1 square aspect ratio')
-				],
-				description: localize('positron.plots.defaultSizingPolicySetting', "The default sizing policy to use for newly created plots."),
-				deprecationMessage: localize('positron.plots.defaultSizingPolicy.deprecated', "This setting is deprecated. Please use 'plots.defaultSizingPolicy' instead."),
+			[OldFreezeSlowPlotsConfigKey]: {
+				type: 'boolean',
+				default: true,
+				description: localize('positron.plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
+				deprecationMessage: localize('positron.plots.freezeSlowPlots.deprecated', "This setting is deprecated. Please use 'plots.freezeSlowPlots' instead."),
 			}
 		}
 	});
 
-// Register the new settings without the positron prefix
+// New configuration
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
 		id: 'plots',
@@ -189,30 +173,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize('plots.defaultSizingPolicySquare', 'Use 1:1 square aspect ratio')
 				],
 				description: localize('plots.defaultSizingPolicySetting', "The default sizing policy to use for newly created plots."),
-			}
-		}
-	});
-
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-	.registerConfiguration({
-		properties: {
-			[OldFreezeSlowPlotsConfigKey]: {
-				type: 'boolean',
-				default: true,
-				description: localize('positron.plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
-				deprecationMessage: localize('positron.plots.freezeSlowPlots.deprecated', "This setting is deprecated. Please use 'plots.freezeSlowPlots' instead."),
-			}
-		}
-	});
-
-// Register the new freezeSlowPlots setting
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-	.registerConfiguration({
-		id: 'plots',
-		order: 100,
-		title: localize('plotsConfigurationTitle', "Plots"),
-		type: 'object',
-		properties: {
+			},
 			[FreezeSlowPlotsConfigKey]: {
 				type: 'boolean',
 				default: true,

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -22,7 +22,7 @@ import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAct
 import { POSITRON_SESSION_CONTAINER } from '../../positronSession/browser/positronSessionContainer.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { localize, localize2 } from '../../../../nls.js';
-import { FreezeSlowPlotsConfigKey } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
+import { OldFreezeSlowPlotsConfigKey, FreezeSlowPlotsConfigKey } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { PLOT_IS_ACTIVE_EDITOR } from '../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 
 // Register the Positron plots service.
@@ -119,6 +119,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize('positron.plots.darkFilterAuto', 'Apply the dark filter when Positron is using a dark theme')
 				],
 				description: localize('positron.plots.darkFilterSetting', "Use a color filter to make light plots appear dark."),
+				deprecationMessage: localize('positron.plots.darkFilter.deprecated', "This setting is deprecated. Please use 'plots.darkFilter' instead."),
 			},
 			'positron.plots.defaultSizingPolicy': {
 				type: 'string',
@@ -140,6 +141,54 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize('positron.plots.defaultSizingPolicySquare', 'Use 1:1 square aspect ratio')
 				],
 				description: localize('positron.plots.defaultSizingPolicySetting', "The default sizing policy to use for newly created plots."),
+				deprecationMessage: localize('positron.plots.defaultSizingPolicy.deprecated', "This setting is deprecated. Please use 'plots.defaultSizingPolicy' instead."),
+			}
+		}
+	});
+
+// Register the new settings without the positron prefix
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		id: 'plots',
+		order: 100,
+		title: localize('plotsConfigurationTitle', "Plots"),
+		type: 'object',
+		properties: {
+			'plots.darkFilter': {
+				type: 'string',
+				default: 'off',
+				enum: [
+					'on',
+					'off',
+					'auto'
+				],
+				enumDescriptions: [
+					localize('plots.darkFilterOn', 'Always apply the dark filter'),
+					localize('plots.darkFilterOff', 'Never apply the dark filter'),
+					localize('plots.darkFilterAuto', 'Apply the dark filter when Positron is using a dark theme')
+				],
+				description: localize('plots.darkFilterSetting', "Use a color filter to make light plots appear dark."),
+			},
+			'plots.defaultSizingPolicy': {
+				type: 'string',
+				default: 'auto',
+				enum: [
+					'auto',
+					'fill',
+					'intrinsic',
+					'landscape',
+					'portrait',
+					'square'
+				],
+				enumDescriptions: [
+					localize('plots.defaultSizingPolicyAuto', 'Automatically size the plot'),
+					localize('plots.defaultSizingPolicyFill', 'Fill the entire available space with the plot'),
+					localize('plots.defaultSizingPolicyIntrinsic', 'Use the plot\'s intrinsic size when available'),
+					localize('plots.defaultSizingPolicyLandscape', 'Use 4:3 landscape aspect ratio'),
+					localize('plots.defaultSizingPolicyPortrait', 'Use 3:4 portrait aspect ratio'),
+					localize('plots.defaultSizingPolicySquare', 'Use 1:1 square aspect ratio')
+				],
+				description: localize('plots.defaultSizingPolicySetting', "The default sizing policy to use for newly created plots."),
 			}
 		}
 	});
@@ -147,10 +196,27 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
 		properties: {
-			[FreezeSlowPlotsConfigKey]: {
+			[OldFreezeSlowPlotsConfigKey]: {
 				type: 'boolean',
 				default: true,
 				description: localize('positron.plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
+				deprecationMessage: localize('positron.plots.freezeSlowPlots.deprecated', "This setting is deprecated. Please use 'plots.freezeSlowPlots' instead."),
+			}
+		}
+	});
+
+// Register the new freezeSlowPlots setting
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		id: 'plots',
+		order: 100,
+		title: localize('plotsConfigurationTitle', "Plots"),
+		type: 'object',
+		properties: {
+			[FreezeSlowPlotsConfigKey]: {
+				type: 'boolean',
+				default: true,
+				description: localize('plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -119,6 +119,27 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize('positron.plots.darkFilterAuto', 'Apply the dark filter when Positron is using a dark theme')
 				],
 				description: localize('positron.plots.darkFilterSetting', "Use a color filter to make light plots appear dark."),
+			},
+			'positron.plots.defaultSizingPolicy': {
+				type: 'string',
+				default: 'auto',
+				enum: [
+					'auto',
+					'fill',
+					'intrinsic',
+					'landscape',
+					'portrait',
+					'square'
+				],
+				enumDescriptions: [
+					localize('positron.plots.defaultSizingPolicyAuto', 'Automatically size the plot'),
+					localize('positron.plots.defaultSizingPolicyFill', 'Fill the entire available space with the plot'),
+					localize('positron.plots.defaultSizingPolicyIntrinsic', 'Use the plot\'s intrinsic size when available'),
+					localize('positron.plots.defaultSizingPolicyLandscape', 'Use 4:3 landscape aspect ratio'),
+					localize('positron.plots.defaultSizingPolicyPortrait', 'Use 3:4 portrait aspect ratio'),
+					localize('positron.plots.defaultSizingPolicySquare', 'Use 1:1 square aspect ratio')
+				],
+				description: localize('positron.plots.defaultSizingPolicySetting', "The default sizing policy to use for newly created plots."),
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -80,7 +80,6 @@ const OldDarkFilterModeConfigKey = 'positron.plots.darkFilter';
 const DarkFilterModeConfigKey = 'plots.darkFilter';
 
 /** The config key used to store the default plot sizing policy setting */
-const OldDefaultSizingPolicyConfigKey = 'positron.plots.defaultSizingPolicy';
 const DefaultSizingPolicyConfigKey = 'plots.defaultSizingPolicy';
 
 interface DataUri {
@@ -524,22 +523,10 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	/**
-	 * Gets the default sizing policy setting value, checking both new and old settings.
-	 * @returns The string value indicating the default sizing policy
+	 * Gets the default sizing policy as defined in the setting.
 	 */
-	private getDefaultSizingPolicySetting(): string {
-		// First check the new setting
-		const newValue = this._configurationService.getValue<string>(DefaultSizingPolicyConfigKey);
-		if (newValue !== undefined) {
-			return newValue;
-		}
-
-		// Fall back to the old setting
-		return this._configurationService.getValue<string>(OldDefaultSizingPolicyConfigKey) ?? 'auto';
-	}
-
 	getDefaultSizingPolicy(): IPositronPlotSizingPolicy {
-		const defaultPolicyId = this.getDefaultSizingPolicySetting();
+		const defaultPolicyId = this._configurationService.getValue<string>(DefaultSizingPolicyConfigKey) ?? 'auto';
 		const policy = this._sizingPolicies.find(policy => policy.id === defaultPolicyId);
 		return policy ?? this._sizingPolicies.find(policy => policy.id === 'auto')!;
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -258,6 +258,13 @@ export const tocData: ITOCEntry<string> = {
 					label: localize('chat', 'Chat'),
 					settings: ['chat.*', 'inlineChat.*', 'mcp']
 				},
+				// --- Start Positron ---
+				{
+					id: 'features/plots',
+					label: localize('plots', 'Plots'),
+					settings: ['plots.*']
+				},
+				// --- End Positron ---
 				{
 					id: 'features/issueReporter',
 					label: localize('issueReporter', 'Issue Reporter'),


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7268

This PR adds a new setting that users can use to configure how their plots are created.

<img width="757" height="588" alt="Screenshot 2025-10-27 at 11 42 32 AM" src="https://github.com/user-attachments/assets/9c2305b4-d2d9-4495-9789-96a79d002fa9" />

While here, I could not bring myself to make another setting whose name includes "Positron", since [all settings are Positron settings](https://connect.posit.it/positron-wiki/extension-naming-guide.html#contribution-points). I used Claude Code to deprecate the two old plots settings, make new versions, and update how we display all (now) three settings so they show up under "Features".

@:plots

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added new `plots.defaultSizingPolicy` setting to configure the sizing policy used for creating plots, and updated other existing plots settings to have new names `plots.darkFilter` and `plots.freezeSlowPlots`.

#### Bug Fixes

- N/A


### QA Notes

- Create a plot, perhaps via R with `plot(runif(10))`
- Notice that it is created with the "auto" sizing policy (you can change the sizing policy at this point)
- Find the setting and choose a different value, such as "portrait"
- Create a new plot
- Notice that it is created with the sizing policy you chose (you should still be able to change the sizing policy via the UI)
- Also confirm for Python (you'll likely need to clear the plots pane between making plots to really start fresh with a "new" plot, if you're working with something like matplotlib)
