### PR TITLE
Add https://support.posit.co to trusted domains

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -833,7 +833,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "5fa6ca081ac9e6cf9d92d0a58a70da34f4d1e1bd",
+        "hashed_secret": "26377711eb08faac61d3d20452042103f9bfb786",
         "is_verified": false,
         "line_number": 273,
         "is_secret": false
@@ -1414,5 +1414,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-13T22:38:47Z"
+  "generated_at": "2025-11-14T21:10:40Z"
 }

--- a/product.json
+++ b/product.json
@@ -316,7 +316,8 @@
 		"https://connect.posit.cloud",
 		"https://login.staging.posit.cloud",
 		"https://staging.connect.posit.cloud",
-		"https://posit.co"
+		"https://posit.co",
+		"https://support.posit.co"
 	],
 	"defaultChatAgent": {
 		"extensionId": "positron.positron-assistant",


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10579

I also had to update the baseline 🤷‍♀️ 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

All the Posit links on the homepage for Help should be "trusted" and open straight through without the trust dialog.