### PR TITLE
Make 'no language model' error message more generic

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -542,8 +542,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 			model = await this._languageModels.getDefaultLanguageModel(extension);
 			if (!model) {
 				// --- Start Positron ---
-				// TODO: make this more generic once we support more model providers https://github.com/posit-dev/positron/issues/8301
-				throw new Error('No language models available for chat. Please ensure you have logged into Anthropic as a language model provider by clicking `Configure Model Providers...` or running the command `Positron Assistant: Configure Language Model Providers` and authenticating with Anthropic.');
+				throw new Error('No language models available for chat. Please ensure you have logged into a language model provider by running the command `Positron Assistant: Configure Language Model Providers` and authenticating with a provider.');
 				/*
 				throw new Error('Language model unavailable');
 				*/


### PR DESCRIPTION
Addresses #9823 

When the original issue was filed, Assistant would fail silently when the user sent a message without a model configured. In doing my own testing, Assistant was providing a helpful message, but it called out 'Anthropic' as the only potential provider. This PR updates the wording of that error to be more generic.


### QA Notes

@:assistant
