### PR TITLE
e2e: fix the failing new folder flow and re-enable test explorer test

### DIFF
--- a/test/e2e/fixtures/test-setup/settings.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/settings.fixtures.ts
@@ -18,7 +18,7 @@ export function SettingsFixture(app: Application) {
 			await settings.set(newSettings, { keepOpen });
 
 			if (reload === true || (reload === 'web' && app.web === true)) {
-				await app.workbench.hotKeys.reloadWindow(true);
+				await app.workbench.hotKeys.reloadWindow(false);
 			}
 			if (waitMs) {
 				await app.code.driver.page.waitForTimeout(waitMs); // wait for settings to take effect

--- a/test/e2e/tests/interpreters/includes-excludes.test.ts
+++ b/test/e2e/tests/interpreters/includes-excludes.test.ts
@@ -19,7 +19,7 @@ test.describe('Interpreter: Includes', {
 		await settings.set({
 			'python.interpreters.include': [buildPythonPath('include')],
 			'positron.r.customRootFolders': [buildRPath('customRoot')]
-		}, { reload: true });
+		}, { reload: true, waitForReady: true });
 	});
 
 	test('Python - Can Include an Interpreter', async function ({ sessions }) {
@@ -52,7 +52,7 @@ test.describe('Interpreter: Excludes', {
 		await settings.set({
 			'python.interpreters.exclude': [excludedPythonPath],
 			'positron.r.interpreters.exclude': [excludedRPath]
-		}, { reload: true });
+		}, { reload: true, waitForReady: true });
 	});
 
 	test('R - Can Exclude an Interpreter', { tag: [tags.ARK] }, async function ({ sessions }) {
@@ -77,7 +77,7 @@ test.describe('Interpreter: Override', {
 		await settings.set({
 			'python.interpreters.override': [overridePythonPath],
 			'positron.r.interpreters.override': [overrideRPath]
-		}, { reload: true });
+		}, { reload: true, waitForReady: true });
 	});
 
 	test('R - Can Override Interpreter Discovery', { tag: [tags.ARK] }, async function ({ sessions }) {

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -25,6 +25,7 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 
 	test('R - Verify Basic Test Explorer Functionality', {
 		tag: [tags.ARK],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10682' }]
 	}, async function ({ app, openFolder }) {
 
 		// Open R package embedded in qa-example-content

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -16,14 +16,14 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 			// don't use native file picker
 			await settings.set({
 				'files.simpleDialog.enable': true
-			}, { reload: true });
+			}, { reload: true, waitForReady: true });
 		} catch (e) {
 			await app.code.driver.takeScreenshot('testExplorerSetup');
 			throw e;
 		}
 	});
 
-	test.skip('R - Verify Basic Test Explorer Functionality', {
+	test('R - Verify Basic Test Explorer Functionality', {
 		tag: [tags.ARK],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10682' }]
 	}, async function ({ app, openFolder }) {

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -23,7 +23,7 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 		}
 	});
 
-	test('R - Verify Basic Test Explorer Functionality', {
+	test.skip('R - Verify Basic Test Explorer Functionality', {
 		tag: [tags.ARK],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10682' }]
 	}, async function ({ app, openFolder }) {

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -25,7 +25,6 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 
 	test('R - Verify Basic Test Explorer Functionality', {
 		tag: [tags.ARK],
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10682' }]
 	}, async function ({ app, openFolder }) {
 
 		// Open R package embedded in qa-example-content


### PR DESCRIPTION
### Summary
I previously update the logic in settings to always wait for ready, but missed the code block below that actually handles that.

### QA Notes

@:interpreter @:new-folder-flow