### PR TITLE
[maint] update 1.106 dependencies for positron-python

### DIFF
--- a/extensions/positron-python/package-lock.json
+++ b/extensions/positron-python/package-lock.json
@@ -59,7 +59,7 @@
                 "@types/sinon": "^17.0.3",
                 "@types/stack-trace": "0.0.29",
                 "@types/tmp": "^0.0.33",
-                "@types/vscode": "^1.104.0",
+                "@types/vscode": "^1.106.0",
                 "@types/webpack": "^5.28.5",
                 "@types/which": "^2.0.1",
                 "@types/winreg": "^1.2.30",
@@ -1850,9 +1850,9 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.105.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.105.0.tgz",
-            "integrity": "sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==",
+            "version": "1.106.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
+            "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -2163,7 +2163,7 @@
         "@types/sinon": "^17.0.3",
         "@types/stack-trace": "0.0.29",
         "@types/tmp": "^0.0.33",
-        "@types/vscode": "^1.104.0",
+        "@types/vscode": "^1.106.0",
         "@types/webpack": "^5.28.5",
         "@types/which": "^2.0.1",
         "@types/winreg": "^1.2.30",


### PR DESCRIPTION
repeat of #9947 for the latest upstream merge! 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Update vscode types in `positron-python` extension.


### QA Notes

CI is green
