### PR TITLE
Bump Ark to 0.1.216

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -974,7 +974,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.214"
+      "ark": "0.1.216"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/952
- https://github.com/posit-dev/ark/pull/948
- https://github.com/posit-dev/ark/pull/947
- https://github.com/posit-dev/ark/pull/946
- https://github.com/posit-dev/ark/pull/949

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron now reads R repository configuration from /etc/rstudio/repos.conf automatically if no other repository configuration is present (https://github.com/posit-dev/positron/issues/10094)

#### Bug Fixes

- Fixed a crash when interrupting R while output is emitted in the console (https://github.com/posit-dev/positron/issues/9467).
- The "Restore workspace" setting is now respected on Windows (thanks @kv9898, https://github.com/posit-dev/positron/issues/9927).
- The R backend now works on macOS 11 (thanks @kv9898, https://github.com/posit-dev/positron/issues/10192).
- The R backend is now more robust to loading issues of internal graphics packages such as ragg (https://github.com/posit-dev/ark/issues/917).


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
