### PR TITLE
Fix Anthropic sign-in error

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -101,11 +101,9 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			apiKey: undefined // will be filled in below if needed
 		};
 
-		if (modelConfig?.baseUrl) {
-			const apiKey = await storage.get(`apiKey-${modelConfig.id}`);
-			if (apiKey) {
-				modelConfig.apiKey = apiKey;
-			}
+		const apiKey = await storage.get(`apiKey-${modelConfig.id}`);
+		if (apiKey) {
+			modelConfig.apiKey = apiKey;
 		}
 
 		if (!modelConfig) {


### PR DESCRIPTION
Address #10823 

### Release Notes

Fix the missing API key when signing in to Anthropic. Now it retrieves the key from secret storage and adds it to the config if a key exists.

This affected the API key sign-in method only. Using the environment variable didn't have this problem.

#### New Features

- N/A

#### Bug Fixes

- Fix API key error when signing in to Anthropic


### QA Notes