### PR TITLE
e2e: fix session-state flake

### DIFF
--- a/test/e2e/tests/sessions/session-state.test.ts
+++ b/test/e2e/tests/sessions/session-state.test.ts
@@ -62,8 +62,9 @@ test.describe('Sessions: State', {
 
 		// Restart R session, verify R to returns to active --> idle and Python remains disconnected
 		await sessions.restart(rSessionId, { waitForIdle: false });
-		await sessions.expectStatusToBe(rSessionId, 'active');
-		await sessions.expectStatusToBe(rSessionId, 'idle', { timeout: 60000 });
+		// await sessions.expectStatusToBe(rSessionId, 'active'); // sometimes we miss the active state since it occurs very quickly, checking console text to confirm restart
+		await console.waitForConsoleContents('restarted.', { timeout: 20000 });
+		await sessions.expectStatusToBe(rSessionId, 'idle');
 		await sessions.expectStatusToBe(pySessionId, 'disconnected');
 
 		// Shutdown R, verify both Python and R in disconnected state


### PR DESCRIPTION
### Summary
The session-state test has been flaking because it watches the status icon to confirm the sequence `idle` → `active` → `idle` when a session restarts. In R sessions, that transition can happen so fast that the test never sees the intermediate state. This update shifts the assertion to rely on console output plus the final status icon, making the restart check more reliable.

### QA Notes

n/a
