### PR TITLE
e2e: cherry-pick disable pyrefly for e2e

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -8,5 +8,9 @@
     "positron.importSettings.enable": false,
     "positron.assistant.enable": true,
     "positron.assistant.testModels": true,
-	"posit.workbench.showWorkbenchFlaskHint": false
+	"posit.workbench.showWorkbenchFlaskHint": false,
+	"extensions.allowed": {
+        "meta.pyrefly": false,
+        "*": true
+    }
 }


### PR DESCRIPTION
Porting over the commit that disables Pyrefly on e2e tests.
Originally from this #10830 

### QA Notes

@:web

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
