### PR TITLE
Positron-nb-assistant-feedback-fixes

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -921,7 +921,7 @@
       {
         "name": "editNotebookCells",
         "displayName": "Edit Notebook Cells",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content), operation='update' to modify existing cells (requires cellIndex and content), or operation='delete' to remove cells (requires cellIndex). Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), or operation='delete' to remove cells (requires cellIndex). Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -959,6 +959,10 @@
             "cellIndex": {
               "type": "number",
               "description": "Index of the cell to modify or delete (0-based). Required when operation is 'update' or 'delete'."
+            },
+            "run": {
+              "type": "boolean",
+              "description": "Whether to execute the cell after adding it. Defaults to true for code cells. Ignored for markdown cells."
             }
           },
           "required": [

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -55,7 +55,7 @@ You are assisting the user within a Jupyter notebook in Positron.
 
 **Modify cells:** Use EditNotebookCells with `operation: 'update'`, `cellIndex`, and `content`. Explain changes before applying.
 
-**Add cells:** Use EditNotebookCells with `operation: 'add'`, `cellType`, `index`, and `content`. When you add cell at index N, cells N+ shift to N+1, N+2, etc.
+**Add cells:** Use EditNotebookCells with `operation: 'add'`. Code cells are run by default (set `run: false` to skip execution). Returns outputs for code cells. When you add cell at index N, cells N+ shift to N+1, N+2, etc.
 
 **Delete cells:** Use EditNotebookCells with `operation: 'delete'` and `cellIndex`. When you delete cell at index N, cells N+1+ shift down to N, N+1, etc.
 

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -26,29 +26,10 @@ You MUST use notebook-specific tools. NEVER use file tools.
 ✓ Use EditNotebookCells tool
 </anti-patterns>
 
-<notebook-context>
+<notebook-context-instructions>
 You are assisting the user within a Jupyter notebook in Positron.
-
-<notebook-info>
-  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
-  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
-  {{@if(positron.notebookContext.allCells)}}
-  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
-  {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
-  {{/if}}
-</notebook-info>
-
-<selected-cells>
-{{positron.notebookSelectedCellsInfo}}
-</selected-cells>
-
-{{@if(positron.notebookAllCellsInfo)}}
-{{positron.notebookAllCellsInfo}}
-{{/if}}
-
-{{positron.notebookContextNote}}
-</notebook-context>
+The current notebook state (kernel info, cell contents, selection) is provided in a separate context message below.
+</notebook-context-instructions>
 
 <workflows>
 **Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
@@ -65,15 +46,13 @@ You are assisting the user within a Jupyter notebook in Positron.
 </workflows>
 
 <critical-rules>
-- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
-- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
+- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, etc.)
+- Cell indices are shown in the notebook context (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST check execution state: order [N], status (running/pending/idle), success/failure, duration
 - MUST consider cell dependencies before modifications/execution
 - **IMPORTANT:** When you add or delete cells, remember that indices shift:
   - Adding cell at index 2: cells 2+ become 3+
   - Deleting cell at index 2: cells 3+ become 2+
 - MUST maintain clear notebook structure with appropriate markdown documentation
-
-**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
 </critical-rules>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -28,33 +28,14 @@ If the user requests cell modifications or execution, explain that these require
 ✓ Use EditNotebookCells tool
 </anti-patterns>
 
-<notebook-context>
+<notebook-context-instructions>
 You are assisting the user within a Jupyter notebook in Positron.
-
-<notebook-info>
-  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
-  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
-  {{@if(positron.notebookContext.allCells)}}
-  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
-  {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
-  {{/if}}
-</notebook-info>
-
-<selected-cells>
-{{positron.notebookSelectedCellsInfo}}
-</selected-cells>
-
-{{@if(positron.notebookAllCellsInfo)}}
-{{positron.notebookAllCellsInfo}}
-{{/if}}
-
-{{positron.notebookContextNote}}
-</notebook-context>
+The current notebook state (kernel info, cell contents, selection) is provided in a separate context message below.
+</notebook-context-instructions>
 
 <critical-rules>
 - ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, etc.)
-- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
+- Cell indices are shown in the notebook context (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST consider notebook's execution state, cell dependencies, and execution history
 - MUST pay attention to cell status (selection, execution status, execution order, success/failure, duration)
 - Execution order numbers [N] indicate sequence in which cells were executed
@@ -68,6 +49,4 @@ You are assisting the user within a Jupyter notebook in Positron.
 
 **Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>
-
-**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -29,29 +29,10 @@ If the user requests cell execution, suggest switching to Agent mode for executi
 ✓ Use EditNotebookCells tool
 </anti-patterns>
 
-<notebook-context>
+<notebook-context-instructions>
 You are assisting the user within a Jupyter notebook in Positron with modification access.
-
-<notebook-info>
-  <kernel language="{{positron.notebookContext.kernelLanguage}}" id="{{positron.notebookContext.kernelId}}"/>
-  <cell-count total="{{positron.notebookContext.cellCount}}" selected="{{positron.notebookContext.selectedCells.length}}"/>
-  {{@if(positron.notebookContext.allCells)}}
-  <context-mode>Full notebook (< 20 cells, all cells provided below)</context-mode>
-  {{#else}}
-  <context-mode>Selected cells only (use GetNotebookCells for other cells)</context-mode>
-  {{/if}}
-</notebook-info>
-
-<selected-cells>
-{{positron.notebookSelectedCellsInfo}}
-</selected-cells>
-
-{{@if(positron.notebookAllCellsInfo)}}
-{{positron.notebookAllCellsInfo}}
-{{/if}}
-
-{{positron.notebookContextNote}}
-</notebook-context>
+The current notebook state (kernel info, cell contents, selection) is provided in a separate context message below.
+</notebook-context-instructions>
 
 <workflows>
 **Mode capabilities:** View, modify, add, delete cells. Cannot execute (Agent mode only). If execution requested: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
@@ -70,8 +51,8 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
 </workflows>
 
 <critical-rules>
-- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, last cell = {{positron.notebookContext.cellCount}} - 1)
-- Cell indices are shown in the context above (e.g., `<cell index="0">`, `<cell index="1">`)
+- ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, etc.)
+- Cell indices are shown in the notebook context (e.g., `<cell index="0">`, `<cell index="1">`)
 - MUST check execution state: order [N], status (running/pending/idle), success/failure, duration
 - MUST consider cell dependencies before modifications
 - **IMPORTANT:** When you add or delete cells, remember that indices shift:
@@ -80,7 +61,5 @@ You are assisting the user within a Jupyter notebook in Positron with modificati
 - When modifying cells, preserve notebook structure and maintain cell dependencies
 - When adding cells, choose positions that respect logical flow
 - When execution requested → "Cannot execute in Edit mode. Switch to Agent mode to run cells."
-
-**Notebook URI (for reference only):** {{positron.notebookContext.uri}}
 </critical-rules>
 {{/if}}

--- a/extensions/positron-assistant/src/notebookContextFilter.ts
+++ b/extensions/positron-assistant/src/notebookContextFilter.ts
@@ -19,6 +19,18 @@ export const MAX_CELLS_FOR_ALL_CELLS_CONTEXT = 20;
 const SLIDING_WINDOW_SIZE = 10;
 
 /**
+ * Maximum total characters for notebook context serialization.
+ * Approximately 12K tokens (assuming ~4 chars per token).
+ */
+export const MAX_NOTEBOOK_CONTEXT_CHARS = 50_000;
+
+/**
+ * Maximum content length per non-selected cell when truncating.
+ * Aggressive limit to ensure selected cells are preserved fully.
+ */
+export const MAX_NON_SELECTED_CELL_CONTENT_CHARS = 2_000;
+
+/**
  * Calculates a sliding window of cells around an anchor cell index.
  * @param totalCells Total number of cells in the notebook
  * @param anchorIndex Index of the cell to center the window around
@@ -36,12 +48,173 @@ export function calculateSlidingWindow(
 }
 
 /**
+ * Extended notebook cell interface that tracks truncation metadata.
+ * Used internally to track when cell content has been truncated.
+ */
+interface TruncatedNotebookCell extends positron.notebooks.NotebookCell {
+	/** Original content length before truncation, if truncation occurred */
+	originalContentLength?: number;
+}
+
+/**
+ * Type guard to check if a cell has truncation metadata.
+ *
+ * @param cell The cell to check
+ * @returns True if the cell has originalContentLength property
+ */
+export function hasTruncationMetadata(cell: positron.notebooks.NotebookCell): cell is TruncatedNotebookCell {
+	return 'originalContentLength' in cell;
+}
+
+/**
+ * Gets the original content length from a cell if it was truncated.
+ *
+ * @param cell The cell to check
+ * @returns The original content length, or undefined if not truncated
+ */
+export function getOriginalContentLength(cell: positron.notebooks.NotebookCell): number | undefined {
+	return hasTruncationMetadata(cell) ? cell.originalContentLength : undefined;
+}
+
+/**
+ * Truncates cell content to a maximum length, adding a truncation indicator.
+ *
+ * @param content The cell content to truncate
+ * @param maxLength Maximum length for the content
+ * @returns Truncated content with indicator, or original content if within limit
+ */
+function truncateCellContent(content: string, maxLength: number): string {
+	if (content.length <= maxLength) {
+		return content;
+	}
+	// Truncate and add indicator (accounting for indicator length)
+	const truncationIndicator = '... [truncated]';
+	const availableLength = maxLength - truncationIndicator.length;
+	return content.substring(0, Math.max(0, availableLength)) + truncationIndicator;
+}
+
+/**
+ * Estimates the total serialized size of cells when formatted as XML.
+ * This is a rough estimate based on cell content length plus XML overhead.
+ *
+ * @param cells Array of notebook cells to estimate
+ * @param selectedIndices Set of cell indices that are selected (preserved fully)
+ * @param assumeTruncated If true, assumes non-selected cells are already truncated. Defaults to false.
+ * @returns Estimated total character count for serialized output
+ */
+function estimateContextSize(
+	cells: positron.notebooks.NotebookCell[],
+	selectedIndices: Set<number>,
+	assumeTruncated: boolean = false
+): number {
+	let totalSize = 0;
+	// Base XML overhead per cell (tags, attributes, etc.) - rough estimate
+	const XML_OVERHEAD_PER_CELL = 200;
+
+	for (const cell of cells) {
+		const isSelected = selectedIndices.has(cell.index);
+		// Selected cells always use full content
+		// Non-selected cells: use actual size if not assuming truncation, otherwise use truncated estimate
+		const contentSize = isSelected
+			? cell.content.length
+			: (assumeTruncated
+				? Math.min(cell.content.length, MAX_NON_SELECTED_CELL_CONTENT_CHARS)
+				: cell.content.length);
+		totalSize += contentSize + XML_OVERHEAD_PER_CELL;
+	}
+
+	return totalSize;
+}
+
+/**
+ * Applies content budget limiting to cells, preserving selected cells fully
+ * while truncating non-selected cells and potentially reducing cell count.
+ *
+ * @param cells Array of notebook cells to apply budget to
+ * @param selectedIndices Set of cell indices that are selected (must be preserved)
+ * @param budget Maximum total character budget
+ * @returns Array of cells with content truncated as needed to fit budget
+ */
+function applyContentBudget(
+	cells: positron.notebooks.NotebookCell[],
+	selectedIndices: Set<number>,
+	budget: number
+): TruncatedNotebookCell[] {
+	// First pass: truncate non-selected cell content
+	const truncatedCells: TruncatedNotebookCell[] = cells.map(cell => {
+		const isSelected = selectedIndices.has(cell.index);
+		if (isSelected) {
+			// Preserve selected cells fully
+			return { ...cell };
+		}
+
+		// Truncate non-selected cells
+		const originalLength = cell.content.length;
+		const truncatedContent = truncateCellContent(cell.content, MAX_NON_SELECTED_CELL_CONTENT_CHARS);
+		const truncated: TruncatedNotebookCell = {
+			...cell,
+			content: truncatedContent,
+			originalContentLength: originalLength > truncatedContent.length ? originalLength : undefined
+		};
+		return truncated;
+	});
+
+	// Estimate size after truncation (assume truncated since we just truncated them)
+	const currentSize = estimateContextSize(truncatedCells, selectedIndices, true);
+
+	// If still over budget, reduce non-selected cells (but always keep selected cells)
+	if (currentSize > budget) {
+		// Separate selected and non-selected cells
+		const selectedCells: TruncatedNotebookCell[] = [];
+		const nonSelectedCells: TruncatedNotebookCell[] = [];
+
+		for (const cell of truncatedCells) {
+			if (selectedIndices.has(cell.index)) {
+				selectedCells.push(cell);
+			} else {
+				nonSelectedCells.push(cell);
+			}
+		}
+
+		// Calculate budget available for non-selected cells (they're already truncated)
+		const selectedCellsSize = estimateContextSize(selectedCells, selectedIndices, false);
+		const availableBudget = Math.max(0, budget - selectedCellsSize);
+
+		// Keep non-selected cells that fit in remaining budget (they're already truncated)
+		const keptNonSelectedCells: TruncatedNotebookCell[] = [];
+		let usedBudget = 0;
+		for (const cell of nonSelectedCells) {
+			const cellSize = estimateContextSize([cell], new Set(), true);
+			if (usedBudget + cellSize <= availableBudget) {
+				keptNonSelectedCells.push(cell);
+				usedBudget += cellSize;
+			} else {
+				// Stop adding cells once budget is exceeded
+				break;
+			}
+		}
+
+		// Combine selected cells (always included) with kept non-selected cells
+		// Preserve original order by sorting by index
+		const result = [...selectedCells, ...keptNonSelectedCells].sort((a, b) => a.index - b.index);
+		return result;
+	}
+
+	return truncatedCells;
+}
+
+/**
  * Filters notebook context based on notebook size and selection state.
  *
  * Filtering rules:
  * - Small notebooks (<20 cells): Keep all cells
  * - Large notebooks (>=20 cells) with selection: Apply sliding window around last selected cell
  * - Large notebooks (>=20 cells) without selection: Remove allCells field
+ *
+ * Additionally applies content-aware size limiting to prevent exceeding character budget:
+ * - Preserves selected cells fully
+ * - Truncates non-selected cell content aggressively
+ * - Reduces included cell count if still over budget
  *
  * @param context The notebook context to filter
  * @returns Filtered notebook context
@@ -55,9 +228,22 @@ export function filterNotebookContext(
 	}
 
 	const totalCells = context.cellCount;
+	const selectedIndices = new Set(context.selectedCells.map(cell => cell.index));
 
-	// Small notebooks: keep all cells
+	// Small notebooks: keep all cells, but still apply content budget if needed
 	if (totalCells < MAX_CELLS_FOR_ALL_CELLS_CONTEXT) {
+		// Estimate total content size using actual content (not assuming truncation)
+		const totalContentSize = estimateContextSize(context.allCells, selectedIndices, false);
+
+		// If over budget, apply content-aware filtering
+		if (totalContentSize > MAX_NOTEBOOK_CONTEXT_CHARS) {
+			const budgetedCells = applyContentBudget(context.allCells, selectedIndices, MAX_NOTEBOOK_CONTEXT_CHARS);
+			return {
+				...context,
+				allCells: budgetedCells
+			};
+		}
+
 		return context;
 	}
 
@@ -73,7 +259,20 @@ export function filterNotebookContext(
 	const lastSelectedIndex = Math.max(...context.selectedCells.map(cell => cell.index));
 	const { startIndex, endIndex } = calculateSlidingWindow(totalCells, lastSelectedIndex);
 
-	const filteredCells = context.allCells.slice(startIndex, endIndex);
+	let filteredCells = context.allCells.slice(startIndex, endIndex);
+
+	// Update selectedIndices to only include cells that are actually in the filtered window
+	const filteredSelectedIndices = new Set(
+		filteredCells
+			.filter(cell => selectedIndices.has(cell.index))
+			.map(cell => cell.index)
+	);
+
+	// Apply content-aware budget limiting (use actual sizes, not assuming truncation)
+	const totalContentSize = estimateContextSize(filteredCells, filteredSelectedIndices, false);
+	if (totalContentSize > MAX_NOTEBOOK_CONTEXT_CHARS) {
+		filteredCells = applyContentBudget(filteredCells, filteredSelectedIndices, MAX_NOTEBOOK_CONTEXT_CHARS);
+	}
 
 	return {
 		...context,

--- a/extensions/positron-assistant/src/promptRender.ts
+++ b/extensions/positron-assistant/src/promptRender.ts
@@ -10,7 +10,7 @@ import * as positron from 'positron';
 import * as yaml from 'yaml';
 import { MARKDOWN_DIR } from './constants';
 import { log } from './extension.js';
-import { SerializedNotebookContext, serializeNotebookContext } from './tools/notebookUtils.js';
+import { SerializedNotebookContext } from './tools/notebookUtils.js';
 import * as xml from './xml.js';
 
 const PROMPT_MODE_SELECTIONS_KEY = 'positron.assistant.promptModeSelections';
@@ -26,10 +26,6 @@ interface AugmentedRenderData {
 	hasRSession: boolean;
 	hasPythonSession: boolean;
 	hasNotebookContext: boolean;
-	notebookKernelInfo?: string;
-	notebookSelectedCellsInfo?: string;
-	notebookAllCellsInfo?: string;
-	notebookContextNote?: string;
 }
 
 /**
@@ -37,35 +33,21 @@ interface AugmentedRenderData {
  */
 class PromptTemplateEngine {
 	/**
-	 * Augment render data with helper properties for template conditions
+	 * Augment render data with helper properties for template conditions.
 	 */
 	private static augmentRenderData(data: PromptRenderData): PromptRenderData & AugmentedRenderData {
 		const hasRSession = data.sessions?.some(s => s.languageId === 'r') ?? false;
 		const hasPythonSession = data.sessions?.some(s => s.languageId === 'python') ?? false;
 
-		// Notebook context augmentation
+		// Only track whether notebook context exists, not its content.
+		// Dynamic notebook content is injected as a user message for caching.
 		const hasNotebookContext = !!data.notebookContext;
-		let notebookKernelInfo: string | undefined;
-		let notebookSelectedCellsInfo: string | undefined;
-		let notebookAllCellsInfo: string | undefined;
-		let notebookContextNote: string | undefined;
-
-		if (data.notebookContext) {
-			notebookKernelInfo = data.notebookContext.kernelInfo;
-			notebookSelectedCellsInfo = data.notebookContext.selectedCellsInfo;
-			notebookAllCellsInfo = data.notebookContext.allCellsInfo;
-			notebookContextNote = data.notebookContext.contextNote;
-		}
 
 		return {
 			...data,
 			hasRSession,
 			hasPythonSession,
 			hasNotebookContext,
-			notebookKernelInfo,
-			notebookSelectedCellsInfo,
-			notebookAllCellsInfo,
-			notebookContextNote,
 		};
 	}
 

--- a/extensions/positron-assistant/src/test/notebookContextFilter.test.ts
+++ b/extensions/positron-assistant/src/test/notebookContextFilter.test.ts
@@ -1,0 +1,229 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import { filterNotebookContext, MAX_NOTEBOOK_CONTEXT_CHARS, MAX_NON_SELECTED_CELL_CONTENT_CHARS } from '../notebookContextFilter';
+
+/**
+ * Creates a mock notebook cell for testing
+ */
+function createMockCell(
+	index: number,
+	content: string,
+	type: positron.notebooks.NotebookCellType = positron.notebooks.NotebookCellType.Code,
+	selectionStatus: string = 'unselected'
+): positron.notebooks.NotebookCell {
+	return {
+		id: `cell-${index}`,
+		index,
+		type,
+		content,
+		hasOutput: false,
+		selectionStatus,
+		executionStatus: undefined,
+		executionOrder: undefined,
+		lastRunSuccess: undefined,
+		lastExecutionDuration: undefined
+	};
+}
+
+/**
+ * Creates a mock notebook context for testing
+ */
+function createMockContext(
+	cells: positron.notebooks.NotebookCell[],
+	selectedIndices: number[] = []
+): positron.notebooks.NotebookContext {
+	return {
+		uri: 'test://notebook.ipynb',
+		cellCount: cells.length,
+		kernelId: 'test-kernel',
+		kernelLanguage: 'python',
+		selectedCells: cells.filter(c => selectedIndices.includes(c.index)),
+		allCells: cells
+	};
+}
+
+suite('notebookContextFilter', () => {
+	suite('filterNotebookContext - Content-Aware Filtering', () => {
+		test('should preserve small notebooks under budget', () => {
+			const cells = [
+				createMockCell(0, 'small content'),
+				createMockCell(1, 'another small cell')
+			];
+			const context = createMockContext(cells);
+
+			const result = filterNotebookContext(context);
+
+			assert.strictEqual(result.allCells?.length, 2);
+			assert.strictEqual(result.allCells?.[0].content, 'small content');
+			assert.strictEqual(result.allCells?.[1].content, 'another small cell');
+		});
+
+		test('should truncate non-selected cells when over budget', () => {
+			// Create cells with large content that exceeds budget
+			const largeContent = 'x'.repeat(30_000); // 30K chars per cell
+			const cells = [
+				createMockCell(0, largeContent),
+				createMockCell(1, largeContent),
+				createMockCell(2, largeContent)
+			];
+			const context = createMockContext(cells, [1]); // Select middle cell
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			// Selected cell should be preserved fully
+			const selectedCell = result.allCells.find(c => c.index === 1);
+			assert.ok(selectedCell);
+			assert.strictEqual(selectedCell.content, largeContent);
+
+			// Non-selected cells should be truncated
+			const nonSelectedCells = result.allCells.filter(c => c.index !== 1);
+			for (const cell of nonSelectedCells) {
+				assert.ok(cell.content.length <= MAX_NON_SELECTED_CELL_CONTENT_CHARS);
+				assert.ok(cell.content.includes('[truncated]'));
+			}
+		});
+
+		test('should preserve all selected cells fully', () => {
+			const largeContent = 'x'.repeat(20_000);
+			const cells = [
+				createMockCell(0, largeContent),
+				createMockCell(1, largeContent, positron.notebooks.NotebookCellType.Code, 'selected'),
+				createMockCell(2, largeContent, positron.notebooks.NotebookCellType.Code, 'selected'),
+				createMockCell(3, largeContent)
+			];
+			const context = createMockContext(cells, [1, 2]); // Select cells 1 and 2
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			const selectedCell1 = result.allCells.find(c => c.index === 1);
+			const selectedCell2 = result.allCells.find(c => c.index === 2);
+
+			assert.ok(selectedCell1);
+			assert.ok(selectedCell2);
+			assert.strictEqual(selectedCell1.content, largeContent);
+			assert.strictEqual(selectedCell2.content, largeContent);
+		});
+
+		test('should reduce cell count if still over budget after truncation', () => {
+			// Create many cells with large content
+			const largeContent = 'x'.repeat(15_000);
+			const cells: positron.notebooks.NotebookCell[] = [];
+			for (let i = 0; i < 10; i++) {
+				cells.push(createMockCell(i, largeContent));
+			}
+			const context = createMockContext(cells, [5]); // Select middle cell
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			// Selected cell should always be included
+			const selectedCell = result.allCells.find(c => c.index === 5);
+			assert.ok(selectedCell);
+			assert.strictEqual(selectedCell.content, largeContent);
+
+			// Total size should be within budget
+			const totalSize = result.allCells.reduce((sum, cell) => sum + cell.content.length, 0);
+			// Allow some overhead for XML formatting
+			assert.ok(totalSize < MAX_NOTEBOOK_CONTEXT_CHARS * 1.5, `Total size ${totalSize} should be reasonable`);
+		});
+
+		test('should handle empty cells', () => {
+			const cells = [
+				createMockCell(0, ''),
+				createMockCell(1, 'content')
+			];
+			const context = createMockContext(cells);
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			assert.strictEqual(result.allCells.length, 2);
+		});
+
+		test('should handle context with no allCells', () => {
+			const context: positron.notebooks.NotebookContext = {
+				uri: 'test://notebook.ipynb',
+				cellCount: 5,
+				kernelId: 'test-kernel',
+				kernelLanguage: 'python',
+				selectedCells: [],
+				allCells: undefined
+			};
+
+			const result = filterNotebookContext(context);
+
+			assert.strictEqual(result.allCells, undefined);
+		});
+
+		test('should handle large notebooks without selection', () => {
+			const cells: positron.notebooks.NotebookCell[] = [];
+			for (let i = 0; i < 30; i++) {
+				cells.push(createMockCell(i, `content ${i}`));
+			}
+			const context = createMockContext(cells, []); // No selection
+
+			const result = filterNotebookContext(context);
+
+			// Large notebooks without selection should have allCells removed
+			assert.strictEqual(result.allCells, undefined);
+		});
+
+		test('should apply sliding window for large notebooks with selection', () => {
+			const cells: positron.notebooks.NotebookCell[] = [];
+			for (let i = 0; i < 50; i++) {
+				cells.push(createMockCell(i, `content ${i}`));
+			}
+			const context = createMockContext(cells, [25]); // Select cell 25
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			// Should include cells around index 25 (sliding window)
+			const indices = result.allCells.map(c => c.index);
+			assert.ok(indices.includes(25), 'Should include selected cell');
+			// Should be a window around the selected cell
+			assert.ok(Math.min(...indices) < 25);
+			assert.ok(Math.max(...indices) > 25);
+		});
+
+		test('should handle edge case: single very large selected cell', () => {
+			const hugeContent = 'x'.repeat(100_000); // 100K chars
+			const cells = [
+				createMockCell(0, hugeContent, positron.notebooks.NotebookCellType.Code, 'selected')
+			];
+			const context = createMockContext(cells, [0]);
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			// Selected cell should be preserved even if it's huge
+			assert.strictEqual(result.allCells[0].content, hugeContent);
+		});
+
+		test('should handle mixed cell types', () => {
+			const largeContent = 'x'.repeat(20_000);
+			const cells = [
+				createMockCell(0, largeContent, positron.notebooks.NotebookCellType.Code),
+				createMockCell(1, largeContent, positron.notebooks.NotebookCellType.Markdown, 'selected'),
+				createMockCell(2, largeContent, positron.notebooks.NotebookCellType.Code)
+			];
+			const context = createMockContext(cells, [1]);
+
+			const result = filterNotebookContext(context);
+
+			assert.ok(result.allCells);
+			const selectedMarkdownCell = result.allCells.find(c => c.index === 1);
+			assert.ok(selectedMarkdownCell);
+			assert.strictEqual(selectedMarkdownCell.type, positron.notebooks.NotebookCellType.Markdown);
+			assert.strictEqual(selectedMarkdownCell.content, largeContent);
+		});
+	});
+});
+

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -276,10 +276,11 @@ export const EditNotebookCellsTool = vscode.lm.registerTool<{
 					}
 
 					// Validate content length
-					if (content.length > MAX_CELL_CONTENT_LENGTH) {
+					const contentByteLength = Buffer.byteLength(content, 'utf8');
+					if (contentByteLength > MAX_CELL_CONTENT_LENGTH) {
 						return new vscode.LanguageModelToolResult([
 							new vscode.LanguageModelTextPart(
-								`Content too large: ${content.length} bytes exceeds maximum of ${MAX_CELL_CONTENT_LENGTH} bytes`
+								`Content too large: ${contentByteLength} bytes exceeds maximum of ${MAX_CELL_CONTENT_LENGTH} bytes`
 							)
 						]);
 					}
@@ -367,10 +368,11 @@ export const EditNotebookCellsTool = vscode.lm.registerTool<{
 					}
 
 					// Validate content length
-					if (content.length > MAX_CELL_CONTENT_LENGTH) {
+					const contentByteLength = Buffer.byteLength(content, 'utf8');
+					if (contentByteLength > MAX_CELL_CONTENT_LENGTH) {
 						return new vscode.LanguageModelToolResult([
 							new vscode.LanguageModelTextPart(
-								`Content too large: ${content.length} bytes exceeds maximum of ${MAX_CELL_CONTENT_LENGTH} bytes`
+								`Content too large: ${contentByteLength} bytes exceeds maximum of ${MAX_CELL_CONTENT_LENGTH} bytes`
 							)
 						]);
 					}

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as xml from '../xml.js';
-import { calculateSlidingWindow, filterNotebookContext, MAX_CELLS_FOR_ALL_CELLS_CONTEXT } from '../notebookContextFilter.js';
+import { calculateSlidingWindow, filterNotebookContext, MAX_CELLS_FOR_ALL_CELLS_CONTEXT, getOriginalContentLength } from '../notebookContextFilter.js';
 import { isRuntimeSessionReference } from '../utils.js';
 import { log } from '../extension.js';
 
@@ -169,11 +169,17 @@ export function formatCells(options: FormatCellsOptions): string {
 		const cellLabel = cells.length === 1
 			? prefix
 			: `${prefix} ${idx + 1}`;
+
+		// Check if cell content was truncated (has originalContentLength property)
+		const originalLength = getOriginalContentLength(cell);
+		const wasTruncated = originalLength !== undefined && originalLength > cell.content.length;
+
 		const parts = [
 			`<cell index="${cell.index}" type="${cell.type}">`,
 			`  <label>${cellLabel}</label>`,
 			`  <status>${statusInfo}</status>`,
 			includeContent ? `<content>${cell.content}</content>` : '',
+			wasTruncated ? `  <truncated original-length="${originalLength}" />` : '',
 			`</cell>`
 		];
 		return parts.filter(Boolean).join('\n');

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -125,7 +125,7 @@ Notebook tools are conditionally available based on the assistant mode, with fil
 - `RunNotebookCells` - Execute cells in the kernel using `cellIndices` parameter
 
 **Modification Tools (Edit and Agent modes):**
-- `EditNotebookCells` - Unified tool for adding, modifying, or deleting cells using `operation` parameter ('add', 'update', 'delete')
+- `EditNotebookCells` - Unified tool for adding, modifying, or deleting cells using `operation` parameter ('add', 'update', 'delete'). Code cells added with 'add' are executed by default (set `run: false` to skip execution).
 
 **Read-Only Tools (Available in all modes - Ask, Edit, Agent):**
 - `GetNotebookCells` - Read cell contents with status information using `cellIndices` parameter
@@ -446,8 +446,8 @@ The chosen approach (attached context detection) provides the cleanest implement
    - Execution tools do NOT appear: `RunNotebookCells`
    - All available tools can be referenced using `#getNotebookCells`, `#getCellOutputs`, `#editNotebookCells`
    - Ask "Show me the output of cell 2" → Should use GetCellOutputs
-   - Ask "Update cell 3 to add error handling" → Should use EditNotebookCells with `operation: 'update'`
-   - Ask "Add a new cell after cell 2" → Should use EditNotebookCells with `operation: 'add'`
+  - Ask "Update cell 3 to add error handling" → Should use EditNotebookCells with `operation: 'update'`
+  - Ask "Add a new cell after cell 2" → Should use EditNotebookCells with `operation: 'add'` (code cells run by default)
    - Ask "Run cell 1" → Should respond: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
    - Try referencing: `#editNotebookCells modify cell 3` → Should work
    - Try referencing: `#editNotebookCells add a markdown cell` → Should work
@@ -459,9 +459,9 @@ The chosen approach (attached context detection) provides the cleanest implement
 4. **Verify behavior**:
    - All 4 notebook tools appear in tool list
    - All tools can be referenced: `#runNotebookCells`, `#editNotebookCells`, `#getCellOutputs`, `#getNotebookCells`
-   - Request cell modification → Should use EditNotebookCells with `operation: 'update'`
-   - Request cell execution → Should use RunNotebookCells with `cellIndices`
-   - Request adding new cell → Should use EditNotebookCells with `operation: 'add'`
+  - Request cell modification → Should use EditNotebookCells with `operation: 'update'`
+  - Request cell execution → Should use RunNotebookCells with `cellIndices`
+  - Request adding new cell → Should use EditNotebookCells with `operation: 'add'` (code cells run by default, returns outputs)
    - Assistant can perform all notebook operations
    - Assistant understands index shifting when adding/deleting cells
    - Try referencing: `#runNotebookCells execute cell 0` → Should work

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -16,6 +16,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CellKind, CellEditType } from '../../../contrib/notebook/common/notebookCommon.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { encodeBase64 } from '../../../../base/common/buffer.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 
 /**
  * Main thread implementation of notebook features for extension host communication.
@@ -29,6 +30,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		_extHostContext: IExtHostContext,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		// No initialization needed
 	}
@@ -71,6 +73,65 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		}
 
 		return baseDTO;
+	}
+
+	/**
+	 * Checks if a MIME type represents an image that should be base64 encoded.
+	 * @param mimeType The MIME type to check.
+	 * @returns True if the MIME type is an image type that requires base64 encoding.
+	 */
+	private isImageMimeType(mimeType: string): boolean {
+		// Image types that should be base64 encoded (excluding SVG which is text-based)
+		const imageMimeTypes = [
+			'image/png',
+			'image/jpeg',
+			'image/jpg',
+			'image/gif',
+			'image/webp',
+			'image/bmp'
+		];
+		return imageMimeTypes.includes(mimeType.toLowerCase());
+	}
+
+	/**
+	 * Checks if a MIME type represents text-based content that should be handled as plain text.
+	 * @param mimeType The MIME type to check.
+	 * @returns True if the MIME type is text-based and should be converted to string.
+	 */
+	private isTextBasedMimeType(mimeType: string): boolean {
+		// Text-based MIME types that should be converted to string
+		const textBasedMimeTypes = [
+			'text/latex',
+			'text/html',
+			'application/vnd.code.notebook.error',
+			'application/vnd.code.notebook.stdout',
+			'application/x.notebook.stdout',
+			'application/x.notebook.stream',
+			'application/vnd.code.notebook.stderr',
+			'application/x.notebook.stderr',
+			'text/plain',
+			'text/markdown',
+			'application/json'
+		];
+
+		const lowerMimeType = mimeType.toLowerCase();
+
+		// Check if it's in the known list
+		if (textBasedMimeTypes.includes(lowerMimeType)) {
+			return true;
+		}
+
+		// Check if it starts with 'text/' (covers text/xml, text/csv, etc.)
+		if (lowerMimeType.startsWith('text/')) {
+			return true;
+		}
+
+		// SVG is text-based XML
+		if (lowerMimeType === 'image/svg+xml') {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -303,24 +364,36 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		const outputDTOs: INotebookCellOutputDTO[] = [];
 		for (const output of outputs) {
 			for (const item of output.outputs) {
-				// Handle different MIME types
-				if (item.mime === 'text/plain' || item.mime === 'application/vnd.code.notebook.stdout') {
-					// Plain text outputs
+				const mimeType = item.mime;
+
+				// Handle stderr outputs with prefix
+				if (mimeType === 'application/vnd.code.notebook.stderr') {
 					outputDTOs.push({
-						mimeType: item.mime,
-						data: item.data.toString()
-					});
-				} else if (item.mime === 'application/vnd.code.notebook.stderr') {
-					// Stderr outputs with prefix
-					outputDTOs.push({
-						mimeType: item.mime,
+						mimeType: mimeType,
 						data: `[stderr] ${item.data.toString()}`
 					});
-				} else {
-					// Binary outputs (images, etc.) - convert to base64 using VS Code's browser-compatible encoding
+				}
+				// Handle image MIME types - base64 encode
+				else if (this.isImageMimeType(mimeType)) {
 					const base64Data = encodeBase64(item.data);
 					outputDTOs.push({
-						mimeType: item.mime,
+						mimeType: mimeType,
+						data: base64Data
+					});
+				}
+				// Handle text-based MIME types - convert to string
+				else if (this.isTextBasedMimeType(mimeType)) {
+					outputDTOs.push({
+						mimeType: mimeType,
+						data: item.data.toString()
+					});
+				}
+				// Unknown MIME type - log warning and default to base64 encoding (safer for unknown binary data)
+				else {
+					this._logService.warn(`Unknown MIME type "${mimeType}" in notebook cell output. Defaulting to base64 encoding.`);
+					const base64Data = encodeBase64(item.data);
+					outputDTOs.push({
+						mimeType: mimeType,
 						data: base64Data
 					});
 				}

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -17,6 +17,7 @@ import { CellKind, CellEditType } from '../../../contrib/notebook/common/noteboo
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { encodeBase64 } from '../../../../base/common/buffer.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { isImageMimeType, isTextBasedMimeType } from '../../../contrib/positronNotebook/browser/notebookMimeUtils.js';
 
 /**
  * Main thread implementation of notebook features for extension host communication.
@@ -73,65 +74,6 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		}
 
 		return baseDTO;
-	}
-
-	/**
-	 * Checks if a MIME type represents an image that should be base64 encoded.
-	 * @param mimeType The MIME type to check.
-	 * @returns True if the MIME type is an image type that requires base64 encoding.
-	 */
-	private isImageMimeType(mimeType: string): boolean {
-		// Image types that should be base64 encoded (excluding SVG which is text-based)
-		const imageMimeTypes = [
-			'image/png',
-			'image/jpeg',
-			'image/jpg',
-			'image/gif',
-			'image/webp',
-			'image/bmp'
-		];
-		return imageMimeTypes.includes(mimeType.toLowerCase());
-	}
-
-	/**
-	 * Checks if a MIME type represents text-based content that should be handled as plain text.
-	 * @param mimeType The MIME type to check.
-	 * @returns True if the MIME type is text-based and should be converted to string.
-	 */
-	private isTextBasedMimeType(mimeType: string): boolean {
-		// Text-based MIME types that should be converted to string
-		const textBasedMimeTypes = [
-			'text/latex',
-			'text/html',
-			'application/vnd.code.notebook.error',
-			'application/vnd.code.notebook.stdout',
-			'application/x.notebook.stdout',
-			'application/x.notebook.stream',
-			'application/vnd.code.notebook.stderr',
-			'application/x.notebook.stderr',
-			'text/plain',
-			'text/markdown',
-			'application/json'
-		];
-
-		const lowerMimeType = mimeType.toLowerCase();
-
-		// Check if it's in the known list
-		if (textBasedMimeTypes.includes(lowerMimeType)) {
-			return true;
-		}
-
-		// Check if it starts with 'text/' (covers text/xml, text/csv, etc.)
-		if (lowerMimeType.startsWith('text/')) {
-			return true;
-		}
-
-		// SVG is text-based XML
-		if (lowerMimeType === 'image/svg+xml') {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**
@@ -374,7 +316,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 					});
 				}
 				// Handle image MIME types - base64 encode
-				else if (this.isImageMimeType(mimeType)) {
+				else if (isImageMimeType(mimeType)) {
 					const base64Data = encodeBase64(item.data);
 					outputDTOs.push({
 						mimeType: mimeType,
@@ -382,7 +324,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 					});
 				}
 				// Handle text-based MIME types - convert to string
-				else if (this.isTextBasedMimeType(mimeType)) {
+				else if (isTextBasedMimeType(mimeType)) {
 					outputDTOs.push({
 						mimeType: mimeType,
 						data: item.data.toString()

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Image MIME types that should be base64 encoded when serializing notebook outputs.
+ * Excludes SVG (image/svg+xml) which is text-based XML.
+ */
+export const IMAGE_MIME_TYPES = [
+	'image/png',
+	'image/jpeg',
+	'image/jpg',
+	'image/gif',
+	'image/webp',
+	'image/bmp'
+] as const;
+
+/**
+ * Text-based MIME types that should be converted to string when serializing notebook outputs.
+ * Note: This list is not exhaustive - isTextBasedMimeType() also handles any MIME type starting
+ * with 'text/' and 'image/svg+xml'.
+ */
+export const TEXT_BASED_MIME_TYPES = [
+	'text/latex',
+	'text/html',
+	'application/vnd.code.notebook.error',
+	'application/vnd.code.notebook.stdout',
+	'application/x.notebook.stdout',
+	'application/x.notebook.stream',
+	'application/vnd.code.notebook.stderr',
+	'application/x.notebook.stderr',
+	'text/plain',
+	'text/markdown',
+	'application/json'
+] as const;
+
+/**
+ * Set of image MIME types for fast O(1) lookups.
+ */
+const IMAGE_MIME_TYPES_SET = new Set<string>(IMAGE_MIME_TYPES);
+
+/**
+ * Set of text-based MIME types for fast O(1) lookups.
+ */
+const TEXT_BASED_MIME_TYPES_SET = new Set<string>(TEXT_BASED_MIME_TYPES);
+
+/**
+ * Checks if a MIME type represents an image that should be base64 encoded.
+ * @param mimeType The MIME type to check.
+ * @returns True if the MIME type is an image type that requires base64 encoding.
+ */
+export function isImageMimeType(mimeType: string): boolean {
+	return IMAGE_MIME_TYPES_SET.has(mimeType.toLowerCase());
+}
+
+/**
+ * Checks if a MIME type represents text-based content that should be handled as plain text.
+ * Returns true for:
+ * - MIME types in the TEXT_BASED_MIME_TYPES list
+ * - Any MIME type starting with 'text/' (e.g., 'text/xml', 'text/csv')
+ * - 'image/svg+xml' (SVG is text-based XML)
+ * @param mimeType The MIME type to check.
+ * @returns True if the MIME type is text-based and should be converted to string.
+ */
+export function isTextBasedMimeType(mimeType: string): boolean {
+	const lowerMimeType = mimeType.toLowerCase();
+
+	if (TEXT_BASED_MIME_TYPES_SET.has(lowerMimeType)) {
+		return true;
+	}
+
+	if (lowerMimeType.startsWith('text/')) {
+		return true;
+	}
+
+	if (lowerMimeType === 'image/svg+xml') {
+		return true;
+	}
+
+	return false;
+}
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
@@ -24,6 +24,7 @@ export const IMAGE_MIME_TYPES = [
 export const TEXT_BASED_MIME_TYPES = [
 	'text/latex',
 	'text/html',
+	'application/xml',
 	'application/vnd.code.notebook.error',
 	'application/vnd.code.notebook.stdout',
 	'application/x.notebook.stdout',


### PR DESCRIPTION
Addresses #10856, #10858, #10853, #10851, and #10859.

### Summary

This PR includes several improvements to the Positron Notebooks Assistant based on user feedback:

1. **Fixes AI suggestions error** (#10856): Optimized notebook mode caching to fix the error preventing AI suggestions from appearing in the quickpick
2. **Auto-runs code cells** (#10853): Code cells added by the Assistant now execute automatically, eliminating the 3-5 second delay from requiring two separate tool calls
3. **Auto-renders markdown cells** (#10858): Markdown cells added by the Assistant now render automatically instead of staying in edit mode
4. **Reduces token usage** (#10851): Improved MIME type detection to avoid sending token-expensive base64 data in tool outputs
5. **Performance improvements** (#10859): Caching optimizations significantly reduce response latency and help prevent the Assistant getting stuck "Working..." for extended periods

### Release Notes

#### New Features
- N/A

#### Bug Fixes
-  N/A

### QA Notes

@:positron-notebooks @:assistant
