### PR TITLE
ci: max failure reduction on matrix runs

### DIFF
--- a/.github/actions/cache-multi-paths/action.yml
+++ b/.github/actions/cache-multi-paths/action.yml
@@ -18,18 +18,17 @@ runs:
 
     - name: Cache npm packages
       id: cache-npm
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         path: .npm-cache
-        key: >
-          npm-cache-${{ runner.os }}-${{
-            hashFiles('package-lock.json', 'build/package-lock.json', 'extensions/**/package-lock.json', 'remote/**/package-lock.json')
-          }}
+        key: npm-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           npm-cache-${{ runner.os }}-
 
     - name: Cache ark binary
       id: cache-binaries-ark
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         # Cache both built/downloaded resources used by the extension and a repo-root dev build directory
@@ -43,6 +42,7 @@ runs:
 
     - name: Cache kallichore binary
       id: cache-binaries-kallichore
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         path: |
@@ -54,6 +54,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: cache-playwright
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         path: |
@@ -66,6 +67,7 @@ runs:
 
     - name: Cache Electron binary
       id: cache-electron
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         path: |
@@ -78,6 +80,7 @@ runs:
 
     - name: Cache built-in extensions
       id: cache-builtins
+      continue-on-error: true
       uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -73,6 +73,11 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+      max_failures:
+        required: false
+        description: "Maximum number of test failures before aborting. Should be calculated as: base_max_failures / number_of_shards (e.g., 10 / 4 = 3 for 4 shards)."
+        type: number
+        default: 10
 
 permissions:
   id-token: write
@@ -319,11 +324,11 @@ jobs:
             SKIP_CLONE_ARG=""
           fi
 
-          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 5 --reporter=blob"
+          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }} --reporter=blob"
 
           # Don't fail the shard on test failures - let all shards complete and upload results
           # The merge-reports job will determine pass/fail based on the complete test results
-          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 5 --reporter=blob || true
+          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }} --reporter=blob || true
 
       - name: Upload Blob Report
         if: ${{ always() }}

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -319,11 +319,11 @@ jobs:
             SKIP_CLONE_ARG=""
           fi
 
-          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10 --reporter=blob"
+          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 5 --reporter=blob"
 
           # Don't fail the shard on test failures - let all shards complete and upload results
           # The merge-reports job will determine pass/fail based on the complete test results
-          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 10 --reporter=blob || true
+          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures 5 --reporter=blob || true
 
       - name: Upload Blob Report
         if: ${{ always() }}

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -158,7 +158,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [setup, e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, unit-tests, integration-tests]
+      [e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, unit-tests, integration-tests]
     runs-on: ubuntu-latest
     env:
       notify_on: ${{ github.event_name == 'schedule' && 'always' || inputs.notify_on || 'failure' }}

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -156,7 +156,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, unit-tests, integration-tests]
+      [setup, e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, unit-tests, integration-tests]
     runs-on: ubuntu-latest
     env:
       notify_on: ${{ github.event_name == 'schedule' && 'always' || inputs.notify_on || 'failure' }}
@@ -168,6 +168,6 @@ jobs:
         with:
           gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#positron-test-results"
+          slack_channel: "#test-slack-notifications"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
           notify_on: ${{ env.notify_on }}

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -77,6 +77,7 @@ jobs:
       upload_logs: false
       shards: 4
       matrix: '{"shard":[1,2,3,4]}'
+      max_failures: 3  # 10 max failures / 4 shards = 2.5, rounded up to 3
 
   e2e-windows:
     name: e2e
@@ -108,6 +109,7 @@ jobs:
       upload_logs: false
       shards: 4
       matrix: '{"shard":[1,2,3,4]}'
+      max_failures: 3  # 10 max failures / 4 shards = 2.5, rounded up to 3
 
   e2e-rhel:
     name: e2e

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -170,6 +170,6 @@ jobs:
         with:
           gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#test-slack-notifications"
+          slack_channel: "#positron-test-results"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
           notify_on: ${{ env.notify_on }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -29,6 +29,7 @@ jobs:
       matrix: '{"shard":[1,2]}'
       workers: 2
       allow_soft_fail: true
+      max_failures: 5  # 10 max failures / 2 shards = 5
     secrets: inherit
 
   e2e-windows-electron:
@@ -58,6 +59,7 @@ jobs:
       matrix: '{"shard":[1,2]}'
       workers: 2
       allow_soft_fail: true
+      max_failures: 5  # 10 max failures / 2 shards = 5
     secrets: inherit
 
   unit-tests:

--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -123,6 +123,13 @@ export function TracingFixture() {
 			const isCI = process.env.CI === 'true';
 			if (!isCI || testInfo.status !== testInfo.expectedStatus || testInfo.retry || process.env.PW_TRACE === 'on') {
 				testInfo.attachments.push({ name: 'trace', path: tracePath, contentType: 'application/zip' });
+			} else if (isCI) {
+				// In CI, delete trace files for passing tests to save disk space in blob reports
+				try {
+					await fs.promises.unlink(tracePath);
+				} catch (error) {
+					// Ignore - trace file may not exist or may already be deleted
+				}
 			}
 		}
 	};


### PR DESCRIPTION
### Summary
When leveraging matrix to run e2e tests (like in full suite), the max failure was 10, but it was 10 _FOR EACH shard_ which in the case of a run with a lot of failures ([upstream merge](https://github.com/posit-dev/positron/actions/runs/19466823561)), was creating massive blob reports for later merging and running out of disk space. I updated max failures to be lower based on # of shards. Also some small misc improvements.


### QA Notes
n/a
