### PR TITLE
Assistant: Remove squirrelly dependency

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -12,7 +12,6 @@
         "@anthropic-ai/sdk": "^0.57.0",
         "@github/copilot-language-server": "^1.367.0",
         "@vscode/prompt-tsx": "^0.4.0-alpha.5",
-        "squirrelly": "^9.1.0",
         "vscode-languageclient": "^9.0.1",
         "yaml": "^2.8.1"
       },
@@ -4439,18 +4438,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/squirrelly": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/squirrelly/-/squirrelly-9.1.0.tgz",
-      "integrity": "sha512-kvjFqb7qzC4gX4lkqSaU8QPvUHhDLMiDpxpz7a66vjTH0JtjLJqAXbPrc7ST61EefuuuW05sne2rjGskunrF2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/squirrellyjs/squirrelly?sponsor=1"
       }
     },
     "node_modules/string-width": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -731,7 +731,6 @@
     "@anthropic-ai/sdk": "^0.57.0",
     "@github/copilot-language-server": "^1.367.0",
     "@vscode/prompt-tsx": "^0.4.0-alpha.5",
-    "squirrelly": "^9.1.0",
     "vscode-languageclient": "^9.0.1",
     "yaml": "^2.8.1"
   },

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
@@ -6,7 +6,7 @@ mode:
 order: 100
 description: Prompt for when a Python session is running
 ---
-{{@if(positron.sessions.map(function(s){return s.languageId}).includes("python"))}}
+{{@if(positron.hasPythonSession)}}
 <style-python>
 You write clean, efficient and maintainable Python code.
 

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
@@ -6,7 +6,7 @@ mode:
 order: 100
 description: Prompt for when an R session is running
 ---
-{{@if(positron.sessions.map(function(s){return s.languageId}).includes("r"))}}
+{{@if(positron.hasRSession)}}
 <style-r>
 When writing R code you generally follow tidyverse coding style and principles.
 

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -8,13 +8,217 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as yaml from 'yaml';
-import * as Sqrl from 'squirrelly';
 import { MARKDOWN_DIR } from './constants';
 import { log } from './extension.js';
 
 const PROMPT_MODE_SELECTIONS_KEY = 'positron.assistant.promptModeSelections';
 
 type StoredPromptSelectionConfig = Partial<Record<PromptMetadataMode, { file: string; enabled: boolean }[]>>;
+
+//#region Template engine
+
+/**
+ * Helper properties computed for template conditions
+ */
+interface AugmentedRenderData {
+	hasRSession: boolean;
+	hasPythonSession: boolean;
+}
+
+/**
+ * Simple template engine supporting conditionals and interpolation
+ */
+class PromptTemplateEngine {
+	/**
+	 * Augment render data with helper properties for template conditions
+	 */
+	private static augmentRenderData(data: PromptRenderData): PromptRenderData & AugmentedRenderData {
+		const hasRSession = data.sessions?.some(s => s.languageId === 'r') ?? false;
+		const hasPythonSession = data.sessions?.some(s => s.languageId === 'python') ?? false;
+
+		return {
+			...data,
+			hasRSession,
+			hasPythonSession,
+		};
+	}
+
+	/**
+	 * Resolve a value from an expression (property, string literal, or boolean literal)
+	 */
+	private static resolveValue(expr: string, data: PromptRenderData & AugmentedRenderData): unknown {
+		const trimmed = expr.trim();
+
+		// Handle string literals
+		if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+			(trimmed.startsWith(`'`) && trimmed.endsWith(`'`))) {
+			return trimmed.slice(1, -1);
+		}
+
+		// Handle boolean literals
+		if (trimmed === 'true') {
+			return true;
+		}
+		if (trimmed === 'false') {
+			return false;
+		}
+
+		// Handle property paths starting with 'positron.'
+		if (trimmed.startsWith('positron.')) {
+			const propertyPath = trimmed.slice('positron.'.length);
+			const value = propertyPath.split('.').reduce((obj, key) => obj?.[key], data as any);
+			return value;
+		}
+
+		log.warn('[PromptRender] Invalid expression, must be a literal or start with "positron.":', expr);
+		return undefined;
+	}
+
+	/**
+	 * Resolve a property path or expression from the data object
+	 */
+	private static resolveProperty(path: string, data: PromptRenderData & AugmentedRenderData): unknown {
+		let trimmed = path.trim();
+
+		// Strip outer parentheses if present
+		if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
+			trimmed = trimmed.slice(1, -1).trim();
+		}
+
+		// Handle inequality comparison
+		if (trimmed.includes('!=')) {
+			const separator = trimmed.includes('!==') ? '!==' : '!=';
+			const parts = trimmed.split(separator);
+			if (parts.length === 2) {
+				const left = PromptTemplateEngine.resolveValue(parts[0], data);
+				const right = PromptTemplateEngine.resolveValue(parts[1], data);
+				return left !== right;
+			}
+		}
+
+		// Handle equality comparison
+		if (trimmed.includes('==')) {
+			const separator = trimmed.includes('===') ? '===' : '==';
+			const parts = trimmed.split(separator);
+			if (parts.length === 2) {
+				const left = PromptTemplateEngine.resolveValue(parts[0], data);
+				const right = PromptTemplateEngine.resolveValue(parts[1], data);
+				return left === right;
+			}
+		}
+
+		// Handle negation
+		if (trimmed.startsWith('!')) {
+			return !PromptTemplateEngine.resolveProperty(trimmed.slice(1), data);
+		}
+
+		return PromptTemplateEngine.resolveValue(trimmed, data);
+	}
+
+	/**
+	 * Template parser supporting conditionals and interpolation
+	 */
+	static render(template: string, data: PromptRenderData): string {
+		const augmentedData = PromptTemplateEngine.augmentRenderData(data);
+		let pos = 0;
+		let result = '';
+
+		while (pos < template.length) {
+			// Find next template tag
+			const tagStart = template.indexOf('{{', pos);
+			if (tagStart === -1) {
+				// No more tags, append rest of template
+				result += template.slice(pos);
+				break;
+			}
+
+			// Append text before tag
+			result += template.slice(pos, tagStart);
+
+			// Check tag type
+			if (template.startsWith('{{@if(', tagStart)) {
+				// Conditional tag
+				const conditionStart = tagStart + '{{@if('.length;
+				const conditionEnd = template.indexOf(')', conditionStart);
+				if (conditionEnd === -1) {
+					log.warn('[PromptRender] Malformed {{@if tag: missing )');
+					result += template.slice(tagStart);
+					break;
+				}
+
+				const condition = template.slice(conditionStart, conditionEnd);
+				const blockStart = conditionEnd + ')}}'.length;
+
+				// Find matching {{/if}} using depth tracking
+				let depth = 1;
+				let elsePos = -1;
+				let i = blockStart;
+
+				while (i < template.length && depth > 0) {
+					if (template.startsWith('{{@if(', i)) {
+						depth++;
+						i += '{{@if('.length;
+					} else if (template.startsWith('{{#else}}', i)) {
+						if (depth === 1 && elsePos === -1) {
+							elsePos = i;
+						}
+						i += '{{#else}}'.length;
+					} else if (template.startsWith('{{/if}}', i)) {
+						depth--;
+						if (depth === 0) {
+							// Found matching {{/if}}
+							const ifBlock = elsePos === -1
+								? template.slice(blockStart, i)
+								: template.slice(blockStart, elsePos);
+							const elseBlock = elsePos === -1
+								? ''
+								: template.slice(elsePos + '{{#else}}'.length, i);
+
+							// Evaluate condition and process chosen block
+							const conditionValue = PromptTemplateEngine.resolveProperty(condition, augmentedData);
+							const chosenBlock = conditionValue ? ifBlock : elseBlock;
+							result += PromptTemplateEngine.render(chosenBlock, data);
+
+							pos = i + '{{/if}}'.length;
+							break;
+						}
+						i += '{{/if}}'.length;
+					} else {
+						i++;
+					}
+				}
+
+				if (depth > 0) {
+					log.warn('[PromptRender] Malformed {{@if tag: missing {{/if}}');
+					result += template.slice(tagStart);
+					break;
+				}
+			} else if (template.startsWith('{{', tagStart) && !template.startsWith('{{#else}}', tagStart) && !template.startsWith('{{/if}}', tagStart)) {
+				// Interpolation tag
+				const tagEnd = template.indexOf('}}', tagStart + 2);
+				if (tagEnd === -1) {
+					log.warn('[PromptRender] Malformed interpolation tag: missing }}');
+					result += template.slice(tagStart);
+					break;
+				}
+
+				const expression = template.slice(tagStart + 2, tagEnd);
+				const value = PromptTemplateEngine.resolveProperty(expression, augmentedData);
+				result += value !== undefined && value !== null ? String(value) : '';
+				pos = tagEnd + '}}'.length;
+			} else {
+				// Unexpected tag ({{#else}} or {{/if}} without matching {{@if)
+				log.warn('[PromptRender] Unexpected tag at position', tagStart);
+				result += template.slice(tagStart, tagStart + 2);
+				pos = tagStart + 2;
+			}
+		}
+
+		return result;
+	}
+}
+
+//#endregion
 
 //#region Prompt templating
 
@@ -236,7 +440,7 @@ export class PromptRenderer {
 		// Render prompt template
 		const data: PromptRenderData = { request };
 		log.trace('[PromptRender] Rendering prompt for command:', command, 'with data:', JSON.stringify(data));
-		const result = Sqrl.render(mergedContent, data, { varName: 'positron' });
+		const result = PromptTemplateEngine.render(mergedContent, data);
 
 		return {
 			content: result,
@@ -287,7 +491,7 @@ export class PromptRenderer {
 
 		// Render prompt template
 		log.trace('[PromptRender] Rendering prompt for mode:', mode, 'with data:', JSON.stringify(data));
-		const result = Sqrl.render(mergedContent, data, { varName: 'positron' }) as string;
+		const result = PromptTemplateEngine.render(mergedContent, data);
 
 		return {
 			content: result,

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -408,3 +408,80 @@ function assertContextMessage(
 		assert.strictEqual(message.content.length, 1, `Unexpected message content: ${JSON.stringify(message.content)}`);
 	}
 }
+
+suite('PositronAssistantPromptRenderer', () => {
+	let chatParticipant: PositronAssistantChatParticipant;
+	let model: TestLanguageModelChat;
+	let document: vscode.TextDocument;
+	setup(() => {
+		model = new TestLanguageModelChat();
+		const extensionContext = mock<vscode.ExtensionContext>({});
+		const participantService = new ParticipantService();
+		chatParticipant = new PositronAssistantChatParticipant(extensionContext, participantService);
+		new PromptRenderer(extensionContext);
+	});
+
+	test('Render prompt for Ask mode', async () => {
+		const request = makeChatRequest({ model, references: [] });
+		const sessions = [];
+		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatMode.Ask, { request, sessions });
+		assert.ok(metadata.mode.includes(positron.PositronChatMode.Ask), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
+		assert.ok(content.includes(`You are Positron Assistant`));
+		assert.ok(content.includes(`You are running in "Ask" mode`));
+		assert.ok(content.includes(`When the USER asks a question about Quarto`));
+		assert.ok(content.includes(`When the USER asks a question about Shiny`));
+		assert.ok(content.includes(`Start with a clear warning at the beginning of the response`));
+	});
+
+	test('Render prompt for Terminal', async () => {
+		const request = makeChatRequest({ model, references: [] });
+		const sessions = [];
+		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Terminal, { request, sessions });
+		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Terminal), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
+		assert.ok(content.includes(`Return ONLY a single line terminal command that addresses the user's question.`));
+	});
+
+	test('Render prompt for Editor', async () => {
+		const document = await vscode.workspace.openTextDocument();
+		const selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+		const wholeRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+		const editorData = new vscode.ChatRequestEditorData(document, selection, wholeRange);
+		const request = makeChatRequest({ model, references: [], location2: editorData });
+
+		const sessions = [];
+		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Editor, { request, sessions });
+		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Editor), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
+		assert.ok(content.includes(`You are Positron Assistant`));
+		assert.ok(content.includes(`The user has invoked you from the text editor.`));
+		assert.ok(content.includes(`Your goal is to generate a set of edits to the document that represent the requested change.`));
+		assert.ok(content.includes(`Start with a clear warning at the beginning of the response`));
+	});
+
+	test('Render prompt with non-empty selection and streaming edits', async () => {
+		const document = await vscode.workspace.openTextDocument();
+		const selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 10));
+		const wholeRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 10));
+		const editorData = new vscode.ChatRequestEditorData(document, selection, wholeRange);
+		const request = makeChatRequest({ model, references: [], location2: editorData });
+
+		const sessions = [];
+		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Editor, { streamingEdits: true, request, sessions });
+		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Editor), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
+		assert.ok(content.includes(`You are Positron Assistant`));
+		assert.ok(content.includes(`The user has invoked you from the text editor.`));
+		assert.ok(content.includes(`Unless otherwise directed, focus on the selected text in the \`editor\` context.`));
+	});
+
+	test('Render prompt with active session', async () => {
+		const request = makeChatRequest({ model, references: [] });
+		const sessions = [
+			mock<positron.LanguageRuntimeMetadata>({
+				languageId: 'r'
+			}),
+		];
+
+		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatMode.Agent, { streamingEdits: true, request, sessions });
+		assert.ok(metadata.mode.includes(positron.PositronChatMode.Agent), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
+		assert.ok(content.includes(`When writing R code you generally follow tidyverse coding style and principles.`));
+	});
+});


### PR DESCRIPTION
This PR makes the following changes, with the aim of removing the dependency in the Assistant extension on squirrelly:

1) Added the basic tests I described at https://github.com/posit-dev/positron/pull/9993#discussion_r2465184585, to ensure the changes behave as we expect.

2) Remove squirrelly and instead use our own basic templating engine. Currently this supports simple conditional expressions, but we might need more in the future (e.g. looping, true expression parsing). If so, we can revisit adding a true templating engine.

3) Tweak the R/Python session prompt files to work with the new simplified templating engine.

## QA

With luck, no changes to behaviour should occur. Assistant should work just as before.