### PR TITLE
Assistant: support Snowflake oauth token refresh

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -29,7 +29,7 @@ import { PositronAssistantApi } from './api.js';
 import { autoconfigureWithManagedCredentials, AWS_MANAGED_CREDENTIALS, SNOWFLAKE_MANAGED_CREDENTIALS } from './pwb';
 import { getAllModelDefinitions } from './modelDefinitions';
 import { createModelInfo, getMaxTokens, markDefaultModel } from './modelResolutionHelpers.js';
-import { detectSnowflakeCredentials, extractSnowflakeError, getSnowflakeDefaultBaseUrl } from './snowflakeAuth.js';
+import { detectSnowflakeCredentials, extractSnowflakeError, getSnowflakeDefaultBaseUrl, getSnowflakeConnectionsTomlPath, checkForUpdatedSnowflakeCredentials } from './snowflakeAuth.js';
 import { createOpenAICompatibleFetch } from './openai-fetch-utils.js';
 
 /**
@@ -934,6 +934,7 @@ class OpenAICompatibleLanguageModel extends OpenAILanguageModel implements posit
 
 class SnowflakeLanguageModel extends OpenAILanguageModel {
 	protected aiProvider: OpenAIProvider;
+	private lastConnectionsTomlCheck?: number; // Timestamp of last file check
 
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Chat,
@@ -961,37 +962,69 @@ class SnowflakeLanguageModel extends OpenAILanguageModel {
 		return this._config.baseUrl || SnowflakeLanguageModel.source.defaults.baseUrl!;
 	}
 
-	static override async autoconfigure(): Promise<AutoconfigureResult> {
-		// Token extractor function for Snowflake
-		const snowflakeTokenExtractor = async (): Promise<string | undefined> => {
-			const credentials = await detectSnowflakeCredentials();
-			// Return token only if credentials exist and token is non-empty
-			return credentials?.token && credentials.token.trim().length > 0 ? credentials.token : undefined;
-		};
-
-		const autoconfigureResult = await autoconfigureWithManagedCredentials(
-			SNOWFLAKE_MANAGED_CREDENTIALS,
-			SnowflakeLanguageModel.source.provider.id,
-			SnowflakeLanguageModel.source.provider.displayName,
-			snowflakeTokenExtractor
+	/**
+	 * Check if connections.toml has been modified since our last check and update token if needed
+	 */
+	private async checkForUpdatedCredentials(): Promise<void> {
+		const result = await checkForUpdatedSnowflakeCredentials(
+			this.lastConnectionsTomlCheck,
+			this._config.apiKey
 		);
 
-		// If we successfully got credentials, also include the baseUrl
-		if (autoconfigureResult.signedIn) {
-			try {
-				const credentials = await detectSnowflakeCredentials();
-				if (credentials?.baseUrl) {
-					return {
-						...autoconfigureResult,
-						baseUrl: credentials.baseUrl
-					};
-				}
-			} catch (error) {
-				log.debug(`[Snowflake] Failed to get baseUrl during autoconfigure: ${error}`);
+		if (result.updated && result.credentials) {
+			this._config.apiKey = result.credentials.token;
+			if (result.credentials.baseUrl && result.credentials.baseUrl !== this._config.baseUrl) {
+				this._config.baseUrl = result.credentials.baseUrl;
+			}
+
+			// Recreate the provider with updated credentials
+			this.aiProvider = createOpenAI({
+				apiKey: result.credentials.token,
+				baseURL: this.baseUrl,
+				fetch: createOpenAICompatibleFetch(this.providerName)
+			});
+
+			log.info(`[${this.providerName}] Refreshed credentials for account: ${result.credentials.account}`);
+		}
+		this.lastConnectionsTomlCheck = result.lastModified;
+	}
+
+	/**
+	 * Override to check for updated credentials before making requests
+	 */
+	override async provideLanguageModelChatResponse(
+		model: vscode.LanguageModelChatInformation,
+		messages: vscode.LanguageModelChatMessage2[],
+		options: vscode.ProvideLanguageModelChatResponseOptions,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
+		token: vscode.CancellationToken
+	) {
+		await this.checkForUpdatedCredentials();
+		return super.provideLanguageModelChatResponse(model, messages, options, progress, token);
+	}
+
+	static override async autoconfigure(): Promise<AutoconfigureResult> {
+		// Use the standard PWB flow for environment and settings validation
+		const configureResult = await autoconfigureWithManagedCredentials(
+			SNOWFLAKE_MANAGED_CREDENTIALS,
+			SnowflakeLanguageModel.source.provider.id,
+			SnowflakeLanguageModel.source.provider.displayName
+		);
+
+		// If PWB checks pass, get credentials and return with both token and baseUrl
+		if (configureResult.signedIn) {
+			const credentials = await detectSnowflakeCredentials();
+			if (credentials?.token && credentials.token.trim().length > 0) {
+				return {
+					signedIn: configureResult.signedIn,
+					message: configureResult.message,
+					token: credentials.token,
+					baseUrl: credentials.baseUrl
+				};
 			}
 		}
 
-		return autoconfigureResult;
+		return { signedIn: false };
 	}
 
 	override async parseProviderError(error: any): Promise<string | undefined> {

--- a/extensions/positron-assistant/src/openai-fetch-utils.ts
+++ b/extensions/positron-assistant/src/openai-fetch-utils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-assistant/src/pwb.ts
+++ b/extensions/positron-assistant/src/pwb.ts
@@ -50,14 +50,12 @@ export const SNOWFLAKE_MANAGED_CREDENTIALS: ManagedCredentialConfig = {
  * @param credentialConfig - The credential configuration to check
  * @param providerId - The provider ID to check if enabled
  * @param displayName - The provider display name for logging
- * @param tokenExtractor - Optional function to extract the actual token from the environment
  * @returns A promise that resolves to the autoconfigure result
  */
 export async function autoconfigureWithManagedCredentials<T extends ManagedCredentialConfig>(
 	credentialConfig: T,
 	providerId: string,
-	displayName: string,
-	tokenExtractor?: () => Promise<string | undefined>
+	displayName: string
 ): Promise<AutoconfigureResult> {
 	// Configure automatically if:
 	// - We are on PWB, and
@@ -94,20 +92,8 @@ export async function autoconfigureWithManagedCredentials<T extends ManagedCrede
 
 	log.info(`[${displayName}] Auto-configuring with managed credentials`);
 
-	// Extract token if tokenExtractor is provided
-	let token: string | undefined;
-	if (tokenExtractor) {
-		token = await tokenExtractor();
-		if (!token) {
-			log.warn(`[${displayName}] Token extraction failed despite valid environment`);
-			return { signedIn: false };
-		}
-		log.debug(`[${displayName}] Token extracted successfully`);
-	}
-
 	return {
 		signedIn: true,
-		message: credentialConfig.displayName,
-		...(token && { token })
+		message: credentialConfig.displayName
 	};
 }


### PR DESCRIPTION
### Summary

- This is a followup to https://github.com/posit-dev/positron/pull/10749 for issue https://github.com/posit-dev/positron/issues/8613
- This PR adds oauth token refresh handling for Snowflake
- Approach: before we make a chat request, check to see if the connections.toml file has been updated and refresh the token if it has

### QA Notes

On Workbench, we should no longer get this error in chat when using Snowflake:

```
[Snowflake Cortex] Authentication failed (OAuth access token expired. [1407662652004274]). Please check your credentials and try signing in again.
```