### PR TITLE
e2e: add debug test for positron notebooks

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -97,5 +97,12 @@
     {
         "key": "cmd+j d",
         "command": "positronNotebook.selectKernel" // Select Notebook Kernel
-    }
+    },
+    {
+        "key": "cmd+j s",
+        "command": "workbench.debug.viewlet.action.removeAllBreakpoints" // Debugger: Clear All Breakpoints
+    },    {
+        "key": "cmd+l a",
+        "command": "notebook.debugCell" // Debugger: Debug Cell
+    },
 ]

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -128,7 +128,7 @@ export class Workbench {
 		this.outline = new Outline(code, this.quickaccess);
 		this.extensions = new Extensions(code, this.quickaccess);
 		this.settings = new UserSettings(code, this.hotKeys);
-		this.debug = new Debug(code);
+		this.debug = new Debug(code, this.hotKeys, this.quickaccess);
 		this.editorActionBar = new EditorActionBar(code.driver.page, this.viewer, this.quickaccess);
 		this.problems = new Problems(code, this.quickaccess);
 		this.references = new References(code);

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -252,6 +252,18 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+J M', 'Show the DE Summary Panel on Right');
 	}
 
+	// -----------------------
+	// ---  Debug Actions  ---
+	// -----------------------
+
+	public async debugCell() {
+		await this.pressHotKeys('Cmd+L A', 'Debugger: Debug Cell');
+	}
+
+	public async clearAllBreakpoints() {
+		await this.pressHotKeys('Cmd+J S', 'Debugger: Clear All Breakpoints');
+	}
+
 	/**
 	 * Press the hotkeys.
 	 * Note: Supports multiple key sequences separated by spaces.

--- a/test/e2e/tests/notebook/notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/notebook-debug.test.ts
@@ -21,7 +21,6 @@
  */
 
 
-import { Application } from '../../infra/application.js';
 import { test, tags } from '../_test.setup';
 import { expect } from '@playwright/test';
 
@@ -63,7 +62,7 @@ test.describe('Notebook Debugging', {
 		await app.workbench.debug.setBreakpointOnLine(9); // string formatting
 
 		// Start debugging
-		await debugNotebook(app);
+		await app.workbench.debug.debugCell();
 
 		// BP1
 		await app.workbench.debug.expectCurrentLineIndicatorVisible();
@@ -94,11 +93,3 @@ test.describe('Notebook Debugging', {
 		await app.workbench.debug.unSetBreakpointOnLine(9);
 	});
 });
-
-async function debugNotebook(app: Application): Promise<void> {
-	await test.step('Debug notebook', async () => {
-		await expect(app.code.driver.page.locator('.positron-variables-container').locator('text=No Variables have been created')).toBeVisible();
-		await app.workbench.quickaccess.runCommand('notebook.debugCell');
-		await app.workbench.debug.expectCurrentLineIndicatorVisible();
-	});
-}

--- a/test/e2e/tests/notebook/positron-notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-debug.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Notebook Debugging E2E Test
+ *
+ * This test focuses on the core user experience for debugging notebooks:
+ * - Setting breakpoints in notebook cells
+ * - Inspecting variables at breakpoints
+ * - Using step controls (step over)
+ * - Continuing execution
+ * - Verifying final output
+ *
+ * This single comprehensive test validates the essential debugging workflow
+ * that users rely on, while keeping the e2e suite more lean and maintainable.
+ */
+
+import { test, tags } from '../_test.setup.js';
+
+test.use({ suiteId: __filename });
+
+test.describe('Positron Notebook Debugging', {
+	tag: [tags.WEB, tags.WIN, tags.DEBUG, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async ({ hotKeys }) => {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, logger }) => {
+		const { notebooksPositron, debug } = app.workbench;
+
+		await notebooksPositron.createNewNotebook();
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.addCodeToCell(0, pythonCode);
+
+		// Set 2 breakpoints
+		await debug.setBreakpointOnLine(5); // intermediate calculation
+		await debug.setBreakpointOnLine(9); // string formatting
+
+		// Start debugging
+		await debug.debugCell();
+
+		// Verify 1st breakpoint
+		await debug.expectCurrentLineIndicatorVisible();
+		await debug.expectVariablesToExist([
+			{ label: 'x', value: '10' },
+			{ label: 'y', value: '20' }
+		]);
+
+		// Step over to execute the intermediate calculation (BP1)
+		await debug.stepOver();
+
+		// Verify 2nd breakpoint
+		await debug.continue();
+		await debug.expectCurrentLineIndicatorVisible();
+		await debug.expectVariablesToExist([
+			{ label: 'x', value: '10' },
+			{ label: 'y', value: '20' },
+			{ label: 'intermediate', value: '20' }
+		]);
+
+		// Continue
+		await debug.continue();
+
+		// Verify final output
+		await notebooksPositron.expectOutputAtIndex(0, ['Result from Positron: 40']);
+
+		// Clean up BPs
+		await debug.unSetBreakpointOnLine(5);
+		await debug.unSetBreakpointOnLine(9);
+	});
+});
+
+const pythonCode = [
+	'# Initialize variables',
+	'x = 10',
+	'y = 20',
+	'# Perform calculations with breakpoint here',
+	'intermediate = x * 2',  // BP1
+	'result = intermediate + y',
+	'# String operations',
+	'name = "Positron"',
+	'message = f"Result from {name}: {result}"',  // BP2
+	'# Final output',
+	'print(message)'
+].join('\n');

--- a/test/e2e/tests/notebook/positron-notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-debug.test.ts
@@ -33,7 +33,7 @@ test.describe('Positron Notebook Debugging', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, logger }) => {
+	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, hotKeys }) => {
 		const { notebooksPositron, debug } = app.workbench;
 
 		await notebooksPositron.createNewNotebook();
@@ -66,15 +66,12 @@ test.describe('Positron Notebook Debugging', {
 			{ label: 'intermediate', value: '20' }
 		]);
 
-		// Continue
+		// Continue and verify final output
 		await debug.continue();
-
-		// Verify final output
 		await notebooksPositron.expectOutputAtIndex(0, ['Result from Positron: 40']);
 
 		// Clean up BPs
-		await debug.unSetBreakpointOnLine(5);
-		await debug.unSetBreakpointOnLine(9);
+		await hotKeys.clearAllBreakpoints();
 	});
 });
 


### PR DESCRIPTION
### Summary
Add e2e test coverage for basic debugging in Python Positron Notebooks editor.

### QA Notes

@:debug @:web @:win