### PR TITLE
e2e: sprinkling markdown cells into existing notebook tests

### DIFF
--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -107,4 +107,5 @@ jobs:
           slack_channel: "#positron-test-results"
           notify_on: ${{ env.notify_on }}
           filter_jobs: "(e2e / ([^0-9]*))$"
+          include_job_durations: false
           custom_title: "E2E Cross Browser Tests — `main` (commit <https://github.com/posit-dev/positron/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>)"

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -298,6 +298,7 @@ jobs:
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           USE_KEY: true
           PW_PROJECT_NAME: ${{ inputs.project }}
+          GH_SUMMARY_REPORT: false # prevent reporting individual shard results to github summary
         run: |
           if [ -z "$PW_TAGS" ]; then
             GREP_ARG=""

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ type ExtendedTestOptions = CustomTestOptions & CurrentsFixtures & CurrentsWorker
 
 process.env.PW_TEST = '1';
 const jsonOut = process.env.PW_JSON_FILE || 'test-results/results.json';
-const githubSummaryReport = process.env.GH_SUMMARY_REPORT ? [['@midleman/github-actions-reporter', {}] as const] : [];
+const githubSummaryReport = process.env.GH_SUMMARY_REPORT === 'true' ? [['@midleman/github-actions-reporter', {}] as const] : [];
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,7 @@ type ExtendedTestOptions = CustomTestOptions & CurrentsFixtures & CurrentsWorker
 
 process.env.PW_TEST = '1';
 const jsonOut = process.env.PW_JSON_FILE || 'test-results/results.json';
+const githubSummaryReport = process.env.GH_SUMMARY_REPORT ? [['@midleman/github-actions-reporter', {}] as const] : [];
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -46,7 +47,7 @@ export default defineConfig<ExtendedTestOptions>({
 	},
 	reporter: process.env.CI
 		? [
-			['@midleman/github-actions-reporter'],
+			...githubSummaryReport,
 			['json', { outputFile: jsonOut }],
 			['list'], ['html'], ['blob'],
 			...(process.env.ENABLE_CURRENTS_REPORTER === 'true'

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -42,7 +42,7 @@ export class PositronNotebooks extends Notebooks {
 	// Cell action buttons, menus, tooltips, output, etc
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /More Cell Actions/i });
 	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
-	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: 'Run Cell', exact: true })
+	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: 'Run Cell', exact: true });
 	private cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private cellMarkdown = (index: number) => this.cell.nth(index).locator('.positron-notebook-markdown-rendered');
 	private cellInfoToolTip = this.code.driver.page.getByRole('tooltip', { name: /cell execution details/i });
@@ -168,7 +168,7 @@ export class PositronNotebooks extends Notebooks {
 	 * Action: Create a new Positron notebook.
 	 * @param numCellsToAdd - Number of cells to add after creating the notebook (default: 0).
 	 */
-	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number, markdownCells?: number }): Promise<void> {
+	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number; markdownCells?: number }): Promise<void> {
 		await this.createNewNotebook();
 		await this.expectToBeVisible();
 
@@ -221,7 +221,7 @@ export class PositronNotebooks extends Notebooks {
 		const y = box.y + box.height + OFFSET;
 
 		await this.code.driver.page.mouse.click(x, y);
-	};
+	}
 
 	/**
 	 * Action: Add a new cell of the specified type.
@@ -352,7 +352,7 @@ export class PositronNotebooks extends Notebooks {
 		ariaLabel === 'Markdown cell'
 			? await this.cell.nth(cellIndex).dblclick()
 			: await this.cell.nth(cellIndex).click();
-	};
+	}
 
 	/**
 	 * Action: Add code to a cell at the specified index and run it.

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -225,7 +225,6 @@ export class PositronNotebooks extends Notebooks {
 		const y = box.y + box.height + OFFSET;
 
 		await this.code.driver.page.mouse.click(x, y);
-		await this.code.driver.page.mouse.click(x, y);
 	}
 
 	/**

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -168,9 +168,13 @@ export class PositronNotebooks extends Notebooks {
 	 * Action: Create a new Positron notebook.
 	 * @param numCellsToAdd - Number of cells to add after creating the notebook (default: 0).
 	 */
-	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number; markdownCells?: number }): Promise<void> {
+	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number; markdownCells?: number } = {}): Promise<void> {
 		await this.createNewNotebook();
 		await this.expectToBeVisible();
+
+		if (codeCells === 0 && markdownCells === 0) {
+			return;
+		}
 
 		let totalCellsAdded = 0;
 		const keyboard = this.code.driver.page.keyboard;
@@ -220,6 +224,7 @@ export class PositronNotebooks extends Notebooks {
 		const x = box.x + box.width - OFFSET;
 		const y = box.y + box.height + OFFSET;
 
+		await this.code.driver.page.mouse.click(x, y);
 		await this.code.driver.page.mouse.click(x, y);
 	}
 

--- a/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
@@ -25,7 +25,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 	test('Cell deletion using action bar', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook(6);
+		await notebooksPositron.newNotebook({ codeCells: 6 });
 
 		// ========================================
 		// Test 1: Delete a selected cell (cell 2)
@@ -130,7 +130,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 		const { notebooksPositron } = app.workbench;
 
 		// create notebook with 2 cells
-		await notebooksPositron.newNotebook(2);
+		await notebooksPositron.newNotebook({ codeCells: 2 });
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
 
 		// Copy cell with action bar and paste below using action bar
@@ -157,7 +157,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.newNotebook({ codeCells: 3 });
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// Select multiple cells (cell 0 and cell 1)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -55,7 +55,7 @@ test.describe('Notebook Cell Reordering', {
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.newNotebook({ codeCells: 3 });
 
 		// Verify initial order
 		await notebooksPositron.expectCellCountToBe(3);
@@ -74,7 +74,7 @@ test.describe('Notebook Cell Reordering', {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
-		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.newNotebook({ codeCells: 3 });
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// First cell up -> no change
@@ -95,7 +95,7 @@ test.describe('Notebook Cell Reordering', {
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 4 cells
-		await notebooksPositron.newNotebook(4);
+		await notebooksPositron.newNotebook({ codeCells: 4 });
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2', '# Cell 3']);
 
 		// Move Cell 0 down three times to end
@@ -119,7 +119,7 @@ test.describe('Notebook Cell Reordering', {
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Setup: Create notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
+		await notebooksPositron.newNotebook({ codeCells: 3 });
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2']);
 
 		// Move cell 1 up

--- a/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
@@ -29,7 +29,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		// Setup: Create 5 cells with distinct content
 		// ========================================
 		await test.step('Test Setup: Create notebook and add cells', async () => {
-			await notebooksPositron.newNotebook(5);
+			await notebooksPositron.newNotebook({ codeCells: 5 });
 			await notebooksPositron.expectCellCountToBe(5);
 		});
 

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Edit Mode', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+
+	test('Clicking/dbl clicking into cell focuses editor and enters into edit mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
+
+		// Code cell: Can successfully enter edit mode by single clicking and typing
+		await notebooksPositron.selectCellAtIndex(0);
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: true });
+		await keyboard.type('cell editor good');
+		await notebooksPositron.expectCellContentAtIndexToContain(0, 'cell editor good');
+
+		// Markdown cell: Can successfully enter edit mode by double clicking and typing
+		await notebooksPositron.selectCellAtIndex(2, { editMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true });
+		await keyboard.type('markdown editor good');
+		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown editor good');
+	});
+
+
+	test('Enter key on selected cell enters edit mode and doesn\'t add new lines', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create a new notebook with 3 cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
+
+		// Code cell: Press Enter to enter edit mode and type
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Enter');
+		await notebooksPositron.expectCellIndexToBeSelected(0, {
+			isSelected: true,
+			inEditMode: true
+		});
+		await keyboard.type('code enter key');
+		await notebooksPositron.expectCellContentAtIndexToContain(0, 'code enter key');
+
+		// Markdown cell: Press Enter to enter edit mode and type
+		await notebooksPositron.selectCellAtIndex(2);
+		await keyboard.press('Enter');
+		await notebooksPositron.expectCellIndexToBeSelected(2, {
+			isSelected: true,
+			inEditMode: true
+		});
+		await keyboard.type('markdown enter key');
+		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown enter key');
+
+	});
+
+	test('Shift+Enter on last cell creates new cell and enters edit mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create a new notebook with 3 cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
+
+		// Code cell: Verify pressing Shift+Enter adds a new cell below
+		await notebooksPositron.selectCellAtIndex(2);
+		await notebooksPositron.expectCellCountToBe(3);
+		await keyboard.press('Shift+Enter');
+		await notebooksPositron.expectCellCountToBe(4);
+
+		// Verify the NEW cell (index 3) is now in edit mode with focus
+		await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: true });
+
+		// Verify we can type immediately in the new cell
+		await keyboard.type('new cell content');
+		await notebooksPositron.expectCellContentAtIndexToContain(3, 'new cell content');
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -64,6 +64,7 @@ test.describe('Notebook Focus and Selection', {
 		// Code cell: click away and back should restore edit mode
 		await notebooksPositron.selectCellAtIndex(0);
 		await notebooksPositron.clickAwayFromCell(0);
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
 		await notebooksPositron.selectCellAtIndex(0);
 
 		// verify backspace deletes cell content not cell (indicating edit mode is active)
@@ -72,10 +73,11 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellCountToBe(2);
 
 		// Markdown cell: click away and back should stay in command/view mode
-		await notebooksPositron.selectCellAtIndex(1);
+		await notebooksPositron.selectCellAtIndex(1, { editMode: true });
 		await notebooksPositron.clickAwayFromCell(1);
-		await notebooksPositron.selectCellAtIndex(1);
 		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+		await notebooksPositron.selectCellAtIndex(1);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: true });
 	});
 
 

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -290,7 +290,7 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
 
 		// From cell action menu insert cell below and verify new cell is at index 1
-		await notebooksPositron.triggerCellAction(0, 'Insert code cell below')
+		await notebooksPositron.triggerCellAction(0, 'Insert code cell below');
 		await notebooksPositron.expectCellCountToBe(6);
 		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
 

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -17,12 +17,6 @@ test.describe('Notebook Focus and Selection', {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 	});
 
-	test.beforeEach(async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		await notebooksPositron.newNotebook(5);
-		await notebooksPositron.expectCellCountToBe(5);
-	});
-
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();
 	});
@@ -30,165 +24,143 @@ test.describe('Notebook Focus and Selection', {
 	test('Notebook keyboard behavior with cells', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 3, markdownCells: 2 });
 
-		await test.step('Test 1: Arrow Down navigation moves focus to next cell', async () => {
+		await test.step('Test 1: Arrow keys move cell selection up and down', async () => {
+			// arrow down moves selection down
 			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
 			await keyboard.press('ArrowDown');
-			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
-		});
+			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false, isSelected: true });
 
-		await test.step('Test 2: Arrow Up navigation moves focus to previous cell', async () => {
+			// arrow up moves selection up
 			await notebooksPositron.selectCellAtIndex(3, { editMode: false });
 			await keyboard.press('ArrowUp');
-			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
-		});
+			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false, isSelected: true });
 
-		await test.step('Test 3: Arrow Down at last cell does not change selection', async () => {
+			// arrow down at last cell does not change selection
 			await notebooksPositron.selectCellAtIndex(4, { editMode: false });
 			await keyboard.press('ArrowDown');
-			await notebooksPositron.expectCellIndexToBeSelected(4, { inEditMode: false });
-		});
+			await notebooksPositron.expectCellIndexToBeSelected(4, { inEditMode: false, isSelected: true });
 
-		await test.step('Test 4: Arrow Up at first cell does not change selection', async () => {
+			// arrow up at first cell does not change selection
 			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
 			await keyboard.press('ArrowUp');
-			await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
-		});
+			await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false, isSelected: true });
 
-		await test.step('Test 5: Focus is maintained across multiple navigation operations', async () => {
 			// Navigate down multiple times
 			await keyboard.press('ArrowDown');
-			await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
-
 			await keyboard.press('ArrowDown');
-			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
-
 			await keyboard.press('ArrowDown');
 			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: false });
-
-			// Navigate up
-			await keyboard.press('ArrowUp');
-			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
-		});
-
-
-		await test.step('Test 6: Cell regains edit mode when clicking away and back', async () => {
-			// verify we are starting with 5 cells
-			await notebooksPositron.expectCellCountToBe(5);
-			await notebooksPositron.selectCellAtIndex(1);
-
-			// click away to defocus cell
-			const active = notebooksPositron.cell.nth(1);
-			const box = await active.boundingBox();
-			if (box) {
-				const page = app.code.driver.page;
-				// We want to offset the click as little as possible to avoid
-				// clicking other interactive elements. Here we're clicking just
-				// below the bottom right of the cell which should be a safe
-				// area due to that being where the cell padding is.
-				const OFFSET = 10;
-				const x = box.x + box.width - OFFSET;
-				const y = box.y + box.height + OFFSET;
-
-				await page.mouse.click(x, y);
-			}
-
-			// click back on cell to re-focus
-			await notebooksPositron.selectCellAtIndex(1);
-
-			// verify backspace deletes cell content not cell (indicating edit mode is active)
-			await keyboard.press('Backspace');
-			await notebooksPositron.expectCellCountToBe(5);
-		});
-
-		await test.step('Test 7: Shift+Arrow Down adds next cell to selection', async () => {
-			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
-			await keyboard.press('Shift+ArrowDown');
-			await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
-			await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
 		});
 	});
+
+
+	test('Click away and back: code cell re-enters edit mode, markdown stays in view mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 1 });
+
+		// Code cell: click away and back should restore edit mode
+		await notebooksPositron.selectCellAtIndex(0);
+		await notebooksPositron.clickAwayFromCell(0);
+		await notebooksPositron.selectCellAtIndex(0);
+
+		// verify backspace deletes cell content not cell (indicating edit mode is active)
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+		await keyboard.press('Backspace');
+		await notebooksPositron.expectCellCountToBe(2);
+
+		// Markdown cell: click away and back should stay in command/view mode
+		await notebooksPositron.selectCellAtIndex(1);
+		await notebooksPositron.clickAwayFromCell(1);
+		await notebooksPositron.selectCellAtIndex(1);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+	});
+
 
 	test('Editor mode behavior with notebook cells', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
 
-		await test.step('Test 1: Clicking into cell focuses editor and enters edit mode', async () => {
-			// Clicking on cell should focus and enter edit mode
-			await notebooksPositron.selectCellAtIndex(1);
-			await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false, inEditMode: false });
-			await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true, inEditMode: true });
-			await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false, inEditMode: false });
-			await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: false, inEditMode: false });
-			await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: false, inEditMode: false });
+		await test.step('Test 1: Clicking/dbl clicking into cell focuses editor and enters edit mode', async () => {
+			// Can successfully enter edit mode in code cell by clicking and typing
+			await notebooksPositron.selectCellAtIndex(0);
+			await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: true });
+			await keyboard.type('cell editor good');
+			await notebooksPositron.expectCellContentAtIndexToContain(0, 'cell editor good');
 
-			// Verify we can type into the editor after clicking
-			await keyboard.type('# editor good');
-			await notebooksPositron.expectCellContentAtIndexToContain(1, '# editor good');
+			// Can successfully enter edit mode in markdown cell by double clicking and typing
+			await notebooksPositron.selectCellAtIndex(2, { editMode: true });
+			await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true });
+			await keyboard.type('markdown editor good');
+			await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown editor good');
 		});
 
 		await test.step('Test 2: Enter key on selected cell enters edit mode and doesn\'t add new lines', async () => {
-			// Verify pressing Enter enters edit mode
-			await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+			// Verify pressing Enter enters edit mode on code cell
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+			await keyboard.press('Enter');
+			await notebooksPositron.expectCellIndexToBeSelected(0, {
+				isSelected: true,
+				inEditMode: true
+			});
+			await keyboard.type('code enter key');
+			await notebooksPositron.expectCellContentAtIndexToContain(0, 'code enter key');
+
+			// Verify pressing Enter enters edit mode on markdown cell
+			await notebooksPositron.selectCellAtIndex(2);
 			await keyboard.press('Enter');
 			await notebooksPositron.expectCellIndexToBeSelected(2, {
 				isSelected: true,
 				inEditMode: true
 			});
-
-			// Verify we can type into the editor after pressing Enter
-			await keyboard.type('# test');
-			await notebooksPositron.expectCellContentAtIndexToContain(2, /^# Cell 2# test/);
+			await keyboard.type('markdown enter key');
+			await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown enter key');
 		});
 
 		await test.step('Test 3: Shift+Enter on last cell creates new cell and enters edit mode', async () => {
 			// Verify pressing Shift+Enter adds a new cell below
-			await notebooksPositron.selectCellAtIndex(4);
-			await notebooksPositron.expectCellCountToBe(5);
+			await notebooksPositron.selectCellAtIndex(2);
+			await notebooksPositron.expectCellCountToBe(3);
 			await keyboard.press('Shift+Enter');
-			await notebooksPositron.expectCellCountToBe(6);
+			await notebooksPositron.expectCellCountToBe(4);
 
-			// Verify the NEW cell (index 5) is now in edit mode with focus
-			await notebooksPositron.expectCellIndexToBeSelected(5, { inEditMode: true });
+			// Verify the NEW cell (index 3) is now in edit mode with focus
+			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: true });
 
 			// Verify we can type immediately in the new cell
 			await keyboard.type('new cell content');
-			await notebooksPositron.expectCellContentAtIndexToContain(5, 'new cell content');
+			await notebooksPositron.expectCellContentAtIndexToContain(3, 'new cell content');
 		});
 
 		await test.step('Enter key in edit mode adds newline within cell', async () => {
-			const lineText = '# Cell 3';
-			const numCells = 6;
+			const lineText = '# Cell 1';
 
-			// Start with 6 cells
-			await notebooksPositron.expectCellCountToBe(numCells);
-
-			// Go into edit mode in cell 3
-			await notebooksPositron.selectCellAtIndex(3);
-			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: true });
-			await notebooksPositron.expectCellContentAtIndexToBe(3, lineText);
+			// Go into edit mode in cell index 1
+			await notebooksPositron.selectCellAtIndex(1, { editMode: true });
+			await notebooksPositron.expectCellContentAtIndexToBe(1, lineText);
 
 			// Position cursor in the middle of the cells contents to avoid any trailing newline trimming issues
 			await keyboard.press('Home');
 			const middleIndex = Math.floor(lineText.length / 2);
 			for (let i = 0; i < middleIndex; i++) { // move to middle of line
-				await notebooksPositron.editorAtIndex(3).press('ArrowRight');
+				await notebooksPositron.editorAtIndex(1).press('ArrowRight');
 			}
 
 			// Verify the content was splits into two lines
-			await notebooksPositron.expectCellToHaveLineCount({ cellIndex: 3, numLines: 1 });
+			await notebooksPositron.expectCellToHaveLineCount({ cellIndex: 1, numLines: 1 });
 			await app.code.driver.page.keyboard.press('Enter');
-			await notebooksPositron.expectCellToHaveLineCount({ cellIndex: 3, numLines: 2 });
-			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: true });
-
-			// Verify we still have the same number of cells we started with
-			await notebooksPositron.expectCellCountToBe(numCells);
+			await notebooksPositron.expectCellToHaveLineCount({ cellIndex: 1, numLines: 2 });
+			await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: true });
 		});
 	});
 
 	test('Notebook navigation and default cell selection', async function ({ app }) {
 		const { notebooks, notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 3, markdownCells: 1 });
 
 		const clickTab = (name: string | RegExp) => app.code.driver.page.getByRole('tab', { name }).click();
 		// Depending on when this test is run, the untitled notebook may have a different number
@@ -239,14 +211,14 @@ test.describe('Notebook Focus and Selection', {
 	test("`+ Code` and `+ Markdown` buttons insert the cell after the active cell and make it the new active cell)", async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
 
-		// Start a new notebook with 3 cells
-		await notebooksPositron.newNotebook(3);
+		// Select code cell at index 1
 		await notebooksPositron.selectCellAtIndex(1);
 		await notebooksPositron.expectCellIndexToBeSelected(1, { isActive: true, inEditMode: true });
 
 		// Click the + Code button and verify the cell is inserted after the active cell
-		await notebooksPositron.codeButton.click();
+		await notebooksPositron.addCell('code');
 		await notebooksPositron.expectCellCountToBe(4);
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isActive: true, inEditMode: true });
 
@@ -255,7 +227,7 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellContentAtIndexToContain(2, 'print("Hello, World!")');
 
 		// Click the + Markdown button and verify the cell is inserted after the active cell
-		await notebooksPositron.markdownButton.click();
+		await notebooksPositron.addCell('markdown');
 		await notebooksPositron.expectCellCountToBe(5);
 		await notebooksPositron.expectCellIndexToBeSelected(3, { isActive: true, inEditMode: true });
 
@@ -268,8 +240,8 @@ test.describe('Notebook Focus and Selection', {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
-		// Start a new notebook with 5 cells and select cell 2
-		await notebooksPositron.newNotebook(5);
+		// Create a new notebook with 5 cells and select cell 2
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 3 });
 		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
 
 		// Multi-select up to cell 0 and verify anchor is cell 0
@@ -307,7 +279,7 @@ test.describe('Notebook Focus and Selection', {
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Start a new notebook with 5 cells and select cell 2
-		await notebooksPositron.newNotebook(5);
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 3 });
 		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
 
 		// Multi-select up to cell 0 and verify anchor is cell 0

--- a/test/e2e/tests/notebooks-positron/notebook-markdown.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-markdown.test.ts
@@ -55,8 +55,7 @@ test.describe('Positron Notebooks: Markdown Cells', {
 
 		// verify markdown cell created and in edit mode
 		await notebooksPositron.expectCellCountToBe(2);
-		// ISSUE # 10255 - markdown cell is not in edit mode by default after creation
-		// await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: true });
 
 		// add markdown content to cell
 		await notebooksPositron.addCodeToCell(1, 'This is **bold** and this is *italic*');


### PR DESCRIPTION
### Summary
* Extending test coverage to also check behaviors for markdown cells.
* For merge and full suite workflows: fixing GH Report summary to only occur on merge step and not individual shards.


### QA Notes

@:positron-notebooks