### PR TITLE
Allow positron assistant to scroll notebook to cells changed outside of viewport

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -231,11 +231,6 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		}
 
 		instance.deleteCell(cells[cellIndex]);
-
-		// Notify about assistant cell modification for follow mode
-		// Note: After deletion, the cellIndex may point to a different cell, but we still notify
-		// to handle the case where the deleted cell was outside the viewport
-		await instance.handleAssistantCellModification(cellIndex, 'delete');
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -183,7 +183,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		// Notify for the last cell that was run
 		const lastCellIndex = cellIndices[cellIndices.length - 1];
 		if (lastCellIndex !== undefined) {
-			await instance.handleAssistantCellModification(lastCellIndex, 'run');
+			await instance.handleAssistantCellModification(lastCellIndex);
 		}
 	}
 
@@ -209,7 +209,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		instance.addCell(cellKind, index, false, content);
 
 		// Notify about assistant cell modification for follow mode
-		await instance.handleAssistantCellModification(index, 'add');
+		await instance.handleAssistantCellModification(index);
 
 		return index;
 	}
@@ -291,7 +291,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		], true, undefined, () => undefined, undefined, computeUndoRedo);
 
 		// Notify about assistant cell modification for follow mode
-		await instance.handleAssistantCellModification(cellIndex, 'edit');
+		await instance.handleAssistantCellModification(cellIndex);
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -180,11 +180,9 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		await instance.runCells(cellsToRun);
 
 		// Notify about assistant cell modification for follow mode
-		// Notify for the last cell that was run
-		const lastCellIndex = cellIndices[cellIndices.length - 1];
-		if (lastCellIndex !== undefined) {
-			await instance.handleAssistantCellModification(lastCellIndex);
-		}
+		// Use the last cell that was actually run (from filtered cellsToRun),
+		// not the original cellIndices array which may contain invalid indices
+		await instance.handleAssistantCellModification(lastCell.index);
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -7,7 +7,7 @@ import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensi
 import { MainPositronContext, MainThreadNotebookFeaturesShape, INotebookContextDTO, INotebookCellDTO, INotebookCellOutputDTO } from '../../common/positron/extHost.positron.protocol.js';
 import { NotebookCellType } from '../../common/positron/extHostTypes.positron.js';
 import { IPositronNotebookService } from '../../../contrib/positronNotebook/browser/positronNotebookService.js';
-import { IPositronNotebookInstance } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
+import { IPositronNotebookInstance, NotebookOperationType } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCell, CellSelectionStatus, IPositronNotebookCodeCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from '../../../contrib/positronNotebook/browser/notebookUtils.js';
@@ -177,7 +177,14 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		const lastCell = cellsToRun[cellsToRun.length - 1];
 		lastCell.select(CellSelectionType.Normal);
 
-		return instance.runCells(cellsToRun);
+		await instance.runCells(cellsToRun);
+
+		// Notify about assistant cell modification for follow mode
+		// Notify for the last cell that was run
+		const lastCellIndex = cellIndices[cellIndices.length - 1];
+		if (lastCellIndex !== undefined) {
+			instance.handleAssistantCellModification(lastCellIndex, 'run');
+		}
 	}
 
 	/**
@@ -196,8 +203,13 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 
 		const cellKind = type === NotebookCellType.Code ? CellKind.Code : CellKind.Markup;
 
-		// Add cell with content and enter edit mode
-		instance.addCell(cellKind, index, true, content);
+		// Mark this as an assistant operation to prevent automatic selection/scrolling.
+		// The follow mode will control reveal behavior based on user preferences.
+		instance.setCurrentOperation(NotebookOperationType.AssistantAdd);
+		instance.addCell(cellKind, index, false, content);
+
+		// Notify about assistant cell modification for follow mode
+		instance.handleAssistantCellModification(index, 'add');
 
 		return index;
 	}
@@ -218,7 +230,12 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 			throw new Error(`Cell not found at index: ${cellIndex}`);
 		}
 
-		return instance.deleteCell(cells[cellIndex]);
+		instance.deleteCell(cells[cellIndex]);
+
+		// Notify about assistant cell modification for follow mode
+		// Note: After deletion, the cellIndex may point to a different cell, but we still notify
+		// to handle the case where the deleted cell was outside the viewport
+		instance.handleAssistantCellModification(cellIndex, 'delete');
 	}
 
 	/**
@@ -252,6 +269,10 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 
 		const computeUndoRedo = !instance.isReadOnly || textModel.viewType === 'interactive';
 
+		// Mark this as an assistant operation to prevent automatic selection/scrolling.
+		// The follow mode will control reveal behavior based on user preferences.
+		instance.setCurrentOperation(NotebookOperationType.AssistantEdit);
+
 		textModel.applyEdits([
 			{
 				editType: CellEditType.Replace,
@@ -273,6 +294,9 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 				]
 			}
 		], true, undefined, () => undefined, undefined, computeUndoRedo);
+
+		// Notify about assistant cell modification for follow mode
+		instance.handleAssistantCellModification(cellIndex, 'edit');
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -183,7 +183,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		// Notify for the last cell that was run
 		const lastCellIndex = cellIndices[cellIndices.length - 1];
 		if (lastCellIndex !== undefined) {
-			instance.handleAssistantCellModification(lastCellIndex, 'run');
+			await instance.handleAssistantCellModification(lastCellIndex, 'run');
 		}
 	}
 
@@ -209,7 +209,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		instance.addCell(cellKind, index, false, content);
 
 		// Notify about assistant cell modification for follow mode
-		instance.handleAssistantCellModification(index, 'add');
+		await instance.handleAssistantCellModification(index, 'add');
 
 		return index;
 	}
@@ -235,7 +235,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		// Notify about assistant cell modification for follow mode
 		// Note: After deletion, the cellIndex may point to a different cell, but we still notify
 		// to handle the case where the deleted cell was outside the viewport
-		instance.handleAssistantCellModification(cellIndex, 'delete');
+		await instance.handleAssistantCellModification(cellIndex, 'delete');
 	}
 
 	/**
@@ -296,7 +296,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		], true, undefined, () => undefined, undefined, computeUndoRedo);
 
 		// Notify about assistant cell modification for follow mode
-		instance.handleAssistantCellModification(cellIndex, 'edit');
+		await instance.handleAssistantCellModification(cellIndex, 'edit');
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -345,9 +345,9 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Handle assistant cell modification by showing notifications or auto-following
 	 * when cells are modified outside the viewport.
 	 * @param cellIndex The index of the cell that was modified
-	 * @param action The type of modification ('add' | 'edit' | 'run' | 'delete')
+	 * @param action The type of modification ('add' | 'edit' | 'run')
 	 */
-	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): Promise<void>;
+	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run'): Promise<void>;
 
 	/**
 	 * Event that fires when the notebook editor widget or a cell editor within it gains focus.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -53,7 +53,11 @@ export enum NotebookOperationType {
 	/** Cells restored via undo operation */
 	Undo = 'Undo',
 	/** Cells restored via redo operation */
-	Redo = 'Redo'
+	Redo = 'Redo',
+	/** Cells added by the AI assistant - should not auto-select or scroll */
+	AssistantAdd = 'AssistantAdd',
+	/** Cells edited by the AI assistant - should not auto-select or scroll */
+	AssistantEdit = 'AssistantEdit'
 }
 
 /**
@@ -337,6 +341,13 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 */
 	fireScrollEvent(): void;
 
+	/**
+	 * Handle assistant cell modification by showing notifications or auto-following
+	 * when cells are modified outside the viewport.
+	 * @param cellIndex The index of the cell that was modified
+	 * @param action The type of modification ('add' | 'edit' | 'run' | 'delete')
+	 */
+	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): void;
 
 	/**
 	 * Event that fires when the notebook editor widget or a cell editor within it gains focus.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -347,7 +347,7 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * @param cellIndex The index of the cell that was modified
 	 * @param action The type of modification ('add' | 'edit' | 'run' | 'delete')
 	 */
-	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): void;
+	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): Promise<void>;
 
 	/**
 	 * Event that fires when the notebook editor widget or a cell editor within it gains focus.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -345,9 +345,8 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Handle assistant cell modification by showing notifications or auto-following
 	 * when cells are modified outside the viewport.
 	 * @param cellIndex The index of the cell that was modified
-	 * @param action The type of modification ('add' | 'edit' | 'run')
 	 */
-	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run'): Promise<void>;
+	handleAssistantCellModification(cellIndex: number): Promise<void>;
 
 	/**
 	 * Event that fires when the notebook editor widget or a cell editor within it gains focus.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -155,8 +155,17 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	/**
 	 * Reveal the cell in the viewport
 	 * @param type Reveal type.
+	 * @returns Promise that resolves to true if the cell was successfully revealed, false otherwise.
 	 */
-	reveal(type?: CellRevealType): void;
+	reveal(type?: CellRevealType): Promise<boolean>;
+
+	/**
+	 * Temporarily highlight the cell with a flash animation to draw attention.
+	 * The highlight is automatically removed after the animation completes.
+	 * @param durationMs Optional duration in milliseconds. Defaults to 1500ms.
+	 * @returns Promise that resolves to true if the highlight was successfully added, false otherwise.
+	 */
+	highlightTemporarily(durationMs?: number): Promise<boolean>;
 
 	/**
 	 * Apply notebook editor options to this cell. Used by the IDE to select and/or reveal the cell.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -161,11 +161,11 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 
 	/**
 	 * Temporarily highlight the cell with a flash animation to draw attention.
-	 * The highlight is automatically removed after the animation completes.
-	 * @param durationMs Optional duration in milliseconds. Defaults to 1500ms.
+	 * The highlight animation is controlled by CSS and automatically completes.
+	 * Calling this method multiple times in quick succession will restart the animation.
 	 * @returns Promise that resolves to true if the highlight was successfully added, false otherwise.
 	 */
-	highlightTemporarily(durationMs?: number): Promise<boolean>;
+	highlightTemporarily(): Promise<boolean>;
 
 	/**
 	 * Apply notebook editor options to this cell. Used by the IDE to select and/or reveal the cell.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -189,6 +189,13 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	get container(): HTMLElement | undefined;
 
 	/**
+	 * Check if this cell is currently visible in the viewport.
+	 * A cell is considered visible if at least {@link MIN_CELL_VISIBILITY_RATIO} of it is within the viewport.
+	 * @returns true if the cell is visible, false otherwise
+	 */
+	isInViewport(): boolean;
+
+	/**
 	 *
 	 * @param editor Code editor widget associated with cell.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/createNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/createNotebookCell.ts
@@ -9,6 +9,7 @@ import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { PositronNotebookCodeCell } from './PositronNotebookCodeCell.js';
 import { PositronNotebookMarkdownCell } from './PositronNotebookMarkdownCell.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
+import { IPositronNotebookCell } from './IPositronNotebookCell.js';
 
 /**
  * Instantiate a notebook cell based on the cell's kind
@@ -17,7 +18,7 @@ import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
  * @param instantiationService The instantiation service to use to create the cell
  * @returns The instantiated notebook cell of the correct type.
  */
-export function createNotebookCell(cell: NotebookCellTextModel, instance: PositronNotebookInstance, instantiationService: IInstantiationService) {
+export function createNotebookCell(cell: NotebookCellTextModel, instance: PositronNotebookInstance, instantiationService: IInstantiationService): IPositronNotebookCell {
 	if (cell.cellKind === CellKind.Code) {
 		return instantiationService.createInstance(PositronNotebookCodeCell, cell, instance);
 	} else {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1605,7 +1605,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return visibilityRatio >= 0.5;
 	}
 
-	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): void {
+	async handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): Promise<void> {
 		const cells = this.cells.get();
 		if (cellIndex < 0 || cellIndex >= cells.length) {
 			return;
@@ -1627,9 +1627,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const autoFollow = this.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY) ?? true;
 
 		if (autoFollow) {
-			// Auto-follow: scroll to cell and highlight
-			cell.reveal();
-			cell.highlightTemporarily();
+			const revealed = await cell.reveal();
+			const highlighted = await cell.highlightTemporarily();
+			if (!revealed || !highlighted) {
+				this._logService.debug(`Failed to reveal/highlight cell ${cellIndex} - container not available`);
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -26,6 +26,7 @@ import { CellSelectionType, getActiveCell, getSelectedCells, SelectionState, Sel
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IPositronNotebookService } from './positronNotebookService.js';
 import { IPositronNotebookInstance, KernelStatus, NotebookOperationType } from './IPositronNotebookInstance.js';
+import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from './positronNotebookExperimentalConfig.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { SELECT_KERNEL_ID_POSITRON } from './SelectPositronNotebookKernelAction.js';
@@ -1234,7 +1235,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		const currentOp = this.getAndResetCurrentOperation();
 
-		if (newlyAddedCells.length === 1) {
+		// Skip auto-selection for assistant-added and assistant-edited cells - the follow mode will handle reveal behavior
+		if (currentOp !== NotebookOperationType.AssistantAdd && currentOp !== NotebookOperationType.AssistantEdit && newlyAddedCells.length === 1) {
 			const newCell = newlyAddedCells[0];
 			const shouldAutoEdit = shouldAutoEditOnCellAdd(currentOp, newCell);
 
@@ -1579,6 +1581,56 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return activeCell.index + 1;
 		}
 		return this.cells.get().length;
+	}
+
+	/**
+	 * Check if a cell is currently visible in the viewport.
+	 * A cell is considered visible if at least 50% of it is within the viewport.
+	 * @param cell The cell to check
+	 * @returns true if the cell is visible, false otherwise
+	 */
+	private _isCellInViewport(cell: IPositronNotebookCell): boolean {
+		if (!cell.container || !this._cellsContainer) {
+			return false;
+		}
+
+		const cellRect = cell.container.getBoundingClientRect();
+		const containerRect = this._cellsContainer.getBoundingClientRect();
+
+		const visibleTop = Math.max(containerRect.top, cellRect.top);
+		const visibleBottom = Math.min(containerRect.bottom, cellRect.bottom);
+		const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+		const visibilityRatio = visibleHeight / cellRect.height;
+
+		return visibilityRatio >= 0.5;
+	}
+
+	handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): void {
+		const cells = this.cells.get();
+		if (cellIndex < 0 || cellIndex >= cells.length) {
+			return;
+		}
+
+		const cell = cells[cellIndex];
+		if (!cell) {
+			return;
+		}
+
+		// Check if cell is visible in viewport
+		const isVisible = this._isCellInViewport(cell);
+		if (isVisible) {
+			// Cell is already visible, no action needed
+			return;
+		}
+
+		// Check if auto-follow is enabled
+		const autoFollow = this.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY) ?? true;
+
+		if (autoFollow) {
+			// Auto-follow: scroll to cell and highlight
+			cell.reveal();
+			cell.highlightTemporarily();
+		}
 	}
 
 	// #endregion

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1605,7 +1605,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return visibilityRatio >= 0.5;
 	}
 
-	async handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run' | 'delete'): Promise<void> {
+	async handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run'): Promise<void> {
 		const cells = this.cells.get();
 		if (cellIndex < 0 || cellIndex >= cells.length) {
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -617,16 +617,16 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Reveals a cell in the center of the viewport.
 	 * @param cell The cell to reveal
 	 */
-	revealInCenter(cell: IExtensionApiCellViewModel): void {
-		this._revealCell(cell, CellRevealType.Center);
+	async revealInCenter(cell: IExtensionApiCellViewModel): Promise<void> {
+		await this._revealCell(cell, CellRevealType.Center);
 	}
 
 	/**
 	 * Reveals a cell at the top of the viewport.
 	 * @param cell The cell to reveal
 	 */
-	revealInViewAtTop(cell: IExtensionApiCellViewModel): void {
-		this._revealCell(cell, CellRevealType.Top);
+	async revealInViewAtTop(cell: IExtensionApiCellViewModel): Promise<void> {
+		await this._revealCell(cell, CellRevealType.Top);
 	}
 
 	private _toPositronCell(cell: IExtensionApiCellViewModel): IPositronNotebookCell {
@@ -641,8 +641,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	/**
 	 * @param cell The cell to reveal
 	 */
-	private _revealCell(cell: IExtensionApiCellViewModel, type?: CellRevealType): void {
-		this._toPositronCell(cell).reveal(type);
+	private async _revealCell(cell: IExtensionApiCellViewModel, type?: CellRevealType): Promise<void> {
+		await this._toPositronCell(cell).reveal(type);
 	}
 	//#endregion INotebookEditor
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1583,7 +1583,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this.cells.get().length;
 	}
 
-	async handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run'): Promise<void> {
+	async handleAssistantCellModification(cellIndex: number): Promise<void> {
 		const cells = this.cells.get();
 		if (cellIndex < 0 || cellIndex >= cells.length) {
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1583,28 +1583,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this.cells.get().length;
 	}
 
-	/**
-	 * Check if a cell is currently visible in the viewport.
-	 * A cell is considered visible if at least 50% of it is within the viewport.
-	 * @param cell The cell to check
-	 * @returns true if the cell is visible, false otherwise
-	 */
-	private _isCellInViewport(cell: IPositronNotebookCell): boolean {
-		if (!cell.container || !this._cellsContainer) {
-			return false;
-		}
-
-		const cellRect = cell.container.getBoundingClientRect();
-		const containerRect = this._cellsContainer.getBoundingClientRect();
-
-		const visibleTop = Math.max(containerRect.top, cellRect.top);
-		const visibleBottom = Math.min(containerRect.bottom, cellRect.bottom);
-		const visibleHeight = Math.max(0, visibleBottom - visibleTop);
-		const visibilityRatio = visibleHeight / cellRect.height;
-
-		return visibilityRatio >= 0.5;
-	}
-
 	async handleAssistantCellModification(cellIndex: number, action: 'add' | 'edit' | 'run'): Promise<void> {
 		const cells = this.cells.get();
 		if (cellIndex < 0 || cellIndex >= cells.length) {
@@ -1617,7 +1595,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}
 
 		// Check if cell is visible in viewport
-		const isVisible = this._isCellInViewport(cell);
+		const isVisible = cell.isInViewport();
 		if (isVisible) {
 			// Cell is already visible, no action needed
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -160,16 +160,44 @@
 
 /* Assistant cell highlight animation - used when AI modifies cells */
 .positron-notebook-cell.assistant-highlight {
+	position: relative;
+}
+
+.positron-notebook-cell.assistant-highlight::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background-color: var(--vscode-button-background);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+	pointer-events: none;
+	z-index: 0;
+	opacity: 0;
 	animation: assistant-flash 1.5s ease-in-out;
+	animation-fill-mode: forwards;
 }
 
 @keyframes assistant-flash {
-	0%, 100% { background-color: transparent; }
-	25%, 75% { background-color: var(--vscode-editor-findMatchHighlightBackground); }
+	0%, 100% { opacity: 0; }
+	25%, 75% { opacity: 0.2; }
+}
+
+/* Use border-based highlight for high contrast themes instead of background overlay */
+.hc-black .positron-notebook-cell.assistant-highlight::before,
+.hc-light .positron-notebook-cell.assistant-highlight::before {
+	background-color: transparent;
+	border: 2px solid var(--vscode-focusBorder);
+	animation: assistant-flash-hc 1.5s ease-in-out;
+	animation-fill-mode: forwards;
+}
+
+@keyframes assistant-flash-hc {
+	0%, 100% { opacity: 0; }
+	25%, 75% { opacity: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.positron-notebook-cell.assistant-highlight {
+	.positron-notebook-cell.assistant-highlight::before {
 		animation: none;
+		opacity: 0;
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -157,3 +157,19 @@
 		transition: none;
 	}
 }
+
+/* Assistant cell highlight animation - used when AI modifies cells */
+.positron-notebook-cell.assistant-highlight {
+	animation: assistant-flash 1.5s ease-in-out;
+}
+
+@keyframes assistant-flash {
+	0%, 100% { background-color: transparent; }
+	25%, 75% { background-color: var(--vscode-editor-findMatchHighlightBackground); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.positron-notebook-cell.assistant-highlight {
+		animation: none;
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -26,7 +26,7 @@ import { NotebookDiffEditorInput } from '../../notebook/common/notebookDiffEdito
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { checkPositronNotebookEnabled } from './positronNotebookExperimentalConfig.js';
+import { checkPositronNotebookEnabled, POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from './positronNotebookExperimentalConfig.js';
 import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from '../../../services/workingCopy/common/workingCopyEditorService.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
@@ -1362,6 +1362,46 @@ registerAction2(class extends NotebookAction2 {
 
 // Ask Assistant - Opens assistant chat with prompt options for the notebook
 // Action is defined in AskAssistantAction.ts
+
+// Toggle Assistant Auto-Follow - Status indicator for automatic scrolling to AI-modified cells
+// This action displays as a status indicator showing "Following assistant" when enabled.
+// Clicking the status will toggle auto-follow off.
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.toggleAssistantAutoFollow',
+			title: localize2('toggleAssistantAutoFollow.disabled', 'Follow assistant'),
+			tooltip: localize2('toggleAssistantAutoFollow.disabledTooltip', 'Click to follow assistant edits and automatically scroll to cells modified by the AI assistant.'),
+			icon: ThemeIcon.fromId('eye-watch'),
+			f1: true,
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			positronActionBarOptions: {
+				controlType: 'button',
+				displayTitle: true
+			},
+			toggled: {
+				condition: ContextKeyExpr.equals('config.positron.notebook.assistant.autoFollow', true),
+				title: localize('toggleAssistantAutoFollow.status', 'Following assistant'),
+				tooltip: localize('toggleAssistantAutoFollow.enabledTooltip', 'Click to stop following assistant edits.')
+			},
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 55, // After Ask Assistant (50)
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					ContextKeyExpr.has('config.positron.assistant.notebookMode.enable')
+				)
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		const currentValue = configurationService.getValue<boolean>(POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY) ?? true;
+		configurationService.updateValue(POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY, !currentValue);
+	}
+});
 
 // Kernel Status Widget - Shows live kernel connection status at far right of action bar
 // Widget is self-contained: manages its own menu interactions via ActionBarMenuButton

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
@@ -15,6 +15,9 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 // Configuration key for the Positron notebook setting
 export const POSITRON_NOTEBOOK_ENABLED_KEY = 'positron.notebook.enabled';
 
+// Configuration key for assistant auto-follow setting
+export const POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY = 'positron.notebook.assistant.autoFollow';
+
 /**
  * Retrieves the value of the configuration setting that determines whether to enable
  * the Positron Notebook editor.
@@ -46,6 +49,14 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.enablePositronNotebook',
 				'Enable the Positron Notebook editor for .ipynb files. When disabled, the default VS Code notebook editor will be used.\n\nA restart is required to take effect.'
+			),
+		},
+		[POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.notebook.assistant.autoFollow',
+				'Automatically scroll to cells modified by the AI assistant. When enabled, cells modified outside the viewport will be automatically scrolled into view and highlighted.'
 			),
 		},
 	},


### PR DESCRIPTION
Addresses #10552

Adds auto-follow mode that automatically scrolls to and highlights cells when the notebook assistant modifies them outside the current viewport. When enabled (default), users can track assistant changes in long notebooks without manual scrolling.

https://github.com/user-attachments/assets/f0b4720a-77ca-45c4-9b2e-113fde606e04


### Summary

The implementation monitors assistant operations (add, edit, run, delete) and checks if the modified cell is visible (‚â•50% in viewport). For cells outside the viewport:

- **Auto-follow enabled**: Smoothly scrolls to the cell and applies a temporary highlight animation
- **Auto-follow disabled**: No automatic scrolling occurs

A toggle button in the editor action bar allows users to control this behavior, with the setting persisting via `positron.notebook.assistant.autoFollow` configuration.


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:assistant

**Prerequisites:**
- Enable Positron Assistant notebook mode if not already enabled
- Create or open a notebook with enough cells to require scrolling

**Testing:**

1. Scroll to the top of the notebook so bottom cells are out of view
2. Ask the assistant to modify a cell near the bottom (e.g., "Add a new code cell at the end with `print('test')`")
3. Verify the notebook automatically scrolls to the modified cell
4. Verify the cell briefly highlights with a flash animation
5. Click the "Following assistant" toggle button in the editor action bar to disable
6. Ask the assistant to modify another cell outside the viewport
7. Verify the notebook does NOT scroll this time
8. Re-enable the toggle and verify it works again
