### PR TITLE
e2e: address flake in nb working dir test

### DIFF
--- a/test/e2e/tests/notebook/notebook-working-directory.test.ts
+++ b/test/e2e/tests/notebook/notebook-working-directory.test.ts
@@ -70,7 +70,7 @@ test.describe('Notebook Working Directory Configuration', {
 });
 
 async function verifyWorkingDirectoryEndsWith(notebooks: Notebooks, expectedEnd: string) {
-	await notebooks.openNotebook('working-directory.ipynb');
+	await notebooks.openNotebook('working-directory.ipynb', false);
 	await notebooks.selectInterpreter('Python');
 	await notebooks.runAllCells();
 	await notebooks.assertCellOutput(new RegExp(`^'.*${expectedEnd}'$`));


### PR DESCRIPTION
### Summary

Addressing a flake in `notebooks-working-dir` test. The extra assert (checking for active cell) that is part of opening a notebook is not needed in this test. This was sometimes causing the test to fail/flake.

### QA Notes
@:notebooks