### PR TITLE
e2e test - files pane refreshes once a file is created

### DIFF
--- a/test/e2e/tests/console/files-pane-refresh.test.ts
+++ b/test/e2e/tests/console/files-pane-refresh.test.ts
@@ -5,12 +5,9 @@
 
 // Simple Test: Files Pane Refresh
 // Description: Verify that the Files pane refreshes after creating a file via the console.
-// TODO: I'm unsure about the tags, and whether it fits well within new-folder-flow.
-//       If it does, should I have it as standalone test or include it to another test?
-//		 Open to suggestions
 
 import { test, tags, expect } from '../_test.setup';
-import { createFileViaConsole } from './helpers/new-folder-flow';
+import { createFileViaConsole } from '../new-folder-flow/helpers/new-folder-flow';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/new-folder-flow/files-pane-refresh.test.ts
+++ b/test/e2e/tests/new-folder-flow/files-pane-refresh.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Simple Test: Files Pane Refresh
+// Description: Verify that the Files pane refreshes after creating a file via the console.
+// TODO: I'm unsure about the tags, and whether it fits well within new-folder-flow.
+//       If it does, should I have it as standalone test or include it to another test?
+//		 Open to suggestions
+
+import { test, tags, expect } from '../_test.setup';
+import { createFileViaConsole } from './helpers/new-folder-flow';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Files Pane Refresh', { tag: [tags.WEB, tags.WORKBENCH, tags.CONSOLE] }, () => {
+
+	test.afterAll(async ({ cleanup, app }) => {
+		// Primary removal via filesystem
+		await cleanup.removeTestFiles(['file.txt']);
+
+		// Verify removal in Files pane; if still present, remove via console as a fallback
+		const filesList = app.code.driver.page.locator('.monaco-list > .monaco-scrollable-element');
+		const stillVisible = await filesList.getByText('file.txt').count();
+		if (stillVisible > 0) {
+			await app.workbench.console.executeCode('Python', `import pathlib
+p = pathlib.Path('file.txt')
+try:
+    p.unlink()
+except FileNotFoundError:
+    pass`);
+			await expect(filesList.getByText('file.txt')).toHaveCount(0, { timeout: 10000 });
+		}
+	});
+
+	test('Files pane refreshes after creating file.txt via console', async function ({ app, python }) {
+		await createFileViaConsole(app, 'Python', 'file.txt');
+	});
+	// only Python needed since the  file creation principle is the same with the R console
+});

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -96,3 +96,59 @@ export async function verifyPyprojectTomlNotCreated(app: Application) {
 		await expect(files.getByText('pyproject.toml')).toHaveCount(0, { timeout: 50000 });
 	});
 }
+
+/**
+ * Create a file and a folder via console and verify they appear in the Files pane.
+ */
+export async function createFileAndFolderViaConsole(
+	app: Application,
+	runtime: 'Python' | 'R',
+	fileName: string,
+	folderName: string
+) {
+	await test.step(`Create file and folder via ${runtime} and verify Files pane`, async () => {
+		if (runtime === 'Python') {
+			const pyCode = `
+import os
+with open('${fileName}', 'w') as f:
+    f.write('hello')
+os.makedirs('${folderName}', exist_ok=True)
+`;
+			await app.workbench.console.executeCode('Python', pyCode);
+		} else {
+			const rCode = `
+file.create('${fileName}')
+dir.create('${folderName}', showWarnings = FALSE)
+`;
+			await app.workbench.console.executeCode('R', rCode);
+		}
+
+		await app.workbench.explorer.verifyExplorerFilesExist([fileName]);
+		await app.workbench.explorer.verifyExplorerFilesExist([folderName]);
+	});
+}
+
+/**
+ * Create a single file via console and verify it appears in the Files pane.
+ */
+export async function createFileViaConsole(
+	app: Application,
+	runtime: 'Python' | 'R',
+	fileName: string
+) {
+	await test.step(`Create file via ${runtime} and verify Files pane`, async () => {
+		if (runtime === 'Python') {
+			const pyCode = `
+open('${fileName}', 'w').write('hello')
+`;
+			await app.workbench.console.executeCode('Python', pyCode);
+		} else {
+			const rCode = `
+file.create('${fileName}')
+`;
+			await app.workbench.console.executeCode('R', rCode);
+		}
+
+		await app.workbench.explorer.verifyExplorerFilesExist([fileName]);
+	});
+}


### PR DESCRIPTION
This PR adds a new end-to-end test that verifies the Files pane properly refreshes when a file is created via the console.

### Test Details:
- Creates `file.txt` using the Python console
- Verifies the file appears in the Files pane
- Includes cleanup logic with a fallback mechanism (filesystem removal + console removal if needed)
- Uses the existing `createFileViaConsole` helper from the `new-folder-flow` test suite

### What I'm unsure about
- [x] Tags -- make a new tag? (future if needed)
- [x] Does it fit within the `new-folder-flow`? -- put it somewhere else --> console dir or file explo dir
- [x] Should I have it as standalone test or include it to another test? Standalone

### QA Notes

@:web @:workbench @:console