### PR TITLE
E2E test: bump RHEL container images to version 57

### DIFF
--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     container:
-      image: ghcr.io/posit-dev/positron-rocky8-amd64:53
+      image: ghcr.io/posit-dev/positron-rocky8-amd64:57
       options: --user 0:0
       # Static PAT is needed because the bot can't pass a token to the job for security reasons
       credentials:
@@ -104,7 +104,7 @@ jobs:
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
     services:
       postgres:
-        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:53
+        image: ghcr.io/posit-dev/positron-postgres-rocky8-amd64:57
         credentials:
           username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
           password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}


### PR DESCRIPTION
Just bumping image versions

### QA Notes

@:rhel-web
