### PR TITLE
catalog explorer: dont show connections commands

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -105,17 +105,17 @@
         {
           "command": "positron.connections.closeConnection",
           "group": "inline",
-          "when": "viewItem == database"
+          "when": "view == connections && viewItem == database"
         },
         {
           "command": "positron.connections.previewTable",
           "group": "inline",
-          "when": "viewItem == table"
+          "when": "view == connections && viewItem == table"
         },
         {
           "command": "positron.connections.refresh",
           "group": "inline",
-          "when": "viewItem == database"
+          "when": "view == connections && viewItem == database"
         },
         {
           "command": "positron.connections.removeFromHistory",


### PR DESCRIPTION
The `Preview Table` 👁️ icon was actually a Connections pane command leaking into the Catalog Explorer. We may want a command to guide users from the CE to the Connections pane once there are Snowflake/Databricks Connections implemented, but a good start is to not have broken buttons hanging around in the meantime.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #10109 Fixed bug where Connection Pane's commands are leaking into Catalog Explorer.


### QA Notes

create a catalog, navigate to a table. you should not see 👁️ with `Preview Table`
