### PR TITLE
Bump Workbench extension version to 1.6.38

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -763,7 +763,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "product.json",
-        "hashed_secret": "3fad1defe924338cf88e0d74aa3b600feccafdcb",
+        "hashed_secret": "337fb43091395cb35e29bb7bfeb2495beb5d4369",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
@@ -1400,5 +1400,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-13T22:08:00Z"
+  "generated_at": "2025-11-15T01:22:18Z"
 }

--- a/product.json
+++ b/product.json
@@ -108,10 +108,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.6.34",
+			"version": "1.6.38",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web",
-			"sha256": "4d95688030d3921528ddacf7a0cf74a2cd9b9ed8e497546645df16eabcc8c2f2",
+			"sha256": "fd11f02aaa60e266df1c17487cd4bcdfd80e5e4bb16c034f68656b0dcf2e0b9e",
 			"metadata": {
 				"publisherDisplayName": "Posit Software, PBC"
 			}


### PR DESCRIPTION
Bump workbench extension to 1.6.38


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
