### PR TITLE
Add support for popping entire plots pane to an auxiliary window

### DIFF
--- a/src/vs/base/browser/positronReactRenderer.tsx
+++ b/src/vs/base/browser/positronReactRenderer.tsx
@@ -74,6 +74,11 @@ export interface IReactComponentContainer {
 	readonly onSizeChanged: Event<ISize>;
 
 	/**
+	 * onPositionChanged event (optional).
+	 */
+	readonly onPositionChanged?: Event<IElementPosition>;
+
+	/**
 	 * onVisibilityChanged event.
 	 */
 	readonly onVisibilityChanged: Event<boolean>;

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -134,7 +134,8 @@ export namespace Schemas {
 	export const positronDataExplorer = 'positron-data-explorer';
 	export const positronNotebook = 'positron-notebook';
 	export const positronPlotsEditor = 'positron-plots-editor';
-	export const positronPreviewEditor = 'positron-preview-editor'
+	export const positronPlotsGallery = 'positron-plots-gallery';
+	export const positronPreviewEditor = 'positron-preview-editor';
 
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -23,7 +23,7 @@ import { isMacintosh, isWeb } from '../../../../../base/common/platform.js';
 import { useStateRef } from '../../../../../base/browser/ui/react/useStateRef.js';
 import { FontConfigurationManager } from '../../../../browser/fontConfigurationManager.js';
 import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
-import { POSITRON_PLOTS_VIEW_ID } from '../../../../services/positronPlots/common/positronPlots.js';
+import { PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID } from '../../../../services/positronPlots/common/positronPlots.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from '../positronConsoleIdentifiers.js';
@@ -262,8 +262,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Add the onDidSelectPlot event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidSelectPlot(plotId => {
-			// Ensure that the Plots pane is visible.
-			services.viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+			// Ensure that the Plots pane is visible in the main window.
+			// Don't open the main window view if plots are displayed in the auxiliary window.
+			if (services.positronPlotsService.displayLocation === PlotsDisplayLocation.MainWindow) {
+				services.viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+			}
 
 			// Select the plot in the Plots pane.
 			services.positronPlotsService.selectPlot(plotId);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -18,12 +18,11 @@ import { PositronActionBarContextProvider } from '../../../../../platform/positr
 import { usePositronPlotsContext } from '../positronPlotsContext.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { SizingPolicyMenuButton } from './sizingPolicyMenuButton.js';
-import { HistoryPolicyMenuButton } from './historyPolicyMenuButton.js';
 import { ZoomPlotMenuButton } from './zoomPlotMenuButton.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { StaticPlotClient } from '../../../../services/positronPlots/common/staticPlotClient.js';
 import { PlotsDisplayLocation } from '../../../../services/positronPlots/common/positronPlots.js';
-import { PlotActionTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
+import { PlotActionTarget, PlotsClearAction, PlotsCopyAction, PlotsGalleryInNewWindowAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
 import { DarkFilterMenuButton } from './darkFilterMenuButton.js';
@@ -41,6 +40,7 @@ const savePlot = localize('positronSavePlot', "Save plot");
 const copyPlotToClipboard = localize('positronCopyPlotToClipboard', "Copy plot to clipboard");
 const openPlotInNewWindow = localize('positronOpenPlotInNewWindow', "Open plot in new window");
 const openInEditorTab = localize('positronOpenPlotInEditorTab', "Open in editor tab");
+const openPlotsGalleryInNewWindow = localize('positronOpenPlotsGalleryInNewWindow', "Open plots gallery in new window");
 const clearAllPlots = localize('positronClearAllPlots', "Clear all plots");
 
 /**
@@ -133,6 +133,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		services.commandService.executeCommand(PlotsPopoutAction.ID);
 	};
 
+	const openGalleryInNewWindowHandler = () => {
+		services.commandService.executeCommand(PlotsGalleryInNewWindowAction.ID);
+	};
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...props}>
@@ -210,10 +214,16 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						{enableDarkFilter &&
 							<DarkFilterMenuButton />
 						}
-						<HistoryPolicyMenuButton
-							plotsService={services.positronPlotsService}
-						/>
 						<ActionBarSeparator />
+						{props.displayLocation === PlotsDisplayLocation.MainWindow &&
+							<ActionBarButton
+								align='right'
+								ariaLabel={openPlotsGalleryInNewWindow}
+								icon={ThemeIcon.fromId('window')}
+								tooltip={openPlotsGalleryInNewWindow}
+								onPressed={openGalleryInNewWindowHandler}
+							/>
+						}
 						<ActionBarButton
 							align='right'
 							ariaLabel={clearAllPlots}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -22,6 +22,7 @@ import { HistoryPolicyMenuButton } from './historyPolicyMenuButton.js';
 import { ZoomPlotMenuButton } from './zoomPlotMenuButton.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { StaticPlotClient } from '../../../../services/positronPlots/common/staticPlotClient.js';
+import { PlotsDisplayLocation } from '../../../../services/positronPlots/common/positronPlots.js';
 import { PlotActionTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
@@ -46,6 +47,7 @@ const clearAllPlots = localize('positronClearAllPlots', "Clear all plots");
  * ActionBarsProps interface.
  */
 export interface ActionBarsProps {
+	readonly displayLocation: PlotsDisplayLocation;
 	readonly zoomHandler: (zoomLevel: number) => void;
 	readonly zoomLevel: number;
 }
@@ -90,6 +92,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const enableEditorPlot = hasPlots
 		&& (selectedPlot instanceof PlotClientInstance
 			|| selectedPlot instanceof StaticPlotClient);
+
+	// Only show the "Open in editor" button when in the main window
+	const showOpenInEditorButton = enableEditorPlot
+		&& props.displayLocation === PlotsDisplayLocation.MainWindow;
 
 	// Clear all the plots from the service.
 	const clearAllPlotsHandler = () => {
@@ -191,7 +197,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 								onPressed={popoutPlotHandler}
 							/>
 						}
-						{enableEditorPlot &&
+						{showOpenInEditorButton &&
 							<OpenInEditorMenuButton
 								ariaLabel={openInEditorTab}
 								commandService={services.commandService}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -9,12 +9,13 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { PositronPlotsViewPane } from './positronPlotsView.js';
 import { PositronPlotsService } from './positronPlotsService.js';
-import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from '../../../services/positronPlots/common/positronPlots.js';
+import { IPositronPlotsService, POSITRON_PLOTS_LOCATION_CONTEXT, POSITRON_PLOTS_VIEW_ID, PlotsDisplayLocation } from '../../../services/positronPlots/common/positronPlots.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { MenuRegistry, registerAction2, MenuId, ISubmenuItem } from '../../../../platform/actions/common/actions.js';
@@ -45,6 +46,8 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 			canToggleVisibility: false,
 			canMoveView: true,
 			containerIcon: positronPlotViewIcon,
+			// Only show the view when plots are displayed in the main window
+			when: ContextKeyExpr.equals(POSITRON_PLOTS_LOCATION_CONTEXT.key, PlotsDisplayLocation.MainWindow),
 			openCommandActionDescriptor: {
 				id: 'workbench.action.positron.togglePlots',
 				mnemonicTitle: nls.localize({ key: 'miTogglePlots', comment: ['&& denotes a mnemonic'] }, "&&Plots"),

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -18,7 +18,7 @@ import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from '../../../services
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { MenuRegistry, registerAction2, MenuId, ISubmenuItem } from '../../../../platform/actions/common/actions.js';
-import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsEditorZoomAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction, PlotsSizingPolicyAction, ZoomFiftyAction, ZoomOneHundredAction, ZoomSeventyFiveAction, ZoomToFitAction, ZoomTwoHundredAction } from './positronPlotsActions.js';
+import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsEditorZoomAction, PlotsCopyAction, PlotsEditorAction, PlotsGalleryInNewWindowAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction, PlotsSizingPolicyAction, ZoomFiftyAction, ZoomOneHundredAction, ZoomSeventyFiveAction, ZoomToFitAction, ZoomTwoHundredAction } from './positronPlotsActions.js';
 import { POSITRON_SESSION_CONTAINER } from '../../positronSession/browser/positronSessionContainer.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -74,6 +74,7 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 		registerAction2(PlotsClearAction);
 		registerAction2(PlotsPopoutAction);
 		registerAction2(PlotsEditorAction);
+		registerAction2(PlotsGalleryInNewWindowAction);
 		registerAction2(PlotsActiveEditorCopyAction);
 		registerAction2(PlotsActiveEditorSaveAction);
 		registerAction2(PlotsSizingPolicyAction);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -179,6 +179,21 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				type: 'boolean',
 				default: true,
 				description: localize('plots.frozenSlowPlotsSetting', "Freeze slow to generate plots at a fixed size to avoid re-rendering on viewport changes, improving responsiveness of the IDE when working with complex charts."),
+			},
+			'plots.historyPolicy': {
+				type: 'string',
+				default: 'auto',
+				enum: [
+					'always',
+					'auto',
+					'never'
+				],
+				enumDescriptions: [
+					localize('plots.historyPolicyAlways', 'Always show the plot history filmstrip'),
+					localize('plots.historyPolicyAuto', 'Automatically show the plot history filmstrip when there are multiple plots and sufficient space'),
+					localize('plots.historyPolicyNever', 'Never show the plot history filmstrip')
+				],
+				description: localize('plots.historyPolicySetting', "When the plot history filmstrip is visible."),
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -79,6 +79,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 	const [visible, setVisible] = useState(props.reactComponentContainer.containerVisible);
 	const [showHistory, setShowHistory] = useState(computeHistoryVisibility(services.positronPlotsService.historyPolicy));
 	const [darkFilterMode, setDarkFilterMode] = useState(services.positronPlotsService.darkFilterMode);
+	const [displayLocation, setDisplayLocation] = useState(services.positronPlotsService.displayLocation);
 	const [zoom, setZoom] = useState(ZoomLevel.Fit);
 
 	// Add IReactComponentContainer event handlers.
@@ -128,6 +129,11 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 			setDarkFilterMode(mode);
 		}));
 
+		// Add the event handler for display location changes.
+		disposableStore.add(services.positronPlotsService.onDidChangeDisplayLocation(location => {
+			setDisplayLocation(location);
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
 	}, [computeHistoryVisibility, services.positronPlotsService, props.reactComponentContainer]);
@@ -164,6 +170,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 			<ActionBars
 				{...props}
 				key={services.positronPlotsService.selectedPlotId}
+				displayLocation={displayLocation}
 				zoomHandler={zoomHandler}
 				zoomLevel={zoom}
 			/>

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -15,14 +15,14 @@ import { HistoryPolicy, isZoomablePlotClient, ZoomLevel } from '../../../service
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { PlotsContainer } from './components/plotsContainer.js';
 import { ActionBars } from './components/actionBars.js';
-import { PositronPlotsViewPane } from './positronPlotsView.js';
+import { IReactComponentContainer } from '../../../../base/browser/positronReactRenderer.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 
 /**
  * PositronPlotsProps interface.
  */
 export interface PositronPlotsProps {
-	readonly reactComponentContainer: PositronPlotsViewPane;
+	readonly reactComponentContainer: IReactComponentContainer;
 }
 
 /**
@@ -93,11 +93,13 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 			setShowHistory(computeHistoryVisibility(services.positronPlotsService.historyPolicy));
 		}));
 
-		// Add the onSizeChanged event handler.
-		disposableStore.add(props.reactComponentContainer.onPositionChanged(pos => {
-			setPosX(pos.x);
-			setPosY(pos.y);
-		}));
+		// Add the onPositionChanged event handler (if available).
+		if (props.reactComponentContainer.onPositionChanged) {
+			disposableStore.add(props.reactComponentContainer.onPositionChanged(pos => {
+				setPosX(pos.x);
+				setPosY(pos.y);
+			}));
+		}
 
 		// Add the onVisibilityChanged event handler.
 		disposableStore.add(props.reactComponentContainer.onVisibilityChanged(visible => {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -17,8 +17,7 @@ import { PLOT_IS_ACTIVE_EDITOR } from '../../positronPlotsEditor/browser/positro
 import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/positronPlotsEditorInput.js';
 import { PositronPlotsGalleryEditorInput } from '../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js';
 import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
-import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, PlotsDisplayLocation, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -456,19 +455,15 @@ export class PlotsGalleryInNewWindowAction extends Action2 {
 
 	/**
 	 * Runs the action and opens the plots gallery in a new auxiliary window.
-	 * Hides the plots view in the main window to ensure plots only appear in one location.
+	 * The context key automatically hides the plots view in the main window.
 	 *
 	 * @param accessor The service accessor.
 	 */
 	async run(accessor: ServicesAccessor) {
 		const editorService = accessor.get(IEditorService);
 		const plotsService = accessor.get(IPositronPlotsService);
-		const viewsService = accessor.get(IViewsService);
 
-		// Close the plots view in the main window
-		viewsService.closeView(POSITRON_PLOTS_VIEW_ID);
-
-		// Update the display location
+		// Update the display location (context key will automatically hide the main window view)
 		plotsService.setDisplayLocation(PlotsDisplayLocation.AuxiliaryWindow);
 
 		// Open the plots gallery in the auxiliary window

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -15,6 +15,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { PLOT_IS_ACTIVE_EDITOR } from '../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/positronPlotsEditorInput.js';
+import { PositronPlotsGalleryEditorInput } from '../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js';
 import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
@@ -459,7 +460,6 @@ export class PlotsGalleryInNewWindowAction extends Action2 {
 	 */
 	async run(accessor: ServicesAccessor) {
 		const editorService = accessor.get(IEditorService);
-		const { PositronPlotsGalleryEditorInput } = await import('../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js');
 
 		await editorService.openEditor({
 			resource: PositronPlotsGalleryEditorInput.getNewEditorUri(),

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -18,6 +18,7 @@ import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/posi
 import { PositronPlotsGalleryEditorInput } from '../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js';
 import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, PlotsDisplayLocation, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
+import { EditorsOrder } from '../../../common/editor.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -455,6 +456,7 @@ export class PlotsGalleryInNewWindowAction extends Action2 {
 
 	/**
 	 * Runs the action and opens the plots gallery in a new auxiliary window.
+	 * If the gallery is already open, focuses the existing window instead of creating a new one.
 	 * The context key automatically hides the plots view in the main window.
 	 *
 	 * @param accessor The service accessor.
@@ -462,6 +464,18 @@ export class PlotsGalleryInNewWindowAction extends Action2 {
 	async run(accessor: ServicesAccessor) {
 		const editorService = accessor.get(IEditorService);
 		const plotsService = accessor.get(IPositronPlotsService);
+
+		// Check if there's already a plots gallery editor open
+		const editors = editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE);
+		const existingGalleryEditor = editors.find(editor =>
+			editor.editor instanceof PositronPlotsGalleryEditorInput
+		);
+
+		if (existingGalleryEditor) {
+			// Focus the existing gallery editor
+			await editorService.openEditor(existingGalleryEditor.editor, existingGalleryEditor.groupId);
+			return;
+		}
 
 		// Update the display location (context key will automatically hide the main window view)
 		plotsService.setDisplayLocation(PlotsDisplayLocation.AuxiliaryWindow);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -17,7 +17,8 @@ import { PLOT_IS_ACTIVE_EDITOR } from '../../positronPlotsEditor/browser/positro
 import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/positronPlotsEditorInput.js';
 import { PositronPlotsGalleryEditorInput } from '../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js';
 import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
-import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
+import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -455,12 +456,22 @@ export class PlotsGalleryInNewWindowAction extends Action2 {
 
 	/**
 	 * Runs the action and opens the plots gallery in a new auxiliary window.
+	 * Hides the plots view in the main window to ensure plots only appear in one location.
 	 *
 	 * @param accessor The service accessor.
 	 */
 	async run(accessor: ServicesAccessor) {
 		const editorService = accessor.get(IEditorService);
+		const plotsService = accessor.get(IPositronPlotsService);
+		const viewsService = accessor.get(IViewsService);
 
+		// Close the plots view in the main window
+		viewsService.closeView(POSITRON_PLOTS_VIEW_ID);
+
+		// Update the display location
+		plotsService.setDisplayLocation(PlotsDisplayLocation.AuxiliaryWindow);
+
+		// Open the plots gallery in the auxiliary window
 		await editorService.openEditor({
 			resource: PositronPlotsGalleryEditorInput.getNewEditorUri(),
 			options: {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -15,7 +15,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { PLOT_IS_ACTIVE_EDITOR } from '../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/positronPlotsEditorInput.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPlotClient, IPositronPlotsService, isZoomablePlotClient, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -434,6 +434,43 @@ export class PlotsEditorAction extends Action2 {
 		} else {
 			accessor.get(INotificationService).info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 		}
+	}
+}
+
+/**
+ * Action to open the plots gallery in a new window.
+ */
+export class PlotsGalleryInNewWindowAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.openGalleryInNewWindow';
+
+	constructor() {
+		super({
+			id: PlotsGalleryInNewWindowAction.ID,
+			title: localize2('positronPlots.openGalleryInNewWindow', 'Open Plots Gallery in New Window'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and opens the plots gallery in a new auxiliary window.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const editorService = accessor.get(IEditorService);
+		const { PositronPlotsGalleryEditorInput } = await import('../../positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.js');
+
+		await editorService.openEditor({
+			resource: PositronPlotsGalleryEditorInput.getNewEditorUri(),
+			options: {
+				pinned: true,
+				auxiliary: {
+					compact: true,
+					bounds: { width: 900, height: 700 }
+				}
+			}
+		}, AUX_WINDOW_GROUP);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -10,7 +10,7 @@ import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutpu
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { HTMLFileSystemProvider } from '../../../../platform/files/browser/htmlFileSystemProvider.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotRenderFormat, PlotRenderSettings, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
+import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotRenderFormat, PlotRenderSettings, PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { StaticPlotClient } from '../../../services/positronPlots/common/staticPlotClient.js';
 import { IStorageService, StorageTarget, StorageScope } from '../../../../platform/storage/common/storage.js';
@@ -135,6 +135,12 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 	/** The emitter for the _sizingPolicyEmitter event */
 	private readonly _onDidChangeSizingPolicyEmitter = new Emitter<IPositronPlotSizingPolicy>;
+
+	/** The emitter for the onDidChangeDisplayLocation event */
+	private readonly _onDidChangeDisplayLocationEmitter = new Emitter<PlotsDisplayLocation>();
+
+	/** The current display location of the plots pane */
+	private _displayLocation: PlotsDisplayLocation = PlotsDisplayLocation.MainWindow;
 
 	/** The ID Of the currently selected plot, if any */
 	private _selectedPlotId: string | undefined;
@@ -520,6 +526,28 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 	get darkFilterMode() {
 		return this._selectedDarkFilterMode;
+	}
+
+	/**
+	 * Gets the current display location.
+	 */
+	get displayLocation(): PlotsDisplayLocation {
+		return this._displayLocation;
+	}
+
+	/**
+	 * Event fired when the display location changes.
+	 */
+	readonly onDidChangeDisplayLocation: Event<PlotsDisplayLocation> = this._onDidChangeDisplayLocationEmitter.event;
+
+	/**
+	 * Sets the display location of the plots pane.
+	 */
+	setDisplayLocation(location: PlotsDisplayLocation): void {
+		if (this._displayLocation !== location) {
+			this._displayLocation = location;
+			this._onDidChangeDisplayLocationEmitter.fire(location);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -465,7 +465,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	private _showPlotsPane() {
-		this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+		// Only open the plots view in the main window if that's where plots are currently displayed.
+		// If plots are in the auxiliary window, don't open the main window view.
+		if (this._displayLocation === PlotsDisplayLocation.MainWindow) {
+			this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+		}
 	}
 
 	openPlotInNewWindow(): void {

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { localize } from '../../../../nls.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { EditorExtensions } from '../../../common/editor.js';
+import { PositronPlotsGalleryEditor } from './positronPlotsGalleryEditor.js';
+import { PositronPlotsGalleryEditorInput } from './positronPlotsGalleryEditorInput.js';
+import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
+
+/**
+ * Contribution that registers the Positron Plots Gallery editor.
+ */
+class PositronPlotsGalleryEditorContribution extends Disposable {
+	static readonly ID = 'workbench.contrib.positronPlotsGalleryEditor';
+
+	constructor(
+		@IEditorResolverService editorResolverService: IEditorResolverService,
+		@IInstantiationService instantiationService: IInstantiationService
+	) {
+		super();
+
+		// Register the editor resolver
+		this._register(editorResolverService.registerEditor(
+			`${Schemas.positronPlotsGallery}:**/**`,
+			{
+				id: PositronPlotsGalleryEditorInput.EditorID,
+				label: localize('positronPlotsGalleryEditor', 'Plots Gallery'),
+				priority: RegisteredEditorPriority.builtin
+			},
+			{
+				singlePerResource: false, // Allow multiple instances
+				canSupportResource: resource => resource.scheme === Schemas.positronPlotsGallery
+			},
+			{
+				createEditorInput: ({ resource, options }) => {
+					return {
+						editor: instantiationService.createInstance(
+							PositronPlotsGalleryEditorInput
+						),
+						options: {
+							...options,
+							// Always pin the editor
+							pinned: true
+						}
+					};
+				}
+			}
+		));
+	}
+}
+
+// Register the editor pane
+Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
+	EditorPaneDescriptor.create(
+		PositronPlotsGalleryEditor,
+		PositronPlotsGalleryEditorInput.EditorID,
+		'Plots Gallery',
+	),
+	[
+		new SyncDescriptor(PositronPlotsGalleryEditorInput)
+	]
+);
+
+// Register the contribution
+registerWorkbenchContribution2(
+	PositronPlotsGalleryEditorContribution.ID,
+	PositronPlotsGalleryEditorContribution,
+	WorkbenchPhase.AfterRestored
+);
+
+// Context key for when the plots gallery editor is active
+export const PLOTS_GALLERY_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', PositronPlotsGalleryEditorInput.EditorID);

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
@@ -12,7 +12,8 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
-import { EditorExtensions } from '../../../common/editor.js';
+import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../../../common/editor.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
 import { PositronPlotsGalleryEditor } from './positronPlotsGalleryEditor.js';
 import { PositronPlotsGalleryEditorInput } from './positronPlotsGalleryEditorInput.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
@@ -58,6 +59,47 @@ class PositronPlotsGalleryEditorContribution extends Disposable {
 		));
 	}
 }
+
+/**
+ * Serializer for the Positron Plots Gallery editor.
+ * Enables better behavior when restoring the editor state.
+ */
+class PositronPlotsGalleryEditorSerializer implements IEditorSerializer {
+	/**
+	 * Determines if this editor input can be serialized at all.
+	 */
+	canSerialize(): boolean {
+		return true;
+	}
+
+	/**
+	 * Serializes the editor input.
+	 * We store minimal data - just a marker that this editor existed.
+	 */
+	serialize(input: EditorInput): string | undefined {
+		if (!(input instanceof PositronPlotsGalleryEditorInput)) {
+			return undefined;
+		}
+
+		// Minimal serialization - just indicate this editor existed
+		return JSON.stringify({ existed: true });
+	}
+
+	/**
+	 * Deserializes the editor input.
+	 * Recreates the plots gallery editor when restoring from saved state.
+	 */
+	deserialize(instantiationService: IInstantiationService, serialized: string): EditorInput | undefined {
+		// Recreate the editor input
+		return instantiationService.createInstance(PositronPlotsGalleryEditorInput);
+	}
+}
+
+// Register the editor serializer
+Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
+	PositronPlotsGalleryEditorInput.TypeID,
+	PositronPlotsGalleryEditorSerializer
+);
 
 // Register the editor pane
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.ts
@@ -38,7 +38,7 @@ class PositronPlotsGalleryEditorContribution extends Disposable {
 				priority: RegisteredEditorPriority.builtin
 			},
 			{
-				singlePerResource: false, // Allow multiple instances
+				singlePerResource: true,
 				canSupportResource: resource => resource.scheme === Schemas.positronPlotsGallery
 			},
 			{

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.css
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.css
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-plots-gallery-editor {
+	height: 100%;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './positronPlotsGalleryEditor.css';
+
 // React.
 import React from 'react';
 

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
@@ -126,6 +126,10 @@ export class PositronPlotsGalleryEditor extends EditorPane implements IReactComp
 		// Call the base class
 		await super.setInput(input, options, context, token);
 
+		// Set the display location to auxiliary window
+		// This ensures plots appear in this editor, not in the main window view, if it is open
+		this._positronPlotsService.setDisplayLocation(PlotsDisplayLocation.AuxiliaryWindow);
+
 		// If we don't have a React renderer yet, create one and render the PositronPlots component
 		if (!this._reactRenderer) {
 			this._reactRenderer = this._register(new PositronReactRenderer(this._container));

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import * as DOM from '../../../../base/browser/dom.js';
+import { IReactComponentContainer, ISize, IElementPosition, PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
+import { EditorPane } from '../../../browser/parts/editor/editorPane.js';
+import { IEditorOpenContext } from '../../../common/editor.js';
+import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
+import { PositronPlotsGalleryEditorInput } from './positronPlotsGalleryEditorInput.js';
+import { PositronPlots } from '../../positronPlots/browser/positronPlots.js';
+
+/**
+ * PositronPlotsGalleryEditor class.
+ * This editor displays the full Positron plots gallery (thumbnails, navigation, controls)
+ * and can be opened in the main window or in an auxiliary window.
+ */
+export class PositronPlotsGalleryEditor extends EditorPane implements IReactComponentContainer {
+	//#region Private Properties
+
+	// The main container element
+	private readonly _container: HTMLElement;
+
+	// The React renderer
+	private _reactRenderer?: PositronReactRenderer;
+
+	// The width and height
+	private _width = 0;
+	private _height = 0;
+
+	// Event emitters for the IReactComponentContainer interface
+	private readonly _onSizeChangedEmitter = this._register(new Emitter<ISize>());
+	private readonly _onPositionChangedEmitter = this._register(new Emitter<IElementPosition>());
+	private readonly _onVisibilityChangedEmitter = this._register(new Emitter<boolean>());
+	private readonly _onSaveScrollPositionEmitter = this._register(new Emitter<void>());
+	private readonly _onRestoreScrollPositionEmitter = this._register(new Emitter<void>());
+	private readonly _onFocusedEmitter = this._register(new Emitter<void>());
+
+	//#endregion Private Properties
+
+	//#region IReactComponentContainer Implementation
+
+	get width() {
+		return this._width;
+	}
+
+	get height() {
+		return this._height;
+	}
+
+	get containerVisible() {
+		return this.isVisible();
+	}
+
+	takeFocus(): void {
+		this.focus();
+	}
+
+	readonly onSizeChanged = this._onSizeChangedEmitter.event;
+	readonly onPositionChanged = this._onPositionChangedEmitter.event;
+	readonly onVisibilityChanged: Event<boolean> = this._onVisibilityChangedEmitter.event;
+	readonly onSaveScrollPosition: Event<void> = this._onSaveScrollPositionEmitter.event;
+	readonly onRestoreScrollPosition: Event<void> = this._onRestoreScrollPositionEmitter.event;
+	readonly onFocused: Event<void> = this._onFocusedEmitter.event;
+
+	//#endregion IReactComponentContainer Implementation
+
+	//#region Constructor
+
+	constructor(
+		readonly _group: IEditorGroup,
+		@IStorageService storageService: IStorageService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IThemeService themeService: IThemeService,
+	) {
+		super(
+			PositronPlotsGalleryEditorInput.EditorID,
+			_group,
+			telemetryService,
+			themeService,
+			storageService
+		);
+
+		// Create the container
+		this._container = DOM.$('.positron-plots-gallery-editor');
+	}
+
+	//#endregion Constructor
+
+	//#region EditorPane Overrides
+
+	protected override createEditor(parent: HTMLElement): void {
+		// Append the container
+		parent.appendChild(this._container);
+	}
+
+	override async setInput(
+		input: PositronPlotsGalleryEditorInput,
+		options: IEditorOptions | undefined,
+		context: IEditorOpenContext,
+		token: CancellationToken
+	): Promise<void> {
+		// Call the base class
+		await super.setInput(input, options, context, token);
+
+		// If we don't have a React renderer yet, create one and render the PositronPlots component
+		if (!this._reactRenderer) {
+			this._reactRenderer = this._register(new PositronReactRenderer(this._container));
+			this._reactRenderer.render(
+				<PositronPlots reactComponentContainer={this} />
+			);
+		}
+
+		// Fire visibility changed event
+		this._onVisibilityChangedEmitter.fire(this.isVisible());
+	}
+
+	override clearInput(): void {
+		// Fire visibility changed event
+		this._onVisibilityChangedEmitter.fire(false);
+
+		// Call the base class
+		super.clearInput();
+	}
+
+	override layout(dimension: DOM.Dimension): void {
+		// Update dimensions
+		this._width = dimension.width;
+		this._height = dimension.height;
+
+		// Fire size changed event
+		this._onSizeChangedEmitter.fire({
+			width: dimension.width,
+			height: dimension.height
+		});
+
+		// Fire position changed event
+		const bounding = this._container.getBoundingClientRect();
+		this._onPositionChangedEmitter.fire({
+			x: bounding.x,
+			y: bounding.y
+		});
+	}
+
+	override focus(): void {
+		super.focus();
+		this._onFocusedEmitter.fire();
+	}
+
+	//#endregion EditorPane Overrides
+}

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
@@ -20,6 +20,8 @@ import { IEditorOpenContext } from '../../../common/editor.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { PositronPlotsGalleryEditorInput } from './positronPlotsGalleryEditorInput.js';
 import { PositronPlots } from '../../positronPlots/browser/positronPlots.js';
+import { IPositronPlotsService, PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID } from '../../../services/positronPlots/common/positronPlots.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
 
 /**
  * PositronPlotsGalleryEditor class.
@@ -83,6 +85,8 @@ export class PositronPlotsGalleryEditor extends EditorPane implements IReactComp
 		@IStorageService storageService: IStorageService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
+		@IPositronPlotsService private readonly _positronPlotsService: IPositronPlotsService,
+		@IViewsService private readonly _viewsService: IViewsService,
 	) {
 		super(
 			PositronPlotsGalleryEditorInput.EditorID,
@@ -94,6 +98,14 @@ export class PositronPlotsGalleryEditor extends EditorPane implements IReactComp
 
 		// Create the container
 		this._container = DOM.$('.positron-plots-gallery-editor');
+	}
+
+	override dispose(): void {
+		// Restore the plots view in the main window when this editor is closed
+		this._positronPlotsService.setDisplayLocation(PlotsDisplayLocation.MainWindow);
+		this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+
+		super.dispose();
 	}
 
 	//#endregion Constructor

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.tsx
@@ -20,8 +20,7 @@ import { IEditorOpenContext } from '../../../common/editor.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { PositronPlotsGalleryEditorInput } from './positronPlotsGalleryEditorInput.js';
 import { PositronPlots } from '../../positronPlots/browser/positronPlots.js';
-import { IPositronPlotsService, PlotsDisplayLocation, POSITRON_PLOTS_VIEW_ID } from '../../../services/positronPlots/common/positronPlots.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IPositronPlotsService, PlotsDisplayLocation } from '../../../services/positronPlots/common/positronPlots.js';
 
 /**
  * PositronPlotsGalleryEditor class.
@@ -86,7 +85,6 @@ export class PositronPlotsGalleryEditor extends EditorPane implements IReactComp
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@IPositronPlotsService private readonly _positronPlotsService: IPositronPlotsService,
-		@IViewsService private readonly _viewsService: IViewsService,
 	) {
 		super(
 			PositronPlotsGalleryEditorInput.EditorID,
@@ -102,8 +100,8 @@ export class PositronPlotsGalleryEditor extends EditorPane implements IReactComp
 
 	override dispose(): void {
 		// Restore the plots view in the main window when this editor is closed
+		// The context key will automatically show the view
 		this._positronPlotsService.setDisplayLocation(PlotsDisplayLocation.MainWindow);
-		this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
 
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { EditorInputCapabilities, IUntypedEditorInput } from '../../../common/editor.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
+import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
+
+export interface IPositronPlotsGalleryEditorOptions {
+	// Future: Add options for initial state like selected plot, zoom level, etc.
+}
+
+/**
+ * Editor input for the Positron Plots Gallery editor.
+ * This displays the full plots pane (with thumbnails, navigation, etc.) in an editor or auxiliary window.
+ */
+export class PositronPlotsGalleryEditorInput extends EditorInput {
+	static readonly ID = 'workbench.input.positronPlotsGallery';
+	static readonly EditorID = 'workbench.editor.positronPlotsGallery';
+
+	private static _counter = 0;
+
+	/**
+	 * The resource associated with this editor input.
+	 */
+	readonly resource = URI.from({
+		scheme: Schemas.positronPlotsGallery,
+		path: `plots-gallery-${PositronPlotsGalleryEditorInput._counter++}`
+	});
+
+	/**
+	 * Gets a new URI for a plots gallery editor.
+	 */
+	static getNewEditorUri(): URI {
+		return URI.from({
+			scheme: Schemas.positronPlotsGallery,
+			path: `plots-gallery-${PositronPlotsGalleryEditorInput._counter++}`
+		});
+	}
+
+	constructor(
+		@IPositronPlotsService _positronPlotsService: IPositronPlotsService
+	) {
+		super();
+	}
+
+	override get editorId(): string {
+		return PositronPlotsGalleryEditorInput.EditorID;
+	}
+
+	override get typeId(): string {
+		return PositronPlotsGalleryEditorInput.ID;
+	}
+
+	override get capabilities(): EditorInputCapabilities {
+		return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton;
+	}
+
+	override getName(): string {
+		return localize('positronPlotsGallery.editorName', "Plots Gallery");
+	}
+
+	override getDescription(): string | undefined {
+		return localize('positronPlotsGallery.editorDescription', "View and manage plots");
+	}
+
+	override matches(otherInput: EditorInput | IUntypedEditorInput): boolean {
+		return otherInput instanceof PositronPlotsGalleryEditorInput;
+	}
+}

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
@@ -24,22 +24,26 @@ export class PositronPlotsGalleryEditorInput extends EditorInput {
 	private static _counter = 0;
 
 	/**
-	 * The resource associated with this editor input.
+	 * Creates a new URI for a plots gallery editor instance.
 	 */
-	readonly resource = URI.from({
-		scheme: Schemas.positronPlotsGallery,
-		path: `plots-gallery-${PositronPlotsGalleryEditorInput._counter++}`
-	});
-
-	/**
-	 * Gets a new URI for a plots gallery editor.
-	 */
-	static getNewEditorUri(): URI {
+	private static _createUri(): URI {
 		return URI.from({
 			scheme: Schemas.positronPlotsGallery,
 			path: `plots-gallery-${PositronPlotsGalleryEditorInput._counter++}`
 		});
 	}
+
+	/**
+	 * Gets a new URI for a plots gallery editor.
+	 */
+	static getNewEditorUri(): URI {
+		return PositronPlotsGalleryEditorInput._createUri();
+	}
+
+	/**
+	 * The resource associated with this editor input.
+	 */
+	readonly resource = PositronPlotsGalleryEditorInput._createUri();
 
 	constructor() {
 		super();

--- a/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
+++ b/src/vs/workbench/contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditorInput.ts
@@ -8,7 +8,6 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { EditorInputCapabilities, IUntypedEditorInput } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
-import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 
 export interface IPositronPlotsGalleryEditorOptions {
 	// Future: Add options for initial state like selected plot, zoom level, etc.
@@ -19,7 +18,7 @@ export interface IPositronPlotsGalleryEditorOptions {
  * This displays the full plots pane (with thumbnails, navigation, etc.) in an editor or auxiliary window.
  */
 export class PositronPlotsGalleryEditorInput extends EditorInput {
-	static readonly ID = 'workbench.input.positronPlotsGallery';
+	static readonly TypeID = 'workbench.input.positronPlotsGallery';
 	static readonly EditorID = 'workbench.editor.positronPlotsGallery';
 
 	private static _counter = 0;
@@ -42,9 +41,7 @@ export class PositronPlotsGalleryEditorInput extends EditorInput {
 		});
 	}
 
-	constructor(
-		@IPositronPlotsService _positronPlotsService: IPositronPlotsService
-	) {
+	constructor() {
 		super();
 	}
 
@@ -53,7 +50,7 @@ export class PositronPlotsGalleryEditorInput extends EditorInput {
 	}
 
 	override get typeId(): string {
-		return PositronPlotsGalleryEditorInput.ID;
+		return PositronPlotsGalleryEditorInput.TypeID;
 	}
 
 	override get capabilities(): EditorInputCapabilities {

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -9,8 +9,18 @@ import { IPlotSize, IPositronPlotSizingPolicy } from './sizingPolicy.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IPositronPlotMetadata } from '../../languageRuntime/common/languageRuntimePlotClient.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 
 export const POSITRON_PLOTS_VIEW_ID = 'workbench.panel.positronPlots';
+
+/**
+ * Context key that tracks where plots are currently displayed.
+ * Value is 'MainWindow' or 'AuxiliaryWindow'
+ */
+export const POSITRON_PLOTS_LOCATION_CONTEXT = new RawContextKey<string>(
+	'positronPlotsLocation',
+	'MainWindow'
+);
 
 export const POSITRON_PLOTS_SERVICE_ID = 'positronPlotsService';
 

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -88,6 +88,16 @@ export const isZoomablePlotClient = (obj: any): obj is IZoomablePlotClient => {
 };
 
 /**
+ * The location where the plots pane is currently being displayed.
+ */
+export enum PlotsDisplayLocation {
+	/** Plots are displayed in the main window (auxiliary bar view pane) */
+	MainWindow = 'main',
+	/** Plots are displayed in an auxiliary window */
+	AuxiliaryWindow = 'auxiliary'
+}
+
+/**
  * Creates a suggested file name for a plot.
  * @param storageService The storage service to use.
  * @returns A suggested file name for the plot.
@@ -334,6 +344,23 @@ export interface IPositronPlotsService {
 	 * @param settings The new settings.
 	 */
 	setPlotsRenderSettings(settings: PlotRenderSettings): void;
+
+	/**
+	 * Gets the current display location of the plots pane.
+	 */
+	readonly displayLocation: PlotsDisplayLocation;
+
+	/**
+	 * Notifies subscribers when the display location changes.
+	 */
+	readonly onDidChangeDisplayLocation: Event<PlotsDisplayLocation>;
+
+	/**
+	 * Sets the display location of the plots pane.
+	 *
+	 * @param location The new display location.
+	 */
+	setDisplayLocation(location: PlotsDisplayLocation): void;
 
 	/**
 	 * Placeholder for service initialization.

--- a/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
+++ b/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
@@ -5,7 +5,7 @@
 
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
-import { IPositronPlotsService, IPositronPlotClient, HistoryPolicy, DarkFilter, PlotRenderSettings } from '../../common/positronPlots.js';
+import { IPositronPlotsService, IPositronPlotClient, HistoryPolicy, DarkFilter, PlotRenderSettings, PlotsDisplayLocation } from '../../common/positronPlots.js';
 import { IPositronPlotSizingPolicy } from '../../common/sizingPolicy.js';
 import { IPositronPlotMetadata } from '../../../languageRuntime/common/languageRuntimePlotClient.js';
 
@@ -54,6 +54,11 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	private _selectedDarkFilterMode: DarkFilter = DarkFilter.Auto;
 
 	/**
+	 * Gets or sets the current display location.
+	 */
+	private _displayLocation: PlotsDisplayLocation = PlotsDisplayLocation.MainWindow;
+
+	/**
 	 * The onDidEmitPlot event emitter.
 	 */
 	private readonly _onDidEmitPlotEmitter =
@@ -98,6 +103,12 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	/** The emitter for the _sizingPolicyEmitter event */
 	private readonly _onDidChangeSizingPolicyEmitter =
 		this._register(new Emitter<IPositronPlotSizingPolicy>());
+
+	/**
+	 * The onDidChangeDisplayLocation event emitter.
+	 */
+	private readonly _onDidChangeDisplayLocationEmitter =
+		this._register(new Emitter<PlotsDisplayLocation>());
 
 	//#endregion Private Properties
 
@@ -169,6 +180,13 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	}
 
 	/**
+	 * Gets the current display location.
+	 */
+	get displayLocation(): PlotsDisplayLocation {
+		return this._displayLocation;
+	}
+
+	/**
 	 * The onDidEmitPlot event.
 	 */
 	readonly onDidEmitPlot = this._onDidEmitPlotEmitter.event;
@@ -207,6 +225,11 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	 * The onDidChangeSizingPolicy event.
 	 */
 	readonly onDidChangeSizingPolicy = this._onDidChangeSizingPolicyEmitter.event;
+
+	/**
+	 * The onDidChangeDisplayLocation event.
+	 */
+	readonly onDidChangeDisplayLocation = this._onDidChangeDisplayLocationEmitter.event;
 
 	/**
 	 * Gets the cached plot thumbnail URI for a given plot ID.
@@ -366,6 +389,16 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	setDarkFilterMode(mode: DarkFilter): void {
 		this._selectedDarkFilterMode = mode;
 		this._onDidChangeDarkFilterModeEmitter.fire(mode);
+	}
+
+	/**
+	 * Sets the display location.
+	 */
+	setDisplayLocation(location: PlotsDisplayLocation): void {
+		if (this._displayLocation !== location) {
+			this._displayLocation = location;
+			this._onDidChangeDisplayLocationEmitter.fire(location);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -311,6 +311,7 @@ import './contrib/positronPreview/browser/positronPreview.contribution.js';
 import './contrib/positronPreviewEditor/browser/positronPreviewEditor.contribution.js';
 import './contrib/positronPlots/browser/positronPlots.contribution.js';
 import './contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
+import './contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.contribution.js';
 import './contrib/positronOutputWebview/browser/notebookOutputWebview.contribution.js';
 import './contrib/positronNotebook/browser/positronNotebook.contribution.js';
 import './contrib/positronWelcome/browser/positronWelcome.contribution.js';


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7054

I was playing around with the existing _Chat: New Chat Window_ command and it made me curious how difficult it would be to wire up the plots pane functionality in the same way. The main architectural thing here is that the plots UI would then need to render in two pretty different container types, a view pane (where it currently lives) and an editor pane (which provides a whole bunch of existing functionality for auxiliary windows). To do this, I (with Claude Code's help) changed from using `PositronPlotsViewPane` to plain old `IReactComponentContainer`. The `PositronPlots` component was **already only using** properties from `IReactComponentContainer`:
- `width`, `height`, `containerVisible`
- `onSizeChanged`, `onVisibilityChanged`, `onPositionChanged`
- `takeFocus()`

It was **not** using any `PositronPlotsViewPane`-specific functionality like:
- View pane lifecycle methods
- Panel rendering internals
- ViewDescriptor properties

I _think_ this is a good way to go, so that we can render the plots UI in both of these types of places?

### Some questions:

- Right now, all the plots content is mirrored in both places. Do we like this? Or do we want to move it all to the auxiliary window, and then back?
- Right now, all the plot actions are the same in both places. Do we like this? Do any of them not make sense in the auxiliary window (such as "Open in new window")?
- Do we like "Plots Gallery" as a name for this?
- Right now, this is _only_ available as a command from the command palette. I think I'd like to go with that at first, before surfacing this on the UI after we get some use on it. Thoughts?

@:plots

### Release Notes

#### New Features

- Added new command _Plots: Open Plots Gallery in New Window_ to open the whole Plots pane UI in an auxiliary window. You can also pop out the new standalone window from the plots action bar.
- Added new setting `plots.historyPolicy` to control the when the plot history filmstrip is visible.

#### Bug Fixes

- N/A


### QA Notes

- Make a handful of plots, with both R and Python
- Run the new command _Plots: Open Plots Gallery in New Window_ (or click the new button) to pop out a duplicate of the whole Plots pane UI into an auxiliary window
- Check that all the same actions on the plots work, as they do when in the main window
- The Plots pane should pop back to the default location when you close the auxiliary window
- The new setting `plots.historyPolicy` now controls the behavior of the plot history filmstrip

It doesn't look to me like we currently have any way to do automated tests any auxiliary window functionality; this might be something for us to put on the backlog.
