### PR TITLE
Positron notebooks - Fix overflow for wide output content

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -9,16 +9,26 @@
 	}
 
 	.positron-notebook-cell-outputs {
-		padding-inline: 1rem;
-		padding-block: 0.5rem;
-		& .notebook-error,
-		& .notebook-stderr {
-			color: var(--vscode-positronNotebook-error-color);
-		}
+		overflow: hidden;
 
 		&:empty {
 			/* Dont show empty outputs at all */
 			display: none;
+		}
+	}
+
+	.positron-notebook-code-cell-outputs-inner {
+		padding-inline: 1rem;
+		padding-block: 0.5rem;
+
+		/* Avoid overlap with border which is overlaid from another element so
+		the layout doesn't automatically avoid it*/
+		margin-inline: 1px;
+		overflow-x: auto;
+
+		& .notebook-error,
+		& .notebook-stderr {
+			color: var(--vscode-positronNotebook-error-color);
 		}
 
 		/*

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -10,11 +10,6 @@
 
 	.positron-notebook-cell-outputs {
 		overflow: hidden;
-
-		&:empty {
-			/* Dont show empty outputs at all */
-			display: none;
-		}
 	}
 
 	.positron-notebook-code-cell-outputs-inner {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -30,9 +30,11 @@ interface CellOutputsSectionProps {
 function CellOutputsSection({ outputs }: CellOutputsSectionProps) {
 	return (
 		<div className={`positron-notebook-code-cell-outputs positron-notebook-cell-outputs ${outputs.length > 0 ? 'has-outputs' : 'no-outputs'}`} data-testid='cell-output'>
-			{outputs?.map((output) => (
-				<CellOutput key={output.outputId} {...output} />
-			))}
+			<div className='positron-notebook-code-cell-outputs-inner'>
+				{outputs?.map((output) => (
+					<CellOutput key={output.outputId} {...output} />
+				))}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Addresses #10919.

This PR fixes the UX issues with wide outputs in notebooks. The changes ensure that:
1. Cell focus borders no longer overlap wide dataframes
2. Wide outputs only scroll horizontally within their container, preventing the entire notebook from scrolling horizontally
3. Outputs use proper overflow handling with horizontal scrolling

https://github.com/user-attachments/assets/fdb31a5e-18cb-4e0b-ad99-1698d174abdf


The fix adds a nested container structure where the outer container handles border positioning and prevents document-level overflow, while the inner container provides horizontal scrolling for wide content.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Create a new notebook
2. Run the following code to generate a wide dataframe:

```python
import pandas as pd
import numpy as np

# Create a wide dataframe with many columns
df = pd.DataFrame(np.random.randn(5, 30), 
                  columns=[f'column_{i}' for i in range(30)])
df
```

3. Verify the following behaviors:
   - The cell focus border should not overlap the dataframe content
   - The dataframe should have a horizontal scrollbar within the output area
   - Scrolling the dataframe horizontally should NOT scroll the entire notebook
   - The run button and left navigation should remain visible at all times
   - Empty outputs should not display any visual container
