### PR TITLE
Insert cell above/below actions now enter edit mode immediately

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -798,7 +798,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), false);
+		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), true);
 	}
 
 	/**

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -320,11 +320,10 @@ test.describe('Notebook Focus and Selection', {
 		// From cell action menu insert cell below and verify new cell is at index 1
 		await notebooksPositron.triggerCellAction(0, 'Insert code cell below')
 		await notebooksPositron.expectCellCountToBe(6);
-		// ISSUE: https://github.com/posit-dev/positron/issues/10651
-		// await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
 
-		// // Ensure we can type into the new cell
-		// await keyboard.type('print("New Below")');
-		// await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
+		// Ensure we can type into the new cell
+		await keyboard.type('print("New Below")');
+		await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
 	});
-})
+});


### PR DESCRIPTION
Addresses #10651

This should allow the PR which adds tests for this in https://github.com/posit-dev/positron/pull/10658 to be uncommented and ran against this fix.


https://github.com/user-attachments/assets/aabfee49-1c83-484e-94d7-f49e66f5ab0c



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
