### PR TITLE
Fix action bar actions when editing cell in positron notebook

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/registerCellCommand.ts
@@ -39,10 +39,17 @@ export interface IRegisterCellCommandOptions {
 	/** Optional command metadata including description, args, and return type. As passed to CommandsRegistry.registerCommand. */
 	metadata?: ICommandMetadata;
 
-	/** Visibility condition using context keys (optional). Defaults to `POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED` when not specified.
-	 * When the command is not an "editMode" command, then the keybinding will only run when the cell editor is not focused.
-	 * This is equivalent to the `and(<your when condition>, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated())` condition.
-	 * This is so you dont have to specify not(editor focused) for the majority of commands.
+	/** Visibility condition using context keys (optional).
+	 *
+	 * For action bar items: The `when` condition is used as-is without modification, allowing action bar items
+	 * to remain visible and clickable even when the cell is in edit mode.
+	 *
+	 * For keybindings: The `when` condition is combined with edit mode restrictions based on the `editMode` option:
+	 * - When `editMode: false` (default): Keybindings only work when the notebook container is focused (not when cell editor is focused)
+	 * - When `editMode: true`: Keybindings work when either the container or cell editor is focused
+	 *
+	 * Note: Users should not directly include `POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED` in their `when` condition.
+	 * Edit mode restrictions are handled automatically via the `editMode` option for keybindings only.
 	*/
 	when?: ContextKeyExpression;
 
@@ -97,8 +104,9 @@ export function registerCellCommand({
 			} else {
 				// Handle single cell
 				const state = activeNotebook.selectionStateMachine.state.get();
-				// Get the selected cell and/or the editing cell if edit mode is enabled
-				const cell = getSelectedCell(state) || (editMode ? getEditingCell(state) : undefined);
+				// Always check editing cell if actionBar is present (action bar items should work in edit mode).
+				// Otherwise, only check editing cell if editMode option is enabled.
+				const cell = getSelectedCell(state) || ((actionBar || editMode) ? getEditingCell(state) : undefined);
 				if (cell) {
 					handler(cell, activeNotebook, accessor);
 				}
@@ -111,6 +119,8 @@ export function registerCellCommand({
 	// Optionally register UI metadata
 	if (actionBar) {
 		const humanReadableLabel = String(metadata?.description ?? commandId);
+		// For action bar items, use `when` as-is without adding edit mode restrictions.
+		// Edit mode restrictions are only applied to keybindings via the `editMode` option.
 		const uiItem: INotebookCellActionBarItem = {
 			commandId,
 			label: humanReadableLabel,
@@ -127,7 +137,10 @@ export function registerCellCommand({
 
 	// Optionally register keybinding
 	if (keybinding) {
-		// Determine the when condition based on edit mode
+		// Determine the when condition based on edit mode.
+		// For keybindings, we add edit mode restrictions:
+		// - When `editMode: false` (default): Only allow shortcuts when container is focused (not when cell editor is focused)
+		// - When `editMode: true`: Allow shortcuts when either container or cell editor is focused
 		const defaultCondition = editMode ?
 			ContextKeyExpr.or(
 				POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,


### PR DESCRIPTION
Addresses #10285.

This PR fixes cell action bar commands not working when a cell is in edit mode. Previously, users had to press <kbd>Escape</kbd> to exit edit mode before these actions would respond.

The fix ensures that when commands are triggered from the action bar (via mouse clicks), they can access the editing cell directly. Keybindings continue to behave as before - commands with `editMode: false` only work when the container is focused, not when the cell editor is focused.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

