### PR TITLE
Always show composite bar of auxiliary bar in title position

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -229,9 +229,18 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			run: () => this.configurationService.updateValue('workbench.secondarySideBar.showLabels', !this.configuration.showLabels)
 		});
 
+		// --- Start Positron ---
+		// Just to avoid unused variables warnings
+		new SubmenuAction('workbench.action.panel.position', localize('activity bar position', "Activity Bar Position"), positionActions);
+		// --- End Positron ---
+
 		actions.push(...[
 			new Separator(),
-			new SubmenuAction('workbench.action.panel.position', localize('activity bar position', "Activity Bar Position"), positionActions),
+			// --- Start Positron ---
+			// Disable the Activity Bar Position submenu since we always use TITLE position.
+			// See https://github.com/posit-dev/positron/issues/2951
+			// new SubmenuAction('workbench.action.panel.position', localize('activity bar position', "Activity Bar Position"), positionActions),
+			// --- End Positron ---
 			toAction({ id: ToggleSidebarPositionAction.ID, label: currentPositionRight ? localize('move second side bar left', "Move Secondary Side Bar Left") : localize('move second side bar right', "Move Secondary Side Bar Right"), run: () => this.commandService.executeCommand(ToggleSidebarPositionAction.ID) }),
 			toggleShowLabelsAction,
 			toAction({ id: ToggleAuxiliaryBarAction.ID, label: localize('hide second side bar', "Hide Secondary Side Bar"), run: () => this.commandService.executeCommand(ToggleAuxiliaryBarAction.ID) })

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -243,13 +243,12 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	}
 
 	protected getCompositeBarPosition(): CompositeBarPosition {
-		switch (this.configuration.position) {
-			case ActivityBarPosition.TOP: return CompositeBarPosition.TOP;
-			case ActivityBarPosition.BOTTOM: return CompositeBarPosition.BOTTOM;
-			case ActivityBarPosition.HIDDEN: return CompositeBarPosition.TITLE;
-			case ActivityBarPosition.DEFAULT: return CompositeBarPosition.TITLE;
-			default: return CompositeBarPosition.TITLE;
-		}
+		// --- Start Positron ---
+		// Always keep the composite bar in the TITLE position for the auxiliary bar
+		// to avoid duplication when activity bar is at TOP/BOTTOM.
+		// See https://github.com/posit-dev/positron/issues/2951
+		return CompositeBarPosition.TITLE;
+		// --- End Positron ---
 	}
 
 	override toJSON(): object {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2951

Before:

https://github.com/user-attachments/assets/32c285c7-f998-4356-a152-3d5842617356

After:

https://github.com/user-attachments/assets/d6236884-a5e1-4e3c-8cac-b00830108a23

We also no longer show the "Activity Bar Position" submenu, consistently with the tab bar in the panel:

Before:
<img width="323" height="458" alt="Screenshot 2025-11-26 at 15 01 53" src="https://github.com/user-attachments/assets/7a473a3c-b5a6-4151-8fa9-b6fa0b11de68" />

After:
<img width="344" height="434" alt="Screenshot 2025-11-26 at 15 00 57" src="https://github.com/user-attachments/assets/a25dcdc3-cb2e-4653-a068-64132134aa6b" />


I wonder if we should alway display the full strip of tabs when activity bar is set to hidden. This would effectively mean that the activity bar only refers to the primary side bar, and activity bar settings do not affect the secondary side bar.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Setting the activity bar position to bottom or top no longer causes duplicate tab names in the secondary bar (https://github.com/posit-dev/positron/issues/2951).


### QA Notes

- The tab names should be consistently displayed no matter the position of the activity bar (top, bottom, hidden). Note that when activity bar is hidden, only the current tab name will be displayed. This is currently expected.

- The view-specific actions (like Start a new console) should still be displayed. Instead of being shown in the duplicate strip, they are now shown in the tab bar.

- Right clicking the tab bar should no longer show the "Activity Bar Position" submenu.

I ran the full test suite at https://github.com/posit-dev/positron/actions/runs/19503204821