### PR TITLE
update packages-lock

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -4269,17 +4269,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",

--- a/extensions/positron-python/package-lock.json
+++ b/extensions/positron-python/package-lock.json
@@ -122,7 +122,7 @@
                 "yargs": "^15.3.1"
             },
             "engines": {
-                "vscode": "^1.104.0"
+                "vscode": "^1.106.0"
             }
         },
         "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
There are a couple of outdated package-lock.json files in positron-assistant and positron-python, if you `npm install` from the root of the positron repo. I think https://github.com/posit-dev/positron/pull/10744 and https://github.com/posit-dev/positron/pull/10749 introduced these.