### PR TITLE
Fix assistant flake

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -115,10 +115,12 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 	});
 
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.clickCloseButton();
+		await expect(async () => {
+			await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
+			await app.workbench.assistant.selectModelProvider('echo');
+			await app.workbench.assistant.clickSignOutButton();
+			await app.workbench.assistant.clickCloseButton();
+		}).toPass({ timeout: 30000 });
 	});
 	/**
 	 * Tests that Python code from chat responses can be executed in the console.

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -29,7 +29,8 @@ test.describe('Reticulate', {
 		}
 	});
 
-	test('R - Verify Reticulate Stop/Start Functionality', {
+	// Skippiing due to https://github.com/posit-dev/positron/issues/10345
+	test.skip('R - Verify Reticulate Stop/Start Functionality', {
 		tag: [tags.ARK]
 	}, async function ({ app, sessions, r }) {
 

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -29,8 +29,7 @@ test.describe('Reticulate', {
 		}
 	});
 
-	// Skippiing due to https://github.com/posit-dev/positron/issues/10345
-	test.skip('R - Verify Reticulate Stop/Start Functionality', {
+	test('R - Verify Reticulate Stop/Start Functionality', {
 		tag: [tags.ARK]
 	}, async function ({ app, sessions, r }) {
 


### PR DESCRIPTION
The `afterAll` for the assistant tests can fail when quickInput doesn't open.  This just adds a retry.

See https://github.com/posit-dev/positron/actions/runs/19049636797

Ran 3x with no errors on web where it failed the most.

## QA Notes
@:assistant