### PR TITLE
Add positron notebook awareness to assistant. 

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -289,6 +289,14 @@
               "preview"
             ]
           },
+          "positron.assistant.notebookMode.enable": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "%configuration.notebookMode.enable.description%",
+            "tags": [
+              "experimental"
+            ]
+          },
           "positron.assistant.toolErrors.propagate": {
             "type": "boolean",
             "default": false,

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -731,23 +731,23 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "cellIds": {
+            "cellIndices": {
               "type": "array",
-              "description": "Array of cell IDs to execute. Each cell ID uniquely identifies a cell in the notebook.",
+              "description": "Array of cell indices to execute. Each index is a 0-based position of the cell in the notebook.",
               "items": {
-                "type": "string"
+                "type": "number"
               }
             }
           },
           "required": [
-            "cellIds"
+            "cellIndices"
           ]
         }
       },
       {
         "name": "editNotebookCells",
         "displayName": "Edit Notebook Cells",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content), operation='update' to modify existing cells (requires cellId and content), or operation='delete' to remove cells (requires cellId). Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content), operation='update' to modify existing cells (requires cellIndex and content), or operation='delete' to remove cells (requires cellIndex). Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -782,9 +782,9 @@
               "type": "string",
               "description": "Cell content. Required when operation is 'add' or 'update'."
             },
-            "cellId": {
-              "type": "string",
-              "description": "ID of the cell to modify or delete. Required when operation is 'update' or 'delete'."
+            "cellIndex": {
+              "type": "number",
+              "description": "Index of the cell to modify or delete (0-based). Required when operation is 'update' or 'delete'."
             }
           },
           "required": [
@@ -795,7 +795,7 @@
       {
         "name": "getNotebookCells",
         "displayName": "Get Notebook Cells",
-        "modelDescription": "Retrieve information about notebook cells with flexible operations. Use operation='get' to fetch specific cells by ID or all cells if cellIds is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIds), or operation='getMetadata' to get only cell status information without content.",
+        "modelDescription": "Retrieve information about notebook cells with flexible operations. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), or operation='getMetadata' to get only cell status information without content.",
         "toolReferenceName": "getNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -815,11 +815,11 @@
               ],
               "description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content."
             },
-            "cellIds": {
+            "cellIndices": {
               "type": "array",
-              "description": "Optional array of cell IDs to retrieve. Required for 'getOutputs'. For 'get', returns all cells if omitted. Ignored for 'getSelected' and 'getMetadata'.",
+              "description": "Optional array of cell indices to retrieve (0-based). Required for 'getOutputs'. For 'get', returns all cells if omitted. Ignored for 'getSelected' and 'getMetadata'.",
               "items": {
-                "type": "string"
+                "type": "number"
               }
             }
           },

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -745,10 +745,10 @@
         }
       },
       {
-        "name": "addNotebookCell",
-        "displayName": "Add Notebook Cell",
-        "modelDescription": "Add a new cell (code or markdown) to the active notebook at the specified position. Use this when the user wants to insert new cells or create new content in the notebook.",
-        "toolReferenceName": "addNotebookCell",
+        "name": "editNotebookCells",
+        "displayName": "Edit Notebook Cells",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content), operation='update' to modify existing cells (requires cellId and content), or operation='delete' to remove cells (requires cellId). Use index=-1 to append cells at the end when adding.",
+        "toolReferenceName": "editNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
@@ -757,85 +757,45 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "type": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "add",
+                "update",
+                "delete"
+              ],
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell."
+            },
+            "cellType": {
               "type": "string",
               "enum": [
                 "code",
                 "markdown"
               ],
-              "description": "Type of cell to add. Use 'code' for executable code cells, 'markdown' for documentation cells."
+              "description": "Type of cell to create. Required when operation is 'add'. Use 'code' for executable cells, 'markdown' for documentation."
             },
             "index": {
               "type": "number",
-              "description": "Position to insert the cell (0-based). Use -1 to append at the end of the notebook."
+              "description": "Position to insert the cell (0-based). Required when operation is 'add'. Use -1 to append at the end."
             },
             "content": {
               "type": "string",
-              "description": "Initial content for the new cell."
-            }
-          },
-          "required": [
-            "type",
-            "index",
-            "content"
-          ]
-        }
-      },
-      {
-        "name": "updateNotebookCell",
-        "displayName": "Update Notebook Cell",
-        "modelDescription": "Update the content of an existing cell in the active notebook. Use this when the user wants to modify or edit existing cell content.",
-        "toolReferenceName": "updateNotebookCell",
-        "canBeReferencedInPrompt": true,
-        "tags": [
-          "positron-assistant",
-          "requires-notebook"
-        ],
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "cellId": {
-              "type": "string",
-              "description": "ID of the cell to update. This uniquely identifies the cell in the notebook."
+              "description": "Cell content. Required when operation is 'add' or 'update'."
             },
-            "content": {
-              "type": "string",
-              "description": "New content for the cell. This will replace the existing cell content."
-            }
-          },
-          "required": [
-            "cellId",
-            "content"
-          ]
-        }
-      },
-      {
-        "name": "getCellOutputs",
-        "displayName": "Get Cell Outputs",
-        "modelDescription": "Get the outputs from a specific cell in the active notebook. Use this when the user wants to see the results or output from a previously executed cell.",
-        "toolReferenceName": "getCellOutputs",
-        "canBeReferencedInPrompt": true,
-        "tags": [
-          "positron-assistant",
-          "requires-notebook"
-        ],
-        "inputSchema": {
-          "type": "object",
-          "properties": {
             "cellId": {
               "type": "string",
-              "description": "ID of the cell to get outputs from. This uniquely identifies the cell in the notebook."
+              "description": "ID of the cell to modify or delete. Required when operation is 'update' or 'delete'."
             }
           },
           "required": [
-            "cellId"
+            "operation"
           ]
         }
       },
       {
         "name": "getNotebookCells",
         "displayName": "Get Notebook Cells",
-        "modelDescription": "Get information about cells in the active notebook. If cellIds are provided, returns only those specific cells. If no cellIds are provided, returns all cells in the notebook. Use this when the user asks about cells that are not currently selected, or wants to see the full notebook structure.",
+        "modelDescription": "Retrieve information about notebook cells with flexible operations. Use operation='get' to fetch specific cells by ID or all cells if cellIds is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIds), or operation='getMetadata' to get only cell status information without content.",
         "toolReferenceName": "getNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -845,14 +805,27 @@
         "inputSchema": {
           "type": "object",
           "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "get",
+                "getSelected",
+                "getOutputs",
+                "getMetadata"
+              ],
+              "description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content."
+            },
             "cellIds": {
               "type": "array",
-              "description": "Optional array of cell IDs to retrieve. If omitted, all cells are returned.",
+              "description": "Optional array of cell IDs to retrieve. Required for 'getOutputs'. For 'get', returns all cells if omitted. Ignored for 'getSelected' and 'getMetadata'.",
               "items": {
                 "type": "string"
               }
             }
-          }
+          },
+          "required": [
+            "operation"
+          ]
         }
       }
     ]

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -709,6 +709,138 @@
             }
           }
         }
+      },
+      {
+        "name": "runNotebookCells",
+        "displayName": "Run Notebook Cells",
+        "modelDescription": "Execute one or more cells in the active notebook and return their outputs. Use this when the user wants to run code cells or see the results of cell execution.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "cellIds": {
+              "type": "array",
+              "description": "Array of cell IDs to execute. Each cell ID uniquely identifies a cell in the notebook.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "cellIds"
+          ]
+        }
+      },
+      {
+        "name": "addNotebookCell",
+        "displayName": "Add Notebook Cell",
+        "modelDescription": "Add a new cell (code or markdown) to the active notebook at the specified position. Use this when the user wants to insert new cells or create new content in the notebook.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "code",
+                "markdown"
+              ],
+              "description": "Type of cell to add. Use 'code' for executable code cells, 'markdown' for documentation cells."
+            },
+            "index": {
+              "type": "number",
+              "description": "Position to insert the cell (0-based). Use -1 to append at the end of the notebook."
+            },
+            "content": {
+              "type": "string",
+              "description": "Initial content for the new cell."
+            }
+          },
+          "required": [
+            "type",
+            "index",
+            "content"
+          ]
+        }
+      },
+      {
+        "name": "updateNotebookCell",
+        "displayName": "Update Notebook Cell",
+        "modelDescription": "Update the content of an existing cell in the active notebook. Use this when the user wants to modify or edit existing cell content.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "cellId": {
+              "type": "string",
+              "description": "ID of the cell to update. This uniquely identifies the cell in the notebook."
+            },
+            "content": {
+              "type": "string",
+              "description": "New content for the cell. This will replace the existing cell content."
+            }
+          },
+          "required": [
+            "cellId",
+            "content"
+          ]
+        }
+      },
+      {
+        "name": "getCellOutputs",
+        "displayName": "Get Cell Outputs",
+        "modelDescription": "Get the outputs from a specific cell in the active notebook. Use this when the user wants to see the results or output from a previously executed cell.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "cellId": {
+              "type": "string",
+              "description": "ID of the cell to get outputs from. This uniquely identifies the cell in the notebook."
+            }
+          },
+          "required": [
+            "cellId"
+          ]
+        }
+      },
+      {
+        "name": "getNotebookCells",
+        "displayName": "Get Notebook Cells",
+        "modelDescription": "Get information about cells in the active notebook. If cellIds are provided, returns only those specific cells. If no cellIds are provided, returns all cells in the notebook. Use this when the user asks about cells that are not currently selected, or wants to see the full notebook structure.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "cellIds": {
+              "type": "array",
+              "description": "Optional array of cell IDs to retrieve. If omitted, all cells are returned.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     ]
   },

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -714,7 +714,8 @@
         "name": "runNotebookCells",
         "displayName": "Run Notebook Cells",
         "modelDescription": "Execute one or more cells in the active notebook and return their outputs. Use this when the user wants to run code cells or see the results of cell execution.",
-        "canBeReferencedInPrompt": false,
+        "toolReferenceName": "runNotebookCells",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-notebook"
@@ -739,7 +740,8 @@
         "name": "addNotebookCell",
         "displayName": "Add Notebook Cell",
         "modelDescription": "Add a new cell (code or markdown) to the active notebook at the specified position. Use this when the user wants to insert new cells or create new content in the notebook.",
-        "canBeReferencedInPrompt": false,
+        "toolReferenceName": "addNotebookCell",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-notebook"
@@ -775,7 +777,8 @@
         "name": "updateNotebookCell",
         "displayName": "Update Notebook Cell",
         "modelDescription": "Update the content of an existing cell in the active notebook. Use this when the user wants to modify or edit existing cell content.",
-        "canBeReferencedInPrompt": false,
+        "toolReferenceName": "updateNotebookCell",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-notebook"
@@ -802,7 +805,8 @@
         "name": "getCellOutputs",
         "displayName": "Get Cell Outputs",
         "modelDescription": "Get the outputs from a specific cell in the active notebook. Use this when the user wants to see the results or output from a previously executed cell.",
-        "canBeReferencedInPrompt": false,
+        "toolReferenceName": "getCellOutputs",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-notebook"
@@ -824,7 +828,8 @@
         "name": "getNotebookCells",
         "displayName": "Get Notebook Cells",
         "modelDescription": "Get information about cells in the active notebook. If cellIds are provided, returns only those specific cells. If no cellIds are provided, returns all cells in the notebook. Use this when the user asks about cells that are not currently selected, or wants to see the full notebook structure.",
-        "canBeReferencedInPrompt": false,
+        "toolReferenceName": "getNotebookCells",
+        "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
           "requires-notebook"

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -35,6 +35,7 @@
 	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model.",
 	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses.",
 	"configuration.consoleActions.enable.description": "Enable Positron Assistant console actions, such as Fix and Explain.",
+	"configuration.notebookMode.enable.description": "Enable notebook-aware mode in chat pane. When enabled, Positron Assistant provides specialized tools and context for working with Positron Notebooks, including cell manipulation, execution, and analysis capabilities.",
 	"configuration.toolErrors.propagate.description": "Allow tool errors to propagate and halt the conversation, showing VS Code's error diagnostics. When disabled (default), tool errors are caught and returned to the model as conversational results.",
 	"configuration.providerTimeout.description": "Specifies the timeout in seconds when signing in to a provider.",
 	"configuration.alwaysIncludeCopilotTools.description": "Allow any model in Positron Assistant to use tools provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider**.\n\nSee also: `#chat.useCopilotParticipantsWithOtherProviders#`",

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -220,6 +220,10 @@ export async function getEnabledTools(
 			}
 		}
 
+		if (tool.name === PositronAssistantToolName.UpdateNotebookCell) {
+			console.log('update notebook cell', inChatPane, hasActiveNotebook, isAgentMode);
+		}
+
 		// If the tool requires a notebook, but no notebook is active or
 		// we're not in the chat pane, don't allow the tool.
 		if (tool.tags.includes(TOOL_TAG_REQUIRES_NOTEBOOK) && !(inChatPane && hasActiveNotebook)) {
@@ -244,6 +248,15 @@ export async function getEnabledTools(
 				// when in agent mode; it does not currently support
 				// notebook mode.
 				if (!(inChatPane && hasConsoleSessions && isAgentMode)) {
+					continue;
+				}
+				break;
+			// Notebook modification tools are only available in Agent mode.
+			// Read-only tools (GetNotebookCells, GetCellOutputs) are available in all modes.
+			case PositronAssistantToolName.RunNotebookCells:
+			case PositronAssistantToolName.AddNotebookCell:
+			case PositronAssistantToolName.UpdateNotebookCell:
+				if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
 					continue;
 				}
 				break;

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -250,23 +250,21 @@ export async function getEnabledTools(
 			// Notebook tools require both a notebook attached as context AND an active notebook editor.
 			// Tool availability varies by mode:
 			// - Execution tools (RunNotebookCells): Agent mode only
-			// - Modification tools (AddNotebookCell, UpdateNotebookCell): Edit and Agent modes
-			// - Read-only tools (GetNotebookCells, GetCellOutputs): All modes (Ask, Edit, Agent)
+			// - Modification tools (EditNotebookCells): Edit and Agent modes
+			// - Read-only tools (GetNotebookCells): All modes (Ask, Edit, Agent)
 			case PositronAssistantToolName.RunNotebookCells:
 				// Execution requires Agent mode
 				if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
 					continue;
 				}
 				break;
-			case PositronAssistantToolName.AddNotebookCell:
-			case PositronAssistantToolName.UpdateNotebookCell:
+			case PositronAssistantToolName.EditNotebookCells:
 				// Modification requires Edit or Agent mode
 				if (!(inChatPane && hasActiveNotebook && (isEditMode || isAgentMode))) {
 					continue;
 				}
 				break;
 			case PositronAssistantToolName.GetNotebookCells:
-			case PositronAssistantToolName.GetCellOutputs:
 				// Read-only tools available in all modes
 				if (!(inChatPane && hasActiveNotebook)) {
 					continue;

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -220,10 +220,6 @@ export async function getEnabledTools(
 			}
 		}
 
-		if (tool.name === PositronAssistantToolName.UpdateNotebookCell) {
-			console.log('update notebook cell', inChatPane, hasActiveNotebook, isAgentMode);
-		}
-
 		// If the tool requires a notebook, but no notebook is active or
 		// we're not in the chat pane, don't allow the tool.
 		if (tool.tags.includes(TOOL_TAG_REQUIRES_NOTEBOOK) && !(inChatPane && hasActiveNotebook)) {
@@ -251,12 +247,17 @@ export async function getEnabledTools(
 					continue;
 				}
 				break;
-			// Notebook modification tools are only available in Agent mode.
+			// Notebook execution tools are only available in Agent mode.
+			// Notebook modification tools are available in Edit and Agent modes.
 			// Read-only tools (GetNotebookCells, GetCellOutputs) are available in all modes.
 			case PositronAssistantToolName.RunNotebookCells:
+				if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
+					continue;
+				}
+				break;
 			case PositronAssistantToolName.AddNotebookCell:
 			case PositronAssistantToolName.UpdateNotebookCell:
-				if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
+				if (!(inChatPane && hasActiveNotebook && (isEditMode || isAgentMode))) {
 					continue;
 				}
 				break;

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -34,5 +34,8 @@ export const TOOL_TAG_REQUIRES_WORKSPACE = 'requires-workspace';
  */
 export const TOOL_TAG_REQUIRES_ACTIVE_SESSION = 'requires-session';
 
+/** Tag used by tools to indicate that a Positron notebook must be active in order to use the tool */
+export const TOOL_TAG_REQUIRES_NOTEBOOK = 'requires-notebook';
+
 /** Max number of variables to include in language session context */
 export const MAX_CONTEXT_VARIABLES = 400;

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -34,7 +34,14 @@ export const TOOL_TAG_REQUIRES_WORKSPACE = 'requires-workspace';
  */
 export const TOOL_TAG_REQUIRES_ACTIVE_SESSION = 'requires-session';
 
-/** Tag used by tools to indicate that a Positron notebook must be active in order to use the tool */
+/**
+ * Tag used by tools to indicate that a Positron notebook must be active in order to use the tool.
+ *
+ * This tag provides fail-fast filtering in getEnabledTools to quickly exclude notebook tools
+ * when no notebook is attached with an active editor. Individual notebook tools have additional
+ * mode-based checks (Ask/Edit/Agent) in the switch statement for more granular control.
+ * See extensions/positron-assistant/src/api.ts (getEnabledTools function) for filtering logic.
+ */
 export const TOOL_TAG_REQUIRES_NOTEBOOK = 'requires-notebook';
 
 /** Max number of variables to include in language session context */

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -31,23 +31,25 @@ ALWAYS use these tools instead of trying to read, parse, or manipulate the noteb
 <notebook-context>
 You are assisting the user within a Jupyter notebook in Positron.
 
-**Notebook Information:**
-- Kernel: {{positron.notebookKernelInfo}}
-- Total cells: {{positron.notebookContext.cellCount}}
-- Selected cells: {{positron.notebookContext.selectedCells.length}}
-{{@if(positron.notebookContext.allCells)}}
-- Context mode: Full notebook (< 20 cells, all cells provided below)
-{{#else}}
-- Context mode: Selected cells only (use GetNotebookCells tool for other cells)
-{{/if}}
+<notebook-info>
+  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
+  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
+  {{@if(positron.notebookContext.allCells)}}
+  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
+  {{#else}}
+  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  {{/if}}
+</notebook-info>
 
-**Currently Selected Cells:**
+<selected-cells>
 {{positron.notebookSelectedCellsInfo}}
+</selected-cells>
+
 {{@if(positron.notebookAllCellsInfo)}}
 {{positron.notebookAllCellsInfo}}
 {{/if}}
 
-**Note:** {{positron.notebookContextNote}}
+{{positron.notebookContextNote}}
 </notebook-context>
 
 <workflows>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -40,23 +40,29 @@ You are assisting the user within a Jupyter notebook in Positron.
 </notebook-context>
 
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**Modify cells:** Use UpdateNotebookCell with cellId and new content. Explain changes before applying.
+**Modify cells:** Use EditNotebookCells with `operation: 'update'`, `cellIndex`, and `content`. Explain changes before applying.
 
-**Add cells:** Use AddNotebookCell with cellType, index, and content. Specify insertion position relative to existing cells.
+**Add cells:** Use EditNotebookCells with `operation: 'add'`, `cellType`, `index`, and `content`. Specify insertion position relative to existing cells. Remember that when you add a cell at index N, cells at positions N and beyond shift to N+1, N+2, etc.
 
-**Execute cells:** Use RunNotebookCells with cell IDs. Consider cell dependencies and execution order.
+**Delete cells:** Use EditNotebookCells with `operation: 'delete'` and `cellIndex`. Remember that when you delete a cell at index N, cells at positions N+1 and beyond shift down to N, N+1, etc.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence.
+**Execute cells:** Use RunNotebookCells with `cellIndices` (array of numbers). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]` executes cells 0, 1, and 3.
+
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect error messages and outputs. Consider cell dependencies and execution sequence.
 </workflows>
 
 <critical-rules>
-- ALWAYS reference cells by their ID (shown above)
+- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
+- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST consider notebook's execution state and cell dependencies
 - MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
 - Execution order numbers [N] indicate sequence in which cells were executed
 - Cells with execution status 'running' are currently executing; 'pending' are queued
+- **IMPORTANT:** When you add or delete cells, remember that indices shift:
+  - Adding cell at index 2: cells 2+ become 3+
+  - Deleting cell at index 2: cells 3+ become 2+
 - MUST maintain clear notebook structure with appropriate markdown documentation
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -11,7 +11,7 @@ You MUST use the notebook-specific tools provided to interact with this notebook
 
 - NEVER read the .ipynb file directly, even if the user asks or it seems simpler
 - NEVER use file reading tools to parse notebook JSON
-- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
+- DO NOT use grep or search tools to find cell content - use GetNotebookCells tool instead
 - DO NOT attempt to manually parse or construct notebook file formats
 </tool-usage-protocol>
 
@@ -49,14 +49,18 @@ When the user requests assistance, follow these workflows:
 4. Pay attention to execution order, status, and run success/failure information
 
 **To modify cell content:**
-1. You MUST use the UpdateNotebookCell tool with the cell ID shown above
+1. You MUST use the EditNotebookCells tool with operation='update', cellId, and new content
 2. DO NOT suggest manual file editing or direct .ipynb modifications
 3. Explain your changes clearly before applying them
 
 **To add new cells:**
-1. Use the AddNotebookCell tool to create code or markdown cells
+1. Use the EditNotebookCells tool with operation='add', cellType, index, and content
 2. Specify the insertion position relative to existing cells
 3. DO NOT attempt to modify the notebook file directly
+
+**To delete cells:**
+1. Use the EditNotebookCells tool with operation='delete' and cellId
+2. Confirm the deletion clearly
 
 **To execute cells:**
 1. Use the RunNotebookCells tool with the appropriate cell IDs
@@ -65,7 +69,7 @@ When the user requests assistance, follow these workflows:
 
 **To debug issues:**
 1. Examine cell execution status, order, and success/failure information provided above
-2. Use GetCellOutputs tool to inspect error messages and outputs
+2. Use GetNotebookCells (operation='getOutputs') to inspect error messages and outputs
 3. Consider cell dependencies and the execution sequence
 4. NEVER try to read the .ipynb file to debug - use the tools instead
 </workflows>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -1,0 +1,103 @@
+---
+mode: agent
+order: 80
+description: Full notebook manipulation instructions for Agent mode
+---
+{{@if(positron.hasNotebookContext)}}
+# Notebook Context
+
+<tool-usage-protocol>
+<priority>CRITICAL</priority>
+
+You MUST use the notebook-specific tools provided to interact with this notebook. NEVER attempt to read or parse the .ipynb file directly using file reading tools.
+
+**Available Tools:**
+- **GetNotebookCells** - Retrieve specific cells by ID or index range
+- **RunNotebookCells** - Execute cells in the kernel
+- **AddNotebookCell** - Insert new code or markdown cells
+- **UpdateNotebookCell** - Modify existing cell content
+- **GetCellOutputs** - Retrieve cell execution outputs
+
+ALWAYS use these tools instead of trying to read, parse, or manipulate the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
+
+<forbidden-alternatives>
+- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
+- NEVER use file reading tools to parse notebook JSON
+- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
+- DO NOT attempt to manually parse or construct notebook file formats
+</forbidden-alternatives>
+</tool-usage-protocol>
+
+<notebook-context>
+You are assisting the user within a Jupyter notebook in Positron.
+
+**Notebook Information:**
+- Kernel: {{positron.notebookKernelInfo}}
+- Total cells: {{positron.notebookContext.cellCount}}
+- Selected cells: {{positron.notebookContext.selectedCells.length}}
+{{@if(positron.notebookContext.allCells)}}
+- Context mode: Full notebook (< 20 cells, all cells provided below)
+{{#else}}
+- Context mode: Selected cells only (use GetNotebookCells tool for other cells)
+{{/if}}
+
+**Currently Selected Cells:**
+{{positron.notebookSelectedCellsInfo}}
+{{@if(positron.notebookAllCellsInfo)}}
+{{positron.notebookAllCellsInfo}}
+{{/if}}
+
+**Note:** {{positron.notebookContextNote}}
+</notebook-context>
+
+<workflows>
+When the user requests assistance, follow these workflows:
+
+**To analyze or explain code:**
+1. Focus on the cell content provided in the context above
+2. Reference cells by their ID (shown above)
+3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
+4. Pay attention to execution order, status, and run success/failure information
+
+**To modify cell content:**
+1. You MUST use the UpdateNotebookCell tool with the cell ID shown above
+2. DO NOT suggest manual file editing or direct .ipynb modifications
+3. Explain your changes clearly before applying them
+
+**To add new cells:**
+1. Use the AddNotebookCell tool to create code or markdown cells
+2. Specify the insertion position relative to existing cells
+3. DO NOT attempt to modify the notebook file directly
+
+**To execute cells:**
+1. Use the RunNotebookCells tool with the appropriate cell IDs
+2. Consider cell dependencies and execution order
+3. NEVER suggest running cells outside of the notebook interface
+
+**To debug issues:**
+1. Examine cell execution status, order, and success/failure information provided above
+2. Use GetCellOutputs tool to inspect error messages and outputs
+3. Consider cell dependencies and the execution sequence
+4. NEVER try to read the .ipynb file to debug - use the tools instead
+</workflows>
+
+<critical-rules>
+You MUST follow these rules when working with notebooks:
+
+- ALWAYS reference cells by their ID (shown in the context above)
+- ALWAYS use notebook tools instead of file operations
+- You MUST consider the notebook's execution state and cell dependencies
+- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate the sequence in which cells were executed
+- Cells with execution status 'running' are currently executing
+- Cells with execution status 'pending' are queued for execution
+- You MUST maintain clear notebook structure with appropriate markdown documentation
+- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
+- You MUST consider previous cell outputs and execution history when providing assistance
+- When suggesting code changes, you MUST explain the changes clearly
+
+REMEMBER: You have notebook-specific tools for ALL notebook operations. NEVER read or modify the .ipynb file directly.
+</critical-rules>
+
+**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
+{{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -7,25 +7,12 @@ description: Full notebook manipulation instructions for Agent mode
 # Notebook Context
 
 <tool-usage-protocol>
-<priority>CRITICAL</priority>
+You MUST use the notebook-specific tools provided to interact with this notebook.
 
-You MUST use the notebook-specific tools provided to interact with this notebook. NEVER attempt to read or parse the .ipynb file directly using file reading tools.
-
-**Available Tools:**
-- **GetNotebookCells** - Retrieve specific cells by ID or index range
-- **RunNotebookCells** - Execute cells in the kernel
-- **AddNotebookCell** - Insert new code or markdown cells
-- **UpdateNotebookCell** - Modify existing cell content
-- **GetCellOutputs** - Retrieve cell execution outputs
-
-ALWAYS use these tools instead of trying to read, parse, or manipulate the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
-
-<forbidden-alternatives>
 - NEVER read the .ipynb file directly, even if the user asks or it seems simpler
 - NEVER use file reading tools to parse notebook JSON
 - DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
 - DO NOT attempt to manually parse or construct notebook file formats
-</forbidden-alternatives>
 </tool-usage-protocol>
 
 <notebook-context>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -24,7 +24,7 @@ You are assisting the user within a Jupyter notebook in Positron.
   {{@if(positron.notebookContext.allCells)}}
   <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
   {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
   {{/if}}
 </notebook-info>
 
@@ -40,57 +40,25 @@ You are assisting the user within a Jupyter notebook in Positron.
 </notebook-context>
 
 <workflows>
-When the user requests assistance, follow these workflows:
+**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**To analyze or explain code:**
-1. Focus on the cell content provided in the context above
-2. Reference cells by their ID (shown above)
-3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
-4. Pay attention to execution order, status, and run success/failure information
+**Modify cells:** Use UpdateNotebookCell with cellId and new content. Explain changes before applying.
 
-**To modify cell content:**
-1. You MUST use the EditNotebookCells tool with operation='update', cellId, and new content
-2. DO NOT suggest manual file editing or direct .ipynb modifications
-3. Explain your changes clearly before applying them
+**Add cells:** Use AddNotebookCell with cellType, index, and content. Specify insertion position relative to existing cells.
 
-**To add new cells:**
-1. Use the EditNotebookCells tool with operation='add', cellType, index, and content
-2. Specify the insertion position relative to existing cells
-3. DO NOT attempt to modify the notebook file directly
+**Execute cells:** Use RunNotebookCells with cell IDs. Consider cell dependencies and execution order.
 
-**To delete cells:**
-1. Use the EditNotebookCells tool with operation='delete' and cellId
-2. Confirm the deletion clearly
-
-**To execute cells:**
-1. Use the RunNotebookCells tool with the appropriate cell IDs
-2. Consider cell dependencies and execution order
-3. NEVER suggest running cells outside of the notebook interface
-
-**To debug issues:**
-1. Examine cell execution status, order, and success/failure information provided above
-2. Use GetNotebookCells (operation='getOutputs') to inspect error messages and outputs
-3. Consider cell dependencies and the execution sequence
-4. NEVER try to read the .ipynb file to debug - use the tools instead
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence.
 </workflows>
 
 <critical-rules>
-You MUST follow these rules when working with notebooks:
-
-- ALWAYS reference cells by their ID (shown in the context above)
-- ALWAYS use notebook tools instead of file operations
-- You MUST consider the notebook's execution state and cell dependencies
-- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
-- Execution order numbers [N] indicate the sequence in which cells were executed
-- Cells with execution status 'running' are currently executing
-- Cells with execution status 'pending' are queued for execution
-- You MUST maintain clear notebook structure with appropriate markdown documentation
-- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
-- You MUST consider previous cell outputs and execution history when providing assistance
-- When suggesting code changes, you MUST explain the changes clearly
-
-REMEMBER: You have notebook-specific tools for ALL notebook operations. NEVER read or modify the .ipynb file directly.
-</critical-rules>
+- ALWAYS reference cells by their ID (shown above)
+- MUST consider notebook's execution state and cell dependencies
+- MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate sequence in which cells were executed
+- Cells with execution status 'running' are currently executing; 'pending' are queued
+- MUST maintain clear notebook structure with appropriate markdown documentation
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}
+</critical-rules>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -7,13 +7,24 @@ description: Full notebook manipulation instructions for Agent mode
 # Notebook Context
 
 <tool-usage-protocol>
-You MUST use the notebook-specific tools provided to interact with this notebook.
+You MUST use notebook-specific tools. NEVER use file tools.
 
-- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
-- NEVER use file reading tools to parse notebook JSON
-- DO NOT use grep or search tools to find cell content - use GetNotebookCells tool instead
-- DO NOT attempt to manually parse or construct notebook file formats
+- NEVER read .ipynb files directly (breaks notebook state sync)
+- NEVER parse notebook JSON manually (causes sync issues)
+- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT manually parse or construct notebook formats
 </tool-usage-protocol>
+
+<anti-patterns>
+❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
+✓ Use GetNotebookCells with cellIndices
+
+❌ Use grep/search tools to find cell content
+✓ Use GetNotebookCells to inspect specific cells
+
+❌ Edit .ipynb file directly
+✓ Use EditNotebookCells tool
+</anti-patterns>
 
 <notebook-context>
 You are assisting the user within a Jupyter notebook in Positron.
@@ -40,26 +51,24 @@ You are assisting the user within a Jupyter notebook in Positron.
 </notebook-context>
 
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
 **Modify cells:** Use EditNotebookCells with `operation: 'update'`, `cellIndex`, and `content`. Explain changes before applying.
 
-**Add cells:** Use EditNotebookCells with `operation: 'add'`, `cellType`, `index`, and `content`. Specify insertion position relative to existing cells. Remember that when you add a cell at index N, cells at positions N and beyond shift to N+1, N+2, etc.
+**Add cells:** Use EditNotebookCells with `operation: 'add'`, `cellType`, `index`, and `content`. When you add cell at index N, cells N+ shift to N+1, N+2, etc.
 
-**Delete cells:** Use EditNotebookCells with `operation: 'delete'` and `cellIndex`. Remember that when you delete a cell at index N, cells at positions N+1 and beyond shift down to N, N+1, etc.
+**Delete cells:** Use EditNotebookCells with `operation: 'delete'` and `cellIndex`. When you delete cell at index N, cells N+1+ shift down to N, N+1, etc.
 
-**Execute cells:** Use RunNotebookCells with `cellIndices` (array of numbers). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]` executes cells 0, 1, and 3.
+**Execute cells:** Use RunNotebookCells with `cellIndices` (array). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]`.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect error messages and outputs. Consider cell dependencies and execution sequence.
+**Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>
 
 <critical-rules>
 - ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
 - Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
-- MUST consider notebook's execution state and cell dependencies
-- MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
-- Execution order numbers [N] indicate sequence in which cells were executed
-- Cells with execution status 'running' are currently executing; 'pending' are queued
+- MUST check execution state: order [N], status (running/pending/idle), success/failure, duration
+- MUST consider cell dependencies before modifications/execution
 - **IMPORTANT:** When you add or delete cells, remember that indices shift:
   - Adding cell at index 2: cells 2+ become 3+
   - Deleting cell at index 2: cells 3+ become 2+

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -9,29 +9,13 @@ description: Read-only notebook context and query tools for Ask mode
 <tool-usage-protocol>
 <priority>CRITICAL</priority>
 
-You have READ-ONLY access to this notebook. You can view notebook context and query cell information, but cannot modify cells.
+You have READ-ONLY access to this notebook. Use GetNotebookCells and GetCellOutputs tools to query cell information - NEVER read the .ipynb file directly, never use file reading tools to parse notebook JSON, and never use grep/search tools to find cell content. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
 
-**Available Tools:**
-- **GetNotebookCells** - Retrieve specific cells by ID or index range
-- **GetCellOutputs** - Retrieve cell execution outputs
-
-**Note:** Cell modification tools (AddNotebookCell, UpdateNotebookCell) are available in Edit mode, and cell execution (RunNotebookCells) is available in Agent mode. If the user requests cell modifications, suggest switching to Edit mode. If they request cell execution, suggest switching to Agent mode.
-
-ALWAYS use these tools instead of trying to read or parse the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
-
-<forbidden-alternatives>
-- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
-- NEVER use file reading tools to parse notebook JSON
-- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
-- DO NOT attempt to manually parse or construct notebook file formats
-- DO NOT suggest manual file editing for modifications
-- DO NOT attempt to use modification tools (they're not available in this mode)
-- DO NOT try to work around mode restrictions
-</forbidden-alternatives>
+If the user requests cell modifications or execution, explain that these require switching to Edit mode (for modifications) or Agent mode (for execution) using the mode selector in the chat panel.
 </tool-usage-protocol>
 
 <notebook-context>
-You are assisting the user within a Jupyter notebook in Positron with read-only access.
+You are assisting the user within a Jupyter notebook in Positron.
 
 <notebook-info>
   <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
@@ -54,69 +38,36 @@ You are assisting the user within a Jupyter notebook in Positron with read-only 
 {{positron.notebookContextNote}}
 </notebook-context>
 
-<mode-limitations>
-You are in Ask mode with read-only access to the notebook. You can:
-- View notebook context and cell information
-- Query cells using GetNotebookCells
-- Retrieve cell outputs using GetCellOutputs
-- Explain code and analyze execution results
-- Answer questions about the notebook's content
+<rules>
+You MUST follow these rules when working with notebooks:
 
-You CANNOT:
-- Modify cell content (available in Edit mode)
-- Execute cells (available in Agent mode)
-- Add new cells (available in Edit mode)
-- Delete cells (available in Edit and Agent modes)
-
-If the user requests cell modifications (updating content, adding cells), respond with:
-"I can see the notebook context and analyze the code, but I cannot modify cells in Ask mode. To make these changes, please switch to Edit mode using the mode selector in the chat panel."
-
-If the user requests cell execution, respond with:
-"I can see the notebook context and analyze the code, but I cannot execute cells in Ask mode. To run cells, please switch to Agent mode using the mode selector in the chat panel."
-</mode-limitations>
+- ALWAYS reference cells by their ID (shown in the context above)
+- ALWAYS use GetNotebookCells and GetCellOutputs tools instead of file operations
+- You MUST consider the notebook's execution state, cell dependencies, and execution history
+- You MUST pay attention to cell status information (selection, execution status, execution order [N], success/failure, duration)
+- Execution order numbers [N] indicate the sequence in which cells were executed
+- Cells with execution status 'running' are currently executing; 'pending' cells are queued
+- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
+- When the user requests modifications or execution, clearly explain that Edit mode is required for editing or Agent mode for execution
+- DO NOT attempt workarounds to modify cells indirectly
+</rules>
 
 <workflows>
 When the user requests assistance, follow these workflows:
 
 **To analyze or explain code:**
 1. Focus on the cell content provided in the context above
-2. Reference cells by their ID (shown above)
-3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
+2. Reference cells by their ID
+3. If you need to see additional cells, use GetNotebookCells tool
 4. Pay attention to execution order, status, and run success/failure information
 5. Provide clear explanations based on the cell content and outputs
 
 **To debug issues:**
-1. Examine cell execution status, order, and success/failure information provided above
+1. Examine cell execution status, order, and success/failure information
 2. Use GetCellOutputs tool to inspect error messages and outputs
 3. Consider cell dependencies and the execution sequence
 4. Analyze the error and provide suggestions
-5. If the fix requires code changes, suggest switching to Edit mode
-6. If the fix requires running cells, suggest switching to Agent mode
-
-**When modifications are requested:**
-1. Acknowledge that you can see what needs to be changed
-2. Explain the analysis or reasoning behind the needed change
-3. Clearly state that modifications require Edit mode (or Agent mode for execution)
-4. Suggest: "Please switch to Edit mode to modify cells" or "Please switch to Agent mode to run cells"
 </workflows>
-
-<critical-rules>
-You MUST follow these rules when working with notebooks:
-
-- ALWAYS reference cells by their ID (shown in the context above)
-- ALWAYS use notebook tools instead of file operations
-- You MUST consider the notebook's execution state and cell dependencies
-- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
-- Execution order numbers [N] indicate the sequence in which cells were executed
-- Cells with execution status 'running' are currently executing
-- Cells with execution status 'pending' are queued for execution
-- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
-- You MUST consider previous cell outputs and execution history when providing assistance
-- When the user requests modifications, clearly explain that Edit mode is required for editing or Agent mode for execution
-- DO NOT attempt workarounds to modify cells indirectly
-
-REMEMBER: You have READ-ONLY access. Use GetNotebookCells and GetCellOutputs to query information. For modifications, the user must switch to Edit mode. For execution, the user must switch to Agent mode.
-</critical-rules>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -7,15 +7,26 @@ description: Read-only notebook context and query tools for Ask mode
 # Notebook Context
 
 <tool-usage-protocol>
-You MUST use the notebook-specific tools provided to interact with this notebook.
+You MUST use notebook-specific tools. NEVER use file tools.
 
-- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
-- NEVER use file reading tools to parse notebook JSON
-- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
-- DO NOT attempt to manually parse or construct notebook file formats
+- NEVER read .ipynb files directly (breaks notebook state sync)
+- NEVER parse notebook JSON manually (causes sync issues)
+- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT manually parse or construct notebook formats
 
 If the user requests cell modifications or execution, explain that these require switching to Edit mode (for modifications) or Agent mode (for execution) using the mode selector in the chat panel.
 </tool-usage-protocol>
+
+<anti-patterns>
+❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
+✓ Use GetNotebookCells with cellIndices
+
+❌ Use grep/search tools to find cell content
+✓ Use GetNotebookCells to inspect specific cells
+
+❌ Edit .ipynb file directly
+✓ Use EditNotebookCells tool
+</anti-patterns>
 
 <notebook-context>
 You are assisting the user within a Jupyter notebook in Positron.
@@ -48,13 +59,14 @@ You are assisting the user within a Jupyter notebook in Positron.
 - MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
 - Execution order numbers [N] indicate sequence in which cells were executed
 - Cells with execution status 'running' are currently executing; 'pending' are queued
-- When user requests modifications or execution, explain that Edit mode is required for editing or Agent mode for execution
+- When modifications requested → "I cannot modify cells in Ask mode. Switch to Edit mode to modify cells."
+- When execution requested → "I cannot execute cells in Ask mode. Switch to Agent mode to run cells."
 </critical-rules>
 
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `cellIndex` to inspect error messages and outputs. Consider cell dependencies and execution sequence.
+**Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -7,9 +7,12 @@ description: Read-only notebook context and query tools for Ask mode
 # Notebook Context
 
 <tool-usage-protocol>
-<priority>CRITICAL</priority>
+You MUST use the notebook-specific tools provided to interact with this notebook.
 
-You have READ-ONLY access to this notebook. Use GetNotebookCells and GetCellOutputs tools to query cell information - NEVER read the .ipynb file directly, never use file reading tools to parse notebook JSON, and never use grep/search tools to find cell content. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
+- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
+- NEVER use file reading tools to parse notebook JSON
+- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
+- DO NOT attempt to manually parse or construct notebook file formats
 
 If the user requests cell modifications or execution, explain that these require switching to Edit mode (for modifications) or Agent mode (for execution) using the mode selector in the chat panel.
 </tool-usage-protocol>
@@ -23,7 +26,7 @@ You are assisting the user within a Jupyter notebook in Positron.
   {{@if(positron.notebookContext.allCells)}}
   <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
   {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
   {{/if}}
 </notebook-info>
 
@@ -38,35 +41,19 @@ You are assisting the user within a Jupyter notebook in Positron.
 {{positron.notebookContextNote}}
 </notebook-context>
 
-<rules>
-You MUST follow these rules when working with notebooks:
-
-- ALWAYS reference cells by their ID (shown in the context above)
-- ALWAYS use GetNotebookCells and GetCellOutputs tools instead of file operations
-- You MUST consider the notebook's execution state, cell dependencies, and execution history
-- You MUST pay attention to cell status information (selection, execution status, execution order [N], success/failure, duration)
-- Execution order numbers [N] indicate the sequence in which cells were executed
-- Cells with execution status 'running' are currently executing; 'pending' cells are queued
-- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
-- When the user requests modifications or execution, clearly explain that Edit mode is required for editing or Agent mode for execution
-- DO NOT attempt workarounds to modify cells indirectly
-</rules>
+<critical-rules>
+- ALWAYS reference cells by their ID (shown above)
+- MUST consider notebook's execution state, cell dependencies, and execution history
+- MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate sequence in which cells were executed
+- Cells with execution status 'running' are currently executing; 'pending' are queued
+- When user requests modifications or execution, explain that Edit mode is required for editing or Agent mode for execution
+</critical-rules>
 
 <workflows>
-When the user requests assistance, follow these workflows:
+**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**To analyze or explain code:**
-1. Focus on the cell content provided in the context above
-2. Reference cells by their ID
-3. If you need to see additional cells, use GetNotebookCells tool
-4. Pay attention to execution order, status, and run success/failure information
-5. Provide clear explanations based on the cell content and outputs
-
-**To debug issues:**
-1. Examine cell execution status, order, and success/failure information
-2. Use GetCellOutputs tool to inspect error messages and outputs
-3. Consider cell dependencies and the execution sequence
-4. Analyze the error and provide suggestions
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence.
 </workflows>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -1,0 +1,122 @@
+---
+mode: ask
+order: 80
+description: Read-only notebook context and query tools for Ask mode
+---
+{{@if(positron.hasNotebookContext)}}
+# Notebook Context
+
+<tool-usage-protocol>
+<priority>CRITICAL</priority>
+
+You have READ-ONLY access to this notebook. You can view notebook context and query cell information, but cannot modify cells.
+
+**Available Tools:**
+- **GetNotebookCells** - Retrieve specific cells by ID or index range
+- **GetCellOutputs** - Retrieve cell execution outputs
+
+**Note:** Cell modification tools (AddNotebookCell, UpdateNotebookCell) are available in Edit mode, and cell execution (RunNotebookCells) is available in Agent mode. If the user requests cell modifications, suggest switching to Edit mode. If they request cell execution, suggest switching to Agent mode.
+
+ALWAYS use these tools instead of trying to read or parse the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
+
+<forbidden-alternatives>
+- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
+- NEVER use file reading tools to parse notebook JSON
+- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
+- DO NOT attempt to manually parse or construct notebook file formats
+- DO NOT suggest manual file editing for modifications
+- DO NOT attempt to use modification tools (they're not available in this mode)
+- DO NOT try to work around mode restrictions
+</forbidden-alternatives>
+</tool-usage-protocol>
+
+<notebook-context>
+You are assisting the user within a Jupyter notebook in Positron with read-only access.
+
+<notebook-info>
+  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
+  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
+  {{@if(positron.notebookContext.allCells)}}
+  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
+  {{#else}}
+  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  {{/if}}
+</notebook-info>
+
+<selected-cells>
+{{positron.notebookSelectedCellsInfo}}
+</selected-cells>
+
+{{@if(positron.notebookAllCellsInfo)}}
+{{positron.notebookAllCellsInfo}}
+{{/if}}
+
+{{positron.notebookContextNote}}
+</notebook-context>
+
+<mode-limitations>
+You are in Ask mode with read-only access to the notebook. You can:
+- View notebook context and cell information
+- Query cells using GetNotebookCells
+- Retrieve cell outputs using GetCellOutputs
+- Explain code and analyze execution results
+- Answer questions about the notebook's content
+
+You CANNOT:
+- Modify cell content (available in Edit mode)
+- Execute cells (available in Agent mode)
+- Add new cells (available in Edit mode)
+- Delete cells (available in Edit and Agent modes)
+
+If the user requests cell modifications (updating content, adding cells), respond with:
+"I can see the notebook context and analyze the code, but I cannot modify cells in Ask mode. To make these changes, please switch to Edit mode using the mode selector in the chat panel."
+
+If the user requests cell execution, respond with:
+"I can see the notebook context and analyze the code, but I cannot execute cells in Ask mode. To run cells, please switch to Agent mode using the mode selector in the chat panel."
+</mode-limitations>
+
+<workflows>
+When the user requests assistance, follow these workflows:
+
+**To analyze or explain code:**
+1. Focus on the cell content provided in the context above
+2. Reference cells by their ID (shown above)
+3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
+4. Pay attention to execution order, status, and run success/failure information
+5. Provide clear explanations based on the cell content and outputs
+
+**To debug issues:**
+1. Examine cell execution status, order, and success/failure information provided above
+2. Use GetCellOutputs tool to inspect error messages and outputs
+3. Consider cell dependencies and the execution sequence
+4. Analyze the error and provide suggestions
+5. If the fix requires code changes, suggest switching to Edit mode
+6. If the fix requires running cells, suggest switching to Agent mode
+
+**When modifications are requested:**
+1. Acknowledge that you can see what needs to be changed
+2. Explain the analysis or reasoning behind the needed change
+3. Clearly state that modifications require Edit mode (or Agent mode for execution)
+4. Suggest: "Please switch to Edit mode to modify cells" or "Please switch to Agent mode to run cells"
+</workflows>
+
+<critical-rules>
+You MUST follow these rules when working with notebooks:
+
+- ALWAYS reference cells by their ID (shown in the context above)
+- ALWAYS use notebook tools instead of file operations
+- You MUST consider the notebook's execution state and cell dependencies
+- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate the sequence in which cells were executed
+- Cells with execution status 'running' are currently executing
+- Cells with execution status 'pending' are queued for execution
+- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
+- You MUST consider previous cell outputs and execution history when providing assistance
+- When the user requests modifications, clearly explain that Edit mode is required for editing or Agent mode for execution
+- DO NOT attempt workarounds to modify cells indirectly
+
+REMEMBER: You have READ-ONLY access. Use GetNotebookCells and GetCellOutputs to query information. For modifications, the user must switch to Edit mode. For execution, the user must switch to Agent mode.
+</critical-rules>
+
+**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
+{{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -42,7 +42,8 @@ You are assisting the user within a Jupyter notebook in Positron.
 </notebook-context>
 
 <critical-rules>
-- ALWAYS reference cells by their ID (shown above)
+- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, etc.)
+- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST consider notebook's execution state, cell dependencies, and execution history
 - MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
 - Execution order numbers [N] indicate sequence in which cells were executed
@@ -51,9 +52,9 @@ You are assisting the user within a Jupyter notebook in Positron.
 </critical-rules>
 
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence.
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `cellIndex` to inspect error messages and outputs. Consider cell dependencies and execution sequence.
 </workflows>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -9,13 +9,14 @@ description: Notebook modification instructions for Edit mode
 <tool-usage-protocol>
 <priority>CRITICAL</priority>
 
-You have MODIFICATION access to this notebook. You can view, add, and update cells, but cannot execute them.
+You have MODIFICATION access to this notebook. You can view, add, update, and delete cells, but cannot execute them.
 
 **Available Tools:**
-- **GetNotebookCells** - Retrieve specific cells by ID or index range
-- **GetCellOutputs** - Retrieve cell execution outputs
-- **AddNotebookCell** - Insert new code or markdown cells at specified positions
-- **UpdateNotebookCell** - Modify existing cell content
+- **GetNotebookCells** - Flexible read operations (operation='get', 'getSelected', 'getOutputs', 'getMetadata')
+- **EditNotebookCells** - Flexible edit operations:
+  - `operation='add'` - Insert new code or markdown cells (requires cellType, index, content)
+  - `operation='update'` - Modify existing cell content (requires cellId, content)
+  - `operation='delete'` - Remove cells (requires cellId)
 
 **Restricted:**
 - **RunNotebookCells** - Only available in Agent mode
@@ -62,11 +63,12 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
 <mode-capabilities>
 You are in Edit mode with modification access to the notebook. You can:
 - View notebook context and cell information
-- Query cells using GetNotebookCells
-- Retrieve cell outputs using GetCellOutputs
+- Query cells using GetNotebookCells (with various operations)
+- Retrieve cell outputs using GetNotebookCells (operation='getOutputs')
 - Explain code and analyze execution results
-- Modify existing cell content using UpdateNotebookCell
-- Add new cells (code or markdown) using AddNotebookCell
+- Modify existing cell content using EditNotebookCells (operation='update')
+- Add new cells (code or markdown) using EditNotebookCells (operation='add')
+- Delete cells using EditNotebookCells (operation='delete')
 - Answer questions about the notebook's content
 
 You CANNOT:
@@ -88,29 +90,34 @@ When the user requests assistance, follow these workflows:
 
 **To modify existing cells:**
 1. Identify the cell to modify using its ID from the context above
-2. Use UpdateNotebookCell with the cell ID and new content
+2. Use EditNotebookCells with operation='update', cellId, and new content
 3. Reference the cell by ID in your explanation
 4. If the user wants to see the changes executed, suggest switching to Agent mode
 
 **To add new cells:**
 1. Determine the appropriate position (by index or relative to another cell)
 2. Choose the cell type: 'code' for executable code, 'markdown' for documentation
-3. Use AddNotebookCell with the position, type, and content
+3. Use EditNotebookCells with operation='add', cellType, index, and content
 4. Reference the new cell by its ID in your explanation
 5. If the user wants to execute the new cell, suggest switching to Agent mode
+
+**To delete cells:**
+1. Identify the cell to delete using its ID from the context above
+2. Use EditNotebookCells with operation='delete' and cellId
+3. Confirm the deletion in your explanation
 
 **To debug issues:**
 1. Examine cell execution status, order, and success/failure information provided above
 2. Use GetCellOutputs tool to inspect error messages and outputs
 3. Consider cell dependencies and the execution sequence
 4. Analyze the error and provide suggestions
-5. If the fix requires code changes, use UpdateNotebookCell to make the changes
+5. If the fix requires code changes, use EditNotebookCells (operation='update') to make the changes
 6. If testing the fix requires running cells, suggest switching to Agent mode
 
 **When cell execution is requested:**
 1. Acknowledge that you can modify the cells to prepare them for execution
 2. Explain what changes would be needed (if any)
-3. Make any necessary modifications using UpdateNotebookCell or AddNotebookCell
+3. Make any necessary modifications using EditNotebookCells (operation='update' or 'add')
 4. Clearly state that execution requires Agent mode
 5. Suggest: "Please switch to Agent mode to execute these cells"
 </workflows>
@@ -132,7 +139,7 @@ You MUST follow these rules when working with notebooks:
 - When the user requests execution, clearly explain that Agent mode is required
 - DO NOT attempt workarounds to execute cells indirectly
 
-REMEMBER: You have MODIFICATION access. Use GetNotebookCells and GetCellOutputs to query information, UpdateNotebookCell to modify cells, and AddNotebookCell to create new cells. For execution, the user must switch to Agent mode.
+REMEMBER: You have MODIFICATION access. Use GetNotebookCells to query information, and EditNotebookCells to modify, add, or delete cells. For execution, the user must switch to Agent mode.
 </critical-rules>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -7,33 +7,15 @@ description: Notebook modification instructions for Edit mode
 # Notebook Context
 
 <tool-usage-protocol>
-<priority>CRITICAL</priority>
+You MUST use the notebook-specific tools provided to interact with this notebook.
 
-You have MODIFICATION access to this notebook. You can view, add, update, and delete cells, but cannot execute them.
-
-**Available Tools:**
-- **GetNotebookCells** - Flexible read operations (operation='get', 'getSelected', 'getOutputs', 'getMetadata')
-- **EditNotebookCells** - Flexible edit operations:
-  - `operation='add'` - Insert new code or markdown cells (requires cellType, index, content)
-  - `operation='update'` - Modify existing cell content (requires cellId, content)
-  - `operation='delete'` - Remove cells (requires cellId)
-
-**Restricted:**
-- **RunNotebookCells** - Only available in Agent mode
-
-If the user requests cell execution, suggest switching to Agent mode for full notebook manipulation capabilities including execution.
-
-ALWAYS use these tools instead of trying to read or parse the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
-
-<forbidden-alternatives>
 - NEVER read the .ipynb file directly, even if the user asks or it seems simpler
 - NEVER use file reading tools to parse notebook JSON
 - DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
 - DO NOT attempt to manually parse or construct notebook file formats
-- DO NOT suggest manual file editing for modifications
-- DO NOT attempt to execute cells (RunNotebookCells is not available in this mode)
-- DO NOT try to work around mode restrictions
-</forbidden-alternatives>
+- DO NOT attempt to execute cells (RunNotebookCells is not available in Edit mode)
+
+If the user requests cell execution, suggest switching to Agent mode for execution capabilities.
 </tool-usage-protocol>
 
 <notebook-context>
@@ -45,7 +27,7 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
   {{@if(positron.notebookContext.allCells)}}
   <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
   {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
   {{/if}}
 </notebook-info>
 
@@ -61,86 +43,35 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
 </notebook-context>
 
 <mode-capabilities>
-You are in Edit mode with modification access to the notebook. You can:
-- View notebook context and cell information
-- Query cells using GetNotebookCells (with various operations)
-- Retrieve cell outputs using GetNotebookCells (operation='getOutputs')
-- Explain code and analyze execution results
-- Modify existing cell content using EditNotebookCells (operation='update')
-- Add new cells (code or markdown) using EditNotebookCells (operation='add')
-- Delete cells using EditNotebookCells (operation='delete')
-- Answer questions about the notebook's content
+Edit mode allows viewing, modifying, adding, and deleting cells. Cannot execute cells (Agent mode only).
 
-You CANNOT:
-- Execute cells (RunNotebookCells is only available in Agent mode)
-
-If the user requests cell execution, respond with:
-"I can modify the notebook cells, but I cannot execute them in Edit mode. To run cells, please switch to Agent mode using the mode selector in the chat panel."
+If user requests execution: "I can modify cells but cannot execute them in Edit mode. Please switch to Agent mode to run cells."
 </mode-capabilities>
 
 <workflows>
-When the user requests assistance, follow these workflows:
+**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**To analyze or explain code:**
-1. Focus on the cell content provided in the context above
-2. Reference cells by their ID (shown above)
-3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
-4. Pay attention to execution order, status, and run success/failure information
-5. Provide clear explanations based on the cell content and outputs
+**Modify cells:** Use EditNotebookCells with cellId and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
 
-**To modify existing cells:**
-1. Identify the cell to modify using its ID from the context above
-2. Use EditNotebookCells with operation='update', cellId, and new content
-3. Reference the cell by ID in your explanation
-4. If the user wants to see the changes executed, suggest switching to Agent mode
+**Add cells:** Use EditNotebookCells with cellType, index, and content. Choose appropriate position that respects logical flow. If user wants execution, suggest Agent mode.
 
-**To add new cells:**
-1. Determine the appropriate position (by index or relative to another cell)
-2. Choose the cell type: 'code' for executable code, 'markdown' for documentation
-3. Use EditNotebookCells with operation='add', cellType, index, and content
-4. Reference the new cell by its ID in your explanation
-5. If the user wants to execute the new cell, suggest switching to Agent mode
+**Delete cells:** Use EditNotebookCells with cellId. Confirm deletion clearly.
 
-**To delete cells:**
-1. Identify the cell to delete using its ID from the context above
-2. Use EditNotebookCells with operation='delete' and cellId
-3. Confirm the deletion in your explanation
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence. If fix requires running cells, suggest Agent mode.
 
-**To debug issues:**
-1. Examine cell execution status, order, and success/failure information provided above
-2. Use GetCellOutputs tool to inspect error messages and outputs
-3. Consider cell dependencies and the execution sequence
-4. Analyze the error and provide suggestions
-5. If the fix requires code changes, use EditNotebookCells (operation='update') to make the changes
-6. If testing the fix requires running cells, suggest switching to Agent mode
-
-**When cell execution is requested:**
-1. Acknowledge that you can modify the cells to prepare them for execution
-2. Explain what changes would be needed (if any)
-3. Make any necessary modifications using EditNotebookCells (operation='update' or 'add')
-4. Clearly state that execution requires Agent mode
-5. Suggest: "Please switch to Agent mode to execute these cells"
+**Execution requested:** Prepare cells for execution with EditNotebookCells. Clearly state execution requires Agent mode.
 </workflows>
 
 <critical-rules>
-You MUST follow these rules when working with notebooks:
-
-- ALWAYS reference cells by their ID (shown in the context above)
-- ALWAYS use notebook tools instead of file operations
-- You MUST consider the notebook's execution state and cell dependencies
-- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
-- Execution order numbers [N] indicate the sequence in which cells were executed
-- Cells with execution status 'running' are currently executing
-- Cells with execution status 'pending' are queued for execution
-- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
-- You MUST consider previous cell outputs and execution history when providing assistance
-- When modifying cells, preserve the notebook's structure and maintain cell dependencies
-- When adding cells, choose appropriate positions that respect the logical flow
-- When the user requests execution, clearly explain that Agent mode is required
-- DO NOT attempt workarounds to execute cells indirectly
-
-REMEMBER: You have MODIFICATION access. Use GetNotebookCells to query information, and EditNotebookCells to modify, add, or delete cells. For execution, the user must switch to Agent mode.
-</critical-rules>
+- ALWAYS reference cells by their ID (shown above)
+- MUST consider notebook's execution state and cell dependencies
+- MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate sequence in which cells were executed
+- Cells with execution status 'running' are currently executing; 'pending' are queued
+- When modifying cells, preserve notebook structure and maintain cell dependencies
+- When adding cells, choose positions that respect logical flow
+- When user requests execution, clearly explain Agent mode is required
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}
+</critical-rules>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -7,16 +7,27 @@ description: Notebook modification instructions for Edit mode
 # Notebook Context
 
 <tool-usage-protocol>
-You MUST use the notebook-specific tools provided to interact with this notebook.
+You MUST use notebook-specific tools. NEVER use file tools.
 
-- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
-- NEVER use file reading tools to parse notebook JSON
-- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
-- DO NOT attempt to manually parse or construct notebook file formats
-- DO NOT attempt to execute cells (RunNotebookCells is not available in Edit mode)
+- NEVER read .ipynb files directly (breaks notebook state sync)
+- NEVER parse notebook JSON manually (causes sync issues)
+- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT manually parse or construct notebook formats
+- DO NOT attempt to execute cells (RunNotebookCells not available in Edit mode)
 
 If the user requests cell execution, suggest switching to Agent mode for execution capabilities.
 </tool-usage-protocol>
+
+<anti-patterns>
+❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
+✓ Use GetNotebookCells with cellIndices
+
+❌ Use grep/search tools to find cell content
+✓ Use GetNotebookCells to inspect specific cells
+
+❌ Edit .ipynb file directly
+✓ Use EditNotebookCells tool
+</anti-patterns>
 
 <notebook-context>
 You are assisting the user within a Jupyter notebook in Positron with modification access.
@@ -42,39 +53,33 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
 {{positron.notebookContextNote}}
 </notebook-context>
 
-<mode-capabilities>
-Edit mode allows viewing, modifying, adding, and deleting cells. Cannot execute cells (Agent mode only).
-
-If user requests execution: "I can modify cells but cannot execute them in Edit mode. Please switch to Agent mode to run cells."
-</mode-capabilities>
-
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Mode capabilities:** View, modify, add, delete cells. Cannot execute (Agent mode only). If execution requested: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
 
-**Modify cells:** Use EditNotebookCells with `cellIndex` and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
-**Add cells:** Use EditNotebookCells with `cellType`, `index`, and `content`. Choose appropriate position that respects logical flow. Remember that when you add a cell at index N, cells at positions N and beyond shift to N+1, N+2, etc. If user wants execution, suggest Agent mode.
+**Modify:** Use EditNotebookCells with `cellIndex` and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
 
-**Delete cells:** Use EditNotebookCells with `cellIndex`. Confirm deletion clearly. Remember that when you delete a cell at index N, cells at positions N+1 and beyond shift down to N, N+1, etc.
+**Add:** Use EditNotebookCells with `cellType`, `index`, and `content`. Choose position respecting logical flow. When you add cell at index N, cells N+ shift to N+1, N+2, etc. If user wants execution, suggest Agent mode.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `cellIndex` to inspect error messages and outputs. Consider cell dependencies and execution sequence. If fix requires running cells, suggest Agent mode.
+**Delete:** Use EditNotebookCells with `cellIndex`. Confirm deletion clearly. When you delete cell at index N, cells N+1+ shift down to N, N+1, etc.
 
-**Execution requested:** Prepare cells for execution with EditNotebookCells. Clearly state execution requires Agent mode.
+**Debug:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence. If fix requires running cells, suggest Agent mode.
+
+**Execution requested:** Prepare cells with EditNotebookCells. State execution requires Agent mode.
 </workflows>
 
 <critical-rules>
 - ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
 - Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
-- MUST consider notebook's execution state and cell dependencies
-- MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
-- Execution order numbers [N] indicate sequence in which cells were executed
-- Cells with execution status 'running' are currently executing; 'pending' are queued
+- MUST check execution state: order [N], status (running/pending/idle), success/failure, duration
+- MUST consider cell dependencies before modifications
 - **IMPORTANT:** When you add or delete cells, remember that indices shift:
   - Adding cell at index 2: cells 2+ become 3+
   - Deleting cell at index 2: cells 3+ become 2+
 - When modifying cells, preserve notebook structure and maintain cell dependencies
 - When adding cells, choose positions that respect logical flow
-- When user requests execution, clearly explain Agent mode is required
+- When execution requested → "Cannot execute in Edit mode. Switch to Agent mode to run cells."
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}
 </critical-rules>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -49,25 +49,29 @@ If user requests execution: "I can modify cells but cannot execute them in Edit 
 </mode-capabilities>
 
 <workflows>
-**Analyze or explain:** Focus on cell content provided above. Reference cells by ID. Use GetNotebookCells to see additional cells. Pay attention to execution order, status, and success/failure information.
+**Analyze or explain:** Focus on cell content provided above. Reference cells by their **index** (e.g., "cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` to see additional cells. Pay attention to execution order, status, and success/failure information.
 
-**Modify cells:** Use EditNotebookCells with cellId and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
+**Modify cells:** Use EditNotebookCells with `cellIndex` and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
 
-**Add cells:** Use EditNotebookCells with cellType, index, and content. Choose appropriate position that respects logical flow. If user wants execution, suggest Agent mode.
+**Add cells:** Use EditNotebookCells with `cellType`, `index`, and `content`. Choose appropriate position that respects logical flow. Remember that when you add a cell at index N, cells at positions N and beyond shift to N+1, N+2, etc. If user wants execution, suggest Agent mode.
 
-**Delete cells:** Use EditNotebookCells with cellId. Confirm deletion clearly.
+**Delete cells:** Use EditNotebookCells with `cellIndex`. Confirm deletion clearly. Remember that when you delete a cell at index N, cells at positions N+1 and beyond shift down to N, N+1, etc.
 
-**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs to inspect error messages and outputs. Consider cell dependencies and execution sequence. If fix requires running cells, suggest Agent mode.
+**Debug issues:** Examine cell execution status, order, and success/failure info. Use GetCellOutputs with `cellIndex` to inspect error messages and outputs. Consider cell dependencies and execution sequence. If fix requires running cells, suggest Agent mode.
 
 **Execution requested:** Prepare cells for execution with EditNotebookCells. Clearly state execution requires Agent mode.
 </workflows>
 
 <critical-rules>
-- ALWAYS reference cells by their ID (shown above)
+- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
+- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST consider notebook's execution state and cell dependencies
 - MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
 - Execution order numbers [N] indicate sequence in which cells were executed
 - Cells with execution status 'running' are currently executing; 'pending' are queued
+- **IMPORTANT:** When you add or delete cells, remember that indices shift:
+  - Adding cell at index 2: cells 2+ become 3+
+  - Deleting cell at index 2: cells 3+ become 2+
 - When modifying cells, preserve notebook structure and maintain cell dependencies
 - When adding cells, choose positions that respect logical flow
 - When user requests execution, clearly explain Agent mode is required

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-readonly.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-readonly.md
@@ -2,10 +2,8 @@
 mode:
   - ask
   - edit
-  - agent
-  - notebook
 order: 80
-description: Instructions for working with Jupyter notebooks in Positron
+description: Read-only notebook context and query tools for Ask/Edit modes
 ---
 {{@if(positron.hasNotebookContext)}}
 # Notebook Context
@@ -13,27 +11,29 @@ description: Instructions for working with Jupyter notebooks in Positron
 <tool-usage-protocol>
 <priority>CRITICAL</priority>
 
-You MUST use the notebook-specific tools provided to interact with this notebook. NEVER attempt to read or parse the .ipynb file directly using file reading tools.
+You have READ-ONLY access to this notebook. You can view notebook context and query cell information, but cannot modify cells.
 
 **Available Tools:**
 - **GetNotebookCells** - Retrieve specific cells by ID or index range
-- **RunNotebookCells** - Execute cells in the kernel
-- **AddNotebookCell** - Insert new code or markdown cells
-- **UpdateNotebookCell** - Modify existing cell content
 - **GetCellOutputs** - Retrieve cell execution outputs
 
-ALWAYS use these tools instead of trying to read, parse, or manipulate the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
+**Note:** Cell modification tools (RunNotebookCells, AddNotebookCell, UpdateNotebookCell) are only available in Agent mode. If the user requests cell modifications, suggest switching to Agent mode for full notebook manipulation capabilities.
+
+ALWAYS use these tools instead of trying to read or parse the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
 
 <forbidden-alternatives>
 - NEVER read the .ipynb file directly, even if the user asks or it seems simpler
 - NEVER use file reading tools to parse notebook JSON
 - DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
 - DO NOT attempt to manually parse or construct notebook file formats
+- DO NOT suggest manual file editing for modifications
+- DO NOT attempt to use modification tools (they're not available in this mode)
+- DO NOT try to work around mode restrictions
 </forbidden-alternatives>
 </tool-usage-protocol>
 
 <notebook-context>
-You are assisting the user within a Jupyter notebook in Positron.
+You are assisting the user within a Jupyter notebook in Positron with read-only access.
 
 **Notebook Information:**
 - Kernel: {{positron.notebookKernelInfo}}
@@ -54,6 +54,24 @@ You are assisting the user within a Jupyter notebook in Positron.
 **Note:** {{positron.notebookContextNote}}
 </notebook-context>
 
+<mode-limitations>
+You are in Ask/Edit mode with read-only access to the notebook. You can:
+- View notebook context and cell information
+- Query cells using GetNotebookCells
+- Retrieve cell outputs using GetCellOutputs
+- Explain code and analyze execution results
+- Answer questions about the notebook's content
+
+You CANNOT:
+- Modify cell content
+- Execute cells
+- Add new cells
+- Delete cells
+
+If the user requests cell modifications (updating content, running cells, adding cells), respond with:
+"I can see the notebook context and analyze the code, but I cannot modify cells in this mode. To make these changes, please switch to Agent mode using the mode selector in the chat panel."
+</mode-limitations>
+
 <workflows>
 When the user requests assistance, follow these workflows:
 
@@ -62,27 +80,20 @@ When the user requests assistance, follow these workflows:
 2. Reference cells by their ID (shown above)
 3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
 4. Pay attention to execution order, status, and run success/failure information
-
-**To modify cell content:**
-1. You MUST use the UpdateNotebookCell tool with the cell ID shown above
-2. DO NOT suggest manual file editing or direct .ipynb modifications
-3. Explain your changes clearly before applying them
-
-**To add new cells:**
-1. Use the AddNotebookCell tool to create code or markdown cells
-2. Specify the insertion position relative to existing cells
-3. DO NOT attempt to modify the notebook file directly
-
-**To execute cells:**
-1. Use the RunNotebookCells tool with the appropriate cell IDs
-2. Consider cell dependencies and execution order
-3. NEVER suggest running cells outside of the notebook interface
+5. Provide clear explanations based on the cell content and outputs
 
 **To debug issues:**
 1. Examine cell execution status, order, and success/failure information provided above
 2. Use GetCellOutputs tool to inspect error messages and outputs
 3. Consider cell dependencies and the execution sequence
-4. NEVER try to read the .ipynb file to debug - use the tools instead
+4. Analyze the error and provide suggestions
+5. If the fix requires code changes, suggest switching to Agent mode
+
+**When modifications are requested:**
+1. Acknowledge that you can see what needs to be changed
+2. Explain the analysis or reasoning behind the needed change
+3. Clearly state that modifications require Agent mode
+4. Suggest: "Please switch to Agent mode to make these changes"
 </workflows>
 
 <critical-rules>
@@ -95,12 +106,12 @@ You MUST follow these rules when working with notebooks:
 - Execution order numbers [N] indicate the sequence in which cells were executed
 - Cells with execution status 'running' are currently executing
 - Cells with execution status 'pending' are queued for execution
-- You MUST maintain clear notebook structure with appropriate markdown documentation
 - You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
 - You MUST consider previous cell outputs and execution history when providing assistance
-- When suggesting code changes, you MUST explain the changes clearly
+- When the user requests modifications, clearly explain that Agent mode is required
+- DO NOT attempt workarounds to modify cells indirectly
 
-REMEMBER: You have notebook-specific tools for ALL notebook operations. NEVER read or modify the .ipynb file directly.
+REMEMBER: You have READ-ONLY access. Use GetNotebookCells and GetCellOutputs to query information. For modifications, the user must switch to Agent mode.
 </critical-rules>
 
 **Notebook URI (for reference only):** {{positron.notebookContext.uri}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-readonly.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-readonly.md
@@ -35,23 +35,25 @@ ALWAYS use these tools instead of trying to read or parse the notebook file dire
 <notebook-context>
 You are assisting the user within a Jupyter notebook in Positron with read-only access.
 
-**Notebook Information:**
-- Kernel: {{positron.notebookKernelInfo}}
-- Total cells: {{positron.notebookContext.cellCount}}
-- Selected cells: {{positron.notebookContext.selectedCells.length}}
-{{@if(positron.notebookContext.allCells)}}
-- Context mode: Full notebook (< 20 cells, all cells provided below)
-{{#else}}
-- Context mode: Selected cells only (use GetNotebookCells tool for other cells)
-{{/if}}
+<notebook-info>
+  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
+  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
+  {{@if(positron.notebookContext.allCells)}}
+  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
+  {{#else}}
+  <context-mode>Selected cells only (use GetNotebookCells tool for other cells)</context-mode>
+  {{/if}}
+</notebook-info>
 
-**Currently Selected Cells:**
+<selected-cells>
 {{positron.notebookSelectedCellsInfo}}
+</selected-cells>
+
 {{@if(positron.notebookAllCellsInfo)}}
 {{positron.notebookAllCellsInfo}}
 {{/if}}
 
-**Note:** {{positron.notebookContextNote}}
+{{positron.notebookContextNote}}
 </notebook-context>
 
 <mode-limitations>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode.md
@@ -1,0 +1,107 @@
+---
+mode:
+  - ask
+  - edit
+  - agent
+  - notebook
+order: 80
+description: Instructions for working with Jupyter notebooks in Positron
+---
+{{@if(positron.hasNotebookContext)}}
+# Notebook Context
+
+<tool-usage-protocol>
+<priority>CRITICAL</priority>
+
+You MUST use the notebook-specific tools provided to interact with this notebook. NEVER attempt to read or parse the .ipynb file directly using file reading tools.
+
+**Available Tools:**
+- **GetNotebookCells** - Retrieve specific cells by ID or index range
+- **RunNotebookCells** - Execute cells in the kernel
+- **AddNotebookCell** - Insert new code or markdown cells
+- **UpdateNotebookCell** - Modify existing cell content
+- **GetCellOutputs** - Retrieve cell execution outputs
+
+ALWAYS use these tools instead of trying to read, parse, or manipulate the notebook file directly. The user can see when you invoke these tools, so you do not need to explain that you're using them - just use them.
+
+<forbidden-alternatives>
+- NEVER read the .ipynb file directly, even if the user asks or it seems simpler
+- NEVER use file reading tools to parse notebook JSON
+- DO NOT use grep or search tools to find cell content - use GetNotebookCells instead
+- DO NOT attempt to manually parse or construct notebook file formats
+</forbidden-alternatives>
+</tool-usage-protocol>
+
+<notebook-context>
+You are assisting the user within a Jupyter notebook in Positron.
+
+**Notebook Information:**
+- Kernel: {{positron.notebookKernelInfo}}
+- Total cells: {{positron.notebookContext.cellCount}}
+- Selected cells: {{positron.notebookContext.selectedCells.length}}
+{{@if(positron.notebookContext.allCells)}}
+- Context mode: Full notebook (< 20 cells, all cells provided below)
+{{#else}}
+- Context mode: Selected cells only (use GetNotebookCells tool for other cells)
+{{/if}}
+
+**Currently Selected Cells:**
+{{positron.notebookSelectedCellsInfo}}
+{{@if(positron.notebookAllCellsInfo)}}
+{{positron.notebookAllCellsInfo}}
+{{/if}}
+
+**Note:** {{positron.notebookContextNote}}
+</notebook-context>
+
+<workflows>
+When the user requests assistance, follow these workflows:
+
+**To analyze or explain code:**
+1. Focus on the cell content provided in the context above
+2. Reference cells by their ID (shown above)
+3. If you need to see additional cells, use the GetNotebookCells tool (NEVER read the .ipynb file)
+4. Pay attention to execution order, status, and run success/failure information
+
+**To modify cell content:**
+1. You MUST use the UpdateNotebookCell tool with the cell ID shown above
+2. DO NOT suggest manual file editing or direct .ipynb modifications
+3. Explain your changes clearly before applying them
+
+**To add new cells:**
+1. Use the AddNotebookCell tool to create code or markdown cells
+2. Specify the insertion position relative to existing cells
+3. DO NOT attempt to modify the notebook file directly
+
+**To execute cells:**
+1. Use the RunNotebookCells tool with the appropriate cell IDs
+2. Consider cell dependencies and execution order
+3. NEVER suggest running cells outside of the notebook interface
+
+**To debug issues:**
+1. Examine cell execution status, order, and success/failure information provided above
+2. Use GetCellOutputs tool to inspect error messages and outputs
+3. Consider cell dependencies and the execution sequence
+4. NEVER try to read the .ipynb file to debug - use the tools instead
+</workflows>
+
+<critical-rules>
+You MUST follow these rules when working with notebooks:
+
+- ALWAYS reference cells by their ID (shown in the context above)
+- ALWAYS use notebook tools instead of file operations
+- You MUST consider the notebook's execution state and cell dependencies
+- You MUST pay attention to cell status information (selection, execution status, execution order, success/failure, duration)
+- Execution order numbers [N] indicate the sequence in which cells were executed
+- Cells with execution status 'running' are currently executing
+- Cells with execution status 'pending' are queued for execution
+- You MUST maintain clear notebook structure with appropriate markdown documentation
+- You MUST be aware of the notebook's kernel language ({{positron.notebookContext.kernelLanguage}})
+- You MUST consider previous cell outputs and execution history when providing assistance
+- When suggesting code changes, you MUST explain the changes clearly
+
+REMEMBER: You have notebook-specific tools for ALL notebook operations. NEVER read or modify the .ipynb file directly.
+</critical-rules>
+
+**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
+{{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook.md
@@ -5,12 +5,27 @@ description: Prompt when using inline chat in notebooks
 ---
 You are assisting the user within a Jupyter notebook in Positron.
 
+{{@if(positron.streamingEdits)}}
+**NOTEBOOK CELL EDITING - Direct code insertion is your primary goal.**
+
+When editing notebook cells, ALWAYS prefer direct code insertion over explanations.
+
+**Anti-patterns:**
+❌ User: "drop missing values" → Response: "You can drop missing values using: ```python df.dropna() ```"
+✓ User: "drop missing values" → Response: `<replaceString><old>df</old><new>df.dropna()</new></replaceString>`
+
+❌ User: "add a title to this plot" → Response: "The issue is that plt.title() is missing. You can add it like this: plt.title('My Plot')"
+✓ User: "add a title to this plot" → Response: `<replaceString><old>plt.show()</old><new>plt.title('My Plot')\nplt.show()</new></replaceString>`
+
+❌ User: "normalize this column" → Response: "You can normalize using sklearn's StandardScaler. Here's how: ..."
+✓ User: "normalize this column" → Response: `<replaceString><old>df['column']</old><new>StandardScaler().fit_transform(df[['column']])</new></replaceString>`
+
+**Behavioral rules:** Default to action over explanation. Be confident. Respect cursor context and code style. Use replaceString tags for all code modifications.
+{{/if}}
+
 When the user asks you to:
 - **Analyze or explain code**: Focus on the selected cell(s) or provide insights based on the notebook context
 - **Modify cells**: Use the appropriate tools to update cell content
-- **Add new cells**: Create code or markdown cells as requested
-- **Run code**: Execute cells using the notebook's kernel
-- **Debug**: Help identify issues in notebook code, considering cell execution order
 
 Guidelines:
 - Consider the notebook's execution state and cell dependencies
@@ -18,6 +33,7 @@ Guidelines:
 - Help maintain clear notebook structure with appropriate markdown documentation
 - When suggesting code changes, explain the changes clearly
 - Be aware of the notebook's kernel language (Python, R, etc.)
-- Consider previous cell outputs when providing assistance
+- Consider previous cell imports and outputs when providing assistance
 
 You have access to notebook-specific tools for reading, modifying, executing, and analyzing notebook cells.
+

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook.md
@@ -1,0 +1,23 @@
+---
+mode: notebook
+order: 70
+description: Prompt when using inline chat in notebooks
+---
+You are assisting the user within a Jupyter notebook in Positron.
+
+When the user asks you to:
+- **Analyze or explain code**: Focus on the selected cell(s) or provide insights based on the notebook context
+- **Modify cells**: Use the appropriate tools to update cell content
+- **Add new cells**: Create code or markdown cells as requested
+- **Run code**: Execute cells using the notebook's kernel
+- **Debug**: Help identify issues in notebook code, considering cell execution order
+
+Guidelines:
+- Consider the notebook's execution state and cell dependencies
+- Use cell IDs when referencing specific cells
+- Help maintain clear notebook structure with appropriate markdown documentation
+- When suggesting code changes, explain the changes clearly
+- Be aware of the notebook's kernel language (Python, R, etc.)
+- Consider previous cell outputs when providing assistance
+
+You have access to notebook-specific tools for reading, modifying, executing, and analyzing notebook cells.

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook.md
@@ -14,7 +14,7 @@ When the user asks you to:
 
 Guidelines:
 - Consider the notebook's execution state and cell dependencies
-- Use cell IDs when referencing specific cells
+- Use cell indices when referencing specific cells
 - Help maintain clear notebook structure with appropriate markdown documentation
 - When suggesting code changes, explain the changes clearly
 - Be aware of the notebook's kernel language (Python, R, etc.)

--- a/extensions/positron-assistant/src/notebookContextFilter.ts
+++ b/extensions/positron-assistant/src/notebookContextFilter.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+
+/**
+ * Maximum number of cells in a notebook to include all cells in the context.
+ * Notebooks with more cells will have filtering applied to avoid consuming
+ * too much context space.
+ */
+const MAX_CELLS_FOR_ALL_CELLS_CONTEXT = 20;
+
+/**
+ * Default window size for sliding window filtering.
+ * Number of cells to include before and after an anchor cell.
+ */
+const SLIDING_WINDOW_SIZE = 10;
+
+/**
+ * Calculates a sliding window of cells around an anchor cell index.
+ * @param totalCells Total number of cells in the notebook
+ * @param anchorIndex Index of the cell to center the window around
+ * @param windowSize Number of cells to include before and after the anchor (default 10)
+ * @returns Object with startIndex and endIndex for slicing the cells array
+ */
+export function calculateSlidingWindow(
+	totalCells: number,
+	anchorIndex: number,
+	windowSize: number = SLIDING_WINDOW_SIZE
+): { startIndex: number; endIndex: number } {
+	const startIndex = Math.max(0, anchorIndex - windowSize);
+	const endIndex = Math.min(totalCells, anchorIndex + windowSize + 1);
+	return { startIndex, endIndex };
+}
+
+/**
+ * Filters notebook context based on notebook size and selection state.
+ *
+ * Filtering rules:
+ * - Small notebooks (<20 cells): Keep all cells
+ * - Large notebooks (>=20 cells) with selection: Apply sliding window around last selected cell
+ * - Large notebooks (>=20 cells) without selection: Remove allCells field
+ *
+ * @param context The notebook context to filter
+ * @returns Filtered notebook context
+ */
+export function filterNotebookContext(
+	context: positron.notebooks.NotebookContext
+): positron.notebooks.NotebookContext {
+	// If no allCells or empty, return as-is
+	if (!context.allCells || context.allCells.length === 0) {
+		return context;
+	}
+
+	const totalCells = context.cellCount;
+
+	// Small notebooks: keep all cells
+	if (totalCells < MAX_CELLS_FOR_ALL_CELLS_CONTEXT) {
+		return context;
+	}
+
+	// Large notebooks without selection: remove allCells to save context space
+	if (context.selectedCells.length === 0) {
+		return {
+			...context,
+			allCells: undefined
+		};
+	}
+
+	// Large notebooks with selection: apply sliding window around last selected cell
+	const lastSelectedIndex = Math.max(...context.selectedCells.map(cell => cell.index));
+	const { startIndex, endIndex } = calculateSlidingWindow(totalCells, lastSelectedIndex);
+
+	const filteredCells = context.allCells.slice(startIndex, endIndex);
+
+	return {
+		...context,
+		allCells: filteredCells
+	};
+}

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -1025,10 +1025,10 @@ export class PositronAssistantNotebookParticipant extends PositronAssistantEdito
 		const contextCells = allCells.slice(startIndex, endIndex);
 
 		// Format current cell separately to highlight it
-		const currentCellText = formatCells([currentCell], 'Current Cell');
+		const currentCellText = formatCells({ cells: [currentCell], prefix: 'Current Cell' });
 
 		// Format context cells (including current cell in the window)
-		const contextCellsText = formatCells(contextCells, 'Cell');
+		const contextCellsText = formatCells({ cells: contextCells, prefix: 'Cell' });
 
 		// Get file path for context
 		const notebookPath = uriToString(vscode.Uri.parse(notebookContext.uri));

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -763,6 +763,15 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 export async function getAttachedNotebookContext(
 	request: vscode.ChatRequest
 ): Promise<positron.notebooks.NotebookContext | undefined> {
+	// Check if notebook mode feature is enabled
+	const notebookModeEnabled = vscode.workspace
+		.getConfiguration('positron.assistant.notebookMode')
+		.get('enable', false);
+
+	if (!notebookModeEnabled) {
+		return undefined;
+	}
+
 	// Get active editor's notebook context (unfiltered from main thread)
 	const activeContext = await positron.notebooks.getContext();
 	if (!activeContext) {
@@ -955,6 +964,16 @@ export class PositronAssistantNotebookParticipant extends PositronAssistantEdito
 	id = ParticipantID.Notebook;
 
 	override async getCustomPrompt(request: vscode.ChatRequest): Promise<string> {
+		// Check if notebook mode feature is enabled
+		const notebookModeEnabled = vscode.workspace
+			.getConfiguration('positron.assistant.notebookMode')
+			.get('enable', false);
+
+		if (!notebookModeEnabled) {
+			log.debug('[notebook participant] Notebook mode disabled via feature flag');
+			return super.getCustomPrompt(request);
+		}
+
 		// Get the active notebook context
 		const notebookContext = await positron.notebooks.getContext();
 		if (!notebookContext) {

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -542,7 +542,8 @@ export class PromptRenderer {
 	 * Get combined prompt for a specific command
 	 */
 	static renderModePrompt(mode: PromptMetadataMode, data: PromptRenderData): PromptDocument {
-		return PromptRenderer.instance._renderModePrompt(mode, data);
+		const promptData = PromptRenderer.instance._renderModePrompt(mode, data);
+		return promptData;
 	}
 
 	private _renderModePrompt(mode: PromptMetadataMode, data: PromptRenderData): PromptDocument {

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -62,7 +62,7 @@ class PromptTemplateEngine {
 				: xml.node('kernel', 'No kernel attached');
 
 			// Format selected cells (already XML from formatCells)
-			notebookSelectedCellsInfo = formatCells(ctx.selectedCells, 'Selected Cell');
+			notebookSelectedCellsInfo = formatCells({ cells: ctx.selectedCells, prefix: 'Selected Cell' });
 
 			// Format all cells if available as XML
 			if (ctx.allCells && ctx.allCells.length > 0) {
@@ -70,7 +70,7 @@ class PromptTemplateEngine {
 				const description = isFullNotebook
 					? 'All cells in notebook (notebook has fewer than 20 cells)'
 					: 'Context window around selected cells (notebook has 20+ cells)';
-				notebookAllCellsInfo = xml.node('all-cells', formatCells(ctx.allCells, 'Cell'), {
+				notebookAllCellsInfo = xml.node('all-cells', formatCells({ cells: ctx.allCells, prefix: 'Cell' }), {
 					description
 				});
 			}

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -80,10 +80,10 @@ class PromptTemplateEngine {
 				if (ctx.cellCount < 20) {
 					notebookContextNote = xml.node('note', 'All cells are provided above because this notebook has fewer than 20 cells.');
 				} else {
-					notebookContextNote = xml.node('note', 'A context window around the selected cells is provided above. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.');
+					notebookContextNote = xml.node('note', 'A context window around the selected cells is provided above. Use the GetNotebookCells tool to retrieve additional cells by index when needed.');
 				}
 			} else {
-				notebookContextNote = xml.node('note', 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.');
+				notebookContextNote = xml.node('note', 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by index when needed.');
 			}
 		}
 

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -66,15 +66,25 @@ class PromptTemplateEngine {
 
 			// Format all cells if available as XML
 			if (ctx.allCells && ctx.allCells.length > 0) {
+				const isFullNotebook = ctx.cellCount < 20;
+				const description = isFullNotebook
+					? 'All cells in notebook (notebook has fewer than 20 cells)'
+					: 'Context window around selected cells (notebook has 20+ cells)';
 				notebookAllCellsInfo = xml.node('all-cells', formatCells(ctx.allCells, 'Cell'), {
-					description: 'All cells in notebook (notebook has fewer than 20 cells)'
+					description
 				});
 			}
 
 			// Context note as XML
-			notebookContextNote = xml.node('note', ctx.allCells && ctx.allCells.length > 0
-				? 'All cells are provided above because this notebook has fewer than 20 cells.'
-				: 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.');
+			if (ctx.allCells && ctx.allCells.length > 0) {
+				if (ctx.cellCount < 20) {
+					notebookContextNote = xml.node('note', 'All cells are provided above because this notebook has fewer than 20 cells.');
+				} else {
+					notebookContextNote = xml.node('note', 'A context window around the selected cells is provided above. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.');
+				}
+			} else {
+				notebookContextNote = xml.node('note', 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.');
+			}
 		}
 
 		return {

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -10,6 +10,7 @@ import * as positron from 'positron';
 import * as yaml from 'yaml';
 import { MARKDOWN_DIR } from './constants';
 import { log } from './extension.js';
+import { formatCells } from './tools/notebookUtils.js';
 
 const PROMPT_MODE_SELECTIONS_KEY = 'positron.assistant.promptModeSelections';
 
@@ -23,6 +24,11 @@ type StoredPromptSelectionConfig = Partial<Record<PromptMetadataMode, { file: st
 interface AugmentedRenderData {
 	hasRSession: boolean;
 	hasPythonSession: boolean;
+	hasNotebookContext: boolean;
+	notebookKernelInfo?: string;
+	notebookSelectedCellsInfo?: string;
+	notebookAllCellsInfo?: string;
+	notebookContextNote?: string;
 }
 
 /**
@@ -36,10 +42,46 @@ class PromptTemplateEngine {
 		const hasRSession = data.sessions?.some(s => s.languageId === 'r') ?? false;
 		const hasPythonSession = data.sessions?.some(s => s.languageId === 'python') ?? false;
 
+		// Notebook context augmentation
+		const hasNotebookContext = !!data.notebookContext;
+		let notebookKernelInfo: string | undefined;
+		let notebookSelectedCellsInfo: string | undefined;
+		let notebookAllCellsInfo: string | undefined;
+		let notebookContextNote: string | undefined;
+
+		if (data.notebookContext) {
+			const ctx = data.notebookContext;
+
+			// Format kernel information
+			notebookKernelInfo = ctx.kernelId
+				? `${ctx.kernelLanguage || 'unknown'} (${ctx.kernelId})`
+				: 'No kernel attached';
+
+			// Format selected cells
+			notebookSelectedCellsInfo = formatCells(ctx.selectedCells, 'Selected Cell');
+
+			// Format all cells if available
+			if (ctx.allCells && ctx.allCells.length > 0) {
+				notebookAllCellsInfo = `
+**All Cells in Notebook:**
+${formatCells(ctx.allCells, 'Cell')}`;
+			}
+
+			// Context note
+			notebookContextNote = ctx.allCells && ctx.allCells.length > 0
+				? 'All cells are provided above because this notebook has fewer than 20 cells.'
+				: 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by ID when needed.';
+		}
+
 		return {
 			...data,
 			hasRSession,
 			hasPythonSession,
+			hasNotebookContext,
+			notebookKernelInfo,
+			notebookSelectedCellsInfo,
+			notebookAllCellsInfo,
+			notebookContextNote,
 		};
 	}
 
@@ -261,6 +303,7 @@ interface PromptRenderData {
 	document?: vscode.TextDocument;
 	sessions?: Array<positron.LanguageRuntimeMetadata>;
 	streamingEdits?: boolean;
+	notebookContext?: positron.notebooks.NotebookContext;
 }
 
 export class PromptRenderer {

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -10,6 +10,7 @@ import { PositronAssistantToolName } from './types.js';
 import { ProjectTreeTool } from './tools/projectTreeTool.js';
 import { getWorkspaceGitChanges, GitRepoChangeKind } from './git.js';
 import { DocumentCreateTool } from './tools/documentCreate.js';
+import { registerNotebookTools } from './tools/notebookTools.js';
 
 
 /**
@@ -411,6 +412,14 @@ export function registerAssistantTools(
 	context.subscriptions.push(ProjectTreeTool);
 
 	context.subscriptions.push(DocumentCreateTool);
+
+	// Register notebook-specific tools for notebook participant
+	// These tools enable the assistant to interact with Jupyter notebooks:
+	// - RunNotebookCells: Execute cells and retrieve outputs
+	// - AddNotebookCell: Add new code or markdown cells
+	// - UpdateNotebookCell: Update existing cell content
+	// - GetCellOutputs: Retrieve outputs from executed cells
+	registerNotebookTools(context);
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -1,0 +1,341 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { PositronAssistantToolName } from '../types.js';
+import { log } from '../extension.js';
+
+/**
+ * Formats cell status information into a readable string.
+ * @param cell The cell to format status for
+ * @returns Formatted status string
+ */
+function formatCellStatus(cell: positron.notebooks.NotebookCell): string {
+	const statusParts: string[] = [];
+	statusParts.push(`Selection: ${cell.selectionStatus}`);
+	if (cell.executionStatus !== undefined) {
+		statusParts.push(`Execution: ${cell.executionStatus}`);
+		if (cell.executionOrder !== undefined) {
+			statusParts.push(`Order: [${cell.executionOrder}]`);
+		}
+		if (cell.lastRunSuccess !== undefined) {
+			statusParts.push(`Last run: ${cell.lastRunSuccess ? 'success' : 'failed'}`);
+		}
+		if (cell.lastExecutionDuration !== undefined) {
+			const durationMs = cell.lastExecutionDuration;
+			const durationStr = durationMs < 1000
+				? `${durationMs}ms`
+				: `${(durationMs / 1000).toFixed(2)}s`;
+			statusParts.push(`Duration: ${durationStr}`);
+		}
+	}
+	statusParts.push(cell.hasOutput ? 'Has output' : 'No output');
+	return statusParts.join(' | ');
+}
+
+/**
+ * Tool: Run Notebook Cells
+ *
+ * Executes one or more cells in the active notebook and returns their outputs.
+ */
+export const RunNotebookCellsTool = vscode.lm.registerTool<{
+	cellIds: string[];
+}>(PositronAssistantToolName.RunNotebookCells, {
+	prepareInvocation: async (options, _token) => {
+		return {
+			invocationMessage: vscode.l10n.t('Running notebook cells'),
+			pastTenseMessage: vscode.l10n.t('Ran notebook cells'),
+		};
+	},
+	invoke: async (options, token) => {
+		const cellIds = options.input.cellIds;
+
+		try {
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('No active notebook found')
+				]);
+			}
+
+			await positron.notebooks.runCells(context.uri, cellIds);
+
+			// Get outputs for each cell
+			const outputs: string[] = [];
+			for (const cellId of cellIds) {
+				const cellOutputs = await positron.notebooks.getCellOutputs(context.uri, cellId);
+				if (cellOutputs.length > 0) {
+					outputs.push(`Cell ${cellId}:\n${cellOutputs.join('\n')}`);
+				}
+			}
+
+			const outputText = outputs.length > 0
+				? `Successfully executed ${cellIds.length} cell(s).\n\nOutputs:\n${outputs.join('\n\n')}`
+				: `Successfully executed ${cellIds.length} cell(s).`;
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(outputText)
+			]);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			log.error(`[${PositronAssistantToolName.RunNotebookCells}] Failed to execute cells: ${errorMessage}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to execute cells: ${errorMessage}`)
+			]);
+		}
+	}
+});
+
+/**
+ * Tool: Add Notebook Cell
+ *
+ * Adds a new cell (code or markdown) to the active notebook at the specified position.
+ */
+export const AddNotebookCellTool = vscode.lm.registerTool<{
+	type: 'code' | 'markdown';
+	index: number;
+	content: string;
+}>(PositronAssistantToolName.AddNotebookCell, {
+	prepareInvocation: async (options, _token) => {
+		return {
+			invocationMessage: vscode.l10n.t('Adding notebook cell'),
+			pastTenseMessage: vscode.l10n.t('Added notebook cell'),
+		};
+	},
+	invoke: async (options, token) => {
+		const { type, index, content } = options.input;
+
+		try {
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('No active notebook found')
+				]);
+			}
+
+			// Handle append case (-1 means append at end)
+			const insertIndex = index === -1 ? context.cellCount : index;
+
+			// Convert string type to NotebookCellType enum
+			const cellType = type === 'code'
+				? positron.notebooks.NotebookCellType.Code
+				: positron.notebooks.NotebookCellType.Markdown;
+
+			const cellId = await positron.notebooks.addCell(
+				context.uri,
+				cellType,
+				insertIndex,
+				content
+			);
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Successfully added ${type} cell at index ${insertIndex}. Cell ID: ${cellId}`)
+			]);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			log.error(`[${PositronAssistantToolName.AddNotebookCell}] Failed to add cell: ${errorMessage}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to add cell: ${errorMessage}`)
+			]);
+		}
+	}
+});
+
+/**
+ * Tool: Update Notebook Cell
+ *
+ * Updates the content of an existing cell in the active notebook.
+ */
+export const UpdateNotebookCellTool = vscode.lm.registerTool<{
+	cellId: string;
+	content: string;
+}>(PositronAssistantToolName.UpdateNotebookCell, {
+	prepareInvocation: async (options, _token) => {
+		return {
+			invocationMessage: vscode.l10n.t('Updating notebook cell'),
+			pastTenseMessage: vscode.l10n.t('Updated notebook cell'),
+		};
+	},
+	invoke: async (options, token) => {
+		const { cellId, content } = options.input;
+
+		try {
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('No active notebook found')
+				]);
+			}
+
+			await positron.notebooks.updateCellContent(
+				context.uri,
+				cellId,
+				content
+			);
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Successfully updated cell ${cellId}`)
+			]);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			log.error(`[${PositronAssistantToolName.UpdateNotebookCell}] Failed to update cell: ${errorMessage}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to update cell: ${errorMessage}`)
+			]);
+		}
+	}
+});
+
+/**
+ * Tool: Get Cell Outputs
+ *
+ * Retrieves the outputs from a specific cell in the active notebook.
+ */
+export const GetCellOutputsTool = vscode.lm.registerTool<{
+	cellId: string;
+}>(PositronAssistantToolName.GetCellOutputs, {
+	prepareInvocation: async (options, _token) => {
+		return {
+			invocationMessage: vscode.l10n.t('Getting cell outputs'),
+			pastTenseMessage: vscode.l10n.t('Retrieved cell outputs'),
+		};
+	},
+	invoke: async (options, token) => {
+		const cellId = options.input.cellId;
+
+		try {
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('No active notebook found')
+				]);
+			}
+
+			const outputs = await positron.notebooks.getCellOutputs(context.uri, cellId);
+
+			if (outputs.length === 0) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart(`Cell ${cellId} has no outputs`)
+				]);
+			}
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Outputs for cell ${cellId}:\n\n${outputs.join('\n\n')}`)
+			]);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			log.error(`[${PositronAssistantToolName.GetCellOutputs}] Failed to get outputs: ${errorMessage}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to get outputs: ${errorMessage}`)
+			]);
+		}
+	}
+});
+
+/**
+ * Tool: Get Notebook Cells
+ *
+ * Retrieves information about all cells or specific cells in the active notebook.
+ */
+export const GetNotebookCellsTool = vscode.lm.registerTool<{
+	cellIds?: string[];
+}>(PositronAssistantToolName.GetNotebookCells, {
+	prepareInvocation: async (options, _token) => {
+		return {
+			invocationMessage: vscode.l10n.t('Getting notebook cells'),
+			pastTenseMessage: vscode.l10n.t('Retrieved notebook cells'),
+		};
+	},
+	invoke: async (options, token) => {
+		try {
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('No active notebook found')
+				]);
+			}
+
+			// If specific cell IDs requested, fetch those cells
+			if (options.input.cellIds && options.input.cellIds.length > 0) {
+				const cells: positron.notebooks.NotebookCell[] = [];
+				for (const cellId of options.input.cellIds) {
+					const cell = await positron.notebooks.getCell(context.uri, cellId);
+					if (cell) {
+						cells.push(cell);
+					}
+				}
+
+				if (cells.length === 0) {
+					return new vscode.LanguageModelToolResult([
+						new vscode.LanguageModelTextPart(`No cells found with the specified IDs`)
+					]);
+				}
+
+				const cellInfo = cells.map(cell => {
+					const statusInfo = formatCellStatus(cell);
+					return `### Cell ${cell.index} (${cell.type})
+ID: ${cell.id}
+Status: ${statusInfo}
+\`\`\`
+${cell.content}
+\`\`\``;
+				}).join('\n\n');
+
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart(`Retrieved ${cells.length} cell(s):\n\n${cellInfo}`)
+				]);
+			}
+
+			// Otherwise, fetch all cells
+			const cells = await positron.notebooks.getCells(context.uri);
+
+			if (cells.length === 0) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('The notebook has no cells')
+				]);
+			}
+
+			const cellInfo = cells.map(cell => {
+				const statusInfo = formatCellStatus(cell);
+				return `### Cell ${cell.index} (${cell.type})
+ID: ${cell.id}
+Status: ${statusInfo}
+\`\`\`
+${cell.content}
+\`\`\``;
+			}).join('\n\n');
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Retrieved all ${cells.length} cell(s) from notebook:\n\n${cellInfo}`)
+			]);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			log.error(`[${PositronAssistantToolName.GetNotebookCells}] Failed to get cells: ${errorMessage}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to get cells: ${errorMessage}`)
+			]);
+		}
+	}
+});
+
+/**
+ * Register all notebook tools with the extension context.
+ *
+ * This function should be called during extension activation to register
+ * the notebook tools as disposables.
+ *
+ * @param context The extension context for registering disposables
+ */
+export function registerNotebookTools(context: vscode.ExtensionContext): void {
+	context.subscriptions.push(
+		RunNotebookCellsTool,
+		AddNotebookCellTool,
+		UpdateNotebookCellTool,
+		GetCellOutputsTool,
+		GetNotebookCellsTool
+	);
+}
+

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { PositronAssistantToolName } from '../types.js';
 import { log } from '../extension.js';
-import { convertOutputsToLanguageModelParts, formatCellStatus } from './notebookUtils.js';
+import { convertOutputsToLanguageModelParts, formatCellStatus, formatCells } from './notebookUtils.js';
 
 /**
  * Gets the active notebook context, returning null if no notebook is active.
@@ -49,26 +49,6 @@ function createNotebookToolErrorResult(
 	]);
 }
 
-/**
- * Formats an array of notebook cells into a markdown string representation.
- *
- * @param cells The notebook cells to format
- * @returns A formatted markdown string describing all cells, separated by double newlines
- */
-function formatCellsInfo(cells: positron.notebooks.NotebookCell[]): string {
-	return cells.map(cell => {
-		const statusInfo = formatCellStatus(cell);
-		const parts = [
-			`### Cell ${cell.index} (${cell.type})`,
-			`ID: ${cell.id}`,
-			`Status: ${statusInfo}`,
-			'```',
-			cell.content,
-			'```'
-		];
-		return parts.join('\n');
-	}).join('\n\n');
-}
 
 /**
  * Tool: Run Notebook Cells
@@ -290,7 +270,7 @@ export const GetNotebookCellsTool = vscode.lm.registerTool<{
 					]);
 				}
 
-				const cellInfo = formatCellsInfo(cells);
+				const cellInfo = formatCells(cells, 'Cell');
 
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`Retrieved ${cells.length} cell(s):\n\n${cellInfo}`)
@@ -306,7 +286,7 @@ export const GetNotebookCellsTool = vscode.lm.registerTool<{
 				]);
 			}
 
-			const cellInfo = formatCellsInfo(cells);
+			const cellInfo = formatCells(cells, 'Cell');
 
 			return new vscode.LanguageModelToolResult([
 				new vscode.LanguageModelTextPart(`Retrieved all ${cells.length} cell(s) from notebook:\n\n${cellInfo}`)

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -10,6 +10,27 @@ import { log } from '../extension.js';
 import { convertOutputsToLanguageModelParts, formatCellStatus } from './notebookUtils.js';
 
 /**
+ * Formats an array of notebook cells into a markdown string representation.
+ *
+ * @param cells The notebook cells to format
+ * @returns A formatted markdown string describing all cells, separated by double newlines
+ */
+function formatCellsInfo(cells: positron.notebooks.NotebookCell[]): string {
+	return cells.map(cell => {
+		const statusInfo = formatCellStatus(cell);
+		const parts = [
+			`### Cell ${cell.index} (${cell.type})`,
+			`ID: ${cell.id}`,
+			`Status: ${statusInfo}`,
+			'```',
+			cell.content,
+			'```'
+		];
+		return parts.join('\n');
+	}).join('\n\n');
+}
+
+/**
  * Tool: Run Notebook Cells
  *
  * Executes one or more cells in the active notebook and returns their outputs.
@@ -255,15 +276,7 @@ export const GetNotebookCellsTool = vscode.lm.registerTool<{
 					]);
 				}
 
-				const cellInfo = cells.map(cell => {
-					const statusInfo = formatCellStatus(cell);
-					return `### Cell ${cell.index} (${cell.type})
-ID: ${cell.id}
-Status: ${statusInfo}
-\`\`\`
-${cell.content}
-\`\`\``;
-				}).join('\n\n');
+				const cellInfo = formatCellsInfo(cells);
 
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`Retrieved ${cells.length} cell(s):\n\n${cellInfo}`)
@@ -279,15 +292,7 @@ ${cell.content}
 				]);
 			}
 
-			const cellInfo = cells.map(cell => {
-				const statusInfo = formatCellStatus(cell);
-				return `### Cell ${cell.index} (${cell.type})
-ID: ${cell.id}
-Status: ${statusInfo}
-\`\`\`
-${cell.content}
-\`\`\``;
-			}).join('\n\n');
+			const cellInfo = formatCellsInfo(cells);
 
 			return new vscode.LanguageModelToolResult([
 				new vscode.LanguageModelTextPart(`Retrieved all ${cells.length} cell(s) from notebook:\n\n${cellInfo}`)

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+
+/**
+ * Format cell status information for display in prompts
+ */
+export function formatCellStatus(cell: positron.notebooks.NotebookCell): string {
+	const statusParts: string[] = [];
+
+	// Selection status
+	statusParts.push(`Selection: ${cell.selectionStatus}`);
+
+	// Execution status (only for code cells)
+	if (cell.executionStatus !== undefined) {
+		statusParts.push(`Execution: ${cell.executionStatus}`);
+		if (cell.executionOrder !== undefined) {
+			statusParts.push(`Order: [${cell.executionOrder}]`);
+		}
+		if (cell.lastRunSuccess !== undefined) {
+			statusParts.push(`Last run: ${cell.lastRunSuccess ? 'success' : 'failed'}`);
+		}
+		if (cell.lastExecutionDuration !== undefined) {
+			const durationMs = cell.lastExecutionDuration;
+			const durationStr = durationMs < 1000
+				? `${durationMs}ms`
+				: `${(durationMs / 1000).toFixed(2)}s`;
+			statusParts.push(`Duration: ${durationStr}`);
+		}
+	}
+
+	// Output status
+	statusParts.push(cell.hasOutput ? 'Has output' : 'No output');
+
+	return statusParts.join(' | ');
+}
+
+/**
+ * Format a collection of cells for display in prompts
+ */
+export function formatCells(cells: positron.notebooks.NotebookCell[], prefix: string): string {
+	if (cells.length === 0) {
+		return prefix === 'Selected Cell' ? 'No cells currently selected' : '';
+	}
+
+	return cells.map((cell, idx) => {
+		const statusInfo = formatCellStatus(cell);
+		const cellLabel = cells.length === 1
+			? prefix
+			: `${prefix} ${idx + 1}`;
+		return `
+### ${cellLabel} - ${cell.type} [Index ${cell.index}]
+Cell ID: ${cell.id}
+Status: ${statusInfo}
+\`\`\`
+${cell.content}
+\`\`\``;
+	}).join('\n');
+}

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -40,9 +40,16 @@ export function formatCellStatus(cell: positron.notebooks.NotebookCell): string 
 }
 
 /**
- * Format a collection of cells for display in prompts
+ * Format a collection of cells for display in prompts using XML format
+ *
+ * @param cells The notebook cells to format
+ * @param prefix The prefix to use for cell labels (e.g., 'Selected Cell', 'Cell')
+ * @returns A formatted XML string describing all cells, separated by single newlines
  */
-export function formatCells(cells: positron.notebooks.NotebookCell[], prefix: string): string {
+export function formatCells(
+	cells: positron.notebooks.NotebookCell[],
+	prefix: string
+): string {
 	if (cells.length === 0) {
 		return prefix === 'Selected Cell' ? 'No cells currently selected' : '';
 	}
@@ -52,13 +59,14 @@ export function formatCells(cells: positron.notebooks.NotebookCell[], prefix: st
 		const cellLabel = cells.length === 1
 			? prefix
 			: `${prefix} ${idx + 1}`;
-		return `
-### ${cellLabel} - ${cell.type} [Index ${cell.index}]
-Cell ID: ${cell.id}
-Status: ${statusInfo}
-\`\`\`
-${cell.content}
-\`\`\``;
+		const parts = [
+			`<cell index="${cell.index}" type="${cell.type}" id="${cell.id}">`,
+			`  <label>${cellLabel}</label>`,
+			`  <status>${statusInfo}</status>`,
+			`  <content>${cell.content}</content>`,
+			`</cell>`
+		];
+		return parts.join('\n');
 	}).join('\n');
 }
 

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -103,6 +103,10 @@ export function convertOutputsToLanguageModelParts(
 	for (const output of outputs) {
 		if (output.mimeType.startsWith('image/')) {
 			// Handle image outputs - convert base64 to binary
+			if (!output.data) {
+				resultParts.push(new vscode.LanguageModelTextPart('[Image data unavailable]'));
+				continue;
+			}
 			const imageBuffer = Buffer.from(output.data, 'base64');
 			const imageData = new Uint8Array(imageBuffer);
 			resultParts.push(new vscode.LanguageModelDataPart(imageData, output.mimeType));

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -40,16 +40,26 @@ export function formatCellStatus(cell: positron.notebooks.NotebookCell): string 
 }
 
 /**
+ * Options for formatting notebook cells
+ */
+export interface FormatCellsOptions {
+	/** The notebook cells to format */
+	cells: positron.notebooks.NotebookCell[];
+	/** The prefix to use for cell labels (e.g., 'Selected Cell', 'Cell') */
+	prefix: string;
+	/** Whether to include cell content in the output. Defaults to true. */
+	includeContent?: boolean;
+}
+
+/**
  * Format a collection of cells for display in prompts using XML format
  *
- * @param cells The notebook cells to format
- * @param prefix The prefix to use for cell labels (e.g., 'Selected Cell', 'Cell')
+ * @param options Options for formatting cells
  * @returns A formatted XML string describing all cells, separated by single newlines
  */
-export function formatCells(
-	cells: positron.notebooks.NotebookCell[],
-	prefix: string
-): string {
+export function formatCells(options: FormatCellsOptions): string {
+	const { cells, prefix, includeContent = true } = options;
+
 	if (cells.length === 0) {
 		return prefix === 'Selected Cell' ? 'No cells currently selected' : '';
 	}
@@ -63,10 +73,10 @@ export function formatCells(
 			`<cell index="${cell.index}" type="${cell.type}" id="${cell.id}">`,
 			`  <label>${cellLabel}</label>`,
 			`  <status>${statusInfo}</status>`,
-			`  <content>${cell.content}</content>`,
+			includeContent ? `<content>${cell.content}</content>` : '',
 			`</cell>`
 		];
-		return parts.join('\n');
+		return parts.filter(Boolean).join('\n');
 	}).join('\n');
 }
 

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -70,7 +70,7 @@ export function formatCells(options: FormatCellsOptions): string {
 			? prefix
 			: `${prefix} ${idx + 1}`;
 		const parts = [
-			`<cell index="${cell.index}" type="${cell.type}" id="${cell.id}">`,
+			`<cell index="${cell.index}" type="${cell.type}">`,
 			`  <label>${cellLabel}</label>`,
 			`  <status>${statusInfo}</status>`,
 			includeContent ? `<content>${cell.content}</content>` : '',

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -2,6 +2,10 @@
 
 ## Detection
 
+Notebook mode is enabled differently depending on the chat interface being used:
+
+### Chat Pane Mode
+
 Notebook mode is enabled when **both** conditions are met:
 1. A notebook file (`.ipynb`) is attached as context to the chat request
 2. That notebook has an active Positron notebook editor open
@@ -21,6 +25,21 @@ This function:
 4. Returns `NotebookContext` if there's a match, `undefined` otherwise
 
 **Key behavior:** Users must explicitly attach a notebook file to enable notebook mode, even if a notebook is the active editor. This prevents unintended notebook mode activation.
+
+### Inline Cell Chat Mode
+
+Notebook mode is automatically enabled when using inline chat within a Positron notebook cell. The inline chat controller detects Positron notebooks and routes requests to the notebook participant.
+
+**Detection mechanism:**
+1. When inline chat is triggered in a cell editor, the inline chat controller checks if the editor belongs to a Positron notebook
+2. If yes, the chat location is set to `ChatAgentLocation.Notebook`
+3. This routes the request to the `PositronAssistantNotebookParticipant`
+4. The participant retrieves notebook context and provides cell-aware context
+
+**Locations:**
+- Route detection: `src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts` (function `updateLocationForPositronNotebooks`)
+- Context generation: `extensions/positron-assistant/src/participants.ts` (class `PositronAssistantNotebookParticipant.getCustomPrompt`)
+
 
 ## Context Information
 

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -1,0 +1,189 @@
+# Positron Assistant Notebook Mode
+
+## Detection
+
+Notebook mode is enabled when **both** conditions are met:
+1. A notebook file (`.ipynb`) is attached as context to the chat request
+2. That notebook has an active Positron notebook editor open
+
+The assistant uses a helper function to check these conditions:
+
+```typescript
+const notebookContext = await getAttachedNotebookContext(request);
+```
+
+**Location:** `extensions/positron-assistant/src/participants.ts:759`
+
+This function:
+1. Calls `positron.notebooks.getContext()` to get the active notebook editor
+2. Extracts all `.ipynb` file URIs from `request.references` (attached context)
+3. Checks if the active notebook's URI matches any attached notebook
+4. Returns `NotebookContext` if there's a match, `undefined` otherwise
+
+**Key behavior:** Users must explicitly attach a notebook file to enable notebook mode, even if a notebook is the active editor. This prevents unintended notebook mode activation.
+
+## Context Information
+
+When a notebook is active, `NotebookContext` provides:
+
+- `uri` - Notebook file path
+- `kernelId` / `kernelLanguage` - Active kernel info
+- `cellCount` - Total number of cells
+- `selectedCells[]` - Currently selected cells with:
+  - `id` - Unique cell identifier
+  - `index` - Cell position (0-based)
+  - `type` - 'code' or 'markdown'
+  - `content` - Cell source code
+  - `hasOutput` - Whether cell has output
+  - `selectionStatus` - Selection status ('unselected' | 'selected' | 'active'). Note: 'active' represents cells in editing mode
+  - `executionStatus` - **Code cells only**: Execution status ('running' | 'pending' | 'idle')
+  - `executionOrder` - **Code cells only**: Execution order number from last run
+  - `lastRunSuccess` - **Code cells only**: Whether last execution succeeded
+  - `lastExecutionDuration` - **Code cells only**: Duration of last execution in milliseconds
+  - `lastRunEndTime` - **Code cells only**: Timestamp when last execution ended
+- `allCells[]` - **Optional**: All cells in the notebook (same structure as `selectedCells`). Only included if the notebook has fewer than 20 cells to avoid consuming too much context space.
+
+**Context Construction Location:** `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts:46`
+
+The context is assembled by:
+1. Getting the active notebook instance from the editor
+2. Reading current state from observables (cells, kernel, selection)
+3. Converting selected cells to DTOs (always included) with status information:
+   - Selection status from `cell.selectionStatus` (maps 'editing' to 'active')
+   - Execution status fields from code cell observables (only for code cells)
+4. Converting all cells to DTOs only if `cellCount < MAX_CELLS_FOR_ALL_CELLS_CONTEXT` (currently 20)
+
+## Impact on Chat Behavior
+
+### System Prompt Augmentation
+**Locations:** `participants.ts:859` (Chat/Ask), `participants.ts:884` (Edit), `participants.ts:906` (Agent)
+
+When notebook mode is enabled (attached context + active editor), the assistant's system prompt is augmented with:
+
+1. **Notebook metadata** - URI, kernel, cell count, selected cells
+2. **Cell details** - IDs, content, status information (selection status, execution status, execution order, run success/failure, duration) for selected cells (and all cells if notebook is small enough)
+3. **Usage instructions**:
+   - Focus on selected cells when analyzing/explaining
+   - Use cell IDs when referencing specific cells
+   - Pay attention to cell status information (selection status, execution status, execution order, run success/failure)
+   - Consider execution order and cell dependencies
+   - Maintain notebook structure with markdown cells
+   - Use notebook-specific tools for manipulation
+
+### Tool Availability
+**Location:** `api.ts:177`
+
+```typescript
+const notebookContext = await getAttachedNotebookContext(request);
+const hasActiveNotebook = !!notebookContext;
+```
+
+The `hasActiveNotebook` flag determines which tools are available. Tools tagged with `'requires-notebook'` are only enabled when notebook mode is active (notebook attached as context AND has active editor).
+
+### Behavioral Changes
+
+**Without notebook mode (no attached notebook OR notebook not active editor):**
+- General coding assistant
+- Standard file/editor operations
+- No notebook-specific tools available
+
+**With notebook mode (notebook attached as context AND has active editor):**
+- Notebook-aware assistant
+- Access to notebook-specific tools:
+  - `GetNotebookCells` - Read cell contents with status information (selection status, execution status, execution order, run success/failure, duration)
+  - `RunNotebookCells` - Execute cells
+  - `AddNotebookCell` - Create new cells
+  - `UpdateNotebookCell` - Modify cell content
+  - `GetCellOutputs` - Retrieve cell outputs
+- References cells by ID in responses
+- Suggests cell-based operations
+- System prompt includes selected cell content, metadata, and status information
+- For small notebooks (< 20 cells), system prompt also includes all cell content and status via `allCells` field
+
+## Tool Implementation
+
+All notebook tools check for active notebook and return error if none found:
+
+```typescript
+const context = await positron.notebooks.getContext();
+if (!context) {
+    return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart('No active notebook found')
+    ]);
+}
+```
+
+**Location:** `extensions/positron-assistant/src/tools/notebookTools.ts`
+
+### Cell Status Information
+
+The `GetNotebookCells` tool returns cells with complete status information:
+- **Selection status**: 'unselected' | 'selected' | 'active' (where 'active' indicates editing mode)
+- **Execution status**: 'running' | 'pending' | 'idle' (code cells only)
+- **Execution order**: Number indicating execution sequence (code cells only)
+- **Last run success**: Boolean indicating if last execution succeeded (code cells only)
+- **Execution duration**: Duration in milliseconds (code cells only)
+- **Output status**: Whether the cell has output
+
+This status information helps the assistant understand:
+- Which cells are currently selected or being edited
+- Which cells are executing or queued for execution
+- The execution history and success/failure of previous runs
+- The execution order to understand dependencies
+
+## API Definition
+
+**Location:** `src/positron-dts/positron.d.ts:2331-2474`
+
+Full API namespace: `positron.notebooks`
+
+
+## Implementation Approach
+
+The current implementation uses **attached context detection** without API changes:
+
+### What Was Implemented
+✅ Check attached context for notebook files (`.ipynb`)
+✅ Verify that attached notebook has an active editor
+✅ Enable notebook mode only when both conditions are met
+✅ Keep all logic in extension layer (no core API changes)
+
+### Alternative Approaches (Not Implemented)
+
+**1. API-based URI checking:**
+- Add `positron.notebooks.getContext(uri?: Uri)` parameter
+- Add `positron.notebooks.hasEditorForUri(uri: Uri): boolean` method
+- **Trade-off:** More implementation complexity, cross-layer changes
+
+**2. Separate "Notebook" mode:**
+- New mode alongside Ask/Edit/Agent modes
+- **Trade-off:** UI changes, more modes to maintain
+
+**3. Template-based prompt injection:**
+- Move notebook instructions to `promptRender.ts` templating system
+- **Trade-off:** Would require refactoring existing prompt system
+
+The chosen approach (attached context detection) provides the cleanest implementation with minimal complexity and no API surface changes.
+
+## Testing Scenarios
+
+### Expected Behavior
+
+| Scenario | Notebook Attached? | Notebook Active Editor? | Notebook Mode? |
+|----------|-------------------|------------------------|----------------|
+| 1 | ✅ Yes | ✅ Yes (same file) | ✅ ON |
+| 2 | ✅ Yes | ❌ No (different file active) | ❌ OFF |
+| 3 | ❌ No | ✅ Yes | ❌ OFF |
+| 4 | ✅ Multiple notebooks | ✅ Yes (one is active) | ✅ ON |
+| 5 | ✅ Multiple notebooks | ❌ No (none active) | ❌ OFF |
+
+### How to Test
+
+1. **Attach notebook file** using `@filename.ipynb` in chat
+2. **Open notebook** in Positron notebook editor
+3. **Verify behavior**:
+   - Notebook tools should appear in tool list
+   - System prompt should include selected cell information with status (selection status, execution status, etc.)
+   - Assistant responses should reference cell IDs
+   - `GetNotebookCells` tool should return cells with complete status information
+

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -56,7 +56,7 @@ When a notebook is active, `NotebookContext` provides:
 - `kernelId` / `kernelLanguage` - Active kernel info
 - `cellCount` - Total number of cells
 - `selectedCells[]` - Currently selected cells with:
-  - `id` - Unique cell identifier
+  - `id` - Unique cell identifier (internal use only, not exposed to model)
   - `index` - Cell position (0-based)
   - `type` - 'code' or 'markdown'
   - `content` - Cell source code
@@ -97,10 +97,10 @@ The context is assembled across two layers:
 When notebook mode is enabled (attached context + active editor), the assistant's system prompt is augmented with:
 
 1. **Notebook metadata** - URI, kernel, cell count, selected cells
-2. **Cell details** - IDs, content, status information (selection status, execution status, execution order, run success/failure, duration) for selected cells. For small notebooks (< 20 cells), all cells are included. For large notebooks (>= 20 cells) with selection, a sliding window around the selected cells is included.
+2. **Cell details** - indices, content, status information (selection status, execution status, execution order, run success/failure, duration) for selected cells. For small notebooks (< 20 cells), all cells are included. For large notebooks (>= 20 cells) with selection, a sliding window around the selected cells is included.
 3. **Usage instructions**:
    - Focus on selected cells when analyzing/explaining
-   - Use cell IDs when referencing specific cells
+   - Use cell indices when referencing specific cells
    - Pay attention to cell status information (selection status, execution status, execution order, run success/failure)
    - Consider execution order and cell dependencies
    - Maintain notebook structure with markdown cells
@@ -196,7 +196,7 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
   - `GetNotebookCells` - Read cell contents with status information (selection status, execution status, execution order, run success/failure, duration)
   - `GetCellOutputs` - Retrieve cell execution outputs
 - Can view notebook context, analyze code, explain cells, and inspect outputs
-- References cells by ID in responses
+- References cells by index in responses
 - System prompt includes selected cell content, metadata, and status information
 - For small notebooks (< 20 cells), system prompt includes all cell content and status via `allCells` field
 - For large notebooks (>= 20 cells) with selection, system prompt includes a sliding window of cells around the selected cells via `allCells` field
@@ -212,7 +212,7 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
   - `UpdateNotebookCell` - Modify existing cell content
 - Can view, analyze, and modify notebook cells
 - Can add new code or markdown cells
-- References cells by ID in responses
+- References cells by index in responses
 - System prompt includes selected cell content, metadata, and status information
 - For small notebooks (< 20 cells), system prompt includes all cell content and status via `allCells` field
 - For large notebooks (>= 20 cells) with selection, system prompt includes a sliding window of cells around the selected cells via `allCells` field
@@ -227,7 +227,7 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
   - `AddNotebookCell` - Create new cells at specified positions
   - `UpdateNotebookCell` - Modify existing cell content
 - Can perform all operations: view, analyze, modify, execute, and create cells
-- References cells by ID in responses
+- References cells by index in responses
 - Suggests cell-based operations including modifications
 - System prompt includes selected cell content, metadata, and status information
 - For small notebooks (< 20 cells), system prompt includes all cell content and status via `allCells` field

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -71,7 +71,7 @@ When notebook mode is enabled (attached context + active editor), the assistant'
    - Use notebook-specific tools for manipulation
 
 ### Tool Availability
-**Location:** `api.ts:177`
+**Locations:** `api.ts:177`, `api.ts:250-258`
 
 ```typescript
 const notebookContext = await getAttachedNotebookContext(request);
@@ -80,6 +80,32 @@ const hasActiveNotebook = !!notebookContext;
 
 The `hasActiveNotebook` flag determines which tools are available. Tools tagged with `'requires-notebook'` are only enabled when notebook mode is active (notebook attached as context AND has active editor).
 
+**Mode-Based Tool Restrictions:**
+
+Notebook tools are conditionally available based on the assistant mode:
+
+**Modification Tools (Agent mode only):**
+- `RunNotebookCells` - Execute cells in the kernel
+- `AddNotebookCell` - Create new cells at specified positions
+- `UpdateNotebookCell` - Modify existing cell content
+
+**Read-Only Tools (Available in all modes - Ask, Edit, Agent):**
+- `GetNotebookCells` - Read cell contents with status information
+- `GetCellOutputs` - Retrieve cell execution outputs
+
+Tool filtering in `api.ts` (lines 250-258):
+```typescript
+// Notebook modification tools are only available in Agent mode.
+// Read-only tools (GetNotebookCells, GetCellOutputs) are available in all modes.
+case PositronAssistantToolName.RunNotebookCells:
+case PositronAssistantToolName.AddNotebookCell:
+case PositronAssistantToolName.UpdateNotebookCell:
+	if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
+		continue;
+	}
+	break;
+```
+
 ### Behavioral Changes
 
 **Without notebook mode (no attached notebook OR notebook not active editor):**
@@ -87,18 +113,67 @@ The `hasActiveNotebook` flag determines which tools are available. Tools tagged 
 - Standard file/editor operations
 - No notebook-specific tools available
 
-**With notebook mode (notebook attached as context AND has active editor):**
-- Notebook-aware assistant
-- Access to notebook-specific tools:
+**With notebook mode in Ask/Edit modes (notebook attached + active editor + Ask or Edit mode):**
+- Notebook-aware assistant with **read-only access**
+- Access to read-only tools:
   - `GetNotebookCells` - Read cell contents with status information (selection status, execution status, execution order, run success/failure, duration)
-  - `RunNotebookCells` - Execute cells
-  - `AddNotebookCell` - Create new cells
-  - `UpdateNotebookCell` - Modify cell content
-  - `GetCellOutputs` - Retrieve cell outputs
+  - `GetCellOutputs` - Retrieve cell execution outputs
+- Can view notebook context, analyze code, explain cells, and inspect outputs
 - References cells by ID in responses
-- Suggests cell-based operations
 - System prompt includes selected cell content, metadata, and status information
 - For small notebooks (< 20 cells), system prompt also includes all cell content and status via `allCells` field
+- When modifications are requested, suggests switching to Agent mode
+
+**With notebook mode in Agent mode (notebook attached + active editor + Agent mode):**
+- Notebook-aware assistant with **full manipulation capabilities**
+- Access to all notebook tools:
+  - `GetNotebookCells` - Read cell contents with status information
+  - `GetCellOutputs` - Retrieve cell execution outputs
+  - `RunNotebookCells` - Execute cells in the kernel
+  - `AddNotebookCell` - Create new cells at specified positions
+  - `UpdateNotebookCell` - Modify existing cell content
+- Can perform all operations: view, analyze, modify, execute, and create cells
+- References cells by ID in responses
+- Suggests cell-based operations including modifications
+- System prompt includes selected cell content, metadata, and status information
+- For small notebooks (< 20 cells), system prompt also includes all cell content and status via `allCells` field
+
+## Prompt File Architecture
+
+**Location:** `src/md/prompts/chat/`
+
+Notebook instructions are split into mode-specific prompt files following the established pattern of mode-specific prompts (e.g., `agent.md`, `ask.md`, `edit.md`):
+
+### `notebook-mode-agent.md`
+- **Modes:** `agent`
+- **Order:** 80
+- **Description:** Full notebook manipulation instructions for Agent mode
+- **Content:**
+  - Complete tool list (all 5 tools: GetNotebookCells, GetCellOutputs, RunNotebookCells, AddNotebookCell, UpdateNotebookCell)
+  - Full manipulation workflows (analyze, modify, add, execute, debug)
+  - No restrictions on modifications
+  - Emphasizes using tools instead of direct file access
+
+### `notebook-mode-readonly.md`
+- **Modes:** `[ask, edit]`
+- **Order:** 80
+- **Description:** Read-only notebook context and query tools for Ask/Edit modes
+- **Content:**
+  - Read-only tools only (GetNotebookCells, GetCellOutputs)
+  - Analysis and explanation workflows
+  - Clear guidance about mode limitations
+  - Suggests switching to Agent mode when modifications are requested
+  - Forbidden alternatives include attempting modifications
+
+**Design Rationale:**
+
+This separation ensures:
+1. Appropriate tool availability without runtime conditionals in templates
+2. Clear user guidance about capabilities per mode
+3. Follows existing Positron Assistant architectural patterns
+4. Makes mode-specific behavior explicit and maintainable
+
+When the prompt renderer loads prompts for a specific mode, it automatically includes the appropriate notebook prompt file based on the YAML `mode` header.
 
 ## Tool Implementation
 
@@ -169,21 +244,64 @@ The chosen approach (attached context detection) provides the cleanest implement
 
 ### Expected Behavior
 
-| Scenario | Notebook Attached? | Notebook Active Editor? | Notebook Mode? |
-|----------|-------------------|------------------------|----------------|
-| 1 | ✅ Yes | ✅ Yes (same file) | ✅ ON |
-| 2 | ✅ Yes | ❌ No (different file active) | ❌ OFF |
-| 3 | ❌ No | ✅ Yes | ❌ OFF |
-| 4 | ✅ Multiple notebooks | ✅ Yes (one is active) | ✅ ON |
-| 5 | ✅ Multiple notebooks | ❌ No (none active) | ❌ OFF |
+| Scenario | Notebook Attached? | Notebook Active Editor? | Mode | Notebook Mode? | Available Tools |
+|----------|-------------------|------------------------|------|----------------|-----------------|
+| 1 | ✅ Yes | ✅ Yes (same file) | Ask | ✅ ON (Read-only) | GetNotebookCells, GetCellOutputs |
+| 2 | ✅ Yes | ✅ Yes (same file) | Edit | ✅ ON (Read-only) | GetNotebookCells, GetCellOutputs |
+| 3 | ✅ Yes | ✅ Yes (same file) | Agent | ✅ ON (Full access) | All 5 tools |
+| 4 | ✅ Yes | ❌ No (different file active) | Any | ❌ OFF | None |
+| 5 | ❌ No | ✅ Yes | Any | ❌ OFF | None |
+| 6 | ✅ Multiple notebooks | ✅ Yes (one is active) | Ask/Edit | ✅ ON (Read-only) | GetNotebookCells, GetCellOutputs |
+| 7 | ✅ Multiple notebooks | ✅ Yes (one is active) | Agent | ✅ ON (Full access) | All 5 tools |
+| 8 | ✅ Multiple notebooks | ❌ No (none active) | Any | ❌ OFF | None |
 
 ### How to Test
 
+#### Test 1: Ask Mode - Read-Only Access
 1. **Attach notebook file** using `@filename.ipynb` in chat
 2. **Open notebook** in Positron notebook editor
+3. **Switch to Ask mode** in the mode selector
+4. **Verify behavior**:
+   - Only read-only tools appear in tool list: `GetNotebookCells`, `GetCellOutputs`
+   - Modification tools do NOT appear: `RunNotebookCells`, `AddNotebookCell`, `UpdateNotebookCell`
+   - System prompt includes selected cell information with status
+   - Ask "What does cell 1 do?" → Should work using GetNotebookCells
+   - Ask "Run this cell" → Should suggest switching to Agent mode
+
+#### Test 2: Edit Mode - Read-Only Access
+1. **Attach notebook file** using `@filename.ipynb` in chat
+2. **Open notebook** in Positron notebook editor
+3. **Switch to Edit mode** in the mode selector
+4. **Verify behavior**:
+   - Only read-only tools appear in tool list: `GetNotebookCells`, `GetCellOutputs`
+   - Modification tools do NOT appear
+   - Ask "Show me the output of cell 2" → Should use GetCellOutputs
+   - Ask "Update cell 3 to add error handling" → Should suggest switching to Agent mode
+
+#### Test 3: Agent Mode - Full Access
+1. **Attach notebook file** using `@filename.ipynb` in chat
+2. **Open notebook** in Positron notebook editor
+3. **Switch to Agent mode** in the mode selector
+4. **Verify behavior**:
+   - All 5 notebook tools appear in tool list
+   - Request cell modification → Should use UpdateNotebookCell
+   - Request cell execution → Should use RunNotebookCells
+   - Request adding new cell → Should use AddNotebookCell
+   - Assistant can perform all notebook operations
+
+#### Test 4: Without Attached Notebook
+1. **Do NOT attach any notebook file**
+2. **Open a notebook** in Positron notebook editor
 3. **Verify behavior**:
-   - Notebook tools should appear in tool list
-   - System prompt should include selected cell information with status (selection status, execution status, etc.)
-   - Assistant responses should reference cell IDs
-   - `GetNotebookCells` tool should return cells with complete status information
+   - No notebook tools appear in any mode
+   - No notebook context in system prompt
+   - Assistant behaves as general coding assistant
+
+#### Test 5: Prompt File Loading
+1. Enable trace logging in the extension
+2. Attach notebook and switch between modes
+3. Check console logs to verify:
+   - Ask mode loads `notebook-mode-readonly.md`
+   - Edit mode loads `notebook-mode-readonly.md`
+   - Agent mode loads `notebook-mode-agent.md`
 

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -24,7 +24,13 @@ This function:
 3. Checks if the active notebook's URI matches any attached notebook
 4. Returns `NotebookContext` if there's a match, `undefined` otherwise
 
-**Key behavior:** Users must explicitly attach a notebook file to enable notebook mode, even if a notebook is the active editor. This prevents unintended notebook mode activation.
+**Privacy rationale:** This check ensures:
+
+- **Transparency**: Attached notebooks are shown in the chat window, so users can see which notebook data will be sent to third-party providers before sending. Only attached notebooks are included.
+
+- **Prevents accidental sharing**: Without this check, open notebooks could automatically send data to AI providers without being visible in the chat UI.
+
+**Key behavior:** Notebook mode is only enabled when a notebook is attached (visible in the chat window), even if a notebook is the active editor. This prevents unintended notebook mode activation.
 
 ### Inline Cell Chat Mode
 

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -103,11 +103,11 @@ const notebookContext = await getAttachedNotebookContext(request);
 const hasActiveNotebook = !!notebookContext;
 ```
 
-The `hasActiveNotebook` flag determines which tools are available. Tools tagged with `'requires-notebook'` are only enabled when notebook mode is active (notebook attached as context AND has active editor).
+The `hasActiveNotebook` flag determines which tools are available. Each notebook tool has specific filtering logic in the switch statement based on the assistant mode and notebook context.
 
 **Mode-Based Tool Restrictions:**
 
-Notebook tools are conditionally available based on the assistant mode:
+Notebook tools are conditionally available based on the assistant mode, with filtering implemented in switch-case logic (lines 245-269):
 
 **Execution Tools (Agent mode only):**
 - `RunNotebookCells` - Execute cells in the kernel

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -21,9 +21,7 @@ export enum PositronAssistantToolName {
 	TextSearch = 'positron_findTextInProject_internal',
 	FileContents = 'positron_getFileContents_internal',
 	RunNotebookCells = 'runNotebookCells',
-	AddNotebookCell = 'addNotebookCell',
-	UpdateNotebookCell = 'updateNotebookCell',
-	GetCellOutputs = 'getCellOutputs',
+	EditNotebookCells = 'editNotebookCells',
 	GetNotebookCells = 'getNotebookCells',
 }
 

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -20,6 +20,11 @@ export enum PositronAssistantToolName {
 	DocumentCreate = 'documentCreate',
 	TextSearch = 'positron_findTextInProject_internal',
 	FileContents = 'positron_getFileContents_internal',
+	RunNotebookCells = 'runNotebookCells',
+	AddNotebookCell = 'addNotebookCell',
+	UpdateNotebookCell = 'updateNotebookCell',
+	GetCellOutputs = 'getCellOutputs',
+	GetNotebookCells = 'getNotebookCells',
 }
 
 /**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2324,4 +2324,182 @@ declare module 'positron' {
 		 */
 		export function areCompletionsEnabled(uri: vscode.Uri): Thenable<boolean>;
 	}
+
+	/**
+	 * Namespace for interacting with Positron notebooks
+	 */
+	export namespace notebooks {
+		/**
+		 * Context about the currently active notebook
+		 */
+		export interface NotebookContext {
+			/**
+			 * URI of the notebook
+			 */
+			uri: string;
+
+			/**
+			 * ID of the active kernel
+			 */
+			kernelId?: string;
+
+			/**
+			 * Language of the kernel (e.g., 'python', 'r')
+			 */
+			kernelLanguage?: string;
+
+			/**
+			 * Total number of cells in the notebook
+			 */
+			cellCount: number;
+
+			/**
+			 * Currently selected cells
+			 */
+			selectedCells: NotebookCell[];
+
+			/**
+			 * All cells in the notebook. Included if notebook is small enough
+			 * to fit without taking too much context.
+			 */
+			allCells?: NotebookCell[];
+		}
+
+		/**
+		 * Type of notebook cell
+		 */
+		export enum NotebookCellType {
+			/** A code cell */
+			Code = 'code',
+
+			/** A markdown cell */
+			Markdown = 'markdown',
+		}
+
+		/**
+		 * Represents a cell in a notebook
+		 */
+		export interface NotebookCell {
+			/**
+			 * Unique identifier for the cell
+			 */
+			id: string;
+
+			/**
+			 * Index of the cell in the notebook (0-based)
+			 */
+			index: number;
+
+			/**
+			 * Type of cell
+			 */
+			type: NotebookCellType;
+
+			/**
+			 * Content of the cell
+			 */
+			content: string;
+
+			/**
+			 * Whether the cell has output
+			 */
+			hasOutput: boolean;
+
+			/**
+			 * Selection status of the cell ('unselected' | 'selected' | 'active')
+			 */
+			selectionStatus: string;
+
+			/**
+			 * Execution status of the cell ('running' | 'pending' | 'idle')
+			 * Only present for code cells
+			 */
+			executionStatus?: string;
+
+			/**
+			 * Execution order number for the last execution
+			 * Only present for code cells
+			 */
+			executionOrder?: number;
+
+			/**
+			 * Whether the last execution was successful
+			 * Only present for code cells
+			 */
+			lastRunSuccess?: boolean;
+
+			/**
+			 * Duration of the last execution in milliseconds
+			 * Only present for code cells
+			 */
+			lastExecutionDuration?: number;
+
+			/**
+			 * Timestamp when the last execution ended
+			 * Only present for code cells
+			 */
+			lastRunEndTime?: number;
+		}
+
+		/**
+		 * Get context about the active notebook
+		 * @returns The notebook context or undefined if no notebook is active
+		 */
+		export function getContext(): Thenable<NotebookContext | undefined>;
+
+		/**
+		 * Get all cells from a notebook
+		 * @param notebookUri URI of the notebook
+		 * @returns Array of all cells in the notebook
+		 */
+		export function getCells(notebookUri: string): Thenable<NotebookCell[]>;
+
+		/**
+		 * Get a specific cell from a notebook by its ID
+		 * @param notebookUri URI of the notebook
+		 * @param cellId ID of the cell to retrieve
+		 * @returns The cell or undefined if not found
+		 */
+		export function getCell(notebookUri: string, cellId: string): Thenable<NotebookCell | undefined>;
+
+		/**
+		 * Execute cells in a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellIds Array of cell IDs to execute
+		 */
+		export function runCells(notebookUri: string, cellIds: string[]): Thenable<void>;
+
+		/**
+		 * Add a new cell to a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param type Type of cell to add
+		 * @param index Index where the cell should be inserted
+		 * @param content Initial content for the cell
+		 * @returns The ID of the newly created cell
+		 */
+		export function addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Thenable<string>;
+
+		/**
+		 * Delete a cell from a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellId ID of the cell to delete
+		 */
+		export function deleteCell(notebookUri: string, cellId: string): Thenable<void>;
+
+		/**
+		 * Update the content of a cell in a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellId ID of the cell to update
+		 * @param content New content for the cell
+		 */
+		export function updateCellContent(notebookUri: string, cellId: string, content: string): Thenable<void>;
+
+		/**
+		 * Get the outputs from a code cell
+		 * @param notebookUri URI of the notebook
+		 * @param cellId ID of the cell
+		 * @returns Array of output strings, one per output item
+		 */
+		export function getCellOutputs(notebookUri: string, cellId: string): Thenable<string[]>;
+	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2455,19 +2455,19 @@ declare module 'positron' {
 		export function getCells(notebookUri: string): Thenable<NotebookCell[]>;
 
 		/**
-		 * Get a specific cell from a notebook by its ID
+		 * Get a specific cell from a notebook by its index
 		 * @param notebookUri URI of the notebook
-		 * @param cellId ID of the cell to retrieve
+		 * @param cellIndex Index of the cell to retrieve
 		 * @returns The cell or undefined if not found
 		 */
-		export function getCell(notebookUri: string, cellId: string): Thenable<NotebookCell | undefined>;
+		export function getCell(notebookUri: string, cellIndex: number): Thenable<NotebookCell | undefined>;
 
 		/**
 		 * Execute cells in a notebook
 		 * @param notebookUri URI of the notebook
-		 * @param cellIds Array of cell IDs to execute
+		 * @param cellIndices Array of cell indices to execute
 		 */
-		export function runCells(notebookUri: string, cellIds: string[]): Thenable<void>;
+		export function runCells(notebookUri: string, cellIndices: number[]): Thenable<void>;
 
 		/**
 		 * Add a new cell to a notebook
@@ -2482,17 +2482,17 @@ declare module 'positron' {
 		/**
 		 * Delete a cell from a notebook
 		 * @param notebookUri URI of the notebook
-		 * @param cellId ID of the cell to delete
+		 * @param cellIndex Index of the cell to delete
 		 */
-		export function deleteCell(notebookUri: string, cellId: string): Thenable<void>;
+		export function deleteCell(notebookUri: string, cellIndex: number): Thenable<void>;
 
 		/**
 		 * Update the content of a cell in a notebook
 		 * @param notebookUri URI of the notebook
-		 * @param cellId ID of the cell to update
+		 * @param cellIndex Index of the cell to update
 		 * @param content New content for the cell
 		 */
-		export function updateCellContent(notebookUri: string, cellId: string, content: string): Thenable<void>;
+		export function updateCellContent(notebookUri: string, cellIndex: number, content: string): Thenable<void>;
 
 		/**
 		 * Represents a cell output with its MIME type and data
@@ -2512,9 +2512,9 @@ declare module 'positron' {
 		/**
 		 * Get the outputs from a code cell
 		 * @param notebookUri URI of the notebook
-		 * @param cellId ID of the cell
+		 * @param cellIndex Index of the cell
 		 * @returns Array of output objects with MIME type and data
 		 */
-		export function getCellOutputs(notebookUri: string, cellId: string): Thenable<NotebookCellOutput[]>;
+		export function getCellOutputs(notebookUri: string, cellIndex: number): Thenable<NotebookCellOutput[]>;
 	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2495,11 +2495,26 @@ declare module 'positron' {
 		export function updateCellContent(notebookUri: string, cellId: string, content: string): Thenable<void>;
 
 		/**
+		 * Represents a cell output with its MIME type and data
+		 */
+		export interface NotebookCellOutput {
+			/**
+			 * MIME type of the output (e.g., 'text/plain', 'image/png', 'image/jpeg')
+			 */
+			mimeType: string;
+
+			/**
+			 * Output data - plain text for text outputs, base64-encoded string for images and other binary data
+			 */
+			data: string;
+		}
+
+		/**
 		 * Get the outputs from a code cell
 		 * @param notebookUri URI of the notebook
 		 * @param cellId ID of the cell
-		 * @returns Array of output strings, one per output item
+		 * @returns Array of output objects with MIME type and data
 		 */
-		export function getCellOutputs(notebookUri: string, cellId: string): Thenable<string[]>;
+		export function getCellOutputs(notebookUri: string, cellId: string): Thenable<NotebookCellOutput[]>;
 	}
 }

--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -105,6 +105,7 @@ import './positron/mainThreadConnections.js';
 import './positron/mainThreadEnvironment.js';
 import './positron/mainThreadAiFeatures.js';
 import './positron/mainThreadPlotsService.js';
+import './positron/mainThreadNotebookFeatures.js';
 // --- End Positron ---
 
 export class ExtensionPoints implements IWorkbenchContribution {

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -180,11 +180,9 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 			throw new Error(`No cells found with IDs: ${cellIds.join(', ')}`);
 		}
 
-		if (cellsToRun.length === 1) {
-			// Select the cell
-			const cell = cellsToRun[0];
-			cell.select(CellSelectionType.Normal);
-		}
+		// Select the last cell in the range (somewhat arbitrary)
+		const lastCell = cellsToRun[cellsToRun.length - 1];
+		lastCell.select(CellSelectionType.Normal);
 
 		return instance.runCells(cellsToRun);
 	}

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -1,0 +1,364 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
+import { MainPositronContext, MainThreadNotebookFeaturesShape, INotebookContextDTO, INotebookCellDTO } from '../../common/positron/extHost.positron.protocol.js';
+import { NotebookCellType } from '../../common/positron/extHostTypes.positron.js';
+import { IPositronNotebookService } from '../../../contrib/positronNotebook/browser/positronNotebookService.js';
+import { IPositronNotebookInstance } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookCell, CellSelectionStatus, IPositronNotebookCodeCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { getNotebookInstanceFromActiveEditorPane } from '../../../contrib/positronNotebook/browser/notebookUtils.js';
+import { CellSelectionType, getSelectedCells } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { URI } from '../../../../base/common/uri.js';
+import { CellKind, CellEditType } from '../../../contrib/notebook/common/notebookCommon.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+
+/**
+ * Maximum number of cells in a notebook to include all cells in the context.
+ * Notebooks with more cells will not include the allCells field to avoid
+ * consuming too much context space.
+ */
+const MAX_CELLS_FOR_ALL_CELLS_CONTEXT = 20;
+
+/**
+ * Main thread implementation of notebook features for extension host communication.
+ * Provides methods for interacting with Positron notebooks from extensions.
+ */
+@extHostNamedCustomer(MainPositronContext.MainThreadNotebookFeatures)
+export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesShape {
+	private readonly _disposables = new DisposableStore();
+
+	constructor(
+		_extHostContext: IExtHostContext,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
+	) {
+		// No initialization needed
+	}
+
+	/**
+	 * Helper function to map a cell to DTO
+	 * @param cell The cell to map
+	 * @returns The cell DTO with status information
+	 */
+	private mapCellToDTO(cell: IPositronNotebookCell): INotebookCellDTO {
+		const cellId = cell.uri.toString();
+		const isCodeCell = cell.isCodeCell();
+		const cellOutputs = isCodeCell ? cell.outputs.get() : [];
+
+		// Map selection status: 'editing' -> 'active', others map directly
+		const rawSelectionStatus = cell.selectionStatus.get();
+		const selectionStatus = rawSelectionStatus === CellSelectionStatus.Editing
+			? 'active'
+			: rawSelectionStatus === CellSelectionStatus.Selected
+				? 'selected'
+				: 'unselected';
+
+		const baseDTO: INotebookCellDTO = {
+			id: cellId,
+			index: cell.index,
+			type: cell.kind === CellKind.Code ? NotebookCellType.Code : NotebookCellType.Markdown,
+			content: cell.getContent(),
+			hasOutput: cellOutputs.length > 0,
+			selectionStatus
+		};
+
+		// Add execution-related fields only for code cells
+		if (isCodeCell) {
+			const codeCell = cell as IPositronNotebookCodeCell;
+			baseDTO.executionStatus = codeCell.executionStatus.get();
+			baseDTO.executionOrder = codeCell.lastExecutionOrder.get();
+			baseDTO.lastRunSuccess = codeCell.lastRunSuccess.get();
+			baseDTO.lastExecutionDuration = codeCell.lastExecutionDuration.get();
+			baseDTO.lastRunEndTime = codeCell.lastRunEndTime.get();
+		}
+
+		return baseDTO;
+	}
+
+	/**
+	 * Gets the context information for the currently active notebook.
+	 * @returns The notebook context DTO, or undefined if no notebook is active.
+	 */
+	async $getActiveNotebookContext(): Promise<INotebookContextDTO | undefined> {
+		// Use existing helper function instead of service method
+		const instance = getNotebookInstanceFromActiveEditorPane(this._editorService);
+		if (!instance) {
+			return undefined;
+		}
+
+		// Get current state from observables
+		const cells = instance.cells.get();
+		const kernel = instance.kernel.get();
+		const selectionState = instance.selectionStateMachine.state.get();
+
+		// Map selected cells using helper function
+		const selectedCells: INotebookCellDTO[] = [];
+		const selectedCellsList = getSelectedCells(selectionState);
+		for (const cell of selectedCellsList) {
+			selectedCells.push(this.mapCellToDTO(cell));
+		}
+
+		// Only convert all cells to DTOs if notebook is small enough to avoid unnecessary computation
+		let allCells: INotebookCellDTO[] | undefined = undefined;
+		if (cells.length < MAX_CELLS_FOR_ALL_CELLS_CONTEXT) {
+			allCells = cells.map(cell => this.mapCellToDTO(cell));
+		}
+
+		return {
+			uri: instance.uri.toString(),
+			kernelId: kernel?.id,
+			kernelLanguage: kernel?.runtime.languageId,
+			cellCount: cells.length,
+			selectedCells,
+			allCells
+		};
+	}
+
+	/**
+	 * Gets all cells from a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @returns Array of all cells in the notebook.
+	 */
+	async $getCells(notebookUri: string): Promise<INotebookCellDTO[]> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cellDTOs: INotebookCellDTO[] = [];
+
+		for (const cell of cells) {
+			cellDTOs.push(this.mapCellToDTO(cell));
+		}
+
+		return cellDTOs;
+	}
+
+	/**
+	 * Gets a specific cell from a notebook by its ID.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to retrieve.
+	 * @returns The cell DTO, or undefined if not found.
+	 */
+	async $getCell(notebookUri: string, cellId: string): Promise<INotebookCellDTO | undefined> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cell = cells.find(c => c.uri.toString() === cellId);
+
+		if (!cell) {
+			return undefined;
+		}
+
+		return this.mapCellToDTO(cell);
+	}
+
+	/**
+	 * Runs the specified cells in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIds Array of cell IDs (cell URIs) to run.
+	 */
+	async $runCells(notebookUri: string, cellIds: string[]): Promise<void> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cellsToRun = cells.filter(cell => cellIds.includes(cell.uri.toString()));
+
+		if (cellsToRun.length === 0) {
+			throw new Error(`No cells found with IDs: ${cellIds.join(', ')}`);
+		}
+
+		if (cellsToRun.length === 1) {
+			// Select the cell
+			const cell = cellsToRun[0];
+			cell.select(CellSelectionType.Normal);
+		}
+
+		return instance.runCells(cellsToRun);
+	}
+
+	/**
+	 * Adds a new cell to a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param type The type of cell to add.
+	 * @param index The index where the cell should be inserted.
+	 * @param content The initial content for the cell.
+	 * @returns The ID (URI) of the newly created cell.
+	 */
+	async $addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<string> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cellKind = type === NotebookCellType.Code ? CellKind.Code : CellKind.Markup;
+
+		// Add cell and enter edit mode
+		instance.addCell(cellKind, index, true);
+
+		// Get the newly added cell
+		const cells = instance.cells.get();
+		const newCell = cells[index];
+
+		if (!newCell) {
+			throw new Error('Failed to add cell');
+		}
+
+		// Update content if provided
+		if (content) {
+			await this.$updateCellContent(notebookUri, newCell.uri.toString(), content);
+		}
+
+		return newCell.uri.toString();
+	}
+
+	/**
+	 * Deletes a cell from a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to delete.
+	 */
+	async $deleteCell(notebookUri: string, cellId: string): Promise<void> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cell = cells.find(c => c.uri.toString() === cellId);
+
+		if (!cell) {
+			throw new Error(`Cell not found: ${cellId}`);
+		}
+
+		return instance.deleteCell(cell);
+	}
+
+	/**
+	 * Updates the content of a cell in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to update.
+	 * @param content The new content for the cell.
+	 */
+	async $updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cell = cells.find(c => c.uri.toString() === cellId);
+
+		if (!cell) {
+			throw new Error(`Cell not found: ${cellId}`);
+		}
+
+		// Get the cell's model to access its properties
+		const cellModel = cell.model;
+		const cellIndex = cell.index;
+
+		// Use the notebook text model's applyEdits to replace the cell content
+		// This preserves all other cell properties (language, outputs, metadata, etc.)
+		const textModel = instance.textModel;
+		if (!textModel) {
+			throw new Error(`No text model for notebook: ${notebookUri}`);
+		}
+
+		const computeUndoRedo = !instance.isReadOnly || textModel.viewType === 'interactive';
+
+		textModel.applyEdits([
+			{
+				editType: CellEditType.Replace,
+				index: cellIndex,
+				count: 1,
+				cells: [
+					{
+						source: content,
+						language: cellModel.language,
+						mime: cellModel.mime,
+						cellKind: cellModel.cellKind,
+						outputs: cellModel.outputs.map(output => ({
+							outputId: output.outputId,
+							outputs: output.outputs
+						})),
+						metadata: cellModel.metadata,
+						internalMetadata: cellModel.internalMetadata
+					}
+				]
+			}
+		], true, undefined, () => undefined, undefined, computeUndoRedo);
+	}
+
+	/**
+	 * Gets the outputs from a code cell.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell.
+	 * @returns Array of output strings, one per output item.
+	 */
+	async $getCellOutputs(notebookUri: string, cellId: string): Promise<string[]> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		const cells = instance.cells.get();
+		const cell = cells.find(c => c.uri.toString() === cellId);
+
+		if (!cell) {
+			throw new Error(`Cell not found: ${cellId}`);
+		}
+
+		// Only code cells have outputs
+		if (!cell.isCodeCell()) {
+			return [];
+		}
+
+		// Get outputs from the observable
+		const outputs = cell.outputs.get();
+
+		// Convert outputs to strings
+		const outputStrings: string[] = [];
+		for (const output of outputs) {
+			for (const item of output.outputs) {
+				// Handle different MIME types
+				if (item.mime === 'text/plain') {
+					outputStrings.push(item.data.toString());
+				} else if (item.mime === 'application/vnd.code.notebook.stdout') {
+					outputStrings.push(item.data.toString());
+				} else if (item.mime === 'application/vnd.code.notebook.stderr') {
+					outputStrings.push(`[stderr] ${item.data.toString()}`);
+				} else {
+					outputStrings.push(`[${item.mime}] <binary data>`);
+				}
+			}
+		}
+
+		return outputStrings;
+	}
+
+	/**
+	 * Helper method to get a notebook instance by URI string.
+	 * @param uriString The notebook URI as a string.
+	 * @returns The notebook instance, or undefined if not found.
+	 */
+	private _getInstanceByUri(uriString: string): IPositronNotebookInstance | undefined {
+		const uri = URI.parse(uriString);
+		const instances = this._positronNotebookService.listInstances(uri);
+		return instances.length > 0 ? instances[0] : undefined;
+	}
+
+	dispose(): void {
+		this._disposables.dispose();
+	}
+}
+

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -193,21 +193,8 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 
 		const cellKind = type === NotebookCellType.Code ? CellKind.Code : CellKind.Markup;
 
-		// Add cell and enter edit mode
-		instance.addCell(cellKind, index, true);
-
-		// Get the newly added cell
-		const cells = instance.cells.get();
-		const newCell = cells[index];
-
-		if (!newCell) {
-			throw new Error('Failed to add cell');
-		}
-
-		// Update content if provided
-		if (content) {
-			await this.$updateCellContent(notebookUri, index, content);
-		}
+		// Add cell with content and enter edit mode
+		instance.addCell(cellKind, index, true, content);
 
 		return index;
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -14,7 +14,6 @@ import { IExtensionRegistries } from '../extHost.api.impl.js';
 import { IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { ExtHostConfigProvider } from '../extHostConfiguration.js';
 import { ExtHostPositronContext } from './extHost.positron.protocol.js';
-import * as extHostProtocol from './extHost.positron.protocol.js';
 import * as extHostTypes from './extHostTypes.positron.js';
 import { IExtHostInitDataService } from '../extHostInitDataService.js';
 import { ExtHostPreviewPanels } from './extHostPreviewPanels.js';
@@ -370,7 +369,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				}
 
 				// Helper function to map DTO cell to public API cell
-				const mapCell = (cell: extHostProtocol.INotebookCellDTO): positron.notebooks.NotebookCell => ({
+				const mapCell = (cell: positron.notebooks.NotebookCell): positron.notebooks.NotebookCell => ({
 					id: cell.id,
 					index: cell.index,
 					type: cell.type,
@@ -436,7 +435,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostNotebookFeatures.runCells(notebookUri, cellIds);
 			},
 
-			async addCell(notebookUri: string, type: extHostTypes.NotebookCellType, index: number, content: string): Promise<string> {
+			async addCell(notebookUri: string, type: positron.notebooks.NotebookCellType, index: number, content: string): Promise<string> {
 				return extHostNotebookFeatures.addCell(notebookUri, type, index, content);
 			},
 
@@ -448,7 +447,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostNotebookFeatures.updateCellContent(notebookUri, cellId, content);
 			},
 
-			async getCellOutputs(notebookUri: string, cellId: string): Promise<string[]> {
+			async getCellOutputs(notebookUri: string, cellId: string): Promise<positron.notebooks.NotebookCellOutput[]> {
 				return extHostNotebookFeatures.getCellOutputs(notebookUri, cellId);
 			}
 		};

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -411,8 +411,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				}));
 			},
 
-			async getCell(notebookUri: string, cellId: string): Promise<positron.notebooks.NotebookCell | undefined> {
-				const cell = await extHostNotebookFeatures.getCell(notebookUri, cellId);
+			async getCell(notebookUri: string, cellIndex: number): Promise<positron.notebooks.NotebookCell | undefined> {
+				const cell = await extHostNotebookFeatures.getCell(notebookUri, cellIndex);
 				if (!cell) {
 					return undefined;
 				}
@@ -431,24 +431,30 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				};
 			},
 
-			async runCells(notebookUri: string, cellIds: string[]): Promise<void> {
-				return extHostNotebookFeatures.runCells(notebookUri, cellIds);
+			async runCells(notebookUri: string, cellIndices: number[]): Promise<void> {
+				return extHostNotebookFeatures.runCells(notebookUri, cellIndices);
 			},
 
 			async addCell(notebookUri: string, type: positron.notebooks.NotebookCellType, index: number, content: string): Promise<string> {
-				return extHostNotebookFeatures.addCell(notebookUri, type, index, content);
+				const cellIndex = await extHostNotebookFeatures.addCell(notebookUri, type, index, content);
+				// Get the cell to retrieve its ID
+				const cell = await extHostNotebookFeatures.getCell(notebookUri, cellIndex);
+				if (!cell) {
+					throw new Error(`Failed to retrieve newly added cell at index ${cellIndex}`);
+				}
+				return cell.id;
 			},
 
-			async deleteCell(notebookUri: string, cellId: string): Promise<void> {
-				return extHostNotebookFeatures.deleteCell(notebookUri, cellId);
+			async deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
+				return extHostNotebookFeatures.deleteCell(notebookUri, cellIndex);
 			},
 
-			async updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void> {
-				return extHostNotebookFeatures.updateCellContent(notebookUri, cellId, content);
+			async updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void> {
+				return extHostNotebookFeatures.updateCellContent(notebookUri, cellIndex, content);
 			},
 
-			async getCellOutputs(notebookUri: string, cellId: string): Promise<positron.notebooks.NotebookCellOutput[]> {
-				return extHostNotebookFeatures.getCellOutputs(notebookUri, cellId);
+			async getCellOutputs(notebookUri: string, cellIndex: number): Promise<positron.notebooks.NotebookCellOutput[]> {
+				return extHostNotebookFeatures.getCellOutputs(notebookUri, cellIndex);
 			}
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -234,12 +234,12 @@ export interface INotebookCellOutputDTO {
 export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$getActiveNotebookContext(): Promise<INotebookContextDTO | undefined>;
 	$getCells(notebookUri: string): Promise<INotebookCellDTO[]>;
-	$getCell(notebookUri: string, cellId: string): Promise<INotebookCellDTO | undefined>;
-	$runCells(notebookUri: string, cellIds: string[]): Promise<void>;
-	$addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<string>;
-	$deleteCell(notebookUri: string, cellId: string): Promise<void>;
-	$updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void>;
-	$getCellOutputs(notebookUri: string, cellId: string): Promise<INotebookCellOutputDTO[]>;
+	$getCell(notebookUri: string, cellIndex: number): Promise<INotebookCellDTO | undefined>;
+	$runCells(notebookUri: string, cellIndices: number[]): Promise<void>;
+	$addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<number>;
+	$deleteCell(notebookUri: string, cellIndex: number): Promise<void>;
+	$updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void>;
+	$getCellOutputs(notebookUri: string, cellIndex: number): Promise<INotebookCellOutputDTO[]>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -218,6 +218,17 @@ export interface INotebookContextDTO {
 }
 
 /**
+ * Data transfer object for notebook cell output information.
+ * Supports both text and binary (image) outputs.
+ */
+export interface INotebookCellOutputDTO {
+	/** MIME type of the output (e.g., 'text/plain', 'image/png') */
+	mimeType: string;
+	/** Output data - plain text for text outputs, base64 encoded for images */
+	data: string;
+}
+
+/**
  * Interface that the main process exposes to the extension host for notebook features.
  */
 export interface MainThreadNotebookFeaturesShape extends IDisposable {
@@ -228,7 +239,7 @@ export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<string>;
 	$deleteCell(notebookUri: string, cellId: string): Promise<void>;
 	$updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void>;
-	$getCellOutputs(notebookUri: string, cellId: string): Promise<string[]>;
+	$getCellOutputs(notebookUri: string, cellId: string): Promise<INotebookCellOutputDTO[]>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as extHostProtocol from './extHost.positron.protocol.js';
+import type * as positron from 'positron';
 import { NotebookCellType } from './extHostTypes.positron.js';
 
 /**
@@ -30,7 +31,7 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	 * @param notebookUri The URI of the notebook as a string.
 	 * @returns Array of all cells in the notebook.
 	 */
-	async getCells(notebookUri: string): Promise<extHostProtocol.INotebookCellDTO[]> {
+	async getCells(notebookUri: string): Promise<positron.notebooks.NotebookCell[]> {
 		return this._proxy.$getCells(notebookUri);
 	}
 
@@ -40,7 +41,7 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	 * @param cellId The ID (URI) of the cell to retrieve.
 	 * @returns The cell DTO, or undefined if not found.
 	 */
-	async getCell(notebookUri: string, cellId: string): Promise<extHostProtocol.INotebookCellDTO | undefined> {
+	async getCell(notebookUri: string, cellId: string): Promise<positron.notebooks.NotebookCell | undefined> {
 		return this._proxy.$getCell(notebookUri, cellId);
 	}
 
@@ -88,9 +89,9 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	 * Gets the outputs from a code cell.
 	 * @param notebookUri The URI of the notebook as a string.
 	 * @param cellId The ID (URI) of the cell.
-	 * @returns Array of output strings, one per output item.
+	 * @returns Array of output objects with MIME type and data.
 	 */
-	async getCellOutputs(notebookUri: string, cellId: string): Promise<string[]> {
+	async getCellOutputs(notebookUri: string, cellId: string): Promise<extHostProtocol.INotebookCellOutputDTO[]> {
 		return this._proxy.$getCellOutputs(notebookUri, cellId);
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as extHostProtocol from './extHost.positron.protocol.js';
+import { NotebookCellType } from './extHostTypes.positron.js';
+
+/**
+ * Extension host implementation of notebook features.
+ * Provides a wrapper around the main thread notebook features API for use by extensions.
+ */
+export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookFeaturesShape {
+	private readonly _proxy: extHostProtocol.MainThreadNotebookFeaturesShape;
+
+	constructor(mainContext: extHostProtocol.IMainPositronContext) {
+		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadNotebookFeatures);
+	}
+
+	/**
+	 * Gets the context information for the currently active notebook.
+	 * @returns The notebook context DTO, or undefined if no notebook is active.
+	 */
+	async getActiveNotebookContext(): Promise<extHostProtocol.INotebookContextDTO | undefined> {
+		return this._proxy.$getActiveNotebookContext();
+	}
+
+	/**
+	 * Gets all cells from a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @returns Array of all cells in the notebook.
+	 */
+	async getCells(notebookUri: string): Promise<extHostProtocol.INotebookCellDTO[]> {
+		return this._proxy.$getCells(notebookUri);
+	}
+
+	/**
+	 * Gets a specific cell from a notebook by its ID.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to retrieve.
+	 * @returns The cell DTO, or undefined if not found.
+	 */
+	async getCell(notebookUri: string, cellId: string): Promise<extHostProtocol.INotebookCellDTO | undefined> {
+		return this._proxy.$getCell(notebookUri, cellId);
+	}
+
+	/**
+	 * Runs the specified cells in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIds Array of cell IDs (cell URIs) to run.
+	 */
+	async runCells(notebookUri: string, cellIds: string[]): Promise<void> {
+		return this._proxy.$runCells(notebookUri, cellIds);
+	}
+
+	/**
+	 * Adds a new cell to a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param type The type of cell to add.
+	 * @param index The index where the cell should be inserted.
+	 * @param content The initial content for the cell.
+	 * @returns The ID (URI) of the newly created cell.
+	 */
+	async addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<string> {
+		return this._proxy.$addCell(notebookUri, type, index, content);
+	}
+
+	/**
+	 * Deletes a cell from a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to delete.
+	 */
+	async deleteCell(notebookUri: string, cellId: string): Promise<void> {
+		return this._proxy.$deleteCell(notebookUri, cellId);
+	}
+
+	/**
+	 * Updates the content of a cell in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell to update.
+	 * @param content The new content for the cell.
+	 */
+	async updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void> {
+		return this._proxy.$updateCellContent(notebookUri, cellId, content);
+	}
+
+	/**
+	 * Gets the outputs from a code cell.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellId The ID (URI) of the cell.
+	 * @returns Array of output strings, one per output item.
+	 */
+	async getCellOutputs(notebookUri: string, cellId: string): Promise<string[]> {
+		return this._proxy.$getCellOutputs(notebookUri, cellId);
+	}
+}
+

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -36,22 +36,22 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	}
 
 	/**
-	 * Gets a specific cell from a notebook by its ID.
+	 * Gets a specific cell from a notebook by its index.
 	 * @param notebookUri The URI of the notebook as a string.
-	 * @param cellId The ID (URI) of the cell to retrieve.
+	 * @param cellIndex The index of the cell to retrieve.
 	 * @returns The cell DTO, or undefined if not found.
 	 */
-	async getCell(notebookUri: string, cellId: string): Promise<positron.notebooks.NotebookCell | undefined> {
-		return this._proxy.$getCell(notebookUri, cellId);
+	async getCell(notebookUri: string, cellIndex: number): Promise<positron.notebooks.NotebookCell | undefined> {
+		return this._proxy.$getCell(notebookUri, cellIndex);
 	}
 
 	/**
 	 * Runs the specified cells in a notebook.
 	 * @param notebookUri The URI of the notebook as a string.
-	 * @param cellIds Array of cell IDs (cell URIs) to run.
+	 * @param cellIndices Array of cell indices to run.
 	 */
-	async runCells(notebookUri: string, cellIds: string[]): Promise<void> {
-		return this._proxy.$runCells(notebookUri, cellIds);
+	async runCells(notebookUri: string, cellIndices: number[]): Promise<void> {
+		return this._proxy.$runCells(notebookUri, cellIndices);
 	}
 
 	/**
@@ -60,39 +60,39 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	 * @param type The type of cell to add.
 	 * @param index The index where the cell should be inserted.
 	 * @param content The initial content for the cell.
-	 * @returns The ID (URI) of the newly created cell.
+	 * @returns The index of the newly created cell.
 	 */
-	async addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<string> {
+	async addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<number> {
 		return this._proxy.$addCell(notebookUri, type, index, content);
 	}
 
 	/**
 	 * Deletes a cell from a notebook.
 	 * @param notebookUri The URI of the notebook as a string.
-	 * @param cellId The ID (URI) of the cell to delete.
+	 * @param cellIndex The index of the cell to delete.
 	 */
-	async deleteCell(notebookUri: string, cellId: string): Promise<void> {
-		return this._proxy.$deleteCell(notebookUri, cellId);
+	async deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
+		return this._proxy.$deleteCell(notebookUri, cellIndex);
 	}
 
 	/**
 	 * Updates the content of a cell in a notebook.
 	 * @param notebookUri The URI of the notebook as a string.
-	 * @param cellId The ID (URI) of the cell to update.
+	 * @param cellIndex The index of the cell to update.
 	 * @param content The new content for the cell.
 	 */
-	async updateCellContent(notebookUri: string, cellId: string, content: string): Promise<void> {
-		return this._proxy.$updateCellContent(notebookUri, cellId, content);
+	async updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void> {
+		return this._proxy.$updateCellContent(notebookUri, cellIndex, content);
 	}
 
 	/**
 	 * Gets the outputs from a code cell.
 	 * @param notebookUri The URI of the notebook as a string.
-	 * @param cellId The ID (URI) of the cell.
+	 * @param cellIndex The index of the cell.
 	 * @returns Array of output objects with MIME type and data.
 	 */
-	async getCellOutputs(notebookUri: string, cellId: string): Promise<extHostProtocol.INotebookCellOutputDTO[]> {
-		return this._proxy.$getCellOutputs(notebookUri, cellId);
+	async getCellOutputs(notebookUri: string, cellIndex: number): Promise<extHostProtocol.INotebookCellOutputDTO[]> {
+		return this._proxy.$getCellOutputs(notebookUri, cellIndex);
 	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -416,5 +416,16 @@ export enum CodeAttributionSource {
 	Script = 'script',
 }
 
+/**
+ * Type of notebook cell
+ */
+export enum NotebookCellType {
+	/** A code cell */
+	Code = 'code',
+
+	/** A markdown cell */
+	Markdown = 'markdown',
+}
+
 export { UiRuntimeNotifications } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 export { PlotRenderSettings, PlotRenderFormat } from '../../../services/positronPlots/common/positronPlots.js';

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -60,6 +60,10 @@ import { isNotebookContainingCellEditor as isNotebookWithCellEditor } from '../.
 import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
 import { ICellEditOperation } from '../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../notebook/common/notebookService.js';
+// --- Start Positron ---
+import { IPositronNotebookService } from '../../positronNotebook/browser/positronNotebookService.js';
+import { updateLocationForPositronNotebooks } from './positronNotebookUtils.js';
+// --- End Positron ---
 import { CTX_INLINE_CHAT_EDITING, CTX_INLINE_CHAT_REQUEST_IN_PROGRESS, CTX_INLINE_CHAT_RESPONSE_TYPE, CTX_INLINE_CHAT_VISIBLE, INLINE_CHAT_ID, InlineChatConfigKeys, InlineChatResponseType } from '../common/inlineChat.js';
 import { HunkInformation, Session, StashedSession } from './inlineChatSession.js';
 import { IInlineChatSession2, IInlineChatSessionService } from './inlineChatSessionService.js';
@@ -218,7 +222,10 @@ export class InlineChatController1 implements IEditorContribution {
 		@INotebookEditorService notebookEditorService: INotebookEditorService,
 		@ISharedWebContentExtractorService private readonly _webContentExtractorService: ISharedWebContentExtractorService,
 		@IFileService private readonly _fileService: IFileService,
-		@IChatAttachmentResolveService private readonly _chatAttachmentResolveService: IChatAttachmentResolveService
+		@IChatAttachmentResolveService private readonly _chatAttachmentResolveService: IChatAttachmentResolveService,
+		// --- Start Positron ---
+		@IPositronNotebookService positronNotebookService: IPositronNotebookService,
+		// --- End Positron ---
 	) {
 		this._ctxVisible = CTX_INLINE_CHAT_VISIBLE.bindTo(contextKeyService);
 		this._ctxEditing = CTX_INLINE_CHAT_EDITING.bindTo(contextKeyService);
@@ -260,6 +267,13 @@ export class InlineChatController1 implements IEditorContribution {
 					}
 				}
 			}
+
+			// --- Start Positron ---
+			// Check if this editor is part of a Positron notebook
+			if (!notebookEditor) {
+				updateLocationForPositronNotebooks(this._editor, location, positronNotebookService);
+			}
+			// --- End Positron ---
 
 			const zone = _instaService.createInstance(InlineChatZoneWidget, location, undefined, { editor: this._editor, notebookEditor });
 			this._store.add(zone);
@@ -1275,6 +1289,9 @@ export class InlineChatController2 implements IEditorContribution {
 		@IInlineChatSessionService inlineChatService: IInlineChatSessionService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IChatService chatService: IChatService,
+		// --- Start Positron ---
+		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
+		// --- End Positron ---
 	) {
 
 		const ctxInlineChatVisible = CTX_INLINE_CHAT_VISIBLE.bindTo(contextKeyService);
@@ -1330,6 +1347,12 @@ export class InlineChatController2 implements IEditorContribution {
 					}
 				}
 			}
+			// --- Start Positron ---
+			// Check if this editor is part of a Positron notebook
+			if (!notebookEditor) {
+				updateLocationForPositronNotebooks(this._editor, location, this._positronNotebookService);
+			}
+			// --- End Positron ---
 
 			const result = this._instaService.createInstance(InlineChatZoneWidget,
 				location,

--- a/src/vs/workbench/contrib/inlineChat/browser/positronNotebookUtils.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/positronNotebookUtils.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { IChatWidgetLocationOptions } from '../../chat/browser/chatWidget.js';
+import { ChatAgentLocation } from '../../chat/common/constants.js';
+import { IPositronNotebookService } from '../../positronNotebook/browser/positronNotebookService.js';
+
+/**
+ * Update the location to Notebook if the given editor is part of a Positron
+ * notebook. This allows the request to get routed to the correct notebook
+ * participant which otherwise wouldnt happen because the location is
+ * EditorInline. We could fix this at a different layer but this is the least
+ * invasive way I've found to do it.
+ *
+ * @param editor The code editor to check
+ * @param location The chat widget location to update
+ * @param positronNotebookService The Positron notebook service
+ * @returns true if the editor is part of a Positron notebook, false otherwise
+ */
+export function updateLocationForPositronNotebooks(
+	editor: ICodeEditor,
+	location: IChatWidgetLocationOptions,
+	positronNotebookService: IPositronNotebookService
+): boolean {
+	for (const positronInstance of positronNotebookService.listInstances()) {
+		if (positronInstance.hasCodeEditor(editor)) {
+			location.location = ChatAgentLocation.Notebook;
+			return true;
+		}
+	}
+	return false;
+}
+

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -77,6 +77,9 @@ import { MockLanguageModelToolsService } from '../../../chat/test/common/mockLan
 import { IMcpService } from '../../../mcp/common/mcpTypes.js';
 import { TestMcpService } from '../../../mcp/test/common/testMcpService.js';
 import { INotebookEditorService } from '../../../notebook/browser/services/notebookEditorService.js';
+// --- Start Positron ---
+import { IPositronNotebookService } from '../../../positronNotebook/browser/positronNotebookService.js';
+// --- End Positron ---
 import { RerunAction } from '../../browser/inlineChatActions.js';
 import { InlineChatController1, State } from '../../browser/inlineChatController.js';
 import { IInlineChatSessionService } from '../../browser/inlineChatSessionService.js';
@@ -207,6 +210,11 @@ suite('InlineChatController', function () {
 			[INotebookEditorService, new class extends mock<INotebookEditorService>() {
 				override listNotebookEditors() { return []; }
 			}],
+			// --- Start Positron ---
+			[IPositronNotebookService, new class extends mock<IPositronNotebookService>() {
+				override listInstances() { return []; }
+			}],
+			// --- End Positron ---
 			[IWorkbenchAssignmentService, new NullWorkbenchAssignmentService()],
 			[ILanguageModelsService, new SyncDescriptor(LanguageModelsService)],
 			[ITextModelService, new SyncDescriptor(TextModelResolverService)],

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -187,8 +187,9 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * @param type The kind of cell to create (e.g., code, markdown)
 	 * @param index The position at which to insert the new cell
 	 * @param enterEditMode Whether to put the new cell into edit mode immediately
+	 * @param content Optional content to set for the cell. Defaults to an empty string if not provided.
 	 */
-	addCell(type: CellKind, index: number, enterEditMode: boolean): void;
+	addCell(type: CellKind, index: number, enterEditMode: boolean, content?: string): void;
 
 	/**
 	 * Inserts a new code cell either above or below the current selection

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -724,9 +724,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Adds a new cell to the notebook at the specified index.
 	 * @param type The type of cell to add (`CellKind`)
 	 * @param index The position where the cell should be inserted
+	 * @param enterEditMode Whether to put the new cell into edit mode immediately
+	 * @param content Optional content to set for the cell. Defaults to an empty string if not provided.
 	 * @throws Error if no language is set for the notebook
 	 */
-	addCell(type: CellKind, index: number, enterEditMode: boolean): void {
+	addCell(type: CellKind, index: number, enterEditMode: boolean, content: string = ''): void {
 		this._assertTextModel();
 
 		if (!this.language) {
@@ -758,7 +760,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 						mime: undefined,
 						outputs: [],
 						metadata: undefined,
-						source: ''
+						source: content
 					}
 				]
 			}


### PR DESCRIPTION
This PR adds awareness of positron notebooks to the assistant chat pane. 

@:assistant @:positron-notebooks

Addresses #8555, #9142, #9431, #10342, #7373, #9662, #10387, #10357, #10388 and #10356 

When a positron notebook editor is open and active and it's associated ipynb is attached as context to the chat then we send in context about the notebook (cell count, language, selected cells, etc). 

For a much more thorough overview see the new doc about it `extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md`

<img width="900" height="941" alt="image" src="https://github.com/user-attachments/assets/1b9dae37-fb00-46be-9b85-03d7346d658f" />

In addition we supply a few tools for the notebook to manipulate notebooks (running, editing, deleting and looking at cell output).

This is a rough first step but is intended to provide the backbone upon which we build and polish. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

When the chat is open and a positron notebook is open next to it the chat should know about the notebook itself. 

Prompt:
> What can you tell me about this notebook?

Should return useful info.

When the notebook is not attached in context, then the assistant should not get any of this info. Test this by removing from context and asking the same question. 
<img width="981" height="554" alt="image" src="https://github.com/user-attachments/assets/6ee61e98-33e7-44d7-9257-e5c7a52afe6f" />
