### PR TITLE
e2e: add cut/paste notebook test

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -73,10 +73,11 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async getCellContent(cellIndex: number): Promise<string[]> {
 		const cellType = await this.getCellType(cellIndex);
+
 		if (cellType === 'markdown') {
 			// Enter edit mode to ensure the monaco view-lines are present
-			const inViewMode = await this.expandMarkdownEditor.isVisible();
-			if (inViewMode) {
+			const inEditMode = await this.cell.nth(cellIndex).getByRole('button', { name: 'Collapse markdown editor' }).isVisible();
+			if (!inEditMode) {
 				await this.selectCellAtIndex(cellIndex, { editMode: true });
 			}
 		}
@@ -563,9 +564,10 @@ export class PositronNotebooks extends Notebooks {
 				return;
 			} else {
 				// Single string comparison
-				await expect(async () => {
-					expect(actualContent[0]).toBe(expectedContent);
-				}).toPass({ timeout: DEFAULT_TIMEOUT });
+				if (actualContent.length !== 1) {
+					throw new Error(`Expected single line content but got ${actualContent.length} lines: ${actualContent.join('\n')}`);
+				}
+				expect(actualContent[0]).toBe(expectedContent)
 			}
 		});
 	}

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -75,7 +75,10 @@ export class PositronNotebooks extends Notebooks {
 		const cellType = await this.getCellType(cellIndex);
 		if (cellType === 'markdown') {
 			// Enter edit mode to ensure the monaco view-lines are present
-			await this.selectCellAtIndex(cellIndex, { editMode: true });
+			const inViewMode = await this.expandMarkdownEditor.isVisible();
+			if (inViewMode) {
+				await this.selectCellAtIndex(cellIndex, { editMode: true });
+			}
 		}
 
 		const content = await test.step(`Get markdown content lines of cell at index: ${cellIndex}`, async () => {
@@ -565,28 +568,6 @@ export class PositronNotebooks extends Notebooks {
 				}).toPass({ timeout: DEFAULT_TIMEOUT });
 			}
 		});
-	}
-
-	/**
-	 * Verify: Cell content at specified index contains expected substring or matches RegExp.
-	 * @param cellIndex - The index of the cell to check.
-	 * @param expected - The substring or RegExp expected to be contained in the cell content.
-	 */
-	async expectCellContentAtIndexToContain(cellIndex: number, expected: string | RegExp): Promise<void> {
-		await test.step(
-			`Expect cell ${cellIndex} content to contain: ${expected instanceof RegExp ? expected.toString() : expected}`,
-			async () => {
-				await expect(async () => {
-					const actualContent = await this.getCellContent(cellIndex);
-
-					if (expected instanceof RegExp) {
-						expect(actualContent).toMatch(expected);
-					} else {
-						expect(actualContent).toContain(expected);
-					}
-				}).toPass({ timeout: DEFAULT_TIMEOUT });
-			}
-		);
 	}
 
 	/**

--- a/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename
@@ -35,7 +34,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.selectCellAtIndex(2);
 
 			// Verify cell 2 has correct content before deletion
-			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 2');
+			await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 2');
 
 			// Delete the selected cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(2);
@@ -44,7 +43,7 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(5);
 
 			// Verify what was cell 3 is now at index 2
-			expect(await notebooksPositron.getCellContent(2)).toBe('# Cell 3');
+			await notebooksPositron.expectCellContentAtIndexToBe(2, '# Cell 3');
 		});
 
 		// ========================================
@@ -94,7 +93,8 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 		// ========================================
 		await test.step('Test 4: Delete first cell (cell 0)', async () => {
 			// Verify we're at the first cell with correct content
-			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 0');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
+
 
 			// Delete the first cell using action bar
 			await notebooksPositron.deleteCellWithActionBar(0);
@@ -103,8 +103,8 @@ test.describe('Positron Notebooks: Action Bar Behavior', {
 			await notebooksPositron.expectCellCountToBe(2);
 
 			// Verify what was cell 1 is now at index 0
-			expect(await notebooksPositron.getCellContent(0)).toBe('# Cell 1');
-			expect(await notebooksPositron.getCellContent(1)).toBe('# Cell 3');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 1');
+			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Cell 3');
 		});
 
 		// ========================================

--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -152,6 +152,6 @@ test.describe('Notebook Cell Reordering', {
 		// Move selected cells down
 		await keyboard.press('Alt+ArrowDown');
 		await keyboard.press('Alt+ArrowDown');
-		await notebooksPositron.expectCellContentsToBe(['# Cell 0', 'Cell 4', '# Cell 1', 'Cell 2', 'Cell 3']);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '### Cell 4', '# Cell 1', '### Cell 2', '### Cell 3']);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-paste.test.ts
@@ -123,7 +123,7 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 
 		// Cut selected cells
 		await notebooksPositron.performCellAction('cut');
-		await notebooksPositron.expectCellContentsToBe(['Cell 3', 'Cell 4']);
+		await notebooksPositron.expectCellContentsToBe(['### Cell 3', '### Cell 4']);
 
 		// Select last cell and paste below
 		const lastIndex = await notebooksPositron.getCellCount() - 1;
@@ -131,6 +131,6 @@ test.describe('Positron Notebooks: Cell Copy-Paste Behavior', {
 		await notebooksPositron.performCellAction('paste');
 
 		// Verify moved cells are at the end
-		await notebooksPositron.expectCellContentsToBe(['Cell 3', 'Cell 4', '# Cell 0', '# Cell 1', 'Cell 2']);
+		await notebooksPositron.expectCellContentsToBe(['### Cell 3', '### Cell 4', '# Cell 0', '# Cell 1', '### Cell 2']);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-delete.test.ts
@@ -30,7 +30,7 @@ test.describe('Notebook: Delete', {
 		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
 		await notebooksPositron.performCellAction('delete');
 		await notebooksPositron.expectCellCountToBe(3);
-		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', 'Cell 3']);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '### Cell 3']);
 		await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false });
 
 		// delete from bottom moves focus up to previous cell

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -30,13 +30,13 @@ test.describe('Notebook Edit Mode', {
 		await notebooksPositron.selectCellAtIndex(0);
 		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: true });
 		await keyboard.type('cell editor good');
-		await notebooksPositron.expectCellContentAtIndexToContain(0, '# Cell 0cell editor good');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0cell editor good');
 
 		// Markdown cell: Can successfully enter edit mode by double clicking and typing
 		await notebooksPositron.selectCellAtIndex(2, { editMode: true });
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true });
 		await keyboard.type('markdown editor good');
-		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown editor good### Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, 'markdown editor good### Cell 2');
 	});
 
 
@@ -55,7 +55,7 @@ test.describe('Notebook Edit Mode', {
 			inEditMode: true
 		});
 		await keyboard.type('code enter key');
-		await notebooksPositron.expectCellContentAtIndexToContain(0, '# Cell 0code enter key');
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0code enter key');
 
 		// Markdown cell: Press Enter to enter edit mode and type
 		await notebooksPositron.selectCellAtIndex(2);
@@ -65,7 +65,7 @@ test.describe('Notebook Edit Mode', {
 			inEditMode: true
 		});
 		await keyboard.type('markdown enter key');
-		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown enter key### Cell 2');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, 'markdown enter key### Cell 2');
 
 	});
 
@@ -87,6 +87,6 @@ test.describe('Notebook Edit Mode', {
 
 		// Verify we can type immediately in the new cell
 		await keyboard.type('new cell content');
-		await notebooksPositron.expectCellContentAtIndexToContain(3, 'new cell content');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, 'new cell content');
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -30,13 +30,13 @@ test.describe('Notebook Edit Mode', {
 		await notebooksPositron.selectCellAtIndex(0);
 		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: true });
 		await keyboard.type('cell editor good');
-		await notebooksPositron.expectCellContentAtIndexToContain(0, 'cell editor good');
+		await notebooksPositron.expectCellContentAtIndexToContain(0, '# Cell 0cell editor good');
 
 		// Markdown cell: Can successfully enter edit mode by double clicking and typing
 		await notebooksPositron.selectCellAtIndex(2, { editMode: true });
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true });
 		await keyboard.type('markdown editor good');
-		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown editor good');
+		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown editor good### Cell 2');
 	});
 
 
@@ -55,7 +55,7 @@ test.describe('Notebook Edit Mode', {
 			inEditMode: true
 		});
 		await keyboard.type('code enter key');
-		await notebooksPositron.expectCellContentAtIndexToContain(0, 'code enter key');
+		await notebooksPositron.expectCellContentAtIndexToContain(0, '# Cell 0code enter key');
 
 		// Markdown cell: Press Enter to enter edit mode and type
 		await notebooksPositron.selectCellAtIndex(2);
@@ -65,7 +65,7 @@ test.describe('Notebook Edit Mode', {
 			inEditMode: true
 		});
 		await keyboard.type('markdown enter key');
-		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown enter key');
+		await notebooksPositron.expectCellContentAtIndexToContain(2, 'markdown enter key### Cell 2');
 
 	});
 

--- a/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
@@ -43,8 +43,6 @@ test.describe('Notebook: Empty State Behavior', {
 		// Ensure can redo to delete cells again
 		await notebooksPositron.performCellAction('redo');
 		await notebooksPositron.expectCellCountToBe(0);
-
-
 	});
 
 	test('Can cut/paste on empty notebook', async function ({ app }) {

--- a/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-empty.test.ts
@@ -35,16 +35,45 @@ test.describe('Notebook: Empty State Behavior', {
 		await notebooksPositron.performCellAction('delete');
 		await notebooksPositron.expectCellCountToBe(0);
 
-		// @dhruvisompura skipped while you fix this
 		// Ensure can undo to restore cells
-		// await notebooksPositron.performCellAction('undo');
-		// await notebooksPositron.expectCellCountToBe(4);
-		// await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', 'Cell 2', 'Cell 3']);
+		await notebooksPositron.performCellAction('undo');
+		await notebooksPositron.expectCellCountToBe(4);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '### Cell 2', '### Cell 3']);
 
-		// // Ensure can redo to delete cells again
-		// await notebooksPositron.performCellAction('redo');
-		// await notebooksPositron.expectCellCountToBe(0);
+		// Ensure can redo to delete cells again
+		await notebooksPositron.performCellAction('redo');
+		await notebooksPositron.expectCellCountToBe(0);
 
-		// cut? paste? undo? redo?
+
+	});
+
+	test('Can cut/paste on empty notebook', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// create a new notebook with 2 code cells and 2 markdown cells
+		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 2 });
+
+		// Cut all cells via multiselect
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown'); // all 4 cells selected
+		await notebooksPositron.performCellAction('cut');
+		await notebooksPositron.expectCellCountToBe(0);
+
+		// Paste into empty notebook
+		await notebooksPositron.performCellAction('paste');
+		await notebooksPositron.expectCellCountToBe(4);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '### Cell 2', '### Cell 3']);
+
+		// Undo the paste
+		await notebooksPositron.performCellAction('undo');
+		await notebooksPositron.expectCellCountToBe(0);
+
+		// Redo the paste
+		await notebooksPositron.performCellAction('redo');
+		await notebooksPositron.expectCellCountToBe(4);
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1', '### Cell 2', '### Cell 3']);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -156,7 +156,7 @@ test.describe('Notebook Focus and Selection', {
 		});
 	});
 
-	test("`+ Code` and `+ Markdown` buttons insert the cell after the active cell and make it the new active cell", async function ({ app }) {
+	test('`+ Code` and `+ Markdown` buttons insert the cell after the active cell and make it the new active cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 1 });
@@ -184,7 +184,7 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Heading 1');
 	});
 
-	test("Multi-select and deselect retains anchor/active cell", async function ({ app }) {
+	test('Multi-select and deselect retains anchor/active cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
@@ -222,7 +222,7 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
 	});
 
-	test("Multi-select and insert cell above/below becomes the active cell", async function ({ app }) {
+	test('Multi-select and insert cell above/below becomes the active cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
@@ -247,4 +247,4 @@ test.describe('Notebook Focus and Selection', {
 		await keyboard.type('print("New Below")');
 		await notebooksPositron.expectCellContentAtIndexToBe(1, 'print("New Below")');
 	});
-})
+});

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -172,7 +172,7 @@ test.describe('Notebook Focus and Selection', {
 
 		// Ensure new code cell is editable
 		await keyboard.type('print("Hello, World!")');
-		await notebooksPositron.expectCellContentAtIndexToContain(2, 'print("Hello, World!")');
+		await notebooksPositron.expectCellContentAtIndexToBe(2, 'print("Hello, World!")');
 
 		// Click the + Markdown button and verify the cell is inserted after the active cell
 		await notebooksPositron.addCell('markdown');
@@ -181,7 +181,7 @@ test.describe('Notebook Focus and Selection', {
 
 		// Ensure new markdown cell is editable
 		await keyboard.type('# Heading 1');
-		await notebooksPositron.expectCellContentAtIndexToContain(3, '# Heading 1');
+		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Heading 1');
 	});
 
 	test("Multi-select and deselect retains anchor/active cell", async function ({ app }) {
@@ -245,6 +245,6 @@ test.describe('Notebook Focus and Selection', {
 		// Ensure we can type into the new cell
 		await keyboard.press('Enter'); // enter edit mode
 		await keyboard.type('print("New Below")');
-		await notebooksPositron.expectCellContentAtIndexToContain(1, 'print("New Below")');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, 'print("New Below")');
 	});
 })


### PR DESCRIPTION
### Summary
Adding e2e test coverage for cutting/pasting all cells within a notebook.


### QA Notes

@:positron-notebooks @:web