### PR TITLE
ci: move windows ext slack notify up to caller

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -47,6 +47,10 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+    outputs:
+      extensions_failed:
+        description: "Whether the extensions tests failed"
+        value: ${{ jobs.e2e-windows.outputs.extensions_failed }}
 
   workflow_dispatch:
     inputs:
@@ -355,19 +359,3 @@ jobs:
         with:
           name: inspect-ai-responses
           path: test/assistant-inspect-ai/*.json
-
-  slack-notify:
-    if: ${{ needs.e2e-windows.outputs.extensions_failed == 'true' }}
-    needs:
-      - e2e-windows
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Will notify on: ${{ env.notify_on }}"
-      - name: Notify Slack
-        uses: midleman/slack-workflow-status@v3.1.3
-        with:
-          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#positron-rstats-test-results"
-          filter_jobs: "e2e"

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -110,3 +110,4 @@ jobs:
           slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           slack_channel: "#positron-rstats-test-results"
           filter_jobs: "windows"
+          notify_on: "always"

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -97,7 +97,7 @@ jobs:
           include_job_durations: false
           notify_on: "failure"
 
-  slack-notify-windows-extensions:
+  slack-notify-win-extensions:
     if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}
     needs:
       - e2e-windows-electron

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -96,3 +96,17 @@ jobs:
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
           include_job_durations: false
           notify_on: "failure"
+
+  slack-notify-windows-extensions:
+    if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}
+    needs:
+      - e2e-windows-electron
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: midleman/slack-workflow-status@v3.1.3
+        with:
+          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
+          slack_channel: "#positron-rstats-test-results"
+          filter_jobs: "windows"


### PR DESCRIPTION
### Summary
This should ensure that Slack notifications only include windows for data collection in the alternate Slack channel, and not be added to the notification that goes into #positron-test-results. 

**Current:**
<img width="1351" height="580" alt="Screenshot 2025-12-04 at 12 46 32 PM" src="https://github.com/user-attachments/assets/be10d0ca-78dc-4dbc-99ac-354dd03d3193" />
<img width="617" height="198" alt="Screenshot 2025-12-04 at 1 00 41 PM" src="https://github.com/user-attachments/assets/524997e6-a51a-4f4d-b152-38e83ea85b75" />

**After:**
Both slack notify jobs will be at same level.
The "cancelled" (not run) slack-notify will not appear in our standard slack channel notifications.


### QA Notes

I admit, I didn't test it because we don't have a manual trigger on this workflow. I will keep an eye on merges.