### PR TITLE
Fix: Add missing notebook tooltips

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -15,6 +15,7 @@ import { localize } from '../../../../nls.js';
 import { CellKind } from '../../notebook/common/notebookCommon.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { IconedButton } from './utilityComponents/IconedButton.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 
 export function AddCellButtons({ index }: { index: number }) {
 	const notebookInstance = useNotebookInstance();
@@ -32,8 +33,9 @@ export function AddCodeCellButton({ notebookInstance, index, bordered }: { noteb
 	const fullLabel = localize('newCodeCellLong', 'New Code Cell');
 	return <IconedButton
 		bordered={bordered}
-		codicon='code'
 		fullLabel={fullLabel}
+		hoverManager={notebookInstance.hoverManager}
+		icon={Codicon.code}
 		label={label}
 		onClick={() => notebookInstance.addCell(CellKind.Code, index, true)}
 	/>;
@@ -47,8 +49,9 @@ export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { n
 	const fullLabel = localize('newMarkdownCellLong', 'New Markdown Cell');
 	return <IconedButton
 		bordered={bordered}
-		codicon='markdown'
 		fullLabel={fullLabel}
+		hoverManager={notebookInstance.hoverManager}
+		icon={Codicon.markdown}
 		label={label}
 		onClick={() => notebookInstance.addCell(CellKind.Markup, index, true)}
 	/>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -14,6 +14,7 @@ import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
+import { IHoverManager } from '../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Represents the possible states of a notebook's kernel connection
@@ -159,6 +160,12 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Provides configuration for layout, styling, and display behavior.
 	 */
 	readonly notebookOptions: NotebookOptions;
+
+	/**
+	 * Hover manager for displaying tooltips throughout the notebook.
+	 * Used by action buttons and other interactive elements.
+	 */
+	readonly hoverManager: IHoverManager;
 
 	// ===== Methods =====
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -44,6 +44,8 @@ import { isNotebookLanguageRuntimeSession } from '../../../services/runtimeSessi
 import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 import { IExtensionApiCellViewModel, IContextKeysNotebookViewCellsUpdateEvent, IExtensionApiNotebookViewModel, ContextKeysNotebookViewCellsSplice, IPositronCellViewModel, IPositronActiveNotebookEditor } from './IPositronNotebookEditor.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
 	textModel: NotebookTextModel;
@@ -298,6 +300,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	selectionStateMachine;
 	contextManager: PositronNotebookContextKeyManager;
 	visibleRanges: ICellRange[] = [];
+	hoverManager: PositronActionBarHoverManager;
 
 	/**
 	 * Status of kernel for the notebook.
@@ -392,6 +395,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		@IPositronConsoleService private readonly _positronConsoleService: IPositronConsoleService,
 		@IPositronWebviewPreloadService private readonly _webviewPreloadService: IPositronWebviewPreloadService,
 		@IClipboardService private readonly _clipboardService: IClipboardService,
+		@IHoverService private readonly _hoverService: IHoverService,
 	) {
 		super();
 
@@ -473,6 +477,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this.contextManager = this._register(
 			this._instantiationService.createInstance(PositronNotebookContextKeyManager, this)
+		);
+
+		// Create hover manager for notebook action button tooltips
+		this.hoverManager = this._register(
+			new PositronActionBarHoverManager(false, this.configurationService, this._hoverService)
 		);
 
 		this.selectionStateMachine = this._register(

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -19,6 +19,7 @@ import { useMenu } from '../useMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useMenuActions } from '../useMenuActions.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 
 interface NotebookCellActionBarProps {
 	cell: IPositronNotebookCell;
@@ -26,6 +27,7 @@ interface NotebookCellActionBarProps {
 
 export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	// Context
+	const instance = useNotebookInstance();
 	const contextKeyService = useCellScopedContextKeyService();
 
 	// State
@@ -53,12 +55,14 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 					key={action.id}
 					action={action}
 					cell={cell}
+					hoverManager={instance.hoverManager}
 				/>
 			))}
 
 		{/* Dropdown menu for additional actions - only render if there are menu actions */}
 		{hasSubmenuActions ? (
 			<NotebookCellMoreActionsMenu
+				hoverManager={instance.hoverManager}
 				menuActions={submenuActions}
 			/>
 		) : null}
@@ -71,6 +75,7 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 					key={action.id}
 					action={action}
 					cell={cell}
+					hoverManager={instance.hoverManager}
 				/>
 			))}
 	</div>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -36,7 +36,9 @@ export function CellActionButton({ action, cell }: { action: MenuItemAction | Su
 		<ActionButton
 			key={action.id}
 			ariaLabel={action.label}
-			tooltip={action.tooltip}
+			hoverManager={instance.hoverManager}
+			// Match VSCode behavior: prefer tooltip but default to label
+			tooltip={action.tooltip && action.tooltip.length > 0 ? action.tooltip : action.label}
 			onPressed={() => handleActionClick(action)}
 		>
 			{action.item.icon ?

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -10,14 +10,22 @@ import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { DevErrorIcon, Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+
+interface CellActionButtonProps {
+	action: MenuItemAction | SubmenuItemAction;
+	cell: IPositronNotebookCell;
+	hoverManager?: IHoverManager;
+}
 
 /**
  * Standardized action button component for notebook cell actions. Handles cell selection and command execution.
  * @param action The action to execute
  * @param cell The cell to execute the action on
+ * @param hoverManager Optional hover manager for tooltip display
  * @returns A button that executes the action when clicked.
  */
-export function CellActionButton({ action, cell }: { action: MenuItemAction | SubmenuItemAction; cell: IPositronNotebookCell; }) {
+export function CellActionButton({ action, cell, hoverManager }: CellActionButtonProps) {
 	const instance = useNotebookInstance();
 
 	const handleActionClick = async (action: MenuItemAction | SubmenuItemAction) => {
@@ -36,7 +44,7 @@ export function CellActionButton({ action, cell }: { action: MenuItemAction | Su
 		<ActionButton
 			key={action.id}
 			ariaLabel={action.label}
-			hoverManager={instance.hoverManager}
+			hoverManager={hoverManager}
 			// Match VSCode behavior: prefer tooltip but default to label
 			tooltip={action.tooltip && action.tooltip.length > 0 ? action.tooltip : action.label}
 			onPressed={() => handleActionClick(action)}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -12,10 +12,14 @@ import { showCustomContextMenu } from '../../../../../../workbench/browser/posit
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 
 interface NotebookCellMoreActionsMenuProps {
 	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][]
 }
+
+const moreCellActions = localize('moreCellActions', 'More Cell Actions');
 
 /**
  * More actions dropdown menu component for notebook cells.
@@ -57,10 +61,11 @@ export function NotebookCellMoreActionsMenu({ menuActions }: NotebookCellMoreAct
 			ref={buttonRef}
 			aria-expanded={isMenuOpen}
 			aria-haspopup='menu'
-			ariaLabel={localize('moreActions', 'More actions')}
+			ariaLabel={moreCellActions}
+			tooltip={moreCellActions}
 			onPressed={showMoreActionsMenu}
 		>
-			<div className='button-icon codicon codicon-ellipsis' />
+			<Icon className='button-icon' icon={Codicon.ellipsis} />
 		</ActionButton>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -14,9 +14,11 @@ import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 
 interface NotebookCellMoreActionsMenuProps {
-	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][]
+	hoverManager?: IHoverManager;
+	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][],
 }
 
 const moreCellActions = localize('moreCellActions', 'More Cell Actions');
@@ -25,7 +27,10 @@ const moreCellActions = localize('moreCellActions', 'More Cell Actions');
  * More actions dropdown menu component for notebook cells.
  * Encapsulates all dropdown menu logic including state management and menu display.
  */
-export function NotebookCellMoreActionsMenu({ menuActions }: NotebookCellMoreActionsMenuProps) {
+export function NotebookCellMoreActionsMenu({
+	hoverManager,
+	menuActions,
+}: NotebookCellMoreActionsMenuProps) {
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 	const showMoreActionsMenu = () => {
@@ -62,6 +67,7 @@ export function NotebookCellMoreActionsMenu({ menuActions }: NotebookCellMoreAct
 			aria-expanded={isMenuOpen}
 			aria-haspopup='menu'
 			ariaLabel={moreCellActions}
+			hoverManager={hoverManager}
 			tooltip={moreCellActions}
 			onPressed={showMoreActionsMenu}
 		>

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -693,7 +693,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.delete',
-			title: localize2('positronNotebook.cell.delete.description', "Delete the Selected Cell(s)"),
+			title: localize2('positronNotebook.cell.delete.description', "Delete Cell"),
 			icon: ThemeIcon.fromId('trash'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarRight,
@@ -802,7 +802,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.runAllAbove',
-			title: localize2('positronNotebook.cell.runAllAbove', "Run Above Cells"),
+			title: localize2('positronNotebook.cell.runAllAbove', "Run Cells Above"),
 			icon: ThemeIcon.fromId('run-above'),
 			menu: [{
 				id: MenuId.PositronNotebookCellActionBarLeft,
@@ -842,7 +842,7 @@ registerAction2(class extends CellAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.runAllBelow',
-			title: localize2('positronNotebook.cell.runAllBelow', "Run Below Cells"),
+			title: localize2('positronNotebook.cell.runAllBelow', "Run Cells Below"),
 			icon: ThemeIcon.fromId('run-below'),
 			menu: [{
 				id: MenuId.PositronNotebookCellActionBarLeft,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1288,6 +1288,7 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.addCodeCell',
 			title: localize2('addCodeCell', 'Code'),
+			tooltip: localize2('addCodeCell.tooltip', 'New Code Cell'),
 			icon: ThemeIcon.fromId('add'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
@@ -1324,6 +1325,7 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.addMarkdownCell',
 			title: localize2('addMarkdownCell', 'Markdown'),
+			tooltip: localize2('addMarkdownCell.tooltip', 'New Markdown Cell'),
 			icon: ThemeIcon.fromId('add'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.tsx
@@ -11,21 +11,29 @@ import React from 'react';
 
 // Other dependencies.
 import { ActionButton } from './ActionButton.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
+import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
+import { Icon as IconType } from '../../../../../platform/action/common/action.js';
 
 /**
  * Button with icon to the left for notebook actions etc..
- * @param codicon The codicon to use for the button
+ * @param icon The icon to use for the button
  * @param label The label for the button
+ * @param fullLabel The full label for accessibility
  * @param onClick The function to call when the button is clicked
+ * @param bordered Whether to show a border
+ * @param hoverManager Optional hover manager for tooltips
  * @returns A button with an icon as given by a codicon to the left.
  */
-export function IconedButton({ codicon, label, fullLabel = label, onClick, bordered = false }: { codicon: string; label: string; fullLabel?: string; onClick: () => void; bordered?: boolean }) {
+export function IconedButton({ icon, label, fullLabel = label, onClick, bordered = false, hoverManager }: { icon: IconType; label: string; fullLabel?: string; onClick: () => void; bordered?: boolean; hoverManager?: IHoverManager }) {
 	return <ActionButton
 		ariaLabel={fullLabel}
 		className={`positron-iconed-button ${bordered ? 'bordered' : ''}`}
+		hoverManager={hoverManager}
+		tooltip={fullLabel}
 		onPressed={onClick}
 	>
-		<div className={`button-icon codicon codicon-${codicon}`} />
+		<Icon className={'button-icon'} icon={icon} />
 		<span className='action-label'>
 			{label}
 		</span>


### PR DESCRIPTION
Adds missing tooltips to buttons in the notebook cell action bar, addressing #9896.

I did not add tooltips to the run/interrupt buttons until we decide what to do with the existing hover (#10247).

https://github.com/user-attachments/assets/f0afb36a-ba6b-41bc-bb46-94cb07f36b99

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Verify that helpful tooltips appear on all relevant notebook buttons.

@:positron-notebooks @:web