### PR TITLE
e2e test - "Clear the current URL" button clears the Viewer pane

### DIFF
--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -48,7 +48,7 @@ test.describe('Python Applications', {
 		});
 
 		await test.step('Verify Clear Current URL clears Viewer', async () => {
-			await app.workbench.locator('.codicon-clear-all').click();
+			await app.page.locator('.codicon-clear-all').click();
 
 			await expect(async () => {
 				const iframeLocator = app.web

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -22,7 +22,7 @@ test.describe('Python Applications', {
 		await app.workbench.viewer.clearViewer();
 	});
 
-	test('Python - Verify Basic Dash App', { tag: [tags.WIN] }, async function ({ app, openFile, python }) {
+	test('Python - Verify Basic Dash App', { tag: [tags.WIN] }, async function ({ app, openFile, python, page }) {
 		const viewer = app.workbench.viewer;
 
 		await openFile(join('workspaces', 'python_apps', 'dash_example', 'dash_example.py'));

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -48,7 +48,7 @@ test.describe('Python Applications', {
 		});
 
 		await test.step('Verify Clear Current URL clears Viewer', async () => {
-			await app.workbench.quickaccess.runCommand('positron.preview.clear');
+			await app.workbench.locator('.codicon-clear-all').click();
 
 			await expect(async () => {
 				const iframeLocator = app.web

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -46,6 +46,18 @@ test.describe('Python Applications', {
 					: editorFrameLocator.getByText('Hello World')
 			).toBeVisible({ timeout: 30000 });
 		});
+
+		await test.step('Verify Clear Current URL clears Viewer', async () => {
+			await app.workbench.quickaccess.runCommand('positron.preview.clear');
+
+			await expect(async () => {
+				const iframeLocator = app.web
+					? viewer.viewerFrame.locator('iframe')
+					: viewer.getViewerFrame().locator('iframe');
+				const count = await iframeLocator.count();
+				expect(count).toBe(0);
+			}).toPass({ timeout: 30000 });
+		});
 	});
 
 	test('Python - Verify Basic FastAPI App', {


### PR DESCRIPTION
Adds a test step to confirm that Clear Current URL removes the active iframe and resets the Viewer.

### Why `test.step()`

- Keeping it inside the existing Dash test avoids extra setup and follows the same pattern as other Viewer checks (_e.g.,_ open-in-editor). 
- It fits cleanly into the app’s lifecycle without creating new tests (less time spent running tests).
- Note that the step is placed in the end of the test. Changing the order of steps in the future could lead to failure of other steps. 

### Why only in the Dash app
- The feature is Viewer-specific, not app-specific, so duplicating it across other Python apps offers no extra coverage.
- Dash is the simplest, most stable example, and its clear “Hello World” render allows the test to reliably assert the iframe to no-iframe state transition (from occupied iframe to div-content emptiness). 
- If `test.step()` fails in the future, the presence of "Hello World" would be a clear indicator to look at the screenshots. 

### QA Notes

@:apps @:viewer @:editor @:web