### PR TITLE
Add new command for `positron.executeCodeInConsole` to be used by extensions that handles uri, position, next position

### DIFF
--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -565,7 +565,9 @@ const newCommands: ApiCommand[] = [
 			ApiCommandArgument.Uri.with('uri', 'The URI of the document to execute code from'),
 			ApiCommandArgument.Position.with('position', 'The position in the document to execute code from')
 		],
-		ApiCommandResult.Void
+		new ApiCommandResult<IPosition | undefined, types.Position | undefined>('A promise that resolves to the next position after executing the code.', result => {
+			return result ? typeConverters.Position.to(result) : undefined;
+		})
 	),
 	// --- End Positron
 

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -559,7 +559,7 @@ const newCommands: ApiCommand[] = [
 	),
 	// -- execute code in console
 	new ApiCommand(
-		'positron.executeCodeInConsole', '_executeCodeInConsole', 'Execute code in the Positron console.',
+		'positron.executeCodeFromPosition', '_executeCodeInConsole', 'Execute code in the Positron console.',
 		[
 			ApiCommandArgument.String.with('languageId', 'The language ID of the code to execute'),
 			ApiCommandArgument.Uri.with('uri', 'The URI of the document to execute code from'),

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -557,6 +557,16 @@ const newCommands: ApiCommand[] = [
 			return result;
 		})
 	),
+	// -- execute code in console
+	new ApiCommand(
+		'positron.executeCodeInConsole', '_executeCodeInConsole', 'Execute code in the Positron console.',
+		[
+			ApiCommandArgument.String.with('languageId', 'The language ID of the code to execute'),
+			ApiCommandArgument.Uri.with('uri', 'The URI of the document to execute code from'),
+			ApiCommandArgument.Position.with('position', 'The position in the document to execute code from')
+		],
+		ApiCommandResult.Void
+	),
 	// --- End Positron
 
 	// --- context keys


### PR DESCRIPTION
- Addresses https://github.com/posit-dev/positron/issues/7709
- Related to https://github.com/quarto-dev/quarto/pull/867

I've been collaborating with @vezwork on how to get more language features hooked up in Quarto's visual editor, and we think this is what we need for the Quarto custom editor interface to be able to send code statement-by-statement to the console. Over in the Quarto extension, we can now do something like:

```typescript
  const nextPosition = await vscode.commands.executeCommand(
      'positron.executeCodeInConsole',
      'python',                              // language ID
      vscode.Uri.file('/path/to/script.py'), // document URI
      new vscode.Position(5, 0)              // position
  ) as vscode.Position | undefined;

```

What we get back is the next position to move the cursor to, in Quarto's case for the virtual doc underlying the visual editor.

It's a little weird to now have two commands, both the old `workbench.action.positronConsole.executeCode` and the new `positron.executeCodeInConsole`, but now that we're dealing with positions (and less so, URIs) we need to use the converters that we have access to in `src/vs/workbench/api/common/extHostApiCommands.ts`. I think I'd argue they do different enough things that this is OK? Although you can now technically call `workbench.action.positronConsole.executeCode` with a uri and position, but they would have to be the _internal_ main process versions of those; this feels somewhat weird. Is it worth doing more refactoring here to make this nicer?

@:sessions
@:console

### Release Notes

#### New Features

- Added new command `positron.executeCodeInConsole` for extensions to execute code for a given language, URI, and position (such as for the Quarto visual editor)

#### Bug Fixes

- N/A


### QA Notes

Once we get changes merged on both the Positron and Quarto sides, you should be able to execute multi-line statements in the console from the visual editor. Once we get further along, I can share more detailed examples
