### PR TITLE
Remove stray semicolon

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -784,7 +784,6 @@ export class LanguageModelsService implements ILanguageModelsService {
 			this._logService.trace('[LM] Provider models resolved, firing onDidChangeProviders', vendor);
 			this._onDidChangeProviders.fire({ added: [vendor] });
 			this._onLanguageModelChange.fire();
-;
 		});
 		// --- End Positron ---
 


### PR DESCRIPTION
This change removes a superfluous semicolon introduced in the 1.105 upstream merge, reducing Positron's semicolon count from 891,895 to 891,894. 