### PR TITLE
Do not show editor action bar for auxiliary windows in compact mode

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -26,8 +26,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
 import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
-import { PositronPlotsEditorInput } from '../../../contrib/positronPlotsEditor/browser/positronPlotsEditorInput.js';
-import { IsCompactTitleBarContext } from '../../../common/contextkeys.js';
+import { IsAuxiliaryWindowContext, IsCompactTitleBarContext } from '../../../common/contextkeys.js';
 
 /**
  * Constants.
@@ -232,19 +231,18 @@ export class EditorActionBarControlFactory {
 			return;
 		}
 
-		// Notebooks always disable the editor action bar.
-		if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
+		// Auxiliary windows in compact mode always disable the editor action bar.
+		const isAuxiliaryWindow = IsAuxiliaryWindowContext.getValue(this._contextKeyService);
+		const isCompact = IsCompactTitleBarContext.getValue(this._contextKeyService);
+		if (isAuxiliaryWindow && isCompact) {
 			this.updateEnablement(false);
 			return;
 		}
 
-		// Plots in compact windows disable the editor action bar.
-		if (editorInput.typeId === PositronPlotsEditorInput.TypeID) {
-			const isCompact = IsCompactTitleBarContext.getValue(this._contextKeyService);
-			if (isCompact) {
-				this.updateEnablement(false);
-				return;
-			}
+		// Notebooks always disable the editor action bar.
+		if (editorInput.typeId === NotebookEditorInput.ID || editorInput.typeId === NotebookOutputEditorInput.ID) {
+			this.updateEnablement(false);
+			return;
 		}
 
 		// Settings always enables editor action bar.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10330

This is somewhat related to https://github.com/posit-dev/positron/pull/10839 in that it extends that treatment to _all_ auxiliary windows in compact mode. The other big example, besides our _Plots: Open Plot in New Window_, is _Chat: New Chat Window_. I think this is a good change for _all_ of these types of windows, though.

- If you are in compact mode, you get no editor tab and no editor action bar
- If you are _not_ in compact mode, you get both again

This does not try to make any changes like trying to move the ➕ up to the title bar when the editor action bar is hidden; that would be a more difficult change given that we just totally shut off that ability when we did the editor action bar work. I think we would want to at least have some compelling reports from users before changing that logic. Folks can switch away from compact mode if they want any of those actions in their auxiliary window.


### Release Notes

#### New Features

- Auxiliary windows in compact mode (for example, _Plots: Open Plot in New Window_ and _Chat: New Chat Window_) now hide the editor action bar by default. Switch away from compact mode to access the editor action bar.

#### Bug Fixes

- N/A


### QA Notes

Similar to https://github.com/posit-dev/positron/pull/10839,

- If you make some R and/or Python plots and do "Open in new window", you should not see the editor tab bar or the editor action bar by default. You can bring these back by turning off compact mode.
- If you open a new chat window via the UI or command palette, you should not see the editor tab bar or the editor action bar by default either. You can still bring these back by switching away from compact mode.
