### PR TITLE
Fix stale models when using Bedrock

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -818,7 +818,7 @@ export class OpenAILanguageModel extends AILanguageModel implements positron.ai.
 				})
 			);
 
-			return models;
+			return markDefaultModel(models, this.provider, this._config.model);
 		} catch (error) {
 			log.warn(`[${this.providerName}] Failed to fetch models from API: ${error}`);
 			return undefined;
@@ -1306,7 +1306,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 			})
 		);
 
-		return modelListing;
+		return markDefaultModel(modelListing, this.provider, this._config.model);
 	}
 
 	private async retrieveModelsFromApi(): Promise<vscode.LanguageModelChatInformation[] | undefined> {

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -1363,7 +1363,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 
 			log.debug(`[${this.providerName}] Available models after processing: ${models.map(m => m.name).join(', ')}`);
 
-			return models;
+			return markDefaultModel(models, this.provider, this._config.model);
 		} catch (error) {
 			log.warn(`[${this.providerName}] Failed to fetch models from Bedrock API: ${error}`);
 			this._lastError = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
Address #10763 

If Bedrock is the only provider, there won't be any default models. This causes unexpected behaviour and falling back on the model cache would show unavailable models.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix stale Assistant model listing when Bedrock is the only registered provider


### QA Notes
Bedrock should be the only provider registered. I don't think Copilot has to be registered and unregistered first. Having Bedrock and only Bedrock is what causes a no default model situation, which causes no models to be shown or a stale model list.