### PR TITLE
Assistant: Support autoconfiguring Bedrock 

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -62,12 +62,12 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 			id: 'anthropic-api',
 			displayName: 'Anthropic'
 		},
-		supportedOptions: ['apiKey', 'apiKeyEnvVar'],
+		supportedOptions: ['apiKey', 'autoconfigure'],
 		defaults: {
 			name: DEFAULT_ANTHROPIC_MODEL_NAME,
 			model: DEFAULT_ANTHROPIC_MODEL_MATCH + '-latest',
 			toolCalls: true,
-			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
+			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.EnvVariable, key: 'ANTHROPIC_API_KEY', signedIn: false }
 		},
 	};
 

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -153,11 +153,17 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 
 	// Gather model sources; ignore disabled providers
 	const enabledProviders = await getEnabledProviders();
+	// Models in persistent storage
 	const registeredModels = context.globalState.get<Array<StoredModelConfig>>('positron.assistant.models');
+	// Auto-configured models (e.g., env var based or managed credentials) stored in memory
 	const autoconfiguredModels = getAutoconfiguredModels();
 	const sources: positron.ai.LanguageModelSource[] = [...getLanguageModels(), ...completionModels]
 		.map((provider) => {
+			// Get model data from `registeredModels` (for manually configured models; stored in persistent storage)
+			// or `autoconfiguredModels` (for auto-configured models; e.g., env var based or managed credentials)
 			const isRegistered = registeredModels?.find((modelConfig) => modelConfig.provider === provider.source.provider.id) || autoconfiguredModels.find((modelConfig) => modelConfig.provider === provider.source.provider.id);
+			// Update source data with actual model configuration status if found
+			// Otherwise, use defaults from provider
 			const source: positron.ai.LanguageModelSource = {
 				...provider.source,
 				signedIn: !!isRegistered,
@@ -187,7 +193,9 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 						},
 					};
 				} else if (source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.Custom) {
-					// TODO @samclark2015: Handle custom auto-configuration... do we need to?
+					// No special handling for custom autoconfiguration at this time
+					// The custom autoconfiguration logic should handle everything
+					// and is retrieved from `autoconfiguredModels` above
 					return source;
 				}
 			}

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import { DocumentSelector } from 'vscode-languageclient';
+import * as vscode from 'vscode';
 
 /** The extension root directory. */
 export const EXTENSION_ROOT_DIR = path.join(__dirname, '..');
@@ -49,3 +50,8 @@ export const MAX_CONTEXT_VARIABLES = 400;
 
 /** Max number of models to attempt connecting to when checking auth for a provider */
 export const DEFAULT_MAX_CONNECTION_ATTEMPTS = 3;
+
+/**
+ * Determines if the Posit Web environment is detected.
+ */
+export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && vscode.env.uiKind === vscode.UIKind.Web;

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -34,6 +34,10 @@ let tokenTracker: TokenTracker;
 
 const autoconfiguredModels: ModelConfig[] = [];
 
+/**
+ * Get all models which were automatically configured (e.g., via environment variables or managed credentials).
+ * @returns A list of models that were automatically configured
+ */
 export function getAutoconfiguredModels(): ModelConfig[] {
 	return [...autoconfiguredModels];
 }
@@ -151,6 +155,12 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 			await registerModelWithAPI(config, context, storage);
 			registeredModels.push(config);
 			if (autoModelConfigs.includes(config)) {
+				// In addition, track auto-configured models separately
+				// at a module level so that we can expose them via
+				// getAutoconfiguredModels()
+				// This is needed since auto-configured models are not
+				// stored in persistent storage like manually configured models
+				// are, and configuration data needs to be retrieved from memory.
 				autoconfiguredModels.push(config);
 			}
 		} catch (e) {

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { EncryptedSecretStorage, expandConfigToSource, getEnabledProviders, getModelConfiguration, getModelConfigurations, getStoredModels, GlobalSecretStorage, logStoredModels, ModelConfig, SecretStorage, showConfigurationDialog, StoredModelConfig } from './config';
-import { createModelConfigsFromEnv, newLanguageModelChatProvider } from './models';
+import { createAutomaticModelConfigs, newLanguageModelChatProvider } from './models';
 import { registerMappedEditsProvider } from './edits';
 import { ParticipantService, registerParticipants } from './participants';
 import { newCompletionProvider, registerHistoryTracking } from './completion';
@@ -31,6 +31,12 @@ const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 let modelDisposables: ModelDisposable[] = [];
 let assistantEnabled = false;
 let tokenTracker: TokenTracker;
+
+const autoconfiguredModels: ModelConfig[] = [];
+
+export function getAutoconfiguredModels(): ModelConfig[] {
+	return [...autoconfiguredModels];
+}
 
 /** A chat or completion model provider disposable with associated configuration. */
 class ModelDisposable implements vscode.Disposable {
@@ -108,6 +114,7 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 	// Dispose of existing models
 	disposeModels();
 
+	let autoModelConfigs: ModelConfig[];
 	let modelConfigs: ModelConfig[] = [];
 	try {
 		// Refresh the set of enabled providers
@@ -123,10 +130,10 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 			return enabled;
 		});
 
-		// Add any configs that should automatically work when the right environment variables are set
-		const modelConfigsFromEnv = createModelConfigsFromEnv();
+		// Add any configs that should automatically work when the right conditions are met
+		autoModelConfigs = await createAutomaticModelConfigs();
 		// we add in the config if we don't already have it configured
-		for (const config of modelConfigsFromEnv) {
+		for (const config of autoModelConfigs) {
 			if (!modelConfigs.find(c => c.provider === config.provider)) {
 				modelConfigs.push(config);
 			}
@@ -143,6 +150,9 @@ export async function registerModels(context: vscode.ExtensionContext, storage: 
 		try {
 			await registerModelWithAPI(config, context, storage);
 			registeredModels.push(config);
+			if (autoModelConfigs.includes(config)) {
+				autoconfiguredModels.push(config);
+			}
 		} catch (e) {
 			vscode.window.showErrorMessage(`${e}`);
 		}

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as ai from 'ai';
-import { getMaxConnectionAttempts, getProviderTimeoutMs, ModelConfig, SecretStorage } from './config';
+import { getMaxConnectionAttempts, getProviderTimeoutMs, getEnabledProviders, ModelConfig, SecretStorage } from './config';
 import { AnthropicProvider, createAnthropic } from '@ai-sdk/anthropic';
 import { AzureOpenAIProvider, createAzure } from '@ai-sdk/azure';
 import { createVertex, GoogleVertexProvider } from '@ai-sdk/google-vertex';
@@ -263,7 +263,16 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 //#endregion
 //#region Language Models
 
+type AutoconfigureResult = {
+	signedIn: false;
+} | {
+	signedIn: true;
+	message: string;
+};
+
 abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider {
+	public static source: positron.ai.LanguageModelSource;
+
 	public readonly name;
 	public readonly provider;
 	public readonly id;
@@ -669,6 +678,8 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		}
 		return this._config.model === id;
 	}
+
+	static autoconfigure?: () => Promise<AutoconfigureResult>;
 }
 
 class AnthropicAILanguageModel extends AILanguageModel implements positron.ai.LanguageModelChatProvider {
@@ -683,12 +694,12 @@ class AnthropicAILanguageModel extends AILanguageModel implements positron.ai.La
 			id: 'anthropic-api',
 			displayName: 'Anthropic'
 		},
-		supportedOptions: ['apiKey', 'apiKeyEnvVar'],
+		supportedOptions: ['apiKey', 'autoconfigure'],
 		defaults: {
 			name: DEFAULT_ANTHROPIC_MODEL_NAME,
 			model: DEFAULT_ANTHROPIC_MODEL_MATCH + '-latest',
 			toolCalls: true,
-			apiKeyEnvVar: { key: 'ANTHROPIC_API_KEY', signedIn: false },
+			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.EnvVariable, key: 'ANTHROPIC_API_KEY', signedIn: false },
 		},
 	};
 
@@ -1035,11 +1046,12 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 			id: 'amazon-bedrock',
 			displayName: 'Amazon Bedrock'
 		},
-		supportedOptions: ['toolCalls'],
+		supportedOptions: ['toolCalls', 'autoconfigure'],
 		defaults: {
 			name: 'Claude 4 Sonnet Bedrock',
 			model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
 			toolCalls: true,
+			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.Custom, message: 'Automatically configured using AWS credentials', signedIn: false },
 		},
 	};
 	bedrockClient: BedrockClient;
@@ -1245,6 +1257,35 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 		return undefined;
 	}
 
+	static override async autoconfigure(): Promise<AutoconfigureResult> {
+		// Configure automatically if:
+		// - We are on web, and
+		// - Bedrock is enabled in settings, and
+		// - If managed credentials are available
+
+		// TODO @samclark2015: Re-enable web check before PR!
+		// const isWeb = vscode.env.uiKind === vscode.UIKind.Web;
+		// if (!isWeb) {
+		// 	return undefined;
+		// }
+		const bedrockEnabled = await getEnabledProviders().then(providers => providers.includes(AWSLanguageModel.source.provider.id));
+		if (!bedrockEnabled) {
+			return { signedIn: false };
+		}
+
+		const managedCredentialsAvailable = 'AWS_ROLE_ARN' in process.env && 'AWS_WEB_IDENTITY_TOKEN_FILE' in process.env;
+		if (!managedCredentialsAvailable) {
+			return { signedIn: false };
+		}
+
+		log.info('Auto-configuring Amazon Bedrock language model with managed credentials.');
+
+		return {
+			signedIn: true,
+			message: 'AWS managed credentials',
+		};
+	}
+
 }
 
 //#endregion
@@ -1282,31 +1323,62 @@ export function getLanguageModels() {
  *
  * @returns The model configurations that are configured by the environment.
  */
-export function createModelConfigsFromEnv(): ModelConfig[] {
+export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 	const models = getLanguageModels();
 	const modelConfigs: ModelConfig[] = [];
 
-	models.forEach(model => {
-		if ('apiKeyEnvVar' in model.source.defaults) {
-			const key = model.source.defaults.apiKeyEnvVar?.key;
+	for (const model of models) {
+		if (!('autoconfigure' in model.source.defaults)) {
+			// Not an autoconfigurable model
+			continue;
+		}
+
+		if (model.source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.EnvVariable) {
+			// Handle environment variable based auto-configuration
+			const key = model.source.defaults.autoconfigure?.key;
 			// pragma: allowlist nextline secret
 			const apiKey = key ? process.env[key] : undefined;
 
 			if (key && apiKey) {
-				const modelConfig = {
+				const modelConfig: ModelConfig = {
 					id: `${model.source.provider.id}`,
 					provider: model.source.provider.id,
 					type: positron.PositronLanguageModelType.Chat,
 					name: model.source.provider.displayName,
 					model: model.source.defaults.model,
 					apiKey: apiKey,
-					// pragma: allowlist nextline secret
-					apiKeyEnvVar: 'apiKeyEnvVar' in model.source.defaults ? model.source.defaults.apiKeyEnvVar : undefined,
+					autoconfigure: {
+						type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,
+						key: key,
+						signedIn: true,
+					}
 				};
 				modelConfigs.push(modelConfig);
 			}
+		} else if (model.source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.Custom) {
+			// Handle custom auto-configuration
+			if ('autoconfigure' in model && model.autoconfigure) {
+				const result = await model.autoconfigure();
+				if (result.signedIn) {
+					const modelConfig: ModelConfig = {
+						id: `${model.source.provider.id}`,
+						provider: model.source.provider.id,
+						type: positron.PositronLanguageModelType.Chat,
+						name: model.source.provider.displayName,
+						model: model.source.defaults.model,
+						apiKey: undefined,
+						// pragma: allowlist nextline secret
+						autoconfigure: {
+							type: positron.ai.LanguageModelAutoconfigureType.Custom,
+							message: result.message,
+							signedIn: true
+						}
+					};
+					modelConfigs.push(modelConfig);
+				}
+			}
 		}
-	});
+	}
 
 	return modelConfigs;
 }

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -1263,11 +1263,10 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 		// - Bedrock is enabled in settings, and
 		// - If managed credentials are available
 
-		// TODO @samclark2015: Re-enable web check before PR!
-		// const isWeb = vscode.env.uiKind === vscode.UIKind.Web;
-		// if (!isWeb) {
-		// 	return undefined;
-		// }
+		const isWeb = vscode.env.uiKind === vscode.UIKind.Web;
+		if (!isWeb) {
+			return undefined;
+		}
 		const bedrockEnabled = await getEnabledProviders().then(providers => providers.includes(AWSLanguageModel.source.provider.id));
 		if (!bedrockEnabled) {
 			return { signedIn: false };

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -1335,7 +1335,7 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 
 		if (model.source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.EnvVariable) {
 			// Handle environment variable based auto-configuration
-			const key = model.source.defaults.autoconfigure?.key;
+			const key = model.source.defaults.autoconfigure.key;
 			// pragma: allowlist nextline secret
 			const apiKey = key ? process.env[key] : undefined;
 

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -263,6 +263,11 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 //#endregion
 //#region Language Models
 
+/**
+ * Result of an autoconfiguration attempt.
+ * - Signed in indicates whether the model is configured and ready to use.
+ * - Message provides additional information to be displayed to user in the configuration modal, if signed in.
+ */
 type AutoconfigureResult = {
 	signedIn: false;
 } | {
@@ -679,6 +684,11 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 		return this._config.model === id;
 	}
 
+	/**
+	 * Autoconfigures the language model, if supported.
+	 * May implement functionality such as checking for environment variables or assessing managed credentials.
+	 * @returns A promise that resolves to the autoconfigure result.
+	 */
 	static autoconfigure?: () => Promise<AutoconfigureResult>;
 }
 
@@ -1281,6 +1291,8 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 
 		return {
 			signedIn: true,
+			// Displayed as "Amazon Bedrock has been automatically
+			// configured using AWS managed credentials" in the configuration modal UI
 			message: 'AWS managed credentials',
 		};
 	}

--- a/extensions/positron-assistant/src/pwb.ts
+++ b/extensions/positron-assistant/src/pwb.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getEnabledProviders } from './config';
+import { IS_RUNNING_ON_PWB } from './constants';
+import { log } from './extension';
+import { AutoconfigureResult } from './models.js';
+
+/**
+ * Configuration for managed credentials on Posit Workbench.
+ */
+export interface ManagedCredentialConfig {
+	/** Display name for the credential type shown to users */
+	readonly displayName: string;
+	/** Environment variable name that indicates managed credentials are available */
+	readonly envVar: string;
+	/** Validator function to confirm the env var value for managed credentials */
+	readonly validator: (string) => boolean;
+}
+
+/**
+ * AWS managed credentials configuration for Posit Workbench.
+ */
+export const AWS_MANAGED_CREDENTIALS: ManagedCredentialConfig = {
+	displayName: 'AWS managed credentials',
+	envVar: 'AWS_WEB_IDENTITY_TOKEN_FILE',
+	validator: (value: string) => value.includes('posit-workbench'),
+};
+
+/**
+ * Helper function to autoconfigure language models using managed credentials on Posit Workbench.
+ *
+ * @template T - The credential configuration type (e.g., typeof AWS_MANAGED_CREDENTIALS)
+ * @param credentialConfig - The credential configuration to check
+ * @param providerId - The provider ID to check if enabled
+ * @param displayName - The provider display name for logging
+ * @returns A promise that resolves to the autoconfigure result
+ */
+export async function autoconfigureWithManagedCredentials<T extends ManagedCredentialConfig>(
+	credentialConfig: T,
+	providerId: string,
+	displayName: string
+): Promise<AutoconfigureResult> {
+	// Configure automatically if:
+	// - We are on PWB, and
+	// - the provider is enabled in settings, and
+	// - managed credentials are available
+
+	if (!IS_RUNNING_ON_PWB) {
+		return { signedIn: false };
+	}
+
+	const providerEnabled = await getEnabledProviders().then(
+		providers => providers.includes(providerId)
+	);
+	if (!providerEnabled) {
+		return { signedIn: false };
+	}
+
+	// Check for managed credentials using the provided config
+	const tokenEnv = process.env[credentialConfig.envVar];
+	if (!tokenEnv || !credentialConfig.validator(tokenEnv)) {
+		// PWB managed credentials not set
+		return { signedIn: false };
+	}
+
+	log.info(`[${displayName}] Auto-configuring with managed credentials.`);
+	return {
+		signedIn: true,
+		message: credentialConfig.displayName,
+	};
+}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2225,18 +2225,29 @@ declare module 'positron' {
 			autoconfigure?: LanguageModelAutoconfigure;
 		}
 
+		/**
+		 * Types of autoconfiguration support for language models.
+		 */
 		export enum LanguageModelAutoconfigureType {
+			// Autoconfigured using environment variables
 			EnvVariable = 0,
+			// Autoconfigured using a custom function on the language model provider
+			// E.g., for Workbench managed credentials
 			Custom = 1
 		}
+		/**
+		 * Language model autoconfiguration options.
+		 */
 		export type LanguageModelAutoconfigure = (
 			{
 				type: LanguageModelAutoconfigureType.EnvVariable;
+				// Environment variable key used to retrieve API key, if set
 				key: string;
 				signedIn: boolean;
 			} |
 			{
 				type: LanguageModelAutoconfigureType.Custom;
+				// Message to show in the UI if autoconfiguration was successful
 				message: string;
 				signedIn: boolean;
 			}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2222,8 +2222,25 @@ declare module 'positron' {
 			maxInputTokens?: number;
 			maxOutputTokens?: number;
 			completions?: boolean;
-			apiKeyEnvVar?: { key: string; signedIn: boolean }; // The environment variable name for the API key
+			autoconfigure?: LanguageModelAutoconfigure;
 		}
+
+		export enum LanguageModelAutoconfigureType {
+			EnvVariable = 0,
+			Custom = 1
+		}
+		export type LanguageModelAutoconfigure = (
+			{
+				type: LanguageModelAutoconfigureType.EnvVariable;
+				key: string;
+				signedIn: boolean;
+			} |
+			{
+				type: LanguageModelAutoconfigureType.Custom;
+				message: string;
+				signedIn: boolean;
+			}
+		);
 
 		/**
 		 * Request the current plot data.

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -358,6 +358,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			setCurrentProvider(id: string): Promise<positron.ai.ChatProvider | undefined> {
 				return extHostAiFeatures.setCurrentProvider(id);
 			},
+			LanguageModelAutoconfigureType: extHostTypes.LanguageModelAutoconfigureType
 		};
 
 		const notebooks: typeof positron.notebooks = {

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -394,6 +394,13 @@ export enum PositronLanguageModelType {
 	Completion = 'completion',
 }
 
+// Equivalent in positron.d.ts API: LanguageModelAutoconfigureType
+export enum LanguageModelAutoconfigureType {
+	EnvVariable = 0,
+	Custom = 1
+}
+
+
 /**
  * The possible locations a Positron Assistant chat request can be invoked from.
  */

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react'
-import { IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js'
+import { IPositronLanguageModelAutoconfigure, LanguageModelAutoconfigureType, IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js'
 import { localize } from '../../../../../nls.js'
 import { LabeledTextInput } from '../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js'
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js'
@@ -130,9 +130,10 @@ function interpolate(text: string, value: (key: string) => React.ReactNode | und
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const { authMethod, authStatus, config, source } = props;
 	const { apiKey } = config;
-	const hasEnvApiKey = !!source.defaults.apiKeyEnvVar && source.defaults.apiKeyEnvVar.signedIn;
-	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasEnvApiKey;
-	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN && !hasEnvApiKey;
+
+	const hasAutoconfigure = !!source.defaults.autoconfigure && source.defaults.autoconfigure.signedIn;
+	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasAutoconfigure;
+	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN && !hasAutoconfigure;
 	const showBaseUrl = authMethod === AuthMethod.API_KEY && source.supportedOptions?.includes('baseUrl');
 
 	// This currently only updates the API key for the provider, but in the future it may be extended to support
@@ -142,7 +143,7 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 	};
 
 	return <>
-		{!hasEnvApiKey && <div className='language-model-container input'>
+		{!hasAutoconfigure && <div className='language-model-container input'>
 			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onChange} />}
 			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
 			{showCancelButton &&
@@ -152,7 +153,7 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 			}
 		</div>}
 		{showBaseUrl && <BaseUrl baseUrl={config.baseUrl} provider={props.source.provider} signedIn={authStatus === AuthStatus.SIGNED_IN} onChange={newBaseUrl => props.onChange({ ...config, baseUrl: newBaseUrl })} />}
-		<ExternalAPIKey envKeyName={source.defaults.apiKeyEnvVar} provider={source.provider.id} />
+		<AutoconfiguredModel details={source.defaults.autoconfigure} displayName={source.provider.displayName} provider={source.provider.id} />
 		<ProviderNotice provider={source.provider} />
 	</>;
 }
@@ -241,17 +242,23 @@ const ExternalLink = (props: { href: string, children: React.ReactNode }) => {
 	</a>;
 }
 
-const ExternalAPIKey = (props: { provider: string, envKeyName?: { key: string; signedIn: boolean } }) => {
-
-	return (
-		props.envKeyName ?
-			<div className='language-model-external-api-key'>
-				{
-					props.envKeyName && props.envKeyName.signedIn ?
-						<p>{localize('positron.languageModelConfig.externalApiInUse', "The {0} environment variable is currently in use.", props.envKeyName?.key)}</p>
-						:
-						<p>{localize('positron.languageModelConfig.externalApiSetup', "You can also assign the {0} environment variable and restart Positron.", props.envKeyName.key)}</p>
-				}
-			</div> : null
-	);
+const AutoconfiguredModel = (props: { provider: string, displayName: string, details?: IPositronLanguageModelAutoconfigure }) => {
+	if (props.details?.type === LanguageModelAutoconfigureType.EnvVariable) {
+		return (<div className='language-model-external-api-key'>
+			{
+				props.details.signedIn ?
+					<p>{localize('positron.languageModelConfig.externalApiInUse', "The {0} environment variable is currently in use.", props.details.key)}</p>
+					:
+					<p>{localize('positron.languageModelConfig.externalApiSetup', "You can also assign the {0} environment variable and restart Positron.", props.details.key)}</p>
+			}
+		</div>);
+	} else if (props.details?.type === LanguageModelAutoconfigureType.Custom && props.details.signedIn) {
+		return (<div className='language-model-external-api-key'>
+			{
+				<p>{localize('positron.languageModelConfig.autoconfiguredModelInUse', "{0} has been automatically configured using {1}", props.displayName, props.details.message)}</p>
+			}
+		</div>);
+	} else {
+		return null;
+	}
 }

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -50,6 +50,26 @@ export interface IPositronLanguageModelSource {
 	authMethods?: string[];
 }
 
+// Equivalent in positron.d.ts API: LanguageModelAutoconfigureType
+export enum LanguageModelAutoconfigureType {
+	EnvVariable = 0,
+	Custom = 1
+}
+
+// Equivalent in positron.d.ts API: LanguageModelAutoconfigure
+export type IPositronLanguageModelAutoconfigure = (
+	{
+		type: LanguageModelAutoconfigureType.EnvVariable;
+		key: string;
+		signedIn: boolean;
+	} |
+	{
+		type: LanguageModelAutoconfigureType.Custom;
+		message: string;
+		signedIn: boolean;
+	}
+);
+
 // Equivalent in positron.d.ts API: LanguageModelConfig
 export interface IPositronLanguageModelConfig {
 	type: PositronLanguageModelType;
@@ -67,7 +87,7 @@ export interface IPositronLanguageModelConfig {
 	maxInputTokens?: number;
 	maxOutputTokens?: number;
 	completions?: boolean;
-	apiKeyEnvVar?: { key: string; signedIn: boolean };
+	autoconfigure?: IPositronLanguageModelAutoconfigure;
 }
 
 //#endregion


### PR DESCRIPTION
This PR adds infrastructure to support autoconfiguring Bedrock as a provider when:
- used on Workbench, and
- `amazon-bedrock` is in `positron.assistant.enabledProviders`, and
- environment variables `AWS_WEB_IDENTITY_TOKEN_FILE` contains the substring 'posit-workbench'

TODO:
- [ ] Test on real Workbench instance w/ Managed Credentials

Addresses #10179 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- On Workbench, AWS Bedrock is automatically enabled within Assistant when Managed Credentials are available

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:web @:assistant
