### PR TITLE
Assistant: move installPythonPackage tool to python extension

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -868,31 +868,6 @@
         ]
       },
       {
-        "name": "installPythonPackage",
-        "displayName": "Install Python Package",
-        "modelDescription": "Install Python packages using pip. Provide an array of package names to install.",
-        "icon": "$(package)",
-        "toolReferenceName": "installPythonPackage",
-        "userDescription": "Install Python packages in the current environment",
-        "canBeReferencedInPrompt": true,
-        "tags": [
-          "positron-assistant"
-        ],
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "packages": {
-              "type": "array",
-              "description": "Array of Python package names to install.",
-              "items": {
-                "type": "string",
-                "description": "Name of the Python package to install."
-              }
-            }
-          }
-        }
-      },
-      {
         "name": "runNotebookCells",
         "displayName": "Run Notebook Cells",
         "modelDescription": "Execute one or more cells in the active notebook and return their outputs. Use this when the user wants to run code cells or see the results of cell execution.",

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { isStreamingEditsEnabled, ParticipantID } from './participants.js';
 import { hasAttachedNotebookContext, getAttachedNotebookContext, SerializedNotebookContext } from './tools/notebookUtils.js';
-import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_ACTIVE_SESSION, TOOL_TAG_REQUIRES_WORKSPACE, TOOL_TAG_REQUIRES_NOTEBOOK } from './constants.js';
+import { MARKDOWN_DIR, TOOL_TAG_REQUIRES_ACTIVE_SESSION, TOOL_TAG_REQUIRES_WORKSPACE, TOOL_TAG_REQUIRES_NOTEBOOK, TOOL_TAG_REQUIRES_ACTIONS } from './constants.js';
 import { isWorkspaceOpen } from './utils.js';
 import { PositronAssistantToolName } from './types.js';
 import path = require('path');
@@ -238,6 +238,11 @@ export function getEnabledTools(
 			continue;
 		}
 
+		// If the tool requires actions, skip it in Ask mode.
+		if (tool.tags.includes(TOOL_TAG_REQUIRES_ACTIONS) && isAskMode) {
+			continue;
+		}
+
 		// If the tool is designed for Positron Assistant but we don't have a
 		// Positron assistant ID, skip it.
 		if (tool.name.startsWith('positron') && positronParticipantId === undefined) {
@@ -317,12 +322,6 @@ export function getEnabledTools(
 			// Only include the inspectVariables tool if there are variables defined.
 			case PositronAssistantToolName.InspectVariables:
 				if (!hasVariables) {
-					continue;
-				}
-				break;
-			// Only include the installPythonPackage tool when NOT in Ask mode.
-			case PositronAssistantToolName.InstallPythonPackage:
-				if (isAskMode) {
 					continue;
 				}
 				break;

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -48,6 +48,15 @@ export const TOOL_TAG_REQUIRES_ACTIVE_SESSION = 'requires-session';
  */
 export const TOOL_TAG_REQUIRES_NOTEBOOK = 'requires-notebook';
 
+/**
+ * Tag used by tools to indicate that actions will be performed as part of the tool invocation.
+ * Actions may include code execution in the Console or Terminal, file system modifications, or
+ * other changes to the user's environment that shouldn't be available in Ask mode.
+ *
+ * Tools with this tag will be filtered out of Ask mode sessions to prevent unintended actions.
+ */
+export const TOOL_TAG_REQUIRES_ACTIONS = 'requires-actions';
+
 /** Max number of variables to include in language session context */
 export const MAX_CONTEXT_VARIABLES = 400;
 

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -353,62 +353,6 @@ export function registerAssistantTools(
 	});
 	context.subscriptions.push(getTableSummaryTool);
 
-	const installPythonPackageTool = vscode.lm.registerTool<{
-		packages: string[];
-	}>(PositronAssistantToolName.InstallPythonPackage, {
-		prepareInvocation: async (options, _token) => {
-			const packageNames = options.input.packages.join(', ');
-			const result: vscode.PreparedToolInvocation = {
-				// Display a generic command description rather than a specific pip command
-				// The actual implementation uses environment-aware package management (pip, conda, poetry, etc.)
-				// via the Python extension's installPackages command, not direct pip execution
-				invocationMessage: `Install Python packages: ${packageNames}`,
-				confirmationMessages: {
-					title: vscode.l10n.t('Install Python Packages'),
-					message: options.input.packages.length === 1
-						? vscode.l10n.t('Positron Assistant wants to install the package {0}. Is this okay?', packageNames)
-						: vscode.l10n.t('Positron Assistant wants to install the following packages: {0}. Is this okay?', packageNames)
-				},
-			};
-			return result;
-		},
-		invoke: async (options, _token) => {
-			try {
-				// Use command-based communication - no API leakage
-				const results = await vscode.commands.executeCommand(
-					'python.installPackages',
-					options.input.packages,
-					{ requireConfirmation: false } // Chat handles confirmations
-				);
-
-				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart(Array.isArray(results) ? results.join('\n') : String(results))
-				]);
-			} catch (error) {
-				const errorMessage = error instanceof Error ? error.message : String(error);
-
-				// Parse error code prefixes from Python extension's installPackages command
-				// Expected prefixes: [NO_INSTALLER], [VALIDATION_ERROR]
-				// See: installPackages.ts JSDoc for complete error code documentation
-				let assistantGuidance = '';
-
-				if (errorMessage.startsWith('[NO_INSTALLER]')) {
-					assistantGuidance = '\n\nSuggestion: The Python environment may not be properly configured. Ask the user to check their Python interpreter selection or create a new environment.';
-				} else if (errorMessage.startsWith('[VALIDATION_ERROR]')) {
-					assistantGuidance = '\n\nSuggestion: Check that the package names are correct and properly formatted.';
-				} else {
-					// Fallback for unexpected errors (network issues, permissions, etc.)
-					assistantGuidance = '\n\nSuggestion: This may be a network, permissions, or environment issue. You can suggest the user retry the installation or try manual installation via terminal.';
-				}
-
-				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart(`Package installation encountered an issue: ${errorMessage}${assistantGuidance}`)
-				]);
-			}
-		}
-	});
-
-	context.subscriptions.push(installPythonPackageTool);
 
 	context.subscriptions.push(ProjectTreeTool);
 

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -12,7 +12,6 @@ export enum PositronAssistantToolName {
 	ExecuteCode = 'executeCode',
 	GetTableSummary = 'getTableSummary',
 	GetPlot = 'getPlot',
-	InstallPythonPackage = 'installPythonPackage',
 	InspectVariables = 'inspectVariables',
 	SelectionEdit = 'selectionEdit',
 	ProjectTree = 'getProjectTree',

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1911,6 +1911,33 @@
         ],
         "languageModelTools": [
             {
+                "name": "installPythonPackage",
+                "displayName": "Install Python Package",
+                "modelDescription": "Install Python packages using pip. Provide an array of package names to install.",
+                "icon": "$(package)",
+                "toolReferenceName": "installPythonPackage",
+                "userDescription": "%python.languageModelTools.installPythonPackage.userDescription%",
+                "canBeReferencedInPrompt": true,
+                "tags": [
+                    "positron-assistant",
+                    "requires-session:python",
+                    "requires-actions"
+                ],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "packages": {
+                            "type": "array",
+                            "description": "Array of Python package names to install.",
+                            "items": {
+                                "type": "string",
+                                "description": "Name of the Python package to install."
+                            }
+                        }
+                    }
+                }
+            },
+            {
                 "name": "get_python_environment_details",
                 "displayName": "Get Python Environment Info",
                 "when": "false",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -2,6 +2,7 @@
     "displayName": "Python",
     "description": "Python kernel, Debugging (multi-threaded, remote), code formatting, refactoring, unit tests, and more.",
     "python.command.python.startTerminalREPL.title": "Start Terminal REPL",
+    "python.languageModelTools.installPythonPackage.userDescription": "Install Python packages in the current environment",
     "python.languageModelTools.get_python_environment_details.userDescription": "Get information for a Python Environment, such as Type, Version, Packages, and more.",
     "python.languageModelTools.install_python_packages.userDescription": "Installs Python packages in a Python Environment.",
     "python.languageModelTools.get_python_executable_details.userDescription": "Get executable info for a Python Environment",

--- a/extensions/positron-python/src/client/chat/index.ts
+++ b/extensions/positron-python/src/client/chat/index.ts
@@ -14,6 +14,10 @@ import { ConfigurePythonEnvTool } from './configurePythonEnvTool';
 import { SelectPythonEnvTool } from './selectEnvTool';
 import { CreateVirtualEnvTool } from './createVirtualEnvTool';
 
+// --- Start Positron ---
+import { PositronInstallPackagesTool } from './positron/installPackagesTool';
+// --- End Positron ---
+
 export function registerTools(
     context: IExtensionContext,
     discoverApi: IDiscoveryAPI,
@@ -49,4 +53,14 @@ export function registerTools(
             new ConfigurePythonEnvTool(environmentsApi, serviceContainer, createVirtualEnvTool),
         ),
     );
+
+    // --- Start Positron ---
+    // Add the positron install packages tool
+    ourTools.add(
+        lm.registerTool(
+            PositronInstallPackagesTool.toolName,
+            new PositronInstallPackagesTool(),
+        ),
+    );
+    // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/chat/index.ts
+++ b/extensions/positron-python/src/client/chat/index.ts
@@ -56,11 +56,6 @@ export function registerTools(
 
     // --- Start Positron ---
     // Add the positron install packages tool
-    ourTools.add(
-        lm.registerTool(
-            PositronInstallPackagesTool.toolName,
-            new PositronInstallPackagesTool(),
-        ),
-    );
+    ourTools.add(lm.registerTool(PositronInstallPackagesTool.toolName, new PositronInstallPackagesTool()));
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/chat/positron/installPackagesTool.ts
+++ b/extensions/positron-python/src/client/chat/positron/installPackagesTool.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export interface IPositronInstallPackageArgs {
+	packages: string[];
+}
+
+export class PositronInstallPackagesTool implements vscode.LanguageModelTool<IPositronInstallPackageArgs> {
+	public static readonly toolName = 'installPythonPackage';
+
+	async prepareInvocation(
+		options: vscode.LanguageModelToolInvocationPrepareOptions<IPositronInstallPackageArgs>,
+		_token: vscode.CancellationToken,
+	): Promise<vscode.PreparedToolInvocation> {
+		const packageNames = options.input.packages.join(', ');
+		const result: vscode.PreparedToolInvocation = {
+			// Display a generic command description rather than a specific pip command
+			// The actual implementation uses environment-aware package management (pip, conda, poetry, etc.)
+			// via the Python extension's installPackages command, not direct pip execution
+			invocationMessage: `Install Python packages: ${packageNames}`,
+			confirmationMessages: {
+				title: vscode.l10n.t('Install Python Packages'),
+				message: options.input.packages.length === 1
+					? vscode.l10n.t('Positron Assistant wants to install the package {0}. Is this okay?', packageNames)
+					: vscode.l10n.t('Positron Assistant wants to install the following packages: {0}. Is this okay?', packageNames)
+			},
+		};
+		return result;
+	}
+
+	async invoke(
+		options: vscode.LanguageModelToolInvocationOptions<IPositronInstallPackageArgs>,
+		_token: vscode.CancellationToken,
+	): Promise<vscode.LanguageModelToolResult> {
+		try {
+			// Use command-based communication - no API leakage
+			const results = await vscode.commands.executeCommand(
+				'python.installPackages',
+				options.input.packages,
+				{ requireConfirmation: false } // Chat handles confirmations
+			);
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(Array.isArray(results) ? results.join('\n') : String(results))
+			]);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+
+			// Parse error code prefixes from Python extension's installPackages command
+			// Expected prefixes: [NO_INSTALLER], [VALIDATION_ERROR]
+			// See: installPackages.ts JSDoc for complete error code documentation
+			let assistantGuidance = '';
+
+			if (errorMessage.startsWith('[NO_INSTALLER]')) {
+				assistantGuidance = '\n\nSuggestion: The Python environment may not be properly configured. Ask the user to check their Python interpreter selection or create a new environment.';
+			} else if (errorMessage.startsWith('[VALIDATION_ERROR]')) {
+				assistantGuidance = '\n\nSuggestion: Check that the package names are correct and properly formatted.';
+			} else {
+				// Fallback for unexpected errors (network issues, permissions, etc.)
+				assistantGuidance = '\n\nSuggestion: This may be a network, permissions, or environment issue. You can suggest the user retry the installation or try manual installation via terminal.';
+			}
+
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Package installation encountered an issue: ${errorMessage}${assistantGuidance}`)
+			]);
+		}
+	}
+}

--- a/extensions/positron-python/src/client/chat/positron/installPackagesTool.ts
+++ b/extensions/positron-python/src/client/chat/positron/installPackagesTool.ts
@@ -6,67 +6,78 @@
 import * as vscode from 'vscode';
 
 export interface IPositronInstallPackageArgs {
-	packages: string[];
+    packages: string[];
 }
 
 export class PositronInstallPackagesTool implements vscode.LanguageModelTool<IPositronInstallPackageArgs> {
-	public static readonly toolName = 'installPythonPackage';
+    public static readonly toolName = 'installPythonPackage';
 
-	async prepareInvocation(
-		options: vscode.LanguageModelToolInvocationPrepareOptions<IPositronInstallPackageArgs>,
-		_token: vscode.CancellationToken,
-	): Promise<vscode.PreparedToolInvocation> {
-		const packageNames = options.input.packages.join(', ');
-		const result: vscode.PreparedToolInvocation = {
-			// Display a generic command description rather than a specific pip command
-			// The actual implementation uses environment-aware package management (pip, conda, poetry, etc.)
-			// via the Python extension's installPackages command, not direct pip execution
-			invocationMessage: `Install Python packages: ${packageNames}`,
-			confirmationMessages: {
-				title: vscode.l10n.t('Install Python Packages'),
-				message: options.input.packages.length === 1
-					? vscode.l10n.t('Positron Assistant wants to install the package {0}. Is this okay?', packageNames)
-					: vscode.l10n.t('Positron Assistant wants to install the following packages: {0}. Is this okay?', packageNames)
-			},
-		};
-		return result;
-	}
+    async prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<IPositronInstallPackageArgs>,
+        _token: vscode.CancellationToken,
+    ): Promise<vscode.PreparedToolInvocation> {
+        const packageNames = options.input.packages.join(', ');
+        const result: vscode.PreparedToolInvocation = {
+            // Display a generic command description rather than a specific pip command
+            // The actual implementation uses environment-aware package management (pip, conda, poetry, etc.)
+            // via the Python extension's installPackages command, not direct pip execution
+            invocationMessage: `Install Python packages: ${packageNames}`,
+            confirmationMessages: {
+                title: vscode.l10n.t('Install Python Packages'),
+                message:
+                    options.input.packages.length === 1
+                        ? vscode.l10n.t(
+                              'Positron Assistant wants to install the package {0}. Is this okay?',
+                              packageNames,
+                          )
+                        : vscode.l10n.t(
+                              'Positron Assistant wants to install the following packages: {0}. Is this okay?',
+                              packageNames,
+                          ),
+            },
+        };
+        return result;
+    }
 
-	async invoke(
-		options: vscode.LanguageModelToolInvocationOptions<IPositronInstallPackageArgs>,
-		_token: vscode.CancellationToken,
-	): Promise<vscode.LanguageModelToolResult> {
-		try {
-			// Use command-based communication - no API leakage
-			const results = await vscode.commands.executeCommand(
-				'python.installPackages',
-				options.input.packages,
-				{ requireConfirmation: false } // Chat handles confirmations
-			);
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IPositronInstallPackageArgs>,
+        _token: vscode.CancellationToken,
+    ): Promise<vscode.LanguageModelToolResult> {
+        try {
+            // Use command-based communication - no API leakage
+            const results = await vscode.commands.executeCommand(
+                'python.installPackages',
+                options.input.packages,
+                { requireConfirmation: false }, // Chat handles confirmations
+            );
 
-			return new vscode.LanguageModelToolResult([
-				new vscode.LanguageModelTextPart(Array.isArray(results) ? results.join('\n') : String(results))
-			]);
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(Array.isArray(results) ? results.join('\n') : String(results)),
+            ]);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
 
-			// Parse error code prefixes from Python extension's installPackages command
-			// Expected prefixes: [NO_INSTALLER], [VALIDATION_ERROR]
-			// See: installPackages.ts JSDoc for complete error code documentation
-			let assistantGuidance = '';
+            // Parse error code prefixes from Python extension's installPackages command
+            // Expected prefixes: [NO_INSTALLER], [VALIDATION_ERROR]
+            // See: installPackages.ts JSDoc for complete error code documentation
+            let assistantGuidance = '';
 
-			if (errorMessage.startsWith('[NO_INSTALLER]')) {
-				assistantGuidance = '\n\nSuggestion: The Python environment may not be properly configured. Ask the user to check their Python interpreter selection or create a new environment.';
-			} else if (errorMessage.startsWith('[VALIDATION_ERROR]')) {
-				assistantGuidance = '\n\nSuggestion: Check that the package names are correct and properly formatted.';
-			} else {
-				// Fallback for unexpected errors (network issues, permissions, etc.)
-				assistantGuidance = '\n\nSuggestion: This may be a network, permissions, or environment issue. You can suggest the user retry the installation or try manual installation via terminal.';
-			}
+            if (errorMessage.startsWith('[NO_INSTALLER]')) {
+                assistantGuidance =
+                    '\n\nSuggestion: The Python environment may not be properly configured. Ask the user to check their Python interpreter selection or create a new environment.';
+            } else if (errorMessage.startsWith('[VALIDATION_ERROR]')) {
+                assistantGuidance = '\n\nSuggestion: Check that the package names are correct and properly formatted.';
+            } else {
+                // Fallback for unexpected errors (network issues, permissions, etc.)
+                assistantGuidance =
+                    '\n\nSuggestion: This may be a network, permissions, or environment issue. You can suggest the user retry the installation or try manual installation via terminal.';
+            }
 
-			return new vscode.LanguageModelToolResult([
-				new vscode.LanguageModelTextPart(`Package installation encountered an issue: ${errorMessage}${assistantGuidance}`)
-			]);
-		}
-	}
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(
+                    `Package installation encountered an issue: ${errorMessage}${assistantGuidance}`,
+                ),
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8720
- approach:
    - moved the tool to the python extension
    - tag it with `requires-session:python` so it only shows up when a Python session is active (though it actually uses the Terminal to install the packages, not the Console)
    - also tag it with `requires-actions` so it continues to not be available in Ask mode 
- there is an upstream version of this tool, but we don't yet support it (see https://github.com/posit-dev/positron/issues/8826)

### Release Notes

#### Bug Fixes

- Assistant: disable installPythonPackage tool when in an R context (#8720)

### QA Notes

- installPythonPackage tool functionality should remain the same
- installPythonPackage should not be available in Ask mode, but should be available in all other chat modes
- installPythonPackage should not be available when a Python session is not attached to the chat, e.g. if an R session is attached or if no Console sessions are attached
