### PR TITLE
Positron notebooks: Add the cell editor context menu, fix action label casing, reorder cell actions

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -83,6 +83,7 @@ export class MenuId {
 	static readonly PositronNotebookCellActionBarRight = new MenuId('PositronNotebookCellActionBarRight');
 	static readonly PositronNotebookCellActionBarSubmenu = new MenuId('PositronNotebookCellActionBarSubmenu');
 	static readonly PositronNotebookCellActionLeft = new MenuId('PositronNotebookCellActionLeft');
+	static readonly PositronNotebookCellContext = new MenuId('PositronNotebookCellContext');
 	static readonly EditorActionsLeft = new MenuId('EditorActionsLeft');
 	static readonly EditorActionsRight = new MenuId('EditorActionsRight');
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -40,7 +40,7 @@ import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON
 import { getEditingCell, getSelectedCell, getSelectedCells, SelectionState } from './selectionMachine.js';
 import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
-import { registerAction2, MenuId, Action2, IAction2Options } from '../../../../platform/actions/common/actions.js';
+import { registerAction2, MenuId, Action2, IAction2Options, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { KernelStatusBadge } from './KernelStatusBadge.js';
@@ -54,6 +54,13 @@ import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/com
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 
 const POSITRON_NOTEBOOK_CATEGORY = localize2('positronNotebook.category', 'Notebook');
+
+enum PositronNotebookCellActionGroup {
+	Clipboard = '0_clipboard',
+	Insert = '1_insert',
+	Order = '2_order',
+	Execution = '3_execution',
+}
 
 /**
  * PositronNotebookContribution class.
@@ -351,7 +358,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.selectUp',
-			title: localize2('positronNotebook.selectUp', "Move focus up"),
+			title: localize2('positronNotebook.selectUp', "Move Focus Up"),
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -370,7 +377,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.selectDown',
-			title: localize2('positronNotebook.selectDown', "Move focus down"),
+			title: localize2('positronNotebook.selectDown', "Move Focus Down"),
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -389,7 +396,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.addSelectionDown',
-			title: localize2('positronNotebook.addSelectionDown', "Extend selection down"),
+			title: localize2('positronNotebook.addSelectionDown', "Extend Selection Down"),
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -428,7 +435,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.edit',
-			title: localize2('positronNotebook.cell.edit', "Enter cell edit mode"),
+			title: localize2('positronNotebook.cell.edit', "Enter Cell Edit Mode"),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
@@ -461,7 +468,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.quitEdit',
-			title: localize2('positronNotebook.cell.quitEdit', "Exit cell edit mode"),
+			title: localize2('positronNotebook.cell.quitEdit', "Exit Cell Edit Mode"),
 			keybinding: {
 				when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -576,13 +583,15 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer',
-			title: localize2('positronNotebook.codeCell.insertAbove', "Insert code cell above"),
+			title: localize2('positronNotebook.codeCell.insertAbove', "Insert Code Cell Above"),
 			icon: ThemeIcon.fromId('arrow-up'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 100,
-				group: 'Cell'
-			},
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -600,13 +609,15 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer',
-			title: localize2('positronNotebook.codeCell.insertBelow', "Insert code cell below"),
+			title: localize2('positronNotebook.codeCell.insertBelow', "Insert Code Cell Below"),
 			icon: ThemeIcon.fromId('arrow-down'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 100,
-				group: 'Cell'
-			},
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -624,13 +635,15 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.insertMarkdownCellAboveAndFocusContainer',
-			title: localize2('positronNotebook.markdownCell.insertAbove', "Insert markdown cell above"),
+			title: localize2('positronNotebook.markdownCell.insertAbove', "Insert Markdown Cell Above"),
 			icon: ThemeIcon.fromId('arrow-up'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 100,
-				group: 'Cell'
-			}
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}]
 		});
 	}
 
@@ -643,13 +656,15 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.insertMarkdownCellBelowAndFocusContainer',
-			title: localize2('positronNotebook.markdownCell.insertBelow', "Insert markdown cell below"),
+			title: localize2('positronNotebook.markdownCell.insertBelow', "Insert Markdown Cell Below"),
 			icon: ThemeIcon.fromId('arrow-down'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 100,
-				group: 'Cell'
-			}
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}]
 		});
 	}
 
@@ -662,7 +677,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.delete',
-			title: localize2('positronNotebook.cell.delete.description', "Delete the selected cell(s)"),
+			title: localize2('positronNotebook.cell.delete.description', "Delete the Selected Cell(s)"),
 			icon: ThemeIcon.fromId('trash'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarRight,
@@ -684,17 +699,14 @@ registerAction2(class extends CellAction2 {
 });
 
 // Make sure the run and stop commands are in the same place so they replace one another.
-const CELL_EXECUTION_POSITION = 10;
 registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: POSITRON_EXECUTE_CELL_COMMAND_ID,
-			title: localize2('positronNotebook.cell.execute', "Execute cell"),
+			title: localize2('positronNotebook.cell.execute', "Run Cell"),
 			icon: ThemeIcon.fromId('play'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionLeft,
-				order: CELL_EXECUTION_POSITION,
-				group: 'Execution',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
 					CELL_CONTEXT_KEYS.isRunning.toNegated(),
@@ -713,12 +725,10 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.stopExecution',
-			title: localize2('positronNotebook.cell.stopExecution', "Stop cell execution"),
+			title: localize2('positronNotebook.cell.stopExecution', "Stop Cell Execution"),
 			icon: ThemeIcon.fromId('primitive-square'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionLeft,
-				order: CELL_EXECUTION_POSITION,
-				group: 'Execution',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
 					ContextKeyExpr.or(
@@ -739,12 +749,11 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.debug',
-			title: localize2('positronNotebook.cell.debug', "Debug cell"),
+			title: localize2('positronNotebook.cell.debug', "Debug Cell"),
 			icon: ThemeIcon.fromId('debug-alt-small'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,
-				group: 'Execution',
 				when: CELL_CONTEXT_KEYS.isCode
 			},
 			keybinding: {
@@ -777,17 +786,24 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.runAllAbove',
-			title: localize2('positronNotebook.cell.runAllAbove', "Run all code cells above this cell"),
+			title: localize2('positronNotebook.cell.runAllAbove', "Run Above Cells"),
 			icon: ThemeIcon.fromId('run-above'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 20,
-				group: 'Execution',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
 					CELL_CONTEXT_KEYS.isFirst.toNegated()
 				)
-			}
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Execution,
+				order: 10,
+				when: ContextKeyExpr.and(
+					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
+					CELL_CONTEXT_KEYS.isFirst.toNegated()
+				)
+			}]
 		});
 	}
 
@@ -810,17 +826,24 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.runAllBelow',
-			title: localize2('positronNotebook.cell.runAllBelow', "Run all code cells below this cell"),
+			title: localize2('positronNotebook.cell.runAllBelow', "Run Cell and Below"),
 			icon: ThemeIcon.fromId('run-below'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 21,
-				group: 'Execution',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
 					CELL_CONTEXT_KEYS.isLast.toNegated()
 				)
-			}
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Execution,
+				order: 20,
+				when: ContextKeyExpr.and(
+					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
+					CELL_CONTEXT_KEYS.isLast.toNegated()
+				)
+			}]
 		});
 	}
 
@@ -842,12 +865,11 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.openMarkdownEditor',
-			title: localize2('positronNotebook.cell.openMarkdownEditor', "Open markdown editor"),
+			title: localize2('positronNotebook.cell.openMarkdownEditor', "Open Markdown Editor"),
 			icon: ThemeIcon.fromId('chevron-down'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,
-				group: 'Markdown',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isMarkdown.isEqualTo(true),
 					CELL_CONTEXT_KEYS.markdownEditorOpen.toNegated()
@@ -881,7 +903,6 @@ registerAction2(class extends CellAction2 {
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,
-				group: 'Markdown',
 				when: ContextKeyExpr.and(
 					CELL_CONTEXT_KEYS.isMarkdown.isEqualTo(true),
 					CELL_CONTEXT_KEYS.markdownEditorOpen.isEqualTo(true)
@@ -935,7 +956,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.executeAndSelectBelow',
-			title: localize2('positronNotebook.cell.executeAndSelectBelow', "Execute cell and select below"),
+			title: localize2('positronNotebook.cell.executeAndSelectBelow', "Execute Cell and Select Below"),
 			keybinding: {
 				when: ContextKeyExpr.or(
 					POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
@@ -985,11 +1006,15 @@ registerAction2(class extends CellAction2 {
 			id: 'positronNotebook.copyCells',
 			title: localize2('positronNotebook.cell.copyCells', "Copy Cell"),
 			icon: ThemeIcon.fromId('copy'),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: 'Clipboard',
-				order: 10
-			},
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 20
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 20
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -1009,11 +1034,15 @@ registerAction2(class extends CellAction2 {
 		super({
 			id: 'positronNotebook.cutCells',
 			title: localize2('positronNotebook.cell.cutCells', "Cut Cell"),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: 'Clipboard',
-				order: 20
-			},
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 10
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 10
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -1033,11 +1062,15 @@ registerAction2(class extends CellAction2 {
 		super({
 			id: 'positronNotebook.pasteCells',
 			title: localize2('positronNotebook.cell.pasteCells', "Paste Cell Below"),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: 'Clipboard',
+				group: PositronNotebookCellActionGroup.Clipboard,
 				order: 40
-			},
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 40
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -1057,11 +1090,15 @@ registerAction2(class extends CellAction2 {
 		super({
 			id: 'positronNotebook.pasteCellsAbove',
 			title: localize2('positronNotebook.cell.pasteCellsAbove', "Paste Cell Above"),
-			menu: {
+			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: 'Clipboard',
+				group: PositronNotebookCellActionGroup.Clipboard,
 				order: 30
-			},
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Clipboard,
+				order: 30
+			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -1080,12 +1117,12 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.moveUp',
-			title: localize2('positronNotebook.cell.moveUp', "Move cell up"),
+			title: localize2('positronNotebook.cell.moveUp', "Move Cell Up"),
 			icon: ThemeIcon.fromId('arrow-up'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 110,
-				group: 'Cell Order',
+				order: 10,
+				group: PositronNotebookCellActionGroup.Order,
 				when: CELL_CONTEXT_KEYS.canMoveUp
 			},
 			keybinding: {
@@ -1109,12 +1146,12 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.moveDown',
-			title: localize2('positronNotebook.cell.moveDown', "Move cell down"),
+			title: localize2('positronNotebook.cell.moveDown', "Move Cell Down"),
 			icon: ThemeIcon.fromId('arrow-down'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				order: 111,
-				group: 'Cell Order',
+				order: 20,
+				group: PositronNotebookCellActionGroup.Order,
 				when: CELL_CONTEXT_KEYS.canMoveDown
 			},
 			keybinding: {
@@ -1304,3 +1341,12 @@ registerNotebookWidget({
 // Register actions
 registerAction2(ExecuteSelectionInConsoleAction);
 registerAction2(UpdateNotebookWorkingDirectoryAction);
+
+// Add the Notebook Cell submenu to the editor context menu (right click in cell editor)
+MenuRegistry.appendMenuItem(MenuId.EditorContext, {
+	submenu: MenuId.PositronNotebookCellContext,
+	title: localize('positronNotebook.menu.editorContext.cell', 'Notebook Cell'),
+	group: '2_notebook',
+	when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+	order: 0
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -415,7 +415,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.addSelectionUp',
-			title: localize2('positronNotebook.addSelectionUp', "Extend selection up"),
+			title: localize2('positronNotebook.addSelectionUp', "Extend Selection Up"),
 			keybinding: {
 				when: POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
@@ -826,7 +826,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.runAllBelow',
-			title: localize2('positronNotebook.cell.runAllBelow', "Run Cell and Below"),
+			title: localize2('positronNotebook.cell.runAllBelow', "Run Below Cells"),
 			icon: ThemeIcon.fromId('run-below'),
 			menu: [{
 				id: MenuId.PositronNotebookCellActionBarLeft,
@@ -898,7 +898,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.collapseMarkdownEditor',
-			title: localize2('positronNotebook.cell.collapseMarkdownEditor', "Collapse markdown editor"),
+			title: localize2('positronNotebook.cell.collapseMarkdownEditor', "Collapse Markdown Editor"),
 			icon: ThemeIcon.fromId('chevron-up'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
@@ -928,7 +928,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.executeOrToggleEditor',
-			title: localize2('positronNotebook.cell.executeOrToggleEditor', "Execute cell or toggle editor"),
+			title: localize2('positronNotebook.cell.executeOrToggleEditor', "Execute Cell or Toggle Editor"),
 			keybinding: {
 				when: ContextKeyExpr.or(
 					POSITRON_NOTEBOOK_EDITOR_CONTAINER_FOCUSED,

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -40,7 +40,7 @@ export class PositronNotebooks extends Notebooks {
 	// Cell action buttons, menus, tooltips, output, etc
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /more actions/i });
 	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
-	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByLabel(/execute cell/i);
+	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByLabel(/run cell/i);
 	private cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private cellMarkdown = (index: number) => this.cell.nth(index).locator('.positron-notebook-markdown-rendered');
 	private cellInfoToolTip = this.code.driver.page.getByRole('tooltip', { name: /cell execution details/i });
@@ -529,7 +529,7 @@ export class PositronNotebooks extends Notebooks {
 
 				// hover over the run button to show the tooltip
 				await this.cell.nth(index).click();
-				await this.code.driver.page.getByRole('button', { name: 'Execute cell' }).hover();
+				await this.code.driver.page.getByRole('button', { name: 'Run cell' }).hover();
 
 				// make sure only the right tooltip is visible (i've been seeing multiple tooltips sometimes)
 				await expect(this.cellInfoToolTipAtIndex(index)).toBeVisible();


### PR DESCRIPTION
This PR adds the `Notebook Cell` submenu to cell editor right-click context menus, addressing #8799.

> [!NOTE]
> Actions that are conditional (e.g. Run All Above, which is disabled on the first cell) don't show up at all until we propagate cell context keys to cell editor widgets (#10466).

<img width="486" height="501" alt="image" src="https://github.com/user-attachments/assets/da78756c-d56f-458c-9d27-4c241da9f61d" />

Also:

1. Changes all Positron notebook action labels to title case.
2. Reorders the cell action bar menu.

Before:

<img width="426" height="480" alt="image" src="https://github.com/user-attachments/assets/f8023b2f-439b-4f4d-8332-019d832adbea" />

After:

<img width="426" height="480" alt="image" src="https://github.com/user-attachments/assets/00c02f74-9739-490f-ac3e-edd5757847eb" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Try the submenu:

1. Right click in a notebook cell editor
2. Verify that the Notebook Cell submenu is visible
3. Try actions from the Notebook Cell submenu

Double-check that the submenu isn't leaking into other editors e.g. a .py file.

@:positron-notebooks @:web