### PR TITLE
Fix disappearing editor action bar when notebook is moved

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -328,10 +328,6 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		return this._control.value;
 	}
 
-	override get scopedContextKeyService(): IContextKeyService | undefined {
-		return this.notebookInstance?.scopedContextKeyService ?? this._containerScopedContextKeyService;
-	}
-
 	/**
 	 * Gets or sets the PositronReactRenderer for the PositronNotebook component.
 	 */


### PR DESCRIPTION
Addresses #10462

I am pretty sure that I introduced the above bug when I fixed #9089. I am pretty sure the culprit is this part here: https://github.com/posit-dev/positron/pull/10260/files#r2476066640

I thought it may have been load bearing code for #9089 but in the process of debugging #10462, I removed the code and things started working as expected. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
See testing steps in #10462. We probably want to make sure #9089 didn't have a regression either.

@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
