### PR TITLE
Fix detection of repos.conf for web mode

### DIFF
--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -184,6 +184,11 @@ export function createJupyterKernelSpec(
 function findReposConf(): string | undefined {
 	const xdg = require('xdg-portable/cjs');
 	const configDirs: Array<string> = xdg.configDirs();
+	// on Unix-alikes, also check /etc; RStudio uses /etc/rstudio instead of the
+	// XDG dir /etc/xdg/rstudio
+	if (process.platform !== 'win32') {
+		configDirs.push('/etc');
+	}
 	for (const product of ['rstudio', 'positron']) {
 		for (const configDir of configDirs) {
 			const reposConf = path.join(configDir, product, 'repos.conf');


### PR DESCRIPTION
Addresses the client (Positron side) of https://github.com/posit-dev/positron/issues/10094. 

In web/Workbench mode, Positron automatically uses the PPM repos if they are available, which is great -- but `repos.conf` should take priority. https://github.com/posit-dev/ark/pull/948 addressed this in ark itself; we also need this change to avoid getting the automatic PPM repos in web mode. 

### QA Notes

Despite being intended for Workbench use, `/etc/rstudio/repos.conf` applies to all Unix-alikes in both desktop and server modes. 