### PR TITLE
Allow more runtime states to be deleted

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1203,11 +1203,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				runtimeState === RuntimeState.Offline ||
 				runtimeState === RuntimeState.Exiting ||
 				runtimeState === RuntimeState.Restarting ||
-				runtimeState === RuntimeState.Interrupting
-			) {
-				// Sessions in these states can be deleted without shutting down.
-				// They either never successfully started, are not responsive,
-				// or are already in a transitional state.
+				runtimeState === RuntimeState.Interrupting) {
+				// Sessions in these states can be deleted (trashed) without shutting down.
 				this._logService.debug(`Deleting session ${sessionId} in state '${runtimeState}' without shutdown`);
 			} else {
 				// Otherwise throw error for any unexpected states.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1196,8 +1196,21 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				runtimeState === RuntimeState.Ready) {
 				// If the runtime is in a state where it can be shut down, do so.
 				await this.shutdownRuntimeSession(session, RuntimeExitReason.Shutdown);
+			} else if (
+				runtimeState === RuntimeState.Uninitialized ||
+				runtimeState === RuntimeState.Initializing ||
+				runtimeState === RuntimeState.Starting ||
+				runtimeState === RuntimeState.Offline ||
+				runtimeState === RuntimeState.Exiting ||
+				runtimeState === RuntimeState.Restarting ||
+				runtimeState === RuntimeState.Interrupting
+			) {
+				// Sessions in these states can be deleted without shutting down.
+				// They either never successfully started, are not responsive,
+				// or are already in a transitional state.
+				this._logService.debug(`Deleting session ${sessionId} in state '${runtimeState}' without shutdown`);
 			} else {
-				// Otherwise throw error.
+				// Otherwise throw error for any unexpected states.
 				throw new Error(`Cannot delete session because it is in state '${runtimeState}'`);
 			}
 		}


### PR DESCRIPTION
Addresses #8303

I think we were overly strict in what we could/could not delete here. IMO we should allow deleting in cases like:

- Uninitialized, Initializing, Starting (sessions that never successfully started)
- Offline (sessions that are no longer responsive)
- Exiting, Restarting, Interrupting (sessions already in transitional states)

Thoughts on any of those?

I did not implement the ideas outlined in https://github.com/posit-dev/positron/issues/8303#issuecomment-3006183558 because I tend to think the trashcan is a pretty good way to go, actually. Trash your broken sessions and start new ones with all the regular UI, easy peasy! Depending on what you have in terms of multiple sessions, another session may end up in the top spot. I think our UI works well here and IMO we don't need new special components.

@:sessions

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed bug where consoles that failed to start could not be deleted


### QA Notes

- Make a new folder in a regular terminal
- Do `uv venv` in the new folder, in your regular terminal
- Start up Positron and see the venv start
- Go to the regular terminal and do `rm -rf .venv`
- Your first session looks like it is still running but the underlying venv is gone now
- Start a new session from the same runtime, like with the plus button
- The new session will try to start up but will FAIL
- For this failed session, you should be able to use the trashcan to delete it, with no "Failed to delete session: {0}" message
- After that, you _should_ be able to start a new session of some type and use it in a healthy fashion

