### PR TITLE
e2e: fix flake in vscode import settings test

### DIFF
--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -137,8 +137,8 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 async function expectDiffToBeVisible(page: Page, visible = true) {
 	if (visible) {
 		await expect(page.getByRole('tab', { name: 'settings.json' })).toBeVisible();
-		expect(await page.getByText('<<<<<<< Existing').count()).toBeGreaterThan(0);
-		expect(await page.getByText('>>>>>>> Incoming').count()).toBeGreaterThan(0);
+		await expect(page.getByText('<<<<<<< Existing')).not.toHaveCount(0)
+		await expect(page.getByText('>>>>>>> Incoming')).not.toHaveCount(0);
 	} else {
 		await page.waitForTimeout(3000); // waiting to avoid false positive
 		await expect(page.getByRole('tab', { name: 'settings.json' })).not.toBeVisible();

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -29,7 +29,7 @@ test.use({
 });
 
 test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] }, () => {
-	test.beforeAll(async ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings, hotKeys }) => {
+	test.beforeAll(async ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings }) => {
 		await vscodeUserSettings.append({
 			'test': 'vs-code-settings',
 			'editor.fontSize': 12,


### PR DESCRIPTION
### Summary

I noticed the `import-vscode-settings.test.ts` was flaking because the diff wasn’t fully rendered before the count check ran. Updated the test to wait for locator assertions to resolve instead of evaluating them immediately.

### QA Notes

@:vscode-settings