### PR TITLE
e2e test - unskip tests after pyrefly addition

### DIFF
--- a/test/e2e/tests/console/files-pane-refresh.test.ts
+++ b/test/e2e/tests/console/files-pane-refresh.test.ts
@@ -5,12 +5,9 @@
 
 // Simple Test: Files Pane Refresh
 // Description: Verify that the Files pane refreshes after creating a file via the console.
-// TODO: I'm unsure about the tags, and whether it fits well within new-folder-flow.
-//       If it does, should I have it as standalone test or include it to another test?
-//		 Open to suggestions
 
 import { test, tags, expect } from '../_test.setup';
-import { createFileViaConsole } from './helpers/new-folder-flow';
+import { createFileViaConsole } from '../new-folder-flow/helpers/new-folder-flow';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/diagnostics/diagnostics.test.ts
+++ b/test/e2e/tests/diagnostics/diagnostics.test.ts
@@ -17,7 +17,7 @@ test.describe('Diagnostics', {
 		await runCommand('workbench.action.closeAllEditors');
 	});
 
-	test.skip('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
+	test('Python - Verify diagnostics isolation between sessions in the editor and problems view', async function ({ app, runCommand, sessions }) {
 		const { problems, editor, console } = app.workbench;
 
 		// Start Python Session and install 'termcolor'

--- a/test/e2e/tests/new-folder-flow/files-pane-refresh.test.ts
+++ b/test/e2e/tests/new-folder-flow/files-pane-refresh.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Simple Test: Files Pane Refresh
+// Description: Verify that the Files pane refreshes after creating a file via the console.
+// TODO: I'm unsure about the tags, and whether it fits well within new-folder-flow.
+//       If it does, should I have it as standalone test or include it to another test?
+//		 Open to suggestions
+
+import { test, tags, expect } from '../_test.setup';
+import { createFileViaConsole } from './helpers/new-folder-flow';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Files Pane Refresh', { tag: [tags.WEB, tags.WORKBENCH, tags.CONSOLE] }, () => {
+
+	test.afterAll(async ({ cleanup, app }) => {
+		// Primary removal via filesystem
+		await cleanup.removeTestFiles(['file.txt']);
+
+		// Verify removal in Files pane; if still present, remove via console as a fallback
+		const filesList = app.code.driver.page.locator('.monaco-list > .monaco-scrollable-element');
+		const stillVisible = await filesList.getByText('file.txt').count();
+		if (stillVisible > 0) {
+			await app.workbench.console.executeCode('Python', `import pathlib
+p = pathlib.Path('file.txt')
+try:
+    p.unlink()
+except FileNotFoundError:
+    pass`);
+			await expect(filesList.getByText('file.txt')).toHaveCount(0, { timeout: 10000 });
+		}
+	});
+
+	test('Files pane refreshes after creating file.txt via console', async function ({ app, python }) {
+		await createFileViaConsole(app, 'Python', 'file.txt');
+	});
+	// only Python needed since the  file creation principle is the same with the R console
+});

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -96,3 +96,59 @@ export async function verifyPyprojectTomlNotCreated(app: Application) {
 		await expect(files.getByText('pyproject.toml')).toHaveCount(0, { timeout: 50000 });
 	});
 }
+
+/**
+ * Create a file and a folder via console and verify they appear in the Files pane.
+ */
+export async function createFileAndFolderViaConsole(
+	app: Application,
+	runtime: 'Python' | 'R',
+	fileName: string,
+	folderName: string
+) {
+	await test.step(`Create file and folder via ${runtime} and verify Files pane`, async () => {
+		if (runtime === 'Python') {
+			const pyCode = `
+import os
+with open('${fileName}', 'w') as f:
+    f.write('hello')
+os.makedirs('${folderName}', exist_ok=True)
+`;
+			await app.workbench.console.executeCode('Python', pyCode);
+		} else {
+			const rCode = `
+file.create('${fileName}')
+dir.create('${folderName}', showWarnings = FALSE)
+`;
+			await app.workbench.console.executeCode('R', rCode);
+		}
+
+		await app.workbench.explorer.verifyExplorerFilesExist([fileName]);
+		await app.workbench.explorer.verifyExplorerFilesExist([folderName]);
+	});
+}
+
+/**
+ * Create a single file via console and verify it appears in the Files pane.
+ */
+export async function createFileViaConsole(
+	app: Application,
+	runtime: 'Python' | 'R',
+	fileName: string
+) {
+	await test.step(`Create file via ${runtime} and verify Files pane`, async () => {
+		if (runtime === 'Python') {
+			const pyCode = `
+open('${fileName}', 'w').write('hello')
+`;
+			await app.workbench.console.executeCode('Python', pyCode);
+		} else {
+			const rCode = `
+file.create('${fileName}')
+`;
+			await app.workbench.console.executeCode('R', rCode);
+		}
+
+		await app.workbench.explorer.verifyExplorerFilesExist([fileName]);
+	});
+}

--- a/test/e2e/tests/outline/outline.test.ts
+++ b/test/e2e/tests/outline/outline.test.ts
@@ -32,7 +32,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 			await outline.focus();
 		});
 
-		test.skip('Verify outline is based on editor and per session', async function ({ app, sessions }) {
+		test('Verify outline is based on editor and per session', async function ({ app, sessions }) {
 			const { outline, console, editor } = app.workbench;
 
 			// No active session - verify no outlines
@@ -141,7 +141,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.WIN, tags.OUTLINE] }, () => {
 
 	test.describe('Outline: Basic', () => {
 
-		test.skip('Python - Verify Outline Contents', async function ({ app, python, openFile }) {
+		test('Python - Verify Outline Contents', async function ({ app, python, openFile }) {
 			await openFile(join('workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 			await app.workbench.outline.expectOutlineToContain([
 				'data_file_path',


### PR DESCRIPTION
As requested in #10819 , the tests in `diagnostics.test.ts`and `outline.test.ts` that were skipped upon pyrefly addition are now being unskipped. 

### QA Notes

@:web @:win @:outline @:diagnostics