### PR TITLE
Update Keybinding for Clear Outputs Command

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1193,7 +1193,7 @@ registerAction2(class extends NotebookAction2 {
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyK
+				primary: KeyMod.Alt | KeyCode.KeyK
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1193,7 +1193,7 @@ registerAction2(class extends NotebookAction2 {
 			keybinding: {
 				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.Alt | KeyCode.KeyK
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyK)
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1159,7 +1159,7 @@ registerAction2(class extends NotebookAction2 {
 				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
 			},
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
+				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
 			}
@@ -1191,7 +1191,7 @@ registerAction2(class extends NotebookAction2 {
 				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
 			},
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
+				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.KeyK
 			}


### PR DESCRIPTION
This PR addresses #9907

The keybinding for the `positronNotebook.clearAllOutputs` command was "Command+Shift+K" but that keybinding conflicts with Quarto render preview so we need to change it. The new keybinding is "Cmd+K K" key chord.

JupyterLab and built-in notebooks in VS Code do NOT have a default keybinding for this action so I picked an alternative that seemed to have minimal conflicts. I thought about using "Command+Shift+O" which used to be the keybinding in older versions of Jupyter but that conflicts with many other keybindings we have.

On top of updating the keybinding, I also updated the when clause for when the "Run All" and "Clear Outputs" keybindings. These keybindings now only check if the active editor is a positron notebook, and doesn't require the notebook to be "focused". 

I made this change because the keybindings weren't working in the following scenario:
1. Open a notebook
2. Click "Run All" from action bar
3. Press "Option+K" to clear outputs - FAIL

The `POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED` context key was `false` when a user clicked on a button in the action bar because technically focused has moved out of the notebook editor. The user needed to click into a cell, press "Escape" to exit edit mode, and then press "Cmd+K K" to clear outputs 😭. This didn't make a lot of sense for a notebook-wide action so I updated this behavior.

**AFTER**


https://github.com/user-attachments/assets/f1c86207-aa77-4db3-844e-69d018246d2e




### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
