### PR TITLE
e2e: refactor include/exclude

### DIFF
--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -95,7 +95,7 @@ export class QuickInput {
 	async selectQuickInputElementContaining(text: string, { timeout, force = true }: { timeout?: number; force?: boolean } = {}): Promise<string> {
 		const firstMatch = this.code.driver.page.locator(`${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`).first();
 
-		const firstMatchResult = await firstMatch.locator('.quick-input-list-row').nth(0).textContent() || '';
+		const firstMatchResult = await firstMatch.locator('.quick-input-list-row').nth(0).textContent({ timeout }) || '';
 		await firstMatch.click({ force, timeout });
 		await this.code.driver.page.mouse.move(0, 0);
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -451,7 +451,7 @@ export class Sessions {
 			// Wait until the desired runtime appears in the list and select it.
 			// We need to click instead of using 'enter' because the Python select interpreter command
 			// may include additional items above the desired interpreter string.
-			await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`);
+			await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, { timeout: 5000 });
 			await this.quickinput.waitForQuickInputClosed();
 
 			// Move mouse to prevent tooltip hover

--- a/test/e2e/tests/interpreters/helpers/include-excludes.ts
+++ b/test/e2e/tests/interpreters/helpers/include-excludes.ts
@@ -9,37 +9,48 @@ import { SessionRuntimes, Sessions } from '../../../pages/sessions.js';
 /**
  * Helper function to build R path based on environment.
  * Reads version from POSITRON_R_ALT_VER_SEL environment variable.
- * @param usage - Whether to build path for 'exclude' or 'override'
+ * @param usage - Whether to build path for 'include', 'exclude', or 'override'
  */
-export function buildRPath(usage: 'exclude' | 'override' = 'exclude'): string {
+export function buildRPath(usage: 'include' | 'exclude' | 'override' = 'exclude'): string {
 	const version = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
 	const majorMinor = version.split('.').slice(0, 2).join('.');
-	if (process.env.CI) {
-		// Linux: excludes use directory path, overrides use full binary path
-		return usage === 'exclude' ? `/opt/R/${version}` : `/opt/R/${version}/bin/R`;
+
+	if (usage === 'include') {
+		// Include path - the hidden R interpreter location
+		return process.env.CI
+			? '/root/scratch'
+			: '/Users/runner/scratch'; // <-- modify for local testing
+	} else if (usage === 'exclude') {
+		// Exclude path - the standard R installation location for the version
+		return process.env.CI
+			? `/opt/R/${version}`
+			: `/Library/Frameworks/R.framework/Versions/${majorMinor}-arm64`; // <-- modify for local testing
 	} else {
-		// macOS: excludes include /Resources, overrides don't
-		const resourcesPath = usage === 'exclude' ? '/Resources' : '';
-		return `/Library/Frameworks/R.framework/Versions/${majorMinor}-arm64${resourcesPath}/bin/R`;
+		// Override path - the hidden R interpreter location
+		return process.env.CI
+			? `/root/scratch/r-env/bin/R`
+			: `/Users/runner/scratch/r-env/bin/R`; // <-- modify for local testing
 	}
 }
 
 /**
  * Helper function to build Python path based on environment.
  * Reads version from POSITRON_PY_ALT_VER_SEL environment variable.
- * @param usage - Whether to build path for 'exclude' or 'override'
+ * @param usage - Whether to build path for 'include', 'exclude', or 'override'
  */
-export function buildPythonPath(usage: 'exclude' | 'override' = 'exclude'): string {
+export function buildPythonPath(usage: 'include' | 'exclude' | 'override' = 'exclude'): string {
 	const version = process.env.POSITRON_PY_ALT_VER_SEL || 'alternate Python not set';
-	if (usage === 'exclude') {
-		return process.env.CI
-			? `~/.pyenv`
-			: `/Users/runner/.pyenv/versions/${version}`;
-	} else {
-		// Override path - the hidden Python interpreter location
+
+	if (usage === 'include' || usage === 'override') {
+		// Include and Override path - the hidden Python interpreter directory
 		return process.env.CI
 			? '/root/scratch/python-env'
-			: '/Users/runner/scratch/python-env';
+			: '/Users/runner/scratch/python-env'; // <-- modify for local testing
+	} else {
+		// Exclude path - the standard pyenv location for the version
+		return process.env.CI
+			? `~/.pyenv`
+			: `/Users/runner/.pyenv/versions/${version}`; // <-- modify for local testing
 	}
 }
 

--- a/test/e2e/tests/interpreters/helpers/include-excludes.ts
+++ b/test/e2e/tests/interpreters/helpers/include-excludes.ts
@@ -9,14 +9,14 @@ import { SessionRuntimes, Sessions } from '../../../pages/sessions.js';
 /**
  * Helper function to build R path based on environment.
  * Reads version from POSITRON_R_ALT_VER_SEL environment variable.
- * @param usage - Whether to build path for 'include', 'exclude', or 'override'
+ * @param usage - Whether to build path for 'customRoot', 'exclude', or 'override'
  */
-export function buildRPath(usage: 'include' | 'exclude' | 'override' = 'exclude'): string {
+export function buildRPath(usage: 'customRoot' | 'exclude' | 'override' = 'exclude'): string {
 	const version = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
 	const majorMinor = version.split('.').slice(0, 2).join('.');
 
-	if (usage === 'include') {
-		// Include path - the hidden R interpreter location
+	if (usage === 'customRoot') {
+		// Custom root - the custom folder for R discovery
 		return process.env.CI
 			? '/root/scratch'
 			: '/Users/runner/scratch'; // <-- modify for local testing

--- a/test/e2e/tests/interpreters/helpers/include-excludes.ts
+++ b/test/e2e/tests/interpreters/helpers/include-excludes.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { fail } from 'assert';
+import { SessionRuntimes, Sessions } from '../../../pages/sessions.js';
+
+/**
+ * Helper function to build R path based on environment.
+ * Reads version from POSITRON_R_ALT_VER_SEL environment variable.
+ * @param usage - Whether to build path for 'exclude' or 'override'
+ */
+export function buildRPath(usage: 'exclude' | 'override' = 'exclude'): string {
+	const version = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
+	const majorMinor = version.split('.').slice(0, 2).join('.');
+	if (process.env.CI) {
+		// Linux: excludes use directory path, overrides use full binary path
+		return usage === 'exclude' ? `/opt/R/${version}` : `/opt/R/${version}/bin/R`;
+	} else {
+		// macOS: excludes include /Resources, overrides don't
+		const resourcesPath = usage === 'exclude' ? '/Resources' : '';
+		return `/Library/Frameworks/R.framework/Versions/${majorMinor}-arm64${resourcesPath}/bin/R`;
+	}
+}
+
+/**
+ * Helper function to build Python path based on environment.
+ * Reads version from POSITRON_PY_ALT_VER_SEL environment variable.
+ * @param usage - Whether to build path for 'exclude' or 'override'
+ */
+export function buildPythonPath(usage: 'exclude' | 'override' = 'exclude'): string {
+	const version = process.env.POSITRON_PY_ALT_VER_SEL || 'alternate Python not set';
+	if (usage === 'exclude') {
+		return process.env.CI
+			? `~/.pyenv`
+			: `/Users/runner/.pyenv/versions/${version}`;
+	} else {
+		// Override path - the hidden Python interpreter location
+		return process.env.CI
+			? '/root/scratch/python-env'
+			: '/Users/runner/scratch/python-env';
+	}
+}
+
+/**
+ * Helper function to verify that starting a session fails (e.g., when interpreter is excluded).
+ * If the session starts successfully, the test will fail.
+ */
+export async function expectSessionStartToFail(
+	sessions: Sessions,
+	interpreterName: SessionRuntimes,
+	excludedPath: string
+): Promise<void> {
+	let sessionStarted = false;
+	try {
+		await sessions.start(interpreterName, { reuse: false });
+		sessionStarted = true;
+	} catch (e) {
+		// Expected - session should fail to start
+	}
+
+	if (sessionStarted) {
+		fail(`Expected interpreter to be excluded: ${excludedPath}`);
+	}
+}

--- a/test/e2e/tests/interpreters/helpers/include-excludes.ts
+++ b/test/e2e/tests/interpreters/helpers/include-excludes.ts
@@ -12,7 +12,10 @@ import { SessionRuntimes, Sessions } from '../../../pages/sessions.js';
  * @param usage - Whether to build path for 'customRoot', 'exclude', or 'override'
  */
 export function buildRPath(usage: 'customRoot' | 'exclude' | 'override' = 'exclude'): string {
-	const version = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
+	const version = process.env.POSITRON_R_ALT_VER_SEL
+	if (!version) {
+		throw new Error('Environment variable POSITRON_R_ALT_VER_SEL not set');
+	}
 	const majorMinor = version.split('.').slice(0, 2).join('.');
 
 	if (usage === 'customRoot') {
@@ -39,7 +42,10 @@ export function buildRPath(usage: 'customRoot' | 'exclude' | 'override' = 'exclu
  * @param usage - Whether to build path for 'include', 'exclude', or 'override'
  */
 export function buildPythonPath(usage: 'include' | 'exclude' | 'override' = 'exclude'): string {
-	const version = process.env.POSITRON_PY_ALT_VER_SEL || 'alternate Python not set';
+	const version = process.env.POSITRON_PY_ALT_VER_SEL;
+	if (!version) {
+		throw new Error('Environment variable POSITRON_PY_ALT_VER_SEL not set');
+	}
 
 	if (usage === 'include' || usage === 'override') {
 		// Include and Override path - the hidden Python interpreter directory

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -10,6 +10,28 @@ test.use({
 	suiteId: __filename
 });
 
+/**
+ * Helper function to verify that starting a session fails (e.g., when interpreter is excluded).
+ * If the session starts successfully, the test will fail.
+ */
+async function expectSessionStartToFail(
+	sessions: any,
+	interpreterName: string,
+	excludedPath: string
+): Promise<void> {
+	let sessionStarted = false;
+	try {
+		await sessions.start(interpreterName, { reuse: false });
+		sessionStarted = true;
+	} catch (e) {
+		// Expected - session should fail to start
+	}
+
+	if (sessionStarted) {
+		fail(`Expected interpreter to be excluded: ${excludedPath}`);
+	}
+}
+
 // these are CI only tests; its not recommended to try and get your local machine to run these tests
 test.describe('Interpreter: Includes', {
 	tag: [tags.INTERPRETER, tags.WEB]
@@ -47,62 +69,38 @@ test.describe('Interpreter: Includes', {
 test.describe('Interpreter: Excludes', {
 	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
+	let excludedRPath: string;
+	let excludedPythonPath: string;
+	let alternateR: string;
+	let alternatePython: string;
 
-	test.beforeAll(async function ({ settings }) {
+	test.beforeAll(async function ({ settings, app }) {
+		// setup excluded R paths
+		alternateR = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
+		const rMajorMinor = alternateR?.split('.').slice(0, 2).join('.');
+		excludedRPath = process.env.CI
+			? `/opt/R/${alternateR}`
+			: `/Library/Frameworks/R.framework/Versions/${rMajorMinor}-arm64/Resources/bin/R`;
+
+		// setup excluded Python paths
+		alternatePython = process.env.POSITRON_PY_ALT_VER_SEL || 'alternate Python not set';
+		excludedPythonPath = process.env.CI
+			? `~/.pyenv`
+			: `/Users/runner/.pyenv/versions/${alternatePython}`;
+
+		// override settings to exclude the alternate interpreters
 		await settings.set({
-			'python.interpreters.exclude': ["~/.pyenv"],
-			'positron.r.interpreters.exclude': ["/opt/R/4.4.2"],
+			'python.interpreters.exclude': [excludedPythonPath],
+			'positron.r.interpreters.exclude': [excludedRPath]
 		}, { reload: true });
 	});
 
-	test('R - Can Exclude an Interpreter', {
-		tag: [tags.ARK]
-	}, async function ({ app, sessions }) {
-
-		const alternateR = process.env.POSITRON_R_ALT_VER_SEL;
-
-		if (!alternateR) {
-			return fail('Alternate R version not set');
-		}
-
-		const failMessage = 'selectInterpreter was supposed to fail as /opt/R/4.4.2 was excluded';
-		try {
-			await sessions.start('rAlt', { reuse: false });
-			fail(failMessage);
-		} catch (e) {
-			if (e instanceof Error && e.message.includes(failMessage)) {
-				fail(failMessage);
-			}
-			// Success = interpreter was correctly excluded
-		}
-
-		await app.code.driver.page.keyboard.press('Escape');
+	test('R - Can Exclude an Interpreter', { tag: [tags.ARK] }, async function ({ sessions }) {
+		await expectSessionStartToFail(sessions, 'rAlt', excludedRPath);
 	});
 
-	test('Python - Can Exclude an Interpreter', async function ({ app, settings, sessions }) {
-
-		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
-
-		if (!alternatePython) {
-			return fail('Alternate Python version not set');
-		}
-
-		const failMessage = 'selectInterpreter was supposed to fail as /root/.pyenv was excluded';
-		await settings.set({
-			'python.interpreters.exclude': ["/root/.pyenv"]
-		}, { reload: true, waitMs: 5000 });
-
-		try {
-			await sessions.start('pythonAlt', { reuse: false });
-			fail(failMessage);
-		} catch (e) {
-			if (e instanceof Error && e.message.includes(failMessage)) {
-				fail(failMessage);
-			}
-			// Success = interpreter was correctly excluded
-		}
-
-		await app.code.driver.page.keyboard.press('Escape');
+	test('Python - Can Exclude an Interpreter', async function ({ sessions }) {
+		await expectSessionStartToFail(sessions, 'pythonAlt', excludedPythonPath);
 	});
 
 });
@@ -110,59 +108,29 @@ test.describe('Interpreter: Excludes', {
 test.describe('Interpreter: Override', {
 	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
+	let overrideRPath: string;
+	let overridePythonPath: string;
 
 	test.beforeAll(async function ({ settings }) {
-		const pythonPath = '/root/scratch/python-env';
+		const alternateR = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
+
+		overridePythonPath = '/root/scratch/python-env';
+		overrideRPath = `/opt/R/${alternateR}/bin/R`;
 
 		await settings.set({
-			'python.interpreters.override': [pythonPath],
-			'positron.r.interpreters.override': ["/opt/R/4.4.2/bin/R"]
+			// 'python.interpreters.override': [overridePythonPath],
+			'positron.r.interpreters.override': [overrideRPath]
 		}, { reload: true });
 	});
 
 	test('R - Can Override Interpreter Discovery', {
 		tag: [tags.ARK]
-	}, async function ({ app, sessions }) {
-
-		const alternateR = process.env.POSITRON_R_ALT_VER_SEL;
-
-		if (!alternateR) {
-			return fail('Alternate R version not set');
-		}
-
-		const failMessage = 'selectInterpreter was supposed to fail as /opt/R/4.4.2 was overriden';
-		try {
-			await sessions.start('r', { reuse: false });
-			fail(failMessage);
-		} catch (e) {
-			if (e instanceof Error && e.message.includes(failMessage)) {
-				fail(failMessage);
-			}
-			// Success = interpreter was correctly overriden
-		}
-		await app.code.driver.page.keyboard.press('Escape');
+	}, async function ({ sessions }) {
+		await expectSessionStartToFail(sessions, 'r', overrideRPath);
 	});
 
-	test('Python - Can Override Interpreter Discovery', async function ({ app, sessions }) {
-
-		const alternatePython = process.env.POSITRON_PY_ALT_VER_SEL;
-
-		if (!alternatePython) {
-			return fail('Alternate Python version not set');
-		}
-
-		const failMessage = 'selectInterpreter was supposed to fail as ~/.pyenv was overriden';
-		try {
-			await sessions.start('python', { reuse: false });
-			fail(failMessage);
-		} catch (e) {
-			if (e instanceof Error && e.message.includes(failMessage)) {
-				fail(failMessage);
-			}
-			// Success = interpreter was correctly overriden
-		}
-
-		await app.code.driver.page.keyboard.press('Escape');
+	test('Python - Can Override Interpreter Discovery', async function ({ sessions }) {
+		await expectSessionStartToFail(sessions, 'python', overridePythonPath);
 	});
 
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -16,11 +16,9 @@ test.describe('Interpreter: Includes', {
 }, () => {
 
 	test.beforeAll(async function ({ settings }) {
-		const basePath = '/root/scratch';
-
 		await settings.set({
-			'python.interpreters.include': [`${basePath}/python-env`],
-			'positron.r.customRootFolders': [basePath]
+			'python.interpreters.include': [buildPythonPath('include')],
+			'positron.r.customRootFolders': [buildRPath('include')]
 		}, { reload: true });
 	});
 
@@ -89,5 +87,4 @@ test.describe('Interpreter: Override', {
 	test('Python - Can Override Interpreter Discovery', async function ({ sessions }) {
 		await expectSessionStartToFail(sessions, 'python', overridePythonPath);
 	});
-
 });

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -18,7 +18,7 @@ test.describe('Interpreter: Includes', {
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
 			'python.interpreters.include': [buildPythonPath('include')],
-			'positron.r.customRootFolders': [buildRPath('include')]
+			'positron.r.customRootFolders': [buildRPath('customRoot')]
 		}, { reload: true });
 	});
 

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -5,34 +5,12 @@
 
 import { fail } from 'assert';
 import { test, tags } from '../_test.setup';
+import { buildPythonPath, buildRPath, expectSessionStartToFail } from './helpers/include-excludes.js';
 
 test.use({
 	suiteId: __filename
 });
 
-/**
- * Helper function to verify that starting a session fails (e.g., when interpreter is excluded).
- * If the session starts successfully, the test will fail.
- */
-async function expectSessionStartToFail(
-	sessions: any,
-	interpreterName: string,
-	excludedPath: string
-): Promise<void> {
-	let sessionStarted = false;
-	try {
-		await sessions.start(interpreterName, { reuse: false });
-		sessionStarted = true;
-	} catch (e) {
-		// Expected - session should fail to start
-	}
-
-	if (sessionStarted) {
-		fail(`Expected interpreter to be excluded: ${excludedPath}`);
-	}
-}
-
-// these are CI only tests; its not recommended to try and get your local machine to run these tests
 test.describe('Interpreter: Includes', {
 	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
@@ -47,7 +25,6 @@ test.describe('Interpreter: Includes', {
 	});
 
 	test('Python - Can Include an Interpreter', async function ({ sessions }) {
-
 		const hiddenPython = process.env.POSITRON_HIDDEN_PY;
 
 		hiddenPython
@@ -55,15 +32,13 @@ test.describe('Interpreter: Includes', {
 			: fail('Hidden Python version not set');
 	});
 
-	test('R - Can Include an Interpreter',
-		{ tag: [tags.ARK] }, async function ({ sessions }) {
+	test('R - Can Include an Interpreter', { tag: [tags.ARK] }, async function ({ sessions }) {
+		const hiddenR = process.env.POSITRON_HIDDEN_R;
 
-			const hiddenR = process.env.POSITRON_HIDDEN_R;
-
-			hiddenR
-				? await sessions.start('rHidden')
-				: fail('Hidden R version not set');
-		});
+		hiddenR
+			? await sessions.start('rHidden')
+			: fail('Hidden R version not set');
+	});
 });
 
 test.describe('Interpreter: Excludes', {
@@ -71,24 +46,11 @@ test.describe('Interpreter: Excludes', {
 }, () => {
 	let excludedRPath: string;
 	let excludedPythonPath: string;
-	let alternateR: string;
-	let alternatePython: string;
 
-	test.beforeAll(async function ({ settings, app }) {
-		// setup excluded R paths
-		alternateR = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
-		const rMajorMinor = alternateR?.split('.').slice(0, 2).join('.');
-		excludedRPath = process.env.CI
-			? `/opt/R/${alternateR}`
-			: `/Library/Frameworks/R.framework/Versions/${rMajorMinor}-arm64/Resources/bin/R`;
+	test.beforeAll(async function ({ settings }) {
+		excludedRPath = buildRPath('exclude');
+		excludedPythonPath = buildPythonPath('exclude');
 
-		// setup excluded Python paths
-		alternatePython = process.env.POSITRON_PY_ALT_VER_SEL || 'alternate Python not set';
-		excludedPythonPath = process.env.CI
-			? `~/.pyenv`
-			: `/Users/runner/.pyenv/versions/${alternatePython}`;
-
-		// override settings to exclude the alternate interpreters
 		await settings.set({
 			'python.interpreters.exclude': [excludedPythonPath],
 			'positron.r.interpreters.exclude': [excludedRPath]
@@ -102,7 +64,6 @@ test.describe('Interpreter: Excludes', {
 	test('Python - Can Exclude an Interpreter', async function ({ sessions }) {
 		await expectSessionStartToFail(sessions, 'pythonAlt', excludedPythonPath);
 	});
-
 });
 
 test.describe('Interpreter: Override', {
@@ -112,20 +73,16 @@ test.describe('Interpreter: Override', {
 	let overridePythonPath: string;
 
 	test.beforeAll(async function ({ settings }) {
-		const alternateR = process.env.POSITRON_R_ALT_VER_SEL || 'alternate R not set';
-
-		overridePythonPath = '/root/scratch/python-env';
-		overrideRPath = `/opt/R/${alternateR}/bin/R`;
+		overridePythonPath = buildPythonPath('override');
+		overrideRPath = buildRPath('override');
 
 		await settings.set({
-			// 'python.interpreters.override': [overridePythonPath],
+			'python.interpreters.override': [overridePythonPath],
 			'positron.r.interpreters.override': [overrideRPath]
 		}, { reload: true });
 	});
 
-	test('R - Can Override Interpreter Discovery', {
-		tag: [tags.ARK]
-	}, async function ({ sessions }) {
+	test('R - Can Override Interpreter Discovery', { tag: [tags.ARK] }, async function ({ sessions }) {
 		await expectSessionStartToFail(sessions, 'r', overrideRPath);
 	});
 


### PR DESCRIPTION
 ### Summary

Refactored interpreter include/exclude/override E2E tests to improve maintainability and environment compatibility:
  - Extracted environment-aware path builders that switch between Linux (CI) and macOS (local) paths
  - Parameterized hardcoded version strings (4.4.2 → POSITRON_R_ALT_VER_SEL) - fixes version mismatch flakes
  - Reduced interpreter selection timeout from 30s → 5s (unnecessary wait time) overall reducing test execution time
  
  ### QA Notes
  @:interpreter
  
  I ran the include-exclude tests on repeat and both results look great!
  linux - https://github.com/posit-dev/positron/actions/runs/19966615395
  chromium - https://github.com/posit-dev/positron/actions/runs/19966630303