### PR TITLE
Positron notebooks: Fix cell remounts

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -66,10 +66,14 @@ export function PositronNotebookComponent() {
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			<div ref={containerRef} className='positron-notebook-cells-container'>
-				{notebookCells.length ? notebookCells.map((cell, index) => <>
-					<NotebookCell key={cell.handle} cell={cell as PositronNotebookCellGeneral} />
-					<AddCellButtons index={index + 1} />
-				</>) : <div>{localize('noCells', 'No cells')}</div>
+				{notebookCells.length ?
+					notebookCells.map((cell, index) =>
+						<React.Fragment key={cell.handle}>
+							<NotebookCell cell={cell as PositronNotebookCellGeneral} />
+							<AddCellButtons index={index + 1} />
+						</React.Fragment>
+					) :
+					<div>{localize('noCells', 'No cells')}</div>
 				}
 			</div>
 			<ScreenReaderOnly className='notebook-announcements'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -95,9 +95,9 @@ function useFontStyles(): React.CSSProperties {
 	const family = fontInfo.fontFamily ?? `"SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace`;
 
 	return {
-		'--vscode-positronNotebook-text-output-font-family': family,
-		'--vscode-positronNotebook-text-output-font-size': `${fontInfo.fontSize}px`,
-	} as React.CSSProperties;
+		['--vscode-positronNotebook-text-output-font-family' as string]: family,
+		['--vscode-positronNotebook-text-output-font-size' as string]: `${fontInfo.fontSize}px`,
+	};
 }
 
 function NotebookCell({ cell }: {


### PR DESCRIPTION
This fixes a performance issue where we were remounting cells whenever a cell was added or deleted, because the `key` was on the child node instead of the fragment. Addresses #10454.

Before:

https://github.com/user-attachments/assets/d1f11288-a34f-4051-ab1e-bd7808b5f3c8

After:

https://github.com/user-attachments/assets/95f082fc-c3cb-405e-8453-182f2c258b25

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

See #10454 for a repro.

@:positron-notebooks @:web