### PR TITLE
Include build number in Positron version string for better version tracking (i.e. for dailies)

### DIFF
--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -27,7 +27,7 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 		super();
 
 		const storageFilePath = join(this.environmentService.extensionsPath, '.version');
-		const currentVersion = this.productService.positronVersion;
+		const currentVersion = `${this.productService.positronVersion}-${this.productService.positronBuildNumber}`;
 
 		const lastKnownVersion = existsSync(storageFilePath) ? readFileSync(storageFilePath, 'utf8').trim() : '';
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10688

In this PR, I updated the version string to include both the version and build number so that folks on daily builds can also get those bootstrap installed extensions working correctly.

I think the best way to check that this is working correctly is to simulate a build number change by manually editing `~/.positron-dev/extensions/.version` to have a different build number.

@:extensions

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed how bootstrap installed extensions check Positron's version so that the dailies get correct extensions installed.


### QA Notes

You can also simulate a build number change by manually editing the `.version` file for your _release_ build, i.e. at `~/.positron/extensions/.version`, or alternatively, you could carefully notice when you get a daily build update and see that the bootstrap extensions get installed afresh. 

You can see when this happens in the "Shared" output channel, with a message like:

> [info] [Shared] First launch after first install, upgrade, or downgrade. Installing bootstrapped extensions