### PR TITLE
Assistant: disable followups by default

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -278,7 +278,7 @@
           },
           "positron.assistant.followups.enable": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%configuration.followups.enable.description%"
           },
           "positron.assistant.consoleActions.enable": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -279,6 +279,9 @@
           "positron.assistant.followups.enable": {
             "type": "boolean",
             "default": false,
+            "tags": [
+              "experimental"
+            ],
             "description": "%configuration.followups.enable.description%"
           },
           "positron.assistant.consoleActions.enable": {


### PR DESCRIPTION
addresses https://github.com/posit-dev/positron/issues/10613

In a discussion on Friday re: #10087, we concluded that we ought to revisit followups to 1) bring the context back "in sync" with the current conversation, 2) integrate it back into the UI, and 3) disable it by default. I vote we go ahead and make 3) happen in the meantime, as users can't see the followups even with the setting enabled and it will increase token costs.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

To confirm this works, confirm that you don't have `positron.assistant.followups.enable` set and then, in Trace-level Assistant logs, observe that logging stops as soon as PA responds to the user rather than kicking off a request with "Based on what I have asked so far...".

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
