### PR TITLE
Positron notebooks: fall back to dev error icon; use icon in runtime status

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/icon.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/icon.tsx
@@ -14,6 +14,9 @@ import { asCSSUrl } from '../../../../base/browser/cssValue.js';
 import { ThemeIcon as ThemeIconClass } from '../../../../base/common/themables.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { asCssVariable } from '../../../theme/common/colorUtils.js';
+import { editorErrorForeground } from '../../../theme/common/colorRegistry.js';
 
 /**
  * IconProps interface.
@@ -21,6 +24,7 @@ import { usePositronReactServicesContext } from '../../../../base/browser/positr
 interface IconProps {
 	readonly icon: IconType;
 	readonly className?: string;
+	readonly style?: React.CSSProperties,
 }
 
 /**
@@ -29,6 +33,7 @@ interface IconProps {
 interface ThemeIconProps {
 	readonly icon: ThemeIconClass;
 	readonly className?: string;
+	readonly style?: React.CSSProperties,
 }
 
 /**
@@ -37,6 +42,7 @@ interface ThemeIconProps {
 interface URIIconProps {
 	readonly icon: { dark?: URI; light?: URI };
 	readonly className?: string;
+	readonly style?: React.CSSProperties,
 }
 
 /**
@@ -50,6 +56,7 @@ const ThemeIcon = (props: ThemeIconProps) => {
 	return (
 		<div
 			className={positronClassNames(props.className, ...iconClassNames)}
+			style={props.style}
 		/>
 	);
 };
@@ -91,7 +98,7 @@ const URIIcon = (props: URIIconProps) => {
 	return (
 		<div
 			className={props.className}
-			style={iconStyle}
+			style={{ ...props.style, ...iconStyle }}
 		/>
 	);
 };
@@ -104,8 +111,25 @@ const URIIcon = (props: URIIconProps) => {
  */
 export const Icon = (props: IconProps) => {
 	if (ThemeIconClass.isThemeIcon(props.icon)) {
-		return <ThemeIcon className={props.className} icon={props.icon} />;
+		return <ThemeIcon
+			className={props.className}
+			icon={props.icon}
+			style={props.style}
+		/>;
 	} else {
-		return <URIIcon className={props.className} icon={props.icon} />;
+		return <URIIcon
+			className={props.className}
+			icon={props.icon}
+			style={props.style}
+		/>;
 	}
 };
+
+/** An icon representing a developer error. */
+export const DevErrorIcon = () => {
+	// Blank icon with an easy-to-catch background color for debugging
+	return <Icon
+		icon={Codicon.blank}
+		style={{ backgroundColor: asCssVariable(editorErrorForeground) }}
+	/>;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
@@ -16,6 +16,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../../platform/theme/common/iconRegistry.js';
 import { localize } from '../../../../../nls.js';
 import { asCssVariable, ColorIdentifier } from '../../../../../platform/theme/common/colorUtils.js';
+import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
 
 export const enum RuntimeStatus {
 	Active = 'Active',
@@ -59,16 +60,13 @@ export interface RuntimeStatusIconProps {
 
 export const RuntimeStatusIcon = ({ status }: RuntimeStatusIconProps) => {
 	const icon = statusToIcon[status];
-	const className = ThemeIcon.asClassName(icon);
-	const color = statusToIconColor[status];
-	const colorCss = asCssVariable(color);
-	return (
-		<span
-			className={className}
-			style={{
-				color: colorCss,
-				animation: status === RuntimeStatus.Active ? 'spin 2s linear infinite' : undefined
-			}}
-		/>
-	);
+	const colorId = statusToIconColor[status];
+	const color = asCssVariable(colorId);
+	return <Icon
+		icon={icon}
+		style={{
+			animation: status === RuntimeStatus.Active ? 'spin 2s linear infinite' : undefined,
+			color,
+		}}
+	/>
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -9,8 +9,7 @@ import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
-import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
-import { Codicon } from '../../../../../../base/common/codicons.js';
+import { DevErrorIcon, Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 
 /**
  * Standardized action button component for notebook cell actions. Handles cell selection and command execution.
@@ -40,8 +39,10 @@ export function CellActionButton({ action, cell }: { action: MenuItemAction | Su
 			tooltip={action.tooltip}
 			onPressed={() => handleActionClick(action)}
 		>
-			{/* Default to a warning symbol as a dev warning - we shouldn't have cell actions without icons */}
-			{<Icon icon={action.item.icon ?? Codicon.warning} />}
+			{action.item.icon ?
+				<Icon icon={action.item.icon} /> :
+				// Cell actions should have icons; this is a developer error
+				<DevErrorIcon />}
 		</ActionButton>
 	);
 }


### PR DESCRIPTION
Follow up to address @dhruvisompura's great suggestion in https://github.com/posit-dev/positron/pull/10276. This adds a `DevErrorIcon` component that uses the `blank` codicon with background color set to the foreground error color for easier debugging.

For example, when removing the `trash` icon from the delete cell action:

<img width="244" height="138" alt="image" src="https://github.com/user-attachments/assets/4cb715d8-6bf5-45d0-8c01-aac3fc03a816" />

Also a tiny refactor to use `Icon` in `RuntimeStatus`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:positron-notebooks @:web