### PR TITLE
Do not enter edit mode when inserting cell

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -807,7 +807,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), true);
+		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), false);
 	}
 
 	/**

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -320,10 +320,11 @@ test.describe('Notebook Focus and Selection', {
 		// From cell action menu insert cell below and verify new cell is at index 1
 		await notebooksPositron.triggerCellAction(0, 'Insert code cell below')
 		await notebooksPositron.expectCellCountToBe(6);
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
+		// ISSUE: https://github.com/posit-dev/positron/issues/10651
+		// await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
 
-		// Ensure we can type into the new cell
-		await keyboard.type('print("New Below")');
-		await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
+		// // Ensure we can type into the new cell
+		// await keyboard.type('print("New Below")');
+		// await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
 	});
-});
+})

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -318,13 +318,13 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
 
 		// From cell action menu insert cell below and verify new cell is at index 1
-		await notebooksPositron.triggerCellAction(0, 'Insert code cell below')
+		await notebooksPositron.triggerCellAction(0, 'Insert code cell below');
 		await notebooksPositron.expectCellCountToBe(6);
-		// ISSUE: https://github.com/posit-dev/positron/issues/10651
-		// await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: false });
 
-		// // Ensure we can type into the new cell
-		// await keyboard.type('print("New Below")');
-		// await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
+		// Ensure we can type into the new cell
+		await keyboard.press('Enter'); // enter edit mode
+		await keyboard.type('print("New Below")');
+		await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
 	});
 })


### PR DESCRIPTION
Reverts changes made for #10651. 

We do not want to enter edit mode when inserting new cells. Users have to press `Enter` to enter edit mode.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
