### PR TITLE
ci: 4x for merge job

### DIFF
--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -183,7 +183,8 @@ jobs:
         run: |
           if [ -d /__w/positron/test/e2e/qa-example-content-cache ]; then
             rm -rf /tmp/qa-example-content-cache || true
-            cp -R /__w/positron/test/e2e/qa-example-content-cache /tmp/qa-example-content-cache || true
+            # Move instead of copy to avoid duplication
+            mv /__w/positron/test/e2e/qa-example-content-cache /tmp/qa-example-content-cache || true
             if [ -f /tmp/qa-example-content-cache/.cached-commit ]; then
               echo "✓ Seeded /tmp/qa-example-content-cache"
             fi

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -353,7 +353,7 @@ jobs:
     name: ${{ inputs.display_name }}
     if: ${{ !cancelled() }}
     needs: [e2e-ubuntu-run]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4x
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Summary
I just looked again and it's the merge job (not the run job) that ran out of space. Bumping to 4x.
For the record, out of many of my test runs, never saw this. I suspect if there are a lot of failures, there are more screenshots etc to attach and take up space.

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
