### PR TITLE
Bump the rstudio.rstudio-workbench extension to 1.6.34 (#10555)

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -201,7 +201,7 @@
         "filename": ".github/workflows/test-assistant-llm.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 35,
         "is_secret": false
       },
       {
@@ -209,7 +209,17 @@
         "filename": ".github/workflows/test-assistant-llm.yml",
         "hashed_secret": "74d50d4e7dbf232033bcb82f4c4ad6223a354c8e",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 73,
+        "is_secret": false
+      }
+    ],
+    ".github/workflows/test-cross-browser.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/test-cross-browser.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 46,
         "is_secret": false
       }
     ],
@@ -229,7 +239,7 @@
         "filename": ".github/workflows/test-merge.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -239,7 +249,7 @@
         "filename": ".github/workflows/test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 49,
         "is_secret": false
       }
     ],
@@ -1400,5 +1410,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-13T22:08:00Z"
+  "generated_at": "2025-11-13T22:38:47Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "build/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "build/secrets/.secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -389,7 +385,8 @@
         "filename": "build/azure-pipelines/product-release.yml",
         "hashed_secret": "1bf2ebe6cfdadfebbe51dd18d36f3d42a9bf2d62",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 29,
+        "is_secret": false
       }
     ],
     "build/azure-pipelines/web/product-build-web-node-modules.yml": [
@@ -766,7 +763,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "6fffa1fb96139d6eb243f67d9475156b107f7eec",
+        "hashed_secret": "3fad1defe924338cf88e0d74aa3b600feccafdcb",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1403,5 +1400,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-12T12:56:14Z"
+  "generated_at": "2025-11-13T22:08:00Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.6.31",
+			"version": "1.6.34",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "056a082d65c00e31f4c76942b1814b7dde6d9b2a0bef47555d1926d8099b8f0b",
+			"sha256": "4d95688030d3921528ddacf7a0cf74a2cd9b9ed8e497546645df16eabcc8c2f2",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Cherry-picked https://github.com/posit-dev/positron/pull/10555 from the release/2025.11 branch

---

Updates the bundled `rstudio.rstudio-workbench` extension to version 1.6.34.

Package checksum:
`4d95688030d3921528ddacf7a0cf74a2cd9b9ed8e497546645df16eabcc8c2f2` Commit:
[`902edb87a2012434e2b7048d09e4395e3ec4cd79`](https://github.com/rstudio/rstudio-workbench-vscode-ext/commit/902edb87a2012434e2b7048d09e4395e3ec4cd79) Branch: `main`

**PR Reviewer**: before merging, please check out these changes locally, run `detect-secrets` to [update the secrets baseline file](https://github.com/posit-dev/positron/tree/main/build/secrets#updating-the-baseline-secrets-file), audit the baseline file if necessary, and push the updates to the secrets baseline file to this PR.