### PR TITLE
E2E test: another reticulate fix - ensure type is visible in variables pane

### DIFF
--- a/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
+++ b/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
@@ -76,6 +76,7 @@ async function ensureVariablePresent(app: Application, variableName: string, val
 			expect(variablesMap.get(variableName)).toStrictEqual({ value: value, type: 'int' });
 			await app.workbench.layouts.enterLayout('stacked');
 		} catch (e) {
+			await app.workbench.layouts.enterLayout('stacked');
 			console.log('Resending enter key');
 			await app.workbench.console.sendEnterKey();
 			throw e;

--- a/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
+++ b/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
@@ -71,8 +71,10 @@ async function ensureVariablePresent(app: Application, variableName: string, val
 
 	await expect(async () => {
 		try {
+			await app.workbench.layouts.enterLayout('fullSizedAuxBar');
 			const variablesMap = await app.workbench.variables.getFlatVariables();
 			expect(variablesMap.get(variableName)).toStrictEqual({ value: value, type: 'int' });
+			await app.workbench.layouts.enterLayout('stacked');
 		} catch (e) {
 			console.log('Resending enter key');
 			await app.workbench.console.sendEnterKey();

--- a/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
+++ b/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
@@ -61,10 +61,10 @@ export async function verifyReticulateFunctionality(
 	}).toPass({ timeout: 20000 });
 
 	await app.workbench.console.pasteCodeToConsole('print(r.y)', true);
-	await app.workbench.console.waitForConsoleContents(value2);
+	await ensureConsoleDataPresent(app, value2);
 
 	await app.workbench.console.pasteCodeToConsole('print(z)', true);
-	await app.workbench.console.waitForConsoleContents(value3);
+	await ensureConsoleDataPresent(app, value3);
 }
 
 async function ensureVariablePresent(app: Application, variableName: string, value: string) {
@@ -77,6 +77,19 @@ async function ensureVariablePresent(app: Application, variableName: string, val
 			await app.workbench.layouts.enterLayout('stacked');
 		} catch (e) {
 			await app.workbench.layouts.enterLayout('stacked');
+			console.log('Resending enter key');
+			await app.workbench.console.sendEnterKey();
+			throw e;
+		}
+	}).toPass({ timeout: 10000 });
+}
+
+async function ensureConsoleDataPresent(app: Application, value: string) {
+
+	await expect(async () => {
+		try {
+			await app.workbench.console.waitForConsoleContents(value);
+		} catch (e) {
 			console.log('Resending enter key');
 			await app.workbench.console.sendEnterKey();
 			throw e;


### PR DESCRIPTION
Seeing failure when scraping vars because type is not visible

### QA Notes

@:reticulate @:web
