### PR TITLE
assistant: make `positron.assistant.filterModels` more permissive

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -308,10 +308,10 @@
           "positron.assistant.filterModels": {
             "type": "array",
             "default": [
-              "Claude*",
-              "GPT*",
-              "anthropic/claude*",
-              "openai/gpt*"
+              "*Claude*",
+              "*GPT*",
+              "*claude*",
+              "*gpt*"
             ],
             "markdownDescription": "%configuration.filterModels.description%",
             "items": {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -717,6 +717,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 						const config = this._configurationService.getValue<{ filterModels: string[] }>('positron.assistant');
 						this._logService.trace('[LM] Applying model filters:', config.filterModels);
 						if (config.filterModels.length > 0 && !config.filterModels.some(pattern =>
+							match(pattern, modelAndIdentifier.identifier) ||
 							match(pattern, modelAndIdentifier.metadata.id) ||
 							match(pattern, modelAndIdentifier.metadata.name))
 						) {


### PR DESCRIPTION
Cherry pick https://github.com/posit-dev/positron/pull/10314 from the `release/2025.11` branch.

> - A follow up to #10168 / https://github.com/posit-dev/positron/issues/9983, which caused all 
> OpenAI models to be filtered out, resulting in the provider not showing up in the chat dropdown.
> 
> ### QA Notes
> 
> Claude and GPT models should be available by default for all providers. In particular, OpenAI should show up as a provider in chat again.