### PR TITLE
Assistant: Use active chat mode for prompt renderer when invoked via API

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -15,7 +15,7 @@ import path = require('path');
 import fs = require('fs');
 import { log } from './extension.js';
 import { CopilotService } from './copilot.js';
-import { PromptRenderer } from './promptRender.js';
+import { PromptMetadataMode, PromptRenderer } from './promptRender.js';
 
 /**
  * This is the API exposed by Positron Assistant to other extensions.
@@ -415,18 +415,16 @@ export function getPositronContextPrompts(positronContext: positron.ai.ChatConte
 	return result;
 }
 
-function validateChatMode(mode: string | undefined): positron.PositronChatMode | positron.PositronChatAgentLocation {
-	switch (mode) {
-		case 'ask':
-		case 'edit':
-		case 'agent':
-			return mode as positron.PositronChatMode;
-		case 'editor':
-		case 'notebook':
-		case 'terminal':
-			return mode as positron.PositronChatAgentLocation;
-		// Default to 'agent' mode for e.g. custom modes
-		default:
-			return positron.PositronChatMode.Agent;
+function isEnumMember<T extends Record<string, unknown>>(
+	value: unknown | undefined,
+	enumObj: T
+): value is T[keyof T] {
+	return value !== undefined && Object.values(enumObj).includes(value);
+}
+
+function validateChatMode(mode: string | undefined): PromptMetadataMode {
+	if (isEnumMember(mode, positron.PositronChatMode) || isEnumMember(mode, positron.PositronChatAgentLocation)) {
+		return mode;
 	}
+	return positron.PositronChatMode.Agent;
 }

--- a/extensions/positron-assistant/src/diagnostics.ts
+++ b/extensions/positron-assistant/src/diagnostics.ts
@@ -177,6 +177,9 @@ async function getChatExportInfo(): Promise<string> {
 			return 'No active chat session';
 		}
 
+		// Currently selected mode in the Chat panel
+		const chatMode = await positron.ai.getCurrentChatMode();
+
 		// Cast to access internal structure (API returns object type for stability)
 		const chatData = chatExport as any;
 
@@ -198,6 +201,7 @@ async function getChatExportInfo(): Promise<string> {
 		return `Active chat session found:
 - Total requests: ${requestCount}
 - Current agent/model: ${currentModel}
+- Currently selected mode: ${chatMode}
 - Location: ${chatData.initialLocation || 'N/A'}`;
 	} catch (error) {
 		return `Error retrieving chat export: ${formatError(error)}`;

--- a/extensions/positron-assistant/src/md/prompts/chat/warning.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/warning.md
@@ -8,7 +8,7 @@ mode:
 order: 60
 description: Instructions for issuing warnings
 ---
-{{@if(positron.request.id === "positron.assistant.editor")}}
+{{@if(positron.mode === "editor")}}
 If the suggested edit includes destructive, dangerous, or difficult to reverse actions, you follow these guidelines:
 {{#else}}
 When responding with code or instructions that are destructive, dangerous, or difficult to reverse, you follow these guidelines:
@@ -19,13 +19,13 @@ When responding with code or instructions that are destructive, dangerous, or di
   - Modifying system files or directories
 - Enclose the warning text in `<warning>` tags. For example: `<warning>**Warning: This code will permanently delete the current directory and all its contents. Use with caution!**</warning>`
 - The warning text should clearly describe the destructive or dangerous nature of the suggested action or code
-{{@if(positron.request.id !== "positron.assistant.editor")}}
+{{@if(positron.mode !== "editor")}}
 - Start with a clear warning at the beginning of the response
 - Include additional warnings alongside the code or instructions where appropriate
 {{/if}}
 
 <example>
-{{@if(positron.request.id === "positron.assistant.editor")}}
+{{@if(positron.mode === "editor")}}
 <warning>
 **Warning: This code will permanently delete the directory and all its contents. Use with caution!**
 </warning>

--- a/extensions/positron-assistant/src/md/prompts/commands/explain.md
+++ b/extensions/positron-assistant/src/md/prompts/commands/explain.md
@@ -7,7 +7,7 @@ mode:
 You are a world-class coding tutor. Your code explanations perfectly balance high-level concepts and granular details. Your approach ensures that students not only understand how to write code, but also grasp the underlying principles that guide effective programming.
 
 ## Task
-{{@if(positron.request.id === "positron.assistant.chat")}}
+{{@if(positron.mode === "ask")}}
 The user has attached a file to the chat. Explain the code in the file and how it relates to the user's question. Be sure to follow the rules.
 {{#else}}
 Answer the user's question. Be sure to follow the rules.

--- a/extensions/positron-assistant/src/md/prompts/commands/fix.md
+++ b/extensions/positron-assistant/src/md/prompts/commands/fix.md
@@ -5,9 +5,9 @@ mode:
  - editor
 ---
 
-The user has {{@if(positron.request.id === "positron.assistant.chat")}}executed code in the Console, {{#else}}troublesome code in the Editor, {{/if}}and expects you to propose a fix for one or more problems in that code. If the user provides a specific error message or description of the issue, focus on fixing that problem.
+The user has {{@if(positron.mode === "ask")}}executed code in the Console, {{#else}}troublesome code in the Editor, {{/if}}and expects you to propose a fix for one or more problems in that code. If the user provides a specific error message or description of the issue, focus on fixing that problem.
 
-{{@if(positron.request.id === "positron.assistant.chat")}}
+{{@if(positron.mode === "ask")}}
 The error code may originate in a file on disk. Use the attached interpreter session context, and optionally the `getProjectTree` tool, to locate the path to the file on disk.
 {{#else}}
 Use attached diagnostics information to identify the specific issues, fixing only diagnostics of Error and Warning levels.
@@ -17,7 +17,7 @@ The troublesome code may have errors such as spelling mistakes, bad names, etc. 
 
 Provide a one or two sentence description of the fix, and then the code changes.
 
-{{@if(positron.request.id === "positron.assistant.chat")}}
+{{@if(positron.mode === "ask")}}
 Your response must conform to this Markdown example:
 ````markdown
 One or two sentence description of the fix.

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -766,7 +766,8 @@ export class PositronAssistantChatParticipant extends PositronAssistantParticipa
 		const notebookContext = await getAttachedNotebookContext(request);
 
 		// Render prompt with notebook context
-		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatMode.Ask, {
+		const prompt = PromptRenderer.renderModePrompt({
+			mode: positron.PositronChatMode.Ask,
 			request,
 			sessions,
 			notebookContext
@@ -788,7 +789,8 @@ export class PositronAssistantEditParticipant extends PositronAssistantParticipa
 		const notebookContext = await getAttachedNotebookContext(request);
 
 		// Render prompt with notebook context
-		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatMode.Edit, {
+		const prompt = PromptRenderer.renderModePrompt({
+			mode: positron.PositronChatMode.Edit,
 			request,
 			sessions,
 			notebookContext
@@ -810,7 +812,8 @@ export class PositronAssistantAgentParticipant extends PositronAssistantParticip
 		const notebookContext = await getAttachedNotebookContext(request);
 
 		// Render prompt with notebook context
-		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatMode.Agent, {
+		const prompt = PromptRenderer.renderModePrompt({
+			mode: positron.PositronChatMode.Agent,
 			request,
 			sessions,
 			notebookContext
@@ -828,7 +831,11 @@ export class PositronAssistantTerminalParticipant extends PositronAssistantParti
 		// The terminal prompt includes how to handle warnings in the response.
 		const activeSessions = await positron.runtime.getActiveSessions();
 		const sessions = activeSessions.map(session => session.runtimeMetadata);
-		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Terminal, { request, sessions });
+		const prompt = PromptRenderer.renderModePrompt({
+			mode: positron.PositronChatAgentLocation.Terminal,
+			request,
+			sessions
+		});
 		return prompt.content;
 	}
 }
@@ -843,7 +850,11 @@ export class PositronAssistantEditorParticipant extends PositronAssistantPartici
 		}
 
 		const streamingEdits = isStreamingEditsEnabled();
-		const prompt = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Editor, { request, streamingEdits });
+		const prompt = PromptRenderer.renderModePrompt({
+			mode: positron.PositronChatAgentLocation.Editor,
+			request,
+			streamingEdits
+		});
 		return prompt.content;
 	}
 

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -288,6 +288,7 @@ interface PromptRenderData {
 	sessions?: Array<positron.LanguageRuntimeMetadata>;
 	streamingEdits?: boolean;
 	notebookContext?: SerializedNotebookContext;
+	mode?: PromptMetadataMode;
 }
 
 export class PromptRenderer {
@@ -511,13 +512,13 @@ export class PromptRenderer {
 	/**
 	 * Get combined prompt for a specific command
 	 */
-	static renderModePrompt(mode: PromptMetadataMode, data: PromptRenderData): PromptDocument {
-		const promptData = PromptRenderer.instance._renderModePrompt(mode, data);
+	static renderModePrompt(data: PromptRenderData): PromptDocument {
+		const promptData = PromptRenderer.instance._renderModePrompt(data);
 		return promptData;
 	}
 
-	private _renderModePrompt(mode: PromptMetadataMode, data: PromptRenderData): PromptDocument {
-		const matchingDocuments = this.getModePromptDocuments(mode);
+	private _renderModePrompt(data: PromptRenderData): PromptDocument {
+		const matchingDocuments = this.getModePromptDocuments(data.mode);
 		if (matchingDocuments.length === 0) {
 			return { content: '', metadata: {} };
 		}
@@ -527,7 +528,7 @@ export class PromptRenderer {
 		const mergedMetadata = this.mergeMetadata(matchingDocuments);
 
 		// Render prompt template
-		log.trace('[PromptRender] Rendering prompt for mode:', mode, 'with data:', JSON.stringify(data));
+		log.trace('[PromptRender] Rendering prompt for mode:', data.mode, 'with data:', JSON.stringify(data));
 		const result = PromptTemplateEngine.render(mergedContent, data);
 
 		return {

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -426,7 +426,7 @@ suite('PositronAssistantPromptRenderer', () => {
 	test('Render prompt for Ask mode', async () => {
 		const request = makeChatRequest({ model, references: [] });
 		const sessions = [];
-		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatMode.Ask, { request, sessions });
+		const { content, metadata } = PromptRenderer.renderModePrompt({ mode: positron.PositronChatMode.Ask, request, sessions });
 		assert.ok(metadata.mode.includes(positron.PositronChatMode.Ask), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
 		assert.ok(content.includes(`You are Positron Assistant`));
 		assert.ok(content.includes(`You are running in "Ask" mode`));
@@ -438,7 +438,7 @@ suite('PositronAssistantPromptRenderer', () => {
 	test('Render prompt for Terminal', async () => {
 		const request = makeChatRequest({ model, references: [] });
 		const sessions = [];
-		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Terminal, { request, sessions });
+		const { content, metadata } = PromptRenderer.renderModePrompt({ mode: positron.PositronChatAgentLocation.Terminal, request, sessions });
 		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Terminal), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
 		assert.ok(content.includes(`Return ONLY a single line terminal command that addresses the user's question.`));
 	});
@@ -451,12 +451,12 @@ suite('PositronAssistantPromptRenderer', () => {
 		const request = makeChatRequest({ model, references: [], location2: editorData });
 
 		const sessions = [];
-		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Editor, { request, sessions });
+		const { content, metadata } = PromptRenderer.renderModePrompt({ mode: positron.PositronChatAgentLocation.Editor, request, sessions });
 		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Editor), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
 		assert.ok(content.includes(`You are Positron Assistant`));
 		assert.ok(content.includes(`The user has invoked you from the text editor.`));
 		assert.ok(content.includes(`Your goal is to generate a set of edits to the document that represent the requested change.`));
-		assert.ok(content.includes(`Start with a clear warning at the beginning of the response`));
+		assert.ok(content.includes(`If the suggested edit includes destructive, dangerous, or difficult to reverse actions, you follow these guidelines:`));
 	});
 
 	test('Render prompt with non-empty selection and streaming edits', async () => {
@@ -467,7 +467,7 @@ suite('PositronAssistantPromptRenderer', () => {
 		const request = makeChatRequest({ model, references: [], location2: editorData });
 
 		const sessions = [];
-		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatAgentLocation.Editor, { streamingEdits: true, request, sessions });
+		const { content, metadata } = PromptRenderer.renderModePrompt({ mode: positron.PositronChatAgentLocation.Editor, streamingEdits: true, request, sessions });
 		assert.ok(metadata.mode.includes(positron.PositronChatAgentLocation.Editor), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
 		assert.ok(content.includes(`You are Positron Assistant`));
 		assert.ok(content.includes(`The user has invoked you from the text editor.`));
@@ -482,7 +482,7 @@ suite('PositronAssistantPromptRenderer', () => {
 			}),
 		];
 
-		const { content, metadata } = PromptRenderer.renderModePrompt(positron.PositronChatMode.Agent, { streamingEdits: true, request, sessions });
+		const { content, metadata } = PromptRenderer.renderModePrompt({ mode: positron.PositronChatMode.Agent, streamingEdits: true, request, sessions });
 		assert.ok(metadata.mode.includes(positron.PositronChatMode.Agent), `Unexpected mode in prompt metadata: ${JSON.stringify(metadata)}`);
 		assert.ok(content.includes(`When writing R code you generally follow tidyverse coding style and principles.`));
 	});

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2362,6 +2362,11 @@ declare module 'positron' {
 		export function getCurrentProvider(): Thenable<ChatProvider | undefined>;
 
 		/**
+		 * Get the currently selected mode in the chat UI.
+		 */
+		export function getCurrentChatMode(): Thenable<string | undefined>;
+
+		/**
 		 * Get all the available langauge model providers.
 		 */
 		export function getProviders(): Thenable<ChatProvider[]>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -352,6 +352,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			getCurrentProvider(): Promise<positron.ai.ChatProvider | undefined> {
 				return extHostAiFeatures.getCurrentProvider();
 			},
+			getCurrentChatMode(): Promise<string | undefined> {
+				return extHostAiFeatures.getCurrentChatMode();
+			},
 			getProviders(): Promise<positron.ai.ChatProvider[]> {
 				return extHostAiFeatures.getProviders();
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -168,6 +168,7 @@ export interface MainThreadAiFeaturesShape {
 	$removeLanguageModelConfig(source: IPositronLanguageModelSource): void;
 	$areCompletionsEnabled(file: UriComponents): Thenable<boolean>;
 	$getCurrentProvider(): Thenable<IPositronChatProvider | undefined>;
+	$getCurrentChatMode(): Thenable<string | undefined>;
 	$getProviders(): Thenable<IPositronChatProvider[]>;
 	$setCurrentProvider(id: string): Thenable<IPositronChatProvider | undefined>;
 }
@@ -176,6 +177,7 @@ export interface ExtHostAiFeaturesShape {
 	$responseLanguageModelConfig(id: string, config: IPositronLanguageModelConfig, action: string): Thenable<void>;
 	$onCompleteLanguageModelConfig(id: string): void;
 	getCurrentProvider(): Thenable<IPositronChatProvider | undefined>;
+	getCurrentChatMode(): Thenable<string | undefined>;
 	getProviders(): Thenable<IPositronChatProvider[]>;
 	setCurrentProvider(id: string): Thenable<IPositronChatProvider | undefined>;
 }

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -115,6 +115,10 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 		return this._proxy.$getCurrentProvider();
 	}
 
+	async getCurrentChatMode(): Promise<string | undefined> {
+		return this._proxy.$getCurrentChatMode();
+	}
+
 	async getProviders(): Promise<IPositronChatProvider[]> {
 		return this._proxy.$getProviders();
 	}


### PR DESCRIPTION
As reported by @nstrayer, when invoking the prompt renderer via API it has no knowledge of the currently selected chat mode, defaulting to "ask" mode. This happens when using any model provided by the GitHub Copilot provider.

To reproduce, select a GitHub model, select the "Assistant" output channel in trace mode, and send a request in Agent or Edit mode. Then note the output log showing Positron Assistant's portion of the system prompt rendered in "ask" mode.

<img width="810" height="481" alt="Screenshot 2025-11-25 at 13 24 06" src="https://github.com/user-attachments/assets/40805016-b72b-4820-8735-317d5a5d4b96" />

---

This PR orchestrates things so that the prompt renderer uses the currently selected chat mode when invoked by API. Ideally, the requested chat mode would be provided by the GitHub Copilot Chat extension as it calls the Assistant extension API, but this is a stop-gap measure until we can update the fork to do so.

The following changes are made:
 * `positron.ai.getCurrentChatMode()` is added to the Positron API, providing the current chat mode selected in the Chat panel.
 * The above is used in the Positron Assistant extension to get the current chat mode for rendering via API (noting that this path is used only for Copilot models).

Additionally:
 * The system prompt markdown content is updated to **not** match on participant ID. This approach cannot work with Copilot models. Instead the chat mode is moved to be included in the prompt render data and we match on `mode: string` directly.

### QA Notes

Follow the same procedure outlined above, observe that the prompt renderer renders with the same `mode` as that selected in the UI:


<img width="795" height="628" alt="Screenshot 2025-11-25 at 13 29 36" src="https://github.com/user-attachments/assets/fcf83336-788a-4f34-a9fe-f3c1b827435c" />

