### PR TITLE
Add a regression test for reticulate variables formatting

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-variables.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-variables.test.ts
@@ -10,8 +10,7 @@ test.use({
 });
 
 // In order to run this test on Windows, I think we need to set the env var:
-// RETICULATE_PYTHON
-// to the installed python path
+// RETICULATE_PYTHON to the installed python path
 
 test.describe('Reticulate - Variables pane support', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],

--- a/test/e2e/tests/reticulate/reticulate-variables.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-variables.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// In order to run this test on Windows, I think we need to set the env var:
+// RETICULATE_PYTHON
+// to the installed python path
+
+test.describe('Reticulate - Variables pane support', {
+	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
+}, () => {
+	test('R - Verify Reticulate formats variables in the Variables pane', async function ({ app, sessions, logger }) {
+		// Reticulate relies on some Positron internals to format variables in the Variables pane.
+		// If the internals change it can cause reticulate variable formatting to break.
+		// This allows us to learn if we regress on that functionality.
+
+		await sessions.start('r');
+
+		await app.workbench.console.pasteCodeToConsole('supported <- packageVersion("reticulate") >= "1.44.1"', true);
+		await app.workbench.console.waitForExecutionComplete();
+		try {
+			await app.workbench.variables.expectVariableToBe('supported', 'TRUE');
+		} catch (e) {
+			// skip if not supported version
+			logger.log('Reticulate version does not support variable inspection. Skipping test.');
+			return;
+		}
+
+		await app.workbench.console.pasteCodeToConsole('np <- reticulate::import("numpy", convert = FALSE)', true);
+		await app.workbench.console.waitForExecutionComplete();
+
+		await app.workbench.console.pasteCodeToConsole('arr <- np$array(c(1L, 2L, 3L))', true);
+		await app.workbench.console.waitForExecutionComplete();
+
+		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+		const variablesMap = await app.workbench.variables.getFlatVariables();
+
+		expect(variablesMap.get('np')?.value.includes('module')).toBe(true);
+		expect(variablesMap.get('arr')?.value.includes('[1,2,3]')).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

We recently regressed on this funcitonality https://github.com/rstudio/reticulate/pull/1859
This tests should helps us learn when this breaks.

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:reticulate
