### PR TITLE
Set `secrets = false` in hygiene precommit hook

### DIFF
--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -46,7 +46,7 @@ const positCopyrightHeaderLinesHash = [
  * @param {boolean} linting
  * @param {boolean} secrets - should we scan for secrets?
  */
-function hygiene(some, linting = true, secrets = true) {
+function hygiene(some, linting = true, secrets = false) {
 	// --- End Positron ---
 	const eslint = require('./gulp-eslint');
 	const gulpstylelint = require('./stylelint');


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron-builds/issues/652 to some level, with just an initial switch of this default so we no longer run `detect-secrets` in the precommit hook. Now that we have [push protection from the native GitHub secret scanning](https://github.com/posit-dev/positron/security/secret_scanning/bypass_requests) we can try out turning this off, in this lightweight way. We can follow up later with a more thorough removal of the code that manages this tool.


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

N/A
