### PR TITLE
assistant: check for non-positron-registered models when setting hasChatModels

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -149,7 +149,19 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 	}
 
 	// Set context for if we have chat models available for use
-	const hasChatModels = registeredModels.filter(config => config.type === 'chat').length > 0;
+	// Check both Positron-registered models and other language models (e.g., Copilot)
+	const hasPositronChatModels = registeredModels.filter(config => config.type === 'chat').length > 0;
+	let hasOtherChatModels = false;
+
+	try {
+		// Check if there are any other models available (e.g., Copilot)
+		const availableModels = await vscode.lm.selectChatModels();
+		hasOtherChatModels = availableModels.length > 0;
+	} catch (error) {
+		log.warn('Failed to check for available language models', error);
+	}
+
+	const hasChatModels = hasPositronChatModels || hasOtherChatModels;
 	vscode.commands.executeCommand('setContext', hasChatModelsContextKey, hasChatModels);
 }
 


### PR DESCRIPTION
### Summary

- addresses #10115

When Copilot is the sole authenticated provider, we were setting the `hasChatModels` context key to false, since we weren't checking for non-Positron-Assistant-registered models when setting the value. That context key needs to be true for the Console Actions to be enabled. We now also check for non-Positron-Assistant-registered models when setting that context key.

### Release Notes

#### Bug Fixes

- Assistant: fix issue where Console Fix/Explain Actions were hidden when only logged in with Copilot (#10115)

### QA Notes

1. Ensure positron.assistant.enable and positron.assistant.consoleActions.enable are both enabled
2. Log in to Copilot only, in Positron Assistant (log out of all other providers)
3. Trigger an error in the console
4. Fix/Explain should show in the console

<img width="888" height="849" alt="10115_fix" src="https://github.com/user-attachments/assets/d38201ec-b15a-423d-8a21-702546fa672b" />