### PR TITLE
e2e: skip failing debug test

### DIFF
--- a/test/e2e/tests/notebook/positron-notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/positron-notebook-debug.test.ts
@@ -21,7 +21,7 @@ import { test, tags } from '../_test.setup.js';
 
 test.use({ suiteId: __filename });
 
-test.describe('Positron Notebook Debugging', {
+test.describe.skip('Positron Notebook Debugging', {
 	tag: [tags.WEB, tags.WIN, tags.DEBUG, tags.POSITRON_NOTEBOOKS]
 }, () => {
 


### PR DESCRIPTION
### Summary

Skipping test for now because something in #10263 caused a breaking change to debug feature.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
