### PR TITLE
add click of toast button to shiny test

### DIFF
--- a/test/e2e/tests/shiny/shiny.test.ts
+++ b/test/e2e/tests/shiny/shiny.test.ts
@@ -27,6 +27,11 @@ test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tag
 			: app.workbench.viewer.getViewerLocator('h1');
 
 		await expect(async () => {
+			// Check if "Keep waiting" button appears and click it if present
+			const keepWaitingButton = app.workbench.toasts.getOptionButton('Keep waiting');
+			if (await keepWaitingButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+				await keepWaitingButton.click();
+			}
 			await expect(headerLocator).toHaveText('Restaurant tipping', { timeout: 20000 });
 		}).toPass({ timeout: 60000 });
 	});


### PR DESCRIPTION
Fix for flaky shiny test.

It now takes over the 10s threshold to start and a toast pops that needs to be dismissed for the app to show.

### QA Notes
@:apps
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
