### PR TITLE
E2E test: fix for remote ssh test (ubuntu > ubuntu)

### DIFF
--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -61,12 +61,17 @@ test.describe('Remote SSH', {
 	tag: [tags.REMOTE_SSH]
 }, () => {
 
-	test.beforeAll(async ({ }) => {
+	test.beforeAll(async ({ app, settings }) => {
+
+		await settings.set({ 'extensions.supportNodeGlobalNavigator': false });
+
 		try {
 			sshKeyscan('127.0.0.1', 3456, '/tmp/known_hosts');
 		} catch (err) {
 			throw new Error(`ssh-keyscan failed: ${(err as Error).message}`);
 		}
+
+		await app.restart();
 
 	});
 


### PR DESCRIPTION
Fix based on AI input for failing remote ssh test.

Can only test in positron-builds.

### QA Notes

