### PR TITLE
Address superfluous 'error shutting down connection' errors in supervisor logs

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -181,7 +181,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.59"
+      "kallichore": "0.1.60"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
This change addresses an issue that causes the supervisor to log some scary-looking (but ultimately innocuous) errors about failing to shut down connections. 

The underlying issue is that the default HTTP agent uses HTTP keep alive, so the connection is not closed after a request is completed. This generates errors on the server end when we try to close the connections from that end and find that they were not gracefully ended by the client.

There are two fixes here, in the interest of defending this better:

- On the server side, we log these "errors" at the debug level, as we can recover gracefully and they do not present any concern for end users
- On the client side, we pick up the new version of the server with the aforementioned update, and we don't use keep-alive for domain socket connections

Kallichore side: https://github.com/posit-dev/kallichore/pull/56.

Addresses https://github.com/posit-dev/positron/issues/11004.
