### PR TITLE
Add streaming support to notebook ai suggested actions

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,7 +16,7 @@ import { registerCopilotAuthProvider } from './authProvider.js';
 import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
-import { generateNotebookSuggestions } from './notebookSuggestions.js';
+import { generateNotebookSuggestions, type NotebookActionSuggestion } from './notebookSuggestions.js';
 import { TokenUsage, TokenTracker } from './tokens.js';
 import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 import { AnthropicLanguageModel } from './anthropic.js';
@@ -279,16 +279,20 @@ function registerGenerateNotebookSuggestionsCommand(
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'positron-assistant.generateNotebookSuggestions',
-			async (notebookUri: string, token?: vscode.CancellationToken) => {
+			async (notebookUri: string, progressCallbackCommand?: string, token?: vscode.CancellationToken) => {
 				// Create a token source only if no token is provided
 				let tokenSource: vscode.CancellationTokenSource | undefined;
-				// If there is no provided token, create a new one and also
-				// assign it to the tokenSource so we know to dispose it later.
 				const cancellationToken = token || (tokenSource = new vscode.CancellationTokenSource()).token;
 				try {
-					return await generateNotebookSuggestions(notebookUri, participantService, log, cancellationToken);
+					return await generateNotebookSuggestions(
+						notebookUri,
+						participantService,
+						log,
+						cancellationToken,
+						progressCallbackCommand
+					);
 				} finally {
-					// We only want to dispose the token if we created it
+					// Only dispose if we created the token
 					tokenSource?.dispose();
 				}
 			}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,7 +16,7 @@ import { registerCopilotAuthProvider } from './authProvider.js';
 import { ALL_DOCUMENTS_SELECTOR, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
 import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
-import { generateNotebookSuggestions, type NotebookActionSuggestion } from './notebookSuggestions.js';
+import { generateNotebookSuggestions, type NotebookActionSuggestion, type NotebookSuggestionsResult } from './notebookSuggestions.js';
 import { TokenUsage, TokenTracker } from './tokens.js';
 import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 import { AnthropicLanguageModel } from './anthropic.js';
@@ -279,7 +279,7 @@ function registerGenerateNotebookSuggestionsCommand(
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'positron-assistant.generateNotebookSuggestions',
-			async (notebookUri: string, progressCallbackCommand?: string, token?: vscode.CancellationToken) => {
+			async (notebookUri: string, progressCallbackCommand?: string, token?: vscode.CancellationToken): Promise<NotebookSuggestionsResult> => {
 				// Create a token source only if no token is provided
 				let tokenSource: vscode.CancellationTokenSource | undefined;
 				const cancellationToken = token || (tokenSource = new vscode.CancellationTokenSource()).token;

--- a/extensions/positron-assistant/src/md/prompts/notebook/suggestions.md
+++ b/extensions/positron-assistant/src/md/prompts/notebook/suggestions.md
@@ -14,18 +14,26 @@ You are an AI assistant for Jupyter notebooks in Positron. Your task is to analy
 
 ## Output Format
 
-You MUST return only valid JSON in the output, and nothing else. Format the response as an array of objects with the following structure:
+You MUST return only valid XML in the output, and nothing else. Format the response using the following structure:
 
-```json
-[
-  {
-    "label": "Brief action title (max 50 chars)",
-    "detail": "Longer explanation of what this action will do",
-    "query": "The full prompt that will be sent to the assistant to execute this action",
-    "mode": "ask" | "edit" | "agent"
-  }
-]
+```xml
+<suggestions>
+  <suggestion>
+    <label>Brief action title (max 50 chars)</label>
+    <detail>Longer explanation of what this action will do</detail>
+    <query>The full prompt that will be sent to the assistant to execute this action</query>
+    <mode>ask</mode>
+  </suggestion>
+  <suggestion>
+    <label>Another action title</label>
+    <detail>Another explanation</detail>
+    <query>Another prompt</query>
+    <mode>edit</mode>
+  </suggestion>
+</suggestions>
 ```
+
+Valid values for mode are: `ask`, `edit`, or `agent`
 
 ## Examples
 
@@ -33,81 +41,81 @@ You MUST return only valid JSON in the output, and nothing else. Format the resp
 
 Context: Notebook has 10 cells, cell 5 failed with a NameError, 3 cells selected
 
-```json
-[
-  {
-    "label": "Debug the NameError in cell 5",
-    "detail": "Investigate and fix the undefined variable causing the error",
-    "query": "Can you help me debug the NameError in cell 5 and suggest a fix?",
-    "mode": "agent"
-  },
-  {
-    "label": "Explain the selected cells",
-    "detail": "Get a detailed explanation of what the selected code does",
-    "query": "Can you explain what the code in the selected cells does?",
-    "mode": "ask"
-  },
-  {
-    "label": "Add error handling",
-    "detail": "Add try-catch blocks to make the code more robust",
-    "query": "Can you add error handling to the selected cells?",
-    "mode": "edit"
-  }
-]
+```xml
+<suggestions>
+  <suggestion>
+    <label>Debug the NameError in cell 5</label>
+    <detail>Investigate and fix the undefined variable causing the error</detail>
+    <query>Can you help me debug the NameError in cell 5 and suggest a fix?</query>
+    <mode>agent</mode>
+  </suggestion>
+  <suggestion>
+    <label>Explain the selected cells</label>
+    <detail>Get a detailed explanation of what the selected code does</detail>
+    <query>Can you explain what the code in the selected cells does?</query>
+    <mode>ask</mode>
+  </suggestion>
+  <suggestion>
+    <label>Add error handling</label>
+    <detail>Add try-catch blocks to make the code more robust</detail>
+    <query>Can you add error handling to the selected cells?</query>
+    <mode>edit</mode>
+  </suggestion>
+</suggestions>
 ```
 
 ### Example 2: Empty Notebook
 
 Context: Notebook has 0 cells, Python kernel
 
-```json
-[
-  {
-    "label": "Get started with data analysis",
-    "detail": "Create a basic data analysis workflow with pandas",
-    "query": "Can you help me set up a basic data analysis workflow with pandas? Please create cells for loading data, exploring it, and visualizing it.",
-    "mode": "agent"
-  },
-  {
-    "label": "Create a data science template",
-    "detail": "Set up a standard data science notebook structure",
-    "query": "Can you create a template notebook structure for data science work with sections for imports, data loading, exploration, modeling, and conclusions?",
-    "mode": "edit"
-  }
-]
+```xml
+<suggestions>
+  <suggestion>
+    <label>Get started with data analysis</label>
+    <detail>Create a basic data analysis workflow with pandas</detail>
+    <query>Can you help me set up a basic data analysis workflow with pandas? Please create cells for loading data, exploring it, and visualizing it.</query>
+    <mode>agent</mode>
+  </suggestion>
+  <suggestion>
+    <label>Create a data science template</label>
+    <detail>Set up a standard data science notebook structure</detail>
+    <query>Can you create a template notebook structure for data science work with sections for imports, data loading, exploration, modeling, and conclusions?</query>
+    <mode>edit</mode>
+  </suggestion>
+</suggestions>
 ```
 
 ### Example 3: Notebook with Outputs
 
 Context: Notebook has 15 cells, all executed successfully, last cell shows a matplotlib plot, 0 cells selected
 
-```json
-[
-  {
-    "label": "Explain the visualization",
-    "detail": "Get insights about the plot in the last cell",
-    "query": "Can you explain what the visualization in the last cell shows and what insights we can draw from it?",
-    "mode": "ask"
-  },
-  {
-    "label": "Improve the plot aesthetics",
-    "detail": "Enhance the visual appearance of the matplotlib plot",
-    "query": "Can you suggest improvements to make the plot in the last cell more visually appealing and publication-ready?",
-    "mode": "edit"
-  },
-  {
-    "label": "Add summary statistics",
-    "detail": "Create a new cell with statistical analysis of the plotted data",
-    "query": "Can you add a cell that calculates and displays summary statistics for the data shown in the plot?",
-    "mode": "agent"
-  },
-  {
-    "label": "Export results to file",
-    "detail": "Save the plot and data to files",
-    "query": "Can you help me export the visualization and underlying data to files?",
-    "mode": "agent"
-  }
-]
+```xml
+<suggestions>
+  <suggestion>
+    <label>Explain the visualization</label>
+    <detail>Get insights about the plot in the last cell</detail>
+    <query>Can you explain what the visualization in the last cell shows and what insights we can draw from it?</query>
+    <mode>ask</mode>
+  </suggestion>
+  <suggestion>
+    <label>Improve the plot aesthetics</label>
+    <detail>Enhance the visual appearance of the matplotlib plot</detail>
+    <query>Can you suggest improvements to make the plot in the last cell more visually appealing and publication-ready?</query>
+    <mode>edit</mode>
+  </suggestion>
+  <suggestion>
+    <label>Add summary statistics</label>
+    <detail>Create a new cell with statistical analysis of the plotted data</detail>
+    <query>Can you add a cell that calculates and displays summary statistics for the data shown in the plot?</query>
+    <mode>agent</mode>
+  </suggestion>
+  <suggestion>
+    <label>Export results to file</label>
+    <detail>Save the plot and data to files</detail>
+    <query>Can you help me export the visualization and underlying data to files?</query>
+    <mode>agent</mode>
+  </suggestion>
+</suggestions>
 ```
 
-Remember: Return ONLY valid JSON. Do not include any explanatory text, markdown formatting, or additional commentary.
+Remember: Return ONLY valid XML. Do not include any explanatory text, markdown formatting, or additional commentary.


### PR DESCRIPTION
Addresses #10568.

https://github.com/user-attachments/assets/57984490-1a1a-4e8d-9c45-4b5778ff95f4

This PR switches the "Generate AI suggestions" feature from JSON to XML format, enabling progressive display of suggestions as they're generated.

### Summary

Uses `StreamingTagLexer` to parse XML responses progressively:
- Updated prompt format to request XML instead of JSON in `suggestions.md`
- Replaced JSON accumulation with streaming XML parser in `notebookSuggestions.ts`
- Added progressive updates to QuickPick via callback command in `AskAssistantAction.ts`
- Removed old "Suggest next steps" action (too similar to AI suggestions)

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:assistant

1. Open a notebook with Python or R code
2. Click "Ask Positron Assistant" in the cell toolbar
3. Select "Generate AI suggestions"
4. Verify suggestions appear progressively (first within 1-2 seconds, others incrementally)
