### PR TITLE
Fix Positron Assistant startup on Windows

### DIFF
--- a/extensions/positron-assistant/src/commands/index.ts
+++ b/extensions/positron-assistant/src/commands/index.ts
@@ -48,7 +48,7 @@ function registerAssistantCommand(command: string, handler: IChatRequestHandler)
 		if (err instanceof Error) {
 			log.error(`Error retrieving metadata for command ${command}: ${err.message}`);
 		} else {
-			log.error(`Unknown error retrieving metadata for command ${command}: ${String(err)}`);
+			log.error(`Unknown error retrieving metadata for command ${command}: ${JSON.stringify(err)}`);
 		}
 		return;
 	}

--- a/extensions/positron-assistant/src/commands/index.ts
+++ b/extensions/positron-assistant/src/commands/index.ts
@@ -19,7 +19,7 @@ import {
 	PositronAssistantNotebookParticipant,
 	PositronAssistantTerminalParticipant
 } from '../participants.js';
-import { PromptRenderer } from '../promptRender.js';
+import { PromptMetadata, PromptMetadataMode, PromptRenderer } from '../promptRender.js';
 
 /**
  * A function that handles chat requests.
@@ -41,7 +41,17 @@ export interface IChatRequestHandler {
 }
 
 function registerAssistantCommand(command: string, handler: IChatRequestHandler) {
-	const metadata = PromptRenderer.getCommandMetadata(command);
+	let metadata: PromptMetadata<PromptMetadataMode[]>;
+	try {
+		metadata = PromptRenderer.getCommandMetadata(command);
+	} catch (err) {
+		if (err instanceof Error) {
+			log.error(`Error retrieving metadata for command ${command}: ${err.message}`);
+		} else {
+			log.error(`Unknown error retrieving metadata for command ${command}: ${String(err)}`);
+		}
+		return;
+	}
 	const modes = metadata.mode ?? [];
 	for (const mode of modes) {
 		switch (mode) {

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -377,7 +377,7 @@ export function activate(context: vscode.ExtensionContext) {
 				});
 			}
 		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
+			const msg = error instanceof Error ? error.message : JSON.stringify(error);
 			vscode.window.showErrorMessage(
 				vscode.l10n.t('Positron Assistant: Failed to enable assistant. {0}', [msg])
 			);

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -81,7 +81,8 @@ export class PromptRenderer {
 	 * Parse YAML frontmatter from markdown content
 	 */
 	private parseYamlFrontmatter(content: string): PromptDocument {
-		const yamlMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+		// Match both Windows and Unix line endings
+		const yamlMatch = content.match(/^---\r?\n([\s\S]*?)\n---\r?\n([\s\S]*)$/);
 
 		if (!yamlMatch) {
 			return { metadata: {}, content };

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -21,7 +21,7 @@ type StoredPromptSelectionConfig = Partial<Record<PromptMetadataMode, { file: st
 /**
  * YAML frontmatter metadata for prompt files
  */
-interface PromptMetadata<T = PromptMetadataMode | PromptMetadataMode[]> {
+export interface PromptMetadata<T = PromptMetadataMode | PromptMetadataMode[]> {
 	description?: string;
 	mode?: T;
 	tools?: string[];
@@ -30,7 +30,7 @@ interface PromptMetadata<T = PromptMetadataMode | PromptMetadataMode[]> {
 }
 
 /** Possible vales for the `mode` prompt metadata property */
-type PromptMetadataMode = positron.PositronChatMode | positron.PositronChatAgentLocation;
+export type PromptMetadataMode = positron.PositronChatMode | positron.PositronChatAgentLocation;
 
 /**
  * Parsed prompt document
@@ -146,7 +146,7 @@ export class PromptRenderer {
 	/**
 	 * Merge metadata from multiple documents
 	 */
-	private mergeMetadata(documents: ParsedPromptDocument[]) {
+	private mergeMetadata(documents: ParsedPromptDocument[]): PromptMetadata<PromptMetadataMode[]> {
 		const merged: PromptMetadata<PromptMetadataMode[]> = {};
 		const allTools = new Set<string>();
 		const allModes = new Set<PromptMetadataMode>();
@@ -188,22 +188,26 @@ export class PromptRenderer {
 	/**
 	 * Get combined prompt metadata for a specific command
 	 */
-	static getCommandMetadata(command: string) {
+	static getCommandMetadata(command: string): PromptMetadata<PromptMetadataMode[]> {
 		return PromptRenderer.instance._getCommandMetadata(command);
 	}
 
-	private _getCommandMetadata(command: string) {
+	private _getCommandMetadata(command: string): PromptMetadata<PromptMetadataMode[]> {
 		const commandsPath = path.join(MARKDOWN_DIR, 'prompts', 'commands');
 		const documents = this.loadPromptDocuments(commandsPath);
 		const matchingDocuments: ParsedPromptDocument[] = [];
+		const allCommands = new Set<string>();
 		for (const doc of documents) {
+			if (doc.metadata.command) {
+				allCommands.add(doc.metadata.command);
+			}
 			if (doc.metadata.command === command) {
 				matchingDocuments.push(doc);
 			}
 		}
 
 		if (matchingDocuments.length === 0) {
-			throw new Error(`No prompt documents found for command: ${command}`);
+			throw new Error(`No prompt documents found for command: ${command} in ${commandsPath} (available commands: ${Array.from(allCommands).join(', ')})`);
 		}
 		return this.mergeMetadata(matchingDocuments);
 	}
@@ -219,14 +223,18 @@ export class PromptRenderer {
 		const commandsPath = path.join(MARKDOWN_DIR, 'prompts', 'commands');
 		const documents = this.loadPromptDocuments(commandsPath);
 		const matchingDocuments: ParsedPromptDocument[] = [];
+		const allCommands = new Set<string>();
 		for (const doc of documents) {
+			if (doc.metadata.command) {
+				allCommands.add(doc.metadata.command);
+			}
 			if (doc.metadata.command === command) {
 				matchingDocuments.push(doc);
 			}
 		}
 
 		if (matchingDocuments.length === 0) {
-			throw new Error(`No prompt documents found for command: ${command}`);
+			throw new Error(`No prompt documents found for command: ${command} in ${commandsPath} (available commands: ${Array.from(allCommands).join(', ')})`);
 		}
 
 		// Merge prompts


### PR DESCRIPTION
This change fixes an issue that prevents Assistant from starting up on Windows. The main problem is here:

https://github.com/posit-dev/positron/blob/d3e82f32b5e6a763a226e915ea5732fdc3ee78d5/extensions/positron-assistant/src/promptRender.ts#L287-L292

This regex doesn't work on Windows since Windows uses `\r\n` for line endings, which means that
- yaml headers are not extracted, so
- yaml headers can't be parsed, so
- we can't identify which commands any of the metadata files are for, so
- no metadata is found for commands, so 
- an exception is thrown during the `activate()` method, so
- the Positron Assistant extension fails to activate, so
- the Copilot Chat extension (which lists Positron Assistant as a dependency) fails to activate so,
- no chat features work at all.

The only vital part of this change is updating the regex so it works on Windows. But I've also made a few changes to try to make this slightly more fault tolerant:
- if we fail to register a command, we log an error but don't fail activating the whole extension
- at the top level we again wrap in a try/catch; any errors here are converted to notifications but again do not block activation entirely
- more detailed logging when reading command metadata (where we were looking, what commands we did find, etc.)

Addresses #10233 