### PR TITLE
Positron notebooks: Connect to existing notebook context keys & restart after shutdown

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -14,13 +14,14 @@ import { MainThreadNotebookEditors } from './mainThreadNotebookEditors.js';
 import { extHostCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { editorGroupToColumn } from '../../services/editor/common/editorGroupColumn.js';
 // --- Start Positron ---
-/* Swap out implementations for proxies that include Positron notebooks as well
+/* Swap out implementations for narrower interfaces fulfilled by Positron notebooks
+and proxies that include Positron notebooks as well
 import { getNotebookEditorFromEditorPane, IActiveNotebookEditor, INotebookEditor } from '../../contrib/notebook/browser/notebookBrowser.js';
 import { INotebookEditorService } from '../../contrib/notebook/browser/services/notebookEditorService.js';
 */
-import { IActiveNotebookEditor, INotebookEditor } from '../../contrib/notebook/browser/notebookBrowser.js';
 import { getNotebookEditorFromEditorPane } from '../../contrib/positronNotebook/browser/NotebookEditorProxyService.js';
 import { INotebookEditorProxyService } from '../../contrib/positronNotebook/browser/INotebookEditorProxyService.js';
+import { IExtensionApiActiveNotebookEditor as IActiveNotebookEditor, IExtensionApiNotebookEditor as INotebookEditor } from '../../contrib/positronNotebook/browser/IPositronNotebookEditor.js';
 // --- End Positron ---
 import { NotebookTextModel } from '../../contrib/notebook/common/model/notebookTextModel.js';
 import { INotebookService } from '../../contrib/notebook/common/notebookService.js';

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -11,11 +11,13 @@ import { EditorActivation } from '../../../platform/editor/common/editor.js';
 // --- Start Positron ---
 import { POSITRON_NOTEBOOK_EDITOR_ID, usingPositronNotebooks } from '../../contrib/positronNotebook/common/positronNotebookCommon.js';
 import { checkPositronNotebookEnabled } from '../../contrib/positronNotebook/browser/positronNotebookExperimentalConfig.js';
-/* Swap out implementations for proxies that include Positron notebooks as well
+/* Swap out implementations for narrower interfaces fulfilled by Positron notebooks
+and proxies that include Positron notebooks as well
 import { getNotebookEditorFromEditorPane, INotebookEditor, INotebookEditorOptions } from '../../contrib/notebook/browser/notebookBrowser.js';
 */
-import { INotebookEditor, INotebookEditorOptions } from '../../contrib/notebook/browser/notebookBrowser.js';
+import { INotebookEditorOptions } from '../../contrib/notebook/browser/notebookBrowser.js';
 import { getNotebookEditorFromEditorPane } from '../../contrib/positronNotebook/browser/NotebookEditorProxyService.js';
+import { IExtensionApiNotebookEditor as INotebookEditor } from '../../contrib/positronNotebook/browser/IPositronNotebookEditor.js';
 // --- End Positron ---
 import { INotebookEditorService } from '../../contrib/notebook/browser/services/notebookEditorService.js';
 import { ICellRange } from '../../contrib/notebook/common/notebookRange.js';

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
@@ -6,7 +6,13 @@
 import * as DOM from '../../../../../base/browser/dom.js';
 import { DisposableStore, dispose, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+// --- Start Positron ---
+/* Replace interfaces with narrower versions so that we have to implement less in Positron notebooks
 import { ICellViewModel, INotebookEditorDelegate, KERNEL_EXTENSIONS } from '../notebookBrowser.js';
+*/
+import { KERNEL_EXTENSIONS } from '../notebookBrowser.js';
+import { IContextKeysCellViewModel as ICellViewModel, IContextKeysNotebookEditor as INotebookEditorDelegate } from '../../../positronNotebook/browser/IPositronNotebookEditor.js';
+// --- End Positron ---
 import { KERNEL_HAS_VARIABLE_PROVIDER, NOTEBOOK_CELL_TOOLBAR_LOCATION, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_HAS_RUNNING_CELL, NOTEBOOK_HAS_SOMETHING_RUNNING, NOTEBOOK_INTERRUPTIBLE_KERNEL, NOTEBOOK_KERNEL, NOTEBOOK_KERNEL_COUNT, NOTEBOOK_KERNEL_SELECTED, NOTEBOOK_KERNEL_SOURCE_COUNT, NOTEBOOK_LAST_CELL_FAILED, NOTEBOOK_MISSING_KERNEL_EXTENSION, NOTEBOOK_USE_CONSOLIDATED_OUTPUT_BUTTON, NOTEBOOK_VIEW_TYPE } from '../../common/notebookContextKeys.js';
 import { ICellExecutionStateChangedEvent, IExecutionStateChangedEvent, INotebookExecutionStateService, INotebookFailStateChangedEvent, NotebookExecutionType } from '../../common/notebookExecutionStateService.js';
 import { INotebookKernelService } from '../../common/notebookKernelService.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/INotebookEditorProxyService.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/INotebookEditorProxyService.ts
@@ -3,18 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from '../../../../base/common/event.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
+import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
 
 export const INotebookEditorProxyService = createDecorator<INotebookEditorProxyService>('INotebookEditorProxyService');
 
 /**
- * Proxy that combines Positron and VSCode notebook editors behind the INotebookEditorService interface.
+ * Proxy that combines Positron and VSCode notebook editors behind a subset of the INotebookEditorService interface.
  */
-export type INotebookEditorProxyService = Pick<
-	INotebookEditorService,
-	'_serviceBrand' |
-	'listNotebookEditors' |
-	'onDidAddNotebookEditor' |
-	'onDidRemoveNotebookEditor'
->;
+export interface INotebookEditorProxyService {
+	_serviceBrand: undefined;
+
+	onDidAddNotebookEditor: Event<IPositronNotebookEditor>;
+	onDidRemoveNotebookEditor: Event<IPositronNotebookEditor>;
+	listNotebookEditors(): readonly IPositronNotebookEditor[];
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookEditor.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookEditor.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ICellViewModel, INotebookEditor, INotebookViewModel } from '../../notebook/browser/notebookBrowser.js';
+import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
+
+/**
+ * This module is our solution to partially implementing INotebookEditor
+ * to benefit from upstream features, as required.
+ *
+ * The idea is as follows:
+ *
+ * 1. We define narrower interfaces per feature e.g. IExtensionApiNotebookEditor
+ *    for integrating with the extension API.
+ * 2. We update features to depend on our narrower interfaces e.g. IExtensionApiNotebookEditor
+ *    as INotebookEditor.
+ * 3. We define a single union of all per-feature interfaces e.g. IPositronNotebookEditor.
+ * 4. Our main interfaces extend these union interfaces e.g. IPositronNotebookInstance
+ *    extends IPositronNotebookEditor.
+ *
+ * See also INotebookEditorServiceProxy.
+ */
+
+//#region Extension API
+export type IExtensionApiNotebookViewModel = Pick<INotebookViewModel, 'viewType'>;
+export type IExtensionApiCellViewModel = Pick<ICellViewModel, 'handle'>;
+export interface IExtensionApiNotebookEditor extends Pick<
+	INotebookEditor,
+	// Basic
+	| 'getId'
+	// Text model
+	| 'textModel'
+	| 'onDidChangeModel'
+	// Selected cells: vscode.NotebookEditor.selections
+	| 'getSelections'
+	| 'setSelections'
+	| 'onDidChangeSelection'
+	// Visible cells: vscode.NotebookEditor.visibleRanges
+	| 'visibleRanges'
+	| 'onDidChangeVisibleRanges'
+	// Cell structure: to retrieve a cell to be revealed and to ensure the revealed range is within the notebook length
+	| 'getLength'
+	// Reveal: to reveal a cell
+	| 'revealCellRangeInView'
+	// Focus
+	| 'onDidFocusWidget'
+> {
+	hasModel(): this is IExtensionApiActiveNotebookEditor;
+	cellAt(index: number): IExtensionApiCellViewModel | undefined;
+	getViewModel(): IExtensionApiNotebookViewModel | undefined;
+	revealInCenter(cell: IExtensionApiCellViewModel): void;
+	revealInCenterIfOutsideViewport(cell: IExtensionApiCellViewModel): Promise<void>;
+	revealInViewAtTop(cell: IExtensionApiCellViewModel): void;
+}
+export interface IExtensionApiActiveNotebookEditor extends IExtensionApiNotebookEditor {
+	cellAt(index: number): IExtensionApiCellViewModel;
+	textModel: NotebookTextModel;
+	getViewModel(): IExtensionApiNotebookViewModel;
+}
+//#endregion Extension API
+
+//#region Context keys
+export interface IContextKeysCellOutputViewModel {
+}
+export interface IContextKeysCellViewModel extends Pick<
+	ICellViewModel,
+	| 'model'
+> {
+	outputsViewModels: IContextKeysCellOutputViewModel[];
+}
+export type ContextKeysNotebookViewCellsSplice = [
+	number,
+	number,
+	IContextKeysCellViewModel[],
+];
+export interface IContextKeysNotebookViewCellsUpdateEvent {
+	readonly splices: readonly ContextKeysNotebookViewCellsSplice[];
+}
+export interface IContextKeysNotebookEditor extends Pick<
+	INotebookEditor,
+	| 'onDidChangeModel'
+	| 'textModel'
+	| 'notebookOptions'
+	| 'getDomNode'
+	| 'getLength'
+> {
+	readonly onDidChangeViewCells: Event<IContextKeysNotebookViewCellsUpdateEvent>;
+	hasModel(): this is IContextKeysActiveNotebookEditor;
+	readonly scopedContextKeyService: IContextKeyService | undefined;
+}
+export interface IContextKeysActiveNotebookEditor extends IContextKeysNotebookEditor {
+	cellAt(index: number): IContextKeysCellViewModel;
+	textModel: NotebookTextModel;
+}
+//#endregion Context keys
+
+//#region Combined
+export interface IPositronCellOutputViewModel extends IContextKeysCellOutputViewModel {
+}
+export interface IPositronCellViewModel extends IExtensionApiCellViewModel, IContextKeysCellViewModel {
+	outputsViewModels: IPositronCellOutputViewModel[];
+}
+
+export interface IPositronActiveNotebookEditor extends IExtensionApiActiveNotebookEditor, IContextKeysActiveNotebookEditor {
+	cellAt(index: number): IPositronCellViewModel;
+	hasModel(): this is IPositronActiveNotebookEditor;
+}
+
+export interface IPositronNotebookEditor extends IExtensionApiNotebookEditor, IContextKeysNotebookEditor {
+	cellAt(index: number): IPositronCellViewModel | undefined;
+	hasModel(): this is IPositronActiveNotebookEditor;
+}
+//#endregion Combined

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -14,6 +14,7 @@ import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
+import { INotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
 /**
  * Represents the possible states of a notebook's kernel connection
@@ -125,6 +126,11 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Observable of the notebook's selected kernel.
 	 */
 	readonly kernel: IObservable<RuntimeNotebookKernel | undefined>;
+
+	/**
+	 * Observable of the notebook's active runtime session.
+	 */
+	readonly runtimeSession: IObservable<INotebookLanguageRuntimeSession | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -14,7 +14,6 @@ import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
-import { INotebookLanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
 /**
  * Represents the possible states of a notebook's kernel connection
@@ -126,11 +125,6 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Observable of the notebook's selected kernel.
 	 */
 	readonly kernel: IObservable<RuntimeNotebookKernel | undefined>;
-
-	/**
-	 * Observable of the notebook's active runtime session.
-	 */
-	readonly runtimeSession: IObservable<INotebookLanguageRuntimeSession | undefined>;
 
 	/**
 	 * State machine that manages cell selection behavior and state.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -9,11 +9,11 @@ import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositr
 import { SelectionStateMachine } from './selectionMachine.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
-import { IBaseCellEditorOptions, INotebookEditor } from '../../notebook/browser/notebookBrowser.js';
+import { IBaseCellEditorOptions } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
-import { IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
+import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
 
 /**
  * Represents the possible states of a notebook's kernel connection
@@ -56,37 +56,6 @@ export enum NotebookOperationType {
 }
 
 /**
- * Subset of INotebookEditor required to integrate with the extension API,
- * so we don't have to implement the entire INotebookEditor interface (...yet)
- * See mainThreadNotebookDocumentsAndEditors.ts and mainThreadNotebookEditors.ts.
- */
-type INotebookEditorForExtensionApi = Pick<
-	INotebookEditor,
-	// Basic
-	| 'getId'
-	// Text/view model
-	| 'textModel'  // only used for .uri
-	| 'hasModel'
-	| 'getViewModel'  // only used for .viewType
-	// Selected cells: vscode.NotebookEditor.selections
-	| 'getSelections'
-	| 'setSelections'
-	| 'onDidChangeSelection'
-	// Visible cells: vscode.NotebookEditor.visibleRanges
-	| 'visibleRanges'
-	| 'onDidChangeVisibleRanges'
-	// Cell structure: to retrieve a cell to be revealed and to ensure the revealed range is within the notebook length
-	| 'getLength'
-	| 'cellAt'  // returned ICellViewModel is only used by passing to a reveal method below
-	// Reveal: to reveal a cell
-	| 'revealInCenter'
-	| 'revealCellRangeInView'
-	| 'revealInCenterIfOutsideViewport'
-	| 'revealInViewAtTop'
-	| 'onDidFocusWidget'
->;
-
-/**
  * Interface defining the public API for interacting with a Positron notebook instance.
  * This interface abstracts away the complexity of notebook management and provides
  * a clean contract for the React UI layer to interact with notebook functionality.
@@ -97,7 +66,7 @@ type INotebookEditorForExtensionApi = Pick<
  * - Controls cell selection and editing states
  * - Provides methods for common notebook operations
  */
-export interface IPositronNotebookInstance extends INotebookEditorForExtensionApi {
+export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	// ===== Properties =====
 	/**
 	 * URI of the notebook file being edited. This serves as the unique identifier
@@ -109,8 +78,6 @@ export interface IPositronNotebookInstance extends INotebookEditorForExtensionAp
 	 * The notebook view type. Only Jupyter notebooks are supported currently.
 	 */
 	readonly viewType: 'jupyter-notebook';
-
-	readonly scopedContextKeyService: IScopedContextKeyService | undefined;
 
 	/**
 	 * Indicates whether this notebook instance is currently connected to a view/editor.

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
@@ -91,15 +91,14 @@ export function KernelStatusBadge() {
 		const actions: (MenuItemAction | SubmenuItemAction)[] = [];
 		for (const [_group, groupActions] of menu.current.getActions({
 			arg: {
-				uri: notebookInstance.uri,
-				ui: true,
+				instance: notebookInstance,
 			} satisfies IPositronNotebookActionBarContext,
 			shouldForwardArgs: true,
 		})) {
 			actions.push(...groupActions);
 		}
 		return actions;
-	}, [menu, notebookInstance.uri]);
+	}, [menu, notebookInstance]);
 
 	return (
 		<ActionBarMenuButton

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -13,6 +13,7 @@ import { CellRevealType, INotebookEditorOptions } from '../../../notebook/browse
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { IOutputItemDto } from '../../../notebook/common/notebookCommon.js';
+import { IPositronCellViewModel } from '../IPositronNotebookEditor.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
@@ -26,7 +27,7 @@ export enum CellSelectionStatus {
  * Wrapper class for notebook cell that exposes the properties that the UI needs to render the cell.
  * This interface is extended to provide the specific properties for code and markdown cells.
  */
-export interface IPositronNotebookCell extends Disposable {
+export interface IPositronNotebookCell extends Disposable, IPositronCellViewModel {
 
 	/**
 	 * The kind of cell
@@ -64,19 +65,9 @@ export interface IPositronNotebookCell extends Disposable {
 	getContent(): string;
 
 	/**
-	 * The notebook text model for the cell.
-	 */
-	readonly cellModel: PositronNotebookCellTextModel;
-
-	/**
 	 * The cell's code editor widget.
 	 */
 	readonly editor: ICodeEditor | undefined;
-
-	/**
-	 * Get the handle number for cell from cell model
-	 */
-	get handleId(): number;
 
 	/**
 	 * Delete this cell
@@ -299,15 +290,4 @@ export interface NotebookCellOutputs {
 	readonly outputs: IOutputItemDto[];
 	readonly parsed: ParsedOutput;
 	preloadMessageResult?: NotebookPreloadOutputResults | undefined;
-}
-
-/**
- * Partial interface of the vscode `NotebookCellTextModel` class.
- */
-export interface PositronNotebookCellTextModel {
-	readonly uri: URI;
-	readonly handle: number;
-	readonly language: string;
-	readonly cellKind: CellKind;
-	readonly outputs: Pick<NotebookCellOutputs, 'outputId' | 'outputs'>[];
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -15,6 +15,7 @@ import { IPositronWebviewPreloadService } from '../../../../services/positronWeb
 import { pickPreferredOutputItem } from './notebookOutputUtils.js';
 import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
+import { IPositronCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
 export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implements IPositronNotebookCodeCell {
 	override kind: CellKind.Code = CellKind.Code;
@@ -35,7 +36,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	) {
 		super(cellModel, instance, _executionStateService, _textModelResolverService);
 
-		this.outputs = observableFromEvent(this, this.cellModel.onDidChangeOutputs, () => {
+		this.outputs = observableFromEvent(this, this.model.onDidChangeOutputs, () => {
 			/** @description cellOutputs */
 			return this.parseCellOutputs();
 		});
@@ -53,6 +54,10 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 		this.lastRunEndTime = this._internalMetadata.map(m => /** @description lastRunEndTime */ m.runEndTime);
 	}
 
+	override get outputsViewModels(): IPositronCellOutputViewModel[] {
+		return this.outputs.get();
+	}
+
 	/**
 	 * Turn the cell outputs into an array of NotebookCellOutputs objects that we know how to render
 	 * @returns Output list with a prefered output item parsed for rendering
@@ -60,7 +65,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	parseCellOutputs(): NotebookCellOutputs[] {
 		const parsedOutputs: NotebookCellOutputs[] = [];
 
-		this.cellModel.outputs.forEach((output) => {
+		this.model.outputs.forEach((output) => {
 			const outputItems = output.outputs || [];
 			const preferredOutputItem = pickPreferredOutputItem(outputItems);
 			if (!preferredOutputItem) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookMarkdownCell.ts
@@ -30,7 +30,7 @@ export class PositronNotebookMarkdownCell extends PositronNotebookCellGeneral im
 		// Create the markdown string observable
 		this.markdownString = observableFromEvent(
 			this,
-			this.cellModel.onDidChangeContent,
+			this.model.onDidChangeContent,
 			() => /** @description markdownString */ this.getContent()
 		);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -67,7 +67,7 @@ export function PositronNotebookComponent() {
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			<div ref={containerRef} className='positron-notebook-cells-container'>
 				{notebookCells.length ? notebookCells.map((cell, index) => <>
-					<NotebookCell key={cell.handleId} cell={cell as PositronNotebookCellGeneral} />
+					<NotebookCell key={cell.handle} cell={cell as PositronNotebookCellGeneral} />
 					<AddCellButtons index={index + 1} />
 				</>) : <div>{localize('noCells', 'No cells')}</div>
 				}

--- a/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
@@ -12,7 +12,7 @@ import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositr
  * This preserves all cell data without creating standalone text models.
  */
 export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
-	const cellModel = cell.cellModel;
+	const cellModel = cell.model;
 
 	return {
 		source: cell.getContent(),
@@ -38,7 +38,7 @@ export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
  */
 export function serializeCellsToClipboard(cells: IPositronNotebookCell[]): string {
 	const cellsData = cells.map(cell => {
-		const cellModel = cell.cellModel;
+		const cellModel = cell.model;
 
 		// Create a serializable representation of the cell
 		const cellData = {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -59,7 +59,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 		const disposables = new DisposableStore();
 
-		const language = cell.cellModel.language;
+		const language = cell.model.language;
 
 		// We need to ensure the EditorProgressService (or a fake) is available
 		// in the service collection because monaco editors will try and access

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -116,7 +116,9 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 			icon: Codicon.positronRestartRuntimeThin,
 			f1: true,
 			category,
-			precondition: ActiveNotebookHasRunningRuntime,
+			precondition: ContextKeyExpr.or(
+				NOTEBOOK_POSITRON_KERNEL_SELECTED,  // Only set in vscode notebooks
+			),
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyChord(KeyCode.Digit0, KeyCode.Digit0),
@@ -128,7 +130,7 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 					id: MenuId.NotebookToolbar,
 					group: 'navigation/execute@5',
 					order: 5,
-					when: NOTEBOOK_POSITRON_KERNEL_SELECTED,
+					when: NOTEBOOK_POSITRON_KERNEL_SELECTED
 				},
 				// Positron notebooks
 				{

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -5,7 +5,7 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyChord, KeyCode } from '../../../../base/common/keyCodes.js';
-import { isUriComponents, URI } from '../../../../base/common/uri.js';
+import { URI } from '../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -17,12 +17,15 @@ import { IProgressService, ProgressLocation } from '../../../../platform/progres
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { RuntimeExitReason } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { INotebookLanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { NotebookEditorWidget } from '../../notebook/browser/notebookEditorWidget.js';
+import { IActiveNotebookEditor } from '../../notebook/browser/notebookBrowser.js';
 import { NOTEBOOK_KERNEL } from '../../notebook/common/notebookContextKeys.js';
 import { POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from '../../positronNotebook/browser/ContextKeysManager.js';
+import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { checkPositronNotebookEnabled } from '../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
+import { PositronNotebookInstance } from '../../positronNotebook/browser/PositronNotebookInstance.js';
 import { usingPositronNotebooks } from '../../positronNotebook/common/positronNotebookCommon.js';
 import { ActiveNotebookHasRunningRuntime, isNotebookEditorInput } from '../common/activeRuntimeNotebookContextManager.js';
+import { IRuntimeNotebookKernelService } from '../common/interfaces/runtimeNotebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../common/runtimeNotebookKernelConfig.js';
 
 const category = localize2('positron.runtimeNotebookKernel.category', "Notebook");
@@ -33,26 +36,31 @@ const NOTEBOOK_POSITRON_KERNEL_SELECTED = ContextKeyExpr.regex(NOTEBOOK_KERNEL.k
 /** The context for actions run from the VSCode notebook editor toolbar. */
 interface INotebookEditorToolbarContext {
 	ui: boolean;
-	notebookEditor: NotebookEditorWidget;
+	notebookEditor: IActiveNotebookEditor;
 	source: 'notebookToolbar';
 }
 
+/** The context for actions run from the Positron notebook editor action bar. */
 export interface IPositronNotebookActionBarContext {
-	ui: boolean;
-	uri: URI;
+	/** The active notebook instance */
+	instance: IPositronNotebookInstance;
 }
 
 function isPositronNotebookActionBarContext(obj: unknown): obj is IPositronNotebookActionBarContext {
 	const context = obj as IPositronNotebookActionBarContext;
-	return !!context && typeof context.ui === 'boolean' && isUriComponents(context.uri);
+	return !!context &&
+		context.instance instanceof PositronNotebookInstance;
 }
 
 /** The context for actions in a notebook using a language runtime kernel. */
 interface IRuntimeNotebookKernelActionContext {
+	/** The notebook's URI */
+	notebookUri: URI;
+	viewType?: string;
 	/** The notebook's language runtime session, if any */
 	runtimeSession: INotebookLanguageRuntimeSession | undefined;
+	/** The source of the action */
 	source: {
-		/** The source of the action */
 		id: 'positronNotebookActionBar' | 'vscodeNotebookToolbar' | 'command';
 		/** Debug message noting the source of the action */
 		debugMessage: string;
@@ -60,44 +68,44 @@ interface IRuntimeNotebookKernelActionContext {
 }
 
 abstract class BaseRuntimeNotebookKernelAction extends Action2 {
-	abstract runWithContext(accessor: ServicesAccessor, context?: IRuntimeNotebookKernelActionContext): Promise<void>;
+	abstract runWithContext(accessor: ServicesAccessor, context: IRuntimeNotebookKernelActionContext): Promise<void>;
 
 	override async run(accessor: ServicesAccessor, context?: INotebookEditorToolbarContext | IPositronNotebookActionBarContext): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 		// Try to use the notebook URI from the context - set if run via the notebook editor toolbar.
-		let notebookUri: URI | undefined;
+		let notebookUri: URI;
 		let source: IRuntimeNotebookKernelActionContext['source'];
 		if (context) {
 			if (isPositronNotebookActionBarContext(context)) {
 				source = {
 					id: 'positronNotebookActionBar',
-					debugMessage: 'User clicked restart button in Positron notebook editor toolbar',
+					debugMessage: `User clicked ${this.desc.id} button in Positron notebook editor toolbar`,
 				};
-				notebookUri = context.uri;
+				notebookUri = context.instance.uri;
 			} else {
 				source = {
 					id: 'vscodeNotebookToolbar',
-					debugMessage: 'User clicked restart button in VSCode notebook editor toolbar'
+					debugMessage: `User clicked ${this.desc.id} button in VSCode notebook editor toolbar`
 				};
-				notebookUri = context.notebookEditor.textModel?.uri;
+				notebookUri = context.notebookEditor.textModel.uri;
 			}
 		} else {
 			source = {
 				id: 'command',
-				debugMessage: `Restart notebook kernel command ${RuntimeNotebookKernelRestartAction.ID} executed`,
+				debugMessage: `${this.desc.id} notebook kernel command executed`,
 			};
 			const activeEditor = editorService.activeEditor;
 			if (!isNotebookEditorInput(activeEditor)) {
-				throw new Error('No active notebook. This command should only be available when a notebook is active.');
+				throw new Error(`No active notebook. Command ${this.desc.id} should only be available when a notebook is active.`);
 			}
 			notebookUri = activeEditor.resource;
 		}
 
-		const runtimeSession = notebookUri && runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
+		const runtimeSession = runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
 
-		return this.runWithContext(accessor, { runtimeSession, source });
+		return this.runWithContext(accessor, { notebookUri, runtimeSession, source });
 	}
 }
 
@@ -141,16 +149,24 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 		});
 	}
 
-	override async runWithContext(accessor: ServicesAccessor, context?: IRuntimeNotebookKernelActionContext): Promise<void> {
-		const session = context?.runtimeSession;
-		if (!session) {
-			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
-		}
+	override async runWithContext(accessor: ServicesAccessor, context: IRuntimeNotebookKernelActionContext): Promise<void> {
+		const { runtimeSession: session, notebookUri } = context;
 
 		const configurationService = accessor.get(IConfigurationService);
 		const progressService = accessor.get(IProgressService);
 		const notificationService = accessor.get(INotificationService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
+
+		if (!session) {
+			if (!notebookUri) {
+				throw new Error(`No session or URI found for active notebook. Command ${this.desc.id} should only be enabled when a URI is available.`);
+			}
+
+			// If trying to restart with no active session, start a new session
+			const runtimeNotebookKernelService = accessor.get(IRuntimeNotebookKernelService);
+			await runtimeNotebookKernelService.ensureSessionStarted(notebookUri, context.source.debugMessage);
+			return;
+		}
 
 		// Restart the session.
 		try {
@@ -200,10 +216,11 @@ export class RuntimeNotebookKernelShutdownAction extends BaseRuntimeNotebookKern
 		});
 	}
 
-	override async runWithContext(accessor: ServicesAccessor, context?: IRuntimeNotebookKernelActionContext): Promise<void> {
-		const session = context?.runtimeSession;
+	override async runWithContext(accessor: ServicesAccessor, context: IRuntimeNotebookKernelActionContext): Promise<void> {
+		const session = context.runtimeSession;
 		if (!session) {
-			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
+			// If there's already no session, nothing to do
+			return;
 		}
 
 		const configurationService = accessor.get(IConfigurationService);

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -124,9 +124,7 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 			icon: Codicon.positronRestartRuntimeThin,
 			f1: true,
 			category,
-			precondition: ContextKeyExpr.or(
-				NOTEBOOK_POSITRON_KERNEL_SELECTED,  // Only set in vscode notebooks
-			),
+			precondition: NOTEBOOK_POSITRON_KERNEL_SELECTED,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyChord(KeyCode.Digit0, KeyCode.Digit0),

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -9,7 +9,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeExitReason } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { INotebookLanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
@@ -156,6 +156,22 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			// Kernel source actions are currently constant so we don't need this event.
 			onDidChangeSourceActions: undefined,
 		}));
+	}
+
+	public async ensureSessionStarted(notebookUri: URI, source: string): Promise<INotebookLanguageRuntimeSession> {
+		// Get the notebook text model
+		const notebook = this._notebookService.getNotebookTextModel(notebookUri);
+		if (!notebook) {
+			throw new Error(`Could not ensure session is started for notebook without text model: ${notebookUri}`);
+		}
+		// Get the selected kernel
+		const kernel = this.getSelectedKernel(notebook);
+		if (!kernel) {
+			throw new Error(`Could not ensure session is started for notebook without selected kernel: ${notebookUri}`);
+		}
+
+		// Ensure the kernel has a started session
+		return await kernel.ensureSessionStarted(notebook.uri, source);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.ts
@@ -6,6 +6,8 @@
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { Event } from '../../../../../base/common/event.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../../services/positronConsole/common/positronConsoleCodeExecution.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { INotebookLanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 
 // Create the decorator for the service (used in dependency injection).
 export const IRuntimeNotebookKernelService = createDecorator<IRuntimeNotebookKernelService>('runtimeNotebookKernelService');
@@ -25,4 +27,11 @@ export interface IRuntimeNotebookKernelService {
 	 * Event that is fired when code executes in any notebook.
 	 */
 	onDidExecuteCode: Event<ILanguageRuntimeCodeExecutedEvent>;
+
+	/**
+	 * Ensure that a language runtime session is started for a notebook.
+	 * @param notebookUri The URI of the notebook
+	 * @param source The source of the action for debugging purposes
+	 */
+	ensureSessionStarted(notebookUri: URI, source: string): Promise<INotebookLanguageRuntimeSession>;
 }

--- a/test/e2e/tests/notebook/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebook/notebook-kernel-behavior.test.ts
@@ -35,20 +35,19 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
 
-		// select kernel and ensure while starting, restart/shutdown are disabled
+		// select kernel and ensure while starting, restart is enabled & shutdown is disabled
 		await notebooksPositron.kernel.select('Python', { waitForReady: false });
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Restart Kernel', enabled: false },
+			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
 
-		// ensure once started and ready, restart/shutdown are enabled
+		// ensure once started and ready, shutdown is enabled
 		await notebooksPositron.kernel.expectKernelToBe({
 			kernelGroup: 'Python',
 			status: 'idle'
 		});
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: true },
 		]);
 
@@ -70,7 +69,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			status: 'disconnected'
 		});
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Restart Kernel', enabled: false },
+			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
 			{ label: 'Change Kernel', enabled: true },
 			{ label: 'Open Notebook Console', enabled: false },


### PR DESCRIPTION
This PR:

1. Connects Positron notebooks to the existing notebook context keys that are used elsewhere in core Positron (e.g. in point 3 below) and in extensions (#10296).
2. Updated the way we handle `INotebookEditor` so that we can implement different subsets of the interface for different features, we now use this for (a) extension API, and (b) notebook context keys.
3. Enables the _Restart Kernel_ command for any notebook with one of our kernels selected, even when the session is shutdown.
4. Restarting from an exited session now starts a new session (#10227).

https://github.com/user-attachments/assets/e13c8cbf-b1a3-4c1e-917f-57b269e8045d

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks