### PR TITLE
deduplicate python hovers and completions in core (cherry-pick from release/2025.12 branch)

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -303,8 +303,6 @@ class PositronJediLanguageServerProtocol(JediLanguageServerProtocol):
 
         # Remove LSP features that are redundant with Pyrefly.
         features_to_remove = [
-            "textDocument/hover",
-            "textDocument/signatureHelp",
             "textDocument/declaration",
             "textDocument/definition",
             "textDocument/typeDefinition",

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -193,6 +193,14 @@ export interface Hover {
 	 * Can decrease the verbosity of the hover
 	 */
 	canDecreaseVerbosity?: boolean;
+
+	// --- Start Positron ---
+	/**
+	 * Id of the extension that provided this hover.
+	 * Used to filter duplicate hovers from certain extensions.
+	 */
+	extensionId?: string;
+	// --- End Positron ---
 }
 
 /**

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -326,8 +326,40 @@ export async function provideSuggestionItems(
 		return Promise.reject(new CancellationError());
 	}
 
+	// --- Start Positron ---
+	// Deduplicate completion items that have the same insertText.
+	// When duplicates are found:
+	//   - If one item is from our Python extension and the other is not, prefer the one not from our Python extension.
+	//   - If both items are from our Python extension, the first-seen item is kept.
+	//   - If both items are from other extensions, the first-seen item is kept.
+	const msPythonExtensionId = 'ms-python.python';
+	const deduplicatedResult: CompletionItem[] = [];
+	const seen = new Map<string, CompletionItem>();
+
+	for (const item of result) {
+		const key = item.completion.insertText;
+		const existing = seen.get(key);
+		if (existing) {
+			// If the existing item is from ms-python.python and the new one is not,
+			// replace with the new one
+			if (existing.extensionId?.value === msPythonExtensionId &&
+				item.extensionId?.value !== msPythonExtensionId) {
+				const existingIndex = deduplicatedResult.indexOf(existing);
+				if (existingIndex !== -1) {
+					deduplicatedResult[existingIndex] = item;
+					seen.set(key, item);
+				}
+			}
+		} else {
+			// Otherwise, keep the existing item (skip the duplicate)
+			seen.set(key, item);
+			deduplicatedResult.push(item);
+		}
+	}
+
 	return new CompletionItemModel(
-		result.sort(getSuggestionComparator(options.snippetSortOrder)),
+		deduplicatedResult.sort(getSuggestionComparator(options.snippetSortOrder)),
+		// --- End Positron ---
 		needsClipboard,
 		{ entries: durations, elapsed: sw.elapsed() },
 		disposables,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7229,6 +7229,11 @@ declare namespace monaco.languages {
 		 * Can decrease the verbosity of the hover
 		 */
 		canDecreaseVerbosity?: boolean;
+		/**
+		 * Id of the extension that provided this hover.
+		 * Used to filter duplicate hovers from certain extensions.
+		 */
+		extensionId?: string;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1863,6 +1863,12 @@ export interface HoverWithId extends languages.Hover {
 	 * Id of the hover
 	 */
 	id: number;
+	// --- Start Positron ---
+	/**
+	 * Id of the extension that provided this hover
+	 */
+	extensionId?: string;
+	// --- End Positron ---
 }
 
 // -- extension host


### PR DESCRIPTION
Cherry-pick https://github.com/posit-dev/positron/pull/10955 onto the main branch.