### PR TITLE
ci: reduce PR e2e tests to 2 workers

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -44,7 +44,7 @@ jobs:
       install_undetectable_interpreters: false
       install_license: false
       upload_logs: false
-      workers: 3
+      workers: 2
       allow_soft_fail: false
     secrets: inherit
 

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -130,7 +130,7 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 			await stop();
 			renamedLogsPath = await renameTempLogsDir(logger, logsPath, workerInfo);
 		}
-	}, { scope: 'worker', auto: true, timeout: 60000 }],
+	}, { scope: 'worker', auto: true, timeout: 80000 }],
 
 	sessions: [
 		async ({ app }, use) => {

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -114,7 +114,7 @@ test.describe('Notebooks', {
 			}).toPass({ timeout: 15000 });
 		});
 
-		test('Python - Ensure LSP works across cells', async function ({ app }) {
+		test.skip('Python - Ensure LSP works across cells', async function ({ app }) {
 			const { notebooks } = app.workbench;
 
 			await notebooks.insertNotebookCell('code');


### PR DESCRIPTION
### Summary

This PR aims to improve CI reliability by addressing resource contention and timing issues in our test infrastructure introduced by Pyrefly extension.

* Reduced # of workers from 3 to 2 on PR runs.
* Extended app startup timeout from 60s to 80s.
* Skipping notebook cell LSP test

### QA Notes

n/a