### PR TITLE
E2E test: basic catalog explorer test & reticulate workarounds

### DIFF
--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -128,6 +128,8 @@ jobs:
       SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       RETICULATE_PYTHON: /root/.venv/bin/python
+      DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
+      DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -113,7 +113,8 @@ jobs:
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       RETICULATE_PYTHON: /root/.venv/bin/python
       HOME: /root
-
+      DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
+      DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -143,6 +143,8 @@ jobs:
       SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       RETICULATE_PYTHON: /root/.venv/bin/python
+      DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
+      DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -87,7 +87,8 @@ jobs:
       AWS_S3_BUCKET: positron-test-reports
       E2E_CONNECT_SERVER: ${{ secrets.E2E_CONNECT_SERVER}}
       E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY}}
-
+      DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
+      DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -22,6 +22,7 @@ export enum TestTags {
 	APPS = '@:apps',
 	ARK = '@:ark',
 	ASSISTANT = '@:assistant',
+	CATALOG_EXPLORER = '@:catalog-explorer',
 	CONNECTIONS = '@:connections',
 	CONSOLE = '@:console',
 	CRITICAL = '@:critical',

--- a/test/e2e/tests/catalog-explorer/catalog-explorer.test.ts
+++ b/test/e2e/tests/catalog-explorer/catalog-explorer.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const workspace = process.env.DATABRICKS_WORKSPACE || 'workspace';
+const pat = process.env.DATABRICKS_PAT || 'dummypat';
+
+test.describe('Catalog Explorer', {
+	tag: [tags.CATALOG_EXPLORER, tags.WEB, tags.WIN],
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+
+		await settings.set({
+			'catalogExplorer.enabled': true
+		});
+
+		await app.restart();
+	});
+
+	test('Verify Basic Databricks Catalog Explorer functionality', async function ({ app, python }) {
+
+		await app.code.driver.page.getByRole('button', { name: 'Catalog Explorer Section' }).click();
+
+		await app.code.driver.page.getByText('Configure a Catalog Provider').click();
+
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		await app.workbench.quickInput.type('Databricks');
+		await app.workbench.quickInput.selectQuickInputElement(0, true);
+
+		await app.workbench.quickInput.type(workspace);
+		await app.code.driver.page.keyboard.press('Enter');
+		await app.workbench.quickInput.type(pat);
+		await app.code.driver.page.keyboard.press('Enter');
+
+		await expect(app.code.driver.page.locator('.label-name').filter({ hasText: 'main' })).toBeVisible();
+		await expect(app.code.driver.page.locator('.label-name').filter({ hasText: 'samples' })).toBeVisible();
+		await expect(app.code.driver.page.locator('.label-name').filter({ hasText: 'system' })).toBeVisible();
+		await expect(app.code.driver.page.locator('.label-name').filter({ hasText: 'workshops' })).toBeVisible();
+
+		// cannot see dialog that doubles checks if removal is wanted in e2e tests
+		// await app.code.driver.page.getByText(workspace.replace('https://','')).hover();
+		// await app.code.driver.page.locator('.action-label[aria-label*="Remove Catalog Provider"]').click();
+
+	});
+});

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -20,13 +20,16 @@ test.describe('Reticulate', {
 	test.beforeAll(async function ({ app, settings }) {
 		try {
 			await settings.set({
-				'positron.reticulate.enabled': true
-			}, { 'reload': 'web' });
+				'positron.reticulate.enabled': true,
+				'kernelSupervisor.transport': 'tcp'
+			});
 
 		} catch (e) {
 			await app.code.driver.takeScreenshot('reticulateSetup');
 			throw e;
 		}
+
+		await app.restart();
 	});
 
 	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions, logger }) {

--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -21,12 +21,15 @@ test.describe('Reticulate', {
 		try {
 			await settings.set({
 				'positron.reticulate.enabled': true,
-			}, { 'reload': 'web' });
+				'kernelSupervisor.transport': 'tcp'
+			});
 
 		} catch (e) {
 			await app.code.driver.takeScreenshot('reticulateSetup');
 			throw e;
 		}
+
+		await app.restart();
 	});
 
 	test('R - Verify Reticulate Restart', {

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -20,13 +20,16 @@ test.describe('Reticulate', {
 	test.beforeAll(async function ({ app, settings }) {
 		try {
 			await settings.set({
-				'positron.reticulate.enabled': true
-			}, { 'reload': 'web' });
+				'positron.reticulate.enabled': true,
+				'kernelSupervisor.transport': 'tcp'
+			});
 
 		} catch (e) {
 			await app.code.driver.takeScreenshot('reticulateSetup');
 			throw e;
 		}
+
+		await app.restart();
 	});
 
 	test('R - Verify Reticulate Stop/Start Functionality', {


### PR DESCRIPTION
* Added a simple catalog explorer test
* Added tcp transport workaround to all reticulate tests

### QA Notes

@:web @:win @:catalog-explorer @:reticulate
