### PR TITLE
Fix integration test

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -694,6 +694,14 @@ export class LanguageModelsService implements ILanguageModelsService {
 				// --- Start Positron ---
 				// Track included models after applying configuration filters for logging
 				const includedModels = [];
+
+				// Get unfiltered providers from configuration
+				let unfilteredProviders =
+					this._configurationService.getValue<string[]>('positron.assistant.unfilteredProviders');
+				if (!unfilteredProviders) {
+					// If no configuration, default to known test providers
+					unfilteredProviders = ['test-lm-vendor', 'echo'];
+				}
 				// --- End Positron ---
 
 				this._clearModelCache(vendor);
@@ -705,7 +713,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 
 					// --- Start Positron ---
 					// Get and apply LLM allow filters from configuration.
-					if (vendor !== 'test-lm-vendor' && vendor !== 'echo') { // Always allow test models
+					if (unfilteredProviders.indexOf(vendor) === -1) {
 						const config = this._configurationService.getValue<{ filterModels: string[] }>('positron.assistant');
 						this._logService.trace('[LM] Applying model filters:', config.filterModels);
 						if (config.filterModels.length > 0 && !config.filterModels.some(pattern =>

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -705,13 +705,15 @@ export class LanguageModelsService implements ILanguageModelsService {
 
 					// --- Start Positron ---
 					// Get and apply LLM allow filters from configuration.
-					const config = this._configurationService.getValue<{ filterModels: string[] }>('positron.assistant');
-					this._logService.trace('[LM] Applying model filters:', config.filterModels);
-					if (config.filterModels.length > 0 && !config.filterModels.some(pattern =>
-						match(pattern, modelAndIdentifier.metadata.id) ||
-						match(pattern, modelAndIdentifier.metadata.name))
-					) {
-						continue;
+					if (vendor !== 'test-lm-vendor' && vendor !== 'echo') { // Always allow test models
+						const config = this._configurationService.getValue<{ filterModels: string[] }>('positron.assistant');
+						this._logService.trace('[LM] Applying model filters:', config.filterModels);
+						if (config.filterModels.length > 0 && !config.filterModels.some(pattern =>
+							match(pattern, modelAndIdentifier.metadata.id) ||
+							match(pattern, modelAndIdentifier.metadata.name))
+						) {
+							continue;
+						}
 					}
 					includedModels.push(modelAndIdentifier.identifier);
 					// --- End Positron ---

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -13,7 +13,7 @@ test.use({
 /**
  * Test suite for the setup of Positron Assistant.
  */
-test.describe.skip('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
+test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB, tags.CRITICAL] }, () => {
 	/**
 	 * Verifies that the Positron Assistant can be opened and that the
 	 * add model button is visible in the interface. Once Assistant is on by default,
@@ -100,7 +100,7 @@ test.describe.skip('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT,
 /**
  * Test suite Positron Assistant actions from the chat interface.
  */
-test.describe.skip('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');


### PR DESCRIPTION
Fixes an integration test regression caused by model filtering excluding test models.

Addresses https://github.com/posit-dev/positron/issues/10270.