### PR TITLE
Fix model provider error message

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -141,4 +141,6 @@
 
 .language-model-error.error-msg {
 	word-break: break-word;
+	margin-right: 90px;
+	padding-bottom: 10px;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -341,7 +341,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	};
 
 	return <OKModalDialog
-		height={450}
+		height={500}
 		okButtonTitle={(() => localize('positron.languageModelModalDialog.close', "Close"))()}
 		renderer={props.renderer}
 		title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}


### PR DESCRIPTION
Address #7632 

Gives a bit more space to the dialog height so that the error message can display without scrolling. Added a right margin so that the text won't extend into the button. Added bottom padding so that the dialog will scroll if the text does extend past the dialog height.

<img width="610" height="509" alt="image" src="https://github.com/user-attachments/assets/2d22070c-7fab-4bfe-ab6f-5dae5a6aefa7" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix model provider config dialog error message covered by dialog button


### QA Notes