### PR TITLE
Use new Ark's REPL engine

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -928,7 +928,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "posit-dev/ark@feature/read-srcref"
+      "ark": "0.1.219"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -928,7 +928,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.218"
+      "ark": "posit-dev/ark@feature/read-srcref"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -65,8 +65,8 @@ test.describe('R Debugging', {
 		await debug.expectBrowserModeFrame(1);
 
 		// Verify call stack order
-		await debug.expectCallStackAtIndex(0, 'inner()inner()2:');
-		await debug.expectCallStackAtIndex(1, 'outer(5)inner(x)2:');
+		await debug.expectCallStackAtIndex(0, 'inner()inner(x)');
+		await debug.expectCallStackAtIndex(1, 'outer(5)inner(x)');
 		await debug.expectCallStackAtIndex(2, '<global>outer(5)');
 
 		// Verify the call stack redirects to correct data frame(s)
@@ -269,4 +269,3 @@ async function verifyVariableInConsole(app: Application, name: string, expectedT
 		await expect(app.code.driver.page.getByText(expectedText)).toBeVisible({ timeout: 30000 });
 	});
 }
-

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -210,40 +210,6 @@ test.describe('R Debugging', {
 		await executeCode('R', 'fruit_avg(dat, "berry")', { waitForReady: false });
 		await console.waitForConsoleContents('Found 2 fruits!', { expectedCount: 2 });
 	});
-
-	test('R - Verify debugging with `options(error = recover)` interactive recovery mode', async ({ app, page, openFile, runCommand, executeCode }) => {
-		const { console } = app.workbench;
-
-		await openFile('workspaces/r-debugging/fruit_avg.r');
-		await runCommand('r.sourceCurrentFile');
-
-		// Enable recovery mode so errors trigger the interactive debugger
-		await executeCode('R', 'options(error = recover)');
-
-		// Trigger an error: this should throw an error inside rowMeans(mini_dat)
-		await executeCode('R', 'fruit_avg(dat, "black")', { waitForReady: false });
-
-		// Confirm recovery prompt appears and frame selection is offered
-		await console.waitForConsoleContents('Enter a frame number, or 0 to exit');
-		await console.waitForConsoleContents('1: fruit_avg(dat, "black")');
-
-		// Select the inner function frame
-		await console.waitForConsoleContents('Selection:');
-		await page.keyboard.type('1');
-		await page.keyboard.press('Enter');
-
-		// Confirm error message appears in sidebar
-		await console.expectConsoleToContainError("'x' must be an array of at least two dimensions");
-
-		// Check the contents of mini_dat in the console
-		await console.focus();
-		await verifyVariableInConsole(app, 'mini_dat', '[1] 4 9 6');
-
-		// Quit the debugger
-		await page.keyboard.type('Q');
-		await page.keyboard.press('Enter');
-		await console.waitForReady('>');
-	});
 });
 
 


### PR DESCRIPTION
Positron side of https://github.com/posit-dev/ark/pull/960

We'll merge this after the December release is out.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- R consoles can now be restarted while the debugger is active (https://github.com/posit-dev/positron/issues/6553).
- Some syntax errors no longer cause a distracting backtrace in the console (https://github.com/posit-dev/ark/issues/598, https://github.com/posit-dev/ark/issues/722).


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:ark
