### PR TITLE
python: remove tempfile path from single line tracebacks

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -399,6 +399,10 @@ class PositronShell(ZMQInteractiveShell):
             # Don't modify the traceback in a notebook. The frontend assumes that it's unformatted
             # and applies its own formatting.
             return super()._showtraceback(etype, evalue, stb)  # type: ignore IPython type annotation is wrong
+        if len(stb) == 1:
+            # Avoid using tempfile name of the PositronShell for single-line tracebacks.
+            evalue_msg = evalue.msg
+            return super()._showtraceback(etype, evalue_msg, stb)  # type: ignore IPython type annotation is wrong
 
         # Remove the first two lines of the traceback, which are the "---" header and the repeated
         # exception name and "Traceback (most recent call last)".

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -14,7 +14,6 @@ import re
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Container, cast
-from webbrowser import get
 
 import psutil
 import traitlets

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -14,6 +14,7 @@ import re
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Container, cast
+from webbrowser import get
 
 import psutil
 import traitlets
@@ -401,7 +402,7 @@ class PositronShell(ZMQInteractiveShell):
             return super()._showtraceback(etype, evalue, stb)  # type: ignore IPython type annotation is wrong
         if len(stb) == 1:
             # Avoid using tempfile name of the PositronShell for single-line tracebacks.
-            evalue_msg = evalue.msg
+            evalue_msg = getattr(evalue, "msg", "")
             return super()._showtraceback(etype, evalue_msg, stb)  # type: ignore IPython type annotation is wrong
 
         # Remove the first two lines of the traceback, which are the "---" header and the repeated


### PR DESCRIPTION
before:

<img width="401" height="144" alt="Screenshot 2025-12-01 at 1 40 52 PM" src="https://github.com/user-attachments/assets/533071ff-33ef-42ec-9a4c-c4971c980361" />

after. the default is to have collapsed tracebacks:

<img width="265" height="118" alt="Screenshot 2025-12-01 at 1 41 00 PM" src="https://github.com/user-attachments/assets/319eae3e-60bf-44ab-8ea4-407902c648bb" />

<img width="273" height="195" alt="Screenshot 2025-12-01 at 1 41 10 PM" src="https://github.com/user-attachments/assets/bd6744c5-0ecf-4c07-b6cf-6c304e6a2338" />

We don't want to use all the information available in the exception (eg, no filename) for single-line Syntax Error tracebacks, only the type of error + message. So adjusting what we pass in to reflect that.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #2075 Python syntax errors show traceback and remove tempfile information.


### QA Notes

  ```python
  # %%
  a = [1, 2, 3, 4, 5]
  for i in a
      print(i)
  ```

  ```python
  # %%
  a = [1, 2, 3, 4, 5]
  for i in a:
  ```
