### PR TITLE
Always show execution order of cell

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
@@ -136,6 +136,13 @@ export function CellExecutionInfoPopup({
 		);
 	}
 
+	// Check if we have any content to display
+	// If we only have execution order but no other metadata, don't show the popup
+	const hasAnyContent = hasExecutionResult || isCurrentlyRunning || hasTimingInfo;
+	if (!hasAnyContent) {
+		return null;
+	}
+
 	return (
 		<div
 			aria-label='Cell execution details'
@@ -144,15 +151,6 @@ export function CellExecutionInfoPopup({
 		>
 			{/* Popup body: lists high-level status then timing metadata */}
 			{/* Status Section */}
-			{hasExecutionOrder && (
-				<div aria-label='Execution order' className='popup-row'>
-					{/* Execution order row: shows the cell's execution sequence number when available */}
-					<span className='popup-label-text'>
-						{localize('cellExecution.order.label', 'Execution order:')}
-					</span>
-					<span className='popup-value-text'>{executionOrder}</span>
-				</div>
-			)}
 			{hasExecutionResult && (
 				<div aria-label='Execution status' className='popup-row'>
 					{/* Execution result row: success/failure indicator with label */}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -7,7 +7,7 @@
 .left-hand-action-container {
 	/* Private CSS variables for all dimensions */
 	--_container-size: 20px;  /* Match circle size exactly */
-	--_circle-size: 20px;
+	--_circle-size: 18px;
 	--_circle-border-width: 1px;
 	--_icon-size: 11px;  /* Slightly larger for better visibility */
 	--_container-offset-left: -24px;  /* Fine-tune position */
@@ -89,8 +89,8 @@
 
 .cell-execution-status-animation {
 	position:absolute;
-	width: 100%;
-	height: 100%;
+	width: var(--_circle-size, 18px);
+	height: var(--_circle-size, 18px);
 	background-color: transparent;
 	border-radius: 50%;
 	user-select: none;
@@ -176,8 +176,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: var(--_circle-size, 20px);
-	height: var(--_circle-size, 20px);
+	width: var(--_circle-size, 18px);
+	height: var(--_circle-size, 18px);
 }
 
 /* Hover effects for the button */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -29,8 +29,8 @@
 	z-index: 10;
 }
 
-/* Hide the circle outline when the cell isn't running and not selected/hovered */
-.left-hand-action-container:not([data-execution-status='running']):not(:has(.action-button-wrapper)) {
+/* Hide the circle outline when the cell isn't running */
+.left-hand-action-container:not([data-execution-status='running']) {
 	--_circle-border-width: 0;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -12,7 +12,7 @@
 	--_circle-border-width: 1px;
 	--_icon-size: 11px;  /* Slightly larger for better visibility */
 	--_container-offset-left: -24px;  /* Fine-tune position */
-	--_container-offset-top: 12px;  /* Aligns with first line of code. May need to be made dynamic. */
+	--_container-offset-top: 4px;
 	--_badge-font-size: 10px;
 
 	/* Container positioning - easily adjustable via variables */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -7,18 +7,17 @@
 .left-hand-action-container {
 	/* Private CSS variables for all dimensions */
 	--_container-size: 20px;  /* Match circle size exactly */
-	--_button-size: 14px;  /* Slightly smaller for padding inside circle */
 	--_circle-size: 20px;
 	--_circle-border-width: 1px;
 	--_icon-size: 11px;  /* Slightly larger for better visibility */
 	--_container-offset-left: -24px;  /* Fine-tune position */
-	--_container-offset-top: 4px; /* Position container slightly down from top */
+	--_container-element-margin: 2px;
 	--_badge-font-size: 10px;
 
 	/* Container positioning - easily adjustable via variables */
 	position: absolute;
-	top: var(--_container-offset-top);
-	bottom: 0; /* Stretch to bottom to allow flex alignment */
+	top: 0;
+	bottom: 0;
 	left: var(--_container-offset-left);
 	width: var(--_container-size);
 
@@ -34,6 +33,7 @@
 	position: relative;
 	width: var(--_container-size);
 	height: var(--_container-size);
+	margin-top: var(--_container-element-margin);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -45,6 +45,7 @@
 	position: relative;
 	width: var(--_container-size);
 	height: var(--_container-size);
+	margin-bottom: var(--_container-element-margin);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -109,8 +110,8 @@
 
 .execution-order-badge-container {
 	pointer-events: none;
-	width: var(--_circle-size);
-	height: var(--_circle-size);
+	width: var(--_container-size);
+	height: var(--_container-size);
 	font-size: 7px;
 	display: flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -185,3 +185,8 @@
 	/* Adjust for play icon which tends to be off-center */
 	padding-left: 1px;
 }
+
+.left-hand-action-container-bottom {
+	top: auto;
+	bottom: 0;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -30,20 +30,20 @@
 }
 
 /* Hide the circle outline when the cell isn't running */
-.left-hand-action-container:not([data-execution-status='running']) {
+.left-hand-action-container-top:not([data-execution-status='running']) {
 	--_circle-border-width: 0;
 }
 
 /* Status-specific styling for the container */
-.left-hand-action-container[data-execution-status='running'] {
+.left-hand-action-container-top[data-execution-status='running'] {
 	color: var(--vscode-debugIcon-startForeground);
 }
 
-.left-hand-action-container[data-execution-status='success'] {
+.left-hand-action-container-top[data-execution-status='success'] {
 	border-color: color-mix(in srgb, var(--vscode-testing-iconPassed) 70%, transparent);
 }
 
-.left-hand-action-container[data-execution-status='failed'] {
+.left-hand-action-container-top[data-execution-status='failed'] {
 	border-color: color-mix(in srgb, var(--vscode-testing-iconFailed) 70%, transparent);
 }
 
@@ -51,15 +51,15 @@
 	color: var(--vscode-testing-iconFailed);
 }
 
-.left-hand-action-container[data-execution-status='neutral'] {
+.left-hand-action-container-top[data-execution-status='neutral'] {
 	border-color: var(--vscode-textLink-foreground);
 }
 
-.left-hand-action-container[data-execution-status='pending'] {
+.left-hand-action-container-top[data-execution-status='pending'] {
 	color: color-mix(in srgb, var(--vscode-widget-border) 70%, transparent);
 }
 
-.left-hand-action-container[data-execution-status='queued'] {
+.left-hand-action-container-top[data-execution-status='queued'] {
 	border-color: color-mix(in srgb, var(--vscode-widget-border) 60%, transparent);
 }
 
@@ -73,14 +73,14 @@
 	border: var(--_circle-border-width, 1px) solid color-mix(in srgb, var(--vscode-descriptionForeground) 50%, transparent);
 }
 
-.left-hand-action-container[data-execution-status='running'] .cell-execution-status-animation {
+.left-hand-action-container-top[data-execution-status='running'] .cell-execution-status-animation {
 	border: var(--_circle-border-width, 1px) solid var(--vscode-debugIcon-startForeground);
 	border-top-color: transparent;
 	animation: spin 1.2s cubic-bezier(0.4, 0.3, 0.5, 0.7) infinite;
 	transform-origin: center;
 }
 
-.left-hand-action-container[data-execution-status='pending'] .cell-execution-status-animation {
+.left-hand-action-container-top[data-execution-status='pending'] .cell-execution-status-animation {
 	border: 1px dashed color-mix(in srgb, var(--vscode-widget-border) 50%, transparent);
 }
 
@@ -98,7 +98,7 @@
 	transition: border-color 0.15s ease;
 }
 
-.left-hand-action-container .codicon-notebook-execute {
+.left-hand-action-container-top .codicon-notebook-execute {
 	/* Move button a smidge to the left to center it in circle */
 	transform: translate(0.7px, 0);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -98,9 +98,9 @@
 	transition: border-color 0.15s ease;
 }
 
-.left-hand-action-container .codicon-play {
-	/* Move around play button a bit to make things line up properly. */
-	transform: translate(0.7px, 0) scaleY(0.8);
+.left-hand-action-container .codicon-notebook-execute {
+	/* Move button a smidge to the left to center it in circle */
+	transform: translate(0.7px, 0);
 }
 
 .execution-order-badge-container span.execution-order-badge {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -12,21 +12,44 @@
 	--_circle-border-width: 1px;
 	--_icon-size: 11px;  /* Slightly larger for better visibility */
 	--_container-offset-left: -24px;  /* Fine-tune position */
-	--_container-offset-top: 4px;
+	--_container-offset-top: 4px; /* Position container slightly down from top */
 	--_badge-font-size: 10px;
 
 	/* Container positioning - easily adjustable via variables */
 	position: absolute;
 	top: var(--_container-offset-top);
+	bottom: 0; /* Stretch to bottom to allow flex alignment */
 	left: var(--_container-offset-left);
 	width: var(--_container-size);
-	height: var(--_container-size);
 
-	/* Center children */
+	/* Vertical layout with items at top and bottom */
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	z-index: 10;
+}
+
+/* Position element to the top of the cell */
+.left-hand-action-container-top {
+	position: relative;
+	width: var(--_container-size);
+	height: var(--_container-size);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: 10;
+	flex-shrink: 0;
+}
+
+/* Positions element to the bottom of the cell */
+.left-hand-action-container-bottom {
+	position: relative;
+	width: var(--_container-size);
+	height: var(--_container-size);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	margin-top: auto; /* Push element to bottom */
 }
 
 /* Hide the circle outline when the cell isn't running */
@@ -184,9 +207,4 @@
 	justify-content: center;
 	/* Adjust for play icon which tends to be off-center */
 	padding-left: 1px;
-}
-
-.left-hand-action-container-bottom {
-	top: auto;
-	bottom: 0;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -93,21 +93,20 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 
 	const dataExecutionStatus = executionStatus || 'idle';
 
-	const actionMenu = (isSelected || isHovered) && primaryLeftAction ? (
-		<div className={`action-button-wrapper ${isRunning ? 'running' : ''}`}>
-			<CellActionButton action={primaryLeftAction} cell={cell} />
-		</div>
-	) : null;
+	// Determine if we should show the cell execution button
+	const showActionMenu = (isSelected || isHovered) && primaryLeftAction;
+	// Determine if we should show the execution status indicator (spinner)
+	const showExecutionStatus = showActionMenu || isRunning;
 
 	return (
 		<>
 			<div
-				className='left-hand-action-container'
 				ref={containerRef}
+				className='left-hand-action-container'
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
-				{actionMenu && (
+				{showExecutionStatus && (
 					<div
 						className='left-hand-action-container-top'
 						data-execution-status={dataExecutionStatus}
@@ -118,7 +117,11 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 							className='cell-execution-status-animation'
 							role='status'
 						/>
-						{actionMenu}
+						{showActionMenu && (
+							<div className={`action-button-wrapper ${isRunning ? 'running' : ''}`}>
+								<CellActionButton action={primaryLeftAction} cell={cell} />
+							</div>
+						)}
 					</div>
 				)}
 				<div

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -116,11 +116,8 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 					role='status'
 				/>
 				<ExecutionStatusBadge
-					cellSelected={isSelected}
 					executionOrder={executionOrder}
-					executionStatus={dataExecutionStatus}
 					hasError={hasError}
-					isHovered={isHovered}
 					showPending={showPending}
 				/>
 				{actionMenu}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -101,26 +101,32 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 
 	return (
 		<>
-			{/* Main container for left-hand action menu */}
+			{actionMenu && (
+				<div
+					className='left-hand-action-container left-hand-action-container-top'
+					data-execution-status={dataExecutionStatus}
+				>
+					<div
+						aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
+						aria-live={isRunning ? 'polite' : 'off'}
+						className='cell-execution-status-animation'
+						role='status'
+					/>
+					{actionMenu}
+				</div>
+			)}
 			<div
 				ref={containerRef}
-				className='left-hand-action-container'
+				className='left-hand-action-container left-hand-action-container-bottom'
 				data-execution-status={dataExecutionStatus}
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
-				<div
-					aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
-					aria-live={isRunning ? 'polite' : 'off'}
-					className='cell-execution-status-animation'
-					role='status'
-				/>
 				<ExecutionStatusBadge
 					executionOrder={executionOrder}
 					hasError={hasError}
 					showPending={showPending}
 				/>
-				{actionMenu}
 			</div>
 			{showPopup && containerRef.current && (
 				<Popover

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -103,13 +103,13 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 			<div
 				ref={containerRef}
 				className='left-hand-action-container'
+				data-execution-status={dataExecutionStatus}
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
 				{showExecutionStatus && (
 					<div
 						className='left-hand-action-container-top'
-						data-execution-status={dataExecutionStatus}
 					>
 						<div
 							aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
@@ -126,7 +126,6 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 				)}
 				<div
 					className='left-hand-action-container-bottom'
-					data-execution-status={dataExecutionStatus}
 				>
 					<ExecutionStatusBadge
 						executionOrder={executionOrder}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -101,32 +101,36 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 
 	return (
 		<>
-			{actionMenu && (
-				<div
-					className='left-hand-action-container left-hand-action-container-top'
-					data-execution-status={dataExecutionStatus}
-				>
-					<div
-						aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
-						aria-live={isRunning ? 'polite' : 'off'}
-						className='cell-execution-status-animation'
-						role='status'
-					/>
-					{actionMenu}
-				</div>
-			)}
 			<div
+				className='left-hand-action-container'
 				ref={containerRef}
-				className='left-hand-action-container left-hand-action-container-bottom'
-				data-execution-status={dataExecutionStatus}
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
-				<ExecutionStatusBadge
-					executionOrder={executionOrder}
-					hasError={hasError}
-					showPending={showPending}
-				/>
+				{actionMenu && (
+					<div
+						className='left-hand-action-container-top'
+						data-execution-status={dataExecutionStatus}
+					>
+						<div
+							aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
+							aria-live={isRunning ? 'polite' : 'off'}
+							className='cell-execution-status-animation'
+							role='status'
+						/>
+						{actionMenu}
+					</div>
+				)}
+				<div
+					className='left-hand-action-container-bottom'
+					data-execution-status={dataExecutionStatus}
+				>
+					<ExecutionStatusBadge
+						executionOrder={executionOrder}
+						hasError={hasError}
+						showPending={showPending}
+					/>
+				</div>
 			</div>
 			{showPopup && containerRef.current && (
 				<Popover

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/ExecutionStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/ExecutionStatusBadge.tsx
@@ -6,11 +6,8 @@
 import React from 'react';
 
 interface ExecutionStatusBadgeProps {
-	cellSelected: boolean;
-	isHovered: boolean;
 	executionOrder?: number;
 	showPending: boolean;
-	executionStatus: string;
 	hasError: boolean;
 }
 
@@ -19,18 +16,7 @@ interface ExecutionStatusBadgeProps {
  * Used when the cell is not selected/hovered and showing static execution status.
  * Only renders when the cell is in the 'idle' execution state.
  */
-export function ExecutionStatusBadge({ cellSelected, isHovered, executionOrder, showPending, executionStatus, hasError }: ExecutionStatusBadgeProps) {
-
-	if (cellSelected || isHovered) {
-		// We show action buttons in this case
-		return null;
-	}
-
-	// Only show execution counter when cell is in idle state
-	if (executionStatus !== 'idle') {
-		return null;
-	}
-
+export function ExecutionStatusBadge({ executionOrder, showPending, hasError }: ExecutionStatusBadgeProps) {
 	if (showPending) {
 		return <span className='execution-order-badge'>-</span>;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-code-cell-contents {
+	.positron-notebook-editor-section {
+		position: relative;
+	}
 
 	.positron-notebook-cell-outputs {
 		padding-inline: 1rem;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -47,7 +47,7 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 			hasError={hasError}
 		>
 			<div className='positron-notebook-code-cell-contents'>
-				<div>
+				<div className='positron-notebook-editor-section'>
 					<CellLeftActionMenu cell={cell} hasError={hasError} />
 					<div className='positron-notebook-editor-container'>
 						<CellEditorMonacoWidget cell={cell} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -47,12 +47,15 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 			hasError={hasError}
 		>
 			<div className='positron-notebook-code-cell-contents'>
-				<div className='positron-notebook-editor-container'>
-					<CellEditorMonacoWidget cell={cell} />
+				<div>
+					<CellLeftActionMenu cell={cell} hasError={hasError} />
+					<div className='positron-notebook-editor-container'>
+						<CellEditorMonacoWidget cell={cell} />
+					</div>
 				</div>
 				<CellOutputsSection outputs={outputContents} />
 			</div>
-			<CellLeftActionMenu cell={cell} hasError={hasError} />
+
 		</NotebookCellWrapper>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -49,10 +49,10 @@ export function CellActionButton({ action, cell, hoverManager }: CellActionButto
 			tooltip={action.tooltip && action.tooltip.length > 0 ? action.tooltip : action.label}
 			onPressed={() => handleActionClick(action)}
 		>
-			{action.item.icon ?
-				<Icon icon={action.item.icon} /> :
-				// Cell actions should have icons; this is a developer error
-				<DevErrorIcon />}
+			{action.item.icon
+				? <Icon icon={action.item.icon} />
+				: <DevErrorIcon /> // Cell actions should have icons; this is a developer error
+			}
 		</ActionButton>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -720,7 +720,7 @@ registerAction2(class extends CellAction2 {
 		super({
 			id: POSITRON_EXECUTE_CELL_COMMAND_ID,
 			title: localize2('positronNotebook.cell.execute', "Run Cell"),
-			icon: ThemeIcon.fromId('play'),
+			icon: ThemeIcon.fromId('notebook-execute'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionLeft,
 				when: ContextKeyExpr.and(

--- a/test/e2e/tests/notebooks-positron/notebook-cell-execution-info.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-execution-info.test.ts
@@ -41,8 +41,9 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 		await test.step('Cell 0 - Successful execution info display', async () => {
 			// Verify popup shows success status
 			await notebooksPositron.addCodeToCell(0, 'print("hello world")', { run: true });
+
+			await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 			await notebooksPositron.expectToolTipToContain({
-				order: 1,
 				duration: /\d+(ms|s)/,
 				status: 'Success'
 			}, 30000);
@@ -60,8 +61,8 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			await notebooksPositron.addCodeToCell(1, 'raise Exception("test error")', {
 				run: true,
 			});
+			await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
 			await notebooksPositron.expectToolTipToContain({
-				order: 2,
 				duration: /\d+(ms|s)/,
 				status: 'Failed'
 			});


### PR DESCRIPTION
This PR addresses #10083

We now always show the execution order under the run button for each cell instead of displaying that information inside of a tooltip.

Changes:
* Always show execution order next to cell
* Hovering anywhere to the left of a cell displays the tooltip and run button
* Updated run button icon to `notebook-execute` icon
* Remove circle border around cell
* Only show spinning "execution indicator" when cell is running

**BEFORE**

https://github.com/user-attachments/assets/67397d99-d642-4493-b674-2ae15bb80c0d

**AFTER**

https://github.com/user-attachments/assets/12d8297c-bc91-44ac-a16e-16d1e9248cb9


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
