### PR TITLE
[python] filter syntax ipykernel warnings

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -519,7 +519,6 @@ class PositronIPyKernel(IPythonKernel):
             "ignore",
             category=SyntaxWarning,
             message=r"'return' in a 'finally' block",
-            module="ipykernel",
         )
 
         # Patch holoviews to use our custom notebook extension.

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -513,6 +513,15 @@ class PositronIPyKernel(IPythonKernel):
             module="jedi",
         )
 
+        # Due to PEP0765, this is fixed in ipython 9.X, but we bundle
+        # earlier versions to support Python 3.10
+        warnings.filterwarnings(
+            "ignore",
+            category=SyntaxWarning,
+            message=r"'return' in a 'finally' block",
+            module="ipykernel",
+        )
+
         # Patch holoviews to use our custom notebook extension.
         set_holoviews_extension(self.ui_service)
         handle_bokeh_output(self.session_mode)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #9655 Silence non-actionable syntax warnings in Python 3.14 coming from `ipykernel`.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
