### PR TITLE
python: add preview string in connections pane

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -519,7 +519,11 @@ class ConnectionsService:
                 var_name = decode_access_key(path_key[0])
 
         res, sql_string = conn.preview_object(request.params.path, var_name)
-        title = request.params.path[-1].name
+        try:
+            preview = "" if len(res) < 1000 else " (preview)"
+        except TypeError:  # res does not have len
+            preview = ""
+        title = request.params.path[-1].name + preview
 
         self._kernel.data_explorer_service.register_table(res, title, sql_string=sql_string)
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #9516 Add "(preview)" to Connections tables that are truncated to 1,000 rows.


### QA Notes

- Use `chinook.db` python data from `qa-example-content`
- For tables != 1000 rows, name should be, for example, `album`
- For tables == 1000 rows, name should be, for example, `album (preview)`

We can't tell from the connections pane if the table has exactly 1000 rows and is therefore not a preview, but I think this is okay.
