### PR TITLE
e2e: fix r-pkg-development test

### DIFF
--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -39,7 +39,7 @@ test.describe('R Package Development', { tag: [tags.R_PKG_DEVELOPMENT, tags.ARK]
 			logger.log('Test R Package');
 			await app.workbench.quickaccess.runCommand('r.packageTest');
 			await expect(async () => {
-				await app.workbench.terminal.waitForTerminalText('[ FAIL 1 | WARN 0 | SKIP 0 | PASS 16 ]', { timeout: 20000 });
+				await app.workbench.terminal.waitForTerminalText('[ FAIL 1 | WARN 0 | SKIP 1 | PASS 16 ]', { timeout: 20000 });
 				await app.workbench.terminal.waitForTerminalText('Terminal will be reused by tasks', { timeout: 20000 });
 			}).toPass({ timeout: 70000 });
 		});


### PR DESCRIPTION
### Summary
The test was failing because we weren't correctly accounting for [an empty test](https://github.com/posit-dev/qa-example-content/blob/9554a1f597cc50f3c8a69b1eb27d801bce7b6c0b/workspaces/r_testing/tests/testthat/test-mathstuff.R#L12) (no test body) that gets skipped.

### QA Notes
@:r-pkg-development @:web