### PR TITLE
e2e: add notebook multiselect tests

### DIFF
--- a/.github/actions/cache-multi-paths/action.yml
+++ b/.github/actions/cache-multi-paths/action.yml
@@ -60,6 +60,7 @@ runs:
         path: |
           ~/.cache/ms-playwright
           /root/.cache/ms-playwright
+          /github/home/.cache/ms-playwright
         # Include the e2e lockfile too in case test/e2e has its own playwright deps
         key: playwright-v3-${{ runner.os }}-${{ hashFiles('package-lock.json', 'test/e2e/package-lock.json') }}
         restore-keys: |
@@ -73,6 +74,10 @@ runs:
         path: |
           ~/.cache/electron
           ~/.cache/electron-builder
+          /root/.cache/electron
+          /root/.cache/electron-builder
+          /github/home/.cache/electron
+          /github/home/.cache/electron-builder
         # electron binaries are tied to package-lock and the electron version in package.json
         key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json', 'package.json') }}
         restore-keys: |

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -36,6 +36,8 @@ export class PositronNotebooks extends Notebooks {
 	// Editor action bar
 	editorActionBar = this.code.driver.page.locator('.editor-action-bar-container');
 	kernel: Kernel;
+	markdownButton = this.editorActionBar.getByRole('button', { name: 'Markdown' });
+	codeButton = this.editorActionBar.getByRole('button', { name: 'Code' });
 
 	// Cell action buttons, menus, tooltips, output, etc
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /more actions/i });
@@ -589,11 +591,12 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async expectCellIndexToBeSelected(
 		expectedIndex: number,
-		options?: { isSelected?: boolean; inEditMode?: boolean; timeout?: number }
+		options?: { isSelected?: boolean; inEditMode?: boolean; isActive?: boolean; timeout?: number }
 	): Promise<void> {
 		const {
 			isSelected = true,
 			inEditMode = undefined,
+			isActive = undefined,
 		} = options ?? {};
 
 		await expect(async () => {
@@ -613,6 +616,12 @@ export class PositronNotebooks extends Notebooks {
 				isSelected
 					? expect(selectedIndices).toContain(expectedIndex)
 					: expect(selectedIndices).not.toContain(expectedIndex);
+
+				if (isActive !== undefined) {
+					isActive
+						? await expect(this.moreActionsButtonAtIndex(expectedIndex)).toBeVisible()
+						: await expect(this.moreActionsButtonAtIndex(expectedIndex)).toBeHidden();
+				}
 			});
 
 			await test.step(`Verify cell at index ${expectedIndex} is ${inEditMode ? '' : 'NOT '}in edit mode`, async () => {

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -235,4 +235,61 @@ test.describe('Notebook Focus and Selection', {
 			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: false });
 		});
 	});
-});
+
+	test("`+ Code` and `+ Markdown` buttons insert the cell after the active cell and make it the new active cell)", async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Start a new notebook with 3 cells
+		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.selectCellAtIndex(1);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
+
+		// Click the + Code button and verify the cell is inserted after the active cell
+		await notebooksPositron.codeButton.click();
+		await notebooksPositron.expectCellCountToBe(4);
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isActive: true, inEditMode: true });
+
+		// Click the + Markdown button and verify the cell is inserted after the active cell
+		await notebooksPositron.markdownButton.click();
+		await notebooksPositron.expectCellCountToBe(5);
+		await notebooksPositron.expectCellIndexToBeSelected(3, { isActive: true, inEditMode: true });
+	});
+
+	test("Multi-select and deselect retains anchor/active cell", async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Start a new notebook with 5 cells and select cell 2
+		await notebooksPositron.newNotebook(5);
+		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+
+		// Multi-select up to cell 0 and verify anchor is cell 0
+		await keyboard.press('Shift+ArrowUp');
+		await keyboard.press('Shift+ArrowUp');
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, isActive: true });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true, isActive: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
+
+		// Deselect back down to cell 2 and verify anchor is cell 2
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: true });
+
+		// Multi-select down to cell 4 and verify anchor is cell 4
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true });
+		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true });
+		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
+
+		// Deslect with Escape key and verify anchor is cell 4
+		await keyboard.press('Escape');
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
+	});
+})

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -282,15 +282,15 @@ test.describe('Notebook Focus and Selection', {
 		// Deselect back down to cell 2 and verify anchor is cell 2
 		await keyboard.press('Shift+ArrowDown');
 		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false, isActive: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false, isActive: false });
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: true });
 
 		// Multi-select down to cell 4 and verify anchor is cell 4
 		await keyboard.press('Shift+ArrowDown');
 		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true });
-		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
+		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true, isActive: false });
 		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
 
 		// Deslect with Escape key and verify anchor is cell 4

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -238,6 +238,7 @@ test.describe('Notebook Focus and Selection', {
 
 	test("`+ Code` and `+ Markdown` buttons insert the cell after the active cell and make it the new active cell)", async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
 		// Start a new notebook with 3 cells
 		await notebooksPositron.newNotebook(3);
@@ -249,10 +250,18 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellCountToBe(4);
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isActive: true, inEditMode: true });
 
+		// Ensure new code cell is editable
+		await keyboard.type('print("Hello, World!")');
+		await notebooksPositron.expectCellContentAtIndexToContain(2, 'print("Hello, World!")');
+
 		// Click the + Markdown button and verify the cell is inserted after the active cell
 		await notebooksPositron.markdownButton.click();
 		await notebooksPositron.expectCellCountToBe(5);
 		await notebooksPositron.expectCellIndexToBeSelected(3, { isActive: true, inEditMode: true });
+
+		// Ensure new markdown cell is editable
+		await keyboard.type('# Heading 1');
+		await notebooksPositron.expectCellContentAtIndexToContain(3, '# Heading 1');
 	});
 
 	test("Multi-select and deselect retains anchor/active cell", async function ({ app }) {


### PR DESCRIPTION
### Summary
Added 2 new tests for notebook cell behavior:
* Select multiple cells
   * Ensure that we have focus across multiple cells
   * Ensure only 1 cell is active/anchor and has the cell menu buttons
* Adding new cells from action bar
   * Ensure it is placed after the currently active cell
   * Ensure it becomes the new active cell
   * Ensure can interact with it via keyboard.
 * Also fixing a caching issue I ran into
### QA Notes

@:positron-notebooks @:web @:win


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
