### PR TITLE
stop installing incompatible recursive extension dependencies

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -36,7 +36,8 @@ import { IMarkdownString, MarkdownString } from '../../../base/common/htmlConten
 
 // --- Start Positron ---
 /**
- * List of extension IDs that conflict with Positron built-in features
+ * List of extension IDs that conflict with Positron built-in features.
+ * Please use lower case for everything in here.
  */
 const kPositronDuplicativeExtensions = [
 	'ikuyadeu.r',
@@ -48,7 +49,7 @@ const kPositronDuplicativeExtensions = [
 	'jeanp413.open-remote-ssh',
 	'ms-python.python',
 	'ms-python.vscode-python-envs',
-	'GitHub.copilot-chat'
+	'github.copilot-chat'
 ];
 
 export interface PositronExtensionCompatibility {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/10423. Adds the `ms-python.vscode-python-envs` extension to the list of incompatible Positron extensions.

I also noticed that it was still getting installed as a recursive dependency of other extensions like Pyrefly. So this PR also adds some code that checks for compatibility of recursive dependencies before installing them. In order to do that, I had to move some stuff from the workbench level to the platform level.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Stop the Python Environments Extension from being installed because it conflicts with internal features. You may want to uninstall this extension if it's installed already.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
The python environments extension shouldn't be installable directly or as a dependency of e.g. pyrefly or ty.

If you had it before, it won't delete it.

@ Julia: add a release note reminding users to uninstall this extension.