### PR TITLE
Assistant: fix project tree tool for multi-root workspace and add tests

### DIFF
--- a/extensions/positron-assistant/src/test/tools/projectTreeTool.test.ts
+++ b/extensions/positron-assistant/src/test/tools/projectTreeTool.test.ts
@@ -1,0 +1,253 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { buildProjectTree } from '../../tools/projectTreeTool.js';
+
+/**
+ * Helper function to create test workspace folders with proper path construction.
+ */
+function createTestWorkspaceFolders(): vscode.WorkspaceFolder[] {
+	const extensionRoot = path.join(__dirname, '..', '..', '..');
+
+	return [
+		{
+			uri: vscode.Uri.file(path.join(extensionRoot, 'test-workspace')),
+			name: 'test-workspace',
+			index: 0
+		},
+		{
+			uri: vscode.Uri.file(path.join(extensionRoot, 'test-workspace2')),
+			name: 'test-workspace2',
+			index: 1
+		}
+	];
+}
+
+/**
+ * Helper function to validate test workspace exists.
+ */
+async function validateTestWorkspaceExists(workspaceUri: vscode.Uri): Promise<void> {
+	try {
+		await vscode.workspace.fs.stat(workspaceUri);
+	} catch (error) {
+		throw new Error(`Test workspace directory should exist at: ${workspaceUri.fsPath}`);
+	}
+}
+
+suite('ProjectTreeTool', () => {
+	teardown(() => {
+		sinon.restore();
+	});
+
+	suite('Single Workspace - Files', () => {
+		test('should return correct file info for test workspace', async () => {
+			// Test the actual buildProjectTree function using the real test workspace
+			const options = {
+				input: {
+					include: ['**/*.txt']
+				}
+			} as vscode.LanguageModelToolInvocationOptions<any>;
+
+			const token = new vscode.CancellationTokenSource().token;
+
+			// Verify we have the test workspace available
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			assert.ok(workspaceFolder, 'This test should be run from the ../test-workspace workspace');
+
+			const result = await buildProjectTree(options, token);
+
+			// Verify the result structure
+			assert.ok(result instanceof vscode.LanguageModelToolResult);
+			assert.ok(result.content.length >= 1);
+			assert.ok(result.content[0] instanceof vscode.LanguageModelTextPart);
+
+			const content = (result.content[0] as vscode.LanguageModelTextPart).value;
+			assert.ok(typeof content === 'string');
+
+			// Verify specific .txt files from the test workspace are included
+			assert.ok(content.includes('folder/file.txt'), 'Should include folder/file.txt');
+			assert.ok(content.includes('folder/subfolder/file.txt'), 'Should include folder/subfolder/file.txt');
+
+			// Verify .ts files are filtered out
+			assert.ok(!content.includes('reference.ts'), 'Should NOT include reference.ts when filtering for .txt files');
+
+			// Should not have workspace headers for single workspace
+			assert.ok(!content.includes('##'), 'Single workspace should not have headers');
+		});
+	});
+
+	suite('Single Workspace - Directories', () => {
+		test('should return correct directory info for test workspace', async () => {
+			// Test the actual buildProjectTree function for directories only
+			const options = {
+				input: {
+					include: ['**/*'],
+					directoriesOnly: true
+				}
+			} as vscode.LanguageModelToolInvocationOptions<any>;
+
+			const token = new vscode.CancellationTokenSource().token;
+
+			// Verify we have the test workspace available
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			assert.ok(workspaceFolder, 'This test should be run from the ../test-workspace workspace');
+
+			const result = await buildProjectTree(options, token);
+
+			// Verify the result structure
+			assert.ok(result instanceof vscode.LanguageModelToolResult);
+			assert.ok(result.content.length >= 1);
+
+			const content = (result.content[0] as vscode.LanguageModelTextPart).value;
+			assert.ok(typeof content === 'string');
+
+			// Verify specific directories from the test workspace are included
+			assert.ok(content.includes('folder/'), 'Should include folder/ directory');
+			assert.ok(content.includes('folder/subfolder/'), 'Should include folder/subfolder/ directory');
+
+			// Verify files are filtered out when directoriesOnly is true
+			assert.ok(!content.includes('reference.ts'), 'Should NOT include reference.ts when directoriesOnly is true');
+			assert.ok(!content.includes('file.txt'), 'Should NOT include file.txt when directoriesOnly is true');
+
+			// Should not have workspace headers for single workspace
+			assert.ok(!content.includes('##'), 'Single workspace should not have headers');
+
+			// All directory entries should end with '/'
+			const lines = content.trim().split('\n');
+			const directoryLines = lines.filter(line => !line.startsWith('##') && line.trim().length > 0);
+			directoryLines.forEach(line => {
+				assert.ok(line.trim().endsWith('/'), `Directory line should end with '/': ${line}`);
+			});
+		});
+	});
+
+	suite('Multi-Root Workspace - Files', () => {
+		test('should handle files correctly across multiple workspace folders', async () => {
+			// Test the actual buildProjectTree function for multi-root workspace
+			const options = {
+				input: {
+					include: ['**/*']
+				}
+			} as vscode.LanguageModelToolInvocationOptions<any>;
+
+			const token = new vscode.CancellationTokenSource().token;
+
+			// Set up multiple workspace folders using helper function
+			const testWorkspaceFolders = createTestWorkspaceFolders();
+
+			// Validate test workspaces exist
+			for (const folder of testWorkspaceFolders) {
+				await validateTestWorkspaceExists(folder.uri);
+			}
+
+			// Mock the workspace.workspaceFolders property
+			sinon.stub(vscode.workspace, 'workspaceFolders').value(testWorkspaceFolders);
+
+			const result = await buildProjectTree(options, token);
+
+			// Verify the result structure
+			assert.ok(result instanceof vscode.LanguageModelToolResult);
+			assert.ok(result.content.length >= 1);
+
+			// With multiple workspace folders, should have workspace headers
+			const allContent = result.content.map(part => (part as vscode.LanguageModelTextPart).value).join('\n');
+
+			// Verify all expected files from both workspaces are included
+			assert.ok(allContent.includes('reference.ts'), 'Should include reference.ts from first workspace');
+			assert.ok(allContent.includes('folder/file.txt'), 'Should include folder/file.txt from first workspace');
+			assert.ok(allContent.includes('folder/subfolder/file.txt'), 'Should include folder/subfolder/file.txt from first workspace');
+			assert.ok(allContent.includes('script.py'), 'Should include script.py from second workspace');
+			assert.ok(allContent.includes('data/sample.csv'), 'Should include data/sample.csv from second workspace');
+
+			// Verify workspace names appear as headers
+			assert.ok(allContent.includes('## test-workspace'), 'Should include first workspace name in headers');
+			assert.ok(allContent.includes('## test-workspace2'), 'Should include second workspace name in headers');
+		});
+	});
+
+	suite('Multi-Root Workspace - Directories', () => {
+		test('should handle directories correctly across multiple workspace folders', async () => {
+			// Test the actual buildProjectTree function for multi-root workspace directories
+			const options = {
+				input: {
+					include: ['**/*'],
+					directoriesOnly: true
+				}
+			} as vscode.LanguageModelToolInvocationOptions<any>;
+
+			const token = new vscode.CancellationTokenSource().token;
+
+			// Set up multiple workspace folders using helper function
+			const testWorkspaceFolders = createTestWorkspaceFolders();
+
+			// Validate test workspaces exist
+			for (const folder of testWorkspaceFolders) {
+				await validateTestWorkspaceExists(folder.uri);
+			}
+
+			// Mock the workspace.workspaceFolders property
+			sinon.stub(vscode.workspace, 'workspaceFolders').value(testWorkspaceFolders);
+
+			const result = await buildProjectTree(options, token);
+
+			// Verify the result structure
+			assert.ok(result instanceof vscode.LanguageModelToolResult);
+			assert.ok(result.content.length >= 1);
+
+			// With multiple workspace folders, should have workspace headers
+			const allContent = result.content.map(part => (part as vscode.LanguageModelTextPart).value).join('\n');
+
+			// Verify specific directories from both workspaces are included
+			assert.ok(allContent.includes('folder/'), 'Should include folder/ from first workspace');
+			assert.ok(allContent.includes('folder/subfolder/'), 'Should include folder/subfolder/ from first workspace');
+			assert.ok(allContent.includes('data/'), 'Should include data/ from second workspace');
+
+			// Verify workspace names appear as headers
+			assert.ok(allContent.includes('## test-workspace'), 'Should include first workspace name in headers');
+			assert.ok(allContent.includes('## test-workspace2'), 'Should include second workspace name in headers');
+
+			// Verify files are filtered out when directoriesOnly is true
+			assert.ok(!allContent.includes('reference.ts'), 'Should NOT include files when directoriesOnly is true');
+			assert.ok(!allContent.includes('script.py'), 'Should NOT include files when directoriesOnly is true');
+			assert.ok(!allContent.includes('file.txt'), 'Should NOT include files when directoriesOnly is true');
+			assert.ok(!allContent.includes('sample.csv'), 'Should NOT include files when directoriesOnly is true');
+
+			// All directory entries should end with '/'
+			const lines = allContent.split('\n');
+			const directoryLines = lines.filter(line => !line.startsWith('##') && line.trim().length > 0);
+			directoryLines.forEach(line => {
+				assert.ok(line.trim().endsWith('/'), `Directory line should end with '/': ${line}`);
+			});
+		});
+	});
+
+	suite('Empty workspace', () => {
+		test('should reject when no folders are open in the workspace', async () => {
+			const options = {
+				input: {
+					include: ['**/*']
+				}
+			} as vscode.LanguageModelToolInvocationOptions<any>;
+			const token = new vscode.CancellationTokenSource().token;
+			sinon.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+
+			let errorThrown = false;
+			try {
+				await buildProjectTree(options, token);
+			} catch (error) {
+				errorThrown = true;
+				assert.ok(error instanceof Error);
+				assert.ok(error.message.includes('no workspace folders are open'),
+					`Expected error message to mention 'no workspace folders are open', got: ${error.message}`);
+			}
+
+			assert.ok(errorThrown, 'Expected an error to be thrown when no workspace folders are open');
+		});
+	});
+});

--- a/extensions/positron-assistant/src/tools/projectTreeTool.ts
+++ b/extensions/positron-assistant/src/tools/projectTreeTool.ts
@@ -65,105 +65,39 @@ export const ProjectTreeTool = vscode.lm.registerTool<ProjectTreeInput>(Positron
 			? maxItems
 			: DEFAULT_MAX_ITEMS;
 
-		let findOptions: vscode.FindFiles2Options;
-		if (skipExcludes) {
-			// Skip all automatic exclusions, only use explicit exclude patterns
-			findOptions = {
-				exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
-				useIgnoreFiles: {
-					local: false,
-					parent: false,
-					global: false,
-				},
-				useExcludeSettings: vscode.ExcludeSettingOptions.None,
-			};
-		} else {
-			// Apply all exclusions: default patterns + .gitignore + VS Code settings
-			findOptions = {
-				exclude: [...DEFAULT_EXCLUDE_PATTERNS, ...excludePatterns],
-				useIgnoreFiles: DEFAULT_USE_IGNORE_FILES,
-				useExcludeSettings: DEFAULT_EXCLUDE_SETTING_OPTIONS,
-			};
-		}
-
-
 		log.trace(`[${PositronAssistantToolName.ProjectTree}] Constructing project tree with options: ${JSON.stringify({
 			include: globPatterns,
-			exclude: findOptions.exclude,
-			useIgnoreFiles: findOptions.useIgnoreFiles,
-			useExcludeSettings: findOptions.useExcludeSettings,
+			exclude: excludePatterns,
 			skipDefaultExcludes: skipExcludes,
 			maxItems: itemsLimit,
+			directoriesOnly: directoriesOnly ?? false,
 		}, null, 2)}`);
 
 		// Construct the project tree
-		const workspaceTrees: DirectoryInfo[] = [];
-		for (const folder of workspaceFolders) {
-			if (directoriesOnly) {
-				const directories = await collectDirectories(
-					folder.uri,
-					globPatterns,
-					skipExcludes ? excludePatterns : [...DEFAULT_DIRECTORY_EXCLUDE_PATTERNS, ...excludePatterns],
-					token
-				);
-				workspaceTrees.push({ folder, items: directories, totalItems: directories.length });
-			} else {
-				// NOTE: this will not include empty directories :/
-				const relativePatterns = globPatterns.map(pattern =>
-					new vscode.RelativePattern(folder, pattern)
-				);
-				const matchedFileUris = await vscode.workspace.findFiles2(
-					relativePatterns,
-					findOptions,
-					token
-				);
-				const items = matchedFileUris.map(uri => vscode.workspace.asRelativePath(uri, false));
-				workspaceTrees.push({ folder, items, totalItems: matchedFileUris.length });
-			}
-		}
+		const workspaceTrees = await searchWorkspace(
+			workspaceFolders,
+			globPatterns,
+			excludePatterns,
+			directoriesOnly ?? false,
+			skipExcludes,
+			undefined, // no maxResults limit for main construction
+			token
+		);
 
 		const totalItems = workspaceTrees.reduce((sum, obj) => sum + obj.totalItems, 0);
 
 		// If we applied default exclusions and results are very sparse, check if there are any excluded results.
-		let hasExcludedResults = false;
-		const sparseThreshold = Math.floor(itemsLimit / 10);
-		if (!skipExcludes && totalItems < sparseThreshold) {
-			log.debug(`[${PositronAssistantToolName.ProjectTree}] Default exclusions were applied and results were very sparse. Checking if any items were excluded...`);
-			for (const folder of workspaceFolders) {
-				if (directoriesOnly) {
-					const dirs = await collectDirectories(
-						folder.uri,
-						globPatterns,
-						excludePatterns,
-						token,
-						totalItems + 1
-					);
-					hasExcludedResults = dirs.length > totalItems;
-				} else {
-					const relativePatterns = globPatterns.map(pattern =>
-						new vscode.RelativePattern(folder, pattern)
-					);
-					const matchedUris = await vscode.workspace.findFiles2(
-						relativePatterns,
-						{
-							exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
-							useIgnoreFiles: {
-								local: false,
-								parent: false,
-								global: false,
-							},
-							useExcludeSettings: vscode.ExcludeSettingOptions.None,
-							maxResults: totalItems + 1,
-						},
-						token
-					);
-					hasExcludedResults = matchedUris.length > totalItems;
-				}
-				if (hasExcludedResults) {
-					break;
-				}
-			}
-		}
+		const hasExcludedResults = !skipExcludes
+			? await checkIfExclusionsImpactedResults(
+				workspaceFolders,
+				globPatterns,
+				excludePatterns,
+				directoriesOnly ?? false,
+				totalItems,
+				itemsLimit,
+				token
+			)
+			: false;
 
 		log.debug(`[${PositronAssistantToolName.ProjectTree}] Project tree constructed with ${totalItems} items across ${workspaceFolders.length} workspace folders.`);
 		if (totalItems > itemsLimit) {
@@ -250,6 +184,125 @@ const DIRECTORY_SUFFIX = '/**';
 const DEFAULT_DIRECTORY_EXCLUDE_PATTERNS = DEFAULT_EXCLUDE_PATTERNS
 	.filter(p => p.endsWith(DIRECTORY_SUFFIX))
 	.map(p => p.slice(0, -DIRECTORY_SUFFIX.length));
+
+/**
+ * Shared function to search workspace folders for files or directories
+ * @param workspaceFolders The workspace folders to search
+ * @param globPatterns The include patterns to match
+ * @param excludePatterns The exclude patterns to apply
+ * @param directoriesOnly Whether to search for directories only
+ * @param skipExcludes Whether to skip default exclusions
+ * @param maxResults Maximum number of results to return (optional)
+ * @param token Cancellation token
+ * @returns Array of DirectoryInfo objects with search results
+ */
+async function searchWorkspace(
+	workspaceFolders: readonly vscode.WorkspaceFolder[],
+	globPatterns: string[],
+	excludePatterns: string[],
+	directoriesOnly: boolean,
+	skipExcludes: boolean,
+	maxResults?: number,
+	token?: vscode.CancellationToken
+): Promise<DirectoryInfo[]> {
+	const results: DirectoryInfo[] = [];
+
+	for (const folder of workspaceFolders) {
+		if (directoriesOnly) {
+			const effectiveExcludePatterns = skipExcludes
+				? excludePatterns
+				: [...DEFAULT_DIRECTORY_EXCLUDE_PATTERNS, ...excludePatterns];
+
+			const directories = await collectDirectories(
+				folder.uri,
+				globPatterns,
+				effectiveExcludePatterns,
+				token,
+				maxResults
+			);
+			results.push({ folder, items: directories, totalItems: directories.length });
+		} else {
+			const relativePatterns = globPatterns.map(pattern =>
+				new vscode.RelativePattern(folder, pattern)
+			);
+
+			const findOptions: vscode.FindFiles2Options = skipExcludes
+				? {
+					exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
+					useIgnoreFiles: {
+						local: false,
+						parent: false,
+						global: false,
+					},
+					useExcludeSettings: vscode.ExcludeSettingOptions.None,
+					maxResults,
+				}
+				: {
+					exclude: [...DEFAULT_EXCLUDE_PATTERNS, ...excludePatterns],
+					useIgnoreFiles: DEFAULT_USE_IGNORE_FILES,
+					useExcludeSettings: DEFAULT_EXCLUDE_SETTING_OPTIONS,
+					maxResults,
+				};
+
+			log.debug(`[${PositronAssistantToolName.ProjectTree}] findOptions for folder ${folder.name}: ${JSON.stringify(findOptions, null, 2)}`);
+
+			const matchedFileUris = await vscode.workspace.findFiles2(
+				relativePatterns,
+				findOptions,
+				token
+			);
+			const items = matchedFileUris.map(uri => vscode.workspace.asRelativePath(uri, false));
+			results.push({ folder, items, totalItems: matchedFileUris.length });
+		}
+	}
+
+	return results;
+}
+
+/**
+ * Checks if default exclusions significantly impacted the search results by comparing
+ * results with and without exclusions applied
+ * @param workspaceFolders The workspace folders to search
+ * @param globPatterns The include patterns to match
+ * @param excludePatterns The exclude patterns to apply
+ * @param directoriesOnly Whether to search for directories only
+ * @param totalItems The current total items found with exclusions
+ * @param itemsLimit The maximum items limit for calculating sparse threshold
+ * @param token Cancellation token
+ * @returns Promise<boolean> indicating if exclusions impacted results
+ */
+async function checkIfExclusionsImpactedResults(
+	workspaceFolders: readonly vscode.WorkspaceFolder[],
+	globPatterns: string[],
+	excludePatterns: string[],
+	directoriesOnly: boolean,
+	totalItems: number,
+	itemsLimit: number,
+	token: vscode.CancellationToken
+): Promise<boolean> {
+	const sparseThreshold = Math.floor(itemsLimit / 10);
+
+	// Only check if results are very sparse
+	if (totalItems >= sparseThreshold) {
+		return false;
+	}
+
+	log.debug(`[${PositronAssistantToolName.ProjectTree}] Default exclusions were applied and results were very sparse. Checking if any items were excluded...`);
+
+	// Search without default exclusions to see if there would be more results
+	const resultsWithoutDefaults = await searchWorkspace(
+		workspaceFolders,
+		globPatterns,
+		excludePatterns,
+		directoriesOnly,
+		true, // skipExcludes = true
+		totalItems + 1, // maxResults = totalItems + 1
+		token
+	);
+
+	const totalWithoutDefaults = resultsWithoutDefaults.reduce((sum, obj) => sum + obj.totalItems, 0);
+	return totalWithoutDefaults > totalItems;
+}
 
 async function collectDirectories(
 	workspaceUri: vscode.Uri,

--- a/extensions/positron-assistant/test-workspace2/data/sample.csv
+++ b/extensions/positron-assistant/test-workspace2/data/sample.csv
@@ -1,0 +1,4 @@
+animal,size,spikiness
+Hedgehog,Small,Very-High
+Chinchilla,Small,Low
+Axolotl,Medium,None

--- a/extensions/positron-assistant/test-workspace2/script.py
+++ b/extensions/positron-assistant/test-workspace2/script.py
@@ -1,0 +1,7 @@
+# ---------------------------------------------------------------------------------------------
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+# ---------------------------------------------------------------------------------------------
+
+# Test Python script for multi-root workspace testing
+print("Hello from workspace 2")


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/10980
- fixes incorrect construction of workspace file/directory trees when the tool is run in a multi-root workspace
- adds tests for the project tree tool

#### example tool output

<img width="400" height="784" alt="image" src="https://github.com/user-attachments/assets/60da70fa-f8af-4491-bc61-116ac09b904a" />

```json
          "resultDetails": {
            "input": "{\n  \"include\": [\n    \"**\"\n  ]\n}",
            "output": [
              {
                "type": "embed",
                "isText": true,
                "value": "## qa-example-content\n.gitattributes\n.gitignore\n.Rprofile\ndata-files/100x100/r-100x100.tsv\ndata-files/chinook/chinook.db\ndata-files/chinook/LICENSE.md\ndata-files/flights/flights.csv\ndata-files/flights/flights.tsv\ndata-files/README.md\ndata-files/small_file.csv\ndata-files/spotify_data/data.csv\nDESCRIPTION\ndockerfiles/arm-local/.gitignore\ndockerfiles/arm-local/connect.sh\ndockerfiles/arm-local/README.md\nREADME.md\nrequirements.txt\nutilities/README.md\nworkspaces/ai/test_account.py\nworkspaces/graphviz/example.dot\nworkspaces/r_testing/.gitignore\nworkspaces/r_testing/.Rprofile\nworkspaces/r_testing/NAMESPACE\nworkspaces/r_testing/R/apple.R\nworkspaces/README.md"
              },
              {
                "type": "embed",
                "isText": true,
                "value": "## posit-conf-2025-positron-assistant-demo\n.claude/skills/subfolder/SKILL.md\n.github/agents/customagent.agent.md\n.gitignore\ndata/falcons-roster.csv\ndata/falcons-scores.csv\ndata/falcons-seasons.csv\ndata/georgia-aquarium-species.csv\nimages/banner.png\nllms.txt\npositron.md\npython-demo.py\nr-demo.R\nREADME.md\nrequirements.txt\nsetup/demo-setup.sh"
              },
              {
                "type": "embed",
                "isText": true,
                "value": "Project tree constructed with 210 items across 2 workspace folders (qa-example-content, posit-conf-2025-positron-assistant-demo); the first 50 are provided above."
              }
            ]
          },
```

### Release Notes

#### Bug Fixes

- Assistant: project tree tool now returns accurate results for multi-root workspaces (#10980)

### QA Notes

Added an extension integration test for the project tree tool. Run locally with `npm run test-extension -- -l positron-assistant`.

Test cases

- single workspace: match a subset of the files
- multi-root workspace: when searching directories only and when searching for all files, multi-root info should be returned as expected
- no workspace: tool should error