### PR TITLE
Bump the rstudio.rstudio-workbench extension to 1.6.29 in 2025.11

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -766,7 +766,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "d91392f0fd471b1ce2a396fcd677658736286acd",
+        "hashed_secret": "5bc62ec0e125310dab00565277a5fa1bab6793d9",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1403,5 +1403,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-29T23:53:58Z"
+  "generated_at": "2025-11-03T22:18:30Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.6.27",
+			"version": "1.6.29",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "eb80dcd8732c0ef24cdc303943c103fb219b9ca2fef59c8a9df9ebba79dbc67c",
+			"sha256": "b73085c6e6ffb6b1cb2c3e6c028fca1998421b06a4b76f48f2e64682f8211bf0",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
This PR bumps workbench extension to 1.6.29 in release/2025.11

This is essentially a backport of https://github.com/posit-dev/positron/pull/10298
