### PR TITLE
catalog explorer: rename commands

### DIFF
--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -77,28 +77,28 @@
       {
         "command": "posit.catalog-explorer.copyPythonCodeFile",
         "category": "Catalogs",
-        "title": "Copy Python Download Code",
+        "title": "Download File via Python",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyPythonCodeTable",
         "category": "Catalogs",
-        "title": "Copy Python Connection Code",
+        "title": "Preview Table via Python",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeFile",
         "category": "Catalogs",
-        "title": "Copy R Download Code",
+        "title": "Download File via R",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeTable",
         "category": "Catalogs",
-        "title": "Copy R Connection Code",
+        "title": "Preview Table via R",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       }

--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -56,15 +56,15 @@
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.previewTableInConsole",
+        "command": "posit.catalog-explorer.previewTableInSession",
         "category": "Catalogs",
-        "title": "Preview Table in Console",
+        "title": "Preview Table in Active Session",
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.downloadFileInConsole",
+        "command": "posit.catalog-explorer.downloadFileInSession",
         "category": "Catalogs",
-        "title": "Download File in Console",
+        "title": "Download File in Active Session",
         "enablement": "view == catalog-explorer"
       },
       {
@@ -77,28 +77,28 @@
       {
         "command": "posit.catalog-explorer.copyPythonCodeFile",
         "category": "Catalogs",
-        "title": "Download File via Python",
+        "title": "Download File with Python",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyPythonCodeTable",
         "category": "Catalogs",
-        "title": "Preview Table via Python",
+        "title": "Preview Table with Python",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeFile",
         "category": "Catalogs",
-        "title": "Download File via R",
+        "title": "Download File with R",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeTable",
         "category": "Catalogs",
-        "title": "Preview Table via R",
+        "title": "Preview Table with R",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       }
@@ -157,12 +157,12 @@
           "group": "1_primary@2"
         },
         {
-          "command": "posit.catalog-explorer.downloadFileInConsole",
+          "command": "posit.catalog-explorer.downloadFileInSession",
           "when": "view == catalog-explorer && viewItem == file",
           "group": "1_primary@3"
         },
         {
-          "command": "posit.catalog-explorer.previewTableInConsole",
+          "command": "posit.catalog-explorer.previewTableInSession",
           "when": "view == catalog-explorer && viewItem == table",
           "group": "1_primary@3"
         },

--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -56,9 +56,15 @@
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.openInSession",
+        "command": "posit.catalog-explorer.connectToTableInConsole",
         "category": "Catalogs",
-        "title": "Open in Session",
+        "title": "Connect to Table in Console",
+        "enablement": "view == catalog-explorer"
+      },
+      {
+        "command": "posit.catalog-explorer.downloadFileInConsole",
+        "category": "Catalogs",
+        "title": "Download File in Console",
         "enablement": "view == catalog-explorer"
       },
       {
@@ -69,16 +75,30 @@
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.copyPythonCode",
+        "command": "posit.catalog-explorer.copyPythonCodeFile",
         "category": "Catalogs",
-        "title": "Copy Python Code",
+        "title": "Copy Python Code to Download File",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.copyRCode",
+        "command": "posit.catalog-explorer.copyPythonCodeTable",
         "category": "Catalogs",
-        "title": "Copy R Code",
+        "title": "Copy Python Code to Connect to Table",
+        "icon": "$(copy)",
+        "enablement": "view == catalog-explorer"
+      },
+      {
+        "command": "posit.catalog-explorer.copyRCodeFile",
+        "category": "Catalogs",
+        "title": "Copy R Code to Download File",
+        "icon": "$(copy)",
+        "enablement": "view == catalog-explorer"
+      },
+      {
+        "command": "posit.catalog-explorer.copyRCodeTable",
+        "category": "Catalogs",
+        "title": "Copy R Code to Connect to Table",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       }
@@ -137,8 +157,13 @@
           "group": "1_primary@2"
         },
         {
-          "command": "posit.catalog-explorer.openInSession",
-          "when": "view == catalog-explorer && (viewItem == file || viewItem == table)",
+          "command": "posit.catalog-explorer.downloadFileInConsole",
+          "when": "view == catalog-explorer && viewItem == file",
+          "group": "1_primary@3"
+        },
+        {
+          "command": "posit.catalog-explorer.connectToTableInConsole",
+          "when": "view == catalog-explorer && viewItem == table",
           "group": "1_primary@3"
         },
         {
@@ -147,13 +172,23 @@
           "group": "2_copy@0"
         },
         {
-          "command": "posit.catalog-explorer.copyPythonCode",
-          "when": "view == catalog-explorer && (viewItem == file || viewItem == table)",
+          "command": "posit.catalog-explorer.copyPythonCodeFile",
+          "when": "view == catalog-explorer && viewItem == file",
           "group": "2_copy@1"
         },
         {
-          "command": "posit.catalog-explorer.copyRCode",
-          "when": "view == catalog-explorer && (viewItem == file || viewItem == table)",
+          "command": "posit.catalog-explorer.copyPythonCodeTable",
+          "when": "view == catalog-explorer && viewItem == table",
+          "group": "2_copy@1"
+        },
+        {
+          "command": "posit.catalog-explorer.copyRCodeFile",
+          "when": "view == catalog-explorer && viewItem == file",
+          "group": "2_copy@2"
+        },
+        {
+          "command": "posit.catalog-explorer.copyRCodeTable",
+          "when": "view == catalog-explorer && viewItem == table",
           "group": "2_copy@2"
         }
       ]

--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -56,9 +56,9 @@
         "enablement": "view == catalog-explorer"
       },
       {
-        "command": "posit.catalog-explorer.connectToTableInConsole",
+        "command": "posit.catalog-explorer.previewTableInConsole",
         "category": "Catalogs",
-        "title": "Connect to Table in Console",
+        "title": "Preview Table in Console",
         "enablement": "view == catalog-explorer"
       },
       {
@@ -77,28 +77,28 @@
       {
         "command": "posit.catalog-explorer.copyPythonCodeFile",
         "category": "Catalogs",
-        "title": "Copy Python Code to Download File",
+        "title": "Copy Python Download Code",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyPythonCodeTable",
         "category": "Catalogs",
-        "title": "Copy Python Code to Connect to Table",
+        "title": "Copy Python Connection Code",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeFile",
         "category": "Catalogs",
-        "title": "Copy R Code to Download File",
+        "title": "Copy R Download Code",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       },
       {
         "command": "posit.catalog-explorer.copyRCodeTable",
         "category": "Catalogs",
-        "title": "Copy R Code to Connect to Table",
+        "title": "Copy R Connection Code",
         "icon": "$(copy)",
         "enablement": "view == catalog-explorer"
       }
@@ -162,7 +162,7 @@
           "group": "1_primary@3"
         },
         {
-          "command": "posit.catalog-explorer.connectToTableInConsole",
+          "command": "posit.catalog-explorer.previewTableInConsole",
           "when": "view == catalog-explorer && viewItem == table",
           "group": "1_primary@3"
         },

--- a/extensions/positron-catalog-explorer/src/catalog.ts
+++ b/extensions/positron-catalog-explorer/src/catalog.ts
@@ -393,6 +393,7 @@ export function registerCatalogCommands(
 				await vscode.commands.executeCommand('copyFilePath', node.resourceUri);
 			},
 		),
+
 		vscode.commands.registerCommand(
 			'posit.catalog-explorer.openInSession',
 			async (node: CatalogNode) => await node.openInSession(),
@@ -405,6 +406,7 @@ export function registerCatalogCommands(
 					return;
 				}
 				await vscode.env.clipboard.writeText(code);
+				vscode.window.showInformationMessage('Code copied to clipboard.');
 			},
 		),
 		vscode.commands.registerCommand(
@@ -415,6 +417,44 @@ export function registerCatalogCommands(
 					return;
 				}
 				await vscode.env.clipboard.writeText(code);
+				vscode.window.showInformationMessage('Code copied to clipboard.');
+			},
+		),
+		// each node will handle its own file/table distinction, just delegate to core command
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.connectToTableInConsole',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.openInSession', node);
+			},
+		),
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.downloadFileInConsole',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.openInSession', node);
+			},
+		),
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.copyPythonCodeFile',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.copyPythonCode', node);
+			},
+		),
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.copyPythonCodeTable',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.copyPythonCode', node);
+			},
+		),
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.copyRCodeFile',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.copyRCode', node);
+			},
+		),
+		vscode.commands.registerCommand(
+			'posit.catalog-explorer.copyRCodeTable',
+			async (node: CatalogNode) => {
+				await vscode.commands.executeCommand('posit.catalog-explorer.copyRCode', node);
 			},
 		),
 		vscode.commands.registerCommand(

--- a/extensions/positron-catalog-explorer/src/catalog.ts
+++ b/extensions/positron-catalog-explorer/src/catalog.ts
@@ -422,13 +422,13 @@ export function registerCatalogCommands(
 		),
 		// each node will handle its own file/table distinction, just delegate to core command
 		vscode.commands.registerCommand(
-			'posit.catalog-explorer.previewTableInConsole',
+			'posit.catalog-explorer.previewTableInSession',
 			async (node: CatalogNode) => {
 				await vscode.commands.executeCommand('posit.catalog-explorer.openInSession', node);
 			},
 		),
 		vscode.commands.registerCommand(
-			'posit.catalog-explorer.downloadFileInConsole',
+			'posit.catalog-explorer.downloadFileInSession',
 			async (node: CatalogNode) => {
 				await vscode.commands.executeCommand('posit.catalog-explorer.openInSession', node);
 			},

--- a/extensions/positron-catalog-explorer/src/catalog.ts
+++ b/extensions/positron-catalog-explorer/src/catalog.ts
@@ -422,7 +422,7 @@ export function registerCatalogCommands(
 		),
 		// each node will handle its own file/table distinction, just delegate to core command
 		vscode.commands.registerCommand(
-			'posit.catalog-explorer.connectToTableInConsole',
+			'posit.catalog-explorer.previewTableInConsole',
 			async (node: CatalogNode) => {
 				await vscode.commands.executeCommand('posit.catalog-explorer.openInSession', node);
 			},


### PR DESCRIPTION
Updates 

- `Copy {R/Python} Code` -> `Preview Table via {R/Python}` and `Download File via {R/Python}`
- `Open in Session` -> `Preview Table in Console` and `Download File in Console`

Also added a notification for user feedback that code has been copied to clipboard.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #10107 Updates command names to copy code from the catalog explorer.

#### Bug Fixes

- N/A


### QA Notes

- enable `catalogExplorer.viewTestCatalog` and `catalogExplorer.enable`
- add demo catalog
- right click on table, see the updated command names
- right click on csv, see the updated command names

