### PR TITLE
Use normal whitespace in activity html outputs

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputHtml.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputHtml.css
@@ -1,6 +1,8 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.activity-output-html {}
+.activity-output-html {
+	white-space: normal;
+}


### PR DESCRIPTION
Fixes an issue causing Pandas data frames to render very unpleasantly in the Console.

The issue was that the `white-space` property for the Console was set with the intent of preserving whitespace formatting for console text, but it was ALSO preserving whitespace formatting inside the sanitized HTML components. 

The fix is to use `normal` white space rendering inside HTML outputs. 

Addresses https://github.com/posit-dev/positron/issues/10382. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix rendering of Python data frames in the Console (#10382)

Test tags: `@:console`
