### PR TITLE
Fix: Runtime session not shutting down when notebook is closed

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -3,10 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, IReference } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
-import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { IResolvedTextEditorModel, ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
 import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, CellSelectionStatus, ExecutionStatus } from './IPositronNotebookCell.js';
@@ -29,6 +29,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	protected readonly _editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
 	protected readonly _internalMetadata;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
+	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;
 
 	public readonly executionStatus;
 	public readonly selectionStatus = observableValue<CellSelectionStatus, void>('cellSelectionStatus', CellSelectionStatus.Unselected);
@@ -110,13 +111,12 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	async getTextEditorModel(): Promise<ITextModel> {
-		// TODO: We aren't disposing cells when they're removed, so we're leaking references
-		//       to the notebook and cell text models. This stops notebook documents from ever
-		//       being disposed, which leaves their runtime sessions running.
-		//       We may also want to store and reuse a single reference for all calls to this method.
-		//       See: https://github.com/posit-dev/positron/issues/10215
-		const modelRef = this._register(await this._textModelService.createModelReference(this.uri));
-		return modelRef.object.textEditorModel;
+		// Cache and reuse a single model reference for the lifetime of this cell.
+		// This reference will be disposed when the cell is disposed.
+		if (!this._modelRef) {
+			this._modelRef = this._register(await this._textModelService.createModelReference(this.uri));
+		}
+		return this._modelRef.object.textEditorModel;
 	}
 
 	delete(): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -639,6 +639,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	override dispose() {
 
 		this._logService.debug(this._id, 'dispose');
+
+		this.cells.get().forEach(cell => cell.dispose());
+
 		this._positronNotebookService.unregisterInstance(this);
 		// Remove from the instance map
 		PositronNotebookInstance._instanceMap.delete(this.uri);
@@ -1212,10 +1215,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				return existingCell;
 			}
 			const newCell = createNotebookCell(cell, this, this._instantiationService);
-			// TODO: We should be disposing cells when we're done with them.
-			//       We're currently holding onto notebook and cell text model references
-			//       so text models are never disposed
-			//       See: https://github.com/posit-dev/positron/issues/10215
 			newlyAddedCells.push(newCell);
 
 			return newCell;


### PR DESCRIPTION
Dispose cells when a notebook is disposed, so that text model references aren't leaked, the notebook document is closed, and the runtime session is shutdown. Addresses #10215.

https://github.com/user-attachments/assets/8df16f6e-075f-4241-bbf7-970f9a9f8f23

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Repro steps:

1. Open a notebook
2. Run a cell that sets a variable e.g. `x = 1`
3. Close the notebook
4. Open the notebook again (may have to wait very briefly here if automating)
5. Verify that it is a new session i.e. `x` doesn't exist - FAIL

You can also check in the Runtimes dev pane.