### PR TITLE
Assistant: Add positron custom agents directory

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -54,7 +54,7 @@ import { ILanguageModelToolsConfirmationService } from '../common/languageModelT
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
 import { ChatPromptFilesExtensionPointHandler } from '../common/promptSyntax/chatPromptFilesContribution.js';
 import { PromptsConfig } from '../common/promptSyntax/config/config.js';
-import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, PROMPT_POSITRON_SOURCE_FOLDER, MODE_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
+import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../common/promptSyntax/config/promptFileLocations.js';
 import { PromptLanguageFeaturesProvider } from '../common/promptSyntax/promptFileContributions.js';
 import { AGENT_DOCUMENTATION_URL, INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL } from '../common/promptSyntax/promptTypes.js';
 import { IPromptsService } from '../common/promptSyntax/service/promptsService.js';
@@ -132,7 +132,7 @@ import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.
 // --- Start Positron ---
 import { PositronBuiltinToolsContribution } from './tools/tools.js';
 import { ChatRuntimeSessionContextContribution } from './contrib/chatRuntimeSessionContext.js';
-import { INSTRUCTIONS_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
+import { INSTRUCTIONS_POSITRON_SOURCE_FOLDER, PROMPT_POSITRON_SOURCE_FOLDER, LEGACY_MODE_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
 // --- End Positron ---
 
 // Register configuration
@@ -627,8 +627,8 @@ configurationRegistry.registerConfiguration({
 				AGENT_DOCUMENTATION_URL,
 			),
 			default: {
-					// --- Start Positron ---
-				[MODE_POSITRON_SOURCE_FOLDER]: true,
+				// --- Start Positron ---
+				[LEGACY_MODE_POSITRON_SOURCE_FOLDER]: true,
 				// --- End Positron ---
 				[LEGACY_MODE_DEFAULT_SOURCE_FOLDER]: true,
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -132,6 +132,7 @@ import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.
 // --- Start Positron ---
 import { PositronBuiltinToolsContribution } from './tools/tools.js';
 import { ChatRuntimeSessionContextContribution } from './contrib/chatRuntimeSessionContext.js';
+// eslint-disable-next-line no-duplicate-imports
 import { INSTRUCTIONS_POSITRON_SOURCE_FOLDER, PROMPT_POSITRON_SOURCE_FOLDER, LEGACY_MODE_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
 // --- End Positron ---
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -65,7 +65,8 @@ function isInAgentsFolder(fileUri: URI): boolean {
 // Additional search paths for `.vscode/positron` directory
 export const PROMPT_POSITRON_SOURCE_FOLDER = '.vscode/positron/prompts';
 export const INSTRUCTIONS_POSITRON_SOURCE_FOLDER = '.vscode/positron/instructions';
-export const MODE_POSITRON_SOURCE_FOLDER = '.vscode/positron/chatmodes';
+export const LEGACY_MODE_POSITRON_SOURCE_FOLDER = '.vscode/positron/chatmodes';
+export const AGENTS_POSITRON_SOURCE_FOLDER = '.vscode/positron/agents';
 // --- End Positron ---
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -24,6 +24,10 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 
+// --- Start Positron ---
+import { AGENTS_POSITRON_SOURCE_FOLDER } from '../config/promptFileLocations.js';
+// --- End Positron ---
+
 /**
  * Utility class to locate prompt files.
  */
@@ -104,7 +108,12 @@ export class PromptFilesLocator extends Disposable {
 	}
 
 	public getAgentSourceFolder(): readonly URI[] {
+		// --- Start Positron ---
+		/*
 		return this.toAbsoluteLocations([AGENTS_SOURCE_FOLDER]);
+		*/
+		return this.toAbsoluteLocations([AGENTS_SOURCE_FOLDER, AGENTS_POSITRON_SOURCE_FOLDER]);
+		// --- End Positron ---
 	}
 
 	/**
@@ -189,6 +198,9 @@ export class PromptFilesLocator extends Disposable {
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
 		if (type === PromptsType.agent) {
 			configuredLocations.push(AGENTS_SOURCE_FOLDER);
+			// --- Start Positron ---
+			configuredLocations.push(AGENTS_POSITRON_SOURCE_FOLDER);
+			// --- End Positron ---
 		}
 		const absoluteLocations = this.toAbsoluteLocations(configuredLocations);
 		return absoluteLocations.map(firstNonGlobParentAndPattern);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -25,6 +25,7 @@ import { Disposable, DisposableStore } from '../../../../../../base/common/lifec
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 
 // --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
 import { AGENTS_POSITRON_SOURCE_FOLDER } from '../config/promptFileLocations.js';
 // --- End Positron ---
 


### PR DESCRIPTION
Adds `./.vscode/positron/agents` as a custom Positron directory for chat agents.

Addresses https://github.com/posit-dev/positron/issues/10889.

### QA Notes

With this change the following should be true:

1. The new directory is offered when creating a new chat agent:

<img width="438" height="357" alt="Screenshot 2025-12-08 at 09 29 03" src="https://github.com/user-attachments/assets/d486b588-10b4-4391-93e6-a12ee56151e7" />
<img width="736" height="153" alt="Screenshot 2025-12-08 at 09 29 15" src="https://github.com/user-attachments/assets/3c857fee-dab7-4fc8-a624-fb771c1d9a3c" />

2. Chat agents in `./.vscode/positron/agents` are shown in the selector:

<img width="406" height="359" alt="Screenshot 2025-12-08 at 09 30 23" src="https://github.com/user-attachments/assets/0cdc84cc-c8da-4fb8-b20c-5b9e061c4f30" />

3. Agent instructions are applied as expected:
<img width="1737" height="1108" alt="Screenshot 2025-12-08 at 09 30 37" src="https://github.com/user-attachments/assets/62d0b32d-5d28-4b71-b620-a1cfcc5a09b5" />


