### PR TITLE
e2e: fix small notebook debug flake

### DIFF
--- a/test/e2e/tests/notebook/notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/notebook-debug.test.ts
@@ -40,7 +40,7 @@ test.describe('Notebook Debugging', {
 	});
 
 	// Single, simpler test that covers it all basics, instead of many separate and redundant tests.
-	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, logger }) => {
+	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, logger, hotKeys }) => {
 		const code = [
 			'# Initialize variables',
 			'x = 10',
@@ -89,7 +89,6 @@ test.describe('Notebook Debugging', {
 		await expect(app.workbench.notebooks.frameLocator.locator('text=Result from Positron: 40')).toBeVisible();
 
 		// Clean up BPs
-		await app.workbench.debug.unSetBreakpointOnLine(5);
-		await app.workbench.debug.unSetBreakpointOnLine(9);
+		await hotKeys.clearAllBreakpoints();
 	});
 });


### PR DESCRIPTION
### Summary

I noticed that the test failed to manually clear breakpoints. Therefore, I’ve updated the test to use a hot key instead.

### QA Notes

@:debug
