### PR TITLE
Prevent text overflow in dropdown entries

### DIFF
--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/dropdownEntry.css
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/dropdownEntry.css
@@ -16,6 +16,7 @@
 
 .dropdown-entry > .dropdown-entry-title {
 	grid-column: left / middle;
+	white-space: nowrap;
 }
 
 .dropdown-entry > .dropdown-entry-subtitle {
@@ -23,9 +24,14 @@
 	font-size: 0.9em;
 	opacity: 0.7;
 	margin-left: 0.6em;
+	margin-right: 0.6em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .dropdown-entry > .dropdown-entry-group {
 	grid-column: right / end;
 	opacity: 0.8;
+	white-space: nowrap;
 }

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/dropdownEntry.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/dropdownEntry.tsx
@@ -16,6 +16,7 @@ interface DropdownEntryProps {
 	codicon?: string;
 	title: string;
 	subtitle: string;
+	hoverText?: string;
 	group?: string;
 }
 
@@ -27,7 +28,7 @@ interface DropdownEntryProps {
 export const DropdownEntry = (props: DropdownEntryProps) => {
 	// Render.
 	return (
-		<div className='dropdown-entry'>
+		<div className='dropdown-entry' title={props.hoverText}>
 			{props.codicon ? <div className={`dropdown-entry-icon codicon ${props.codicon}`} /> : null}
 			<div className='dropdown-entry-title'>
 				{props.title}

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/interpreterEntry.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/interpreterEntry.tsx
@@ -28,7 +28,8 @@ export const InterpreterEntry = ({ interpreterInfo }: InterpreterEntryProps) => 
 		<DropdownEntry
 			codicon={interpreterInfo.preferred ? 'codicon-star-full' : undefined}
 			group={interpreterInfo.runtimeSource}
-			subtitle={`${interpreterInfo.runtimePath}`}
+			hoverText={interpreterInfo.runtimePath}
+			subtitle={interpreterInfo.runtimePath}
 			title={`${interpreterInfo.languageName} ${interpreterInfo.languageVersion}`}
 		/>
 	);


### PR DESCRIPTION
Relates #4076 

The dropdown entries were overflowing if too long.

* Overflow text using an ellipsis
* Add matching right margins
* Add title property to the subtitle for hover effect to see full path
* Do not allow the cells to wrap

Here are screenshots of a normal setup and a more exaggerated scenario

<img width="717" height="251" alt="Screenshot 2025-12-09 at 12 14 52 PM" src="https://github.com/user-attachments/assets/e70e4def-103d-404a-a296-d82f8ab30b6f" />
<img width="727" height="209" alt="Screenshot 2025-12-09 at 12 14 08 PM" src="https://github.com/user-attachments/assets/675bd3f7-0ab5-4d6b-8d8a-a0d824a808e2" />

The DropdownEntry is used in a couple other places, all that should behave the same way..

<img width="714" height="263" alt="Screenshot 2025-12-09 at 12 30 01 PM" src="https://github.com/user-attachments/assets/1f31a4ea-4a49-4db9-9fb7-b79c11c2585f" />
<img width="444" height="302" alt="Screenshot 2025-12-09 at 12 29 47 PM" src="https://github.com/user-attachments/assets/476e69dd-9253-4f95-a711-94c40947c9a5" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix text overflow of drop down entries with long text content


### QA Notes

There are two key areas that use this component:

* New Folder from Template -> Python
* Using data explorer, sort the columns, and there should be a "Convert to Code" button that appears, which will include a dropdown.

@:modal @:new-folder-flow
