### PR TITLE
Positron nb assistant copilot fixes

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -59,13 +59,8 @@ export class PositronAssistantApi {
 		const sessions = activeSessions.map(session => session.runtimeMetadata);
 		const streamingEdits = isStreamingEditsEnabled();
 
-		// Get notebook context if available, with error handling
-		let notebookContext: SerializedNotebookContext | undefined;
-		try {
-			notebookContext = await getAttachedNotebookContext(request);
-		} catch (err) {
-			log.error('[PositronAssistantApi] Error checking notebook context:', err);
-		}
+		// Get notebook context if available
+		const notebookContext = await getAttachedNotebookContext(request);
 
 		let prompt = PromptRenderer.renderModePrompt(mode, { sessions, request, streamingEdits, notebookContext }).content;
 

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -143,6 +143,18 @@ export class PositronAssistantApi {
 }
 
 /**
+ * Copilot notebook tool names that should be disabled when Positron notebook mode is active.
+ * These tools conflict with Positron's specialized notebook tools.
+ */
+const COPILOT_NOTEBOOK_TOOLS = new Set([
+	'copilot_editNotebook',
+	'copilot_getNotebookSummary',
+	'copilot_runNotebookCell',
+	'copilot_readNotebookCellOutput',
+	'copilot_createNewJupyterNotebook',
+]);
+
+/**
  * Gets the set of enabled tools for a chat request.
  *
  * @param request The chat request to get enabled tools for.
@@ -339,6 +351,13 @@ export function getEnabledTools(
 		const alwaysIncludeCopilotTools = vscode.workspace.getConfiguration('positron.assistant').get('alwaysIncludeCopilotTools', false);
 		// Check if the tool is provided by Copilot.
 		const copilotTool = tool.source instanceof vscode.LanguageModelToolExtensionSource && tool.source.id === 'GitHub.copilot-chat';
+
+		// Disable Copilot notebook tools when Positron notebook mode is active
+		// to avoid conflicts with Positron's specialized notebook tools.
+		if (copilotTool && hasActiveNotebook && COPILOT_NOTEBOOK_TOOLS.has(tool.name)) {
+			continue;
+		}
+
 		// Check if the user is signed into Copilot.
 		let copilotEnabled;
 		try {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -760,13 +760,8 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 		const activeSessions = await positron.runtime.getActiveSessions();
 		const sessions = activeSessions.map(session => session.runtimeMetadata);
 
-		// Get notebook context if available, with error handling
-		let notebookContext: SerializedNotebookContext | undefined;
-		try {
-			notebookContext = await getAttachedNotebookContext(request);
-		} catch (err) {
-			log.error('[PositronAssistantChatParticipant] Error checking notebook context:', err);
-		}
+		// Get notebook context if available
+		const notebookContext = await getAttachedNotebookContext(request);
 
 		// Render prompt with notebook context
 		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatMode.Ask, {


### PR DESCRIPTION
Addresses #10653.

This PR fixes an issue where the GitHub Copilot chat provider wasn't receiving notebook context in its system prompt when used with Positron Assistant. The Copilot provider now uses the same prompt construction path as the Anthropic provider, ensuring it receives complete notebook information (cells, outputs, variables) upfront rather than needing tool calls for basic context.

Additionally, this PR filters out Copilot's native notebook tools when Positron notebook mode is active to prevent conflicts with Positron's specialized notebook tools.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:assistant @:notebooks

1. Open a Jupyter notebook in Positron with some code cells
2. Open Assistant and switch to Copilot chat provider
3. Ask about the notebook (e.g., "What cells are in this notebook?" or "Summarize what this notebook does")

**Expected**: 
- Assistant should respond with knowledge of notebook cells without making tool calls
- Behavior should match the Anthropic provider experience
- Assistant should use Positron notebook tools (`GetNotebookCells`, `EditNotebookCells`, `RunNotebookCells`) not Copilot-native ones
