### PR TITLE
deduplicate python hovers and completions in core

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -303,8 +303,6 @@ class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
 
         # Remove LSP features that are redundant with Pyrefly.
         features_to_remove = [
-            "textDocument/hover",
-            "textDocument/signatureHelp",
             "textDocument/declaration",
             "textDocument/definition",
             "textDocument/typeDefinition",

--- a/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_haystack.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_haystack.py
@@ -3,6 +3,7 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
+import sys
 from importlib.util import find_spec
 from typing import Any, Dict
 from unittest.mock import patch
@@ -15,6 +16,9 @@ missing_haystack = find_spec("haystack") is None and find_spec("haystack_ai") is
 
 
 @pytest.mark.skipif(missing_haystack, reason="haystack is not installed")
+@pytest.mark.skipif(
+    sys.version_info[:3] == (3, 14, 1), reason="haystack doesn't work with Python 3.14.1"
+)
 def test_haystack_patch_automatically_applied(shell: PositronShell):
     """
     Test that the haystack is_in_jupyter function is automatically patched to return True.

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -193,6 +193,14 @@ export interface Hover {
 	 * Can decrease the verbosity of the hover
 	 */
 	canDecreaseVerbosity?: boolean;
+
+	// --- Start Positron ---
+	/**
+	 * Id of the extension that provided this hover.
+	 * Used to filter duplicate hovers from certain extensions.
+	 */
+	extensionId?: string;
+	// --- End Positron ---
 }
 
 /**

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -326,8 +326,40 @@ export async function provideSuggestionItems(
 		return Promise.reject(new CancellationError());
 	}
 
+	// --- Start Positron ---
+	// Deduplicate completion items that have the same insertText.
+	// When duplicates are found:
+	//   - If one item is from our Python extension and the other is not, prefer the one not from our Python extension.
+	//   - If both items are from our Python extension, the first-seen item is kept.
+	//   - If both items are from other extensions, the first-seen item is kept.
+	const msPythonExtensionId = 'ms-python.python';
+	const deduplicatedResult: CompletionItem[] = [];
+	const seen = new Map<string, CompletionItem>();
+
+	for (const item of result) {
+		const key = item.completion.insertText;
+		const existing = seen.get(key);
+		if (existing) {
+			// If the existing item is from ms-python.python and the new one is not,
+			// replace with the new one
+			if (existing.extensionId?.value === msPythonExtensionId &&
+				item.extensionId?.value !== msPythonExtensionId) {
+				const existingIndex = deduplicatedResult.indexOf(existing);
+				if (existingIndex !== -1) {
+					deduplicatedResult[existingIndex] = item;
+					seen.set(key, item);
+				}
+			}
+		} else {
+			// Otherwise, keep the existing item (skip the duplicate)
+			seen.set(key, item);
+			deduplicatedResult.push(item);
+		}
+	}
+
 	return new CompletionItemModel(
-		result.sort(getSuggestionComparator(options.snippetSortOrder)),
+		deduplicatedResult.sort(getSuggestionComparator(options.snippetSortOrder)),
+		// --- End Positron ---
 		needsClipboard,
 		{ entries: durations, elapsed: sw.elapsed() },
 		disposables,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7229,6 +7229,11 @@ declare namespace monaco.languages {
 		 * Can decrease the verbosity of the hover
 		 */
 		canDecreaseVerbosity?: boolean;
+		/**
+		 * Id of the extension that provided this hover.
+		 * Used to filter duplicate hovers from certain extensions.
+		 */
+		extensionId?: string;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1863,6 +1863,12 @@ export interface HoverWithId extends languages.Hover {
 	 * Id of the hover
 	 */
 	id: number;
+	// --- Start Positron ---
+	/**
+	 * Id of the extension that provided this hover
+	 */
+	extensionId?: string;
+	// --- End Positron ---
 }
 
 // -- extension host


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/10904. 

Turns back on our built-in Python language server (BPLS?) contributions for hover and signature help, in addition to its completion contributions still being on.

Modifies Positron core logic to:
- get rid of hovers and signature help that just contain the text `Unknown` (Pyrefly does this)
- deduplicate hovers by suppressing the BPLS hover if it gets contributed alongside other hovers
- deduplicate completions by `insertText`, preferring non-BPLS entries, then choosing the first it sees

Signature help still takes the first it sees, so it's already deduplicated nicely after the `Unknown` bugfix.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Deduplicate Python completions, and fix some situations where hover popups and function signature help popups wouldn't appear (https://github.com/posit-dev/positron/issues/10904)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->
@:pyrefly @:console @:outline @:problems @:references @:notebooks @:positron-notebooks @:web @:win

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

The test script I was using was
```python
from collections import defaultdict
from itertools import groupby
import os
import pandas as pd

df = pd.DataFrame({'a':[1,2,3]})
df.head()
df[""]
os.environ[""]
x = defaultdict(abc=123)
x.clear()
asd = groupby()

def myfunc(a: int, b: str) -> str:
    """docstr"""
    print(a, b)
    return b + "asd"

asd = myfunc(a=3)
```
- Check out all the hovers and make sure they look good
- Manually write out that code in both the Console and an editor, making sure the completions and function signature help look good
- One particularly challenging test was doing in the Console
```python
>>>import pandas as pd
>>>df = pd.DataFrame({'a': [1,2,3]})
>>>df.head()
>>>df["
```
and making sure hovers, completions, and signature help work as expected. Pyrefly won't work in this scenario (because it can't see the import line) so we have to rely on Jedi.

I'm sure you can think of other ways to break it. ;)