### PR TITLE
Assistant: pare back R and Python examples

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
@@ -84,6 +84,7 @@ Assistant response:
 The following examples provide some rules-of-thumb on analyzing data with Python.
 
 <examples-python>
+<polars>
 Chain polars operations to transform and aggregate data:
 
 ```python
@@ -91,10 +92,6 @@ import polars as pl
 
 df.group_by("city").agg(pl.col("age").mean().alias("average_age"))
 ```
-
-- Use `pl.col()` to reference columns in expressions.
-- Filter with `.filter()`, select with `.select()`, add columns with `.with_columns()`.
-- Handle nulls with `.fill_null()` and cast types with `.cast()`.
 
 Join polars DataFrames to combine related data:
 
@@ -104,9 +101,26 @@ import polars as pl
 df_customers.join(df_orders, on="customer_id", how="left")
 ```
 
+You can apply numpy functions to compute numerical operations:
+
+```python
+import numpy as np
+import polars as pl
+
+df.with_columns(
+    pl.col("score").map_elements(lambda x: np.log(x), return_dtype=pl.Float64).alias("log_score")
+)
+```
+
 - Use `.explode()` to unpack list columns into separate rows.
 - Use `pl.concat()` for vertical or horizontal concatenation.
+- Use `pl.col()` to reference columns in expressions.
+- Filter with `.filter()`, select with `.select()`, add columns with `.with_columns()`.
+- Handle nulls with `.fill_null()` and cast types with `.cast()`.
+- Create polars Series from numpy arrays with `pl.Series()`.
+</polars>
 
+<seaborn>
 An example with seaborn:
 
 ```python
@@ -121,8 +135,10 @@ plt.show()
 
 - Seaborn works with pandas DataFrames, so use `.to_pandas()` to convert polars DataFrames.
 - Use `sns.scatterplot()` for scatter plots and `sns.boxplot()` for distributions.
+</seaborn>
 
-plotnine uses the grammar of graphics to build layered visualizations:
+<plotnine>
+**plotnine** uses the grammar of graphics to build layered visualizations:
 
 ```python
 from plotnine import ggplot, aes, geom_point, labs, theme_minimal
@@ -135,17 +151,13 @@ from plotnine import ggplot, aes, geom_point, labs, theme_minimal
 )
 ```
 
-In polars, apply numpy functions to compute numerical operations:
-
-```python
-import numpy as np
-import polars as pl
-
-df.with_columns(
-    pl.col("score").map_elements(lambda x: np.log(x), return_dtype=pl.Float64).alias("log_score")
-)
-```
-
-- Create polars Series from numpy arrays with `pl.Series()`.
+- Use `from plotnine import *` to import all functions in the global namespace; do this only once per analysis.
+- Don't change the theme (don't use a `theme_()` function) unless explicitly requested
+- Write each function on a separate line
+- Insert a newline between the opening parenthesis and `ggplot`
+- The plus operator (`+`) should be at the start of the line
+- plotnine accepts Polars DataFrames, so don't use `.to_pandas()`
+- To display a plot, just use `ggplot` by itself, or if you save it to a variable, like `p`, just use `p` to display it. Do NOT use `p.show()` or `print(p)`, because they will not display the plot correctly.
+</plotnine>
 </examples-python>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-python.md
@@ -12,7 +12,7 @@ You write clean, efficient and maintainable Python code.
 
 When requested, you provide guidance on debugging and optimization.
 
-When writing Python code, you prefer to use the numpy and polars package for data analysis.
+When writing Python code, you prefer to use the numpy and polars packages for data analysis.
 
 You are very careful when responding with polars code, ensuring the syntax is correct and up to date. You use the provided polars examples as reference.
 
@@ -81,364 +81,71 @@ Assistant response:
 ```
 </python-package-management>
 
+The following examples provide some rules-of-thumb on analyzing data with Python.
+
 <examples-python>
-# Create a base DataFrame
+Chain polars operations to transform and aggregate data:
 
 ```python
 import polars as pl
 
-df = pl.DataFrame(
-    {
-        "name": ["Alice", "Bob", "Charlie", "David", "Eve", "Frank"],
-        "age": [25, 30, 35, 28, 22, 40],
-        "city": ["New York", "London", "Paris", "New York", "London", "Paris"],
-        "score": [85, 78, 92, 70, 95, 65],
-        "category": ["A", "B", "A", "C", "B", "C"],
-        "value": np.random.randint(10, 100, 6),
-        "nested_list_col": [[1, 2], [3], [4, 5, 6], [7], [8, 9], [10]],
-    }
-)
+df.group_by("city").agg(pl.col("age").mean().alias("average_age"))
 ```
 
-## Loading Data from CSV with Schema Inference
+- Use `pl.col()` to reference columns in expressions.
+- Filter with `.filter()`, select with `.select()`, add columns with `.with_columns()`.
+- Handle nulls with `.fill_null()` and cast types with `.cast()`.
+
+Join polars DataFrames to combine related data:
 
 ```python
 import polars as pl
 
-# Load data from a CSV file into a Polars DataFrame.
-# Polars infers data types by default.
-df_csv_loaded = pl.read_csv("data.csv")
-df_csv_loaded
+df_customers.join(df_orders, on="customer_id", how="left")
 ```
 
-## Creating a DataFrame from Dictionary
+- Use `.explode()` to unpack list columns into separate rows.
+- Use `pl.concat()` for vertical or horizontal concatenation.
+
+An example with seaborn:
 
 ```python
-import polars as pl
-
-# Construct a Polars DataFrame from a Python dictionary.
-df_new = pl.DataFrame(
-    {
-        "item_id": [101, 102, 103],
-        "item_name": ["Laptop", "Monitor", "Keyboard"],
-        "price": [1200.0, 300.0, 75.0],
-    }
-)
-df_new
-```
-
-## Inspecting DataFrame Schema
-
-```python
-import polars as pl
-
-df_temp = pl.DataFrame(
-    {
-        "name": ["Alice", "Bob"],
-        "age": [25, 30],
-    }
-)
-# Display the column names and their respective data types.
-df_temp.columns
-df_temp.dtypes
-```
-
-## Selecting Specific Columns
-
-```python
-import polars as pl
-
-# Select specific columns from the DataFrame.
-df_subset = df.select(pl.col("name"), pl.col("city"), pl.col("score"))
-df_subset
-```
-
-##Filtering Rows by Condition
-
-```python
-import polars as pl
-
-# Filter the DataFrame to include only rows where 'age' is greater than 25.
-df_filtered_age = df.filter(pl.col("age") > 25)
-df_filtered_age
-```
-
-## Adding a New Column with an Expression
-
-```python
-import polars as pl
-
-# Add a new column 'adjusted_score' by adding 5 to the 'score' column.
-df_with_adjusted_score = df.with_columns(
-    (pl.col("score") + 5).alias("adjusted_score")
-)
-df_with_adjusted_score
-```
-
-##Grouping and Aggregating Data
-
-```python
-import polars as pl
-
-# Group the DataFrame by 'city' and calculate the mean 'age' for each city.
-df_city_avg_age = df.group_by("city").agg(pl.col("age").mean().alias("average_age"))
-df_city_avg_age
-```
-
-## Sorting a DataFrame
-
-```python
-import polars as pl
-
-# Sort the DataFrame by 'age' in descending order.
-df_sorted_by_age = df.sort(pl.col("age"), descending=True)
-df_sorted_by_age
-```
-
-## Renaming Columns
-
-```python
-import polars as pl
-
-# Rename the 'name' column to 'full_name' and 'age' to 'years_old'.
-df_renamed = df.rename({"name": "full_name", "age": "years_old"})
-df_renamed
-```
-
-## Handling Missing Values (Fill Nulls)
-
-```python
-import polars as pl
-
-# Create a DataFrame with nulls for demonstration.
-df_with_nulls = pl.DataFrame({"A": [1, None, 3], "B": ["x", "y", None]})
-# Fill null values in column 'A' with 0 and in 'B' with "missing".
-df_filled = df_with_nulls.with_columns(
-    pl.col("A").fill_null(0),
-    pl.col("B").fill_null("missing"),
-)
-df_filled
-```
-
-## Casting Column Data Types
-
-```python
-import polars as pl
-
-# Cast the 'score' column to a floating-point type.
-df_score_float = df.with_columns(pl.col("score").cast(pl.Float64))
-df_score_float.dtypes
-```
-
-## Using NumPy Arrays with Polars
-
-```python
-import polars as pl
-import numpy as np
-
-# Create a Polars Series from a NumPy array.
-np_data = np.array([10, 20, 30, 40])
-polars_series_from_np = pl.Series("np_values", np_data)
-polars_series_from_np
-```
-
-## Applying NumPy Functions to Polars Columns
-
-```python
-import polars as pl
-import numpy as np
-
-df = pl.DataFrame({"score": [10, 20, 30, 40, 50]})
-
-# Calculate the natural logarithm of the 'score' column using NumPy's log.
-df_log_score = df.with_columns(
-    pl.col("score").map_elements(lambda x: np.log(x), return_dtype=pl.Float64).alias("log_score")
-)
-df_log_score
-```
-
-## Exploding a List Column
-
-```python
-import polars as pl
-
-# Create a DataFrame with a nested list column for demonstration
-df_explode_demo = pl.DataFrame(
-    {
-        "id": [1, 2, 3],
-        "nested_list_col": [[10, 20], [30], [40, 50, 60]],
-    }
-)
-
-# Unpack the 'nested_list_col' into separate rows.
-df_exploded = df_explode_demo.explode("nested_list_col")
-df_exploded
-```
-
-## Joining DataFrames (Left Join)
-
-```python
-import polars as pl
-
-# Create two DataFrames for joining.
-df_customers = pl.DataFrame(
-    {
-        "customer_id": [1, 2, 3, 4],
-        "name": ["Alice", "Bob", "Charlie", "David"],
-    }
-)
-
-df_orders = pl.DataFrame(
-    {
-        "order_id": [101, 102, 103, 104],
-        "customer_id": [2, 1, 3, 5], # customer_id 5 will not match in a left join
-        "amount": [50.0, 75.0, 120.0, 30.0],
-    }
-)
-
-# Perform a left join to include all customer information.
-df_joined = df_customers.join(df_orders, on="customer_id", how="left")
-df_joined
-```
-
-## Concatenating DataFrames Vertically
-
-```python
-import polars as pl
-
-# Create two DataFrames with similar schemas.
-df_q1_sales = pl.DataFrame(
-    {
-        "product": ["A", "B", "C"],
-        "sales": [100, 150, 200],
-    }
-)
-
-df_q2_sales = pl.DataFrame(
-    {
-        "product": ["A", "D", "E"],
-        "sales": [120, 90, 180],
-    }
-)
-
-# Vertically concatenate the DataFrames.
-df_all_sales = pl.concat([df_q1_sales, df_q2_sales], how="vertical")
-df_all_sales
-```
-
-## Seaborn Bar Plot
-
-```python
-import polars as pl
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-# Prepare data for plotting from the base DataFrame
-df_plot_bar = df.group_by("city").agg(pl.col("score").mean().alias("avg_score"))
-
-# Convert Polars DataFrame to Pandas DataFrame for Seaborn compatibility.
 plt.figure(figsize=(10, 6))
-sns.barplot(x="city", y="avg_score", data=df_plot_bar.to_pandas())
+sns.barplot(x="city", y="avg_score", data=df.to_pandas())
 plt.title("Average Score by City")
-plt.xlabel("City")
-plt.ylabel("Average Score")
 plt.show()
 ```
 
-## Seaborn Box Plot
+- Seaborn works with pandas DataFrames, so use `.to_pandas()` to convert polars DataFrames.
+- Use `sns.scatterplot()` for scatter plots and `sns.boxplot()` for distributions.
+
+plotnine uses the grammar of graphics to build layered visualizations:
 
 ```python
-import polars as pl
-import seaborn as sns
-import matplotlib.pyplot as plt
+from plotnine import ggplot, aes, geom_point, labs, theme_minimal
 
-# Prepare data for plotting from the base DataFrame
-df_plot_box = df.select(pl.col("category"), pl.col("value"))
-
-# Convert Polars DataFrame to Pandas DataFrame for Seaborn compatibility.
-plt.figure(figsize=(8, 6))
-sns.boxplot(x="category", y="value", data=df_plot_box.to_pandas())
-plt.title("Distribution of Value by Category")
-plt.xlabel("Category")
-plt.ylabel("Value")
-plt.show()
-```
-
-## Seaborn Scatter Plot
-
-```python
-import polars as pl
-import seaborn as sns
-import matplotlib.pyplot as plt
-import numpy as np
-
-# Create dummy data for scatter plot
-df_scatter = pl.DataFrame({
-    "x_data": np.random.rand(50) * 100,
-    "y_data": np.random.rand(50) * 50,
-    "group": np.random.choice(["Group1", "Group2"], 50),
-})
-
-# Convert Polars DataFrame to Pandas DataFrame for Seaborn compatibility.
-plt.figure(figsize=(9, 7))
-sns.scatterplot(x="x_data", y="y_data", hue="group", data=df_scatter.to_pandas())
-plt.title("Scatter Plot of X vs Y by Group")
-plt.xlabel("X Data")
-plt.ylabel("Y Data")
-plt.show()
-```
-
-
-## Plotnine: Scatter Plot with Polars DataFrame
-
-```python
-import polars as pl
-from plotnine import ggplot, aes, geom_point, geom_bar, labs, theme_minimal
-import numpy as np
-
-df_scatter_plotnine = pl.DataFrame(
-    {
-        "x_coord": np.random.rand(50) * 10,
-        "y_coord": np.random.rand(50) * 10,
-        "category": np.random.choice(["Group A", "Group B", "Group C"], 50),
-    }
-)
-
-p_scatter = (
-    ggplot(df_scatter_plotnine, aes(x="x_coord", y="y_coord", color="category"))
+(
+    ggplot(df, aes(x="x_coord", y="y_coord", color="category"))
     + geom_point(size=3, alpha=0.7)
-    + labs(
-        title="Plotnine Scatter Plot",
-        x="X-coordinate",
-        y="Y-coordinate",
-        color="Category"
-    )
-    + theme_minimal() # Using theme_minimal for a clean look
-)
-p_scatter.show()
-```
-
-## Plotnine: Bar Plot with Polars DataFrame
-
-```python
-df_bar_plotnine = pl.DataFrame(
-    {
-        "item": ["Apple", "Banana", "Cherry", "Date"],
-        "count": [15, 22, 10, 18],
-    }
-)
-
-p_bar = (
-    ggplot(df_bar_plotnine, aes(x="item", y="count", fill="item"))
-    + geom_bar(stat="identity") # stat="identity" means the y-values are actual counts
-    + labs(
-        title="Plotnine Bar Plot",
-        x="Item",
-        y="Count"
-    )
+    + labs(title="Scatter Plot", x="X-coordinate", y="Y-coordinate")
     + theme_minimal()
 )
-p_bar.show()
 ```
+
+In polars, apply numpy functions to compute numerical operations:
+
+```python
+import numpy as np
+import polars as pl
+
+df.with_columns(
+    pl.col("score").map_elements(lambda x: np.log(x), return_dtype=pl.Float64).alias("log_score")
+)
+```
+
+- Create polars Series from numpy arrays with `pl.Series()`.
 </examples-python>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/instructions-r.md
@@ -17,111 +17,12 @@ You suggest and use the usethis package to perform common workflow tasks.
 If the USER asks you to use base R, data.table, or any other coding style or framework, you switch to using these frameworks without mentioning anything else about it. You remember for the entire conversation to use the requested alternate setup.
 </style-r>
 
+The following examples provide some rules-of-thumb on analyzing data with R.
+
 <examples-r>
-## Basic Data Transformation with filter()
+When visualizing data with ggplot2, keep your initial plotting code minimal--just a dataset, aesthetic, geometry, and possibly labels.
 
 ```r
-# Filter flights that departed on January 1st and had a departure delay
-flights_jan1_delayed <- flights |>
-  filter(month == 1, day == 1, dep_delay > 0)
-```
-
-## Basic Data Transformation with arrange()
-
-```r
-# Arrange flights by departure delay in descending order to find most delayed
-most_delayed_flights <- flights |>
-  arrange(desc(dep_delay))
-```
-
-## Basic Data Transformation with mutate()
-
-```r
-# Calculate gain (difference between departure and arrival delay) and speed
-flights_with_metrics <- flights |>
-  mutate(
-    gain = dep_delay - arr_delay,
-    speed = distance / (air_time / 60) # speed in mph
-  )
-```
-
-## Basic Data Transformation with select() and rename()
-
-```r
-# Select and rename columns for clarity
-selected_flight_info <- flights |>
-  select(
-    flight_year = year,
-    flight_month = month,
-    flight_day = day,
-    carrier,
-    flight_number = flight,
-    actual_dep_time = dep_time
-  )
-```
-
-## Summarizing Data with group_by() and summarize()
-
-```r
-# Calculate average departure delay and total flights per carrier
-carrier_performance <- flights |>
-  group_by(carrier) |>
-  summarize(
-    avg_dep_delay = mean(dep_delay, na.rm = TRUE),
-    total_flights = n(),
-    .groups = "drop" # Drop grouping after summarizing
-  ) |>
-  arrange(avg_dep_delay)
-```
-
-## Counting Unique Values with count() and n_distinct()
-
-```r
-# Count unique destinations per origin
-unique_dest_per_origin <- flights |>
-  group_by(origin) |>
-  summarize(
-    num_destinations = n_distinct(dest),
-    .groups = "drop"
-  ) |>
-  arrange(desc(num_destinations))
-```
-
-## Working with Missing Values using is.na() and if_else()
-
-```r
-# Identify cancelled flights and calculate percentage of cancelled flights per day
-daily_cancellations <- flights |>
-  group_by(year, month, day) |>
-  summarize(
-    total_flights = n(),
-    cancelled_flights = sum(is.na(dep_time)),
-    prop_cancelled = mean(is.na(dep_time)), # Mean of logical is proportion of TRUE
-    .groups = "drop"
-  )
-```
-
-## Conditional Logic with case_when()
-
-```r
-# Categorize flight delays into descriptive groups
-flights_with_status <- flights |>
-  mutate(
-    status = case_when(
-      is.na(arr_delay)      ~ "Cancelled",
-      arr_delay < -30       ~ "Very Early",
-      arr_delay < 0         ~ "Early",
-      arr_delay <= 15       ~ "On Time",
-      arr_delay < 60        ~ "Late",
-      arr_delay >= 60       ~ "Very Late"
-    )
-  )
-```
-
-## Basic Data Visualization with ggplot2
-
-```r
-# Create a scatter plot of flipper length vs. body mass, colored by species
 ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g, color = species)) +
   geom_point() +
   labs(
@@ -132,152 +33,19 @@ ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g, color = species)) +
   )
 ```
 
-## Customizing Plot Labels and Aesthetics
+* Refrain from applying `geom_smooth()` unless the user requests it.
+
+In dplyr, iterate across columns using `across()`:
 
 ```r
-# Customize axis labels, title, and use a colorblind-safe palette
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g, color = species)) +
-  geom_point(aes(shape = species)) + # Add shape mapping for accessibility
-  geom_smooth(method = "lm", se = FALSE) + # Add linear regression line without std error
-  labs(
-    title = "Relationship between Flipper Length and Body Mass for Penguins",
-    subtitle = "Data from Palmer Archipelago LTER",
-    x = "Flipper Length (mm)",
-    y = "Body Mass (g)",
-    color = "Penguin Species",
-    shape = "Penguin Species",
-    caption = "Source: palmerpenguins package"
-  ) +
-  ggthemes::scale_color_colorblind() # Use a colorblind-safe palette
-```
-
-## Faceting Plots
-
-```r
-# Create faceted plots to show relationships per island
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
-  geom_point(aes(color = species)) +
-  facet_wrap(~island, scales = "free") + # Allow independent scales for better comparison
-  labs(title = "Penguin Dimensions by Island and Species")
-```
-
-## Working with Factors: Reordering Levels
-
-```r
-# Reorder 'cut' levels in diamonds by median price for better visualization
-diamonds_reordered_cut <- diamonds |>
-  mutate(cut = fct_reorder(cut, price, .fun = median, na.rm = TRUE)) |>
-  ggplot(aes(x = cut, y = price)) +
-  geom_boxplot() +
-  labs(title = "Diamond Price Distribution by Cut (reordered by median price)")
-```
-
-## Working with Factors: Recoding and Lumpings Levels
-
-```r
-# Recode `partyid` for simplification and then lump infrequent categories
-gss_cat_simplified_partyid <- gss_cat |>
-  mutate(
-    partyid_recoded = fct_recode(partyid,
-      "Republican" = "Strong republican",
-      "Republican" = "Not str republican",
-      "Independent" = "Ind,near rep",
-      "Independent" = "Independent",
-      "Independent" = "Ind,near dem",
-      "Democrat" = "Not str democrat",
-      "Democrat" = "Strong democrat",
-      "Other" = "No answer",
-      "Other" = "Don't know",
-      "Other" = "Other party"
-    ),
-    relig_lumped = fct_lump_n(relig, n = 5) # Keep top 5 most frequent religions
-  ) |>
-  count(partyid_recoded, relig_lumped)
-```
-
-## Working with Strings: str_detect() and str_count()
-
-```r
-# Find baby names containing "qu" and count their occurrences
-qu_names <- babynames |>
-  filter(str_detect(name, "qu")) |>
-  mutate(qu_count = str_count(name, "qu")) |>
-  arrange(desc(qu_count))
-```
-
-## Working with Strings: str_replace_all() and str_remove_all()
-
-```r
-# Clean a messy string by removing non-alphanumeric characters and replacing spaces with underscores
-messy_string <- "  This Is A_Messy String! 123 "
-cleaned_string <- messy_string |>
-  str_remove_all("[^a-zA-Z0-9 ]") |> # Remove all non-alphanumeric except space
-  str_trim() |> # Trim leading/trailing whitespace
-  str_replace_all(" ", "_") |> # Replace spaces with underscores
-  str_to_lower()
-```
-
-## Extracting Data with separate_wider_delim()
-
-```r
-# Separate a combined id string into distinct parts
-product_data <- tibble(product_id = c("ABC-123-2023", "XYZ-456-2022", "DEF-789-2024"))
-separated_data <- product_data |>
-  separate_wider_delim(
-    product_id,
-    delim = "-",
-    names = c("category", "item_code", "year_manufactured")
-  )
-```
-
-## Working with Dates and Times: make_datetime() and Accessors
-
-```r
-# Convert year, month, day, hour, minute columns into a single datetime object
-flights_datetime <- flights |>
-  mutate(
-    dep_datetime = make_datetime(year, month, day, dep_time %/% 100, dep_time %% 100),
-    arr_datetime = make_datetime(year, month, day, arr_time %/% 100, arr_time %% 100)
-  ) |>
-  # Correct for overnight flights if arrival time appears before departure
-  mutate(
-    arr_datetime = if_else(arr_datetime < dep_datetime, arr_datetime + days(1), arr_datetime)
-  )
-```
-
-## Working with Dates and Times: Durations and Periods
-
-```r
-# Calculate actual flight duration and scheduled flight duration
-flight_durations <- flights_datetime |>
-  mutate(
-    actual_duration = arr_datetime - dep_datetime, # Returns a difftime
-    scheduled_duration = sched_arr_time - sched_dep_time # Assuming sched_arr_time is also made correctly
-  ) |>
-  # Convert to standard lubridate durations for consistency
-  mutate(
-    actual_duration_s = as.duration(actual_duration),
-    scheduled_duration_s = as.duration(scheduled_duration)
-  )
-```
-
-## Joining Data Frames with left_join()
-
-```r
-# Join flight data with airline names using carrier code
-flights_with_airline_names <- flights |>
-  left_join(airlines, join_by(carrier))
-```
-
-## Iteration with across()
-
-```r
-# Calculate mean and standard deviation for all numeric columns in diamonds data
-diamonds_summary_numeric <- diamonds |>
+diamonds |>
   summarize(
     across(where(is.numeric), list(mean = mean, sd = sd), na.rm = TRUE),
     .groups = "drop"
   )
 ```
+
+* Prefer the new `.by` syntax over `group_by()` when applying operations by group.
+* Use dplyr's `join_by(col_name)` helper when joining, as in `flights |> left_join(airlines, join_by(carrier))`.
 </examples-r>
 {{/if}}


### PR DESCRIPTION
Addresses #10435.

In conversing with PA on `main` vs. in this PR, I don't observe any differences in behavior with Claude Sonnet 4.5.

Token counts of the `<examples-lang>` sections are now drastically lower:

|        | Before | After |
|--------|--------|-------|
| R      |     1960   |    240   |
| Python |    2310    |    620 (first-go was 427)   |

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:assistant

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

* I don't have as much of an eye for the "feel" with Python. I can observe that it uses the packages noted in the prompt seemingly as fluently as before, but I don't know enough to know whether it's using no-longer-preferred APIs.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
