### PR TITLE
Positron notebook quick-fix errors

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -17,6 +17,7 @@ import { useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOptions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
 
 type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
 
@@ -106,6 +107,11 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 		{
 			truncation.mode === 'scroll'
 				? <TruncationMessage commandService={services.commandService} truncationResult={truncation} />
+				: null
+		}
+		{
+			type === 'error'
+				? <NotebookCellQuickFix errorContent={content} />
 				: null
 		}
 	</>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Container for all quick-fix buttons */
+.notebook-cell-quick-fix {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+/* Split button container - mimics action-bar-button.border style */
+.notebook-cell-quick-fix-split-button {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-positronActionBar-selectBorder);
+	background: transparent;
+}
+
+/* Main action button (left side) */
+.notebook-cell-quick-fix .assistant-action-main {
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	border-radius: 3px 0 0 3px;
+}
+
+.notebook-cell-quick-fix .assistant-action-main:hover {
+	background: var(--vscode-positronActionBar-hoverBackground);
+}
+
+.notebook-cell-quick-fix .assistant-action-main .link-text {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	color: var(--vscode-textLink-foreground);
+	padding: 2px 6px;
+	font-size: 12px;
+}
+
+.notebook-cell-quick-fix .assistant-action-main .link-text .codicon {
+	color: var(--vscode-textLink-foreground);
+	font-size: 12px;
+}
+
+/* Dropdown button (right side) - mimics action-bar-button-drop-down-button */
+.notebook-cell-quick-fix .assistant-action-dropdown {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0 4px;
+	border-left: 1px solid var(--vscode-positronActionBar-selectBorder);
+	cursor: pointer;
+	user-select: none;
+	align-self: stretch;
+	border-radius: 0 3px 3px 0;
+}
+
+.notebook-cell-quick-fix .assistant-action-dropdown:hover {
+	background: var(--vscode-positronActionBar-hoverBackground);
+}
+
+.notebook-cell-quick-fix .assistant-action-dropdown .codicon {
+	color: var(--vscode-textLink-foreground);
+	font-size: 14px;
+	pointer-events: none;
+}
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
@@ -41,11 +41,15 @@
 	color: var(--vscode-textLink-foreground);
 	padding: 2px 6px;
 	font-size: 12px;
+	cursor: pointer;
+	user-select: none;
 }
 
 .notebook-cell-quick-fix .assistant-action-main .link-text .codicon {
 	color: var(--vscode-textLink-foreground);
 	font-size: 12px;
+	cursor: pointer;
+	user-select: none;
 }
 
 /* Dropdown button (right side) - mimics action-bar-button-drop-down-button */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -16,6 +16,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
+import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { CHAT_OPEN_ACTION_ID } from '../../../chat/browser/actions/chatActions.js';
 
 /**
@@ -56,8 +57,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	 * @returns The formatted fix query string
 	 */
 	const buildFixQuery = (): string => {
-		return props.errorContent
-			? `Fix this cell that produced an error:\n\`\`\`\n${props.errorContent}\n\`\`\``
+		const cleanError = removeAnsiEscapeCodes(props.errorContent).trim();
+		return cleanError
+			? `Fix this cell that produced an error:\n\`\`\`\n${cleanError}\n\`\`\``
 			: 'Fix this cell that produced an error.';
 	};
 
@@ -69,8 +71,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	 * @returns The formatted explain query string
 	 */
 	const buildExplainQuery = (): string => {
-		return props.errorContent
-			? `Explain why this cell produced an error:\n\`\`\`\n${props.errorContent}\n\`\`\``
+		const cleanError = removeAnsiEscapeCodes(props.errorContent).trim();
+		return cleanError
+			? `Explain why this cell produced an error:\n\`\`\`\n${cleanError}\n\`\`\``
 			: 'Explain why this cell produced an error.';
 	};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './NotebookCellQuickFix.css';
+
+// React.
+import React, { useRef } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
+import { IAction } from '../../../../../base/common/actions.js';
+import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
+import { CHAT_OPEN_ACTION_ID } from '../../../chat/browser/actions/chatActions.js';
+
+const fixPrompt = '/fix';
+const explainPrompt = '/explain';
+
+interface NotebookCellQuickFixProps {
+	errorContent: string;
+}
+
+/**
+ * Quick fix component for notebook cell errors.
+ * Displays "Fix" and "Explain" split buttons that send the error content to the assistant chat.
+ * Primary click opens quick chat, dropdown opens main chat panel to retain conversation context.
+ *
+ * @param props Component props containing the error content
+ * @returns The rendered component, or null if assistant is not enabled
+ */
+export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
+	const fixButtonRef = useRef<HTMLDivElement>(undefined!);
+	const explainButtonRef = useRef<HTMLDivElement>(undefined!);
+	const fixDropdownRef = useRef<HTMLDivElement>(undefined!);
+	const explainDropdownRef = useRef<HTMLDivElement>(undefined!);
+	const services = usePositronReactServicesContext();
+	const { quickChatService, commandService, contextMenuService } = services;
+
+	// Configuration hooks to conditionally show the quick-fix buttons
+	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
+	const enableNotebookMode = usePositronConfiguration<boolean>('positron.assistant.notebookMode.enable');
+	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
+
+	// Only show buttons if assistant is enabled, notebook mode is enabled, and chat models are available
+	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
+
+	/**
+	 * Builds the query string with prompt and error content in a code block.
+	 *
+	 * @param prompt The prompt prefix (/fix or /explain)
+	 * @returns The formatted query string
+	 */
+	const buildQuery = (prompt: string): string => {
+		return props.errorContent ? `${prompt}\n\`\`\`\n${props.errorContent}\n\`\`\`` : prompt;
+	};
+
+	/**
+	 * Handler for the "Fix" button primary click.
+	 * Opens the quick chat with a fix prompt and the error content in a code block.
+	 */
+	const pressedFixHandler = async () => {
+		quickChatService.open({
+			query: buildQuery(fixPrompt)
+		});
+	};
+
+	/**
+	 * Handler for the "Explain" button primary click.
+	 * Opens the quick chat with an explain prompt and the error content in a code block.
+	 */
+	const pressedExplainHandler = async () => {
+		quickChatService.open({
+			query: buildQuery(explainPrompt)
+		});
+	};
+
+	/**
+	 * Shows the context menu for the Fix button dropdown.
+	 * Provides option to open in main chat panel instead of quick chat.
+	 *
+	 * @param event Mouse event from the dropdown button click
+	 */
+	const showFixDropdownMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		event.stopPropagation();
+
+		const actions: IAction[] = [
+			{
+				id: 'open-in-chat-panel',
+				label: localize('positronNotebookAssistantOpenInChatPanel', "Open in Chat Panel"),
+				tooltip: localize('positronNotebookAssistantOpenInChatPanelTooltip', "Open in main chat panel to retain conversation context"),
+				class: undefined,
+				enabled: true,
+				run: async () => {
+					await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
+						query: buildQuery(fixPrompt)
+					});
+				}
+			}
+		];
+
+		const rect = fixDropdownRef.current.getBoundingClientRect();
+		contextMenuService.showContextMenu({
+			getActions: () => actions,
+			getAnchor: () => ({ x: rect.left, y: rect.bottom }),
+			anchorAlignment: AnchorAlignment.LEFT,
+			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL
+		});
+	};
+
+	/**
+	 * Shows the context menu for the Explain button dropdown.
+	 * Provides option to open in main chat panel instead of quick chat.
+	 *
+	 * @param event Mouse event from the dropdown button click
+	 */
+	const showExplainDropdownMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		event.stopPropagation();
+
+		const actions: IAction[] = [
+			{
+				id: 'open-in-chat-panel',
+				label: localize('positronNotebookAssistantOpenInChatPanel', "Open in Chat Panel"),
+				tooltip: localize('positronNotebookAssistantOpenInChatPanelTooltip', "Open in main chat panel to retain conversation context"),
+				class: undefined,
+				enabled: true,
+				run: async () => {
+					await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
+						query: buildQuery(explainPrompt)
+					});
+				}
+			}
+		];
+
+		const rect = explainDropdownRef.current.getBoundingClientRect();
+		contextMenuService.showContextMenu({
+			getActions: () => actions,
+			getAnchor: () => ({ x: rect.left, y: rect.bottom }),
+			anchorAlignment: AnchorAlignment.LEFT,
+			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL
+		});
+	};
+
+	// Don't render if assistant features are not enabled
+	if (!showQuickFix) {
+		return null;
+	}
+
+	// Tooltip strings
+	const fixTooltip = localize('positronNotebookAssistantFixTooltip', "Ask the assistant to fix this error");
+	const fixDropdownTooltip = localize('positronNotebookAssistantFixDropdownTooltip', "More fix options");
+	const explainTooltip = localize('positronNotebookAssistantExplainTooltip', "Ask the assistant to explain this error");
+	const explainDropdownTooltip = localize('positronNotebookAssistantExplainDropdownTooltip', "More explain options");
+
+	// Render.
+	return (
+		<div className='notebook-cell-quick-fix'>
+			{/* Fix button with split dropdown */}
+			<div className='notebook-cell-quick-fix-split-button'>
+				<PositronButton
+					ariaLabel={fixTooltip}
+					className='assistant-action assistant-action-main'
+					onPressed={pressedFixHandler}
+				>
+					<div ref={fixButtonRef} className='link-text' title={fixTooltip}>
+						<span className='codicon codicon-sparkle' />
+						{localize('positronNotebookAssistantFix', "Fix")}
+					</div>
+				</PositronButton>
+				<div
+					ref={fixDropdownRef}
+					aria-label={fixDropdownTooltip}
+					className='assistant-action assistant-action-dropdown'
+					role='button'
+					tabIndex={0}
+					title={fixDropdownTooltip}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							showFixDropdownMenu(e as unknown as React.MouseEvent<HTMLDivElement>);
+						}
+					}}
+					onMouseDown={showFixDropdownMenu}
+				>
+					<span className='codicon codicon-positron-drop-down-arrow' />
+				</div>
+			</div>
+
+			{/* Explain button with split dropdown */}
+			<div className='notebook-cell-quick-fix-split-button'>
+				<PositronButton
+					ariaLabel={explainTooltip}
+					className='assistant-action assistant-action-main'
+					onPressed={pressedExplainHandler}
+				>
+					<div ref={explainButtonRef} className='link-text' title={explainTooltip}>
+						<span className='codicon codicon-sparkle' />
+						{localize('positronNotebookAssistantExplain', "Explain")}
+					</div>
+				</PositronButton>
+				<div
+					ref={explainDropdownRef}
+					aria-label={explainDropdownTooltip}
+					className='assistant-action assistant-action-dropdown'
+					role='button'
+					tabIndex={0}
+					title={explainDropdownTooltip}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							showExplainDropdownMenu(e as unknown as React.MouseEvent<HTMLDivElement>);
+						}
+					}}
+					onMouseDown={showExplainDropdownMenu}
+				>
+					<span className='codicon codicon-positron-drop-down-arrow' />
+				</div>
+			</div>
+		</div>
+	);
+};
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -18,10 +18,11 @@ import { IAction } from '../../../../../base/common/actions.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
 import { CHAT_OPEN_ACTION_ID } from '../../../chat/browser/actions/chatActions.js';
 
-const fixPrompt = '/fix';
-const explainPrompt = '/explain';
-
+/**
+ * Props for the NotebookCellQuickFix component.
+ */
 interface NotebookCellQuickFixProps {
+	/** The error output content from the cell execution */
 	errorContent: string;
 }
 
@@ -50,32 +51,48 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
 
 	/**
-	 * Builds the query string with prompt and error content in a code block.
+	 * Builds a query string for asking the assistant to fix the erroring cell.
+	 * The assistant already has notebook context including the selected cell,
+	 * so we only need to include the error output.
 	 *
-	 * @param prompt The prompt prefix (/fix or /explain)
-	 * @returns The formatted query string
+	 * @returns The formatted fix query string
 	 */
-	const buildQuery = (prompt: string): string => {
-		return props.errorContent ? `${prompt}\n\`\`\`\n${props.errorContent}\n\`\`\`` : prompt;
+	const buildFixQuery = (): string => {
+		return props.errorContent
+			? `Fix this cell that produced an error:\n\`\`\`\n${props.errorContent}\n\`\`\``
+			: 'Fix this cell that produced an error.';
+	};
+
+	/**
+	 * Builds a query string for asking the assistant to explain the error.
+	 * The assistant already has notebook context including the selected cell,
+	 * so we only need to include the error output.
+	 *
+	 * @returns The formatted explain query string
+	 */
+	const buildExplainQuery = (): string => {
+		return props.errorContent
+			? `Explain why this cell produced an error:\n\`\`\`\n${props.errorContent}\n\`\`\``
+			: 'Explain why this cell produced an error.';
 	};
 
 	/**
 	 * Handler for the "Fix" button primary click.
-	 * Opens the quick chat with a fix prompt and the error content in a code block.
+	 * Opens the quick chat with a fix prompt containing the cell code and error.
 	 */
 	const pressedFixHandler = async () => {
 		quickChatService.open({
-			query: buildQuery(fixPrompt)
+			query: buildFixQuery()
 		});
 	};
 
 	/**
 	 * Handler for the "Explain" button primary click.
-	 * Opens the quick chat with an explain prompt and the error content in a code block.
+	 * Opens the quick chat with an explain prompt containing the cell code and error.
 	 */
 	const pressedExplainHandler = async () => {
 		quickChatService.open({
-			query: buildQuery(explainPrompt)
+			query: buildExplainQuery()
 		});
 	};
 
@@ -98,7 +115,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 				enabled: true,
 				run: async () => {
 					await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-						query: buildQuery(fixPrompt)
+						query: buildFixQuery()
 					});
 				}
 			}
@@ -132,7 +149,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 				enabled: true,
 				run: async () => {
 					await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-						query: buildQuery(explainPrompt)
+						query: buildExplainQuery()
 					});
 				}
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -35,10 +35,8 @@ interface NotebookCellQuickFixProps {
  * @returns The rendered component, or null if assistant is not enabled
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
-	const fixButtonRef = useRef<HTMLDivElement>(undefined!);
-	const explainButtonRef = useRef<HTMLDivElement>(undefined!);
-	const fixDropdownRef = useRef<HTMLDivElement>(undefined!);
-	const explainDropdownRef = useRef<HTMLDivElement>(undefined!);
+	const fixDropdownRef = useRef<HTMLDivElement>(null);
+	const explainDropdownRef = useRef<HTMLDivElement>(null);
 	const services = usePositronReactServicesContext();
 	const { quickChatService, commandService, contextMenuService } = services;
 
@@ -78,7 +76,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 
 	/**
 	 * Handler for the "Fix" button primary click.
-	 * Opens the quick chat with a fix prompt containing the cell code and error.
+	 * Opens the quick chat with a fix prompt and error output.
 	 */
 	const pressedFixHandler = async () => {
 		quickChatService.open({
@@ -88,7 +86,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 
 	/**
 	 * Handler for the "Explain" button primary click.
-	 * Opens the quick chat with an explain prompt containing the cell code and error.
+	 * Opens the quick chat with an explain prompt and error output.
 	 */
 	const pressedExplainHandler = async () => {
 		quickChatService.open({
@@ -100,9 +98,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	 * Shows the context menu for the Fix button dropdown.
 	 * Provides option to open in main chat panel instead of quick chat.
 	 *
-	 * @param event Mouse event from the dropdown button click
+	 * @param event Event from the dropdown button click or keyboard activation
 	 */
-	const showFixDropdownMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+	const showFixDropdownMenu = (event: React.SyntheticEvent<HTMLDivElement>) => {
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -121,6 +119,10 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			}
 		];
 
+		if (!fixDropdownRef.current) {
+			return;
+		}
+
 		const rect = fixDropdownRef.current.getBoundingClientRect();
 		contextMenuService.showContextMenu({
 			getActions: () => actions,
@@ -134,9 +136,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	 * Shows the context menu for the Explain button dropdown.
 	 * Provides option to open in main chat panel instead of quick chat.
 	 *
-	 * @param event Mouse event from the dropdown button click
+	 * @param event Event from the dropdown button click or keyboard activation
 	 */
-	const showExplainDropdownMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+	const showExplainDropdownMenu = (event: React.SyntheticEvent<HTMLDivElement>) => {
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -154,6 +156,10 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 				}
 			}
 		];
+
+		if (!explainDropdownRef.current) {
+			return;
+		}
 
 		const rect = explainDropdownRef.current.getBoundingClientRect();
 		contextMenuService.showContextMenu({
@@ -185,7 +191,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 					className='assistant-action assistant-action-main'
 					onPressed={pressedFixHandler}
 				>
-					<div ref={fixButtonRef} className='link-text' title={fixTooltip}>
+					<div className='link-text' title={fixTooltip}>
 						<span className='codicon codicon-sparkle' />
 						{localize('positronNotebookAssistantFix', "Fix")}
 					</div>
@@ -199,8 +205,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 					title={fixDropdownTooltip}
 					onKeyDown={(e) => {
 						if (e.key === 'Enter' || e.key === ' ') {
-							e.preventDefault();
-							showFixDropdownMenu(e as unknown as React.MouseEvent<HTMLDivElement>);
+							showFixDropdownMenu(e);
 						}
 					}}
 					onMouseDown={showFixDropdownMenu}
@@ -216,7 +221,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 					className='assistant-action assistant-action-main'
 					onPressed={pressedExplainHandler}
 				>
-					<div ref={explainButtonRef} className='link-text' title={explainTooltip}>
+					<div className='link-text' title={explainTooltip}>
 						<span className='codicon codicon-sparkle' />
 						{localize('positronNotebookAssistantExplain', "Explain")}
 					</div>
@@ -230,8 +235,7 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 					title={explainDropdownTooltip}
 					onKeyDown={(e) => {
 						if (e.key === 'Enter' || e.key === ' ') {
-							e.preventDefault();
-							showExplainDropdownMenu(e as unknown as React.MouseEvent<HTMLDivElement>);
+							showExplainDropdownMenu(e);
 						}
 					}}
 					onMouseDown={showExplainDropdownMenu}


### PR DESCRIPTION
Addresses #8607.

This PR adds "Fix" and "Explain" buttons to error outputs in notebooks, bringing notebook error handling to parity with the console experience. When an error occurs in a notebook cell, users now see quick action buttons directly in the output that allow them to:
- **Fix**: Send the error and context to Positron Assistant to get a proposed fix
- **Explain**: Get a detailed explanation of what caused the error

The implementation integrates with Positron Assistant and strips ANSI codes from errors before sending them to avoid token waste and improve chat clarity.


### Demo

https://github.com/user-attachments/assets/e70e378c-21c6-4663-b399-c82a876f584a

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:assistant

1. Open a notebook
2. Execute code that produces an error, for example:

```python
# Python example
x = 1 / 0
```

3. Verify that "Fix" and "Explain" buttons appear below the error traceback
4. Click "Fix" and verify:
   - Positron Assistant opens
   - Error context is sent to the assistant
   - Assistant provides a fix suggestion
5. Click "Explain" and verify:
   - Assistant provides an explanation of the error
6. Test with errors containing ANSI codes to verify they're stripped properly
