### PR TITLE
support #* plumber annotations and @examplesIf

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+')",
+			"begin": "(^\\s*#+(?:'|*))",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"
@@ -455,7 +455,7 @@
 			]
 		},
 		"roxygen-example": {
-			"begin": "(^\\s*#+')\\s*(@examples)\\s*$",
+			"begin": "(^\\s*#+')\\s*(?:(@examples)\\s*|(@examplesIf)\\s.*)$",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line"


### PR DESCRIPTION
This is an attempt to improve on the syntax highlighting of roxygen-like comments in R files. It provides two changes:

1. It alters the identification of roxygen comments to allow either `#'` or `#*` resulting in plumber2 annotations to have the same tag highlighting as expected from roxygen comments
2. It alters the definition of rogygen examples to also include `@examplesIf` tags so that what follows also get standard code highlighting

I'm not in a position to properly test this out so this should be considered a starting point for the team if they agree on these changes.

Additional changes that are related, but orthogonal to this PR are:

* roxygen tag completion should be dynamic by looking for registered `roxy_tag_parse()` methods in the R session which would automatically catch any plumber2 tags
* make sure that `@examplesIf` blocks also allow cmd+enter execution