### PR TITLE
Add configuration for top action bar visibility

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -1650,7 +1650,7 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 				resetSetting('workbench.sideBar.location');
 				resetSetting('workbench.statusBar.visible');
 				// --- Start Positron ---
-				resetSetting('workbench.topActionBar.visible');
+				resetSetting(LayoutSettings.TOP_ACTION_BAR_VISIBLE);
 				// --- End Positron ---
 				resetSetting('workbench.panel.defaultLocation');
 

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -1616,9 +1616,12 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 				selectedItem = quickPick.selectedItems[0] as CustomizeLayoutItem;
 				commandService.executeCommand(selectedItem.id);
 				// --- Start Positron ---
-				// If the string workbench.action.positron starts the id then we want to
-				// close the quick pick
-				if (selectedItem.id.startsWith('workbench.action.positron')) {
+				// Close the quick pick when selecting a Positron layout preset.
+				// Layout presets follow the pattern 'workbench.action.positron<LayoutName>'
+				// (no dot after 'positron'), while other positron actions like toggles
+				// use 'workbench.action.positron.<actionName>' (with a dot after 'positron').
+				if (selectedItem.id.startsWith('workbench.action.positron') &&
+					!selectedItem.id.startsWith('workbench.action.positron.')) {
 					quickPick.hide();
 				}
 				// --- End Positron ---
@@ -1646,6 +1649,9 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 				resetSetting('workbench.activityBar.location');
 				resetSetting('workbench.sideBar.location');
 				resetSetting('workbench.statusBar.visible');
+				// --- Start Positron ---
+				resetSetting('workbench.topActionBar.visible');
+				// --- End Positron ---
 				resetSetting('workbench.panel.defaultLocation');
 
 				if (!isMacintosh || !isNative) {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -3197,6 +3197,12 @@ class LayoutStateModel extends Disposable {
 		if (configurationChangeEvent.affectsConfiguration(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION)) {
 			this.setRuntimeValueAndFire(LayoutStateKeys.SIDEBAR_POSITON, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
 		}
+
+		// --- Start Positron ---
+		if (configurationChangeEvent.affectsConfiguration('workbench.topActionBar.visible')) {
+			this.setRuntimeValueAndFire(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
+		}
+		// --- End Positron ---
 	}
 
 	private updateLegacySettingsFromState<T extends StorageKeyType>(key: RuntimeStateKey<T>, value: T): void {
@@ -3211,6 +3217,8 @@ class LayoutStateModel extends Disposable {
 			this.configurationService.updateValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE, !value);
 		} else if (key === LayoutStateKeys.SIDEBAR_POSITON) {
 			this.configurationService.updateValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION, positionToString(value as Position));
+		} else if (key === LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN) {
+			this.configurationService.updateValue('workbench.topActionBar.visible', !value);
 		}
 	}
 
@@ -3233,6 +3241,7 @@ class LayoutStateModel extends Disposable {
 		this.stateCache.set(LayoutStateKeys.ACTIVITYBAR_HIDDEN.name, this.isActivityBarHidden());
 		this.stateCache.set(LayoutStateKeys.STATUSBAR_HIDDEN.name, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
 		this.stateCache.set(LayoutStateKeys.SIDEBAR_POSITON.name, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
+		this.stateCache.set(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN.name, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
 
 		// Set dynamic defaults: part sizing and side bar visibility
 		const workbenchState = this.contextService.getWorkbenchState();
@@ -3426,6 +3435,11 @@ class LayoutStateModel extends Disposable {
 				case LayoutStateKeys.SIDEBAR_POSITON:
 					this.stateCache.set(key.name, this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left');
 					break;
+				// --- Start Positron ---
+				case LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN:
+					this.stateCache.set(key.name, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
+					break;
+				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -3199,8 +3199,8 @@ class LayoutStateModel extends Disposable {
 		}
 
 		// --- Start Positron ---
-		if (configurationChangeEvent.affectsConfiguration('workbench.topActionBar.visible')) {
-			this.setRuntimeValueAndFire(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
+		if (configurationChangeEvent.affectsConfiguration(LayoutSettings.TOP_ACTION_BAR_VISIBLE)) {
+			this.setRuntimeValueAndFire(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, !this.configurationService.getValue<boolean>(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
 		}
 		// --- End Positron ---
 	}
@@ -3218,7 +3218,7 @@ class LayoutStateModel extends Disposable {
 		} else if (key === LayoutStateKeys.SIDEBAR_POSITON) {
 			this.configurationService.updateValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION, positionToString(value as Position));
 		} else if (key === LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN) {
-			this.configurationService.updateValue('workbench.topActionBar.visible', !value);
+			this.configurationService.updateValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE, !value);
 		}
 	}
 
@@ -3241,7 +3241,7 @@ class LayoutStateModel extends Disposable {
 		this.stateCache.set(LayoutStateKeys.ACTIVITYBAR_HIDDEN.name, this.isActivityBarHidden());
 		this.stateCache.set(LayoutStateKeys.STATUSBAR_HIDDEN.name, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
 		this.stateCache.set(LayoutStateKeys.SIDEBAR_POSITON.name, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
-		this.stateCache.set(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN.name, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
+		this.stateCache.set(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN.name, !this.configurationService.getValue<boolean>(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
 
 		// Set dynamic defaults: part sizing and side bar visibility
 		const workbenchState = this.contextService.getWorkbenchState();
@@ -3437,7 +3437,7 @@ class LayoutStateModel extends Disposable {
 					break;
 				// --- Start Positron ---
 				case LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN:
-					this.stateCache.set(key.name, !this.configurationService.getValue<boolean>('workbench.topActionBar.visible'));
+					this.stateCache.set(key.name, !this.configurationService.getValue<boolean>(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
 					break;
 				// --- End Positron ---
 			}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
@@ -8,7 +8,7 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { PositronTopActionBarVisibleContext } from '../../../common/contextkeys.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, LayoutSettings, Parts } from '../../../services/layout/browser/layoutService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
@@ -20,11 +20,6 @@ export class PositronToggleTopActionBarVisibilityAction extends Action2 {
 	 * The action ID.
 	 */
 	static readonly ID = 'workbench.action.positron.toggleTopActionBarVisibility';
-
-	/**
-	 * The key for the top action bar visibility setting.
-	 */
-	private static readonly topBarVisibleKey = 'workbench.topActionBar.visible';
 
 	/**
 	 * Constructor.
@@ -59,7 +54,7 @@ export class PositronToggleTopActionBarVisibilityAction extends Action2 {
 		const visibility = layoutService.isVisible(Parts.POSITRON_TOP_ACTION_BAR_PART, mainWindow);
 		const newVisibilityValue = !visibility;
 
-		return configurationService.updateValue(PositronToggleTopActionBarVisibilityAction.topBarVisibleKey, newVisibilityValue);
+		return configurationService.updateValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE, newVisibilityValue);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -9,6 +9,8 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { PositronTopActionBarVisibleContext } from '../../../common/contextkeys.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 /**
  * The PositronToggleTopActionBarVisibilityAction.
@@ -45,9 +47,14 @@ export class PositronToggleTopActionBarVisibilityAction extends Action2 {
 	 * Runs the action.
 	 * @param accessor The ServicesAccessor.
 	 */
-	run(accessor: ServicesAccessor): void {
+	run(accessor: ServicesAccessor): Promise<void> {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
-		layoutService.setPartHidden(layoutService.isVisible(Parts.POSITRON_TOP_ACTION_BAR_PART), Parts.POSITRON_TOP_ACTION_BAR_PART);
+		const configurationService = accessor.get(IConfigurationService);
+
+		const visibility = layoutService.isVisible(Parts.POSITRON_TOP_ACTION_BAR_PART, mainWindow);
+		const newVisibilityValue = !visibility;
+
+		return configurationService.updateValue('workbench.topActionBar.visible', newVisibilityValue);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarActions.ts
@@ -22,6 +22,11 @@ export class PositronToggleTopActionBarVisibilityAction extends Action2 {
 	static readonly ID = 'workbench.action.positron.toggleTopActionBarVisibility';
 
 	/**
+	 * The key for the top action bar visibility setting.
+	 */
+	private static readonly topBarVisibleKey = 'workbench.topActionBar.visible';
+
+	/**
 	 * Constructor.
 	 */
 	constructor() {
@@ -54,7 +59,7 @@ export class PositronToggleTopActionBarVisibilityAction extends Action2 {
 		const visibility = layoutService.isVisible(Parts.POSITRON_TOP_ACTION_BAR_PART, mainWindow);
 		const newVisibilityValue = !visibility;
 
-		return configurationService.updateValue('workbench.topActionBar.visible', newVisibilityValue);
+		return configurationService.updateValue(PositronToggleTopActionBarVisibilityAction.topBarVisibleKey, newVisibilityValue);
 	}
 }
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -580,6 +580,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': true,
 				'description': localize('statusBarVisibility', "Controls the visibility of the status bar at the bottom of the workbench.")
 			},
+			// --- Start Positron ---
+			'workbench.topActionBar.visible': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('topActionBarVisibility', "Controls the visibility of the top action bar.")
+			},
+			// --- End Positron ---
 			[LayoutSettings.ACTIVITY_BAR_LOCATION]: {
 				'type': 'string',
 				'enum': ['default', 'top', 'bottom', 'hidden'],

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -581,7 +581,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('statusBarVisibility', "Controls the visibility of the status bar at the bottom of the workbench.")
 			},
 			// --- Start Positron ---
-			'workbench.topActionBar.visible': {
+			[LayoutSettings.TOP_ACTION_BAR_VISIBLE]: {
 				'type': 'boolean',
 				'default': true,
 				'description': localize('topActionBarVisibility', "Controls the visibility of the top action bar.")

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -53,7 +53,10 @@ export const enum LayoutSettings {
 	EDITOR_TABS_MODE = 'workbench.editor.showTabs',
 	EDITOR_ACTIONS_LOCATION = 'workbench.editor.editorActionsLocation',
 	COMMAND_CENTER = 'window.commandCenter',
-	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled'
+	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
+	// --- Start Positron ---
+	TOP_ACTION_BAR_VISIBLE = 'workbench.topActionBar.visible'
+	// --- End Positron ---
 }
 
 export const enum ActivityBarPosition {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6479

This PR adds a new setting `workbench.topActionBar.visible` that works very similarly to `workbench.statusBar.visible`, including maintaining a bidirectional sync with the UI and setting. If you click here in the UI:

<img width="629" height="452" alt="Screenshot_2025-11-02_at_3_39_32 PM" src="https://github.com/user-attachments/assets/3b17304c-c2d5-4645-867b-addb05e282fb" />

the setting will update in your user `settings.json`, just like how the `workbench.statusBar.visible` setting behaves. I think these two are a good comparison, because they both contain a lot of useful information, but folks may prefer to set up a more streamlined UI depending on their preferences.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added a new `workbench.topActionBar.visible` setting to control whether the Positron top bar is visible

#### Bug Fixes

- N/A


### QA Notes

- Open up your user `settings.json` so you can see it in the editor
- Open up the "Customize Layout" quickpick
- Toggle the status bar off (notice your `settings.json`) and then back on; this is existing behavior that we already have
- Now toggle the top bar off (notice your `settings.json`) and then back on; this is the new behavior that this PR adds and it should work the same
- Try putting both in your `settings.json` again and closing Positron; when you open it up again, the settings should be respected
