### PR TITLE
Make Python interruptible on Windows

### DIFF
--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -182,6 +182,7 @@ if __name__ == "__main__":
 
             # Store the main thread ID so we can inject KeyboardInterrupt into it
             import ctypes
+
             main_thread_id = threading.get_ident()
 
             # Get ResetEvent to reset the event after handling
@@ -205,8 +206,7 @@ if __name__ == "__main__":
                             # This is the approach used by _thread.interrupt_main() but we ensure
                             # it targets the correct thread
                             ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                                ctypes.c_long(main_thread_id),
-                                ctypes.py_object(KeyboardInterrupt)
+                                ctypes.c_long(main_thread_id), ctypes.py_object(KeyboardInterrupt)
                             )
                             logger.info(f"KeyboardInterrupt injected, return value: {ret}")
                         except Exception as e:
@@ -216,7 +216,9 @@ if __name__ == "__main__":
             # Start the interrupt monitoring thread
             interrupt_thread = threading.Thread(target=watch_interrupt_event, daemon=True)
             interrupt_thread.start()
-            logger.info(f"Windows interrupt monitoring thread started for event handle {event_handle}")
+            logger.info(
+                f"Windows interrupt monitoring thread started for event handle {event_handle}"
+            )
 
     try:
         loop.run_forever()

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -5,7 +5,6 @@ import asyncio
 import asyncio.events
 import logging
 import os
-import signal
 import sys
 import threading
 

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -6,7 +6,6 @@ import asyncio.events
 import logging
 import os
 import sys
-import threading
 
 from positron.positron_ipkernel import (
     PositronIPKernelApp,

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -155,7 +155,10 @@ if __name__ == "__main__":
         # Log all callbacks that take longer than 0.5 seconds (the current default is too noisy).
         loop.slow_callback_duration = 0.5
 
-    # On Windows, set up interrupt event monitoring
+    # On Windows, set up interrupt event monitoring. Typically ipykernel would
+    # handle JPY_INTERRUPT_EVENT itself, but since we're running a custom event
+    # loop, it will not receive the signal, so we need to do it here and inject
+    # KeyboardInterrupt into the main thread.
     if sys.platform == "win32":
         import ctypes
         import ctypes.wintypes
@@ -191,8 +194,8 @@ if __name__ == "__main__":
                 """Thread function to watch for the Windows interrupt event."""
                 logger.info(f"Interrupt monitoring thread started, watching handle {event_handle}")
                 while True:
-                    # Wait for the event to be signaled (check every 100ms)
-                    result = WaitForSingleObject(event_handle, 100)
+                    # Wait for the event to be signaled (check every 200ms)
+                    result = WaitForSingleObject(event_handle, 200)
                     if result == WAIT_OBJECT_0:
                         logger.info("Interrupt event signaled, injecting KeyboardInterrupt")
                         try:

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -176,8 +176,6 @@ if __name__ == "__main__":
             WaitForSingleObject.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD]
             WaitForSingleObject.restype = ctypes.wintypes.DWORD
 
-            # WAIT_OBJECT_0 = 0x00000000
-            # WAIT_TIMEOUT = 0x00000102
             WAIT_OBJECT_0 = 0
 
             # Store the main thread ID so we can inject KeyboardInterrupt into it

--- a/extensions/positron-python/python_files/posit/positron_language_server.py
+++ b/extensions/positron-python/python_files/posit/positron_language_server.py
@@ -138,6 +138,10 @@ if __name__ == "__main__":
     if args.quiet:
         app.kernel.shell.banner1 = ""
 
+    # On Windows, manually start the poller thread for interrupt handling
+    if sys.platform == "win32" and app.poller is not None:
+        app.poller.start()
+
     app.kernel.start()
 
     logger.info(f"Process ID {os.getpid()}")
@@ -153,70 +157,6 @@ if __name__ == "__main__":
 
         # Log all callbacks that take longer than 0.5 seconds (the current default is too noisy).
         loop.slow_callback_duration = 0.5
-
-    # On Windows, set up interrupt event monitoring. Typically ipykernel would
-    # handle JPY_INTERRUPT_EVENT itself, but since we're running a custom event
-    # loop, it will not receive the signal, so we need to do it here and inject
-    # KeyboardInterrupt into the main thread.
-    if sys.platform == "win32":
-        import ctypes
-        import ctypes.wintypes
-
-        # Get the interrupt event handle from the environment variable
-        interrupt_event = os.environ.get("JPY_INTERRUPT_EVENT")
-        if interrupt_event:
-            logger.info(f"Setting up Windows interrupt event: {interrupt_event}")
-
-            # Convert the event handle string to an integer
-            event_handle = int(interrupt_event)
-
-            # Define Windows API functions
-            kernel32 = ctypes.windll.kernel32
-            WaitForSingleObject = kernel32.WaitForSingleObject
-            WaitForSingleObject.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD]
-            WaitForSingleObject.restype = ctypes.wintypes.DWORD
-
-            WAIT_OBJECT_0 = 0
-
-            # Store the main thread ID so we can inject KeyboardInterrupt into it
-            import ctypes
-
-            main_thread_id = threading.get_ident()
-
-            # Get ResetEvent to reset the event after handling
-            ResetEvent = kernel32.ResetEvent
-            ResetEvent.argtypes = [ctypes.wintypes.HANDLE]
-            ResetEvent.restype = ctypes.wintypes.BOOL
-
-            def watch_interrupt_event():
-                """Thread function to watch for the Windows interrupt event."""
-                logger.info(f"Interrupt monitoring thread started, watching handle {event_handle}")
-                while True:
-                    # Wait for the event to be signaled (check every 200ms)
-                    result = WaitForSingleObject(event_handle, 200)
-                    if result == WAIT_OBJECT_0:
-                        logger.info("Interrupt event signaled, injecting KeyboardInterrupt")
-                        try:
-                            # Reset the event so it can be signaled again
-                            ResetEvent(event_handle)
-
-                            # Inject KeyboardInterrupt into the main thread using ctypes
-                            # This is the approach used by _thread.interrupt_main() but we ensure
-                            # it targets the correct thread
-                            ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                                ctypes.c_long(main_thread_id), ctypes.py_object(KeyboardInterrupt)
-                            )
-                            logger.info(f"KeyboardInterrupt injected, return value: {ret}")
-                        except Exception as e:
-                            logger.error(f"Error injecting KeyboardInterrupt: {e}", exc_info=True)
-                        # Don't break - continue monitoring for future interrupts
-
-            # Start the interrupt monitoring thread
-            interrupt_thread = threading.Thread(target=watch_interrupt_event, daemon=True)
-            interrupt_thread.start()
-            logger.info(
-                f"Windows interrupt monitoring thread started for event handle {event_handle}"
-            )
 
     try:
         loop.run_forever()

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -33,6 +33,33 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE, tags.WIN] 
 
 	});
 
+	test('Python - Verify interrupt stops execution mid-work', async function ({ app, python }) {
+		// Execute code that does work in a loop and prints progress
+		const code = `
+import time
+for i in range(10):
+    print(f"Step {i}")
+    time.sleep(1)
+print("Completed all steps")
+`;
+		await app.workbench.console.executeCode('Python', code, { waitForReady: false });
+
+		// Wait for some work to be done (at least 2-3 steps)
+		await app.workbench.console.waitForConsoleContents('Step 2', { expectedCount: 1, timeout: 10000 });
+
+		// Interrupt the execution
+		await app.workbench.console.interruptExecution();
+
+		// Wait for KeyboardInterrupt to appear
+		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt', { expectedCount: 1, timeout: 5000 });
+
+		// Verify that some work was done (we saw Step 2)
+		await app.workbench.console.waitForConsoleContents('Step 2', { expectedCount: 1, timeout: 1000 });
+
+		// Verify that not all work was completed (Step 9 should not appear)
+		await app.workbench.console.waitForConsoleContents('Step 9', { expectedCount: 0, timeout: 1000 });
+	});
+
 });
 
 // This nesting is necessary because the settings fixture must be used in a


### PR DESCRIPTION
This change addresses a long-standing issue that made it impossible to interrupt Python on Windows. It is really just the last mile of the change; most of the code that makes this work was added to the kernel supervisor several months ago. 

Interrupting ipykernel on Windows is (even before this change) a byzantine process that involves creating an event object, passing its handle to the kernel in a specially named `JPY_INTERRUPT_EVENT` object, and then signaling the object from the controlling process to trigger an interrupt. 

Things are further complicated by the way that we specifically use ipykernel: because ipykernel is not running on the main thread, it doesn't pick up the event signal. 

The fix is to create a top-level loop that listens for the event on Windows, and to inject a `KeyboardInterrupt` when we get it.

Addresses #4604. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed interrupt of Python console on Windows (#4604)


### QA Notes

Note that not all Python statements are interruptible, and in particular that `time.sleep(...)` doesn't have any way to check for interrupts so isn't interruptible in Positron. In general, this change should bring us to parity with other ipykernel frontends like VS Code. 

To avoid a busy loop we only poll for interrupts every 200ms or so, so also note that interrupts won't be instantaneous.

A new test has been added to the e2e suite that checks the new behavior.