### PR TITLE
Do not treat `T` and `F` as reserved words, because they are not

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -265,7 +265,7 @@
 		},
 		"keywords-constant": {
 			"name": "constant.language",
-			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
+			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA)\\b"
 		},
 		"latex": {
 			"patterns": [

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -265,7 +265,7 @@
 		},
 		"keywords-constant": {
 			"name": "constant.language",
-			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
+			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA)\\b"
 		},
 		"latex": {
 			"patterns": [


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10645

Now, `T` and `F` are off the list of special constants and treated like regular variables:

<img width="1395" height="1005" alt="Screenshot_2025-11-18_at_4_20_28 PM" src="https://github.com/user-attachments/assets/51240516-60ab-4bb4-9a7b-599dc87311d8" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R: the syntax highlighting for `T` and `F` now treats them as regular variables (since they are not reserved words or constants in R)

#### Bug Fixes

- N/A


### QA Notes

If you use variables like `T` and `F` in your code, they should be highlighted like regular variables, even though they come pre-assigned to `TRUE` and `FALSE` when you first start R up.
