### PR TITLE
Fix webview to support auxiliary window context

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -36,7 +36,9 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 		// the parent view pane is collapsed.
 		if (props.visible) {
 			client.activate().then(() => {
-				client.claim(this);
+				// Pass the element ref so the webview gets the correct window context
+				// (important for auxiliary windows)
+				client.claim(this, webviewRef.current || undefined);
 				setClientIsClaimed(true);
 			});
 		}

--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -119,12 +119,15 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * Claims the underlying webview.
 	 *
 	 * @param claimant The object taking ownership.
+	 * @param element Optional element to get the window context from. If not provided, uses the stored element.
 	 */
-	public claim(claimant: any) {
+	public claim(claimant: any, element?: HTMLElement) {
 		if (!this._webview.value) {
 			throw new Error('No webview to claim');
 		}
-		this._webview.value.claim(claimant, DOM.getWindow(this._element), undefined);
+		// Use the provided element to get the window context, or fall back to the stored element
+		const targetElement = element || this._element;
+		this._webview.value.claim(claimant, DOM.getWindow(targetElement), undefined);
 		this._claimed = true;
 	}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10512

When HTML plots are rendered in Positron, they use VS Code overlay webviews, which need to be "claimed" with the correct window context to function properly. I had not done that in https://github.com/posit-dev/positron/pull/10329. Before this PR, the original `claim()` implementation tried to determine the window context in a way that fell back to the main window context, but we now need to tell `claim()` which element to use directly.

'@:plots'

### Release Notes

(No release note because the release note for https://github.com/posit-dev/positron/pull/10329 will announce the feature in general.)

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

The altair example that @testlabauto used is a bit problematic, because of https://github.com/posit-dev/positron/issues/2968 and also https://github.com/posit-dev/positron/issues/4892. And then plotly for Python has the problem logged in https://github.com/posit-dev/positron/issues/7741.

I might suggest a different set of plots to test this out. 😅 

Some R plots:

```r
# Interactive ------------------------------------------------------------
library(highcharter)
hchart(mtcars, "scatter", hcaes(wt, mpg, z = drat, color = hp)) |>
  hc_title(text = "Scatter chart with size and color")

# Static -----------------------------------------------------------------
plot(faithful)

# Static -----------------------------------------------------------------
plot(sample(1:100, 20))

# Interactive ------------------------------------------------------------
library(ggplot2)
library(plotly)
p <- ggplot(data = diamonds, aes(x = cut, fill = clarity)) +
            geom_bar(position = "dodge")
ggplotly(p)
```

Some Python plots (you can include some interactive ones but they tend to have other problems as outlined above):

```python
import numpy as np
import pandas as pd

df = pd.DataFrame(np.random.randint(1, 7, 6000), columns=["one"])
df["two"] = df["one"] + np.random.randint(1, 7, 6000)

# make one plot
df.plot.hist(bins=12, alpha=0.5)

# make a new plot with fewer bins
df.plot.hist(bins=8, alpha=0.5)
```

- You should be able to create some of these plots (perhaps intermixed R and Python) and then pop out the new auxiliary window, with the interactive/HTML plots correctly showing up in the new auxiliary window. 
- You should also be able to make new interactive and static plots and have them show up in that window, if it is open. 
- You should be able to close the auxiliary window and have everything come back to the main window plots pane.
