### PR TITLE
Center checkmark in modals

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox.css
@@ -31,7 +31,7 @@
 	outline: 1px solid var(--vscode-focusBorder);
 }
 
-.positron-modal-dialog-box .checkbox-button .check-indicator {
+.positron-modal-dialog-box .checkbox-button .codicon[class*="codicon-"] {
 	font-size: 12px;
 	font-weight: bold;
 	color: var(--vscode-positronModalDialog-checkboxForeground);


### PR DESCRIPTION
Relates #8073 

The checkmark was rendered too-large at 16px because of a global style. We reuse the same selector and combined with the parent `positron-modal-dialog-box` class, our custom component's style will win.

<img width="733" height="531" alt="Screenshot 2025-12-09 at 10 21 20 AM" src="https://github.com/user-attachments/assets/4db47025-422e-4a18-8e6d-957b3a4b751c" />
<img width="735" height="549" alt="Screenshot 2025-12-09 at 10 21 28 AM" src="https://github.com/user-attachments/assets/520aad34-5d94-419a-8340-2503c4c93137" />
<img width="508" height="303" alt="Screenshot 2025-12-09 at 10 21 07 AM" src="https://github.com/user-attachments/assets/e5397287-3204-4834-9a8e-4ab781bd87e0" />
<img width="414" height="313" alt="Screenshot 2025-12-09 at 10 30 07 AM" src="https://github.com/user-attachments/assets/739fcda6-2959-4ae7-8cc5-55db24e0518f" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Center checkmarks in the modal dialogs (e.g. the New Folder from Template Wizard)

### QA Notes

@:modal @:new-folder-flow

* Reproduce through New -> New Folder from Template or New Folder from Git
* The checkmark when saving a plot only applies to interactive plots, e.g. when using the `ggplot-example` in the `qa-example-content` but also it must have intrinsic size, which I am not sure how to setup so I just hardcoded to make it appear.