### PR TITLE
Fix positron-python 1.106 build

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -54,7 +54,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.104.0"
+        "vscode": "^1.106.0"
     },
     "enableTelemetry": false,
     "keywords": [


### PR DESCRIPTION
Fix the build breakage on `positron-python`. Updates the `package.json` to require vscode 1.106.0 or greater.