### PR TITLE
Unpin `uv` in e2e workflows

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -18,11 +18,8 @@ runs:
       with:
         python-version: '3.12.6'
 
-    # Pinning UV due to https://github.com/rstudio/reticulate/issues/1811
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        version: "0.7.22"
 
     - name: Install Python dependencies
       shell: bash

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -127,11 +127,8 @@ jobs:
         with:
           python-version: "3.10.10"
 
-      # Pinning UV due to https://github.com/rstudio/reticulate/issues/1811
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.7.22"
 
       - name: Install node dependencies
         env:


### PR DESCRIPTION
Reticulate issue https://github.com/rstudio/reticulate/issues/1811 has been fixed, so we can unpin `uv` now.

Companion PR: https://github.com/posit-dev/positron-builds/pull/637

### QA Notes
@:reticulate @:web @:win

Note the PR run failure is a reticulate flake, nothing to do with this PR

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
