### PR TITLE
Undo css change that broke notebook spinner visibility

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -54,20 +54,20 @@
 }
 
 /* Hide the circle outline when the cell isn't running */
-.left-hand-action-container-top:not([data-execution-status='running']) {
+.left-hand-action-container:not([data-execution-status='running']) {
 	--_circle-border-width: 0;
 }
 
 /* Status-specific styling for the container */
-.left-hand-action-container-top[data-execution-status='running'] {
+.left-hand-action-container[data-execution-status='running'] {
 	color: var(--vscode-debugIcon-startForeground);
 }
 
-.left-hand-action-container-top[data-execution-status='success'] {
+.left-hand-action-container[data-execution-status='success'] {
 	border-color: color-mix(in srgb, var(--vscode-testing-iconPassed) 70%, transparent);
 }
 
-.left-hand-action-container-top[data-execution-status='failed'] {
+.left-hand-action-container[data-execution-status='failed'] {
 	border-color: color-mix(in srgb, var(--vscode-testing-iconFailed) 70%, transparent);
 }
 
@@ -75,15 +75,15 @@
 	color: var(--vscode-testing-iconFailed);
 }
 
-.left-hand-action-container-top[data-execution-status='neutral'] {
+.left-hand-action-container[data-execution-status='neutral'] {
 	border-color: var(--vscode-textLink-foreground);
 }
 
-.left-hand-action-container-top[data-execution-status='pending'] {
+.left-hand-action-container[data-execution-status='pending'] {
 	color: color-mix(in srgb, var(--vscode-widget-border) 70%, transparent);
 }
 
-.left-hand-action-container-top[data-execution-status='queued'] {
+.left-hand-action-container[data-execution-status='queued'] {
 	border-color: color-mix(in srgb, var(--vscode-widget-border) 60%, transparent);
 }
 
@@ -97,14 +97,14 @@
 	border: var(--_circle-border-width, 1px) solid color-mix(in srgb, var(--vscode-descriptionForeground) 50%, transparent);
 }
 
-.left-hand-action-container-top[data-execution-status='running'] .cell-execution-status-animation {
+.left-hand-action-container[data-execution-status='running'] .cell-execution-status-animation {
 	border: var(--_circle-border-width, 1px) solid var(--vscode-debugIcon-startForeground);
 	border-top-color: transparent;
 	animation: spin 1.2s cubic-bezier(0.4, 0.3, 0.5, 0.7) infinite;
 	transform-origin: center;
 }
 
-.left-hand-action-container-top[data-execution-status='pending'] .cell-execution-status-animation {
+.left-hand-action-container[data-execution-status='pending'] .cell-execution-status-animation {
 	border: 1px dashed color-mix(in srgb, var(--vscode-widget-border) 50%, transparent);
 }
 


### PR DESCRIPTION
Addresses #10905 

The last change I made in https://github.com/posit-dev/positron/pull/10812 to fix the e2e test required moving an html attribute to a different element. The spinner css directly referenced that attribute via a descendant selector and the css wasn't updated to account for that.

The html structure is as follows:
```
<div className='left-hand-action-container' data-execution-status={dataExecutionStatus} >
  <div className='left-hand-action-container-top' />
</div>
```

The css was: `.left-hand-action-container-top[data-execution-status='<value>']` and expected `data-execution-status` to be on the div element with the class `left-hand-action-container-top` but the `data-execution-status` was moved to the element with `left-hand-action-container` class. 

The css needs to be `.left-hand-action-container[data-execution-status='<value>']` so the descendant selector rule is correct.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
