### PR TITLE
python LSP: disable Jedi language server features redundant with Pyrefly

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -578,61 +578,6 @@ POSITRON = create_server()
 _MAGIC_COMPLETIONS: Dict[str, Any] = {}
 
 
-def _is_from_user_namespace(
-    completion: "Completion", user_ns_keys: set, document: TextDocument, position: Position
-) -> bool:
-    """
-    Check if a completion is from the user's namespace.
-
-    This filters out stdlib and third-party completions to avoid overlap with
-    other completion providers (e.g., Pyrefly) that handle those more efficiently.
-
-    Args:
-        completion: Jedi completion object
-        user_ns_keys: Set of keys from the user's namespace
-        document: The text document being completed
-        position: The cursor position
-
-    Returns:
-        True if the completion should be included, False otherwise
-    """
-    if not user_ns_keys:
-        # If there's no user namespace, don't filter anything
-        return True
-
-    # Get the base name (first part before any dots)
-    base_name = completion.name.split(".")[0]
-
-    # Include if the base name is in the user's namespace
-    if base_name in user_ns_keys:
-        return True
-
-    # For attribute completions (e.g., "my_df.column"), check if we're completing
-    # on an object from the user namespace by examining the text before the cursor
-    line = document.lines[position.line] if document.lines else ""
-    text_before_cursor = line[: position.character]
-
-    # Look for the pattern "identifier." before the cursor
-    # Match word characters (including underscores) followed by a dot
-    import re
-
-    match = re.search(r"([\w]+)\.$", text_before_cursor)
-    if match:
-        object_name = match.group(1)
-        if object_name in user_ns_keys:
-            # We're completing attributes of a user namespace object
-            return True
-
-    # Check full_name as a fallback
-    full_name = completion.full_name or ""
-    if "." in full_name:
-        root = full_name.split(".")[0]
-        if root in user_ns_keys:
-            return True
-
-    return False
-
-
 # Server Features
 # Unfortunately we need to re-register these as Pygls Feature Management does
 # not support subclassing of the LSP, and Jedi did not use the expected "ls"
@@ -672,26 +617,15 @@ def positron_completion(
     try:
         jedi_lines = jedi_utils.line_column(params.position)
         completions_jedi_raw = jedi_script.complete(*jedi_lines)
-
-        # Filter completions to only include items from the user's namespace.
-        # This prevents overlap with other completion providers (e.g., Pyrefly) that handle
-        # stdlib and general Python completions more efficiently.
-        user_ns_keys = set(server.shell.user_ns.keys()) if server.shell else set()
-
         if not ignore_patterns:
             # A performance optimization. ignore_patterns should usually be empty;
             # this special case avoid repeated filter checks for the usual case.
-            completions_jedi = (
-                comp
-                for comp in completions_jedi_raw
-                if _is_from_user_namespace(comp, user_ns_keys, document, params.position)
-            )
+            completions_jedi = (comp for comp in completions_jedi_raw)
         else:
             completions_jedi = (
                 comp
                 for comp in completions_jedi_raw
                 if not any(i.match(comp.name) for i in ignore_patterns)
-                and _is_from_user_namespace(comp, user_ns_keys, document, params.position)
             )
         snippet_support = get_capability(
             server.client_capabilities,

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -301,11 +301,9 @@ class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
             else None
         )
 
-        # DON'T MERGE: Unregister language features. This allows testing other LSPs without interference from the Jedi LSP.
+        # Remove LSP features that are redundant with Pyrefly.
         features_to_remove = [
             "textDocument/hover",
-            "textDocument/completion",
-            "completionItem/resolve",
             "textDocument/signatureHelp",
             "textDocument/declaration",
             "textDocument/definition",
@@ -618,7 +616,11 @@ def positron_completion(
 
     try:
         jedi_lines = jedi_utils.line_column(params.position)
-        completions_jedi_raw = jedi_script.complete(*jedi_lines)
+        # --- Start Positron ---
+        # Disable all raw completions in favor of Pyrefly completions
+        completions_jedi_raw = []
+        # completions_jedi_raw = jedi_script.complete(*jedi_lines)
+        # --- End Positron ---
         if not ignore_patterns:
             # A performance optimization. ignore_patterns should usually be empty;
             # this special case avoid repeated filter checks for the usual case.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10305. Updates the language server code so it disables the capabilities that are redundant with Pyrefly, except completions. (There will still be duplicate completions.)

This won't be super maintainable in the long run, so I'll revisit this file next week and really slim it down, hopefully.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:notebooks @:web @:win @:help

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
Language servers have a lot of surface area so there's a lot to verify here, sorry. We definitely want to make sure there's no more duplicate contributions for hover and code outlines. Completions for DataFrame columns, environment variables, and magics should still work, though completions may still be doubled in some cases. The help pane should work.