### PR TITLE
e2e: add soft fail to weekly qa notification script

### DIFF
--- a/product.json
+++ b/product.json
@@ -230,7 +230,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.23.16",
+			"version": "1.23.17",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",

--- a/scripts/slack-skipped-tests.js
+++ b/scripts/slack-skipped-tests.js
@@ -25,7 +25,7 @@ const slackSkippedTests = (slackWebhookUrl) => {
 				},
 				{
 					mrkdwn_in: ['text'],
-					color: softFailedTests === '' ? '#CCCCCC' : '#FFF176',
+					color: softFailedTests === '' ? '#CCCCCC' : 'warning',
 					pretext: ':wrenchin: *Soft-Failed Tests*',
 					text: softFailedTests === '' ? 'There are no soft-failed tests. :tada:' : softFailedTests,
 				},

--- a/scripts/slack-skipped-tests.js
+++ b/scripts/slack-skipped-tests.js
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -8,28 +8,48 @@ const { execSync } = require('child_process');
 const slackSkippedTests = (slackWebhookUrl) => {
 	try {
 		const skippedTests = execSync(
-			`grep -r --include \\*.test.ts -E "describe\\.skip|test\\.skip" test/e2e/tests | sed 's/\\.test\\.ts.*$/.test.ts/'`
-		).toString();
+			'grep -r --include \\*.test.ts -E "describe\\.skip|test\\.skip" test/e2e/tests | sed \'s/\\.test\\.ts.*$/.test.ts/\' || true'
+		).toString().trim();
+
+		const softFailedTests = execSync(
+			'grep -r --include \\*.test.ts -E "tags\\.SOFT_FAIL" test/e2e/tests | sed \'s/\\.test\\.ts.*$/.test.ts/\' || true'
+		).toString().trim();
 
 		const slackMessage = {
 			attachments: [
 				{
 					mrkdwn_in: ['text'],
 					color: skippedTests === '' ? '#CCCCCC' : '#FF0000',
-					pretext: ':skipping:*Skipped Tests*',
+					pretext: ':skipping: *Skipped Tests*',
 					text: skippedTests === '' ? 'There are no skipped tests. :tada:' : skippedTests,
+				},
+				{
+					mrkdwn_in: ['text'],
+					color: softFailedTests === '' ? '#CCCCCC' : '#FFF176',
+					pretext: ':wrenchin: *Soft-Failed Tests*',
+					text: softFailedTests === '' ? 'There are no soft-failed tests. :tada:' : softFailedTests,
 				},
 			],
 		};
 
+		console.log('\nskipped tests:')
 		console.log(skippedTests);
-		console.log(JSON.stringify(slackMessage, null, 2));
+		console.log('\nsoft failed tests:')
+		console.log(softFailedTests);
+		console.log('')
 
-		execSync(
-			`curl -X POST -H 'Content-type: application/json' --data '${JSON.stringify(
-				slackMessage
-			)}' ${slackWebhookUrl}`
-		);
+		// if no webhook URL is provided, just print the message and exit (most likely a dry run)
+		if (!slackWebhookUrl) {
+			console.log(slackMessage);
+			process.exit(0);
+		} else {
+			console.log(JSON.stringify(slackMessage, null, 2));
+			execSync(
+				`curl -X POST -H 'Content-type: application/json' --data '${JSON.stringify(
+					slackMessage
+				)}' ${slackWebhookUrl}`
+			);
+		}
 	} catch (error) {
 		console.error(`Error: ${error}`);
 	}


### PR DESCRIPTION
### Summary
Updating the "skipped tests" slack notification to include tests tagged with "soft fail".

https://github.com/posit-dev/positron/issues/10122

### QA Notes
Output from a dryrun:
<img width="594" height="596" alt="Screenshot 2025-10-28 at 3 49 57 PM" src="https://github.com/user-attachments/assets/8fc529f3-415a-486b-a2ab-904feab3fda8" />
