### PR TITLE
make `findTextInProject` more token-efficient

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/tools.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/tools.md
@@ -11,12 +11,4 @@ We will provide you with a collection of tools to interact with the current Posi
 
 The USER can see when you invoke a tool, so you do not need to tell the user or mention the name of tools when you use them.
 
-You prefer to use knowledge you are already provided with to infer details when assisting the USER with their request. You bias to only running tools if it is necessary to learn something in the running Positron session.
-
-You much prefer to respond to the USER with code to perform a data analysis, rather than directly trying to calculate summaries or statistics for your response.
-
-Tools with tag `high-token-usage` may result in high token usage, so redirect the USER to provide you with the information you need to answer their question without using these tools whenever possible. For example, if the USER asks about their variables or data:
-  - When `session` information is not attached to the USER's query, ask the USER to ensure a Console is running and enable the Console session context.
-  - When file `attachments` are not attached to the USER's query, ask the USER to attach relevant files as context.
-  - DO NOT construct the project tree or search for text using the tools unless the USER specifically asks you to do so.
 </tools>

--- a/extensions/positron-assistant/src/md/prompts/chat/tools.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/tools.md
@@ -11,4 +11,5 @@ We will provide you with a collection of tools to interact with the current Posi
 
 The USER can see when you invoke a tool, so you do not need to tell the user or mention the name of tools when you use them.
 
+You much prefer to respond to the USER with code to perform a data analysis, rather than directly trying to calculate summaries or statistics for your response.
 </tools>

--- a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { relativePath } from '../../../../../base/common/resources.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -123,7 +124,9 @@ export class TextSearchTool implements IToolImpl {
 		const outputLines: string[] = [];
 
 		for (const result of results) {
-			const filePath = result.resource.fsPath;
+			// Make path relative to workspace folder
+			const folder = this._workspaceContextService.getWorkspaceFolder(result.resource);
+			const filePath = folder ? (relativePath(folder.uri, result.resource) ?? result.resource.fsPath) : result.resource.fsPath;
 
 			if (!result.results?.length) {
 				continue;


### PR DESCRIPTION
Addresses #10236, related to #10129.

This PR reduces the "worst-case" number of tokens returned from a poorly specified text search from ~9,000 to ~700.

The return format for a given match used to look like:

```
"file:///Users/simoncouch/Documents/rrr/positron/cgmanifest.json\",
\"path\":\"/Users/simoncouch/Documents/rrr/positron/cgmanifest.json\",
\"scheme\":\"file\"},\"results\":[{\"previewText\":\"\\t\\t\\t\\\"
such a program is covered only if its contents constitute a work based\\\",\\n\",
\"rangeLocations\":[{\"preview\":{\"startLineNumber\":0,\"startColumn\":46,
\"endLineNumber\":0,\"endColumn\":54}
```

The return format for a given return now looks like:

```
"cgmanifest.json:180: \"such a program is covered only if its contents constitute a work based\"
```

So, in the worst-case, before:

<img width="1351" height="936" alt="text_search_result_old" src="https://github.com/user-attachments/assets/25071521-b422-46e9-9bd9-217d3f6544c8" />

After:

<img width="1342" height="926" alt="text_search_result_new" src="https://github.com/user-attachments/assets/8116bdeb-6d85-4e08-8bea-96ea1c9c7369" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
