### PR TITLE
Set up typing on `console.fontLigatures` and `console.fontVariations` so it is the same as the editor counterparts

### DIFF
--- a/src/vs/workbench/browser/fontConfigurationManager.ts
+++ b/src/vs/workbench/browser/fontConfigurationManager.ts
@@ -14,8 +14,8 @@ import { createBareFontInfoFromRawSettings } from '../../editor/common/config/fo
 
 /**
  * Font options interface. Any component that needs to provide font options can define configuration settings
- * matching this interface. (Note that fontLigatures and fontVariations are simplified boolean options vs. the
- * more complex fontLigatures and fontVariations configuration options that are available in the editor.)
+ * matching this interface. Like the editor, fontLigatures and fontVariations can be either booleans for simple
+ * on/off control, or strings for fine-grained control of CSS font-feature-settings and font-variation-settings.
  */
 export interface IFontOptions {
 	/**
@@ -24,9 +24,10 @@ export interface IFontOptions {
 	fontFamily?: string;
 
 	/**
-	 * Enable font ligatures.
+	 * Configures font ligatures or font features. Can be either a boolean to enable/disable ligatures
+	 * or a string for the value of the CSS 'font-feature-settings' property.
 	 */
-	fontLigatures?: boolean;
+	fontLigatures?: boolean | string;
 
 	/**
 	 * The font size
@@ -34,9 +35,11 @@ export interface IFontOptions {
 	fontSize?: number;
 
 	/**
-	 * Enable font variations.
+	 * Configures font variations. Can be either a boolean to enable/disable the translation from
+	 * font-weight to font-variation-settings or a string for the value of the CSS
+	 * 'font-variation-settings' property.
 	 */
-	fontVariations?: boolean;
+	fontVariations?: boolean | string;
 
 	/**
 	 * The font weight

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -197,9 +197,18 @@ configurationRegistry.registerConfiguration({
 		},
 		// Font ligatures.
 		'console.fontLigatures': {
-			type: 'boolean',
-			default: false,
-			description: localize('console.fontLigatures.markdownDescription', "Enable font ligatures ('calt' and 'liga' font features)."),
+			anyOf: [
+				{
+					type: 'boolean',
+					description: localize('console.fontLigatures', "Enables/Disables font ligatures ('calt' and 'liga' font features). Change this to a string for fine-grained control of the 'font-feature-settings' CSS property."),
+				},
+				{
+					type: 'string',
+					description: localize('console.fontFeatureSettings', "Explicit 'font-feature-settings' CSS property. A boolean can be passed instead if one only needs to turn on/off ligatures.")
+				}
+			],
+			description: localize('console.fontLigaturesGeneral', "Configures font ligatures or font features. Can be either a boolean to enable/disable ligatures or a string for the value of the CSS 'font-feature-settings' property."),
+			default: false
 		},
 		// Font size.
 		'console.fontSize': {
@@ -211,9 +220,18 @@ configurationRegistry.registerConfiguration({
 		},
 		// Font variations.
 		'console.fontVariations': {
-			type: 'boolean',
-			default: false,
-			description: localize('console.fontVariations', "Enable the translation from font-weight to font-variation-settings."),
+			anyOf: [
+				{
+					type: 'boolean',
+					description: localize('console.fontVariations', "Enables/Disables the translation from font-weight to font-variation-settings. Change this to a string for fine-grained control of the 'font-variation-settings' CSS property."),
+				},
+				{
+					type: 'string',
+					description: localize('console.fontVariationSettings', "Explicit 'font-variation-settings' CSS property. A boolean can be passed instead if one only needs to translate font-weight to font-variation-settings.")
+				}
+			],
+			description: localize('console.fontVariationsGeneral', "Configures font variations. Can be either a boolean to enable/disable the translation from font-weight to font-variation-settings or a string for the value of the CSS 'font-variation-settings' property."),
+			default: false
 		},
 		// Font weight.
 		'console.fontWeight': {
@@ -1697,7 +1715,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 *
 	 * @param entries The execution history entries to replay.
 	 */
-	replayExecutions(entries: IExecutionHistoryEntry<any>[]): void {
+	replayExecutions(entries: IExecutionHistoryEntry<unknown>[]): void {
 		for (const entry of entries) {
 			if (entry.outputType === ExecutionEntryType.Execution) {
 				// Create the activity and the first item (the input)

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1741,7 +1741,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 							entry.id + '-output',
 							entry.id,
 							new Date(entry.when),
-							{ 'text/plain': entry.output }
+							{ 'text/plain': entry.output as string }
 						);
 					inputItem.addActivityItem(outputActivityItem);
 				}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10593

This PR makes the typing for the new `console.fontLigatures` and `console.fontVariations` settings the same as what we inherited for `editor.fontLigatures` and `editor.fontVariations`, since that is how these settings actually work. This does not change how these settings function but now the hinting in `settings.json` is correct:


<img width="1028" height="336" alt="Screenshot 2025-12-03 at 7 24 59 PM" src="https://github.com/user-attachments/assets/8ba356d3-3c45-4c8c-aa49-1c790681ab96" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed typing for Positron's `console.fontLigatures` setting


### QA Notes

If you use a setting like `"console.fontLigatures": "'ss05'"` you should get no errors and the same hinting that you would get for `"editor.fontLigatures": "'ss05'"`.
