### PR TITLE
fix registerPythonFilePasteAndDropProvider module resolution

### DIFF
--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -16,7 +16,7 @@ import { activateWebAppCommands } from './webAppCommands';
 import { activateWalkthroughCommands } from './walkthroughCommands';
 import { printInterpreterDebugInfo } from './interpreterSettings';
 import { registerLanguageServerManager } from './languageServerManager';
-import { registerPythonFilePasteAndDropProvider } from '../languageFeatures/pythonFilePasteAndDropProvider.js';
+import { registerPythonFilePasteAndDropProvider } from '../languageFeatures/pythonFilePasteAndDropProvider';
 
 export async function activatePositron(serviceContainer: IServiceContainer): Promise<void> {
     try {


### PR DESCRIPTION
Fixes the following compilation error in release builds:

```
[13:11:58] 'vscode-reh-linux-arm64' errored after 4.6 min
[13:11:58] Error in plugin "webpack-stream"
Message:
    Module not found: Error: Can't resolve '../languageFeatures/pythonFilePasteAndDropProvider.js' in '/home/parallels/git/positron/extensions/positron-python/src/client/positron'
Details:
    domainEmitter: [object Object]
    domainThrown: false
```