### PR TITLE
Bug fix revert get enabled tools to sync

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -144,10 +144,10 @@ export class PositronAssistantApi {
  *
  * @returns The list of enabled tool names.
  */
-export async function getEnabledTools(
+export function getEnabledTools(
 	request: vscode.ChatRequest,
 	tools: readonly vscode.LanguageModelToolInformation[],
-	positronParticipantId?: string): Promise<Array<string>> {
+	positronParticipantId?: string): Array<string> {
 
 	const enabledTools: Array<string> = [];
 
@@ -175,7 +175,7 @@ export async function getEnabledTools(
 	}
 
 	// Check if a notebook is attached as context and has an active editor
-	const hasActiveNotebook = await hasAttachedNotebookContext(request);
+	const hasActiveNotebook = hasAttachedNotebookContext(request);
 
 	// Define more readable variables for filtering.
 	const inChatPane = request.location2 === undefined;

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -109,8 +109,8 @@ export class PositronAssistantApi {
 	 *
 	 * @returns The list of enabled tool names.
 	 */
-	public async getEnabledTools(request: vscode.ChatRequest, tools: readonly vscode.LanguageModelToolInformation[]): Promise<Array<string>> {
-		return await getEnabledTools(request, tools);
+	public getEnabledTools(request: vscode.ChatRequest, tools: readonly vscode.LanguageModelToolInformation[]): Array<string> {
+		return getEnabledTools(request, tools);
 	}
 
 	/**

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -261,7 +261,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const positronContext = await positron.ai.getPositronChatContext(request);
 
 		// List of tools for use by the language model.
-		const enabledTools = await getEnabledTools(request, vscode.lm.tools, this.id);
+		const enabledTools = getEnabledTools(request, vscode.lm.tools, this.id);
 		const toolAvailability = new Map(
 			vscode.lm.tools.map(
 				tool => [tool.name as PositronAssistantToolName, enabledTools.includes(tool.name as PositronAssistantToolName)]

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -403,6 +403,43 @@ export function serializeNotebookContext(
 }
 
 /**
+ * Checks if notebook mode feature is enabled in workspace configuration.
+ *
+ * @returns True if notebook mode is enabled, false otherwise
+ */
+function isNotebookModeEnabled(): boolean {
+	return vscode.workspace
+		.getConfiguration('positron.assistant.notebookMode')
+		.get('enable', false);
+}
+
+/**
+ * Extracts notebook URIs from chat request references.
+ * Looks for URIs in two places:
+ * 1. activeSession.notebookUri property in reference values
+ * 2. Direct .ipynb file URIs in reference values
+ *
+ * @param request The chat request containing references
+ * @returns Array of notebook URI strings found in the request
+ */
+function extractAttachedNotebookUris(request: vscode.ChatRequest): string[] {
+	return request.references
+		.map(ref => {
+			// Check for activeSession.notebookUri
+			const sessionNotebookUri = (ref.value as any)?.activeSession?.notebookUri;
+			if (typeof sessionNotebookUri === 'string') {
+				return sessionNotebookUri;
+			}
+			// Check for direct .ipynb file reference
+			if (ref.value instanceof vscode.Uri && ref.value.path.endsWith('.ipynb')) {
+				return ref.value.toString();
+			}
+			return undefined;
+		})
+		.filter(uri => typeof uri === 'string');
+}
+
+/**
  * Checks if there is an attached notebook context without applying filtering or serialization.
  * Returns the raw notebook context if:
  * 1. Notebook mode feature is enabled
@@ -418,11 +455,7 @@ async function getRawAttachedNotebookContext(
 	request: vscode.ChatRequest
 ): Promise<positron.notebooks.NotebookContext | undefined> {
 	// Check if notebook mode feature is enabled
-	const notebookModeEnabled = vscode.workspace
-		.getConfiguration('positron.assistant.notebookMode')
-		.get('enable', false);
-
-	if (!notebookModeEnabled) {
+	if (!isNotebookModeEnabled()) {
 		return undefined;
 	}
 
@@ -433,21 +466,7 @@ async function getRawAttachedNotebookContext(
 	}
 
 	// Extract attached notebook URIs
-	const attachedNotebookUris = request.references
-		.map(ref => {
-			// Check for activeSession.notebookUri
-			const sessionNotebookUri = (ref.value as any)?.activeSession?.notebookUri;
-			if (typeof sessionNotebookUri === 'string') {
-				return sessionNotebookUri;
-			}
-			// Check for direct .ipynb file reference
-			if (ref.value instanceof vscode.Uri && ref.value.path.endsWith('.ipynb')) {
-				return ref.value.toString();
-			}
-			return undefined;
-		})
-		.filter(uri => typeof uri === 'string');
-
+	const attachedNotebookUris = extractAttachedNotebookUris(request);
 	if (attachedNotebookUris.length === 0) {
 		return undefined;
 	}
@@ -468,20 +487,38 @@ async function getRawAttachedNotebookContext(
  * Checks if there is an attached notebook context.
  * Returns true if:
  * 1. Notebook mode feature is enabled
- * 2. A notebook editor is currently active
+ * 2. A Positron notebook editor is currently active
  * 3. That notebook's URI is attached as context
  *
- * This is a lightweight check for tool availability that doesn't require
+ * This is a lightweight synchronous check for tool availability that doesn't require
  * filtering or serialization of the notebook context.
  *
  * @param request The chat request to check for attached notebook context
  * @returns True if there is an attached notebook context, false otherwise
  */
-export async function hasAttachedNotebookContext(
+export function hasAttachedNotebookContext(
 	request: vscode.ChatRequest
-): Promise<boolean> {
-	const context = await getRawAttachedNotebookContext(request);
-	return context !== undefined;
+): boolean {
+	// Check if notebook mode feature is enabled
+	if (!isNotebookModeEnabled()) {
+		return false;
+	}
+
+	// Check if a Positron notebook editor is currently active
+	const activeEditor = vscode.window.activeNotebookEditor;
+	if (!activeEditor || activeEditor.isPositronNotebook !== true) {
+		return false;
+	}
+
+	// Extract attached notebook URIs
+	const attachedNotebookUris = extractAttachedNotebookUris(request);
+	if (attachedNotebookUris.length === 0) {
+		return false;
+	}
+
+	// Check if active notebook is in attached context
+	const activeNotebookUri = activeEditor.notebook.uri.toString();
+	return attachedNotebookUris.includes(activeNotebookUri);
 }
 
 /**

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -65,6 +65,11 @@ export class ExtHostNotebookEditor {
 				get viewColumn() {
 					return that._viewColumn;
 				},
+				// --- Start Positron ---
+				get isPositronNotebook() {
+					return that.id.startsWith('positron-notebook-');
+				},
+				// --- End Positron ---
 				get replOptions() {
 					if (that.viewType === 'repl') {
 						return { appendIndex: this.notebook.cellCount - 1 };

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -15242,6 +15242,13 @@ declare module 'vscode' {
 		 * @param revealType The scrolling strategy for revealing `range`.
 		 */
 		revealRange(range: NotebookRange, revealType?: NotebookEditorRevealType): void;
+		// --- Start Positron ---
+		/**
+		 * Whether this notebook editor is a Positron notebook editor.
+		 * This property is only set to `true` for Positron notebooks
+		*/
+		readonly isPositronNotebook?: boolean;
+		// --- End Positron ---
 	}
 
 	/**


### PR DESCRIPTION
Addresses #10566.

This PR fixes a regression in Copilot Chat introduced by #10440, which made `getEnabledTools` asynchronous. Copilot Chat calls this function synchronously and doesn't handle promises, causing chat requests to fail with "positronEnabledTools.includes is not a function".

The fix reverts `getEnabledTools` to synchronous while maintaining the notebook awareness functionality by:
- Creating `isNotebookModeEnabled()` to synchronously check the workspace configuration
- Creating `extractAttachedNotebookUris()` to synchronously extract notebook URIs from request references
- Making `hasAttachedNotebookContext()` synchronous by checking if notebooks are attached without needing async operations

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Copilot Chat failing with "positronEnabledTools.includes is not a function" error (#10566)

### QA Notes

@:assistant

1. Enable GitHub Copilot Chat in Positron
2. Open a chat session with Copilot
3. Send a message to verify chat works without errors
4. Optional: Test with a Positron notebook attached to verify notebook context still works:
   - Open a `.ipynb` file
   - Attach it to the chat context
   - Send a message and verify notebook-specific tools are available
