### PR TITLE
Bump the rstudio.rstudio-workbench extension to 1.6.31 (#10453)

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -766,7 +766,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "5bc62ec0e125310dab00565277a5fa1bab6793d9",
+        "hashed_secret": "6fffa1fb96139d6eb243f67d9475156b107f7eec",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1403,5 +1403,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-03T22:18:30Z"
+  "generated_at": "2025-11-07T21:12:15Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.6.29",
+			"version": "1.6.31",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "b73085c6e6ffb6b1cb2c3e6c028fca1998421b06a4b76f48f2e64682f8211bf0",
+			"sha256": "056a082d65c00e31f4c76942b1814b7dde6d9b2a0bef47555d1926d8099b8f0b",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Updates the bundled `rstudio.rstudio-workbench` extension to version 1.6.31.

Package checksum:
`056a082d65c00e31f4c76942b1814b7dde6d9b2a0bef47555d1926d8099b8f0b` Commit:
[`629b8cc0be9a3967fb6af6e5ab31d8343674a23a`](https://github.com/rstudio/rstudio-workbench-vscode-ext/commit/629b8cc0be9a3967fb6af6e5ab31d8343674a23a) Branch: `main`

