### PR TITLE
Assistant: make getProjectTree more token-efficient

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -612,15 +612,14 @@
       {
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
-        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files and folders. Empty folders are not included in the tree.",
+        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files. Empty folders are not included in the tree. Always specify targeted include patterns to focus on relevant files (e.g., 'src/**/*.py', 'tests/**').",
         "icon": "$(file-directory)",
         "toolReferenceName": "projectTree",
         "userDescription": "Get the project tree of the current workspace.",
         "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
-          "requires-workspace",
-          "high-token-usage"
+          "requires-workspace"
         ],
         "inputSchema": {
           "type": "object",
@@ -631,10 +630,7 @@
                 "type": "string",
                 "description": "A Glob pattern to include in the project tree. Only the files and folders matching these patterns will be considered. If files are also matched by the `excludes` patterns, they will be filtered out."
               },
-              "description": "Glob patterns to include in the project tree. By default, all files and folders in the workspace will be considered.",
-              "default": [
-                "**/*"
-              ]
+              "description": "Glob patterns to include in the project tree. This parameter is required. Use specific patterns to target relevant files (e.g., ['src/**/*.ts'], ['*.py', 'tests/**'])."
             },
             "exclude": {
               "type": "array",
@@ -667,9 +663,12 @@
             "maxFiles": {
               "type": "number",
               "description": "The maximum number of files to include in the project tree. If this limit is reached, a compressed description of the project will be provided instead.",
-              "default": 500
+              "default": 50
             }
-          }
+          },
+          "required": [
+            "include"
+          ]
         }
       },
       {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -612,7 +612,7 @@
       {
         "name": "getProjectTree",
         "displayName": "Get Project Tree",
-        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files. Empty folders are not included in the tree. Always specify targeted include patterns to focus on relevant files (e.g., 'src/**/*.py', 'tests/**').",
+        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files. Empty folders are not included in the tree.",
         "icon": "$(file-directory)",
         "toolReferenceName": "projectTree",
         "userDescription": "Get the project tree of the current workspace.",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -662,7 +662,7 @@
             },
             "maxFiles": {
               "type": "number",
-              "description": "The maximum number of files to include in the project tree. If this limit is reached, a compressed description of the project will be provided instead.",
+              "description": "The maximum number of files to include in the project tree (<=50). If this limit is reached, a compressed description of the project will be provided instead.",
               "default": 50
             }
           },

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -126,7 +126,15 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 			.sort((a, b) => a.localeCompare(b)) // Resort alphabetically
 			.join('\n'));
 
-		return new vscode.LanguageModelToolResult(results.map(r => new vscode.LanguageModelTextPart(r)));
+		const resultParts = results.map(r => new vscode.LanguageModelTextPart(r));
+
+		if (totalFiles > filesLimit) {
+			const truncatedCount = Math.min(filesLimit, totalFiles);
+			const truncationMessage = `Project tree constructed with ${totalFiles} items; the first ${truncatedCount} are provided above.`;
+			resultParts.push(new vscode.LanguageModelTextPart(truncationMessage));
+		}
+
+		return new vscode.LanguageModelToolResult(resultParts);
 	}
 });
 

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -56,7 +56,11 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 
 		log.trace(`[${PositronAssistantToolName.ProjectTree}] Invoked with options: ${JSON.stringify(options.input, null, 2)}`);
 
-		const filePatterns = include ?? DEFAULT_INCLUDE_PATTERNS;
+		if (!include || include.length === 0) {
+			throw new Error(`The 'include' parameter is required. Specify glob patterns to target specific files (e.g., ["src/**/*.py"], ["*.ts", "tests/**"]).`);
+		}
+
+		const filePatterns = include;
 		const excludePatterns = exclude ?? [];
 		const filterResultsEnabled = filterResults ?? DEFAULT_FILTER_RESULTS;
 		const filesLimit = maxFiles ?? DEFAULT_MAX_FILES;
@@ -141,11 +145,10 @@ function getExcludeSettingOptions(excludeSetting: string) {
 }
 
 // Default values for the project tree tool options
-const DEFAULT_MAX_FILES = 500;
+const DEFAULT_MAX_FILES = 50;
 const DEFAULT_FILTER_RESULTS = true;
 const DEFAULT_USE_IGNORE_FILES = { local: true, parent: true, global: true };
 const DEFAULT_EXCLUDE_SETTING_OPTIONS = vscode.ExcludeSettingOptions.SearchAndFilesExclude;
-const DEFAULT_INCLUDE_PATTERNS = ['**/*'];
 const DEFAULT_EXCLUDE_PATTERNS = [
 	// Directories
 	'**/.build/**',

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -63,7 +63,11 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 		const filePatterns = include;
 		const excludePatterns = exclude ?? [];
 		const filterResultsEnabled = filterResults ?? DEFAULT_FILTER_RESULTS;
-		const filesLimit = maxFiles ?? DEFAULT_MAX_FILES;
+		// Don't allow more than the default max files, even if a higher value is provided,
+		// to prevent excessive token usage.
+		const filesLimit = maxFiles && maxFiles < DEFAULT_MAX_FILES
+			? maxFiles
+			: DEFAULT_MAX_FILES;
 
 		let findOptions: vscode.FindFiles2Options;
 		if (filterResultsEnabled) {


### PR DESCRIPTION
Addresses #10348, PR 3/3 of the epic #10129.

Makes four changes:

1) Newly _requires_ an `include` pattern. The model can of course set the previous default `**/*` if it chooses, but in most cases it likely actually wants a smaller set of results. This follow's Claude Code and Codex's lead.
2) Reduce `DEFAULT_MAX_FILES` from 500 to 50.
3) Make 50 a hard limit rather than a soft one, [as is the case with the text search tool](https://github.com/posit-dev/positron/blob/fe0ff76860dd34165396d7578bd660c8f969ab9a/src/vs/workbench/contrib/chat/browser/tools/textSearchTool.ts#L106-L110)—models can't set a higher number.
4) While the model was told that results would be truncated in its prompt, it had no way of knowing whether a given result was truncated or not. We now notify the model when results are truncated with a message like "Project tree constructed with 432369 items; the first 50 are provided above."

Mostly via 2), our worst-case result is reduced from something like ~4,000 tokens down to 400.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Assistant: improve token efficiency of project tree tool (#10348)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->



<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

