### PR TITLE
Assistant: Set custom User Agent in Posit provider

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -629,6 +629,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				toolInvocationToken: request.toolInvocationToken,
 				// Pass the request ID through modelOptions for token usage tracking
 				requestId: request.id,
+				// Pass the session ID through modelOptions for chat session tracking
+				sessionId: request.sessionId,
 			},
 		}, token);
 

--- a/extensions/positron-assistant/src/posit.ts
+++ b/extensions/positron-assistant/src/posit.ts
@@ -5,6 +5,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import * as os from 'os';
 import Anthropic from '@anthropic-ai/sdk';
 import { deleteConfiguration, ModelConfig, SecretStorage } from './config';
 import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
@@ -318,7 +319,15 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 			messages: anthropicMessages,
 		};
 
-		const stream = this._anthropicClient.messages.stream(body);
+		// Set user agent in stream options
+		const streamOptions = {
+			headers: {
+				'User-Agent': `Positron/${positron.version}+${positron.buildNumber} (${os.platform()}) ${options.requestInitiator}`,
+				'X-Origin-Application': `Positron ${positron.version}+${positron.buildNumber}`,
+			}
+		};
+
+		const stream = this._anthropicClient.messages.stream(body, streamOptions);
 
 		// Log request information - the request ID is only available upon connection.
 		stream.on('connect', () => {

--- a/extensions/positron-assistant/src/posit.ts
+++ b/extensions/positron-assistant/src/posit.ts
@@ -323,7 +323,6 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 		const streamOptions = {
 			headers: {
 				'User-Agent': `Positron/${positron.version}+${positron.buildNumber} (${os.platform()}) ${options.requestInitiator}`,
-				'X-Origin-Application': `Positron ${positron.version}+${positron.buildNumber}`,
 			}
 		};
 

--- a/extensions/positron-assistant/src/posit.ts
+++ b/extensions/positron-assistant/src/posit.ts
@@ -323,6 +323,7 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 		const streamOptions = {
 			headers: {
 				'User-Agent': `Positron/${positron.version}+${positron.buildNumber} (${os.platform()}) ${options.requestInitiator}`,
+				'Session-Id': options.modelOptions?.sessionId,
 			}
 		};
 


### PR DESCRIPTION
Sets a custom User Agent for the Anthropic client when using Posit provider.

### QA Notes

No user facing changes.
