### PR TITLE
Use URI when available for commands to run in console (R, Python)

### DIFF
--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -83,9 +83,8 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                             newTerminalPerFile,
                         })
                             .then(() => {
-                                if (this.shouldTerminalFocusOnStart(file)) {
+                                if (this.shouldTerminalFocusOnStart(file))
                                     this.commandManager.executeCommand('workbench.action.terminal.focus');
-                                }
                             })
                             .catch((ex) => traceError('Failed to execute file in terminal', ex));
                     }),
@@ -178,9 +177,8 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                 sendTelemetryEvent(EventName.ENVIRONMENT_CHECK_TRIGGER, undefined, { trigger: 'run-selection' });
                 triggerCreateEnvironmentCheckNonBlocking(CreateEnvironmentCheckKind.File, file);
                 await this.executeSelectionInTerminal().then(() => {
-                    if (this.shouldTerminalFocusOnStart(file)) {
+                    if (this.shouldTerminalFocusOnStart(file))
                         this.commandManager.executeCommand('workbench.action.terminal.focus');
-                    }
                 });
             }),
         );
@@ -197,9 +195,8 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                     sendTelemetryEvent(EventName.ENVIRONMENT_CHECK_TRIGGER, undefined, { trigger: 'run-selection' });
                     triggerCreateEnvironmentCheckNonBlocking(CreateEnvironmentCheckKind.File, file);
                     await this.executeSelectionInDjangoShell().then(() => {
-                        if (this.shouldTerminalFocusOnStart(file)) {
+                        if (this.shouldTerminalFocusOnStart(file))
                             this.commandManager.executeCommand('workbench.action.terminal.focus');
-                        }
                     });
                 },
             ),
@@ -216,7 +213,7 @@ export class CodeExecutionManager implements ICodeExecutionManager {
 
         // Check on setting terminal.executeInFileDir
         const pythonSettings = this.configSettings.getSettings(file);
-        const cwd = pythonSettings.terminal.executeInFileDir ? path.dirname(fileToExecute.fsPath) : undefined;
+        let cwd = pythonSettings.terminal.executeInFileDir ? path.dirname(fileToExecute.fsPath) : undefined;
 
         // Check on setting terminal.launchArgs
         const launchArgs = pythonSettings.terminal.launchArgs;

--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -83,8 +83,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                             newTerminalPerFile,
                         })
                             .then(() => {
-                                if (this.shouldTerminalFocusOnStart(file))
+                                if (this.shouldTerminalFocusOnStart(file)) {
                                     this.commandManager.executeCommand('workbench.action.terminal.focus');
+                                }
                             })
                             .catch((ex) => traceError('Failed to execute file in terminal', ex));
                     }),
@@ -93,17 +94,22 @@ export class CodeExecutionManager implements ICodeExecutionManager {
         );
         // --- Start Positron ---
         this.disposableRegistry.push(
-            this.commandManager.registerCommand(Commands.Exec_In_Console as any, async () => {
-                // Get the active text editor.
-                // We get the editor here, rather than passing it in, because passing it in also
-                // confuses the Positron Console for a file
-                const editor = vscode.window.activeTextEditor;
-                if (!editor) {
-                    // No editor; nothing to do
-                    return;
+            this.commandManager.registerCommand(Commands.Exec_In_Console as any, async (resource?: Uri) => {
+                let filePath: string | undefined;
+
+                if (resource) {
+                    // Use the provided resource URI (from editor action bar button)
+                    filePath = resource.fsPath;
+                } else {
+                    // Fall back to active text editor (from command palette or other invocations)
+                    const editor = vscode.window.activeTextEditor;
+                    if (!editor) {
+                        // No editor; nothing to do
+                        return;
+                    }
+                    filePath = editor.document.uri.fsPath;
                 }
 
-                const filePath = editor.document.uri.fsPath;
                 if (!filePath) {
                     // File is unsaved; show a warning
                     vscode.window.showWarningMessage('Cannot source unsaved file.');
@@ -112,7 +118,16 @@ export class CodeExecutionManager implements ICodeExecutionManager {
 
                 // Save the file before sourcing it to ensure that the contents are
                 // up to date with editor buffer.
-                await vscode.commands.executeCommand('workbench.action.files.save');
+                if (resource) {
+                    // Save the specific document
+                    const document = await vscode.workspace.openTextDocument(resource);
+                    if (document.isDirty) {
+                        await document.save();
+                    }
+                } else {
+                    // Save the active editor
+                    await vscode.commands.executeCommand('workbench.action.files.save');
+                }
 
                 try {
                     // Check to see if the fsPath is an actual path to a file using
@@ -163,8 +178,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                 sendTelemetryEvent(EventName.ENVIRONMENT_CHECK_TRIGGER, undefined, { trigger: 'run-selection' });
                 triggerCreateEnvironmentCheckNonBlocking(CreateEnvironmentCheckKind.File, file);
                 await this.executeSelectionInTerminal().then(() => {
-                    if (this.shouldTerminalFocusOnStart(file))
+                    if (this.shouldTerminalFocusOnStart(file)) {
                         this.commandManager.executeCommand('workbench.action.terminal.focus');
+                    }
                 });
             }),
         );
@@ -181,8 +197,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                     sendTelemetryEvent(EventName.ENVIRONMENT_CHECK_TRIGGER, undefined, { trigger: 'run-selection' });
                     triggerCreateEnvironmentCheckNonBlocking(CreateEnvironmentCheckKind.File, file);
                     await this.executeSelectionInDjangoShell().then(() => {
-                        if (this.shouldTerminalFocusOnStart(file))
+                        if (this.shouldTerminalFocusOnStart(file)) {
                             this.commandManager.executeCommand('workbench.action.terminal.focus');
+                        }
                     });
                 },
             ),
@@ -199,7 +216,7 @@ export class CodeExecutionManager implements ICodeExecutionManager {
 
         // Check on setting terminal.executeInFileDir
         const pythonSettings = this.configSettings.getSettings(file);
-        let cwd = pythonSettings.terminal.executeInFileDir ? path.dirname(fileToExecute.fsPath) : undefined;
+        const cwd = pythonSettings.terminal.executeInFileDir ? path.dirname(fileToExecute.fsPath) : undefined;
 
         // Check on setting terminal.launchArgs
         const launchArgs = pythonSettings.terminal.launchArgs;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9989

The editor action bar has correctly been passing the resource URI of the editor where the button was clicked, but the extension command handlers were ignoring this parameter and instead using `vscode.window.activeTextEditor`, which returns the focused editor, not necessarily the one with the button. This PR updates the extension commands to use the URI if it is passed in.

@:console
@:editor-action-bar
@:sessions

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed the "play" button behavior for split editors.


### QA Notes

If you set up Positron so that you have split your editor like this, perhaps with a `.R` file on one side and a `.py` file on the other:

<img width="1428" height="890" alt="Screenshot 2025-11-15 at 11 30 36 AM" src="https://github.com/user-attachments/assets/6d31edf1-5ee3-4cba-a88a-acc580f3cda0" />

you should be able to:

- put your cursor in the `.R` file and click the "play" button on the `.py` file, and then see the Python file execute in the Python console
- similarly put your cursor in the `.py` file and click the "play" button on the `.R` file, and then see the R file execute in the R console
