### PR TITLE
Extension tests: Skip VSapi debug tests

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -225,14 +225,14 @@ jobs:
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
 
-      # - name: Run Extensions Test
-      #   id: extensions
-      #   continue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     set +e
-      #     npm run test-extension -- -l positron-r
-      #     echo "exit_code=$?" >> $GITHUB_OUTPUT
+      - name: Run Extensions Test
+        id: extensions
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          npm run test-extension -- -l positron-r
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Run Bootstrap Extensions Test
         if: ${{ inputs.skip_extension_test != true }}
@@ -327,12 +327,12 @@ jobs:
           path: test-results/windows.json
           if-no-files-found: ignore
 
-      # - name: Fail workflow if extension tests failed
-      #   if: |
-      #     steps.extensions.outputs.exit_code != '0'
-      #   run: |
-      #     echo "Extension tests failed."
-      #     exit 1
+      - name: Fail workflow if extension tests failed
+        if: |
+          steps.extensions.outputs.exit_code != '0'
+        run: |
+          echo "Extension tests failed."
+          exit 1
 
       - name: Upload inspect-ai JSON Responses
         if: ${{ always() && inputs.project == 'inspect-ai' }}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
@@ -8,7 +8,7 @@ import { basename } from 'path';
 import { commands, debug, Disposable, FunctionBreakpoint, window, workspace } from 'vscode';
 import { assertNoRpc, closeAllEditors, createRandomFile, disposeAll } from '../utils';
 
-suite('vscode API - debug', function () {
+suite.skip('vscode API - debug', function () {
 
 	teardown(async function () {
 		assertNoRpc();


### PR DESCRIPTION
Prevously to mitigate https://github.com/posit-dev/positron/issues/10121, I skipped all extension tests on windows. 

This is a more targeted mitigation, turning on all the other extension tests.


### QA Notes
see run https://github.com/posit-dev/positron/actions/runs/18855184523
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
