### PR TITLE
E2E test: activate file view during readiness check

### DIFF
--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -209,17 +209,37 @@ export class Application {
 	 */
 	private async checkPositronReady(code: Code): Promise<void> {
 		await measureAndLog(
-			() => expect(code.driver.page.locator(READINESS_LOCATORS.monacoWorkbench)).toBeVisible({ timeout: 30000 }),
+			() => expect(code.driver.page.locator(READINESS_LOCATORS.monacoWorkbench))
+				.toBeVisible({ timeout: 30000 }),
 			'Application#checkPositronReady: wait for monaco workbench',
 			this.logger
 		);
-		await measureAndLog(() => code.whenWorkbenchRestored(), 'Application#checkPositronReady: wait for workbench restored', this.logger);
+
 		await measureAndLog(
-			() => expect(code.driver.page.locator(READINESS_LOCATORS.explorerFoldersView)).toBeVisible({ timeout: 60000 }),
-			'Application#checkPositronReady: wait for explorer view',
+			() => code.whenWorkbenchRestored(),
+			'Application#checkPositronReady: wait for workbench restored',
 			this.logger
 		);
+
+		await expect(async () => {
+			await measureAndLog(
+				async () => {
+					const explorerButton = code.driver.page.locator('.action-item .codicon-explorer-view-icon');
+					await explorerButton.click({ timeout: 5000 });
+				},
+				'Application#checkPositronReady: open explorer view',
+				this.logger
+			);
+
+			await measureAndLog(
+				() => expect(code.driver.page.locator(READINESS_LOCATORS.explorerFoldersView))
+					.toBeVisible({ timeout: 5000 }),
+				'Application#checkPositronReady: wait for explorer view',
+				this.logger
+			);
+		}).toPass({ timeout: 60000 });
 	}
+
 
 	/**
 	 * Posit Workbench readiness checks


### PR DESCRIPTION
We are now seeing the Assistant tab open first on launch. The test framework expects to see the file view, so we need to activate the file view.

Its not yet clear if the Assistant tab should open first, but we need a short term workaround.

### QA Notes
