### PR TITLE
Support syntax highlighting for `@examplesIf`

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+')",
+			"begin": "(^\\s*#+(?:'|\\*))",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"
@@ -455,13 +455,23 @@
 			]
 		},
 		"roxygen-example": {
-			"begin": "(^\\s*#+')\\s*(@examples)\\s*$",
+			"begin": "(^\\s*#+')\\s*(?:(@examples)\\s*|(@examplesIf)\\s+(.*))$",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line"
 				},
 				"2": {
 					"name": "keyword.other"
+				},
+				"3": {
+					"name": "keyword.other"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
 				}
 			},
 			"end": "(?:^\\s*(?=#+'\\s*@))|(?:^\\s*(?!#+'))",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+(?:'|\\*))",
+			"begin": "(^\\s*#+')",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -455,13 +455,23 @@
 			]
 		},
 		"roxygen-example": {
-			"begin": "(^\\s*#+')\\s*(?:(@examples)\\s*|(@examplesIf)\\s.*)$",
+			"begin": "(^\\s*#+')\\s*(?:(@examples)\\s*|(@examplesIf)\\s+(.*))$",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line"
 				},
 				"2": {
 					"name": "{{ roxygen-tag }}"
+				},
+				"3": {
+					"name": "{{ roxygen-tag }}"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
 				}
 			},
 			"end": "(?:^\\s*(?=#+'\\s*@))|(?:^\\s*(?!#+'))",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+')",
+			"begin": "(^\\s*#+(?:'|*))",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"
@@ -455,7 +455,7 @@
 			]
 		},
 		"roxygen-example": {
-			"begin": "(^\\s*#+')\\s*(@examples)\\s*$",
+			"begin": "(^\\s*#+')\\s*(?:(@examples)\\s*|(@examplesIf)\\s.*)$",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line"

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+(?:'|*))",
+			"begin": "(^\\s*#+(?:'|\\*))",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -431,7 +431,7 @@
 			]
 		},
 		"roxygen": {
-			"begin": "(^\\s*#+(?:'|\\*))",
+			"begin": "(^\\s*#+')",
 			"beginCaptures": {
 				"1": {
 					"name": "comment.line.roxygen"


### PR DESCRIPTION
- Applies the changes from https://github.com/posit-dev/positron/pull/10447 in a non-fork PR, because of the problems outlined in https://github.com/posit-dev/positron/issues/6628
- Addresses https://github.com/posit-dev/positron/issues/2318
- Closes https://github.com/posit-dev/positron/pull/10447

For the new `@examplesIf` syntax highlighting, it should look like this, with both the `condition` after `@examplesIf` highlighted as well as the R code beneath it highlighted:

<img width="1479" height="1022" alt="Screenshot 2025-11-10 at 5 41 36 PM" src="https://github.com/user-attachments/assets/49c7ae5e-ed07-4a96-951c-16cc9d2358ce" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Now apply R syntax highlighting to roxygen `@examplesif` sections

#### Bug Fixes

- N/A


### QA Notes

- We should correctly highlight both the `condition` on the same line as `@examplesIf` and the R code under that heading in an R package that uses this syntax for its documentation. You can find an example repo to clone and check it out with a search like [this (all of GitHub)](https://github.com/search?q=language%3Ar+examplesif&type=code) or [this (tidyverse org)](https://github.com/search?q=language%3Ar+examplesif+org%3Atidyverse&type=code).