### PR TITLE
catalog-explorer: Surface the Snowflake user and role in the tooltip

### DIFF
--- a/extensions/positron-catalog-explorer/src/catalog.ts
+++ b/extensions/positron-catalog-explorer/src/catalog.ts
@@ -24,7 +24,7 @@ export interface CatalogProvider extends vscode.Disposable {
 	/**
 	 * Get additional details about the given node, if any.
 	 */
-	getDetails(node: CatalogNode): Promise<string | undefined>;
+	getDetails(node: CatalogNode): Promise<string | vscode.MarkdownString | undefined>;
 
 	/**
 	 * Get the children of the given node, or the top-level children of the
@@ -60,7 +60,7 @@ export class CatalogNode {
 		public readonly resourceUri?: vscode.Uri,
 	) { }
 
-	async getDetails(): Promise<string | undefined> {
+	async getDetails(): Promise<string | vscode.MarkdownString | undefined> {
 		return await this.provider.getDetails(this);
 	}
 


### PR DESCRIPTION
Previously we showed the user and role from the `connections.toml` file in the tooltip for a Snowflake catalog, but this information is often missing or misleading (depending on the authentication method in use), so Chris Ostrouchov (@costrouc) suggested we retrieve it from the connection itself.

The existing `CatalogProvider` interface already has a mechanism for this kind of dynamic tooltip (via the `getDetails()` method), so this commit merely wires it up to an appropriate Snowflake SQL query.

Note that the query only runs once when the user hovers over the catalog provider for the first time, so this doesn't introduce additional overhead or increase the initial loading time the tree view.

<img width="745" height="114" alt="Screenshot_2025-11-21_19-44-17" src="https://github.com/user-attachments/assets/bc32fff1-4c52-4d7d-a46d-92fafec4b600" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

- add snowflake connection to catalog explorer
- hover over the top level node (the line with the ❄️ icon) and you should see a link to the account, your username (email), and the role you are using