### PR TITLE
Add Signin test for Anthropic and OpenAI

### DIFF
--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -136,14 +136,15 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      # - name: Load secret
-      #   uses: 1password/load-secrets-action@v3
-      #   with:
-      #     # Export loaded secrets as environment variables
-      #     export-env: true
-      #   env:
-      #     OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      #     ANTHROPIC: "op://Positron/Anthropic/credential"
+      - name: Load secret
+        uses: 1password/load-secrets-action@v3
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_KEY: "op://Positron/OpenAI/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -159,6 +159,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_KEY: "op://Positron/OpenAI/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -105,6 +105,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_KEY: "op://Positron/OpenAI/credential"
 
       - name: Set screen resolution
         shell: pwsh

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -1,16 +1,17 @@
 {
-    "python.locator": "native",
-    "interpreters.startupBehavior": "manual",
-    "positron.r.kernel.logLevel": "trace",
-    "python.languageServerLogLevel": "debug",
-    "remote.autoForwardPortsFallback": 0,
-    "files.simpleDialog.enable": true,
-    "positron.importSettings.enable": false,
-    "positron.assistant.enable": true,
-    "positron.assistant.testModels": true,
+	"python.locator": "native",
+	"interpreters.startupBehavior": "manual",
+	"positron.r.kernel.logLevel": "trace",
+	"python.languageServerLogLevel": "debug",
+	"remote.autoForwardPortsFallback": 0,
+	"files.simpleDialog.enable": true,
+	"positron.importSettings.enable": false,
+	"positron.assistant.enable": true,
+	"positron.assistant.testModels": true,
+	"positron.assistant.enabledProviders": ["openai-api"],
 	"posit.workbench.showWorkbenchFlaskHint": false,
 	"extensions.allowed": {
-        "meta.pyrefly": false,
-        "*": true
-    }
+		"meta.pyrefly": false,
+		"*": true
+	}
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -22,6 +22,7 @@ const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
 const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-provider-button)';
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-provider-button)';
+const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
 const RUN_BUTTON = 'a.action-label.codicon.codicon-play[role="button"][aria-label="Run in Console"]';
 const APPLY_IN_EDITOR_BUTTON = 'a.action-label.codicon.codicon-git-pull-request-go-to-changes[role="button"][aria-label="Apply in Editor"]';
@@ -130,6 +131,9 @@ export class Assistant {
 				break;
 			case 'copilot':
 				await this.code.driver.page.locator(COPILOT_BUTTON).click();
+				break;
+			case `openai-api`:
+				await this.code.driver.page.locator(OPENAI_BUTTON).click();
 				break;
 			default:
 				throw new Error(`Unsupported model provider: ${provider}`);

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -44,15 +44,30 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	});
 
 	/**
-	 * Tests the sign in and sign out functionality for a model provider.
-	 * This uses the test Echo provider as there is not a valid API key for the other providers.
-	 *
+	 * Tests the sign in and sign out functionality for the Anthropic model provider.
 	 * @param app - Application fixture providing access to UI elements
 	 */
-	test('Echo: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
+	test('Anthropic: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.clickAddModelButton();
-		await app.workbench.assistant.selectModelProvider('echo');
+		await app.workbench.assistant.selectModelProvider('anthropic-api');
+		await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
+		await app.workbench.assistant.clickSignInButton();
+		await app.workbench.assistant.verifySignOutButtonVisible();
+		await app.workbench.assistant.clickSignOutButton();
+		await app.workbench.assistant.verifySignInButtonVisible();
+		await app.workbench.assistant.clickCloseButton();
+	});
+
+	/**
+ * Tests the sign in and sign out functionality for the OpenAI model provider.
+ * @param app - Application fixture providing access to UI elements
+ */
+	test('OpenAI: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.clickAddModelButton();
+		await app.workbench.assistant.selectModelProvider('openai-api');
+		await app.workbench.assistant.enterApiKey(`${process.env.OPENAI_KEY}`);
 		await app.workbench.assistant.clickSignInButton();
 		await app.workbench.assistant.verifySignOutButtonVisible();
 		await app.workbench.assistant.clickSignOutButton();


### PR DESCRIPTION
Added signin/signout tests for real providers

- Added Anthropic and OpenAI sign in
- Removed echo as provider for sign in test
- Added getting OPENAI_KEY to workflows from 1Password

### QA Notes
@:assistant @:web @:win

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
