### PR TITLE
e2e: log shortcuts in trace

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -11,9 +11,5 @@
   "positron.assistant.enabledProviders": [
     "openai-api"
   ],
-  "posit.workbench.showWorkbenchFlaskHint": false,
-  "extensions.allowed": {
-    "meta.pyrefly": false,
-    "*": true
-  }
+  "posit.workbench.showWorkbenchFlaskHint": false
 }

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -11,5 +11,9 @@
   "positron.assistant.enabledProviders": [
     "openai-api"
   ],
-  "posit.workbench.showWorkbenchFlaskHint": false
+  "posit.workbench.showWorkbenchFlaskHint": false,
+  "extensions.allowed": {
+    "meta.pyrefly": false,
+    "*": true
+  }
 }

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -316,8 +316,14 @@ export class HotKeys {
 			});
 
 			// Hacky solution to get shortcut to show up as an action in the trace
-			await this.code.driver.page.evaluate(msg => {
-			}, `Shortcut: ${description}`);
+			if (!this.code.driver.page.isClosed()) {
+				try {
+					await this.code.driver.page.evaluate(msg => {
+					}, `Shortcut: ${description}`);
+				} catch (e) {
+					// Ignore - context may not be ready after navigation
+				}
+			}
 
 			for (const key of keySequences) {
 				await this.code.driver.page.keyboard.press(key);

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -315,6 +315,10 @@ export class HotKeys {
 					.replace(/option/gi, process.platform !== 'darwin' ? 'Alt' : 'Option');
 			});
 
+			// Hacky solution to get shortcut to show up as an action in the trace
+			await this.code.driver.page.evaluate(msg => {
+			}, `Shortcut: ${description}`);
+
 			for (const key of keySequences) {
 				await this.code.driver.page.keyboard.press(key);
 			}


### PR DESCRIPTION
### Summary
Added a little workaround so we can see the shortcut commands in the trace (yes, it's hacky).
Note: html report view does show the shortcut description, this is just for the low level snapshot view.

### QA Notes

n/a
