### PR TITLE
Assistant: simplify `getProjectTree`'s exclusion arguments

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -638,27 +638,12 @@
                 "type": "string",
                 "description": "A Glob pattern to exclude from the project tree. Files and folders matching these patterns will be filtered out, even if they match an included Glob."
               },
-              "description": "Glob patterns to exclude from the project tree. These patterns will be applied in addition to the default excludes. By default, directories for dependencies, build artifacts, and other commonly ignored files are excluded, such as `.venv`, `venv`, `renv`, `node_modules`."
+              "description": "Glob patterns to exclude from the project tree. These patterns will be applied _in addition to_ the default excludes unless `skipDefaultExcludes` is true."
             },
-            "replaceDefaultExcludes": {
+            "skipDefaultExcludes": {
               "type": "boolean",
-              "description": "Whether to replace the default excludes with the provided `exclude` patterns. If false, the provided `exclude` patterns will be added to the default excludes.",
+              "description": "Whether to skip all automatic exclusions (.gitignore rules, VS Code exclude settings, and default exclusions for dependencies, build artifacts, and other commonly ignored files/directories). When true, only the explicit `exclude` patterns will be applied.",
               "default": false
-            },
-            "excludeSettings": {
-              "type": "string",
-              "description": "Which exclude settings to consult when filtering the project tree. Options are: filesExclude or searchAndFilesExclude, or an empty string for no exclude settings.",
-              "default": "searchAndFilesExclude"
-            },
-            "ignoreFiles": {
-              "type": "boolean",
-              "description": "Whether to ignore files that are listed in the `.gitignore` file or other ignore files.",
-              "default": true
-            },
-            "filterResults": {
-              "type": "boolean",
-              "description": "Whether to filter results using excludes and ignore files. If false, none of the excludes or ignores will be applied, and only the `include` patterns will be considered. Use this setting when providing specific includes to locate particular files and folders.",
-              "default": true
             },
             "maxFiles": {
               "type": "number",

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -116,6 +116,7 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 		let excludedCount = 0;
 		const sparseThreshold = Math.floor(filesLimit / 10);
 		if (!skipExcludes && totalFiles < sparseThreshold) {
+			log.debug(`[${PositronAssistantToolName.ProjectTree}] Default exclusions were applied and results were very sparse. Searching files again to determine how many files were excluded...`);
 			let totalFilesBeforeExclusion = 0;
 			for (const folder of workspaceFolders) {
 				const allMatchesUris = await vscode.workspace.findFiles2(
@@ -159,7 +160,8 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 
 		// Inform the model if results were excluded
 		if (excludedCount > 0) {
-			const exclusionMessage = `${excludedCount} result${excludedCount === 1 ? ' was' : 's were'} excluded. Set \`skipDefaultExcludes\` to \`true\` to see them.`;
+			const exclusionMessage = `${excludedCount} result${excludedCount === 1 ? ' was' : 's were'} excluded. Set \`skipDefaultExcludes\` to \`true\` to include them.`;
+			log.debug(`[${PositronAssistantToolName.ProjectTree}] ${exclusionMessage}`);
 			resultParts.push(new vscode.LanguageModelTextPart(exclusionMessage));
 		}
 

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -117,23 +117,20 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 		const sparseThreshold = Math.floor(filesLimit / 10);
 		if (!skipExcludes && totalFiles < sparseThreshold) {
 			log.debug(`[${PositronAssistantToolName.ProjectTree}] Default exclusions were applied and results were very sparse. Searching files again to determine how many files were excluded...`);
-			let totalFilesBeforeExclusion = 0;
-			for (const folder of workspaceFolders) {
-				const allMatchesUris = await vscode.workspace.findFiles2(
-					filePatterns,
-					{
-						exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
-						useIgnoreFiles: {
-							local: false,
-							parent: false,
-							global: false,
-						},
-						useExcludeSettings: vscode.ExcludeSettingOptions.None,
+			const allMatchesUris = await vscode.workspace.findFiles2(
+				filePatterns,
+				{
+					exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
+					useIgnoreFiles: {
+						local: false,
+						parent: false,
+						global: false,
 					},
-					token
-				);
-				totalFilesBeforeExclusion += allMatchesUris.length;
-			}
+					useExcludeSettings: vscode.ExcludeSettingOptions.None,
+				},
+				token
+			);
+			const totalFilesBeforeExclusion = allMatchesUris.length;
 			excludedCount = totalFilesBeforeExclusion - totalFiles;
 		}
 

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -21,10 +21,7 @@ type DirectoryInfo = {
 interface ProjectTreeInput {
 	include?: string[];
 	exclude?: string[];
-	replaceDefaultExcludes?: boolean;
-	excludeSettings?: string;
-	ignoreFiles?: boolean;
-	filterResults?: boolean;
+	skipDefaultExcludes?: boolean;
 	maxFiles?: number;
 }
 
@@ -52,7 +49,7 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 		log.debug(`[${PositronAssistantToolName.ProjectTree}] Constructing project tree for ${workspaceFolders.length} workspace folders...`);
 
 		// Parse the input options
-		const { include, exclude, replaceDefaultExcludes, excludeSettings, ignoreFiles, filterResults, maxFiles } = options.input;
+		const { include, exclude, skipDefaultExcludes, maxFiles } = options.input;
 
 		log.trace(`[${PositronAssistantToolName.ProjectTree}] Invoked with options: ${JSON.stringify(options.input, null, 2)}`);
 
@@ -62,7 +59,7 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 
 		const filePatterns = include;
 		const excludePatterns = exclude ?? [];
-		const filterResultsEnabled = filterResults ?? DEFAULT_FILTER_RESULTS;
+		const skipExcludes = skipDefaultExcludes ?? false;
 		// Don't allow more than the default max files, even if a higher value is provided,
 		// to prevent excessive token usage.
 		const filesLimit = maxFiles && maxFiles < DEFAULT_MAX_FILES
@@ -70,21 +67,23 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 			: DEFAULT_MAX_FILES;
 
 		let findOptions: vscode.FindFiles2Options;
-		if (filterResultsEnabled) {
+		if (skipExcludes) {
+			// Skip all automatic exclusions, only use explicit exclude patterns
 			findOptions = {
-				exclude: replaceDefaultExcludes ? excludePatterns : [...DEFAULT_EXCLUDE_PATTERNS, ...excludePatterns],
-				useIgnoreFiles: ignoreFiles === false ? undefined : DEFAULT_USE_IGNORE_FILES,
-				useExcludeSettings: excludeSettings ? getExcludeSettingOptions(excludeSettings) : DEFAULT_EXCLUDE_SETTING_OPTIONS,
-			};
-		} else {
-			findOptions = {
-				exclude: undefined,
+				exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
 				useIgnoreFiles: {
 					local: false,
 					parent: false,
 					global: false,
 				},
 				useExcludeSettings: vscode.ExcludeSettingOptions.None,
+			};
+		} else {
+			// Apply all exclusions: default patterns + .gitignore + VS Code settings
+			findOptions = {
+				exclude: [...DEFAULT_EXCLUDE_PATTERNS, ...excludePatterns],
+				useIgnoreFiles: DEFAULT_USE_IGNORE_FILES,
+				useExcludeSettings: DEFAULT_EXCLUDE_SETTING_OPTIONS,
 			};
 		}
 
@@ -94,7 +93,7 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 			exclude: findOptions.exclude,
 			useIgnoreFiles: findOptions.useIgnoreFiles,
 			useExcludeSettings: findOptions.useExcludeSettings,
-			filterResults: filterResultsEnabled,
+			skipDefaultExcludes: skipExcludes,
 			maxFiles: filesLimit,
 		}, null, 2)}`);
 
@@ -112,6 +111,30 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 		}
 
 		const totalFiles = workspaceTrees.reduce((sum, obj) => sum + obj.totalFiles, 0);
+
+		// If we applied default exclusions and results are very sparse, run the search without the default exclusions and note if there are additional, excluded results in the tool results.
+		let excludedCount = 0;
+		const sparseThreshold = Math.floor(filesLimit / 10);
+		if (!skipExcludes && totalFiles < sparseThreshold) {
+			let totalFilesBeforeExclusion = 0;
+			for (const folder of workspaceFolders) {
+				const allMatchesUris = await vscode.workspace.findFiles2(
+					filePatterns,
+					{
+						exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
+						useIgnoreFiles: {
+							local: false,
+							parent: false,
+							global: false,
+						},
+						useExcludeSettings: vscode.ExcludeSettingOptions.None,
+					},
+					token
+				);
+				totalFilesBeforeExclusion += allMatchesUris.length;
+			}
+			excludedCount = totalFilesBeforeExclusion - totalFiles;
+		}
 
 		log.debug(`[${PositronAssistantToolName.ProjectTree}] Project tree constructed with ${totalFiles} items across ${workspaceFolders.length} workspace folders.`);
 		if (totalFiles > filesLimit) {
@@ -134,31 +157,18 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 			resultParts.push(new vscode.LanguageModelTextPart(truncationMessage));
 		}
 
+		// Inform the model if results were excluded
+		if (excludedCount > 0) {
+			const exclusionMessage = `${excludedCount} result${excludedCount === 1 ? ' was' : 's were'} excluded. Set \`skipDefaultExcludes\` to \`true\` to see them.`;
+			resultParts.push(new vscode.LanguageModelTextPart(exclusionMessage));
+		}
+
 		return new vscode.LanguageModelToolResult(resultParts);
 	}
 });
 
-/**
- * Convert from the tool input excludeSettings to the vscode.ExcludeSettingOptions
- * @param excludeSetting The exclude setting from the tool input.
- * @returns The corresponding vscode.ExcludeSettingOptions value.
- */
-function getExcludeSettingOptions(excludeSetting: string) {
-	switch (excludeSetting) {
-		case '':
-			return vscode.ExcludeSettingOptions.None;
-		case 'filesExclude':
-			return vscode.ExcludeSettingOptions.FilesExclude;
-		case 'searchAndFilesExclude':
-			return vscode.ExcludeSettingOptions.SearchAndFilesExclude;
-		default:
-			return DEFAULT_EXCLUDE_SETTING_OPTIONS;
-	}
-}
-
 // Default values for the project tree tool options
 const DEFAULT_MAX_FILES = 50;
-const DEFAULT_FILTER_RESULTS = true;
 const DEFAULT_USE_IGNORE_FILES = { local: true, parent: true, global: true };
 const DEFAULT_EXCLUDE_SETTING_OPTIONS = vscode.ExcludeSettingOptions.SearchAndFilesExclude;
 const DEFAULT_EXCLUDE_PATTERNS = [


### PR DESCRIPTION
Addresses #10006.

This PR aims to simplify PA's interface to searching the projectTree. Before, the relevant arguments to the tool were:

* `include`: Globs to include
* `exclude`: Globs to exclude
* `replaceDefaultExcludes`: Whether to skip the default excludes in this tool's metadata.
* `ignoreFiles`: Whether to respect `.gitignore` rules
* `excludeSettings`: Which of the VS Code `settings.json` settings to respect
* `filterResults`: Whether to apply the above three exclusion rules.

With this PR, the interface is:

* `include`: Globs to include
* `exclude`: Globs to exclude
* `skipDefaultExcludes`: Whether to skip the default excludes in this tool's metadata, the `searchAndFilesExclude` metadata, and `.gitignore`. As in "bypass the default exclusions—I need everything."

As a way to evaluate how well the model can interface with the exclusion rules, I used the prompt "What files are in `extensions/node_modules`?" in the Positron workspace. The "default" behavior seemed to be searching with that `includes` and then, upon seeing the empty result, concluding that there's nothing there.

<img width="1116" height="936" alt="model_needs_to_see_exclusions" src="https://github.com/user-attachments/assets/1d61a7d5-16f9-41d4-8b2c-6d24676139c9" />

For a while, I tried to prompt my way into the model recognizing that relevant exclusions were applied, incl. to the point of listing them all out in the package.json:

```
"skipDefaultExcludes": {
  "type": "boolean",
    "description": "Whether to skip all automatic exclusions (.gitignore rules, VS Code exclude settings, and 
    default exclusions). When true, only the explicit `exclude` patterns will be applied. The default excludes are: 
    **/.build/**, **/.git/**, **/.devcontainer/**, **/.hg/**, **/.ipynb_checkpoints/**, **/.pytest_cache/**, **/.svn/**, 
    **/.venv/**, **/.Rproj.user/**, **/.vscode/**, **/__pycache__/**, **/dist/**, **/node_modules/**, **/renv/**, 
    **/venv/**, .DS_Store, .RData, .Rhistory, desktop.ini, package-lock.json, yarn.lock, Thumbs.db, **/*.a, 
    **/*.bak, **/*.csv~, **/*.js.map, **/*.log, **/*.o, **/*.pyo, **/*.so, **/*.tmp.",
  "default": false
},
```

What I ended up opting for was to include a note in the tool result that files were excluded from the search when that is the case (and results are sparse): 

```
2025-11-06 10:30:25.645 [debug] [tool] Tool getProjectTree returned result: [
  {
    "$mid": 21,
    "value": ""
  },
  {
    "$mid": 21,
    "value": "331 results were excluded. Set `skipDefaultExcludes` to `true` to see them."
  }
]
```

This is implemented by running a second search without the default exclusions when `skipDefaultExcludes` is `false` (notably, the default) and results are sparse (effective max / 10, so <5 results by default). I was initially pretty concerned about the performance implications here, but found that the elapsed time to call this tool (even across the entire Positron repository) was still _very_ snappy compared to the generation of tokens from the model.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

* To test the worse-case performance/latency of the tool, open the Positron workspace and ask "Search for files with `positron` in their name with getProjectTree" The latency of the tool return should be similar to what it was before.
* To test that the agent can find files excluded by default when it needs to, open the Positron workspace and ask "What files are in `extensions/node_modules`?" The agent should first see no results but also that some were excluded, then either attempt to call the tool again with `skipDefaultExcludes` to `true` or just note that many matches were excluded.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
