### PR TITLE
Use "compact" auxiliary window for plots opened in new window

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -349,6 +349,20 @@ export function prepareMoveCopyEditors(sourceGroup: IEditorGroup, editors: Edito
 	return editorsWithOptions;
 }
 
+// --- Start Positron ---
+/**
+ * Determines auxiliary window options for editors being moved to a new window.
+ * Returns compact mode options for plot editors.
+ */
+export function getAuxiliaryWindowOptionsForEditors(editors: readonly EditorInput[]): IAuxiliaryWindowOpenOptions | undefined {
+	const hasPlotEditor = editors.some(editor => editor.typeId === 'workbench.input.positronPlots');
+	return hasPlotEditor ? {
+		compact: true,
+		bounds: { width: 900, height: 700 }
+	} : undefined;
+}
+// --- End Positron ---
+
 /**
  * A sub-interface of IEditorService to hide some workbench-core specific
  * events from clients.

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -26,6 +26,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
 import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
+import { PositronPlotsEditorInput } from '../../../contrib/positronPlotsEditor/browser/positronPlotsEditorInput.js';
+import { IsCompactTitleBarContext } from '../../../common/contextkeys.js';
 
 /**
  * Constants.
@@ -186,7 +188,8 @@ export class EditorActionBarControlFactory {
 		private readonly _container: HTMLElement,
 		private readonly _editorGroup: IEditorGroupView,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService
 	) {
 		// Update the enablement for the active editor.
 		this.updateEnablementForEditorInput(this._editorGroup.activeEditor);
@@ -233,6 +236,15 @@ export class EditorActionBarControlFactory {
 		if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
 			this.updateEnablement(false);
 			return;
+		}
+
+		// Plots in compact windows disable the editor action bar.
+		if (editorInput.typeId === PositronPlotsEditorInput.TypeID) {
+			const isCompact = IsCompactTitleBarContext.getValue(this._contextKeyService);
+			if (isCompact) {
+				this.updateEnablement(false);
+				return;
+			}
 		}
 
 		// Settings always enables editor action bar.

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -39,6 +39,10 @@ import { IProgressService, ProgressLocation } from '../../../../platform/progres
 import { resolveCommandsContext } from './editorCommandsContext.js';
 import { IListService } from '../../../../platform/list/browser/listService.js';
 import { prepareMoveCopyEditors } from './editor.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { getAuxiliaryWindowOptionsForEditors } from './editor.js';
+// --- End Positron ---
 
 class ExecuteCommandAction extends Action2 {
 
@@ -2587,9 +2591,19 @@ abstract class BaseMoveCopyEditorToNewWindowAction extends Action2 {
 			return;
 		}
 
-		const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart();
+		// --- Start Positron ---
+		// const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart();
+		// --- End Positron ---
 
 		const { group, editors } = resolvedContext.groupedEditors[0]; // only single group supported for move/copy for now
+
+		// --- Start Positron ---
+		// Use compact mode for plot editors
+		const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(
+			getAuxiliaryWindowOptionsForEditors(editors)
+		);
+		// --- End Positron ---
+
 		const editorsWithOptions = prepareMoveCopyEditors(group, editors, resolvedContext.preserveFocus);
 		if (this.move) {
 			group.moveEditors(editorsWithOptions, auxiliaryEditorPart.activeGroup);
@@ -2650,7 +2664,14 @@ abstract class BaseMoveCopyEditorGroupToNewWindowAction extends Action2 {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 		const activeGroup = editorGroupService.activeGroup;
 
-		const auxiliaryEditorPart = await editorGroupService.createAuxiliaryEditorPart();
+		// --- Start Positron ---
+		// const auxiliaryEditorPart = await editorGroupService.createAuxiliaryEditorPart();
+
+		// Use compact mode for plot editors
+		const auxiliaryEditorPart = await editorGroupService.createAuxiliaryEditorPart(
+			getAuxiliaryWindowOptionsForEditors(activeGroup.editors)
+		);
+		// --- End Positron ---
 
 		editorGroupService.mergeGroup(activeGroup, auxiliaryEditorPart.activeGroup, {
 			mode: this.move ? MergeGroupMode.MOVE_EDITORS : MergeGroupMode.COPY_EDITORS

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -43,9 +43,10 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { WebviewPlotClient } from './webviewPlotClient.js';
-import { ACTIVE_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
+import { ACTIVE_GROUP, AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { PositronPlotCommProxy } from '../../../services/languageRuntime/common/positronPlotCommProxy.js';
+import { PlotResult } from '../../../services/languageRuntime/common/positronPlotComm.js';
 import { DynamicPlotInstance } from './components/dynamicPlotInstance.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
@@ -829,7 +830,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				const code = this._recentExecutions.has(event.message.parent_id) ?
 					this._recentExecutions.get(event.message.parent_id)! : '';
 
-				const data = event.message.data as any;
+				const data = event.message.data as { pre_render?: PlotResult };
 
 				// Create the metadata object
 				const metadata: IPositronPlotMetadata = {
@@ -1489,6 +1490,13 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				scheme: Schemas.positronPlotsEditor,
 				path: plotId,
 			}),
+			options: selectedEditorGroup === AUX_WINDOW_GROUP ? {
+				pinned: true,
+				auxiliary: {
+					compact: true,
+					bounds: { width: 900, height: 700 }
+				}
+			} : undefined
 		}, selectedEditorGroup);
 
 		if (!editorPane) {
@@ -1537,7 +1545,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	 * @returns A new PositronPlotCommProxy instance.
 	 */
 	private createCommProxy(
-		client: IRuntimeClientInstance<any, any>,
+		client: IRuntimeClientInstance<unknown, unknown>,
 		metadata: IPositronPlotMetadata): PositronPlotCommProxy {
 
 		// Get or create the render queue for this session


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7613

With this PR, the new window that opens up when you do "Open in new window" for a plot is now in "compact" mode by default, without the editor action bar:

<img width="1012" height="812" alt="Screenshot 2025-11-29 at 1 10 20 PM" src="https://github.com/user-attachments/assets/47f1117c-68e6-43b7-8080-8cfb2e942d51" />


If you click the icon to leave compact mode, both bars comes back:

<img width="1012" height="812" alt="Screenshot 2025-11-29 at 1 10 24 PM" src="https://github.com/user-attachments/assets/95442e96-b8de-42fc-a469-a0281a20e58a" />

I think it's pretty clear this is a better experience, so we should also say we are addressing https://github.com/posit-dev/positron/issues/10085 with this change rather than making this configurable.

@:plots

### Release Notes

#### New Features

- "Open in new window" for plots now uses compact mode in the new window

#### Bug Fixes

- N/A


### QA Notes

If you make some R and/or Python plots and do "Open in new window", you should not see the editor tab bar or the editor action bar by default. You can bring these back by turning off compact mode here:

<img width="1012" height="812" alt="Screenshot_2025-11-29_at_1_10_20 PM" src="https://github.com/user-attachments/assets/a9735445-3e23-4c13-ba2a-b8b18c1b0762" />
