### PR TITLE
apply catalog explorer (#10413) to patch

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -162,7 +162,8 @@ function fromLocalWebpack(extensionPath, webpackConfigFileName, disableMangle) {
     // strategy.
     const extensionsWithNpmDeps = [
         'positron-proxy',
-        'positron-duckdb'
+        'positron-duckdb',
+        'positron-catalog-explorer'
     ];
     // If the extension has npm dependencies, use the Npm package manager
     // dependency strategy.

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -127,7 +127,8 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, 
 	// strategy.
 	const extensionsWithNpmDeps = [
 		'positron-proxy',
-		'positron-duckdb'
+		'positron-duckdb',
+		'positron-catalog-explorer'
 	];
 
 	// If the extension has npm dependencies, use the Npm package manager

--- a/extensions/positron-catalog-explorer/extension.webpack.config.js
+++ b/extensions/positron-catalog-explorer/extension.webpack.config.js
@@ -16,5 +16,8 @@ module.exports.default = withDefaults({
 	},
 	node: {
 		__dirname: false
+	},
+	externals: {
+		'snowflake-sdk': { commonjs: 'snowflake-sdk' },
 	}
 });


### PR DESCRIPTION
# Applying 74cf83f7fa102507c03f8e972905c1ca929f9ade to patch branch


Similar to `positron-duckdb`, we need to include the `node_modules` to correctly resolve types for snowflake connections.

### Release Notes

<!--
Optionally, replace `N/A` with text to be included in the next release notes.
The `N/A` bullets are ignored. If you refer to one or more Positron issues,
these issues are used to collect information about the feature or bugfix, such
as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #10104 Bundles snowflake packages needed to run in release builds.


### QA Notes

Snowflake should run on a released build, I tested this locally by running

```
npm run gulp vscode
```

and confirmed the catalog explorer worked with snowflake.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
