### PR TITLE
e2e: adding more notebook kernel-related tests

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -746,6 +746,18 @@ export class Kernel {
 	}
 
 	/**
+	 * Action: Open the notebook session scratchpad in console.
+	 */
+	async openNotebookConsole(): Promise<void> {
+		await test.step('Open notebook console', async () => {
+			await this.contextMenu.triggerAndClick({
+				menuTrigger: this.statusBadge,
+				menuItemLabel: /Open Notebook Console/
+			});
+		});
+	}
+
+	/**
 	 * Action: Select notebook kernel and optionally wait for it to be ready
 	 */
 	async select(

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -140,8 +140,8 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		const { notebooksPositron } = app.workbench;
 
 		// start multiple sessions and select R
-		await sessions.start(['python', 'r']);
-		await sessions.select('r');
+		const [, rSession] = await sessions.start(['python', 'r']);
+		await sessions.select(rSession.id);
 
 		// create new notebook and ensure R kernel is auto-selected (from foreground) and started
 		await notebooksPositron.newNotebook();
@@ -157,8 +157,8 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		const rRnotebook = path.join('workspaces', 'r_notebooks', 'Introduction+to+R.ipynb');
 
 		// start multiple sessions and select R
-		await sessions.start(['python', 'r']);
-		await sessions.select('r');
+		const [, rSession] = await sessions.start(['python', 'r']);
+		await sessions.select(rSession.id);
 
 		// open existing python notebook and ensure python kernel is auto-selected (from background) and started
 		await notebooksPositron.openNotebook(pythonNotebook);
@@ -178,8 +178,8 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 	test('ensure notebook console attaches and terminates with active kernel', async function ({ app, sessions }) {
 		const { notebooksPositron, console } = app.workbench;
 
-		await sessions.start(['python', 'r']);
-		await sessions.select('r');
+		const [, rSession] = await sessions.start(['python', 'r']);
+		await sessions.select(rSession.id);
 
 		// create new notebook
 		await notebooksPositron.newNotebook();


### PR DESCRIPTION
### Summary
Added additional e2e test coverage for positron notebook kernel behavior:
* preferred kernel for new notebooks
* preferred kernel for existing notebooks
* opening the notebook console attaches it to the active notebook’s session 

### QA Notes

@:positron-notebooks @:web @:win
