### PR TITLE
Cleanup notebook errors in dev tools when opening positron notebook

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -74,6 +74,7 @@ type INotebookEditorForExtensionApi = Pick<
 	| 'revealCellRangeInView'
 	| 'revealInCenterIfOutsideViewport'
 	| 'revealInViewAtTop'
+	| 'onDidFocusWidget'
 >;
 
 /**
@@ -102,6 +103,12 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 * Used to determine if the notebook is currently being displayed.
 	 */
 	readonly connectedToEditor: boolean;
+
+	/**
+	 * Sets the DOM element that contains the entire notebook editor.
+	 * @param container The container element to set, or null to clear
+	 */
+	setEditorContainer(container: HTMLElement | null): void;
 
 	/**
 	 * The DOM element that contains the cells for the notebook.
@@ -332,4 +339,10 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 * Called by React when scroll or DOM mutations occur.
 	 */
 	fireScrollEvent(): void;
+
+
+	/**
+	 * Event that fires when the notebook editor widget or a cell editor within it gains focus.
+	 */
+	readonly onDidFocusWidget: Event<void>;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -357,6 +357,9 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 			throw new Error('Base element is not set.');
 		}
 
+		// Set the editor container for focus tracking
+		this.notebookInstance.setEditorContainer(this._parentDiv);
+
 		// Create a scoped context key service rooted at the notebook container so cell scopes inherit it.
 		const scopedContextKeyService = this._containerScopedContextKeyService = this.contextKeyService.createScoped(this._parentDiv);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -106,7 +106,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 			editorGroupService,
 		);
 
-		this._logService.info('PositronNotebookEditor created.');
+		this._logService.debug('PositronNotebookEditor created.');
 
 	}
 
@@ -197,7 +197,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 
 	protected override createEditor(parent: HTMLElement): void {
 
-		this._logService.info(this._identifier, 'createEditor');
+		this._logService.debug(this._identifier, 'createEditor');
 		this._parentDiv = DOM.$('.positron-notebook-container');
 		parent.appendChild(this._parentDiv);
 		this._parentDiv.style.display = 'relative';
@@ -222,7 +222,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		token: CancellationToken,
 		noRetry?: boolean
 	): Promise<void> {
-		this._logService.info(this._identifier, 'setInput');
+		this._logService.debug(this._identifier, 'setInput');
 
 
 		this._input = input;
@@ -290,7 +290,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	}
 
 	override clearInput(): void {
-		this._logService.info(this._identifier, 'clearInput');
+		this._logService.debug(this._identifier, 'clearInput');
 
 		if (this.notebookInstance) {
 			this.notebookInstance.detachView();
@@ -334,7 +334,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	 * Disposes the PositronReactRenderer for the PositronNotebook component.
 	 */
 	private _disposeReactRenderer() {
-		this._logService.info(this._identifier, 'disposeReactRenderer');
+		this._logService.debug(this._identifier, 'disposeReactRenderer');
 
 		if (this._positronReactRenderer) {
 			this._positronReactRenderer.dispose();
@@ -347,7 +347,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	}
 
 	private _renderReact(): IScopedContextKeyService {
-		this._logService.info(this._identifier, 'renderReact');
+		this._logService.debug(this._identifier, 'renderReact');
 
 		if (!this.notebookInstance) {
 			throw new Error('Notebook instance is not set.');
@@ -390,7 +390,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	 * dispose override method.
 	 */
 	public override dispose(): void {
-		this._logService.info(this._identifier, 'dispose');
+		this._logService.debug(this._identifier, 'dispose');
 		this.notebookInstance?.detachView();
 
 		this._disposeReactRenderer();

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -56,7 +56,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	readonly uniqueId: string = `positron-notebook-${PositronNotebookEditorInput.count++}`;
 
-	private _identifier = `Positron Notebook | Input(${this.uniqueId}) |`;
 	//#region Static Properties
 
 	/**
@@ -110,7 +109,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	) {
 		// Call the base class's constructor.
 		super();
-		this._logService.info(this._identifier, 'constructor');
 
 		this.notebookInstance = PositronNotebookInstance.getOrCreate(this, undefined, instantiationService);
 	}
@@ -318,8 +316,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 	}
 
 	override async resolve(_options?: IEditorOptions): Promise<IResolvedNotebookEditorModel | null> {
-		this._logService.info(this._identifier, 'resolve');
-
 		if (this.editorOptions) {
 			_options = this.editorOptions;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -143,6 +143,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private _scopedContextKeyService: IScopedContextKeyService | undefined;
 
 	/**
+	 * Disposables for the editor container event listeners
+	 */
+	private readonly _editorContainerListeners = this._register(new DisposableStore());
+
+	/**
 	 * The DOM element that contains the cells for the notebook.
 	 */
 	private _cellsContainer: HTMLElement | undefined = undefined;
@@ -211,6 +216,26 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Unique identifier for the notebook instance. Currently just the notebook URI as a string.
 	 */
 	private _id: string;
+
+	/**
+	 * Sets the DOM element that contains the entire notebook editor.
+	 * This is the top-level container used for focus tracking.
+	 * @param container The container element to set, or null to clear
+	 */
+	setEditorContainer(container: HTMLElement | null): void {
+		// Clean up any existing listeners
+		this._editorContainerListeners.clear();
+
+		if (!container) {
+			return;
+		}
+
+		// Set up focus tracking for the editor container
+		const focusTracker = this._editorContainerListeners.add(DOM.trackFocus(container));
+		this._editorContainerListeners.add(focusTracker.onDidFocus(() => {
+			this._onDidFocusWidget.fire();
+		}));
+	}
 
 	/**
 	 * The DOM element that contains the cells for the notebook.
@@ -422,6 +447,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	//#region INotebookEditor
 	private readonly _onDidChangeSelection = this._register(new Emitter<void>());
 	private readonly _onDidChangeVisibleRanges = this._register(new Emitter<void>());
+	private readonly _onDidFocusWidget = this._register(new Emitter<void>());
 
 	/**
 	 * Event fired when the cell selection changes.
@@ -432,6 +458,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Event fired when the visible range of cells changes.
 	 */
 	readonly onDidChangeVisibleRanges = this._onDidChangeVisibleRanges.event;
+
+	/**
+	 * Event fired when the notebook editor widget or a cell editor within it gains focus.
+	 */
+	readonly onDidFocusWidget = this._onDidFocusWidget.event;
 
 	// The assertion isn't really true; we only implement parts needed by the extension API,
 	// see the note in IPositronNotebookInstance.ts

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -333,7 +333,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (this._notebookOptions) {
 			return this._notebookOptions;
 		}
-		this._logService.info(this._id, 'Generating new notebook options');
+		this._logService.debug(this._id, 'Generating new notebook options');
 
 		this._notebookOptions = this._instantiationService.createInstance(NotebookOptions, DOM.getActiveWindow(), this.isReadOnly, undefined);
 
@@ -436,7 +436,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._webviewPreloadService.attachNotebookInstance(this);
 
-		this._logService.info(this._id, 'constructor');
+		this._logService.debug(this._id, 'constructor');
 
 		// Add listener for content changes to sync cells
 		this._register(this.onDidChangeContent(() => {
@@ -551,7 +551,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	override dispose() {
 
-		this._logService.info(this._id, 'dispose');
+		this._logService.debug(this._id, 'dispose');
 		this._positronNotebookService.unregisterInstance(this);
 		// Remove from the instance map
 		PositronNotebookInstance._instanceMap.delete(this.uri);
@@ -949,7 +949,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._scopedContextKeyService = scopedContextKeyService;
 		this.contextManager.setContainer(container, scopedContextKeyService);
 
-		this._logService.info(this._id, 'attachView');
+		this._logService.debug(this._id, 'attachView');
 	}
 
 	/**
@@ -1004,7 +1004,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	detachView(): void {
 		this._container = undefined;
-		this._logService.info(this._id, 'detachView');
+		this._logService.debug(this._id, 'detachView');
 		this._notebookOptions?.dispose();
 		this._notebookOptions = undefined;
 	}
@@ -1013,7 +1013,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Closes the notebook instance and disposes of all resources.
 	 */
 	close(): void {
-		this._logService.info(this._id, 'Closing a notebook instance');
+		this._logService.debug(this._id, 'Closing a notebook instance');
 		this.dispose();
 	}
 
@@ -1115,13 +1115,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @returns
 	 */
 	private async _runCells(cells: IPositronNotebookCell[]): Promise<void> {
-		this._logService.info(this._id, '_runCells');
+		this._logService.debug(this._id, '_runCells');
 
 		this._assertTextModel();
 
 		// Make sure we have a kernel to run the cells.
 		if (this.kernelStatus.get() !== KernelStatus.Connected) {
-			this._logService.info(this._id, 'No kernel connected, attempting to connect');
+			this._logService.debug(this._id, 'No kernel connected, attempting to connect');
 			// Attempt to connect to the kernel
 			await this._commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -150,10 +150,10 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 			resizeEditor();
 		}));
 
-		services.logService.info('Positron Notebook | useCellEditorWidget() | Setting up editor widget');
+		services.logService.debug('Positron Notebook | useCellEditorWidget() | Setting up editor widget');
 
 		return () => {
-			services.logService.info('Positron Notebook | useCellEditorWidget() | Disposing editor widget');
+			services.logService.debug('Positron Notebook | useCellEditorWidget() | Disposing editor widget');
 			disposables.dispose();
 			cell.detachEditor();
 		};

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -112,7 +112,6 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	}
 
 	public attachNotebookInstance(instance: IPositronNotebookInstance): void {
-		console.log('Adding notebook instance to webview preloads knowledge', instance);
 		const notebookId = instance.getId();
 		if (this._notebookToDisposablesMap.has(notebookId)) {
 			// Clear existing disposables


### PR DESCRIPTION
Addresses #10022

This PR addresses the sad state of the dev console when opening up a positron notebook. 

Before this PR opening a notebook would cause a cascade of red in the devtools console...

Before changes:
<img width="814" height="1282" alt="image" src="https://github.com/user-attachments/assets/fa33db3f-7f9b-4603-a8d4-f92cb6a7ab83" />

After this PR it's a much less chaotic scene:

<img width="816" height="276" alt="image" src="https://github.com/user-attachments/assets/cd0325f5-c569-4e2d-bcee-fcf230bb24f4" />

## Fixes

There were three main error fix areas and one general log hygiene fix

1. We were adding a scoped context key service to each cell's monaco editor widget. The problem was the monaco editor widget itself was adding a context key service and when it tried to and found there was an existing one, it errored. No obvious functionality problems, but still not ideal. Fixed this by just letting it use the one it creates later. 

2. The Monaco editor was trying to get the editor progress service from DI. The problem is this service is not available outside of standalone full-page monaco editors. We copied the VSCode notebook approach to fixing this which is to just give it a dummy service when it tries to import. 

3. The editor manager was attempting to access the onDidFocusWidget property on the notebook instance. This is one of the properties we hadnt yet implemented from INotebookEditor. Fix was just adding it and hooking it up properly. 

4. We were really overzealous with our logging in the Info level. I switched most of the logs to the debug type to avoid polluting the console. 


### QA Notes:

There should be no behavior changes from these updates. (Maybe a bit more stability?) 

The logs should be a lot cleaner. 

