### PR TITLE
Bump ark to 0.1.218

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -928,7 +928,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.217"
+      "ark": "0.1.218"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/positron/issues/8559
- https://github.com/posit-dev/ark/issues/966

### Release Notes

#### New Features

- `Cmd + Enter` within roxygen2 `@examples` and `@examplesIf` tags now executes entire R expressions rather than executing one line at a time (https://github.com/posit-dev/ark/pull/965).

#### Bug Fixes

- Fixed a bug in the R backend that caused visible errors when the `R_PROFILE` or `R_PROFILE_USER` environment variables were set to paths that don't exist (https://github.com/posit-dev/ark/issues/966).

### QA Notes

@:ark