### PR TITLE
Connections Pane: Databricks Support

### DIFF
--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -10,7 +10,7 @@
 
 # Then iterate through supported PYTHON_VERSIONS to make sure we covered the latest versions.
 
-databricks-sql-connector[pyarrow]==4.1.4
+databricks-sql-connector[pyarrow]==4.1.3
 duckdb==1.4.1
 fastcore==1.8.9; python_version == '3.9'
 fastcore==1.8.13; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -10,6 +10,7 @@
 
 # Then iterate through supported PYTHON_VERSIONS to make sure we covered the latest versions.
 
+databricks-sql-connector[pyarrow]==4.1.4
 duckdb==1.4.1
 fastcore==1.8.9; python_version == '3.9'
 fastcore==1.8.13; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -10,7 +10,7 @@
 
 # Then iterate through supported PYTHON_VERSIONS to make sure we covered the latest versions.
 
-databricks-sql-connector[pyarrow]==4.0.5
+databricks-sql-connector[pyarrow]==2.0.2
 duckdb==1.4.1
 fastcore==1.8.9; python_version == '3.9'
 fastcore==1.8.13; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -10,7 +10,7 @@
 
 # Then iterate through supported PYTHON_VERSIONS to make sure we covered the latest versions.
 
-databricks-sql-connector[pyarrow]==4.1.3
+databricks-sql-connector[pyarrow]==4.0.5
 duckdb==1.4.1
 fastcore==1.8.9; python_version == '3.9'
 fastcore==1.8.13; python_version >= '3.10'

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -8,7 +8,7 @@ import contextlib
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, Tuple, TypedDict, NotRequired
+from typing import TYPE_CHECKING, Any, Tuple, TypedDict
 
 import comm
 
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
     import sqlalchemy
     from comm.base_comm import BaseComm
+    from typing_extensions import NotRequired
 
     from .positron_ipkernel import PositronIPyKernel
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1025,9 +1025,7 @@ class DatabricksConnection(Connection):
         self.host = str(conn.session.host) or "<unknown>"
         self.display_name = f"Databricks ({self.HOST_SUFFIX_RE.sub('', self.host, count=1)})"
         self.type = "Databricks"
-        # TODO: generate connection code based on authentication method extracted from the
-        # connection object
-        self.code = "# Databricks connection code depends on your authentication method.\n"
+        self.code = self._make_code()
 
         self.icon = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjMzMSIgdmlld0JveD0iMCAwIDMwMCAzMzEiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0yODMuOTIzIDEzNi40NDlMMTUwLjE0NCAyMTMuNjI0TDYuODg5OTUgMTMxLjE2OEwwIDEzNC45ODJWMTk0Ljg0NEwxNTAuMTQ0IDI4MS4xMTVMMjgzLjkyMyAyMDQuMjM0VjIzNS45MjZMMTUwLjE0NCAzMTMuMUw2Ljg4OTk1IDIzMC42NDRMMCAyMzQuNDU4VjI0NC43MjlMMTUwLjE0NCAzMzFMMzAwIDI0NC43MjlWMTg0Ljg2N0wyOTMuMTEgMTgxLjA1MkwxNTAuMTQ0IDI2My4yMTVMMTYuMDc2NiAxODYuMzM0VjE1NC42NDNMMTUwLjE0NCAyMzEuNTI0TDMwMCAxNDUuMjUzVjg2LjI3MTNMMjkyLjUzNiA4MS44Njk3TDE1MC4xNDQgMTYzLjczOUwyMi45NjY1IDkwLjk2NjNMMTUwLjE0NCAxNy44OTk4TDI1NC42NDEgNzguMDU1TDI2My44MjggNzIuNzczVjY1LjQzNzFMMTUwLjE0NCAwTDAgODYuMjcxM1Y5NS42NjEzTDE1MC4xNDQgMTgxLjkzM0wyODMuOTIzIDEwNC43NThWMTM2LjQ0OVoiIGZpbGw9IiNGRjM2MjEiLz4KPC9zdmc+Cg=="
 
@@ -1179,3 +1177,22 @@ class DatabricksConnection(Connection):
     def _qualify(self, identifier: str) -> str:
         escaped = identifier.replace("`", "``")
         return f"`{escaped}`"
+
+    def _make_code(self) -> str:
+        try:
+            hostname = str(self.conn.session.http_client.config.hostname)
+        except AttributeError:
+            hostname = "<hostname>"
+
+        try:
+            http_path = str(self.conn.session.http_path)
+        except AttributeError:
+            http_path = "<http_path>"
+
+        return (
+            "from databricks import sql\n"
+            "con = sql.connect(\n"
+            f"    server_hostname = '{hostname}',\n"
+            f"    http_path       = '{http_path}'\n"
+            ")\n"
+        )

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1048,11 +1048,7 @@ class DatabricksConnection(Connection):
             "schema": ConnectionObjectInfo({"contains": None, "icon": None}),
             "table": ConnectionObjectInfo({"contains": "data", "icon": None}),
             "view": ConnectionObjectInfo({"contains": "data", "icon": None}),
-            # TODO: Volumes are like tables, but they can't be inspected further.
-            # Maybe we can support it?
-            # To nicely support it we need to expand the connections pane contract
-            # to allow objects that can't be previewed or inspected further.
-            # Maybe a `has_children` method can be added in a backward compatible way.
+
             "volume": ConnectionObjectInfo({"contains": None, "icon": None}),
         }
 
@@ -1169,8 +1165,8 @@ class DatabricksConnection(Connection):
             frame = cursor.fetchall_arrow().to_pandas()
         var_name = var_name or "conn"
         return frame, (
-            f"with {var_name}.cursor() as cursor:"
-            f"    cursor.execute({sql!r})"
+            f"with {var_name}.cursor() as cursor:\n"
+            f"    cursor.execute({sql!r})\n"
             f"    {table.name} = cursor.fetchall_arrow().to_pandas()"
         )
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1048,7 +1048,6 @@ class DatabricksConnection(Connection):
             "schema": ConnectionObjectInfo({"contains": None, "icon": None}),
             "table": ConnectionObjectInfo({"contains": "data", "icon": None}),
             "view": ConnectionObjectInfo({"contains": "data", "icon": None}),
-
             "volume": ConnectionObjectInfo({"contains": None, "icon": None}),
         }
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1026,6 +1026,8 @@ class DatabricksConnection(Connection):
         # connection object
         self.code = "# Databricks connection code depends on your authentication method.\n"
 
+        self.icon = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjMzMSIgdmlld0JveD0iMCAwIDMwMCAzMzEiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0yODMuOTIzIDEzNi40NDlMMTUwLjE0NCAyMTMuNjI0TDYuODg5OTUgMTMxLjE2OEwwIDEzNC45ODJWMTk0Ljg0NEwxNTAuMTQ0IDI4MS4xMTVMMjgzLjkyMyAyMDQuMjM0VjIzNS45MjZMMTUwLjE0NCAzMTMuMUw2Ljg4OTk1IDIzMC42NDRMMCAyMzQuNDU4VjI0NC43MjlMMTUwLjE0NCAzMzFMMzAwIDI0NC43MjlWMTg0Ljg2N0wyOTMuMTEgMTgxLjA1MkwxNTAuMTQ0IDI2My4yMTVMMTYuMDc2NiAxODYuMzM0VjE1NC42NDNMMTUwLjE0NCAyMzEuNTI0TDMwMCAxNDUuMjUzVjg2LjI3MTNMMjkyLjUzNiA4MS44Njk3TDE1MC4xNDQgMTYzLjczOUwyMi45NjY1IDkwLjk2NjNMMTUwLjE0NCAxNy44OTk4TDI1NC42NDEgNzguMDU1TDI2My44MjggNzIuNzczVjY1LjQzNzFMMTUwLjE0NCAwTDAgODYuMjcxM1Y5NS42NjEzTDE1MC4xNDQgMTgxLjkzM0wyODMuOTIzIDEwNC43NThWMTM2LjQ0OVoiIGZpbGw9IiNGRjM2MjEiLz4KPC9zdmc+Cg=="
+
     def disconnect(self):
         with contextlib.suppress(Exception):
             self.conn.close()

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1022,7 +1022,16 @@ class DatabricksConnection(Connection):
 
     def __init__(self, conn: Any):
         self.conn = conn
-        self.host = str(conn.session.host) or "<unknown>"
+
+        # try conn.host
+        host = getattr(conn, "host", None)
+        if host is None:
+            # fallback to conn.session.host
+            host = getattr(getattr(conn, "session", None), "host", None)
+        if host is None:
+            host = "<unknown>"
+        self.host = str(host)
+
         self.display_name = f"Databricks ({self.HOST_SUFFIX_RE.sub('', self.host, count=1)})"
         self.type = "Databricks"
         self.code = self._make_code()

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import re
 import uuid
 from typing import TYPE_CHECKING, Any, Tuple, TypedDict
 
@@ -1017,11 +1018,12 @@ class SnowflakeConnection(Connection):
 class DatabricksConnection(Connection):
     """Support for Databricks connections to databases."""
 
+    HOST_SUFFIX_RE = re.compile(r"\.(?:cloud\.)?databricks\.com$", re.IGNORECASE)
+
     def __init__(self, conn: Any):
         self.conn = conn
-        # TODO: remove the databricks.com part for brevity
-        self.display_name = conn.session.host
-        self.host = conn.session.host
+        self.host = str(conn.session.host) or "<unknown>"
+        self.display_name = f"Databricks ({self.HOST_SUFFIX_RE.sub('', self.host, count=1)})"
         self.type = "Databricks"
         # TODO: generate connection code based on authentication method extracted from the
         # connection object

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -8,7 +8,7 @@ import contextlib
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, Tuple, TypedDict
+from typing import TYPE_CHECKING, Any, Tuple, TypedDict, NotRequired
 
 import comm
 
@@ -48,6 +48,7 @@ class ConnectionObjectInfo(TypedDict):
 class ConnectionObject(TypedDict):
     name: str
     kind: str
+    has_children: NotRequired[bool]
 
 
 class ConnectionObjectFields(TypedDict):
@@ -1090,6 +1091,7 @@ class DatabricksConnection(Connection):
                         {
                             "name": row["volume_name"],
                             "kind": "volume",
+                            "has_children": False,
                         }
                     )
                     for row in volumes

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1136,11 +1136,6 @@ class DatabricksConnection(Connection):
         ]
 
     def preview_object(self, path: list[ObjectSchema], var_name: str | None = None):
-        try:
-            import pandas as pd
-        except ImportError as e:
-            raise ModuleNotFoundError("Pandas is required for previewing Databricks tables.") from e
-
         if len(path) != 3:
             raise ValueError(f"Path length must be 3, but got {len(path)}. Path: {path}")
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -1199,4 +1199,5 @@ class DatabricksConnection(Connection):
             f"    server_hostname = '{hostname}',\n"
             f"    http_path       = '{http_path}'\n"
             ")\n"
+            "%connection_show con\n"
         )

--- a/extensions/positron-python/python_files/posit/positron/connections_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/connections_comm.py
@@ -31,6 +31,11 @@ class ObjectSchema(BaseModel):
         description="The object type (table, catalog, schema)",
     )
 
+    has_children: Optional[StrictBool] = Field(
+        default=None,
+        description="Indicates if the object has children that can be listed. This property is optional and when omitted, it is assumed that the object may have children unless its kind is 'field'.",
+    )
+
 
 class FieldSchema(BaseModel):
     """

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1227,6 +1227,18 @@ class SnowflakeConnectionInspector(BaseConnectionInspector):
         return True
 
 
+class DatabricksConnectionInspector(BaseConnectionInspector):
+    CLASS_QNAME = ("databricks.sql.client.Connection",)
+
+    def _is_active(self, value) -> bool:
+        try:
+            # a connection is active if you can acquire a cursor from it
+            value.cursor()
+        except Exception:
+            return False
+        return True
+
+
 class IbisExprInspector(PositronInspector["ibis.Expr"]):
     def has_children(self) -> bool:
         return False
@@ -1267,6 +1279,7 @@ INSPECTOR_CLASSES: dict[str, type[PositronInspector]] = {
     **dict.fromkeys(DuckDBConnectionInspector.CLASS_QNAME, DuckDBConnectionInspector),
     **dict.fromkeys(IbisDataFrameInspector.CLASS_QNAME, IbisDataFrameInspector),
     **dict.fromkeys(SnowflakeConnectionInspector.CLASS_QNAME, SnowflakeConnectionInspector),
+    **dict.fromkeys(DatabricksConnectionInspector.CLASS_QNAME, DatabricksConnectionInspector),
     "ibis.Expr": IbisExprInspector,
     "boolean": BooleanInspector,
     "bytes": BytesInspector,

--- a/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_connections.py
@@ -341,10 +341,10 @@ class TestDatabricksConnectionsService:
         return [{"kind": "catalog", "name": self.CATALOG_NAME}]
 
     def _schema_path(self):
-        return self._catalog_path() + [{"kind": "schema", "name": self.SCHEMA_NAME}]
+        return [*self._catalog_path(), {"kind": "schema", "name": self.SCHEMA_NAME}]
 
     def _table_path(self):
-        return self._schema_path() + [{"kind": "table", "name": self.TABLE_NAME}]
+        return [*self._schema_path(), {"kind": "table", "name": self.TABLE_NAME}]
 
     def _resolve_path(self, kind: str):
         if kind == "root":
@@ -371,24 +371,22 @@ class TestDatabricksConnectionsService:
         assert comm_id in connections_service.comms
 
     @pytest.mark.parametrize(
-        ("path_kind", "expected"),
+        "path_kind",
         [
-            pytest.param("root", False, id="root"),
-            pytest.param("catalog", False, id="catalog"),
-            pytest.param("schema", False, id="schema"),
-            pytest.param("table", True, id="table"),
+            pytest.param("root", id="root"),
+            pytest.param("catalog", id="catalog"),
+            pytest.param("schema", id="schema"),
+            pytest.param("table", id="table"),
         ],
     )
-    def test_contains_data(
-        self, connections_service: ConnectionsService, path_kind: str, expected: bool
-    ):
+    def test_contains_data(self, connections_service: ConnectionsService, path_kind: str):
         dummy_comm, comm_id = self._open_comm(connections_service)
         path = self._resolve_path(path_kind)
 
         msg = _make_msg(params={"path": path}, method="contains_data", comm_id=comm_id)
         dummy_comm.handle_msg(msg)
         result = dummy_comm.messages[0]["data"]["result"]
-        assert result is expected
+        assert result is (path_kind == "table")
 
     @pytest.mark.parametrize(
         ("path_kind", "expected"),

--- a/extensions/positron-python/python_files/posit/test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/test-requirements.txt
@@ -1,3 +1,4 @@
+databricks-sql-connector[pyarrow]
 duckdb
 fastcore
 geopandas; python_version < '3.14'

--- a/positron/comms/connections-backend-openrpc.json
+++ b/positron/comms/connections-backend-openrpc.json
@@ -174,6 +174,10 @@
 					"kind": {
 						"type": "string",
 						"description": "The object type (table, catalog, schema)"
+					},
+					"has_children": {
+						"type": "boolean",
+						"description": "Indicates if the object has children that can be listed. This property is optional and when omitted, it is assumed that the object may have children unless its kind is 'field'."
 					}
 				}
 			},

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -62,6 +62,10 @@
 	justify-content: center;
 }
 
+.connections-item .expand-collapse-area .animate-spin {
+	animation: spin 1s linear infinite;
+}
+
 .connections-item.selected {
 	color: var(--vscode-positronVariables-activeSelectionForeground);
 	background: var(--vscode-positronVariables-activeSelectionBackground);

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -9,6 +9,26 @@
 	left: 0.5px;
 }
 
+.connections-items-container .no-entries-message {
+	padding: 10px;
+	justify-content: center;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+}
+
+.no-entries-message  .positron-button {
+	border: 1px solid;
+	border-color: var(--vscode-positronVariables-foreground);
+	border-radius: 5px;
+	display: flex;
+	align-items: center;
+}
+
+.no-entries-message .positron-button .codicon {
+	padding: 2px;
+}
+
 .connections-item {
 	display: flex;
 	cursor: pointer;
@@ -62,7 +82,7 @@
 	justify-content: center;
 }
 
-.connections-item .expand-collapse-area .animate-spin {
+.connections-items-container .animate-spin {
 	animation: spin 1s linear infinite;
 }
 

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -194,6 +194,8 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 					return 'positron-schema-connection';
 				case 'catalog':
 					return 'positron-catalog-connection';
+				case 'volume':
+					return 'file-symlink-directory';
 				case 'field':
 					switch (props.item.dtype?.toLowerCase()) {
 						case 'character':
@@ -207,6 +209,8 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 						case 'double':
 						case 'fixed':
 						case 'real':
+						case 'bigint':
+						case 'int':
 							return 'positron-data-type-number';
 						case 'boolean':
 						case 'bool':

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -171,7 +171,7 @@ const NoEntriesMessage = ({ height, onTryAgain, timeout = 5000 }: { height: numb
 	const [failed, setFailed] = useState<boolean>(false);
 
 	useEffect(() => {
-		let t = null;
+		let t: ReturnType<typeof setTimeout> | null = null;
 		if (!failed) {
 			t = setTimeout(() => {
 				setFailed(true);

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -332,7 +332,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		useEffect(() => {
 			if (!expanding) {
 				setShowSpinner(false)
-				return
+				return;
 			}
 			const id = setTimeout(() => setShowSpinner(true), delay);
 			return () => clearTimeout(id)

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -54,7 +54,7 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 	const [selectedId, setSelectedId] = useState<string>();
 	const activeInstance = services.positronConnectionsService.getConnections().find(item => item.id === activeInstanceId);
 
-	const [entries, setEntries] = useState<IPositronConnectionEntry[]>(activeInstance?.getEntries() || []);
+	const [entries, setEntries] = useState<IPositronConnectionEntry[] | undefined>(activeInstance?.getEntries() || undefined);
 
 	useEffect(() => {
 		if (!activeInstance) {
@@ -102,6 +102,10 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 	};
 
 	const ItemEntry = (props: ItemEntryProps) => {
+		if (!entries) {
+			return null;
+		}
+
 		const itemProps = entries[props.index];
 
 		return (
@@ -139,7 +143,7 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 					}
 				</div>
 				{
-					entries.length ?
+					entries !== undefined ?
 						<List
 							height={height - ACTION_BAR_HEIGHT - DETAILS_BAR_HEIGHT}
 							innerRef={innerRef}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -236,6 +236,12 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		props.onToggleExpand(props.item.id);
 	};
 
+	useEffect(() => {
+		if (!props.item.expanded) {
+			setExpanding(false);
+		}
+	}, [props.item.expanded]);
+
 	const iconClass = (kind?: string) => {
 		if (kind) {
 			switch (kind.toLowerCase()) {
@@ -331,12 +337,12 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 
 		useEffect(() => {
 			if (!expanding) {
-				setShowSpinner(false)
+				setShowSpinner(false);
 				return;
 			}
 			const id = setTimeout(() => setShowSpinner(true), delay);
-			return () => clearTimeout(id)
-		}, [expanding, delay])
+			return () => clearTimeout(id);
+		}, [expanding, delay]);
 
 
 		if (expanded === undefined) {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -177,7 +177,10 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 
 	// If the connection is not expandable, we add some more padding.
 	const padding = props.item.level * 10 + (props.item.expanded === undefined ? 26 : 0);
+	const [expanding, setExpanding] = useState<boolean>(false);
+
 	const handleExpand = () => {
+		setExpanding(true);
 		props.onToggleExpand(props.item.id);
 	};
 
@@ -270,6 +273,38 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		}
 	};
 
+	// props.item.expanded
+	const DelayedExpandIcon = (({ expanded, expanding, delay = 200 }: { expanded: boolean | undefined; expanding: boolean; delay?: number }) => {
+		const [showSpinner, setShowSpinner] = useState<boolean>(false);
+
+		useEffect(() => {
+			if (!expanding) {
+				setShowSpinner(false)
+				return
+			}
+			const id = setTimeout(() => setShowSpinner(true), delay);
+			return () => clearTimeout(id)
+		}, [expanding, delay])
+
+
+		if (expanded === undefined) {
+			return <></>;
+		}
+
+		const className = showSpinner ?
+			`codicon codicon-loading animate-spin` :
+			`codicon codicon-chevron-${expanded ? 'down' : 'right'}`;
+
+		return (
+			<div
+				className='expand-collapse-area'
+				onClick={handleExpand}
+			>
+				<div className={className} />
+			</div>
+		)
+	});
+
 	return (
 		<div
 			className={positronClassNames(
@@ -279,19 +314,10 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 			style={props.style}
 		>
 			<div className='nesting' style={{ width: `${padding}px` }}></div>
-			{
-				props.item.expanded === undefined ?
-					<></> :
-					<div
-						className='expand-collapse-area'
-						onClick={handleExpand}
-					>
-						<div
-							className={`codicon codicon-chevron-${props.item.expanded ? 'down' : 'right'}`}
-						>
-						</div>
-					</div>
-			}
+			<DelayedExpandIcon
+				expanded={props.item.expanded}
+				expanding={expanding}
+			/>
 			<div
 				className='connections-details'
 				onMouseDown={rowMouseDownHandler}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeConnectionsClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeConnectionsClient.ts
@@ -12,8 +12,10 @@ export class ConnectionsClientInstance extends Disposable {
 
 	constructor(client: IRuntimeClientInstance<any, any>) {
 		super();
-
-		this._positronConnectionsComm = new PositronConnectionsComm(client);
+		this._positronConnectionsComm = new PositronConnectionsComm(client, {
+			// No timeout for listing objects
+			list_objects: { timeout: undefined },
+		});
 		this._register(this._positronConnectionsComm);
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeConnectionsClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeConnectionsClient.ts
@@ -13,8 +13,9 @@ export class ConnectionsClientInstance extends Disposable {
 	constructor(client: IRuntimeClientInstance<any, any>) {
 		super();
 		this._positronConnectionsComm = new PositronConnectionsComm(client, {
-			// No timeout for listing objects
+			// No timeout for listing or previewing objects
 			list_objects: { timeout: undefined },
+			preview_object: { timeout: undefined },
 		});
 		this._register(this._positronConnectionsComm);
 	}

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -25,6 +25,13 @@ export interface ObjectSchema {
 	 */
 	kind: string;
 
+	/**
+	 * Indicates if the object has children that can be listed. This property
+	 * is optional and when omitted, it is assumed that the object may have
+	 * children unless its kind is 'field'.
+	 */
+	has_children?: boolean;
+
 }
 
 /**

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
@@ -53,7 +53,7 @@ class BaseConnectionsInstance extends Disposable {
 
 export class PositronConnectionsInstance extends BaseConnectionsInstance implements IPositronConnectionInstance {
 
-	private readonly onDidChangeEntriesEmitter = this._register(new Emitter<IPositronConnectionEntry[]>());
+	private readonly onDidChangeEntriesEmitter = this._register(new Emitter<IPositronConnectionEntry[] | undefined>());
 	readonly onDidChangeEntries = this.onDidChangeEntriesEmitter.event;
 
 	private readonly onDidChangeStatusEmitter = this._register(new Emitter<boolean>());
@@ -64,7 +64,7 @@ export class PositronConnectionsInstance extends BaseConnectionsInstance impleme
 
 	private _active: boolean = true;
 	private _children: IPositronConnectionItem[] | undefined;
-	private _entries: IPositronConnectionEntry[] = [];
+	private _entries: IPositronConnectionEntry[] | undefined = undefined;
 
 	private _expanded_entries: Set<string> = new Set();
 

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
@@ -78,7 +78,7 @@ export class PositronConnectionsInstance extends BaseConnectionsInstance impleme
 				let icon: string | undefined = await object.getIcon();
 				if (!icon || icon === '') {
 					icon = undefined;
-				} else if (!icon.startsWith("data:image/")) {
+				} else if (!icon.startsWith('data:image/')) {
 					// icon paths starting with data:image/ are assumed to be data URI's
 					// not file paths.
 					icon = FileAccess.uriToBrowserUri(URI.file(icon)).toString();
@@ -389,6 +389,7 @@ class PositronConnectionItem implements IPositronConnectionItem {
 		this._name = last_elt.name;
 		this._kind = last_elt.kind;
 		this._dtype = last_elt.dtype;
+		this._has_children = last_elt.has_children;
 	}
 
 	get id() {

--- a/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsInstance.ts
@@ -50,10 +50,13 @@ export interface IPositronConnectionInstance {
 	disconnect?(): Promise<void>;
 	refresh?(): Promise<void>;
 
-	onDidChangeEntries: Event<IPositronConnectionEntry[]>;
+	onDidChangeEntries: Event<IPositronConnectionEntry[] | undefined>;
 	onDidChangeStatus: Event<boolean>;
 	refreshEntries(): Promise<void>;
-	getEntries(): IPositronConnectionEntry[];
+	// Returns undefined if entries have not been loaded yet
+	// or if there was an error loading them.
+	// Otherwise returns a list of entries.
+	getEntries(): IPositronConnectionEntry[] | undefined;
 
 	onToggleExpandEmitter: Emitter<string>;
 }

--- a/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsInstance.ts
@@ -36,6 +36,11 @@ export class ConnectionMetadata implements IConnectionMetadata {
 	}
 }
 
+export interface IPositronConnectionsEntriesChangedEvent {
+	entries: IPositronConnectionEntry[] | undefined;
+	error?: Error;
+}
+
 /***
  * A Connection Instance represents the root of a connection to a data
  * source. Children of a connection instance are tables, views, and other
@@ -50,7 +55,7 @@ export interface IPositronConnectionInstance {
 	disconnect?(): Promise<void>;
 	refresh?(): Promise<void>;
 
-	onDidChangeEntries: Event<IPositronConnectionEntry[] | undefined>;
+	onDidChangeEntries: Event<IPositronConnectionsEntriesChangedEvent>;
 	onDidChangeStatus: Event<boolean>;
 	refreshEntries(): Promise<void>;
 	// Returns undefined if entries have not been loaded yet

--- a/src/vs/workbench/services/positronConnections/test/positronConnectionInstanceMock.ts
+++ b/src/vs/workbench/services/positronConnections/test/positronConnectionInstanceMock.ts
@@ -5,7 +5,7 @@
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../base/common/event.js';
-import { IPositronConnectionEntry, IPositronConnectionInstance } from '../common/interfaces/positronConnectionsInstance.js';
+import { IPositronConnectionInstance, IPositronConnectionsEntriesChangedEvent } from '../common/interfaces/positronConnectionsInstance.js';
 
 export class TestConnectionInstance extends Disposable implements IPositronConnectionInstance {
 	id: string;
@@ -35,7 +35,7 @@ export class TestConnectionInstance extends Disposable implements IPositronConne
 		return Promise.resolve();
 	}
 
-	onDidChangeEntriesEmitter = new Emitter<IPositronConnectionEntry[]>();
+	onDidChangeEntriesEmitter = new Emitter<IPositronConnectionsEntriesChangedEvent>();
 	onDidChangeStatusEmitter = new Emitter<boolean>();
 
 	onDidChangeEntries = this.onDidChangeEntriesEmitter.event;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

This PR adds databricks support for the connections pane. Addresses https://github.com/posit-dev/positron/issues/10429?issue=posit-dev%7Cpositron%7C10430

Some Databricks interactions may take a while, like listing all catalogs because of cold starts. Eg if the warehouse is turned off, we may need to wait for it to turn on before the listing can be shown. This leads to RPC timeout errors.
To handle this, we've added a loading state for connections, that is shown while connections don't have any entries to display. We've also made `list_objects` never timeout, it's up for the implementation of the `list_objects` to timeout if needed and raise an error instead.

We've also added a similar loading state when clicking on the expand button. We now show a small spining icon that indicates that something is going on.

Databricks catalgos may have `volumes` which are leaf like nodes in the DB because they can't be expanded, but they are not table/view 'fields'. To handle this case, we've added a new optional field in the connections openRPC contract called 'has_children', if `False` it means that the obejct can no longer be expanded. By default this is assumed to be `True` unless the object 'kind' is 'field'.

To try it out, you can:

```
from databricks import sql
connection = sql.connect(
    server_hostname = "<host_name>",
    http_path              = "<http_path>",
    access_token       = "<PAT>" 
)
%connection_show connection
```

Feel free to ask questions for help with setting up.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added Connections Pane support for Databricks SQL Connector (#10427).

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:connections