### PR TITLE
Positron notebooks - Reduce info popup trigger area to only execution count

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellExecutionInfoPopup.tsx
@@ -115,9 +115,12 @@ export function CellExecutionInfoPopup({
 	const completedMoreThanAnHourAgo =
 		lastRunEndTime !== undefined && isMoreThanOneHourAgo(lastRunEndTime);
 
-	// Check if cell has never been run
+	// Check if cell has never been run (no execution order and no current session data)
 	const hasNeverBeenRun =
 		!hasExecutionOrder && !hasExecutionResult && !isCurrentlyRunning;
+
+	// Check if we have any current session content to display
+	const hasCurrentSessionContent = hasExecutionResult || isCurrentlyRunning || hasTimingInfo;
 
 	// If cell has never been run, show a simple message
 	if (hasNeverBeenRun) {
@@ -136,10 +139,26 @@ export function CellExecutionInfoPopup({
 		);
 	}
 
-	// Check if we have any content to display
-	// If we only have execution order but no other metadata, don't show the popup
-	const hasAnyContent = hasExecutionResult || isCurrentlyRunning || hasTimingInfo;
-	if (!hasAnyContent) {
+	// If we have an execution order but no current session data, show a message
+	// indicating the cell was run in a previous session
+	if (hasExecutionOrder && !hasCurrentSessionContent) {
+		return (
+			<div
+				aria-label='Cell execution details'
+				className='cell-execution-info-popup'
+				role='tooltip'
+			>
+				<div className='popup-row'>
+					<span className='popup-label'>
+						{localize('cellExecution.notRunThisSession', 'Not run this session')}
+					</span>
+				</div>
+			</div>
+		);
+	}
+
+	// If we still have no content somehow, don't show the popup
+	if (!hasCurrentSessionContent) {
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.css
@@ -25,7 +25,6 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	z-index: 10;
 }
 
 /* Position element to the top of the cell */
@@ -159,17 +158,28 @@
 }
 
 /* Execution order badge styling */
-.execution-order-badge {
+span.execution-order-badge {
 	font-weight: 500;
 	font-size: var(--_badge-font-size, 10px);
 	line-height: 1;
 	color: inherit;
 	font-family: var(--monaco-monospace-font);
+	cursor: pointer;
 }
 
 /* Error state styling - use error color for execution badge */
 .execution-order-badge-container[data-has-error="true"] {
 	color: var(--vscode-errorForeground);
+}
+
+/* Wrapper for the execution status badge - provides consistent hover target */
+.execution-status-badge-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: var(--_container-size, 20px);
+	min-height: var(--_container-size, 20px);
+	cursor: default;
 }
 
 /* Animation for running state */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -7,14 +7,11 @@
 import './CellLeftActionMenu.css';
 
 // React.
-import React, { useRef, useState, useCallback } from 'react';
+import React from 'react';
 
 // Other dependencies.
-import * as DOM from '../../../../../base/browser/dom.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
-import { CellExecutionInfoPopup } from './CellExecutionInfoPopup.js';
-import { Popover } from '../../../../browser/positronComponents/popover/popover.js';
 import { CellSelectionStatus } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { ExecutionStatusBadge } from './ExecutionStatusBadge.js';
 import { useMenu } from '../useMenu.js';
@@ -28,26 +25,19 @@ interface CellLeftActionMenuProps {
 	hasError: boolean;
 }
 
-const POPUP_DELAY = 100;
-
 /**
  * Left-side action menu for notebook cells that dynamically displays either:
  * - Execution status badges ([1], [2], etc.) when idle
  * - Action buttons (play, stop, etc.) when selected or hovered
- * - Execution info popup on hover with timing details
+ * - Execution info popup on hover over the badge with timing details
  */
 export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) {
 	// Context
 	const contextKeyService = useCellScopedContextKeyService();
 
-	// Reference hooks.
-	const containerRef = useRef<HTMLDivElement>(null);
-	const hoverTimeoutIdRef = useRef<number | null>(null);
-
 	// State hooks.
 	const leftMenu = useMenu(MenuId.PositronNotebookCellActionLeft, contextKeyService);
 	const leftActions = useMenuActions(leftMenu);
-	const [showPopup, setShowPopup] = useState(false);
 
 	// Observed values for status display and popup
 	const selectionStatus = useObservedValue(cell.selectionStatus);
@@ -65,86 +55,48 @@ export function CellLeftActionMenu({ cell, hasError }: CellLeftActionMenuProps) 
 	const showPending = executionOrder === undefined;
 	const isSelected = selectionStatus !== CellSelectionStatus.Unselected;
 
-	// Icon hover handlers for popup
-	const handleMouseEnter = useCallback(() => {
-		if (!showPopup && containerRef.current) {
-			const targetWindow = DOM.getWindow(containerRef.current);
-			const timeoutId = targetWindow.setTimeout(() => {
-				setShowPopup(true);
-			}, POPUP_DELAY);
-
-			hoverTimeoutIdRef.current = timeoutId;
-		}
-	}, [showPopup]);
-
-	const handleMouseLeave = useCallback(() => {
-		// Clear the hover timeout if we leave before the popup shows
-		if (hoverTimeoutIdRef.current !== null && containerRef.current) {
-			const targetWindow = DOM.getWindow(containerRef.current);
-			targetWindow.clearTimeout(hoverTimeoutIdRef.current);
-			hoverTimeoutIdRef.current = null;
-		}
-		// Note: The popup will handle its own auto-close behavior
-	}, []);
-
-
 	const dataExecutionStatus = executionStatus || 'idle';
 
-	// Determine visibility class - show when selected or running (CSS handles hover/focus)
-	const shouldShowTopContainer = isSelected || isRunning;
+	// Determine if we should show the cell execution button
+	const showActionMenu = isSelected && primaryLeftAction;
+	// Determine if we should show the execution status indicator (spinner)
+	const showExecutionStatus = showActionMenu || isRunning;
 
 	return (
-		<>
-			<div
-				ref={containerRef}
-				className='left-hand-action-container'
-				data-execution-status={dataExecutionStatus}
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
-			>
-				{(primaryLeftAction || isRunning) && (
-					<div
-						className={`left-hand-action-container-top ${shouldShowTopContainer ? 'visible' : ''}`}
-					>
-						<div
-							aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
-							aria-live={isRunning ? 'polite' : 'off'}
-							className='cell-execution-status-animation'
-							role='status'
-						/>
-						{primaryLeftAction && (
-							<div className={`action-button-wrapper ${isRunning ? 'running' : ''}`}>
-								<CellActionButton action={primaryLeftAction} cell={cell} />
-							</div>
-						)}
-					</div>
-				)}
+		<div
+			className='left-hand-action-container'
+			data-execution-status={dataExecutionStatus}
+		>
+			{showExecutionStatus && (
 				<div
-					className='left-hand-action-container-bottom'
+					className='left-hand-action-container-top'
 				>
-					<ExecutionStatusBadge
-						executionOrder={executionOrder}
-						hasError={hasError}
-						showPending={showPending}
+					<div
+						aria-label={isRunning ? 'Cell is executing' : 'Cell execution status indicator'}
+						aria-live={isRunning ? 'polite' : 'off'}
+						className='cell-execution-status-animation'
+						role='status'
 					/>
+					{showActionMenu && (
+						<div className={`action-button-wrapper ${isRunning ? 'running' : ''}`}>
+							<CellActionButton action={primaryLeftAction} cell={cell} />
+						</div>
+					)}
 				</div>
-			</div>
-			{showPopup && containerRef.current && (
-				<Popover
-					anchorElement={containerRef.current}
-					autoCloseDelay={POPUP_DELAY}
-					autoCloseOnMouseLeave={true}
-					onClose={() => setShowPopup(false)}
-				>
-					<CellExecutionInfoPopup
-						duration={duration}
-						executionOrder={executionOrder}
-						executionStatus={executionStatus}
-						lastRunEndTime={lastRunEndTime}
-						lastRunSuccess={lastRunSuccess}
-					/>
-				</Popover>
 			)}
-		</>
+			<div
+				className='left-hand-action-container-bottom'
+			>
+				<ExecutionStatusBadge
+					duration={duration}
+					executionOrder={executionOrder}
+					executionStatus={executionStatus}
+					hasError={hasError}
+					lastRunEndTime={lastRunEndTime}
+					lastRunSuccess={lastRunSuccess}
+					showPending={showPending}
+				/>
+			</div>
+		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/ExecutionStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/ExecutionStatusBadge.tsx
@@ -3,33 +3,121 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React from 'react';
+// React.
+import React, { useRef, useState, useCallback } from 'react';
+
+// Other dependencies.
+import * as DOM from '../../../../../base/browser/dom.js';
+import { CellExecutionInfoPopup } from './CellExecutionInfoPopup.js';
+import { Popover } from '../../../../browser/positronComponents/popover/popover.js';
 
 interface ExecutionStatusBadgeProps {
+	/** Execution order number to display (e.g., 1, 2, 3) */
 	executionOrder?: number;
+	/** Whether to show the pending state (-) */
 	showPending: boolean;
+	/** Whether the cell has an error */
 	hasError: boolean;
+	/** Duration of last execution in milliseconds */
+	duration?: number;
+	/** Timestamp of last run end time */
+	lastRunEndTime?: number;
+	/** Whether the last run was successful */
+	lastRunSuccess?: boolean;
+	/** Current execution status */
+	executionStatus?: string;
 }
+
+const POPUP_DELAY = 100;
 
 /**
  * Component that displays execution order badges like [1], [2], or [-] for pending cells.
- * Used when the cell is not selected/hovered and showing static execution status.
- * Only renders when the cell is in the 'idle' execution state.
+ * Includes a hover-triggered popover showing execution timing details.
+ * Always renders a wrapper element for consistent hover targeting, even when badge content is empty.
  */
-export function ExecutionStatusBadge({ executionOrder, showPending, hasError }: ExecutionStatusBadgeProps) {
-	if (showPending) {
-		return <span className='execution-order-badge'>-</span>;
-	}
+export function ExecutionStatusBadge({
+	executionOrder,
+	showPending,
+	hasError,
+	duration,
+	lastRunEndTime,
+	lastRunSuccess,
+	executionStatus
+}: ExecutionStatusBadgeProps) {
+	// Reference hooks.
+	const containerRef = useRef<HTMLDivElement>(null);
+	const hoverTimeoutIdRef = useRef<number | null>(null);
 
-	if (executionOrder !== undefined) {
-		return (
-			<div className='execution-order-badge-container' data-has-error={hasError}>
-				<span className='execution-order-badge-bracket'>[</span>
-				<span className='execution-order-badge'> {String(executionOrder)} </span>
-				<span className='execution-order-badge-bracket'>]</span>
+	// State hooks.
+	const [showPopup, setShowPopup] = useState(false);
+
+	// Hover handlers for popup
+	const handleMouseEnter = useCallback(() => {
+		if (!showPopup && containerRef.current) {
+			const targetWindow = DOM.getWindow(containerRef.current);
+			const timeoutId = targetWindow.setTimeout(() => {
+				setShowPopup(true);
+			}, POPUP_DELAY);
+
+			hoverTimeoutIdRef.current = timeoutId;
+		}
+	}, [showPopup]);
+
+	const handleMouseLeave = useCallback(() => {
+		// Clear the hover timeout if we leave before the popup shows
+		if (hoverTimeoutIdRef.current !== null && containerRef.current) {
+			const targetWindow = DOM.getWindow(containerRef.current);
+			targetWindow.clearTimeout(hoverTimeoutIdRef.current);
+			hoverTimeoutIdRef.current = null;
+		}
+		// Note: The popup will handle its own auto-close behavior
+	}, []);
+
+	// Render badge content based on state
+	const renderBadgeContent = () => {
+		if (showPending) {
+			return <span className='execution-order-badge'>-</span>;
+		}
+
+		if (executionOrder !== undefined) {
+			return (
+				<div className='execution-order-badge-container' data-has-error={hasError}>
+					<span className='execution-order-badge-bracket'>[</span>
+					<span className='execution-order-badge'> {String(executionOrder)} </span>
+					<span className='execution-order-badge-bracket'>]</span>
+				</div>
+			);
+		}
+
+		return null;
+	};
+
+	return (
+		<>
+			<div
+				ref={containerRef}
+				className='execution-status-badge-wrapper'
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				{renderBadgeContent()}
 			</div>
-		);
-	}
-
-	return null;
+			{showPopup && containerRef.current && (
+				<Popover
+					anchorElement={containerRef.current}
+					autoCloseDelay={POPUP_DELAY}
+					autoCloseOnMouseLeave={true}
+					onClose={() => setShowPopup(false)}
+				>
+					<CellExecutionInfoPopup
+						duration={duration}
+						executionOrder={executionOrder}
+						executionStatus={executionStatus}
+						lastRunEndTime={lastRunEndTime}
+						lastRunSuccess={lastRunSuccess}
+					/>
+				</Popover>
+			)}
+		</>
+	);
 }

--- a/test/e2e/tests/notebooks-positron/notebook-cell-execution-info.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-execution-info.test.ts
@@ -43,7 +43,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			await notebooksPositron.addCodeToCell(0, 'print("hello world")', { run: true });
 
 			await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
-			await notebooksPositron.expectToolTipToContain({
+			await notebooksPositron.expectToolTipToContain(0, {
 				duration: /\d+(ms|s)/,
 				status: 'Success'
 			}, 30000);
@@ -62,7 +62,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 				run: true,
 			});
 			await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
-			await notebooksPositron.expectToolTipToContain({
+			await notebooksPositron.expectToolTipToContain(1, {
 				duration: /\d+(ms|s)/,
 				status: 'Failed'
 			});
@@ -80,7 +80,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			await notebooksPositron.addCodeToCell(2, 'import time; time.sleep(3)', { run: true });
 			await notebooksPositron.expectSpinnerAtIndex(2);
 			await notebooksPositron.expectExecutionStatusToBe(2, 'running');
-			await notebooksPositron.expectToolTipToContain({
+			await notebooksPositron.expectToolTipToContain(2, {
 				status: 'Currently running...'
 			});
 
@@ -94,7 +94,7 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 		// ========================================
 		await test.step('Cell 3 - Relative time display', async () => {
 			await notebooksPositron.addCodeToCell(3, 'print("relative time test")', { run: true });
-			await notebooksPositron.expectToolTipToContain({
+			await notebooksPositron.expectToolTipToContain(3, {
 				completed: /Just now|seconds ago/,
 			});
 
@@ -111,8 +111,8 @@ test.describe('Positron Notebooks: Cell Execution Tooltip', {
 			await notebooksPositron.moveMouseAway();
 			await notebooksPositron.expectToolTipVisible(false);
 
-			// Test that hovering again after closing still works
-			await notebooksPositron.runCellButtonAtIndex(4).hover();
+			// Test that hovering over execution badge shows popup again
+			await notebooksPositron.hoverExecutionBadge(4);
 			await notebooksPositron.expectToolTipVisible(true);
 		});
 	});


### PR DESCRIPTION
Addresses #10940.

Fixes the cell execution info popup behavior in notebooks to only show when hovering directly on the execution count number. Previously, the popup would appear when hovering anywhere on the left side of the cell, which was distracting and got in the way during normal editing.

The implementation moves the hover trigger from the entire left action bar to specifically the execution status badge component, providing more precise control over when the execution details are displayed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open a notebook and execute a few cells to get execution count numbers
2. Hover over various parts of the left margin (cell margin gutter, run button area, etc.)
3. Verify the execution info popup does NOT appear
4. Hover directly on the execution count number (e.g., `[1]`, `[2]`, etc.)
5. Verify the execution info popup DOES appear showing execution time and timestamp
6. Move mouse away and verify popup disappears
