### PR TITLE
Handle command button part

### DIFF
--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -335,6 +335,8 @@ export function toLanguageModelChatMessage(turns: vscode.ChatContext['history'])
 					return acc + `\n\nSuggested text edits: ${JSON.stringify(content.edits)}\n\n`;
 				} else if (content instanceof vscode.ChatResponseAnchorPart) {
 					return acc + `\n\nAnchor: ${content.title ? `${content.title} ` : ''}${JSON.stringify(content.value2)}\n\n`;
+				} else if (content instanceof vscode.ChatResponseCommandButtonPart) {
+					return acc;
 				} else {
 					// TODO: Lower more history entry types to text.
 					throw new Error(`Unsupported response kind when lowering chat agent response: ${content.constructor.name}`);


### PR DESCRIPTION
Address #10364

Shiny has responses that include command buttons and they aren't handled by Assistant when it tries to review the chat history.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix error when chat history has a participant


### QA Notes