### PR TITLE
e2e: add notebook delete and multiselect tests

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -204,6 +204,7 @@ export class PositronNotebooks extends Notebooks {
 		if (codeCells > 0) {
 			for (let i = 0; i < codeCells; i++) {
 				await this.addCodeToCell(i, `# Cell ${i}`);
+				await this.expectCellCountToBe(totalCellsAdded + 1);
 				totalCellsAdded++;
 			}
 		}
@@ -212,10 +213,10 @@ export class PositronNotebooks extends Notebooks {
 			for (let i = 0; i < markdownCells; i++) {
 				await this.addCell('markdown');
 				await keyboard.type(`### Cell ${totalCellsAdded}`);
+				await this.expectCellCountToBe(totalCellsAdded + 1);
 				totalCellsAdded++;
 			}
 		}
-		await this.expectCellCountToBe(codeCells + markdownCells);
 	}
 
 	/**
@@ -455,6 +456,7 @@ export class PositronNotebooks extends Notebooks {
 					await this.code.driver.page.keyboard.press('KeyV');
 					break;
 				case 'undo':
+					// await this.hotKeys.undo();
 					await this.code.driver.page.keyboard.press('KeyZ');
 					break;
 				case 'redo':

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -456,7 +456,6 @@ export class PositronNotebooks extends Notebooks {
 					await this.code.driver.page.keyboard.press('KeyV');
 					break;
 				case 'undo':
-					// await this.hotKeys.undo();
 					await this.code.driver.page.keyboard.press('KeyZ');
 					break;
 				case 'redo':

--- a/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
@@ -31,7 +31,6 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		await test.step('Test 1: Copy single cell and paste at end', async () => {
 			// Perform copy on cell 2
 			await notebooksPositron.selectCellAtIndex(2, { editMode: false });
-			await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
 			await notebooksPositron.performCellAction('copy');
 
 			// Move to last cell and perform paste
@@ -40,7 +39,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 			await notebooksPositron.expectCellCountToBe(6);
 
 			// Verify pasted contents are correct at new index 5
-			await notebooksPositron.expectCellContentAtIndexToBe(5, '# Cell 2');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '# Cell 2', '# Cell 3', '# Cell 4', '# Cell 2']);
 		});
 
 		// ========================================
@@ -48,13 +47,12 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		// ========================================
 		await test.step('Test 2: Cut single cell and paste at different position', async () => {
 			// Perform cut on cell 1
-			await notebooksPositron.selectCellAtIndex(1, { editMode: false });
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 1');
+			await notebooksPositron.selectCellAtIndex(1, { editMode: false }); // # Cell 1
 			await notebooksPositron.performCellAction('cut');
 
 			// Verify cell count decreased and cell 1 is removed
 			await notebooksPositron.expectCellCountToBe(5);
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 2');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 2', '# Cell 3', '# Cell 4', '# Cell 2']);
 
 			// Move to index 3 and paste
 			await notebooksPositron.selectCellAtIndex(3, { editMode: false });
@@ -62,27 +60,24 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 
 			// Verify cell count restored and cell content is correct
 			await notebooksPositron.expectCellCountToBe(6);
-			await notebooksPositron.expectCellContentAtIndexToBe(4, '# Cell 1');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 2', '# Cell 3', '# Cell 4', '# Cell 1', '# Cell 2']);
 		});
 
 		// ========================================
 		// Test 3: Copy cell and paste multiple times (clipboard persistence)
 		// ========================================
 		await test.step('Test 3: Copy cell and paste multiple times (clipboard persistence)', async () => {
-			await notebooksPositron.expectCellCountToBe(6);
-
 			// Copy cell 0
-			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false }); // # Cell 0
 			await notebooksPositron.performCellAction('copy');
 
 			// Paste at position 2
-			await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+			await notebooksPositron.selectCellAtIndex(2, { editMode: false }); // # Cell 3
 			await notebooksPositron.performCellAction('paste');
 
 			// Verify first paste
 			await notebooksPositron.expectCellCountToBe(7);
-			await notebooksPositron.expectCellContentAtIndexToBe(3, '# Cell 0');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 2', '# Cell 3', '# Cell 0', '# Cell 4', '# Cell 1', '# Cell 2']);
 
 			// Paste again at position 5
 			await notebooksPositron.selectCellAtIndex(5, { editMode: false });
@@ -90,7 +85,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 
 			// Verify second paste
 			await notebooksPositron.expectCellCountToBe(8);
-			await notebooksPositron.expectCellContentAtIndexToBe(6, '# Cell 0');
+			await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 2', '# Cell 3', '# Cell 0', '# Cell 4', '# Cell 1', '# Cell 0', '# Cell 2']);
 		});
 
 		// ========================================
@@ -110,18 +105,6 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 			// Verify cell count restored and content is correct
 			await notebooksPositron.expectCellCountToBe(8);
 			await notebooksPositron.expectCellContentAtIndexToBe(1, cellToMoveContent);
-		});
-
-		// ========================================
-		// Test 5: Cut all cells and verify notebook can be empty
-		// ========================================
-		await test.step('Verify other cells shifted down correctly', async () => {
-			while (await notebooksPositron.getCellCount() > 0) {
-				await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-				await notebooksPositron.performCellAction('cut');
-			}
-
-			await notebooksPositron.expectCellCountToBe(0);
 		});
 	});
 

--- a/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Focus and Selection', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Delete single cell moves focus to correct cell', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// create a new notebook with 2 code cells and 2 markdown cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 2 });
+
+		// delete from top/middle moves focus down to next cell
+		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+		await notebooksPositron.performCellAction('delete');
+		await notebooksPositron.expectCellCountToBe(3);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', 'Cell 3']);
+		await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
+
+		// delete from bottom moves focus up to previous cell
+		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+		await notebooksPositron.performCellAction('delete');
+		await notebooksPositron.expectCellCountToBe(2);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+	});
+
+	test('Delete multiple selected cells moves focus to correct cell', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// create a new notebook with 8 code cells
+		await notebooksPositron.newNotebook({ codeCells: 8 });
+
+		// Multiselect and delete cells in middle
+		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown'); // cells at index 1,2,3 selected
+		await notebooksPositron.performCellAction('delete');
+		await notebooksPositron.expectCellCountToBe(5);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 4', '# Cell 5', '# Cell 6', '# Cell 7']);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+
+		// Multiselect and delete multiple cells at end
+		await notebooksPositron.selectCellAtIndex(4, { editMode: false });
+		await keyboard.press('Shift+ArrowUp');
+		await keyboard.press('Shift+ArrowUp');
+		await notebooksPositron.performCellAction('delete'); // cells at index 2,3,4 selected
+		await notebooksPositron.expectCellCountToBe(2);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 4']);
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+	});
+});
+

--- a/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Notebook Focus and Selection', {
+test.describe('Notebook: Delete', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook: Empty State Behavior', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Can delete all, undo, redo on empty notebook', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// create a new notebook with 2 code cells and 2 markdown cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 2 });
+
+		// Delete all cells via multiselect
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown'); // all 4 cells selected
+		await notebooksPositron.performCellAction('delete');
+		await notebooksPositron.expectCellCountToBe(0);
+
+		// @dhruvisompura skipped while you fix this
+		// Ensure can undo to restore cells
+		// await notebooksPositron.performCellAction('undo');
+		// await notebooksPositron.expectCellCountToBe(4);
+		// await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', 'Cell 2', 'Cell 3']);
+
+		// // Ensure can redo to delete cells again
+		// await notebooksPositron.performCellAction('redo');
+		// await notebooksPositron.expectCellCountToBe(0);
+
+		// cut? paste? undo? redo?
+	});
+});


### PR DESCRIPTION
### Summary
Just extending notebooks e2e test coverage to include:
* delete cell behavior
* empty notebook state behavior

### QA Notes

@:positron-notebooks @:web @:windows