### PR TITLE
E2E test: more remote ssh tests

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,5 +1,5 @@
 # For Playwright projects: e2e-electron, e2e-chromium, e2e-firefox, e2e-webkit, etc
-# Copy and rename to .env.e2e-local in the root of the repo
+# Copy and rename to .env.e2e in the root of the repo
 
 POSITRON_PY_VER_SEL=3.10.15
 POSITRON_PY_ALT_VER_SEL=3.9.6

--- a/test/e2e/infra/code.ts
+++ b/test/e2e/infra/code.ts
@@ -426,3 +426,46 @@ export function findElements(element: IElement, fn: (element: IElement) => boole
 
 	return result;
 }
+
+// --- Start Positron ---
+/**
+ * Creates a minimal Code instance from a Playwright Page for use with POMs in secondary windows.
+ * This is not a fully functional Code instance - only suitable for POM interactions that primarily
+ * use code.driver.page. Operations requiring the main process (like exit() or tracing) will not work.
+ *
+ * @param parentCode The parent Code instance to borrow configuration from
+ * @param page The Playwright Page for the secondary window
+ * @returns A minimal Code instance wrapping the given page
+ */
+export function createCodeFromPage(parentCode: Code, page: playwright.Page): Code {
+	// Create a minimal PlaywrightDriver with the new page
+	const minimalOptions: LaunchOptions = {
+		workspacePath: '',
+		logger: parentCode.logger,
+		logsPath: '',
+		crashesPath: '',
+		quality: parentCode.quality,
+		version: parentCode.version
+	};
+
+	const driver = new PlaywrightDriver(
+		parentCode.electronApp!,  // Use parent's electron app
+		page.context(),           // Get context from the page
+		page,                     // The new page
+		undefined,                // No server process
+		page.waitForLoadState(),  // Simple load promise
+		minimalOptions
+	);
+
+	// Create a minimal Code instance
+	return new Code(
+		driver,
+		parentCode.logger,        // Reuse parent logger
+		null,                     // No main process
+		undefined,                // No safeToKill
+		parentCode.quality,
+		parentCode.version,
+		parentCode.electronApp
+	);
+}
+// --- End Positron ---

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Code } from './code';
+import * as playwright from 'playwright';
+import { Code, createCodeFromPage } from './code';
 import { Modals } from '../pages/dialog-modals';
 import { Toasts } from '../pages/dialog-toasts';
 import { Popups } from '../pages/dialog-popups.js';
@@ -137,4 +138,9 @@ export class Workbench {
 		this.assistant = new Assistant(code, this.quickaccess, this.toasts);
 		this.positConnect = new PositConnect(code);
 	}
+}
+
+export function createWorkbenchFromPage(parentCode: Code, page: playwright.Page): Workbench {
+	const code = createCodeFromPage(parentCode, page);
+	return new Workbench(code);
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -193,8 +193,8 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 
 	runDockerCommand: async ({ }, use, testInfo) => {
 		await use(async (command: string, description: string) => {
-			if (testInfo.project.name !== 'e2e-workbench') {
-				throw new Error('runDockerCommand is only available in the e2e-workbench project');
+			if (testInfo.project.name !== 'e2e-workbench' && testInfo.project.name !== 'e2e-remote-ssh') {
+				throw new Error('runDockerCommand is only available in the e2e-workbench & e2e-remote-ssh projects');
 			}
 			return runDockerCommand(command, description); // <-- return result
 		});

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import { fail } from 'assert';
 import { Application } from '../../infra';
 import { Locator, Page } from '@playwright/test';
+import { pythonDynamicPlot } from '../shared/plots.constants.js';
 
 test.use({
 	suiteId: __filename
@@ -583,26 +584,6 @@ async function compareImages({
 		}
 	});
 }
-
-const pythonDynamicPlot = `import pandas as pd
-import matplotlib.pyplot as plt
-data_dict = {'name': ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
-				'age': [20, 20, 21, 20, 21, 20],
-				'math_marks': [100, 90, 91, 98, 92, 95],
-				'physics_marks': [90, 100, 91, 92, 98, 95],
-				'chem_marks': [93, 89, 99, 92, 94, 92]
-				}
-
-df = pd.DataFrame(data_dict)
-
-df.plot(kind='scatter',
-		x='math_marks',
-		y='physics_marks',
-		color='red')
-
-plt.title('ScatterPlot')
-plt.show()`;
-
 
 const pythonStaticPlot = `import graphviz as gv
 import IPython

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createWorkbenchFromPage } from '../../infra/workbench';
 
 test.use({
 	suiteId: __filename
@@ -96,6 +97,7 @@ test.describe('Remote SSH', {
 		// Grab the new window (no URL/title/selector filtering)
 		const sshWin = await sshWinPromise;
 
+
 		// Continue as before
 		await expect(sshWin.getByText('Enter password')).toBeVisible({ timeout: 60_000 });
 		await sshWin.keyboard.type('root');
@@ -105,6 +107,9 @@ test.describe('Remote SSH', {
 		await expect(alertLocator).toBeVisible({ timeout: 10_000 });
 		await expect(alertLocator).not.toBeVisible({ timeout: 60_000 });
 
+		const sshWorkbench = createWorkbenchFromPage(app.code, sshWin);
+
+		await sshWorkbench.sessions.start('python');
 
 	});
 });

--- a/test/e2e/tests/shared/plots.constants.ts
+++ b/test/e2e/tests/shared/plots.constants.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const pythonDynamicPlot = `import pandas as pd
+import matplotlib.pyplot as plt
+data_dict = {'name': ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+				'age': [20, 20, 21, 20, 21, 20],
+				'math_marks': [100, 90, 91, 98, 92, 95],
+				'physics_marks': [90, 100, 91, 92, 98, 95],
+				'chem_marks': [93, 89, 99, 92, 94, 92]
+				}
+
+df = pd.DataFrame(data_dict)
+
+df.plot(kind='scatter',
+		x='math_marks',
+		y='physics_marks',
+		color='red')
+
+plt.title('ScatterPlot')
+plt.show()`;


### PR DESCRIPTION
More remote SSH tests.
* pass interpreter settings through to remote ssh session
* create a stub workbench instance for POM access using parent workbench members and new page.
* mutate env vars to pass through "REMOTE" python and R versions
* start python & check that its the correct one
* start R & check that its the correct one

### QA Notes

@:plots