### PR TITLE
Auto refresh models after adding a new provider

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -777,16 +777,16 @@ export class LanguageModelsService implements ILanguageModelsService {
 		this._providerExtensions.set(vendor, extensionId);
 		// --- End Positron ---
 
-		if (this._hasStoredModelForVendor(vendor)) {
-			// --- Start Positron ---
-			// Fire the provider change event after models are resolved so UI knows usable providers are available
-			this._resolveLanguageModels(vendor, true).then(() => {
-				this._logService.trace('[LM] Provider models resolved, firing onDidChangeProviders', vendor);
-				this._onDidChangeProviders.fire({ added: [vendor] });
-				this._onLanguageModelChange.fire(vendor);
-			});
-			// --- End Positron ---
-		}
+		// --- Start Positron ---
+		// Fire the provider change event after models are resolved so UI knows usable providers are available
+		//if (this._hasStoredModelForVendor(vendor)) {
+		this._resolveLanguageModels(vendor, true).then(() => {
+			this._logService.trace('[LM] Provider models resolved, firing onDidChangeProviders', vendor);
+			this._onDidChangeProviders.fire({ added: [vendor] });
+			this._onLanguageModelChange.fire(vendor);
+		});
+		//}
+		// --- End Positron ---
 
 		const modelChangeListener = provider.onDidChange(async () => {
 			await this._resolveLanguageModels(vendor, true);


### PR DESCRIPTION
Addresses #10793 

The 1.106.0 upstream merge brought in a change intended to improve efficiency that prevented model registration when adding a provider that wasn't already configured by a user. This prevented the model list from refreshing when a user signed into a new provider.

This change resolves that issue. I left the conditional statement commented out in hopes that it would make things easier with the next upstream merge, but I'm open to other ways of handling this.

### QA Notes
Repro notes detailed on original issue 
@:assistant