### PR TITLE
Assistant: Improves inline chat text editing

### DIFF
--- a/extensions/positron-assistant/src/replaceSelectionProcessor.ts
+++ b/extensions/positron-assistant/src/replaceSelectionProcessor.ts
@@ -102,7 +102,12 @@ export class ReplaceSelectionProcessor {
 		const lines = text.split(/\r?\n/);
 		const lineDelta = lines.length - 1;
 		const characterDelta = lines.at(-1)!.length;
-		this._insertPosition = this._insertPosition!.translate(lineDelta, characterDelta);
+		if (lineDelta === 0) {
+			this._insertPosition = this._insertPosition!.translate(lineDelta, characterDelta);
+		} else {
+			// If we added new lines, reset the character position to the length of the last line.
+			this._insertPosition = this._insertPosition.translate({ lineDelta }).with({ character: characterDelta });
+		}
 	}
 
 	private onReplaceSelectionClose(): void {


### PR DESCRIPTION
Fixes an issue in Assistant's streaming text replacement logic when inserting text across multiple lines in inline chat. The existing logic did not reset the insertion position's character location when moving to a new line, leading to text being inserted mid-way through a line - possibly interposing with existing text. 

<img width="1529" height="354" alt="Screenshot 2025-12-03 at 12 52 30 PM" src="https://github.com/user-attachments/assets/5283b098-1512-4b3d-b9a6-a1f6ea381191" />

Addresses #10914


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Inline chat now better handles inserting text when editing a selection


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
