### PR TITLE
Positron Notebooks: Improve dark theme accessibility

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -29,14 +29,8 @@
 		--vscode-notebook-outputContainerBackgroundColor,
 		white
 	);
-	--vscode-positronNotebook-action-bar-background: var(
-		--vscode-dropdown-background,
-		white
-	);
-	--vscode-positronNotebook-action-bar-border-color: var(
-		--vscode-input-border,
-		grey
-	);
+	--vscode-positronNotebook-action-bar-background: var(--vscode-editor-background);
+	--vscode-positronNotebook-action-bar-border-color: var(--vscode-notebook-cellToolbarSeparator);
 
 	/* Size variables used throughout notebooks */
 	--vscode-positronNotebook-cell-radius: 8px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -13,6 +13,12 @@
 	overflow: hidden; /* Clip content to respect rounded corners */
 }
 
+/* Set cell editor background */
+.positron-cell-editor-monaco-widget .monaco-editor-background,
+.positron-cell-editor-monaco-widget .margin-view-overlays {
+	background: var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background));
+}
+
 /* On hover, when NOT selected/editing: change border color to hover color */
 .positron-notebook-cell:not(.selected):not(.editing):hover .positron-cell-editor-monaco-widget {
 	border-color: var(--vscode-editorWidget-border);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -29,6 +29,15 @@
 	opacity: 0.8;
 }
 
+/* Use theme link colors */
+.notebook-output-truncation-message a {
+	color: var(--vscode-textLink-foreground);
+}
+.notebook-output-truncation-message a:hover,
+.notebook-output-truncation-message a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
 .positron-notebook-text-output.long-output-scroll + .notebook-output-truncation-message {
 	text-align: right;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -37,7 +37,8 @@
 	content: "";
 	position: absolute;
 	width: var(--_positron-notebook-selection-bar-width);
-	background-color: var(--vscode-editor-background);
+	/* Match the cell editor background */
+	background: var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background));
 	left: 0; /* Align with focus ring by removing gap */
 	top: var(--_positron-notebook-selection-bar-inset);
 	bottom: var(--_positron-notebook-selection-bar-inset);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
@@ -4,10 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-cell {
-	/* Override the default editor background */
-	--vscode-editor-background: var(--vscode-checkbox-background, #f8f8f8);
-	--vscode-editorGutter-background: var(--vscode-editor-background);
-
 	position: relative;
 	margin-left: 12px;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.css
@@ -22,5 +22,5 @@
 }
 
 .positron-iconed-button.bordered {
-	border: 1px solid var(--vscode-positronNotebook-deemphasized-foreground);
+	border: 1px solid var(--vscode-positronNotebook-action-bar-border-color);
 }


### PR DESCRIPTION
Fixes a few colors to use existing theme colors that are more accessible (and prettier, I think). This should have very little effect on the light theme and mainly improves the dark theme.

1. "Change behavior" link for long outputs (#10603) - Light and Dark
2. Cell action bar border and background color - Dark only
3. Cell editor background color - Dark only
4. Add cell button border - Light and Dark

_Note: The Codicons are also different in my screenshots but that's an unrelated upstream change._

### Before - Dark

<img width="910" height="781" alt="image" src="https://github.com/user-attachments/assets/05874ace-fa2c-43bd-ab86-25c8374d39db" />

### After - Dark

<img width="910" height="781" alt="image" src="https://github.com/user-attachments/assets/2c2ebb8d-2d79-4392-9fe0-9a0d9c4d9fb3" />

### Before - Light

<img width="910" height="781" alt="image" src="https://github.com/user-attachments/assets/22a078a6-f836-4d0b-8164-c6e5406f7923" />

### After - Light

<img width="910" height="781" alt="image" src="https://github.com/user-attachments/assets/73d1c4a5-24c9-46a6-910e-0e08cb1089ff" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web