### PR TITLE
Clean up completion providers in chat status

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -828,7 +828,7 @@ class OpenAICompatibleLanguageModel extends OpenAILanguageModel implements posit
 			model: 'openai-compatible',
 			baseUrl: 'https://localhost:1337/v1',
 			toolCalls: true,
-			completions: true,
+			completions: false,
 		},
 	};
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -589,9 +589,17 @@ class ChatStatusDashboard extends Disposable {
 				description: '',
 				detail: '',
 			};
+
+			// Next Edit Suggestions not currently supported in Positron.
+			// When enabled, remove the defaultChat.nextEditSuggestionsSetting check and use the setting directly.
+			const nesEnabled = defaultChat.nextEditSuggestionsSetting
+				? this.configurationService.getValue<boolean>(defaultChat.nextEditSuggestionsSetting) ?? false
+				: false;
+
 			this.languageFeaturesService.inlineCompletionsProvider.allNoModel().forEach(provider => {
 				const name = provider.displayName;
-				if (name) {
+				const shouldExclude = provider.groupId === 'nes' && !nesEnabled;
+				if (name && !shouldExclude) {
 					// add an element to the container with the name
 					entry.description += `${name}\n`;
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -596,12 +596,15 @@ class ChatStatusDashboard extends Disposable {
 				? this.configurationService.getValue<boolean>(defaultChat.nextEditSuggestionsSetting) ?? false
 				: false;
 
-			this.languageFeaturesService.inlineCompletionsProvider.allNoModel().forEach(provider => {
+			const providers = this.languageFeaturesService.inlineCompletionsProvider.allNoModel();
+			const details = new Array<HTMLDivElement>();
+			providers.forEach(provider => {
 				const name = provider.displayName;
 				const shouldExclude = provider.groupId === 'nes' && !nesEnabled;
 				if (name && !shouldExclude) {
-					// add an element to the container with the name
-					entry.description += `${name}\n`;
+					const span = document.createElement('div');
+					span.innerText = name;
+					details.push(span);
 				}
 			});
 
@@ -618,7 +621,7 @@ class ChatStatusDashboard extends Disposable {
 			}) : undefined);
 			*/
 
-			if (entry.description.length === 0) {
+			if (details.length === 0) {
 				entry.description = localize('noCompletionProviders', "No completion providers available");
 			}
 
@@ -627,6 +630,9 @@ class ChatStatusDashboard extends Disposable {
 
 			itemDisposables.value = rendered.disposables;
 			this.element.appendChild(rendered.element);
+			for (const detail of details) {
+				rendered.element.appendChild(detail);
+			}
 		}
 
 		// Provider token usage


### PR DESCRIPTION
Addresses #9700 and #10332 

We had been attempting to display Completion Providers in the chat status by appending them to a string with newline characters. The newlines were being ignored so the providers were listed on a single line and it was confusing. I replaced this with an approach that creates a `<div>` element for each provider, mimicking how we list Provider Token Usage.

We now filter out completion providers that have a groupId of `nes` from being displayed in the chat status as Next Edit Suggestions are not currently supported. I did this by checking by only including nes providers when VS Code's nes setting is enabled. This setting doesn't currently exist in Positron, but including this logic will include them if we add support.

Completions are now disabled for OpenAI Compatible custom providers. This change requires a state refresh to take affect.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Assistant: Remove "Next Edit Suggestions" from being displayed in chat status (https://github.com/posit-dev/positron/issues/9700)
- Assistant: Disable completions for Custom Providers (https://github.com/posit-dev/positron/issues/10332)


### QA Notes

@:assistant
