### PR TITLE
Always select a console session for executing code

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -650,7 +650,8 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		// If no session was provided and the language desired is the language
 		// of the current console session, prefer that
 		if (!positronConsoleInstance) {
-			if (this._activePositronConsoleInstance?.runtimeMetadata.languageId === languageId) {
+			if (this._activePositronConsoleInstance?.runtimeMetadata.languageId === languageId &&
+				this._activePositronConsoleInstance?.sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 				positronConsoleInstance = this._positronConsoleInstancesBySessionId.get(
 					this._activePositronConsoleInstance.sessionId);
 				sessionId = positronConsoleInstance?.sessionId;
@@ -666,7 +667,9 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 			// most recently created session
 			allInstances.sort((a, b) => b.sessionMetadata.createdTimestamp - a.sessionMetadata.createdTimestamp);
 			for (const instance of allInstances) {
-				if (instance.runtimeMetadata.languageId === languageId) {
+				if (instance.runtimeMetadata.languageId === languageId &&
+					instance.sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Console
+				) {
 					positronConsoleInstance = instance;
 					break;
 				}


### PR DESCRIPTION
This change addresses a small bug which made it easy to accidentally send code from a script into a console meant for notebook operations. 

The fix is to always route code execution requests (from the editor, API, etc.) into traditional consoles. Notebook consoles support execution via running notebook cells or directly entering code. 

Addresses https://github.com/posit-dev/positron/issues/9761.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing code from scripts to be executed in a notebook console if it had the same language (#9761) 


### QA Notes

See repro notes in original issue. Note that this also affects other ways of running code, e.g. from Assistant. 
