### PR TITLE
Add a spinning icon when previewing a table

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -69,10 +69,9 @@
 	flex-shrink: 0;
 	flex-grow: 0;
 	padding: 0 5px;
-	outline-width: 0;
 }
 
-.connections-item .connections-icon[tabindex="0"]:focus:not(:focus-visible) {
+.connections-item .connections-icon:focus:not(:focus-visible) {
 	outline-width: 0;
 }
 

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -73,7 +73,7 @@
 }
 
 .connections-item .connections-icon[tabindex="0"]:focus {
-	outline-width: 0px;
+	outline-width: 0;
 }
 
 .connections-item .connections-icon .disabled {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -72,7 +72,7 @@
 	outline-width: 0;
 }
 
-.connections-item .connections-icon[tabindex="0"]:focus {
+.connections-item .connections-icon[tabindex="0"]:focus:not(:focus-visible) {
 	outline-width: 0;
 }
 

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -69,6 +69,11 @@
 	flex-shrink: 0;
 	flex-grow: 0;
 	padding: 0 5px;
+	outline-width: 0;
+}
+
+.connections-item .connections-icon[tabindex="0"]:focus {
+	outline-width: 0px;
 }
 
 .connections-item .connections-icon .disabled {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -296,7 +296,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 	}
 
 	/*
-	Icon showing if the element kind (table, view, schema, etc)
+	Icon showing the element kind (table, view, schema, etc)
 
 	The icon can be either a base64 encoded image or a codicon class.
 	If it's a base64 encoded image, we render an img tag.

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -18,7 +18,7 @@ import { IPositronConnectionEntry } from '../../../../services/positronConnectio
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { usePositronConnectionsContext } from '../positronConnectionsContext.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
-import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+import { KeyboardModifiers, PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
 
 const DETAILS_BAR_HEIGHT = 26;
 
@@ -376,7 +376,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 	const PreviewButton = (({ onPreview }: { onPreview: (() => Promise<void>) | undefined }) => {
 		const [showSpinner, setShowSpinner] = useState<boolean>(false);
 
-		const previewCallback = onPreview ? async () => {
+		const previewCallback = onPreview ? async (_e: KeyboardModifiers) => {
 			setShowSpinner(true);
 			try {
 				await onPreview();

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -18,6 +18,7 @@ import { IPositronConnectionEntry } from '../../../../services/positronConnectio
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { usePositronConnectionsContext } from '../positronConnectionsContext.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
+import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
 
 const DETAILS_BAR_HEIGHT = 26;
 
@@ -384,15 +385,14 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 			}
 		};
 
-		return <div
-			className={positronClassNames(
-				'connections-icon',
-				{ 'disabled': props.item.preview === undefined || showSpinner }
-			)}
-			onClick={previewCallback}
+		return <PositronButton
+			ariaLabel={localize('positron.schemaNavigation.previewElement', 'Preview element')}
+			className='connections-icon'
+			disabled={onPreview === undefined || showSpinner}
+			onPressed={previewCallback}
 		>
-			{showSpinner ? <div className="codicon codicon-loading animate-spin" /> : <ElementIcon />}
-		</div>
+			{showSpinner ? <div className='codicon codicon-loading animate-spin' /> : <ElementIcon />}
+		</PositronButton>
 	});
 
 	return (

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -294,7 +294,14 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		return '';
 	}
 
-	const icon = (() => {
+	/*
+	Icon showing if the element kind (table, view, schema, etc)
+
+	The icon can be either a base64 encoded image or a codicon class.
+	If it's a base64 encoded image, we render an img tag.
+	If it's a codicon class, we render a div with the appropriate class.
+	*/
+	const ElementIcon = (() => {
 		// icon is a base64 encoded png
 		if (props.item.icon) {
 			return <img
@@ -310,7 +317,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 			)}
 		>
 		</div>
-	})();
+	});
 
 	const rowMouseDownHandler = (e: MouseEvent<HTMLElement>) => {
 		// Consume the event.
@@ -365,6 +372,29 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		)
 	});
 
+	const PreviewButton = (({ onPreview }: { onPreview: (() => Promise<void>) | undefined }) => {
+		const [showSpinner, setShowSpinner] = useState<boolean>(false);
+
+		const previewCallback = async () => {
+			setShowSpinner(true);
+			try {
+				await onPreview?.();
+			} finally {
+				setShowSpinner(false);
+			}
+		};
+
+		return <div
+			className={positronClassNames(
+				'connections-icon',
+				{ 'disabled': props.item.preview === undefined || showSpinner }
+			)}
+			onClick={previewCallback}
+		>
+			{showSpinner ? <div className="codicon codicon-loading animate-spin" /> : <ElementIcon />}
+		</div>
+	});
+
 	return (
 		<div
 			className={positronClassNames(
@@ -386,15 +416,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 				{props.item.dtype && <span className='connections-dtype'>{props.item.dtype}</span>}
 				{props.item.error && <span className='connections-error codicon codicon-error' title={props.item.error}></span>}
 			</div>
-			<div
-				className={positronClassNames(
-					'connections-icon',
-					{ 'disabled': props.item.preview === undefined }
-				)}
-				onClick={() => props.item.preview?.()}
-			>
-				{icon}
-			</div>
+			<PreviewButton onPreview={props.item.preview} />
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -376,14 +376,14 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 	const PreviewButton = (({ onPreview }: { onPreview: (() => Promise<void>) | undefined }) => {
 		const [showSpinner, setShowSpinner] = useState<boolean>(false);
 
-		const previewCallback = async () => {
+		const previewCallback = onPreview ? async () => {
 			setShowSpinner(true);
 			try {
-				await onPreview?.();
+				await onPreview();
 			} finally {
 				setShowSpinner(false);
 			}
-		};
+		} : undefined;
 
 		return <PositronButton
 			ariaLabel={localize('positron.schemaNavigation.previewElement', 'Preview element')}


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/10835


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- A spinning icon is shown when the connections pane is loading a table preview (https://github.com/posit-dev/positron/issues/10835).

#### Bug Fixes

- N/A

### QA Notes

To reproduce, create a connection with eg BigQuery which can be quite slow at previewing and then click on to preview a table:


https://github.com/user-attachments/assets/db5f63e2-8b07-448e-8cc8-d6ca173a7b78


