### PR TITLE
Rework kernel status

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -159,7 +159,7 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 			busy: false,
 			// If the session is a notebook session, set the current notebook URI
 			// to dynamic data so that it can be displayed in the UI.
-			currentNotebookUri: metadata.notebookUri || undefined,
+			currentNotebookUri: metadata.notebookUri,
 			currentWorkingDirectory: '',
 			...initialState.dynState,
 		};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
@@ -65,7 +65,10 @@ export const RuntimeStatusIcon = ({ status }: RuntimeStatusIconProps) => {
 	return (
 		<span
 			className={className}
-			style={{ color: colorCss }}
+			style={{
+				color: colorCss,
+				animation: status === RuntimeStatus.Active ? 'spin 2s linear infinite' : undefined
+			}}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -96,6 +96,11 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 */
 	readonly uri: URI;
 
+	/**
+	 * The notebook view type. Only Jupyter notebooks are supported currently.
+	 */
+	readonly viewType: 'jupyter-notebook';
+
 	readonly scopedContextKeyService: IScopedContextKeyService | undefined;
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -7,27 +7,36 @@ import { IObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { SelectionStateMachine } from './selectionMachine.js';
-import { INotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IBaseCellEditorOptions, INotebookEditor } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
+
 /**
  * Represents the possible states of a notebook's kernel connection
  */
 export enum KernelStatus {
-	/** No kernel has been initialized yet */
-	Uninitialized = 'Uninitialized',
-	/** Attempting to establish a connection to the kernel */
-	Connecting = 'Connecting',
-	/** Successfully connected to the kernel */
-	Connected = 'Connected',
-	/** Connection to the kernel has been lost */
-	Disconnected = 'Disconnected',
-	/** An error occurred while connecting to or communicating with the kernel */
-	Errored = 'Errored'
+	/** Discovering available kernels */
+	Discovering = 'Preparing',
+	/** No kernel has been selected for the notebook */
+	Unselected = 'Unselected',
+	/** The kernel is restarting*/
+	Restarting = 'Restarting',
+	/** Changing from one kernel to another */
+	Switching = 'Switching',
+	/** The kernel is starting */
+	Starting = 'Starting',
+	/** The kernel is ready to receive a request */
+	Idle = 'Idle',
+	/** The kernel is busy handling a request */
+	Busy = 'Busy',
+	/** The kernel is in the process of exiting */
+	Exiting = 'Exiting',
+	/** The kernel has exited */
+	Exited = 'Exited',
 }
 
 /**
@@ -140,10 +149,9 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	readonly kernelStatus: IObservable<KernelStatus>;
 
 	/**
-	 * Observable reference to the current runtime session for the notebook.
-	 * This manages the connection to the kernel and execution environment.
+	 * Observable of the notebook's selected kernel.
 	 */
-	readonly runtimeSession: IObservable<INotebookLanguageRuntimeSession | undefined>;
+	readonly kernel: IObservable<RuntimeNotebookKernel | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.css
@@ -18,7 +18,7 @@
 	align-items: center;
 	column-gap: 4px;
 
-	.runtime-name {
+	.kernel-label {
 		/* Grow items after session name to fill available space */
 		flex: 1;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -102,7 +102,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	async getTextEditorModel(): Promise<ITextModel> {
-		const modelRef = await this._textModelService.createModelReference(this.uri);
+		// TODO: We aren't disposing cells when they're removed, so we're leaking references
+		//       to the notebook and cell text models. This stops notebook documents from ever
+		//       being disposed, which leaves their runtime sessions running.
+		//       We may also want to store and reuse a single reference for all calls to this method.
+		const modelRef = this._register(await this._textModelService.createModelReference(this.uri));
 		return modelRef.object.textEditorModel;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -106,6 +106,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		//       to the notebook and cell text models. This stops notebook documents from ever
 		//       being disposed, which leaves their runtime sessions running.
 		//       We may also want to store and reuse a single reference for all calls to this method.
+		//       See: https://github.com/posit-dev/positron/issues/10215
 		const modelRef = this._register(await this._textModelService.createModelReference(this.uri));
 		return modelRef.object.textEditorModel;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -261,7 +261,8 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		}
 
 		// Set the notebook instance model
-		notebookInstance.setModel(model.notebook, options?.viewState);
+		const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
+		notebookInstance.setModel(model.notebook, viewState);
 
 		// Trigger the selection change event when the notebook was edited.
 		this._instanceDisposableStore.add(

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -239,11 +239,15 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		// without having to pass the options to the resolve method.
 		input.editorOptions = options;
 
+		// TODO: Implement restoring view state here, and IPositronNotebookInstance.getEditorViewState
+		//       for popping notebooks into a new window
+		// const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
+		const { notebookInstance } = input;
+
 		// Update the editor control given the notebook instance.
 		// This has to be done before we `await super.setInput` since that fires events
 		// with listeners that call `this.getControl()` expecting an up-to-date control
 		// i.e. with `activeCodeEditor` being the editor of the selected cell in the notebook.
-		const { notebookInstance } = input;
 		this._control.value = new PositronNotebookEditorControl(notebookInstance);
 
 		await super.setInput(input, options, context, token);
@@ -261,8 +265,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		}
 
 		// Set the notebook instance model
-		const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
-		notebookInstance.setModel(model.notebook, viewState);
+		notebookInstance.setModel(model.notebook);
 
 		// Trigger the selection change event when the notebook was edited.
 		this._instanceDisposableStore.add(

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -239,8 +239,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		// without having to pass the options to the resolve method.
 		input.editorOptions = options;
 
-		// TODO: Implement restoring view state here, and IPositronNotebookInstance.getEditorViewState
-		//       for popping notebooks into a new window
+		// NOTE: Placeholder if we need to use editor view state:
 		// const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
 		const { notebookInstance } = input;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -86,7 +86,7 @@ export class PositronNotebookEditorInput extends EditorInput {
 	// This is a reference to the model that is currently being edited in the editor.
 	private _editorModelReference: IReference<IResolvedNotebookEditorModel> | null = null;
 
-	public readonly viewType = 'jupyter-notebook';
+	public readonly viewType = 'jupyter-notebook' as const;
 
 	notebookInstance: PositronNotebookInstance;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -459,6 +459,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	readonly onDidChangeVisibleRanges = this._onDidChangeVisibleRanges.event;
 
+	get viewType() {
+		return this._input.viewType;
+	}
+
 	/**
 	 * Event fired when the notebook editor widget or a cell editor within it gains focus.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1060,6 +1060,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				return existingCell;
 			}
 			const newCell = createNotebookCell(cell, this, this._instantiationService);
+			// TODO: We should be disposing cells when we're done with them.
+			//       We're currently holding onto notebook and cell text model references
+			//       so text models are never disposed
 			newlyAddedCells.push(newCell);
 
 			return newCell;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -987,15 +987,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * fully determine the view we see.
 	 */
 	getEditorViewState(): INotebookEditorViewState {
-		this._assertTextModel();
-		const selectedKernel = this.notebookKernelService.getSelectedOrSuggestedKernel(this.textModel);
+		// TODO: Implement editor view state here, and restoring in PositronNotebookEditor.setInput
+		//       for popping notebooks into a new window
 		return {
 			editingCells: {},
 			cellLineNumberStates: {},
 			editorViewStates: {},
 			collapsedInputCells: {},
 			collapsedOutputCells: {},
-			selectedKernelId: selectedKernel?.id,
 		};
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1031,8 +1031,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * fully determine the view we see.
 	 */
 	getEditorViewState(): INotebookEditorViewState {
-		// TODO: Implement editor view state here, and restoring in PositronNotebookEditor.setInput
-		//       for popping notebooks into a new window
+		// NOTE: Placeholder if we need to use editor view state
 		return {
 			editingCells: {},
 			cellLineNumberStates: {},
@@ -1159,6 +1158,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			// TODO: We should be disposing cells when we're done with them.
 			//       We're currently holding onto notebook and cell text model references
 			//       so text models are never disposed
+			//       See: https://github.com/posit-dev/positron/issues/10215
 			newlyAddedCells.push(newCell);
 
 			return newCell;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -411,17 +411,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			}));
 		}
 
-		// Attach existing runtime session for the notebook if any
-		const runtimeSession = this.runtimeSessionService.getNotebookSessionForNotebookUri(this.uri);
-		if (runtimeSession) {
-			this._maybeAttachSession(runtimeSession);
-		}
-
-		// Attach any runtime sessions that start for the notebook
-		this._register(this.runtimeSessionService.onWillStartSession(({ session }) => {
-			this._maybeAttachSession(session);
-		}));
-
 		// Observe the current selected kernel from the notebook kernel service
 		this.kernel = observableFromEvent(
 			this,
@@ -462,6 +451,17 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._language = this.kernel.map(
 			kernel => /** @description positronNotebookLanguage */ kernel?.runtime?.languageId ?? 'plaintext'
 		);
+
+		// Attach existing runtime session for the notebook if any
+		const runtimeSession = this.runtimeSessionService.getNotebookSessionForNotebookUri(this.uri);
+		if (runtimeSession) {
+			this._maybeAttachSession(runtimeSession);
+		}
+
+		// Attach any runtime sessions that start for the notebook
+		this._register(this.runtimeSessionService.onWillStartSession(({ session }) => {
+			this._maybeAttachSession(session);
+		}));
 
 		this.contextManager = this._register(
 			this._instantiationService.createInstance(PositronNotebookContextKeyManager)

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1067,8 +1067,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private readonly _runtimeSessionDisposables = this._register(new MutableDisposable<DisposableStore>());
 
 	private _maybeAttachSession(session: ILanguageRuntimeSession): void {
-		// TODO: If we only update dynstate in the runtime session service, we'll need to update this check and probably others
-		// Only attach the session for this notebook
 		if (!isNotebookLanguageRuntimeSession(session) ||
 			!this._isThisNotebook(session.metadata.notebookUri)) {
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -578,7 +578,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * includes setting up listeners for changes to the model and
 	 * setting up the initial state of the notebook.
 	 */
-	setModel(model: NotebookTextModel, viewState?: INotebookEditorViewState): void {
+	setModel(model: NotebookTextModel): void {
 		this._textModel.set(model, undefined);
 
 		this._modelStore.clear();
@@ -600,12 +600,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			this._onDidChangeContent.fire();
 		}));
 
-		// Select the appropriate kernel for the notebook
-		this._selectKernelForNotebook(model, viewState);
-
 		this._onDidChangeContent.fire();
 	}
-
 
 	/**
 	 * Sets editor options for the notebook or a specific cell.
@@ -1041,25 +1037,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	private _isThisNotebook(uri: URI): boolean {
 		return isEqual(uri, this._input.resource);
-	}
-
-	private _selectKernelForNotebook(model: NotebookTextModel, viewState?: INotebookEditorViewState): void {
-		// If the view state specified a kernel, try to select it
-		const selectedKernelId = viewState?.selectedKernelId;
-		if (selectedKernelId) {
-			const matching = this.notebookKernelService.getMatchingKernel(model);
-			const kernel = matching.all.find(k => k.id === viewState.selectedKernelId);
-			if (kernel) {
-				this.notebookKernelService.selectKernelForNotebook(kernel, model);
-				return;
-			}
-		}
-
-		// If we still haven't selected a kernel, and there's a single suggested kernel, select it.
-		const matching = this.notebookKernelService.getMatchingKernel(model);
-		if (!matching.selected && matching.suggestions.length === 1) {
-			this.notebookKernelService.selectKernelForNotebook(matching.suggestions[0], model);
-		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -30,17 +30,18 @@ import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellT
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { SELECT_KERNEL_ID_POSITRON } from './SelectPositronNotebookKernelAction.js';
 import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
-import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { autorun, observableValue, runOnChange } from '../../../../base/common/observable.js';
+import { autorunDelta, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { cellToCellDto2, serializeCellsToClipboard } from './cellClipboardUtils.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { isNotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSession.js';
+import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
@@ -52,30 +53,39 @@ interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookIn
  * defines how the notebook UI interprets runtime session states and displays
  * them to the user as kernel connection status. As we expand the states we
  * report this map will evolve.
- *
- * States are grouped by their semantic meaning:
- * - Connecting: Runtime is initializing or starting
- * - Connected: Runtime is operational and ready to execute code
- * - Disconnected: Runtime has ended or is shutting down
  */
-const RUNTIME_STATE_TO_KERNEL_STATUS: Partial<Record<RuntimeState, KernelStatus>> = {
+const RUNTIME_STATE_TO_KERNEL_STATUS: Record<RuntimeState, KernelStatus> = {
 	// Runtime is starting up
-	[RuntimeState.Uninitialized]: KernelStatus.Connecting,
-	[RuntimeState.Initializing]: KernelStatus.Connecting,
-	[RuntimeState.Starting]: KernelStatus.Connecting,
-	[RuntimeState.Restarting]: KernelStatus.Connecting,
+	[RuntimeState.Uninitialized]: KernelStatus.Starting,
+	[RuntimeState.Initializing]: KernelStatus.Starting,
+	[RuntimeState.Starting]: KernelStatus.Starting,
+	[RuntimeState.Restarting]: KernelStatus.Restarting,
 
 	// Runtime is operational
-	[RuntimeState.Ready]: KernelStatus.Connected,
-	[RuntimeState.Idle]: KernelStatus.Connected,
-	[RuntimeState.Busy]: KernelStatus.Connected,
-	[RuntimeState.Interrupting]: KernelStatus.Connected,
+	[RuntimeState.Ready]: KernelStatus.Idle,
+	[RuntimeState.Idle]: KernelStatus.Idle,
+	[RuntimeState.Interrupting]: KernelStatus.Idle,
+
+	// Runtime is busy
+	[RuntimeState.Busy]: KernelStatus.Busy,
+
+	// Runtime is exiting
+	[RuntimeState.Exiting]: KernelStatus.Exiting,
 
 	// Runtime is shutting down or ended
-	[RuntimeState.Exiting]: KernelStatus.Disconnected,
-	[RuntimeState.Exited]: KernelStatus.Disconnected,
-	[RuntimeState.Offline]: KernelStatus.Disconnected,
+	[RuntimeState.Exited]: KernelStatus.Exited,
+	[RuntimeState.Offline]: KernelStatus.Exited,
 } as const;
+
+const RUNTIME_STARTUP_PHASE_TO_KERNEL_STATUS: Record<RuntimeStartupPhase, KernelStatus> = {
+	[RuntimeStartupPhase.Initializing]: KernelStatus.Discovering,
+	[RuntimeStartupPhase.AwaitingTrust]: KernelStatus.Discovering,
+	[RuntimeStartupPhase.Reconnecting]: KernelStatus.Discovering,
+	[RuntimeStartupPhase.Starting]: KernelStatus.Discovering,
+	[RuntimeStartupPhase.Discovering]: KernelStatus.Unselected,
+	[RuntimeStartupPhase.Complete]: KernelStatus.Unselected,
+} as const;
+
 
 /**
  * Implementation of IPositronNotebookInstance that handles the core notebook functionality
@@ -283,12 +293,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	/**
 	 * Status of kernel for the notebook.
 	 */
-	kernelStatus = observableValue<KernelStatus>('positronNotebookKernelStatus', KernelStatus.Uninitialized);
+	kernelStatus;
 
 	/**
-	 * Current runtime for the notebook.
+	 * The current selected notebook kernel.
 	 */
-	runtimeSession;
+	kernel;
 
 	/**
 	 * Language for the notebook.
@@ -360,6 +370,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		private _input: PositronNotebookEditorInput,
 		private _creationOptions: INotebookEditorCreationOptions | undefined,
 		@ICommandService private readonly _commandService: ICommandService,
+		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
 		@INotebookExecutionService private readonly notebookExecutionService: INotebookExecutionService,
 		@INotebookExecutionStateService private readonly notebookExecutionStateService: INotebookExecutionStateService,
 		@INotebookKernelService private readonly notebookKernelService: INotebookKernelService,
@@ -378,45 +389,78 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._id = _input.uniqueId;
 		this.cells = observableValue<IPositronNotebookCell[]>('positronNotebookCells', []);
 
-		// Track the current runtime session for this notebook
-		this.runtimeSession = observableValue('positronNotebookRuntimeSession', this.runtimeSessionService.getNotebookSessionForNotebookUri(this.uri));
-		this._register(this.runtimeSessionService.onDidStartRuntime((session) => {
-			if (isNotebookLanguageRuntimeSession(session) && this._isThisNotebook(session.metadata.notebookUri)) {
-				this.runtimeSession.set(session, undefined);
-			}
+		const { startupPhase } = this._languageRuntimeService;
+		this.kernelStatus = observableValue<KernelStatus>('positronNotebookKernelStatus', RUNTIME_STARTUP_PHASE_TO_KERNEL_STATUS[startupPhase]);
+
+		if (this.kernelStatus.get() === KernelStatus.Discovering) {
+			const d = this._register(new DisposableStore());
+			// Watch for discovery to complete
+			d.add(this._languageRuntimeService.onDidChangeRuntimeStartupPhase(startupPhase => {
+				const kernelStatus = RUNTIME_STARTUP_PHASE_TO_KERNEL_STATUS[startupPhase];
+				if (kernelStatus !== KernelStatus.Discovering) {
+					d.dispose();
+					this.kernelStatus.set(kernelStatus, undefined);
+				}
+			}));
+			// Stop listening if we leave the preparing status from elsewhere
+			// e.g. if a runtime session starts for the notebook
+			d.add(runOnChange(this.kernelStatus, (kernelStatus) => {
+				if (kernelStatus !== KernelStatus.Discovering) {
+					d.dispose();
+				}
+			}));
+		}
+
+		// Attach existing runtime session for the notebook if any
+		const runtimeSession = this.runtimeSessionService.getNotebookSessionForNotebookUri(this.uri);
+		if (runtimeSession) {
+			this._maybeAttachSession(runtimeSession);
+		}
+
+		// Attach any runtime sessions that start for the notebook
+		this._register(this.runtimeSessionService.onWillStartSession(({ session }) => {
+			this._maybeAttachSession(session);
 		}));
 
-		// Clear the runtime session observable when the session ends and update kernel status
-		this._register(autorun(reader => {
-			const session = this.runtimeSession.read(reader);
-			if (session) {
-				// Update kernel status based on current runtime state
-				const runtimeState = session.getRuntimeState();
-				const kernelStatus = RUNTIME_STATE_TO_KERNEL_STATUS[runtimeState] ?? KernelStatus.Errored;
-				this.kernelStatus.set(kernelStatus, undefined);
+		// Observe the current selected kernel from the notebook kernel service
+		this.kernel = observableFromEvent(
+			this,
+			Event.filter(this.notebookKernelService.onDidChangeSelectedNotebooks, ({ notebook }) => this._isThisNotebook(notebook)),
+			() => {
+				/** @description positronNotebookInstanceKernel */
+				const { selected } = this.notebookKernelService.getMatchingKernel({
+					uri: this.uri,
+					notebookType: this._input.viewType,
+				});
+				if (selected) {
+					if (selected instanceof RuntimeNotebookKernel) {
+						return selected;
+					} else {
+						this._logService.warn(this._id, `Ignoring unknown kernel ${selected.id} for notebook ${this.uri}`);
+					}
+				}
+				return;
+			},
+		);
 
-				// Listen for runtime state changes and update kernel status accordingly
-				this._register(session.onDidChangeRuntimeState((newState) => {
-					const newKernelStatus = RUNTIME_STATE_TO_KERNEL_STATUS[newState] ?? KernelStatus.Errored;
-					this.kernelStatus.set(newKernelStatus, undefined);
-				}));
-
-				const d = this._register(session.onDidEndSession(() => {
-					// Clean up the previous listener. The final one will get
-					// taken care of by the main disposal logic
-					d.dispose();
-					this.runtimeSession.set(undefined, undefined);
-					this.kernelStatus.set(KernelStatus.Uninitialized, undefined);
-				}));
+		// If a new kernel is selected for this notebook, attach its runtime
+		this._register(autorunDelta(this.kernel, ({ lastValue: oldKernel, newValue: newKernel }) => {
+			if (newKernel) {
+				if (oldKernel) {
+					this.kernelStatus.set(KernelStatus.Switching, undefined);
+				} else {
+					// If the kernel was selected but the runtime isn't attached yet, set the kernel status to
+					// starting. We expect the runtimeSession to be attached soon, at which point we'll
+					// update the kernel status to the runtime session state
+					this.kernelStatus.set(KernelStatus.Starting, undefined);
+				}
 			} else {
-				// No session - reset to uninitialized
-				this.kernelStatus.set(KernelStatus.Uninitialized, undefined);
 			}
 		}));
 
 		// Derive the notebook language from the runtime session
-		this._language = this.runtimeSession.map(
-			session => /** @description positronNotebookLanguage */ session?.runtimeMetadata.languageId ?? 'plaintext'
+		this._language = this.kernel.map(
+			kernel => /** @description positronNotebookLanguage */ kernel?.runtime?.languageId ?? 'plaintext'
 		);
 
 		this.contextManager = this._register(
@@ -1021,7 +1065,59 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Private Methods
 
+	private readonly _runtimeSessionDisposables = this._register(new MutableDisposable<DisposableStore>());
 
+	private _maybeAttachSession(session: ILanguageRuntimeSession): void {
+		// TODO: If we only update dynstate in the runtime session service, we'll need to update this check and probably others
+		// Only attach the session for this notebook
+		if (!isNotebookLanguageRuntimeSession(session) ||
+			!this._isThisNotebook(session.metadata.notebookUri)) {
+			return;
+		}
+
+		// Ignore sessions that don't match the selected kernel's runtime
+		// This shouldn't happen and probably indicates a bug
+		const kernelRuntimeId = this.kernel.get()?.runtime.runtimeId;
+		const sessionRuntimeId = session.runtimeMetadata.runtimeId;
+		if (kernelRuntimeId !== session.runtimeMetadata.runtimeId) {
+			this._logService.warn(this._id,
+				`Unexpected session started for notebook ${this.uri.fsPath}. ` +
+				`Expected runtime ${kernelRuntimeId}, found ${sessionRuntimeId}`);
+			return;
+		}
+
+		this.kernelStatus.set(RUNTIME_STATE_TO_KERNEL_STATUS[session.getRuntimeState()], undefined);
+
+		const disposables = this._runtimeSessionDisposables.value = new DisposableStore();
+
+		// Clean up when the session ends
+		this._register(session.onDidEndSession(() => {
+			disposables.dispose();
+			this.kernelStatus.set(KernelStatus.Exited, undefined);
+		}));
+
+		// Listen for runtime state changes and update kernel status accordingly
+		disposables.add(session.onDidChangeRuntimeState((runtimeState) => {
+			const kernelStatus = this.kernelStatus.get();
+			// Detach if we're switching kernels and the old session starts exiting
+			// We'll update the kernel status when attaching to the new session
+			if (kernelStatus === KernelStatus.Switching &&
+				(runtimeState === RuntimeState.Exiting ||
+					runtimeState === RuntimeState.Exited ||
+					runtimeState === RuntimeState.Offline ||
+					runtimeState === RuntimeState.Uninitialized)) {
+				disposables.dispose();
+			} else {
+				const kernelStatus = RUNTIME_STATE_TO_KERNEL_STATUS[runtimeState];
+				this.kernelStatus.set(kernelStatus, undefined);
+
+				// Detach when restart sequence starts - ignore intermediate states
+				if (kernelStatus === KernelStatus.Restarting) {
+					disposables.dispose();
+				}
+			}
+		}));
+	}
 
 	private _assertTextModel(): asserts this is IPositronNotebookInstanceRequiredTextModel {
 		if (this.textModel === undefined) {
@@ -1102,8 +1198,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._assertTextModel();
 
-		// Make sure we have a kernel to run the cells.
-		if (this.kernelStatus.get() !== KernelStatus.Connected) {
+		if (!this.kernel.get()) {
+			// Make sure we have a kernel to run the cells.
 			this._logService.debug(this._id, 'No kernel connected, attempting to connect');
 			// Attempt to connect to the kernel
 			await this._commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookService.ts
@@ -60,7 +60,7 @@ export interface IPositronNotebookService {
 	usingPositronNotebooks(): boolean;
 }
 
-class PositronNotebookService extends Disposable implements IPositronNotebookService {
+export class PositronNotebookService extends Disposable implements IPositronNotebookService {
 
 	// Needed for service branding in dependency injector.
 	_serviceBrand: undefined;

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -14,7 +14,7 @@ import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/
 import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
 import { CellEditType, CellKind, ICellEditOperation } from '../../notebook/common/notebookCommon.js';
-import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
+import { INotebookKernelService, INotebookTextModelLike } from '../../notebook/common/notebookKernelService.js';
 import { INotebookService } from '../../notebook/common/notebookService.js';
 import { ActiveRuntimeNotebookContextManager } from '../common/activeRuntimeNotebookContextManager.js';
 import { registerRuntimeNotebookKernelActions } from './runtimeNotebookKernelActions.js';
@@ -24,19 +24,7 @@ import { RuntimeNotebookKernel } from './runtimeNotebookKernel.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { LANGUAGE_RUNTIME_SELECT_RUNTIME_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
-
-/**
- * The affinity of a kernel for a notebook.
- *
- * NOTE: This should match vscode.NotebookControllerAffinity.
- */
-enum NotebookKernelAffinity {
-	/** The default affinity. */
-	Default = 1,
-
-	/** A kernel will be automatically started if it is a notebook's only preferred kernel. */
-	Preferred = 2
-}
+import { isEqual } from '../../../../base/common/resources.js';
 
 /**
  * The service responsible for managing {@link RuntimeNotebookKernel}s.
@@ -98,7 +86,7 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 				);
 			} else if (oldKernel && !newKernel) {
 				// The user switched from a known kernel to an unknown kernel, shutdown the old kernel's runtime.
-				this._runtimeSessionService.shutdownNotebookSession(
+				await this._runtimeSessionService.shutdownNotebookSession(
 					e.notebook,
 					RuntimeExitReason.Shutdown,
 					`Runtime kernel ${oldKernel.id} deselected for notebook`,
@@ -106,15 +94,14 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			}
 		}));
 
-		// When a notebook is added, update its kernel affinity for kernel auto-selection.
-		this._register(this._notebookService.onWillAddNotebookDocument(async notebook => {
-			await this.updateKernelNotebookAffinity(notebook);
+		// Ensure that a kernel is selected for added notebook documents
+		this._register(this._notebookService.onWillAddNotebookDocument(notebook => {
+			this.attachNotebook(notebook);
 		}));
 
-		// Update the kernel affinity of all existing notebooks.
+		// Ensure that a kernel is selected for all existing notebook documents
 		for (const notebook of this._notebookService.getNotebookTextModels()) {
-			this.updateKernelNotebookAffinity(notebook)
-				.catch(err => this._logService.error(`Error updating affinity for notebook ${notebook.uri.fsPath}: ${err}`));
+			this.attachNotebook(notebook);
 		}
 
 		// When a notebook is closed, shutdown the corresponding session.
@@ -236,35 +223,17 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 	}
 
 	/**
-	 * Update a notebook's affinity for all kernels.
-	 *
-	 * Positron automatically starts a kernel if it is the only 'preferred' kernel for the notebook.
-	 *
-	 * @param notebook The notebook whose affinity to update.
-	 * @returns Promise that resolves when the notebook's affinity has been updated for all kernels.
+	 * Get the selected kernel for a notebook.
 	 */
-	private async updateKernelNotebookAffinity(notebook: NotebookTextModel): Promise<void> {
-		const cells = notebook.cells;
-		if (cells.length === 0 ||
-			(cells.length === 1 && cells[0].getValue() === '')) {
-			// If its an empty notebook (i.e. it has a single empty cell, or no cells),
-			// wait for its data to be updated. This works around the  fact that `vscode.openNotebookDocument()`
-			// first creates a notebook (triggering `onDidOpenNotebookDocument`),
-			// and later updates its content (triggering `onDidChangeNotebookDocument`).
-			await new Promise<void>((resolve) => {
-				// Apply a short timeout to avoid waiting indefinitely.
-				const timeout = setTimeout(() => {
-					disposable.dispose();
-					resolve();
-				}, 50);
-				const disposable = notebook.onDidChangeContent(_e => {
-					clearTimeout(timeout);
-					disposable.dispose();
-					resolve();
-				});
-			});
-		}
+	private getSelectedKernel(notebook: INotebookTextModelLike): RuntimeNotebookKernel | undefined {
+		const { selected } = this._notebookKernelService.getMatchingKernel(notebook);
+		return selected && this._kernels.get(selected.id);
+	}
 
+	/**
+	 * Try to determine the preferred kernel for a notebook.
+	 */
+	private getPreferredKernel(notebook: NotebookTextModel): RuntimeNotebookKernel | undefined {
 		// Get the notebook's language.
 		const languageId = getNotebookLanguage(notebook);
 		if (!languageId) {
@@ -272,33 +241,83 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			return;
 		}
 
-		// Get the preferred kernel for the language.
-		let preferredRuntime: ILanguageRuntimeMetadata;
+		// Get the preferred runtime for the notebook's language.
+		let runtime: ILanguageRuntimeMetadata | undefined;
 		try {
-			const preferred = this._runtimeStartupService.getPreferredRuntime(languageId);
-			if (preferred) {
-				preferredRuntime = preferred;
-			} else {
-				this._logService.debug(`No preferred runtime for language ${languageId}`);
-				return;
-			}
+			runtime = this._runtimeStartupService.getPreferredRuntime(languageId);
+			this._logService.debug(`No preferred runtime for language ${languageId}`);
 		} catch (err) {
 			// It may error if there are no registered runtimes for the language, so log and return.
 			this._logService.debug(`Failed to get preferred runtime for language ${languageId}. Reason: ${err.toString()}`);
 			return;
 		}
-		const preferredKernel = this._kernelsByRuntimeId.get(preferredRuntime.runtimeId);
-		this._logService.debug(`Preferred kernel for notebook ${notebook.uri.fsPath}: ${preferredKernel?.label}`);
 
-		// Set the affinity across all known kernels.
-		for (const kernel of this._kernels.values()) {
-			const affinity = kernel === preferredKernel
-				? NotebookKernelAffinity.Preferred
-				: NotebookKernelAffinity.Default;
-			this._notebookKernelService.updateKernelNotebookAffinity(kernel, notebook.uri, affinity);
-			this._logService.trace(`Updated notebook affinity for kernel: ${kernel.label}, ` +
-				`notebook: ${notebook.uri.fsPath}, affinity: ${affinity}`);
+		// Get the preferred runtime's matching kernel.
+		if (runtime) {
+			const kernel = this._kernelsByRuntimeId.get(runtime.runtimeId);
+			if (kernel) {
+				return kernel;
+			} else {
+				this._logService.warn(`No kernel for preferred runtime ${runtime.runtimeId} for notebook ${notebook.uri}`);
+			}
 		}
+
+		return;
+	}
+
+	/**
+	 * Get the selected kernel for a notebook if one is selected, otherwise select a kernel
+	 * matching the preferred runtime for the notebook's language.
+	 */
+	private getOrSelectKernel(notebook: NotebookTextModel): RuntimeNotebookKernel | undefined {
+		// If another of our kernels is already selected, nothing to do
+		// e.g. the user manually selected it in a previous session
+		const selectedKernel = this.getSelectedKernel(notebook);
+		if (selectedKernel) {
+			return selectedKernel;
+		}
+
+		// Try to get the preferred kernel for the notebook
+		const preferredKernel = this.getPreferredKernel(notebook);
+		if (preferredKernel) {
+			// Select the preferred kernel
+			this._notebookKernelService.selectKernelForNotebook(preferredKernel, notebook);
+			return preferredKernel;
+		}
+
+		return;
+	}
+
+	private attachNotebook(notebook: NotebookTextModel): void {
+		// If a kernel is already selected for the notebook, there's nothing to do
+		if (this.getOrSelectKernel(notebook)) {
+			return;
+		}
+
+		// Couldn't select a kernel, it's possible that the notebook contents are still arriving
+		// e.g. `vscode.openNotebookDocument()` first creates a notebook (triggering `onWillOpenNotebookDocument`),
+		// and later updates its contents (triggering `onDidChangeNotebookDocument`)
+		const disposables = this._register(new DisposableStore());
+
+		// Try again on each content change
+		disposables.add(notebook.onDidChangeContent(() => {
+			// Still haven't selected a kernel, try again with the updated contents
+			if (this.getOrSelectKernel(notebook)) {
+				disposables.dispose();
+			}
+		}));
+
+		// Stop listening if one of our kernels is selected in some other way
+		disposables.add(this._notebookKernelService.onDidChangeSelectedNotebooks((event) => {
+			if (isEqual(event.notebook, notebook.uri) &&
+				event.newKernel &&
+				this._kernels.has(event.newKernel)) {
+				disposables.dispose();
+			}
+		}));
+
+		// Stop listening when the notebook is disposed
+		disposables.add(notebook.onWillDispose(() => disposables.dispose()));
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -12,7 +12,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpener, IOpenerService, OpenExternalOptions, OpenInternalOptions } from '../../../../platform/opener/common/opener.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeExitReason, RuntimeState, LanguageStartupBehavior, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
-import { ILanguageRuntimeGlobalEvent, INotebookLanguageRuntimeSession, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, ILanguageRuntimeSessionStateEvent, INotebookSessionUriChangedEvent, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeStartMode } from './runtimeSessionService.js';
+import { ILanguageRuntimeGlobalEvent, INotebookLanguageRuntimeSession, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, ILanguageRuntimeSessionStateEvent, INotebookSessionUriChangedEvent, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeStartMode, INotebookRuntimeSessionMetadata } from './runtimeSessionService.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IModalDialogPromptInstance, IPositronModalDialogsService } from '../../positronModalDialogs/common/positronModalDialogs.js';
@@ -2335,6 +2335,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// with our mapping, which helps debugging and ensures session properties
 			// reflect current reality
 			session.dynState.currentNotebookUri = newUri;
+			// TODO: Is metadata supposed to be immutable?
+			session.metadata.notebookUri = newUri;
 			workingDirectoryWasChanged = await this.promptAndUpdateWorkingDirectoryIfChanged(session, newUri);
 
 			// 3. Finally remove the old mapping - we do this last because it's
@@ -2540,6 +2542,14 @@ function awaitStateChange(
  * @param session The session to check
  */
 export function isNotebookLanguageRuntimeSession(session: ILanguageRuntimeSession): session is INotebookLanguageRuntimeSession {
-	return session.metadata.notebookUri !== undefined &&
-		session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook;
+	return isNotebookRuntimeSessionMetadata(session.metadata);
+}
+
+/**
+ * Checks whether a session's metadata is for a notebook session.
+ * @param metadata The session metadata to check
+ */
+export function isNotebookRuntimeSessionMetadata(metadata: IRuntimeSessionMetadata): metadata is INotebookRuntimeSessionMetadata {
+	return metadata.notebookUri !== undefined &&
+		metadata.sessionMode === LanguageRuntimeSessionMode.Notebook;
 }

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -33,6 +33,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IPathService } from '../../path/common/pathService.js';
 import { untildify } from '../../../../base/common/labels.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { isEqual } from '../../../../base/common/resources.js';
 
 /**
  * Get a map key corresponding to a session.
@@ -2335,7 +2336,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// with our mapping, which helps debugging and ensures session properties
 			// reflect current reality
 			session.dynState.currentNotebookUri = newUri;
-			// TODO: Is metadata supposed to be immutable?
 			session.metadata.notebookUri = newUri;
 			workingDirectoryWasChanged = await this.promptAndUpdateWorkingDirectoryIfChanged(session, newUri);
 
@@ -2382,7 +2382,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 			// 3. Restore original URI and working directory in session state if needed
 			// Why: Keep the session's internal state consistent with our mappings
-			if (session.dynState.currentNotebookUri === newUri) {
+			if (isEqual(session.dynState.currentNotebookUri, newUri)) {
+				session.dynState.currentNotebookUri = oldUri;
+			}
+			if (isEqual(session.metadata.notebookUri, newUri)) {
 				session.dynState.currentNotebookUri = oldUri;
 			}
 			if (workingDirectoryWasChanged) {

--- a/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
@@ -54,6 +54,7 @@ import { EphemeralStateService } from '../../../platform/ephemeralState/common/e
 import { ILanguageService } from '../../../editor/common/languages/language.js';
 import { IRuntimeNotebookKernelService } from '../../contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { RuntimeNotebookKernelService } from '../../contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.js';
+import { IPositronNotebookService, PositronNotebookService } from '../../contrib/positronNotebook/browser/positronNotebookService.js';
 
 export function positronWorkbenchInstantiationService(
 	disposables: Pick<DisposableStore, 'add'> = new DisposableStore(),
@@ -83,8 +84,9 @@ export function positronWorkbenchInstantiationService(
 	// Positron services.
 	instantiationService.stub(IEphemeralStateService, instantiationService.createInstance(EphemeralStateService));
 	instantiationService.stub(IPositronNewFolderService, disposables.add(instantiationService.createInstance(PositronNewFolderService)));
-	instantiationService.stub(IRuntimeNotebookKernelService, disposables.add(instantiationService.createInstance(RuntimeNotebookKernelService)));
 	instantiationService.stub(IRuntimeStartupService, disposables.add(instantiationService.createInstance(RuntimeStartupService)));
+	instantiationService.stub(IPositronNotebookService, disposables.add(instantiationService.createInstance(PositronNotebookService)));
+	instantiationService.stub(IRuntimeNotebookKernelService, disposables.add(instantiationService.createInstance(RuntimeNotebookKernelService)));
 	instantiationService.stub(IPositronNotebookOutputWebviewService, instantiationService.createInstance(PositronNotebookOutputWebviewService));
 	instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
 	instantiationService.stub(IPositronWebviewPreloadService, disposables.add(instantiationService.createInstance(PositronWebviewPreloadService)));

--- a/test/e2e/tests/notebook/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebook/notebook-kernel-behavior.test.ts
@@ -58,15 +58,17 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			kernelGroup: 'Python',
 			status: 'active'
 		});
-		// ISSUE - https://github.com/posit-dev/positron/issues/10145
-		// await notebooksPositron.kernel.expectKernelToBe({
-		// 	kernelGroup: 'Python',
-		// 	status: 'idle'
-		// })
-		await notebooksPositron.kernel.expectStatusToBe('idle', 15000); // remove once above issue is resolved
+		await notebooksPositron.kernel.expectKernelToBe({
+			kernelGroup: 'Python',
+			status: 'idle'
+		});
 
 		// shut down kernel and ensure menu options
 		await notebooksPositron.kernel.shutdown();
+		await notebooksPositron.kernel.expectKernelToBe({
+			kernelGroup: 'Python',
+			status: 'disconnected'
+		});
 		await notebooksPositron.kernel.expectMenuToContain([
 			{ label: 'Restart Kernel', enabled: false },
 			{ label: 'Shutdown Kernel', enabled: false },


### PR DESCRIPTION
This PR reworks how we manage kernels, runtimes, and sessions in the notebook instance, attempting to be more stable & consistent. Addresses #9722, #10145.

* Also made it faster and fixed a race condition when reconnecting to an existing session e.g. after a window reload
* Removed progress notifications for starting, shutting down, and restarting Positron notebooks
* We now display "Discovering Interpreters..." while the runtime startup phase is in progress

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

#### Expected behavior

The kernel status shouldn't revert to "No kernel selected" in the middle of any of these operations, as it currently does.

We shouldn't really ever see "No kernel selected" unless there are no interpreters available, since we already try to select the workspace's interpreter once its available. Same way that workspace selection works.

1. Opening a notebook for the first time[^clean] → Automatically select & start the workspace-selected interpreter for the same language (even if not foreground), clear state
2. Creating a notebook for the first time[^clean] → Automatically select & start the foreground workspace-selected interpreter, clear state
3. Close and reopen a notebook → Remember and start the previously selected kernel, state is cleared ==TBD whether closing a notebook should shutdown the session==
4. Restart Kernel → `active` until the interpreter is ready, then `idle`, state is cleared
5. Change Kernel → `active` until the new interpreter is ready, then `idle`, state is cleared
6. Save an untitled notebook → no status or interpreter name change, can reference a variable defined before saving
7.  Opening a notebook immediately on first start (while Positron is discovering interpreters) → Active status icon, with simplified language runtime startup phase text i.e. either "Discovering Interpreters..." by default or "Awaiting Trust..." for that phase specifically since it requires the user to do something
8. Reload the window while a notebook is open → `active` while reconnecting, then `idle`, runtime name should display immediately

[^clean]: In a dev build, I think you can remove any existing state by doing `rm -rf .profile-oss` in the `positron` repo folder.

@:positron-notebooks @:web