### PR TITLE
catalog explorer: add restart to setting

### DIFF
--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -23,7 +23,7 @@
         "catalogExplorer.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable or disable the experimental Catalog Explorer extension. When disabled, the extension will not activate.",
+          "markdownDescription": "Enable or disable the experimental Catalog Explorer extension. When disabled, the extension will not activate. Requires a restart of Positron to take effect.",
           "tags": [
             "experimental"
           ]


### PR DESCRIPTION
Adding extra context to Catalog Explorer enable setting.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Adding extra context to Catalog Explorer enable setting.


### QA Notes


