### PR TITLE
Use correct URI scheme when opening an editor or using opener service

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -242,7 +242,10 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 				if (ed.kind === 'uri') {
 					file = URI.parse(ed.file);
 				} else {
-					file = URI.file(ed.file);
+					file = URI.from({
+						scheme: this._pathService.defaultUriScheme,
+						path: ed.file
+					});
 				}
 
 				const editor: ITextResourceEditorInput = {
@@ -261,7 +264,10 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 			} else if (ev.name === UiFrontendEvent.OpenWithSystem) {
 				// Open a file or folder with system default application
 				const openWith = ev.data as OpenWithSystemEvent;
-				const uri = URI.file(openWith.path);
+				const uri = URI.from({
+					scheme: this._pathService.defaultUriScheme,
+					path: openWith.path
+				});
 
 				// Use VS Code's opener service with external option
 				await this._openerService.open(uri, { openExternal: true });


### PR DESCRIPTION
This PR addresses:

- https://github.com/posit-dev/positron/issues/10378
- https://github.com/posit-dev/positron/issues/5975

With this change, you can now correctly use the `UiFrontendEvent.OpenEditor` event such as via `rstudioapi::navigateToFile()` on a web build:


<img width="1445" height="1032" alt="Screenshot 2025-12-06 at 4 49 05 PM" src="https://github.com/user-attachments/assets/edcd3575-f0d1-4acd-9241-d2f4fd09e102" />

It also makes reprex work:

<img width="1445" height="1032" alt="Screenshot 2025-12-06 at 4 49 57 PM" src="https://github.com/user-attachments/assets/2b31123f-545d-4212-9472-b61656215bcf" />

This is similar to https://github.com/posit-dev/positron/pull/10092 so I did a bit of an audit and fixed one more example of us inappropriately handling the scheme. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Workbench: fixed a bug when opening editors such as with `rstudioapi::navigateToFile()` or when using reprex


### QA Notes

If you have a real file that really exists at a `/real/path/that/does/exist`, then with this PR you should be able to successfully run `.ps.ui.navigateToFile("/real/path/that/does/exist")` from the R console both:

- in a regular desktop build (this always worked)
- in a web build (this is now fixed with this PR)
