### PR TITLE
Fix cleanup of R sessions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -185,6 +185,7 @@
 				"order": 4
 			}
 		},
+		// --- Start Positron
 		{
 			// Note this uses the version of Code/Positron you launch it from.
 			// i.e., launch from dev Positron if your tests need dev Positron.
@@ -205,6 +206,7 @@
 				"order": 5
 			}
 		},
+		// --- End Positron
 		{
 			"type": "extensionHost",
 			"request": "launch",

--- a/extensions/positron-r/.zed/settings.json
+++ b/extensions/positron-r/.zed/settings.json
@@ -1,0 +1,19 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "languages": {
+    "TypeScript": {
+      "tab_size": 2,
+      "hard_tabs": true,
+      "ensure_final_newline_on_save": true,
+      "remove_trailing_whitespace_on_save": true,
+      "format_on_save": "on",
+      "formatter": "language_server",
+      "code_actions_on_format": {
+        "source.fixAll.eslint": false
+      }
+    }
+  }
+}

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -76,7 +76,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 			if (!isInstalled) {
 				return;
 			}
-			const session = RSessionManager.instance.getConsoleSession();
+			const session = await RSessionManager.instance.getConsoleSession();
 			if (!session) {
 				return;
 			}
@@ -169,7 +169,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		vscode.commands.registerCommand('r.scriptPath', async () => {
-			const session = RSessionManager.instance.getConsoleSession();
+			const session = await RSessionManager.instance.getConsoleSession();
 			if (!session) {
 				throw new Error(`Cannot get Rscript path; no R session available`);
 			}

--- a/extensions/positron-r/src/llm-tools.ts
+++ b/extensions/positron-r/src/llm-tools.ts
@@ -15,7 +15,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 	const rListPackageHelpTopicsTool = vscode.lm.registerTool<{ sessionIdentifier: string; packageName: string }>('listPackageHelpTopics', {
 		invoke: async (options, token) => {
 			const manager = RSessionManager.instance;
-			const session = manager.getSessionById(options.input.sessionIdentifier);
+			const session = await manager.getSessionById(options.input.sessionIdentifier);
 			if (!session) {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`No active R session with identifier ${options.input.sessionIdentifier}`),
@@ -44,7 +44,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 	const rListAvailableVignettesTool = vscode.lm.registerTool<{ sessionIdentifier: string; packageName: string }>('listAvailableVignettes', {
 		invoke: async (options, token) => {
 			const manager = RSessionManager.instance;
-			const session = manager.getSessionById(options.input.sessionIdentifier);
+			const session = await manager.getSessionById(options.input.sessionIdentifier);
 			if (!session) {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`No active R session with identifier ${options.input.sessionIdentifier}`),
@@ -73,7 +73,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 	const rGetPackageVignetteTool = vscode.lm.registerTool<{ sessionIdentifier: string; packageName: string; vignetteName: string }>('getPackageVignette', {
 		invoke: async (options, token) => {
 			const manager = RSessionManager.instance;
-			const session = manager.getSessionById(options.input.sessionIdentifier);
+			const session = await manager.getSessionById(options.input.sessionIdentifier);
 			if (!session) {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`No active R session with identifier ${options.input.sessionIdentifier}`),
@@ -103,7 +103,7 @@ export function registerRLanguageModelTools(context: vscode.ExtensionContext): v
 	const rGetHelpPageTool = vscode.lm.registerTool<{ sessionIdentifier: string; packageName?: string; helpTopic: string }>('getHelpPage', {
 		invoke: async (options, token) => {
 			const manager = RSessionManager.instance;
-			const session = manager.getSessionById(options.input.sessionIdentifier);
+			const session = await manager.getSessionById(options.input.sessionIdentifier);
 			if (!session) {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(`No active R session with identifier ${options.input.sessionIdentifier}`),

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -99,6 +99,9 @@ export class RSessionManager implements vscode.Disposable {
 			throw Error(`Foreground session with ID ${sessionId} must not be a background session.`);
 		}
 
+		// Multiple `activateConsoleSession()` might run concurrently if the
+		// `didChangeForegroundSession` event fires rapidly. We might want to queue
+		// the handling.
 		this._lastForegroundSessionId = session.metadata.sessionId;
 		await this.activateConsoleSession(session, 'foreground session changed');
 	}

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -61,7 +61,14 @@ export class RSessionManager implements vscode.Disposable {
 			throw new Error(`Session ${sessionId} already registered.`);
 		}
 		this._sessions.set(sessionId, session);
-		this._disposables.push(
+
+		session.register({
+			dispose: () => {
+				this._sessions.delete(sessionId);
+			}
+		});
+
+		session.register(
 			session.onDidChangeRuntimeState(async (state) => {
 				await this.didChangeSessionRuntimeState(session, state);
 			})

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -5,12 +5,10 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { RSession } from './session';
+import { RSession, getActiveRSessions } from './session';
 
 /**
- * Manages all the R sessions. We keep our own references to each session in a
- * singleton instance of this class so that we can invoke methods/check status
- * directly, without going through Positron's API.
+ * Manages all the R sessions.
  */
 export class RSessionManager implements vscode.Disposable {
 	/// Singleton instance
@@ -20,9 +18,6 @@ export class RSessionManager implements vscode.Disposable {
 	/// Note that these aren't currently ever disposed of because this is a singleton,
 	/// but we may improve on this in the future so it is good practice to track them.
 	private readonly _disposables: vscode.Disposable[] = [];
-
-	/// Map of session IDs to RSession instances
-	private _sessions: Map<string, RSession> = new Map();
 
 	/// The most recent foreground R session (foreground implies it is a console session)
 	private _lastForegroundSessionId: string | null = null;
@@ -50,24 +45,11 @@ export class RSessionManager implements vscode.Disposable {
 	}
 
 	/**
-	 * Registers a runtime with the manager. Throws an error if a runtime with
-	 * the same ID is already registered.
+	 * Registers a runtime with the manager.
 	 *
-	 * @param id The runtime's ID
-	 * @param runtime The runtime.
+	 * @param session The session.
 	 */
-	setSession(sessionId: string, session: RSession): void {
-		if (this._sessions.has(sessionId)) {
-			throw new Error(`Session ${sessionId} already registered.`);
-		}
-		this._sessions.set(sessionId, session);
-
-		session.register({
-			dispose: () => {
-				this._sessions.delete(sessionId);
-			}
-		});
-
+	setSession(session: RSession): void {
 		session.register(
 			session.onDidChangeRuntimeState(async (state) => {
 				await this.didChangeSessionRuntimeState(session, state);
@@ -106,11 +88,10 @@ export class RSessionManager implements vscode.Disposable {
 			return;
 		}
 
-		// TODO: Switch to `getActiveRSessions()` built on `positron.runtime.getActiveSessions()`
-		// and remove `this._sessions` entirely.
-		const session = this._sessions.get(sessionId);
+		const sessions = await getActiveRSessions();
+		const session = sessions.find(s => s.metadata.sessionId === sessionId);
 		if (!session) {
-			// The foreground session is for another language.
+			// The foreground session is for another language or was deactivated in the meantime
 			return;
 		}
 
@@ -127,7 +108,8 @@ export class RSessionManager implements vscode.Disposable {
 	 */
 	private async activateConsoleSession(session: RSession, reason: string): Promise<void> {
 		// Deactivate other console session servers first
-		await Promise.all(Array.from(this._sessions.values())
+		const sessions = await getActiveRSessions();
+		await Promise.all(sessions
 			.filter(s => {
 				return s.metadata.sessionId !== session.metadata.sessionId &&
 					s.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console;
@@ -159,9 +141,10 @@ export class RSessionManager implements vscode.Disposable {
 	 *
 	 * @returns The R console session, or undefined if there isn't one.
 	 */
-	getConsoleSession(): RSession | undefined {
+	async getConsoleSession(): Promise<RSession | undefined> {
+		const sessions = await getActiveRSessions();
+
 		// Sort the sessions by creation time (descending)
-		const sessions = Array.from(this._sessions.values());
 		sessions.sort((a, b) => b.created - a.created);
 
 		// Remove any sessions that aren't console sessions and have either
@@ -193,8 +176,9 @@ export class RSessionManager implements vscode.Disposable {
 	 * @param sessionId The session identifier
 	 * @returns The R session, or undefined if not found
 	 */
-	getSessionById(sessionId: string): RSession | undefined {
-		return this._sessions.get(sessionId);
+	async getSessionById(sessionId: string): Promise<RSession | undefined> {
+		const sessions = await getActiveRSessions();
+		return sessions.find(s => s.metadata.sessionId === sessionId);
 	}
 
 	/**

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -129,7 +129,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		this._created = Date.now();
 
 		// Register this session with the session manager
-		RSessionManager.instance.setSession(metadata.sessionId, this);
+		RSessionManager.instance.setSession(this);
 
 		this.onDidChangeRuntimeState(async (state) => {
 			await this.onStateChange(state);
@@ -988,7 +988,7 @@ export function createJupyterKernelExtra(): JupyterKernelExtra {
 export async function checkInstalled(pkgName: string,
 	pkgVersion?: string,
 	session?: RSession): Promise<boolean> {
-	session = session || RSessionManager.instance.getConsoleSession();
+	session = session || await RSessionManager.instance.getConsoleSession();
 	if (session) {
 		return session.checkInstalled(pkgName, pkgVersion);
 	}
@@ -996,7 +996,7 @@ export async function checkInstalled(pkgName: string,
 }
 
 export async function getLocale(session?: RSession): Promise<Locale> {
-	session = session || RSessionManager.instance.getConsoleSession();
+	session = session || await RSessionManager.instance.getConsoleSession();
 	if (session) {
 		return session.getLocale();
 	}
@@ -1004,9 +1004,15 @@ export async function getLocale(session?: RSession): Promise<Locale> {
 }
 
 export async function getEnvVars(envVars: string[], session?: RSession): Promise<EnvVar[]> {
-	session = session || RSessionManager.instance.getConsoleSession();
+	session = session || await RSessionManager.instance.getConsoleSession();
 	if (session) {
 		return session.getEnvVars(envVars);
 	}
 	throw new Error(`Cannot get env var information; no R session available`);
+}
+
+/** Get the active R language runtime sessions. */
+export async function getActiveRSessions(): Promise<RSession[]> {
+	const sessions = await positron.runtime.getActiveSessions();
+	return sessions.filter((session) => session instanceof RSession) as RSession[];
 }

--- a/extensions/positron-r/src/test/ark-comm.test.ts
+++ b/extensions/positron-r/src/test/ark-comm.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
@@ -49,12 +49,12 @@ suite('ArkComm', () => {
 					i: -10
 				}
 			}
-		)
+		);
 	});
 
 	test('Can send request', async () => {
 		const requestReply = await assertRequest(comm, 'test_request', { i: 11 });
-		assert.deepStrictEqual(requestReply, { i: -11 })
+		assert.deepStrictEqual(requestReply, { i: -11 });
 	});
 
 	test('Invalid method sends error', async () => {
@@ -86,7 +86,7 @@ async function assertNextMessage(comm: Comm): Promise<CommBackendMessage> {
 		whenTimeout(5000, () => assert.fail(`Timeout while expecting comm message on ${comm.id}`)),
 	]) as any;
 
-	assert.strictEqual(result.done, false)
+	assert.strictEqual(result.done, false);
 	return result.value;
 }
 

--- a/extensions/positron-r/src/test/debugger.test.ts
+++ b/extensions/positron-r/src/test/debugger.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as vscode from 'vscode';
 import * as assert from 'assert';
@@ -55,7 +55,7 @@ suite('Debugger', () => {
 					new RegExp('Virtual namespace of package graphics'),
 					`Unexpected editor contents for ${ed.document.uri.fsPath}: Expected graphics namespace`
 				);
-			})
+			});
 		});
 	});
 
@@ -86,7 +86,7 @@ suite('Debugger', () => {
 					new RegExp('f <- function'),
 					`Unexpected editor contents for ${ed.document.uri.fsPath}`
 				);
-			})
+			});
 		});
 	});
 });

--- a/extensions/positron-r/src/test/discovery.test.ts
+++ b/extensions/positron-r/src/test/discovery.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as assert from 'assert';
 import * as Fs from "fs";

--- a/extensions/positron-r/src/test/hyperlink.test.ts
+++ b/extensions/positron-r/src/test/hyperlink.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as assert from 'assert';
 import { matchRunnable } from '../hyperlink';

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';

--- a/extensions/positron-r/src/test/lsp.unit.test.ts
+++ b/extensions/positron-r/src/test/lsp.unit.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as assert from 'assert';
 import * as testKit from './kit';
@@ -45,7 +45,7 @@ suite('Session manager', () => {
 			// The LSP of the first session eventually goes back online
 			testKit.pollForSuccess(() => {
 				assert.strictEqual(ses1Lsp.state, ArkLspState.Running);
-			})
+			});
 
 			// We would expect the following but currently we start the LSP client
 			// anew on each activation, so the event handler is no longer active.

--- a/extensions/positron-r/src/test/mocha-setup.ts
+++ b/extensions/positron-r/src/test/mocha-setup.ts
@@ -9,8 +9,10 @@ import * as testKit from './kit';
 export let currentTestName: string | undefined;
 
 suiteSetup(async () => {
-	// Set global Positron log level to trace for easier debugging
-	await vscode.commands.executeCommand('_extensionTests.setLogLevel', 'trace');
+	// Set global Positron log level to debug on CI for easier debugging
+	if (process.env.CI) {
+		await vscode.commands.executeCommand('_extensionTests.setLogLevel', 'debug');
+	}
 
 	// Set Ark kernel process log level to trace
 	await vscode.workspace.getConfiguration().update('positron.r.kernel.logLevel', 'trace', vscode.ConfigurationTarget.Global);

--- a/extensions/positron-r/src/test/mocha-setup.ts
+++ b/extensions/positron-r/src/test/mocha-setup.ts
@@ -9,9 +9,9 @@ import * as testKit from './kit';
 export let currentTestName: string | undefined;
 
 suiteSetup(async () => {
-	// Set global Positron log level to debug on CI for easier debugging
+	// Set global Positron log level to trace on CI for easier debugging
 	if (process.env.CI) {
-		await vscode.commands.executeCommand('_extensionTests.setLogLevel', 'debug');
+		await vscode.commands.executeCommand('_extensionTests.setLogLevel', 'trace');
 	}
 
 	// Set Ark kernel process log level to trace

--- a/extensions/positron-r/src/test/rstudioapi.test.ts
+++ b/extensions/positron-r/src/test/rstudioapi.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as vscode from 'vscode';
 import * as path from 'path';

--- a/extensions/positron-r/src/test/view.test.ts
+++ b/extensions/positron-r/src/test/view.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './mocha-setup'
+import './mocha-setup';
 
 import * as vscode from 'vscode';
 import * as path from 'path';

--- a/extensions/positron-r/src/uri-handler.ts
+++ b/extensions/positron-r/src/uri-handler.ts
@@ -24,7 +24,7 @@ export async function registerUriHandler() {
 //    "fragment": "",
 //    "fsPath": "/cli"
 // }
-function handleUri(uri: vscode.Uri): void {
+async function handleUri(uri: vscode.Uri): Promise<void> {
 	if (uri.path !== '/cli') {
 		return;
 	}
@@ -44,7 +44,7 @@ function handleUri(uri: vscode.Uri): void {
 		return;
 	}
 
-	const session = RSessionManager.instance.getConsoleSession();
+	const session = await RSessionManager.instance.getConsoleSession();
 	if (!session) {
 		return;
 	}
@@ -54,7 +54,7 @@ function handleUri(uri: vscode.Uri): void {
 }
 
 export async function prepCliEnvVars(session?: RSession): Promise<EnvVar> {
-	session = session || RSessionManager.instance.getConsoleSession();
+	session = session || await RSessionManager.instance.getConsoleSession();
 	if (!session) {
 		return {};
 	}

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -447,7 +447,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		};
 		await this._api.newSession(session);
 
-		this.log(`${kernelSpec.display_name} session '${this.metadata.sessionId}' created in ${workingDir} with command:`, vscode.LogLevel.Info);
+		this.log(`Session ${session.display_name} (${this.metadata.sessionId}) created in ${workingDir} with command:`, vscode.LogLevel.Info);
 		this.log(args.join(' '), vscode.LogLevel.Info);
 
 		this._established.open();


### PR DESCRIPTION
Progress towards #10121 

Logs involving the session manager are a bit confusing because sessions are never cleaned up, and so the manager keeps trying to deactivate LSP in sessions that no longer exist. This also causes it hold onto `RSession` objects, preventing garbage collection.

To fix this:

- `RSession` gains a `register()` method for external resources that should be cleaned up when the session is disposed of.
- The manager's event handler is now registered in `RSession`, instead of the singleton's own disposables.
- The manager no longer maintains a list of session and instead queries the main thread for active sessions. Because of this process crossing a bunch of methods are now async.

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:ark