### PR TITLE
Fix styling for code in headers in the Help pane

### DIFF
--- a/extensions/positron-proxy/resources/scripts_help.html
+++ b/extensions/positron-proxy/resources/scripts_help.html
@@ -35,7 +35,7 @@
 				color: var(--vscode-textLink-foreground) !important;
 			}
 
-			code, pre, tt {
+			code, pre {
 				font-family: var(--vscode-editor-font-family) !important;
 				font-size: inherit !important;
 			}

--- a/extensions/positron-proxy/resources/scripts_help.html
+++ b/extensions/positron-proxy/resources/scripts_help.html
@@ -34,6 +34,11 @@
 			a {
 				color: var(--vscode-textLink-foreground) !important;
 			}
+
+			code, pre, tt {
+				font-family: var(--vscode-editor-font-family) !important;
+				font-size: inherit !important;
+			}
 		</style>
 		<style id="help-style-overrides">
 			::-webkit-scrollbar {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3136

With this PR, we now ensure that code elements in the Help pane inherit their font size from their parent element.

The particular `?rlang::.data` page now looks like this:

<img width="608" height="807" alt="Screenshot 2025-12-06 at 4 22 34 PM" src="https://github.com/user-attachments/assets/720ed01d-027a-481c-b924-797752402625" />

@:help

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed styling of code elements in the Help pane


### QA Notes

A Help page like `?rlang::.data` that has code elements in headers should render those code elements in the same size as the header. We should also spot check some other use of the Help pane to ensure things still look good.
