### PR TITLE
ci: bump posit.shiny ext

### DIFF
--- a/product.json
+++ b/product.json
@@ -269,8 +269,8 @@
 		},
 		{
 			"name": "posit.shiny",
-			"version": "1.3.1",
-			"sha256sum": "aa7054fb54854408913a55191be78f2ab183cbb8c8294ad41cc74c0a1dfa4b57",
+			"version": "1.3.2",
+			"sha256sum": "c030931ff473103523c5ec167cbadc377737bdaa2ab7a09005fa1cda390cc19a",
 			"repo": "https://github.com/posit-dev/shiny-vscode",
 			"metadata": {
 				"id": "7ffa9a66-85ab-44de-ab80-2eecce45b0fe",


### PR DESCRIPTION
### QA Summary
Bump `posit.shiny` from `1.3.1` to `1.3.2`.

### QA Notes
n/a