### PR TITLE
Update Markdown Output Rendering

### DIFF
--- a/src/vs/base/common/htmlParser.ts
+++ b/src/vs/base/common/htmlParser.ts
@@ -85,6 +85,24 @@ const voidElements: Record<string, boolean> = {
 };
 
 /**
+ * Quick lookup table for table elements.
+ *
+ * Per HTML spec:
+ * - <table> can only contain: caption, colgroup, thead, tbody, tfoot, tr
+ * - <thead>, <tbody>, <tfoot> can only contain: tr
+ * - <tr> can only contain: td, th
+ * - <colgroup> can only contain: col
+ */
+const tableElements: Record<string, boolean> = {
+	'table': true,
+	'thead': true,
+	'tbody': true,
+	'tfoot': true,
+	'tr': true,
+	'colgroup': true
+};
+
+/**
  * Checks if a node is nested inside a <pre> element.
  * In <pre> elements, whitespace must be preserved per HTML spec.
  *
@@ -105,6 +123,19 @@ function isInsidePreElement(node: HtmlNode | undefined): boolean {
 		current = current.parent;
 	}
 	return false;
+}
+
+/**
+ * Checks if a node is a table elemen
+ *
+ * @param node The node to check (typically parent of a text node)
+ * @returns true if node is a table element
+ */
+function isTableElement(node: HtmlNode | undefined): boolean {
+	if (!node || !node.name) {
+		return false;
+	}
+	return tableElements[node.name] === true;
 }
 
 /**
@@ -321,14 +352,22 @@ export function parseHtml(html: string): Array<HtmlNode> {
 				nextChar &&
 				nextChar !== '<'
 			) {
-				// This is a text node; add it as a child node
-				if (current.children === undefined) {
-					current.children = [];
+				const textContent = html.slice(start, html.indexOf('<', start));
+				const isWhitespace = whitespaceRE.test(textContent);
+				// Check if we are in a table element context with whitespace-only text node
+				const whitespaceInTable = isWhitespace && isTableElement(current);
+
+				// Don't add whitespace-only text nodes if they are inside table elements
+				if (!whitespaceInTable) {
+					// This is a text node; add it as a child node
+					if (current.children === undefined) {
+						current.children = [];
+					}
+					current.children.push({
+						type: 'text',
+						content: decode(textContent),
+					});
 				}
-				current.children.push({
-					type: 'text',
-					content: decode(html.slice(start, html.indexOf('<', start))),
-				});
 			}
 
 			// if we're at root, push new base node
@@ -383,11 +422,14 @@ export function parseHtml(html: string): Array<HtmlNode> {
 					content = ' ';
 				}
 
-				// Don't add whitespace-only text nodes if they would be trailing text nodes
-				// or if they would be leading whitespace-only text nodes:
+				// Check if we are in a table element context with whitespace-only text node
+				const whitespaceInTable = whitespaceRE.test(content) && isTableElement(current);
+
+				// Don't add whitespace-only text nodes if they would be: trailing text nodes
+				// leading whitespace-only text nodes, or inside table elements:
 				//  * end > -1 indicates this is not a trailing text node
 				//  * leading node is when level is -1 and parent has length 0
-				if ((end > -1 && level + parent.length >= 0) || content !== ' ') {
+				if (!whitespaceInTable && ((end > -1 && level + parent.length >= 0) || content !== ' ')) {
 					parent.push({
 						type: 'text',
 						parent: current,

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
@@ -108,7 +108,7 @@ function markedHighlight(options: marked.MarkedOptions & {
 			code({ text, lang, escaped }: marked.Tokens.Code) {
 				const classAttr = lang ? ` class="language-${escape(lang)}"` : '';
 				text = text.replace(/\n$/, '');
-				return `<pre><code${classAttr}>${escaped ? text : escape(text)}\n</code></pre>`;
+				return `<pre><code${classAttr}>${escaped ? text : escape(text)}</code></pre>`;
 			},
 		},
 	};

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -142,10 +142,18 @@
 		border-radius: 4px;
 	}
 
+	/** code block styling */
+	pre {
+		background-color: var(--vscode-textCodeBlock-background);
+		padding: 16px;
+		border-radius: 4px;
+	}
+
 	pre code {
 		line-height: 1.357em;
 		white-space: pre-wrap;
 		padding: 0;
+		background-color: transparent; /* override inline code style */
 	}
 
 	li p {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -101,6 +101,7 @@
 	table {
 		border-collapse: collapse;
 		border-spacing: 0;
+		margin-bottom: 0.7em;
 	}
 
 	table th,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -125,10 +125,12 @@
 	}
 
 	blockquote {
-		margin: 0 7px 0 5px;
+		margin: 0 7px 0 0;
 		padding: 0 16px 0 10px;
 		border-left-width: 5px;
 		border-left-style: solid;
+		border-left-color: var(--vscode-textBlockQuote-border);
+		background-color: var(--vscode-textBlockQuote-background);
 	}
 
 	code {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.css
@@ -133,9 +133,13 @@
 		background-color: var(--vscode-textBlockQuote-background);
 	}
 
+	/* inline code styling */
 	code {
 		font-size: 1em;
 		font-family: var(--vscode-repl-font-family);
+		background-color: var(--vscode-textPreformat-background);
+		padding: 1px 3px;
+		border-radius: 4px;
 	}
 
 	pre code {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -99,10 +99,14 @@
 	border: none;
 }
 
-/* When selected/editing AND no outputs: restore bottom rounding */
+/* When code cell is selected/editing AND no outputs: restore bottom rounding */
 .positron-notebook-cell.selected:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::after,
 .positron-notebook-cell.editing:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::after,
-.positron-notebook-cell:not(.selected):not(.editing):hover:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::after {
+.positron-notebook-cell:not(.selected):not(.editing):hover:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-container::after,
+/* When markdown cell is in edit mode (no output shown): restore bottom rounding */
+.positron-notebook-cell.selected:not(:has(.positron-notebook-cell-outputs)) .positron-notebook-editor-container::after,
+.positron-notebook-cell.editing:not(:has(.positron-notebook-cell-outputs)) .positron-notebook-editor-container::after,
+.positron-notebook-cell:not(.selected):not(.editing):hover:not(:has(.positron-notebook-cell-outputs)) .positron-notebook-editor-container::after {
 	border-bottom-left-radius: var(--_positron-notebook-selection-bar-radius);
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -33,20 +33,23 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 			<div className={`positron-notebook-editor-container ${editorShown ? '' : 'editor-hidden'}`}>
 				{editorShown ? <CellEditorMonacoWidget cell={cell} /> : null}
 			</div>
-			<div className='cell-contents positron-notebook-cell-outputs'>
-				<div className='positron-notebook-markdown-rendered' onDoubleClick={() => {
-					cell.toggleEditor();
-				}}>
-					{
-						markdownString.length > 0 ?
-							<Markdown content={markdownString} />
-							: <div className='empty-output-msg'>
-								{emptyMarkdownCell}
-								{!editorShown && doubleClickToEdit}
-							</div>
-					}
+			{!editorShown && (
+				<div className='cell-contents positron-notebook-cell-outputs'>
+					<div
+						className='positron-notebook-markdown-rendered'
+						onDoubleClick={() => cell.toggleEditor()}
+					>
+						{
+							markdownString.length > 0 ?
+								<Markdown content={markdownString} />
+								: <div className='empty-output-msg'>
+									{emptyMarkdownCell}
+									{doubleClickToEdit}
+								</div>
+						}
+					</div>
 				</div>
-			</div>
+			)}
 		</NotebookCellWrapper>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -864,7 +864,7 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.cell.openMarkdownEditor',
 			title: localize2('positronNotebook.cell.openMarkdownEditor', "Open Markdown Editor"),
-			icon: ThemeIcon.fromId('chevron-down'),
+			icon: ThemeIcon.fromId('edit'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,
@@ -899,7 +899,7 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.cell.collapseMarkdownEditor',
 			title: localize2('positronNotebook.cell.collapseMarkdownEditor', "Collapse Markdown Editor"),
-			icon: ThemeIcon.fromId('chevron-up'),
+			icon: ThemeIcon.fromId('check'),
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,


### PR DESCRIPTION
Addresses #10291 

This updates some of the markdown rendering styles to better match up with the styles used in other notebooks.

What did get fixed:
- tables
- block quotes
- inline code
- code blocks

What did not get fixed:
- embedded images (there is a separate isse #10594)
- math expressions (there is a separate issue #10479)
- text content spanning multiple lines: Our markdown rendering logic converts single newlines to spaces instead of treating them as line breaks. Built-in notebooks treat newlines as line breaks. Not sure if this is on purpose, but its easy to change.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
