### PR TITLE
Positron Notebook fix command palette not working when in cell edit mode. 

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -119,6 +119,12 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	readonly connectedToEditor: boolean;
 
 	/**
+	 * The DOM element that contains the entire notebook editor (including toolbar, cells, etc.).
+	 * This is the top-level container for the notebook UI.
+	 */
+	readonly container: HTMLElement | undefined;
+
+	/**
 	 * Sets the DOM element that contains the entire notebook editor.
 	 * @param container The container element to set, or null to clear
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -202,6 +202,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// #endregion
 
 	/**
+	 * Public getter for the notebook editor container.
+	 * Used for focus scope checking to determine if focus is still within the notebook.
+	 */
+	get container(): HTMLElement | undefined {
+		return this._container;
+	}
+
+	/**
 	 * Event emitter for when the text model changes.
 	 */
 	private readonly _onDidChangeContent = this._register(new Emitter<void>());


### PR DESCRIPTION
Addresses #10239.

Fixes an issue where actions that moved focus outside of a notebook would cause the notebook to grab focus. This manifest in things like the command palette not being able to be opened when editing a cell because the cell would exit edit mode due to focus loss in the monaco editor, then enter select mode, which would then focus the cell container, stealing focus from the command palette and closing it. 

This PR addresses that by explicitely checking if focus is lost to something outside the editor and avoiding reacting if that's the case. 

We do this by adding a `container` property to `IPositronNotebookInstance` to track the notebook editors DOM container, allowing the Monaco widget to check whether focus is leaving the notebook entirely or just moving to a child element (like the command palette).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open any notebook (Python or R)
2. Click into a cell to enter edit mode (cursor should be blinking in the cell)
3. Press `Shift+Cmd+P` (or `Shift+Ctrl+P` on Windows/Linux) to open the command palette
4. Verify the command palette opens and stays open (does not immediately close)
5. Search for and execute any command successfully
6. Make sure after command palette closes that focus returns to cell editor. 
