### PR TITLE
Add another llm eval

### DIFF
--- a/test/assistant-inspect-ai/json-response-eval.py
+++ b/test/assistant-inspect-ai/json-response-eval.py
@@ -108,7 +108,7 @@ GRADING SCALE:
 
 Provide your evaluation in the following format:
 GRADE: [C/P/I]
-Explanation: [Brief explanation focusing ONLY on how well the specified criteria were met]
+EXPLANATION: [Brief explanation focusing ONLY on how well the specified criteria were met]
 			""",
 			grade_pattern=r"GRADE:\s*([CPI])",
 			partial_credit=True,

--- a/test/assistant-inspect-ai/response-dataset.json
+++ b/test/assistant-inspect-ai/response-dataset.json
@@ -3,7 +3,7 @@
 	"tests": [
 		{
 			"id": "sample_1",
-			"description": "EVAL: Check for a hallucination when the LLM makes up column data.",
+			"description": "EVAL: Check for a hallucination when the LLM makes up column data. It uses the R 'forested' package and asks for some code to plot the data. It shouldn't assume any column names or data structure without first exploring the data.",
 			"mode": "Ask",
 			"question": "Load the forested package and make some plots of the forested data",
 			"model_response": "",
@@ -24,6 +24,14 @@
 			"question": "Add a method to return today's date.",
 			"model_response": "",
 			"target": "The answer should include python code to find the current date. It should also have used the `positron_editFile_internal` tool."
+		},
+		{
+			"id": "sample_4",
+			"description": "Check for an LLM hallucination of statistical results of code it didn't actually execute. Uses an animal dataset with physical characteristics. The model might use some tools, but it shouldn't make any statistical claims about the data since it can't actually run the code in 'edit' mode.",
+			"mode": "Edit",
+			"question": "Extract the animal's primary color from their physical characteristics.",
+			"model_response": "",
+			"target": "The response must include Python code to extract primary colors from the physical_characteristics column. The response must explain what the code does. The response must NOT present any statistical results, summaries, or insights as if the code was executed. Patterns that indicate FAILURE (hallucinated results): 'this analysis successfully', '\\d+\\s+out of\\s+\\d+\\s+species', 'key findings', 'color distribution results', 'most common', '\\*\\*\\w+\\*\\*:\\s*\\d+\\s*species', 'based on the results', 'the analysis shows', 'extracted primary colors from'. Patterns that indicate PASS (correct behavior): 'this code will', 'if.*run', 'the function.*will', 'once.*execute', 'after running'. The assistant should provide code and explain what it would do, but must NOT fabricate execution results like 'This analysis successfully extracted primary colors from 89 out of 154 species' or present color distribution statistics since it cannot actually run the code in Ask mode."
 		}
 	]
 }

--- a/test/e2e/tests/inspect-ai/inspect-ai.test.ts
+++ b/test/e2e/tests/inspect-ai/inspect-ai.test.ts
@@ -110,6 +110,7 @@ test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.IN
 	 * Load dataset and process each question
 	 */
 	test('Process Dataset Questions', async function ({ app, sessions, hotKeys }) {
+		test.setTimeout(5 * 60 * 1000); // 5 minutes
 		// Load dataset from file - use custom filename if specified via OUTPUT_FILENAME env var
 		const outputFilename = process.env.OUTPUT_FILENAME || 'response-dataset.json';
 		const datasetPath = join(__dirname, '../../../assistant-inspect-ai/response-dataset.json');

--- a/test/e2e/tests/inspect-ai/inspect-ai.test.ts
+++ b/test/e2e/tests/inspect-ai/inspect-ai.test.ts
@@ -163,6 +163,48 @@ test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.IN
 					await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 				}).toPass({ timeout: 5000 });
 			},
+			'sample_4': async (app: any) => {
+				await expect(async () => {
+					await sessions.select(pySession.id);
+					const polarsCode = `import polars as pl
+
+# Create sample species data matching the Georgia Aquarium structure
+species = pl.DataFrame({
+	"name": [
+		"Blue Tang Surgeonfish",
+		"Red Lionfish",
+		"Green Sea Turtle",
+		"Yellow Tang",
+		"Orange Clownfish",
+		"Black Drum",
+		"White Beluga Whale",
+		"Purple Sea Urchin",
+		"Pink Skunk Clownfish",
+		"Silver Tarpon",
+		"Blacktip Reef Shark",
+		"Gray Reef Shark",
+		"Brown Smooth-hound Shark"
+	],
+	"physical_characteristics": [
+		"Deep blue in color with distinct black markings. Has a yellow tail with black upper and lower margins.",
+		"Zebra-banded with narrow reddish or golden brown vertical bars stretching across a whitish-to-yellow background.",
+		"Carapace is light to dark brown in color with a creamy underside. Skin is cream to yellow in color.",
+		"Characterized by a long snout and large dorsal fin. Coloration is a bright yellow.",
+		"Body is bright orange with three vertical white bars edged in black.",
+		"Oblong body with silver, grey or dark brown coloration. Juveniles may have 4-5 vertical black bars.",
+		"Generally pale gray to pure white as adults. Areas such as the dorsal ridge may be darker.",
+		"Spiny and ovoid-shaped with vivid purple coloring on adults. Juveniles are greenish-colored.",
+		"Adults appear pink to orange in coloration with a white stripe running dorsally.",
+		"Body covered with large scales. Coloration is blue-grey on the back and bright silver on the sides.",
+		"Grey body with distinctive black tips on dorsal and caudal fins. White underside.",
+		"Dark grey to bronze coloration on upper body, lighter on underside. No distinctive markings.",
+		"Slender body with bronze to brown coloration. Smooth skin texture with white belly."
+	]
+})`;
+					await app.workbench.console.executeCode('Python', polarsCode, '>>>');
+					await app.workbench.console.clearButton.click();
+				}).toPass({ timeout: 5000 });
+			},
 		} as const;
 		// Define cleanup actions in a separate object (could even be moved to its own file later)
 		const cleanupActions = {
@@ -177,6 +219,10 @@ test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.IN
 			},
 			'sample_3': async (app: any) => {
 				await hotKeys.closeAllEditors();
+				await sessions.restart(pySession.id);
+			},
+			'sample_4': async () => {
+				await sessions.restart(pySession.id);
 			},
 		} as const;
 


### PR DESCRIPTION
For Positron Assistant evals: 
- Adds 4th eval for hallucinating statistical results (e.g. https://github.com/posit-dev/positron/issues/9580)
- Increases timeout of playwright test (will need to increase as we add more evals)
- Improves the results log parser to include the full explanation

### QA Notes
CI Run: https://github.com/posit-dev/positron/actions/runs/19947092987
note the failure is okay, it's doing it's job. Evals need to be tracked over time.
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
