### PR TITLE
e2e: update soft fail script

### DIFF
--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -489,14 +489,7 @@ jobs:
           else
             # When soft-fail is disabled, fail if ANY tests failed
             echo "Checking for any test failures in $JSON_REPORT"
-            FAILED_COUNT=$(jq '[.suites[].specs[] | select(.ok == false)] | length' "$JSON_REPORT")
-            echo "Found $FAILED_COUNT failed test(s)"
-            if [ "$FAILED_COUNT" -gt 0 ]; then
-              echo "Tests failed - exiting with error"
-              exit 1
-            else
-              echo "All tests passed"
-            fi
+            node scripts/check-soft-fail-failures.js "$JSON_REPORT" --no-soft-fail
           fi
 
       - name: Clean up blob report artifacts

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -482,15 +482,15 @@ jobs:
             exit 1
           fi
 
-          if [[ "${{ inputs.allow_soft_fail }}" == "true" ]]; then
-            # When soft-fail is enabled, only fail if non-soft-fail tests failed
-            echo "Checking for non-soft-fail failures in $JSON_REPORT"
-            node scripts/check-soft-fail-failures.js "$JSON_REPORT"
+          EXTRA_ARGS=""
+          if [[ "${{ inputs.allow_soft_fail }}" != "true" ]]; then
+            echo "SOFT-FAIL DISABLED: standard test failure behavior"
+            EXTRA_ARGS="--no-soft-fail"
           else
-            # When soft-fail is disabled, fail if ANY tests failed
-            echo "Checking for any test failures in $JSON_REPORT"
-            node scripts/check-soft-fail-failures.js "$JSON_REPORT" --no-soft-fail
+            echo "SOFT-FAIL ENABLED: soft-fail tests won't fail the job"
           fi
+
+          node scripts/check-soft-fail-failures.js "$JSON_REPORT" $EXTRA_ARGS
 
       - name: Clean up blob report artifacts
         if: success()

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Kernel Behavior', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.SOFT_FAIL] // soft fail due to https://github.com/posit-dev/positron/issues/10546
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {


### PR DESCRIPTION
### Summary
  The "Check test results" step in merge job used a flawed jq query when `allow_soft_fail: false`.

  The query had two issues:
  1. Missed nested specs - Only checked .suites[].specs[] at the first level, missing failures in nested suites
  2. Assumed .ok always exists - Failed to catch specs where .ok was missing/null

Solution:
  - Enhanced scripts/check-soft-fail-failures.js with `--no-soft-fail` flag support
  - When `--no-soft-fail` is passed, the script fails on ANY test failure (not just non-soft-fail ones)

### QA Notes

Example run: https://github.com/posit-dev/positron/actions/runs/19640792216
Another run going right now: https://github.com/posit-dev/positron/actions/runs/19644106092

In addition, I had Claude test the script changes locally:
  - ✅ Nested test failures (old jq query found 0, new script finds them)
  - ✅ Regular failures with --no-soft-fail (exit 1)
  - ✅ Soft-fail only without flag (exit 0)
  - ✅ Soft-fail only with --no-soft-fail (exit 1)
  - ✅ Mixed failures without flag (exit 1, reports only regular)
  - ✅ Mixed failures with --no-soft-fail (exit 1, reports both)
  