### PR TITLE
e2e: Fix broken SCM test due to layout change

### DIFF
--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -42,6 +42,7 @@ export class SCM {
 
 	async openChange(name: string): Promise<void> {
 		await this.layout.enterLayout('fullSizedSidebar');
+		await this.code.driver.page.keyboard.press('Control+Shift+G'); // need to switch to scm view as it may have reset
 
 		await this.code.driver.page.locator(SCM_RESOURCE_CLICK(name)).last().click();
 

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -50,6 +50,7 @@ export class SCM {
 	}
 
 	async stage(name: string): Promise<void> {
+		await this.code.driver.page.keyboard.press('Control+Shift+G'); // need to switch to scm view as it may have reset
 		await this.code.driver.page.locator(SCM_RESOURCE_ACTION_CLICK(name, 'Stage Changes')).click();
 		await this.waitForChange(name, 'Staged');
 	}

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -56,6 +56,7 @@ export class SCM {
 	}
 
 	async commit(message: string): Promise<void> {
+		await this.code.driver.page.keyboard.press('Control+Shift+G'); // need to switch to scm view as it may have reset
 		await this.code.driver.page.locator(SCM_INPUT_TEXTAREA).click({ force: true });
 		await expect(this.code.driver.page.locator(SCM_INPUT_TEXTAREA)).toBeFocused();
 		await this.code.driver.page.locator(SCM_INPUT_TEXTAREA).fill(message);

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -143,6 +143,10 @@ test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS, tags.WIN, tags.WORKBENC
 	});
 
 	test.describe('Assistant Layout', () => {
+		test.afterEach('Reset Layout', async function ({ app }) {
+			await app.workbench.layouts.enterLayout('stacked');
+		});
+
 
 		test('Verify Assistant Layout displays all three main parts', async function ({ app }) {
 			const layouts = app.workbench.layouts;


### PR DESCRIPTION
Recent layout change broke the SCM tests.

- Adds in a switch the SCM pane when needed
- Add defense to the layout test to reset afterEach

### QA Notes
@:layouts @:scm
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
