### PR TITLE
e2e: re-enable currents reporter on merges

### DIFF
--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -324,11 +324,11 @@ jobs:
             SKIP_CLONE_ARG=""
           fi
 
-          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }} --reporter=blob"
+          echo "Running: npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }}"
 
           # Don't fail the shard on test failures - let all shards complete and upload results
           # The merge-reports job will determine pass/fail based on the complete test results
-          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }} --reporter=blob || true
+          eval SKIP_BOOTSTRAP=true $SKIP_CLONE_ARG npx playwright test --project ${{ inputs.project }} --workers ${{ inputs.workers }} $SHARD_ARG $GREP_ARG --repeat-each ${{ inputs.repeat_each }} --max-failures ${{ inputs.max_failures }} || true
 
       - name: Upload Blob Report
         if: ${{ always() }}

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -500,7 +500,7 @@ jobs:
 
       - name: Clean up blob report artifacts
         if: success()
-        continue-on-error: true
         uses: geekyeggo/delete-artifact@v5
         with:
           name: blob-report-${{ inputs.project }}-*
+          failOnError: false

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -172,4 +172,5 @@ jobs:
           slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           slack_channel: "#positron-test-results"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
+          include_job_durations: false
           notify_on: ${{ env.notify_on }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -94,4 +94,5 @@ jobs:
           slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           slack_channel: "#positron-test-results"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
+          include_job_durations: false
           notify_on: "failure"


### PR DESCRIPTION
### Summary
Just some small fixes:
* Re-enabling currents on merges. Oopsie!
* Removing job durations from slack notify on matrix runs because it's misleading. (The time to merge the reports is what displays)
* Don't let artifact cleanup fail job

### QA Notes

n/a