### PR TITLE
Check /etc/rstudio for repos.conf

### DIFF
--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -184,6 +184,11 @@ export function createJupyterKernelSpec(
 function findReposConf(): string | undefined {
 	const xdg = require('xdg-portable/cjs');
 	const configDirs: Array<string> = xdg.configDirs();
+	// on Unix-alikes, also check /etc; RStudio uses /etc/rstudio instead of the
+	// XDG dir /etc/xdg/rstudio
+	if (process.platform !== 'win32') {
+		configDirs.push('/etc');
+	}
 	for (const product of ['rstudio', 'positron']) {
 		for (const configDir of configDirs) {
 			const reposConf = path.join(configDir, product, 'repos.conf');


### PR DESCRIPTION
Backport of https://github.com/posit-dev/positron/pull/10284 for 2025.11. The release notes will indicate that this works, and it was raised by a customer, so it should be included in the patch release.

