### PR TITLE
e2e: adding notebook multiselect tests

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -680,6 +680,11 @@ export class PositronNotebooks extends Notebooks {
 		});
 	}
 
+	/**
+	 * Verify: multiple cells are selected.
+	 * @param expectedIndices - The indices of the cells expected to be selected.
+	 * @param timeout - Timeout for the expectation.
+	 */
 	async expectCellsToBeSelected(expectedIndices: number[], timeout = DEFAULT_TIMEOUT): Promise<void> {
 		await test.step(`Verify cells at indices [${expectedIndices.join(', ')}] are selected`, async () => {
 			for (const index of expectedIndices) {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -68,9 +68,31 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
+	 * Get cell content at specified index.
+	 * @param cellIndex - The index of the cell.
+	 * @returns - The content of the cell.
+	 */
+	async getCellContent(cellIndex: number): Promise<string> {
+		const cellType = await this.getCellType(cellIndex);
+		return cellType === 'code'
+			? await this.getCodeCellContent(cellIndex)
+			: await this.getMarkdownCellContent(cellIndex);
+	}
+
+
+	/**
+	 * Get markdown cell content at specified index.
+	 */
+	private async getMarkdownCellContent(cellIndex: number): Promise<string> {
+		return await test.step(`Get markdown content of cell at index: ${cellIndex}`, async () => {
+			return await this.cellMarkdown(cellIndex).textContent() ?? '';
+		});
+	}
+
+	/**
 	 * Get code cell content at specified index.
 	 */
-	async getCodeCellContent(cellIndex: number): Promise<string> {
+	private async getCodeCellContent(cellIndex: number): Promise<string> {
 		return await test.step(`Get content of cell at index: ${cellIndex}`, async () => {
 			const editor = this.cell.nth(cellIndex).locator('.positron-cell-editor-monaco-widget .view-lines');
 			const content = await editor.textContent() ?? '';
@@ -531,7 +553,7 @@ export class PositronNotebooks extends Notebooks {
 			const cellType = await this.getCellType(cellIndex);
 			const actualContent = cellType === 'code'
 				? await this.getCodeCellContent(cellIndex)
-				: await this.cellMarkdown(cellIndex).textContent() ?? '';
+				: await this.getMarkdownCellContent(cellIndex);
 			await expect(async () => {
 				expect(actualContent).toBe(expectedContent);
 			}).toPass({ timeout: DEFAULT_TIMEOUT });

--- a/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
@@ -35,7 +35,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.selectCellAtIndex(2);
 
 			// Verify cell 2 has correct content before deletion
-			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 2');
+			expect(await notebooksPositron.getCodeCellContent(2)).toBe('# Cell 2');
 
 			// Delete the selected cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(2);
@@ -44,7 +44,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(5);
 
 			// Verify what was cell 3 is now at index 2
-			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+			expect(await notebooksPositron.getCodeCellContent(2)).toBe('# Cell 3');
 		});
 
 		// ========================================
@@ -94,7 +94,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 		// ========================================
 		await test.step('Test 4: Delete first cell (cell 0)', async () => {
 			// Verify we're at the first cell with correct content
-			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+			expect(await notebooksPositron.getCodeCellContent(0)).toBe('# Cell 0');
 
 			// Delete the first cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(0);
@@ -103,8 +103,8 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(2);
 
 			// Verify what was cell 1 is now at index 0
-			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 1');
-			expect(await notebooksPositron.getCellContent(1)).toBe('# Cell 3');
+			expect(await notebooksPositron.getCodeCellContent(0)).toBe('# Cell 1');
+			expect(await notebooksPositron.getCodeCellContent(1)).toBe('# Cell 3');
 		});
 
 		// ========================================

--- a/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
@@ -35,7 +35,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.selectCellAtIndex(2);
 
 			// Verify cell 2 has correct content before deletion
-			expect(await notebooksPositron.getCodeCellContent(2)).toBe('# Cell 2');
+			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 2');
 
 			// Delete the selected cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(2);
@@ -44,7 +44,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(5);
 
 			// Verify what was cell 3 is now at index 2
-			expect(await notebooksPositron.getCodeCellContent(2)).toBe('# Cell 3');
+			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 3');
 		});
 
 		// ========================================
@@ -94,7 +94,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 		// ========================================
 		await test.step('Test 4: Delete first cell (cell 0)', async () => {
 			// Verify we're at the first cell with correct content
-			expect(await notebooksPositron.getCodeCellContent(0)).toBe('# Cell 0');
+			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 0');
 
 			// Delete the first cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(0);
@@ -103,8 +103,8 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(2);
 
 			// Verify what was cell 1 is now at index 0
-			expect(await notebooksPositron.getCodeCellContent(0)).toBe('# Cell 1');
-			expect(await notebooksPositron.getCodeCellContent(1)).toBe('# Cell 3');
+			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 1');
+			expect(await notebooksPositron.getCellContent(1)).toBe('# Cell 3');
 		});
 
 		// ========================================

--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -34,9 +34,9 @@ test.describe('Notebook Cell Reordering', {
 		expect(initialCount).toBeGreaterThan(2); // Need at least 3 cells to test moving
 
 		// Get the content of the first three cells to verify order
-		const cell0Content = await notebooksPositron.getCodeCellContent(0);
-		const cell1Content = await notebooksPositron.getCodeCellContent(1);
-		const cell2Content = await notebooksPositron.getCodeCellContent(2);
+		const cell0Content = await notebooksPositron.getCellContent(0);
+		const cell1Content = await notebooksPositron.getCellContent(1);
+		const cell2Content = await notebooksPositron.getCellContent(2);
 
 		// Select "Move cell down"
 		await notebooksPositron.triggerCellAction(0, 'Move cell down');

--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -34,9 +34,9 @@ test.describe('Notebook Cell Reordering', {
 		expect(initialCount).toBeGreaterThan(2); // Need at least 3 cells to test moving
 
 		// Get the content of the first three cells to verify order
-		const cell0Content = await notebooksPositron.getCellContent(0);
-		const cell1Content = await notebooksPositron.getCellContent(1);
-		const cell2Content = await notebooksPositron.getCellContent(2);
+		const cell0Content = await notebooksPositron.getCodeCellContent(0);
+		const cell1Content = await notebooksPositron.getCodeCellContent(1);
+		const cell2Content = await notebooksPositron.getCodeCellContent(2);
 
 		// Select "Move cell down"
 		await notebooksPositron.triggerCellAction(0, 'Move cell down');
@@ -134,5 +134,25 @@ test.describe('Notebook Cell Reordering', {
 		// Redo the move
 		await notebooksPositron.performCellAction('redo');
 		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0', '# Cell 2']);
+	});
+
+	// @dhruvisompura unskip me
+	test.skip('Multiselect: move multiple cells', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create notebook with 5 cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 3 });
+
+		// Select cells 1, 2, and 3
+		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([1, 2, 3]);
+
+		// Move selected cells down
+		await keyboard.press('Alt+ArrowDown');
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', 'Cell 4', '# Cell 1', 'Cell 2', 'Cell 3']);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
@@ -99,7 +99,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		await test.step('Test 4: Cut and paste at beginning of notebook', async () => {
 			// Cut cell 4 (from the middle of the notebook)
 			await notebooksPositron.selectCellAtIndex(4, { editMode: false });
-			const cellToMoveContent = await notebooksPositron.getCodeCellContent(4);
+			const cellToMoveContent = await notebooksPositron.getCellContent(4);
 			await notebooksPositron.performCellAction('cut');
 			await notebooksPositron.expectCellCountToBe(7);
 

--- a/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename
@@ -22,16 +21,9 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Should correctly copy and paste cell content in various scenarios', async function ({ app }) {
+	test('Single: Copy and paste cell content in various scenarios', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
-
-		// ========================================
-		// Setup: Create 5 cells with distinct content
-		// ========================================
-		await test.step('Test Setup: Create notebook and add cells', async () => {
-			await notebooksPositron.newNotebook({ codeCells: 5 });
-			await notebooksPositron.expectCellCountToBe(5);
-		});
+		await notebooksPositron.newNotebook({ codeCells: 5 });
 
 		// ========================================
 		// Test 1: Copy single cell and paste at end
@@ -48,7 +40,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 			await notebooksPositron.expectCellCountToBe(6);
 
 			// Verify pasted contents are correct at new index 5
-			expect(await notebooksPositron.getCellContent(5)).toBe('# Cell 2');
+			await notebooksPositron.expectCellContentAtIndexToBe(5, '# Cell 2');
 		});
 
 		// ========================================
@@ -107,7 +99,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		await test.step('Test 4: Cut and paste at beginning of notebook', async () => {
 			// Cut cell 4 (from the middle of the notebook)
 			await notebooksPositron.selectCellAtIndex(4, { editMode: false });
-			const cellToMoveContent = await notebooksPositron.getCellContent(4);
+			const cellToMoveContent = await notebooksPositron.getCodeCellContent(4);
 			await notebooksPositron.performCellAction('cut');
 			await notebooksPositron.expectCellCountToBe(7);
 
@@ -131,5 +123,32 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 
 			await notebooksPositron.expectCellCountToBe(0);
 		});
+	});
+
+	// @dhruvisompura unskip me
+	test.skip('Multiselect: Cut from top and paste at bottom', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create notebook with 5 cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 3 });
+
+		// Select cells 0, 1, and 2
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
+
+		// Cut selected cells
+		await notebooksPositron.performCellAction('cut');
+		await notebooksPositron.expectCellContentsToBe(['Cell 3', 'Cell 4']);
+
+		// Select last cell and paste below
+		const lastIndex = await notebooksPositron.getCellCount() - 1;
+		await notebooksPositron.selectCellAtIndex(lastIndex, { editMode: false });
+		await notebooksPositron.performCellAction('paste');
+
+		// Verify moved cells are at the end
+		await notebooksPositron.expectCellContentsToBe(['Cell 3', 'Cell 4', '# Cell 0', '# Cell 1', 'Cell 2']);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-undo-redo.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-undo-redo.test.ts
@@ -22,38 +22,24 @@ test.describe('Positron Notebooks: Cell Undo-Redo Behavior', {
 	});
 
 	test('Should correctly undo and redo cell actions', async function ({ app }) {
-		const { notebooks, notebooksPositron } = app.workbench;
+		const { notebooksPositron } = app.workbench;
 
-		await test.step('Test Setup: Create notebook', async () => {
-			await notebooks.createNewNotebook();
-			await notebooksPositron.expectToBeVisible();
-		});
+		await notebooksPositron.newNotebook({ codeCells: 2 });
 
 		// ========================================
 		// Test 1: Basic add cell and undo/redo
 		// ========================================
 		await test.step('Test 1: Add cell and undo/redo', async () => {
-			// Start with initial cell
-			await notebooksPositron.addCodeToCell(0, '# Initial Cell');
-			await notebooksPositron.expectCellCountToBe(1);
-			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Initial Cell');
-
-			// Add a second cell
-			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-			await notebooksPositron.performCellAction('addCellBelow');
-			await notebooksPositron.addCodeToCell(1, '# Second Cell');
-			await notebooksPositron.expectCellCountToBe(2);
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Second Cell');
-
-			// Undo the add cell operation
+			// Undo the last cell operation
+			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
 			await notebooksPositron.performCellAction('undo');
 			await notebooksPositron.expectCellCountToBe(1);
-			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Initial Cell');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
 
 			// Redo the add cell operation to add back cell
 			await notebooksPositron.performCellAction('redo');
 			await notebooksPositron.expectCellCountToBe(2);
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Second Cell');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
 		});
 
 		// ========================================
@@ -61,23 +47,21 @@ test.describe('Positron Notebooks: Cell Undo-Redo Behavior', {
 		// ========================================
 		await test.step('Test 2: Delete cell and undo/redo', async () => {
 			// Add a third cell for deletion test
-			await notebooksPositron.selectCellAtIndex(1);
+			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
 			await notebooksPositron.performCellAction('addCellBelow');
 			await notebooksPositron.addCodeToCell(2, '# Cell to Delete');
 			await notebooksPositron.expectCellCountToBe(3);
 
 			// Delete the middle cell
-			await notebooksPositron.selectCellAtIndex(1);
+			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
 			await notebooksPositron.performCellAction('delete');
 			await notebooksPositron.expectCellCountToBe(2);
-			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Initial Cell');
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell to Delete');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell to Delete']);
 
 			// Undo the delete
 			await notebooksPositron.performCellAction('undo');
 			await notebooksPositron.expectCellCountToBe(3);
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Second Cell');
-			await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell to Delete');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell to Delete']);
 
 			// Redo the delete
 			await notebooksPositron.performCellAction('redo');


### PR DESCRIPTION
### Summary
Adding a couple notebook tests focused on multiselect behavior:
* moving a series of cells together
* cut a series of cells from top, paste to bottom

Also general housekeeping on some tests, but no functional changes.

Next up:
* I'll be working on empty notebook and all the commands (cut, copy, paste, redo, undo, etc)

### QA Notes
@:positron-notebooks