### PR TITLE
python: rm "preview" from new project wizard for Python 3.14

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvUtils.ts
@@ -18,7 +18,7 @@ export function getUvPythonVersions(): { versions: string[] } {
 export async function pickPythonVersion(token?: CancellationToken): Promise<string | undefined> {
     const items: QuickPickItem[] = SUPPORTED_UV_PYTHON_VERSIONS.map((v) => ({
         label: 'Python',
-        description: v === '3.14' ? `${v} (preview)` : v,
+        description: v,
     }));
     const selection = await showQuickPickWithBack(
         items,

--- a/src/vs/workbench/browser/positronNewFolderFlow/utilities/uvUtils.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/utilities/uvUtils.ts
@@ -42,7 +42,7 @@ export const uvInterpretersToDropdownItems = (
 					preferred: false,
 					runtimeId: version,
 					languageName: 'Python',
-					languageVersion: version === '3.14' ? `${version} (preview)` : version,
+					languageVersion: version,
 					runtimePath: '',
 					runtimeSource: PythonEnvironmentProvider.Uv,
 				},


### PR DESCRIPTION
to merge post #10727 

We don't have preview anywhere else for 3.14, so I feel pretty fine with removing it here.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

- go to new project wizard
- select python
- create new python 3.14 project
- should not say "(preview)" next to project

BEFORE
<img width="719" height="615" alt="Screenshot 2025-11-24 at 4 57 29 PM" src="https://github.com/user-attachments/assets/6f56ab4c-5418-474a-b784-e6ab21bb1d2c" />

AFTER
<img width="719" height="615" alt="Screenshot 2025-11-24 at 5 00 05 PM" src="https://github.com/user-attachments/assets/49561f10-45bd-4752-9293-9ef74aa79872" />

