### PR TITLE
Positron nb cell tab navigation

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
@@ -12,6 +12,7 @@
 	color: inherit;
 }
 
-.positron-add-cell-buttons:hover {
+.positron-add-cell-buttons:hover,
+.positron-add-cell-buttons:focus-within {
 	opacity: 1;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -138,6 +138,13 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	readonly selectionStateMachine: SelectionStateMachine;
 
 	/**
+	 * Find the cell that currently has DOM focus within the notebook container.
+	 * Useful for keyboard navigation where Tab moves focus but doesn't change selection.
+	 * @returns The focused cell, or null if no cell has focus
+	 */
+	getFocusedCell(): IPositronNotebookCell | null;
+
+	/**
 	 * Indicates whether this notebook instance has been disposed.
 	 * Used to prevent operations on destroyed instances.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -189,6 +189,12 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	get container(): HTMLElement | undefined;
 
 	/**
+	 * Get the notebook container that this cell belongs to.
+	 * @returns The notebook container element, or undefined if not available
+	 */
+	getNotebookContainer(): HTMLElement | undefined;
+
+	/**
 	 * Check if this cell is currently visible in the viewport.
 	 * A cell is considered visible if at least {@link MIN_CELL_VISIBILITY_RATIO} of it is within the viewport.
 	 * @returns true if the cell is visible, false otherwise

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -189,12 +189,6 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	get container(): HTMLElement | undefined;
 
 	/**
-	 * Get the notebook container that this cell belongs to.
-	 * @returns The notebook container element, or undefined if not available
-	 */
-	getNotebookContainer(): HTMLElement | undefined;
-
-	/**
 	 * Check if this cell is currently visible in the viewport.
 	 * A cell is considered visible if at least {@link MIN_CELL_VISIBILITY_RATIO} of it is within the viewport.
 	 * @returns true if the cell is visible, false otherwise

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -78,6 +78,13 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly editor: ICodeEditor | undefined;
 
 	/**
+	 * Current cell outputs as an observable.
+	 * Returns undefined for markdown cells (which have no outputs).
+	 * Code cells override this to return their outputs observable.
+	 */
+	readonly outputs: IObservable<NotebookCellOutputs[]> | undefined;
+
+	/**
 	 * Delete this cell
 	 */
 	delete(): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -175,19 +175,6 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this._container;
 	}
 
-	getNotebookContainer(): HTMLElement | undefined {
-		return this._instance.container;
-	}
-
-	/**
-	 * Check if this cell's container contains the given element.
-	 * @param element The element to check
-	 * @returns true if the element is contained within this cell's container, false otherwise
-	 */
-	containsElement(element: Element): boolean {
-		return this._container?.contains(element) ?? false;
-	}
-
 	attachEditor(editor: CodeEditorWidget): void {
 		this._editor.set(editor, undefined);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -175,6 +175,19 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this._container;
 	}
 
+	getNotebookContainer(): HTMLElement | undefined {
+		return this._instance.container;
+	}
+
+	/**
+	 * Check if this cell's container contains the given element.
+	 * @param element The element to check
+	 * @returns true if the element is contained within this cell's container, false otherwise
+	 */
+	containsElement(element: Element): boolean {
+		return this._container?.contains(element) ?? false;
+	}
+
 	attachEditor(editor: CodeEditorWidget): void {
 		this._editor.set(editor, undefined);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -11,11 +11,11 @@ import { ITextModel } from '../../../../../editor/common/model.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
-import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, CellSelectionStatus, ExecutionStatus } from './IPositronNotebookCell.js';
+import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
-import { derived, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { derived, IObservable, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
 
 /**
  * Minimum visibility ratio required for a cell to be considered visible in the viewport.
@@ -96,6 +96,14 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 
 	get outputsViewModels(): IContextKeysCellOutputViewModel[] {
 		return [];
+	}
+
+	/**
+	 * Current cell outputs as an observable.
+	 * Base implementation returns undefined; code cells override this.
+	 */
+	get outputs(): IObservable<NotebookCellOutputs[]> | undefined {
+		return undefined;
 	}
 
 	get index(): number {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -19,7 +19,7 @@ import { IPositronCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
 export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implements IPositronNotebookCodeCell {
 	override kind: CellKind.Code = CellKind.Code;
-	outputs;
+	private readonly _outputs;
 
 	// Execution timing observables
 	lastExecutionDuration;
@@ -36,7 +36,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	) {
 		super(cellModel, instance, _executionStateService, _textModelResolverService);
 
-		this.outputs = observableFromEvent(this, this.model.onDidChangeOutputs, () => {
+		this._outputs = observableFromEvent(this, this.model.onDidChangeOutputs, () => {
 			/** @description cellOutputs */
 			return this.parseCellOutputs();
 		});
@@ -55,7 +55,11 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	}
 
 	override get outputsViewModels(): IPositronCellOutputViewModel[] {
-		return this.outputs.get();
+		return this._outputs.get();
+	}
+
+	override get outputs() {
+		return this._outputs;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -213,6 +213,21 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		return this._container;
 	}
 
+	getFocusedCell(): IPositronNotebookCell | null {
+		const container = this.container;
+		if (!container) {
+			return null;
+		}
+
+		const activeElement = container.ownerDocument.activeElement;
+		if (!activeElement || !container.contains(activeElement)) {
+			return null;
+		}
+
+		// Find which cell contains the focused element
+		return this.cells.get().find(cell => cell.container?.contains(activeElement)) ?? null;
+	}
+
 	/**
 	 * Event emitter for when the text model changes.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -25,12 +25,14 @@
 }
 
 /* Show focus outline with default VS Code focus color */
+.positron-cell-editor-monaco-widget:focus,
 .positron-cell-editor-monaco-widget:focus-within {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
 /* When the parent cell has an error, highlight the editor with error color */
+.positron-notebook-cell[data-has-error="true"] .positron-cell-editor-monaco-widget:focus,
 .positron-notebook-cell[data-has-error="true"] .positron-cell-editor-monaco-widget:focus-within {
 	outline-color: var(--vscode-positronNotebook-error-color);
 }
@@ -38,4 +40,26 @@
 /* Ensure the editor container has minimum height for empty cells */
 .positron-monaco-editor-container {
 	min-height: 1rem;
+}
+
+/* Focus target element - hidden by default, visible when focused */
+.positron-cell-editor-focus-target {
+	height: 0;
+	width: 100%;
+	overflow: hidden;
+}
+
+.positron-cell-editor-focus-target:focus {
+	height: auto;
+	padding: 4px 8px;
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+	background: var(--vscode-editor-background);
+}
+
+/* Show hint text when focused */
+.positron-cell-editor-focus-target:focus::after {
+	content: 'Press Enter to edit';
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -46,11 +46,29 @@
 .positron-cell-editor-focus-target {
 	position: absolute;
 	inset: 0;
-	z-index: 1;
+	z-index: 2;
 	pointer-events: none;
+	border-radius: var(--vscode-positronNotebook-cell-radius);
 }
 
 .positron-cell-editor-focus-target:focus {
 	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: -1px;
+	outline-offset: 1px;
+}
+
+/* Remove bottom-left radius when there are outputs below */
+.positron-notebook-cell.selected .positron-cell-editor-focus-target,
+.positron-notebook-cell.editing .positron-cell-editor-focus-target,
+.positron-notebook-cell:not(.selected):not(.editing):hover .positron-cell-editor-focus-target {
+	border-bottom-left-radius: 0;
+}
+
+/* Restore bottom-left radius when no outputs */
+.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs.no-outputs) .positron-cell-editor-focus-target,
+.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs.no-outputs) .positron-cell-editor-focus-target,
+.positron-notebook-cell:not(.selected):not(.editing):hover:has(.positron-notebook-cell-outputs.no-outputs) .positron-cell-editor-focus-target,
+.positron-notebook-cell.selected:not(:has(.positron-notebook-cell-outputs)) .positron-cell-editor-focus-target,
+.positron-notebook-cell.editing:not(:has(.positron-notebook-cell-outputs)) .positron-cell-editor-focus-target,
+.positron-notebook-cell:not(.selected):not(.editing):hover:not(:has(.positron-notebook-cell-outputs)) .positron-cell-editor-focus-target {
+	border-bottom-left-radius: var(--vscode-positronNotebook-cell-radius);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.css
@@ -42,24 +42,15 @@
 	min-height: 1rem;
 }
 
-/* Focus target element - hidden by default, visible when focused */
+/* Focus target element - overlays the editor, visible only when focused */
 .positron-cell-editor-focus-target {
-	height: 0;
-	width: 100%;
-	overflow: hidden;
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	pointer-events: none;
 }
 
 .positron-cell-editor-focus-target:focus {
-	height: auto;
-	padding: 4px 8px;
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
-	background: var(--vscode-editor-background);
-}
-
-/* Show hint text when focused */
-.positron-cell-editor-focus-target:focus::after {
-	content: 'Press Enter to edit';
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -9,6 +9,9 @@ import './CellEditorMonacoWidget.css';
 // React.
 import React from 'react';
 
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+
 import { EditorExtensionsRegistry, IEditorContributionDescription } from '../../../../../editor/browser/editorExtensions.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 
@@ -35,10 +38,35 @@ import { CTX_INLINE_CHAT_FOCUSED } from '../../../../contrib/inlineChat/common/i
  */
 export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGeneral }) {
 	const { editorPartRef } = useCellEditorWidget(cell);
-	return <div
-		ref={editorPartRef}
-		className='positron-cell-editor-monaco-widget'
-	/>;
+
+	/**
+	 * Handler for keyboard events on the focus target.
+	 * When Enter is pressed, focuses the Monaco editor to enter edit mode.
+	 *
+	 * @param e Keyboard event from the focus target element
+	 */
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			// Focus the Monaco editor to enter edit mode
+			cell.editor?.focus();
+		}
+	};
+
+	return <>
+		<div
+			className='positron-cell-editor-focus-target'
+			tabIndex={0}
+			role='button'
+			aria-label={localize('editCell', 'Edit cell - Press Enter to edit')}
+			onKeyDown={handleKeyDown}
+		/>
+		<div
+			ref={editorPartRef}
+			className='positron-cell-editor-monaco-widget'
+			tabIndex={-1}
+		/>
+	</>;
 }
 
 /**
@@ -93,6 +121,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 		const editor = disposables.add(editorInstaService.createInstance(CodeEditorWidget, editorPartRef.current, {
 			...editorOptions.getDefaultValue(),
+			tabIndex: -1, // Remove editor from tab order - use Enter to focus
 			dimension: {
 				width: 0,
 				height: 0,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -55,16 +55,16 @@ export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGen
 
 	return <>
 		<div
-			className='positron-cell-editor-focus-target'
-			tabIndex={0}
-			role='button'
-			aria-label={localize('editCell', 'Edit cell - Press Enter to edit')}
-			onKeyDown={handleKeyDown}
-		/>
-		<div
 			ref={editorPartRef}
 			className='positron-cell-editor-monaco-widget'
 			tabIndex={-1}
+		/>
+		<div
+			aria-label={localize('editCell', 'Edit cell - Press Enter to edit')}
+			className='positron-cell-editor-focus-target'
+			role='button'
+			tabIndex={0}
+			onKeyDown={handleKeyDown}
 		/>
 	</>;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -272,10 +272,17 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 				lastValue.active === cell &&
 				newValue.type === SelectionState.SingleSelection &&
 				newValue.active === cell) {
-				// Return focus to the focus trap so user can continue tabbing
-				// For markdown cells, this component unmounts so the focus is lost anyway
-				// and NotebookCellWrapper will focus the container instead
-				focusTargetRef.current?.focus();
+				// Only focus the focus trap if the cell has outputs.
+				// When there are no outputs, the focus trap has tabIndex=-1 (not in tab order),
+				// so focusing it would disrupt keyboard navigation. In that case, let
+				// NotebookCellWrapper handle focus by focusing the cell container instead.
+				const hasOutputs = cell.outputsViewModels.length > 0;
+				if (hasOutputs) {
+					focusTargetRef.current?.focus();
+				} else {
+					// Focus the cell container for cells without outputs
+					cell.container?.focus();
+				}
 			}
 		});
 		return () => disposable.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -40,6 +40,13 @@ export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGen
 	const { editorPartRef, focusTargetRef } = useCellEditorWidget(cell);
 
 	/**
+	 * Skip focus trap when cell has no outputs (avoids double-tab with same visual).
+	 * When there are no outputs, the focus trap and cell container share the same visual
+	 * styling, requiring users to tab twice to see any change.
+	 */
+	const hasOutputs = cell.outputsViewModels.length > 0;
+
+	/**
 	 * Handler for keyboard events on the focus target.
 	 * When Enter is pressed, focuses the Monaco editor to enter edit mode.
 	 *
@@ -64,7 +71,8 @@ export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGen
 			aria-label={localize('editCell', 'Edit cell - Press Enter to edit')}
 			className='positron-cell-editor-focus-target'
 			role='button'
-			tabIndex={0}
+			// Skip focus trap when no outputs - see hasOutputs comment above for details
+			tabIndex={hasOutputs ? 0 : -1}
 			onKeyDown={handleKeyDown}
 		/>
 	</>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -38,6 +38,27 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
+	visibility: hidden;
+}
+
+/* Show when selected, running, or explicitly visible */
+.left-hand-action-container-top.visible {
+	visibility: visible;
+}
+
+/* Show on hover (matches existing behavior) */
+.left-hand-action-container:hover .left-hand-action-container-top {
+	visibility: visible;
+}
+
+/* Show when cell or its children are focused via tab */
+.positron-notebook-cell:focus-within .left-hand-action-container-top {
+	visibility: visible;
+}
+
+/* Always show execution status animation when running */
+.left-hand-action-container[data-execution-status='running'] .left-hand-action-container-top {
+	visibility: visible;
 }
 
 /* Positions element to the bottom of the cell */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -48,7 +48,6 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 	const leftMenu = useMenu(MenuId.PositronNotebookCellActionLeft, contextKeyService);
 	const leftActions = useMenuActions(leftMenu);
 	const [showPopup, setShowPopup] = useState(false);
-	const [isHovered, setIsHovered] = useState(false);
 
 	// Observed values for status display and popup
 	const selectionStatus = useObservedValue(cell.selectionStatus);
@@ -68,7 +67,6 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 
 	// Icon hover handlers for popup
 	const handleMouseEnter = useCallback(() => {
-		setIsHovered(true);
 		if (!showPopup && containerRef.current) {
 			const targetWindow = DOM.getWindow(containerRef.current);
 			const timeoutId = targetWindow.setTimeout(() => {
@@ -80,7 +78,6 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 	}, [showPopup]);
 
 	const handleMouseLeave = useCallback(() => {
-		setIsHovered(false);
 		// Clear the hover timeout if we leave before the popup shows
 		if (hoverTimeoutIdRef.current !== null && containerRef.current) {
 			const targetWindow = DOM.getWindow(containerRef.current);
@@ -93,10 +90,8 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 
 	const dataExecutionStatus = executionStatus || 'idle';
 
-	// Determine if we should show the cell execution button
-	const showActionMenu = (isSelected || isHovered) && primaryLeftAction;
-	// Determine if we should show the execution status indicator (spinner)
-	const showExecutionStatus = showActionMenu || isRunning;
+	// Determine visibility class - show when selected or running (CSS handles hover/focus)
+	const shouldShowTopContainer = isSelected || isRunning;
 
 	return (
 		<>
@@ -107,9 +102,9 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
-				{showExecutionStatus && (
+				{(primaryLeftAction || isRunning) && (
 					<div
-						className='left-hand-action-container-top'
+						className={`left-hand-action-container-top ${shouldShowTopContainer ? 'visible' : ''}`}
 					>
 						<div
 							aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
@@ -117,7 +112,7 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 							className='cell-execution-status-animation'
 							role='status'
 						/>
-						{showActionMenu && (
+						{primaryLeftAction && (
 							<div className={`action-button-wrapper ${isRunning ? 'running' : ''}`}>
 								<CellActionButton action={primaryLeftAction} cell={cell} />
 							</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.css
@@ -75,3 +75,14 @@
 	pointer-events: none;
 }
 
+/* Focus styles for keyboard accessibility */
+.notebook-cell-quick-fix .assistant-action-main:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.notebook-cell-quick-fix .assistant-action-dropdown:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -11,6 +11,13 @@
 	--_positron-notebook-selection-bar-inset: 0;
 }
 
+/* We need to overpower the upstream .monaco-workbench [tabindex="0"]:focus selector here */
+.monaco-workbench div.positron-notebook-cell.positron-notebook-code-cell[tabindex="0"]:focus {
+	/* When the cell is selected via tab navigation we need to move the focus
+	ring out so it's not covered up by the selection bar */
+	outline-offset: 0px;
+}
+
 /* Base styles for selected and editing states */
 .positron-notebook-cell.selected,
 .positron-notebook-cell.editing {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -73,6 +73,13 @@ export function NotebookCellWrapper({ cell, children, hasError }: {
 	const cellType = cell.kind === CellKind.Code ? 'Code' : 'Markdown';
 	const isSelected = selectionStatus === CellSelectionStatus.Selected || selectionStatus === CellSelectionStatus.Editing;
 
+	/**
+	 * Check if the cell has outputs to determine aria-label.
+	 * When there are no outputs, the focus trap is skipped, so we need to include
+	 * the "Press Enter to edit" instruction in the cell container's aria-label.
+	 */
+	const hasOutputs = cell.outputsViewModels.length > 0;
+
 	// State for ARIA announcements
 	const [announcement, setAnnouncement] = React.useState<string>('');
 
@@ -110,7 +117,9 @@ export function NotebookCellWrapper({ cell, children, hasError }: {
 
 	return <div
 		ref={cellRef}
-		aria-label={localize('notebookCell', '{0} cell', cellType)}
+		aria-label={hasOutputs
+			? localize('notebookCell', '{0} cell', cellType)
+			: localize('notebookCellEditable', '{0} cell - Press Enter to edit', cellType)}
 		aria-selected={isSelected}
 		className={`positron-notebook-cell positron-notebook-${cell.kind === CellKind.Code ? 'code' : 'markdown'}-cell ${selectionStatus}`}
 		data-has-error={hasError}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -431,7 +431,8 @@ registerAction2(class extends NotebookAction2 {
 	}
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
-		notebook.selectionStateMachine.enterEditor().catch(err => {
+		const focusedCell = notebook.getFocusedCell();
+		notebook.selectionStateMachine.enterEditor(focusedCell ?? undefined).catch(err => {
 			console.error('Error entering editor:', err);
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { autorunDelta, IObservable, observableValueOpts } from '../../../../base/common/observable.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { PositronNotebookCellGeneral } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
@@ -341,8 +342,10 @@ export class SelectionStateMachine extends Disposable {
 	 * This method intelligently handles focus:
 	 * - If the editor already has focus (e.g., from a focus event), it only updates state
 	 * - If the editor doesn't have focus (e.g., from a keyboard shortcut), it gives focus
+	 * - When no cell is provided, checks which cell has DOM focus (from Tab navigation)
+	 *   and enters edit mode for that cell instead of the selected cell
 	 *
-	 * @param cell The cell to edit. If omitted, uses currently selected cell.
+	 * @param cell The cell to edit. If omitted, checks for focused cell or uses currently selected cell.
 	 */
 	async enterEditor(cell?: IPositronNotebookCell): Promise<void> {
 		// Determine which cell to edit
@@ -352,12 +355,41 @@ export class SelectionStateMachine extends Disposable {
 			// Use the provided cell
 			cellToEdit = cell;
 		} else {
-			// Use the active cell (works in both single and multi-selection)
+			// No cell provided - check if there's a focused cell within the notebook
 			const state = this._state.get();
 			if (state.type === SelectionState.NoCells) {
 				return;
 			}
-			cellToEdit = state.active;
+
+			// Get the notebook container from a cell to check focus
+			const cells = this._cells.get();
+			if (cells.length === 0) {
+				return;
+			}
+
+			// Get the notebook container from the first cell
+			const notebookContainer = cells[0].getNotebookContainer();
+
+			// Try to find the cell that has DOM focus
+			if (notebookContainer) {
+				const activeElement = notebookContainer.ownerDocument.activeElement;
+				if (activeElement && notebookContainer.contains(activeElement)) {
+					// Find which cell contains the focused element
+					const focusedCell = cells.find(c => {
+						const cellInstance = c as PositronNotebookCellGeneral;
+						return cellInstance.containsElement(activeElement);
+					});
+
+					if (focusedCell) {
+						cellToEdit = focusedCell;
+					}
+				}
+			}
+
+			// Fall back to the active cell if no focused cell was found
+			if (!cellToEdit) {
+				cellToEdit = state.active;
+			}
 		}
 
 		// Update state to editing mode

--- a/src/vs/workbench/contrib/positronNotebook/browser/useObservedValue.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useObservedValue.tsx
@@ -14,13 +14,28 @@ import { IObservable, runOnChange } from '../../../../base/common/observable.js'
  * @param observable Observable value with value to be extracted
  * @returns The current value of the observable.
  */
-export function useObservedValue<T>(observable: IObservable<T>): T {
-	const [value, setValue] = React.useState(observable.get());
+export function useObservedValue<T>(observable: IObservable<T>): T;
+/**
+ * Automatically updates the component when the observable changes.
+ * When observable is undefined, returns the defaultValue without subscribing.
+ * @param observable Observable value with value to be extracted, or undefined
+ * @param defaultValue Value to return when observable is undefined
+ * @returns The current value of the observable, or defaultValue if observable is undefined.
+ */
+export function useObservedValue<T>(observable: IObservable<T> | undefined, defaultValue: T): T;
+export function useObservedValue<T>(observable: IObservable<T> | undefined, defaultValue?: T): T {
+	const [value, setValue] = React.useState(observable?.get() ?? defaultValue as T);
 
 	React.useEffect(() => {
+		if (!observable) {
+			setValue(defaultValue as T);
+			return;
+		}
+		// Sync state in case observable changed
+		setValue(observable.get());
 		const disposable = runOnChange(observable, setValue);
 		return () => disposable.dispose();
-	}, [observable]);
+	}, [observable, defaultValue]);
 
 	return value;
 }


### PR DESCRIPTION
Addresses #10975.

### Summary

This PR fixes keyboard navigation in Positron notebooks to properly support tab key navigation. Previously, users would get stuck in a focus trap within Monaco editors when trying to navigate with <kbd>Tab</kbd>, making it impossible to navigate between cells using the tab key.

Philosophically I think of tab navigation like mouse hovering. This is why the notebook doesn't 'select' a cell when you tab into it from another cell. If you are tabbed into a cell and press enter, however, you will enter the edit mode for the focused cell. This just felt natural to me but I'm open to feedback. 

https://github.com/user-attachments/assets/515011ba-45cb-48d7-80f0-e413dd6ecbd0

The fix introduces a focus target overlay system that:
- Allows tab navigation to move through notebook cells without getting trapped in the editor
- Makes cell outputs and interactive elements (like fix/explain buttons) keyboard-accessible
- Maintains proper visual feedback with focus outlines
- Preserves <kbd>Enter</kbd> key functionality to enter editing mode

One key design decision that has been made that feedback is welcome on is that when we have a cell with no outputs, we skip this focus trap behavior in favor of just jumping over the editor cell. This is because otherwise there would be two focus states that look identical to the user (cell-wide, and editor). This way there's just a single tab needed to navigate through. Since the enter-key can be used to go into the editor from either position, there is no loss of functionality. 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:notebooks @:accessibility

Test tab navigation through notebook cells:

1. Open a multi-cell notebook
2. Set focus inside the editor (a click works easily)
3. Tab around the notebook and make sure that you dont get stuck anywhere and can keep getting all the way thought the notebook.
