### PR TITLE
catalog explorer: bundle `snowflake-sdk`

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -162,7 +162,8 @@ function fromLocalWebpack(extensionPath, webpackConfigFileName, disableMangle) {
     // strategy.
     const extensionsWithNpmDeps = [
         'positron-proxy',
-        'positron-duckdb'
+        'positron-duckdb',
+        'positron-catalog-explorer'
     ];
     // If the extension has npm dependencies, use the Npm package manager
     // dependency strategy.

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -127,7 +127,8 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, 
 	// strategy.
 	const extensionsWithNpmDeps = [
 		'positron-proxy',
-		'positron-duckdb'
+		'positron-duckdb',
+		'positron-catalog-explorer'
 	];
 
 	// If the extension has npm dependencies, use the Npm package manager

--- a/extensions/positron-catalog-explorer/extension.webpack.config.js
+++ b/extensions/positron-catalog-explorer/extension.webpack.config.js
@@ -16,5 +16,8 @@ module.exports.default = withDefaults({
 	},
 	node: {
 		__dirname: false
+	},
+	externals: {
+		'snowflake-sdk': { commonjs: 'snowflake-sdk' },
 	}
 });


### PR DESCRIPTION
Similar to `positron-duckdb`, we need to include the `node_modules` to correctly resolve types for snowflake connections.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #10104 Bundles snowflake packages needed to run in release builds.


### QA Notes

Snowflake should run on a released build, I tested this locally by running

```
npm run gulp vscode
```

and confirmed the catalog explorer worked with snowflake.
