### PR TITLE
Positron notebooks - Add new functionality to edit tool for moving cells.

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -845,7 +845,7 @@
       {
         "name": "editNotebookCells",
         "displayName": "Edit Notebook Cells",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), or operation='delete' to remove cells (requires cellIndex). Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndex), or operation='reorder' to reorganize cells. For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -860,9 +860,10 @@
               "enum": [
                 "add",
                 "update",
-                "delete"
+                "delete",
+                "reorder"
               ],
-              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell."
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions."
             },
             "cellType": {
               "type": "string",
@@ -887,6 +888,21 @@
             "run": {
               "type": "boolean",
               "description": "Whether to execute the cell after adding it. Defaults to true for code cells. Ignored for markdown cells."
+            },
+            "fromIndex": {
+              "type": "number",
+              "description": "Current index of the cell to move (0-based). Required when operation is 'reorder' and not using newOrder."
+            },
+            "toIndex": {
+              "type": "number",
+              "description": "Target index to move the cell to (0-based). Required when operation is 'reorder' and not using newOrder."
+            },
+            "newOrder": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Array specifying new cell order. newOrder[i] is the original index of the cell that should be at position i. Must be a valid permutation containing each index 0 to cellCount-1 exactly once. Use this for full notebook reordering. Alternative to fromIndex/toIndex for operation='reorder'."
             }
           },
           "required": [

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -71,6 +71,76 @@ export function validateCellIndices(
 }
 
 /**
+ * Validation result for permutation arrays
+ */
+export interface PermutationValidation {
+	valid: boolean;
+	error?: string;
+	isIdentity?: boolean;
+}
+
+/**
+ * Validates a permutation array for reordering cells.
+ * A valid permutation must contain each index from 0 to cellCount-1 exactly once.
+ *
+ * @param newOrder The proposed new order array
+ * @param cellCount The total number of cells in the notebook
+ * @returns Validation result with error message if invalid, and whether it's an identity permutation
+ */
+export function validatePermutation(
+	newOrder: number[],
+	cellCount: number
+): PermutationValidation {
+	// Check length matches
+	if (newOrder.length !== cellCount) {
+		return {
+			valid: false,
+			error: `Permutation length (${newOrder.length}) must match cell count (${cellCount})`
+		};
+	}
+
+	// Handle empty notebook case
+	if (cellCount === 0) {
+		return { valid: true, isIdentity: true };
+	}
+
+	// An identity permutation is just one where each index maps to itself. Aka a no-op.
+	let isIdentity = true;
+
+	// Check if any indices are outside of the valid range
+	for (const [i, index] of newOrder.entries()) {
+		if (!Number.isInteger(index) || index < 0 || index >= cellCount) {
+			return {
+				valid: false,
+				error: `Invalid index in permutation: ${index} (must be integer between 0 and ${cellCount - 1})`
+			};
+		}
+
+		// Check for identity at the same time
+		if (index !== i) {
+			isIdentity = false;
+		}
+	}
+
+	// If identity permutation, no need to check further
+	if (isIdentity) {
+		return { valid: true, isIdentity: true };
+	}
+
+	// Make sure there are no duplicates and all indices are present
+	const uniqueIndices = new Set(newOrder);
+
+	if (uniqueIndices.size !== cellCount) {
+		return {
+			valid: false,
+			error: 'Invalid permutation: must contain each index from 0 to cellCount-1 exactly once'
+		};
+	}
+
+	return { valid: true, isIdentity: false };
+}
+
+/**
  * Fetches and formats cell content for preview in confirmation dialogs.
  * Truncates long content with ellipsis.
  *

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2575,5 +2575,22 @@ declare module 'positron' {
 		 * @returns Array of output objects with MIME type and data
 		 */
 		export function getCellOutputs(notebookUri: string, cellIndex: number): Thenable<NotebookCellOutput[]>;
+
+		/**
+		 * Move a cell from one index to another in a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param fromIndex The current index of the cell to move
+		 * @param toIndex The target index where the cell should be moved to
+		 */
+		export function moveCell(notebookUri: string, fromIndex: number, toIndex: number): Thenable<void>;
+
+		/**
+		 * Reorder all cells in a notebook according to a new order
+		 * @param notebookUri URI of the notebook
+		 * @param newOrder Array representing the new order - newOrder[i] is the index of the cell
+		 *                 that should be at position i in the reordered notebook.
+		 *                 Must be a valid permutation containing each index from 0 to cellCount-1 exactly once.
+		 */
+		export function reorderCells(notebookUri: string, newOrder: number[]): Thenable<void>;
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -459,6 +459,14 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 			async getCellOutputs(notebookUri: string, cellIndex: number): Promise<positron.notebooks.NotebookCellOutput[]> {
 				return extHostNotebookFeatures.getCellOutputs(notebookUri, cellIndex);
+			},
+
+			async moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void> {
+				return extHostNotebookFeatures.moveCell(notebookUri, fromIndex, toIndex);
+			},
+
+			async reorderCells(notebookUri: string, newOrder: number[]): Promise<void> {
+				return extHostNotebookFeatures.reorderCells(notebookUri, newOrder);
 			}
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -242,6 +242,8 @@ export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$deleteCell(notebookUri: string, cellIndex: number): Promise<void>;
 	$updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void>;
 	$getCellOutputs(notebookUri: string, cellIndex: number): Promise<INotebookCellOutputDTO[]>;
+	$moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void>;
+	$reorderCells(notebookUri: string, newOrder: number[]): Promise<void>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -94,5 +94,25 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	async getCellOutputs(notebookUri: string, cellIndex: number): Promise<extHostProtocol.INotebookCellOutputDTO[]> {
 		return this._proxy.$getCellOutputs(notebookUri, cellIndex);
 	}
+
+	/**
+	 * Moves a cell from one index to another in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param fromIndex The current index of the cell to move.
+	 * @param toIndex The target index where the cell should be moved to.
+	 */
+	async moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void> {
+		return this._proxy.$moveCell(notebookUri, fromIndex, toIndex);
+	}
+
+	/**
+	 * Reorders all cells in a notebook according to a new order.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param newOrder Array representing the new order - newOrder[i] is the index of the cell
+	 *                 that should be at position i in the reordered notebook.
+	 */
+	async reorderCells(notebookUri: string, newOrder: number[]): Promise<void> {
+		return this._proxy.$reorderCells(notebookUri, newOrder);
+	}
 }
 


### PR DESCRIPTION
Addresses #10553.

### Summary

This PR adds notebook cell reordering capabilities to the Positron Assistant, enabling users to reorganize cells through natural language prompts like "move all imports to the top cell" or "move the third cell to the bottom."


https://github.com/user-attachments/assets/0e4835d6-1466-4ad4-8541-514bcdffd2d4


The implementation extends the `EditNotebookCellsTool` with a new `reorder` operation that supports both single cell moves (via `fromIndex`/`toIndex`) and full permutation reordering (via `newOrder` array). The feature includes validation for permutations and indices, confirmation prompts for the user, and integration with the notebook editor through the `positron.notebooks.reorderCells` API.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:assistant

1. Open a Jupyter notebook with multiple cells 
2. Open the Positron Assistant
3. Test single cell moves. E.g.  "Move the last cell to the top"
4. Test batch reordering. E.g. "Move all import statements to the top cell"