### PR TITLE
Set log level to trace when positron-r extension tests are running

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -143,7 +143,7 @@ export class ArkLsp implements vscode.Disposable {
 		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly
 		const id = 'positron.r';
 
-		const message = `Creating ${this._dynState.sessionName} language client for session ${this._metadata.sessionId} on port ${port}`;
+		const message = `Creating language client ${this._dynState.sessionName} for session ${this._metadata.sessionId} on port ${port}`;
 
 		LOGGER.info(message);
 		outputChannel.appendLine(message);

--- a/extensions/positron-r/src/test/ark-comm.test.ts
+++ b/extensions/positron-r/src/test/ark-comm.test.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './mocha-setup'
+
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as testKit from './kit';

--- a/extensions/positron-r/src/test/debugger.test.ts
+++ b/extensions/positron-r/src/test/debugger.test.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './mocha-setup'
+
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as testKit from './kit';

--- a/extensions/positron-r/src/test/mocha-setup.ts
+++ b/extensions/positron-r/src/test/mocha-setup.ts
@@ -9,7 +9,10 @@ import * as testKit from './kit';
 export let currentTestName: string | undefined;
 
 suiteSetup(async () => {
-	// Set Ark log level to TRACE for easier debugging of tests
+	// Set global Positron log level to trace for easier debugging
+	await vscode.commands.executeCommand('_extensionTests.setLogLevel', 'trace');
+
+	// Set Ark kernel process log level to trace
 	await vscode.workspace.getConfiguration().update('positron.r.kernel.logLevel', 'trace', vscode.ConfigurationTarget.Global);
 
 	// To be safe


### PR DESCRIPTION
So we get more detailed logs for both positron-r and kernel-supervisor. Would be helpful to figure out https://github.com/posit-dev/positron/issues/10121#issuecomment-3606508054

Since that only affects the Positron process running positron-r tests, that verbosity setting should not have any negative impact on QA and dev teams.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
