### PR TITLE
python: smooth a sharp edge of the languageServer setting

### DIFF
--- a/src/vs/workbench/api/common/extHostConfiguration.ts
+++ b/src/vs/workbench/api/common/extHostConfiguration.ts
@@ -267,6 +267,13 @@ export class ExtHostConfigProvider {
 			update: (key: string, value: unknown, extHostConfigurationTarget: ExtHostConfigurationTarget | boolean, scopeToLanguage?: boolean) => {
 				key = section ? `${section}.${key}` : key;
 				const target = parseConfigurationTarget(extHostConfigurationTarget);
+				// --- Start Positron ---
+				// The pyrefly extension has a hack that briefly overwrites this setting to refresh the language server,
+				// which would leave "python.languageServer": "" in user settings. We don't want that.
+				if (key === 'python.languageServer' && value === '') {
+					return this._proxy.$removeConfigurationOption(target, key, overrides, scopeToLanguage);
+				};
+				// --- End Positron ---
 				if (value !== undefined) {
 					return this._proxy.$updateConfigurationOption(target, key, value, overrides, scopeToLanguage);
 				} else {


### PR DESCRIPTION
I noticed after merging #10626 that upon activating the pyrefly extension, my user settings started gaining `"python.languageServer": ""`. I narrowed the cause down to the [pyrefly hack](https://github.com/facebook/pyrefly/blob/82eb71cbb46a5fde0ebf5eb03d0261f7c88188fe/lsp/src/extension.ts#L398) that tries to refresh the language server. The `previousSetting` in that code is `''`, so that gets left behind.

This should fix that. Honestly I sorta feel like the `if (value !== undefined)` check in the next line should be `if (value !== undefined && value !== '')`, which would accomplish the same thing, but I realize there might be some settings where the empty sting is valid (unlike python.languageServer).

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Activating pyrefly shouldn't leave the empty setting in user settings.