### PR TITLE
Preserve background terminal instances (for Kallichore)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -713,8 +713,8 @@ export class TerminalService extends Disposable implements ITerminalService {
 		// wind up getting killed by the PtyHost. We use these background
 		// instances to run kernel processes, so we need them to stay alive.
 		//
-		// https://github.com/rstudio/positron/issues/939
-		for (const instance of [...this._terminalGroupService.instances, ...this._backgroundedTerminalInstances.map(bg => bg.instance)]) {
+		// https://github.com/posit-dev/positron/issues/939
+		for (const instance of [...this._terminalGroupService.instances]) {
 			if (shouldPersistTerminals && instance.shouldPersist) {
 				instance.detachProcessAndDispose(TerminalExitReason.Shutdown);
 			} else {


### PR DESCRIPTION
This change fixes an issue that is effectively a regression from the 1.106 merge that reintroduced https://github.com/posit-dev/positron/issues/939.

Very briefly, there is a bug in upstream VS Code (https://github.com/microsoft/vscode/issues/189431) which causes hidden terminals to be destroyed ~1 minute after a window reload, with no recourse. Since Kallichore runs in a hidden window, it is terminated along with all sessions. A recent but minor change to this code in 1.106 undid our workaround.

The fix is to replay the important bit of the original fix of #939, which is to skip background terminals when looking for terminals to remove. 

Addresses https://github.com/posit-dev/positron/issues/10798.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue that could cause R and Python sessions to exit unexpectedly after reloading the window (#10798)


### QA Notes

This problem will only reproduce under the following conditions:
- the supervisor is set to exit "immediately" when Positron does
- the supervisor is running in a hidden terminal (there is a setting that makes the terminal visible for debugging)

