### PR TITLE
Assistant: revisit prompting for `editFile(code)` argument

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -45,7 +45,6 @@ import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, ITo
 // eslint-disable-next-line no-duplicate-imports
 import { ToolProgress } from '../../common/languageModelToolsService.js';
 import { getUriForFileOpenOrInsideWorkspace } from './utils.js';
-// --- End Positron ---
 
 const codeInstructions = `
 The edits will be automatically merged into the document and presented as a diff to the user.
@@ -78,7 +77,6 @@ Comment syntax should match the file's language:
 Notably, there are no markdown code fences or backticks like \`\`\`typescript or \`\`\`python.
 `;
 
-// --- Start Positron ---
 // To avoid name collisions with the upstream editFileTool, we are using a different name for the extension tool ID.
 // export const ExtensionEditToolId = 'vscode_editFile';
 // export const InternalEditToolId = 'vscode_editFile_internal';

--- a/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/editFileTool.ts
@@ -48,8 +48,12 @@ import { getUriForFileOpenOrInsideWorkspace } from './utils.js';
 // --- End Positron ---
 
 const codeInstructions = `
-The user is very smart and can understand how to apply your edits to their files, you just need to provide minimal hints.
-Avoid repeating existing code, instead use comments to represent regions of unchanged code. The user prefers that you are as concise as possible. For example:
+The edits will be automatically merged into the document and presented as a diff to the user.
+Provide a line before and after the changed code for context.
+Importantly, use // ...existing code... comments to skip unchanged sections larger than 2 lines.
+
+For example:
+
 // ...existing code...
 { changed code }
 // ...existing code...
@@ -65,6 +69,13 @@ class Person {
 		return this.age;
 	}
 }
+
+Comment syntax should match the file's language:
+- JavaScript/TypeScript: // ...existing code...
+- Python/R: # ...existing code...
+- HTML/XML: <!-- ...existing code... -->
+
+Notably, there are no markdown code fences or backticks like \`\`\`typescript or \`\`\`python.
 `;
 
 // --- Start Positron ---


### PR DESCRIPTION
Addresses #10673.

With these changes, PA seems to be much more likely to generate coherent edits across languages:

1)
<img width="752" alt="Screenshot 2025-11-19 at 4 45 56 PM" src="https://github.com/user-attachments/assets/90a420ba-05da-434d-b63c-3e4e9c5f0d67" />

2)
<img width="752"  alt="Screenshot 2025-11-19 at 4 57 44 PM" src="https://github.com/user-attachments/assets/a15bee22-1042-4e36-9d49-73c263744485" />

3)
<img width="752" alt="Screenshot 2025-11-19 at 5 00 51 PM" src="https://github.com/user-attachments/assets/5a708476-2fe2-4a89-ac59-219cee218b10" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
