### PR TITLE
Delegate Console copy operation to the document

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -411,7 +411,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 					const selection = getSelection();
 					if (selection) {
 						// Copy the selection to the clipboard.
-						services.clipboardService.writeText(selection.toString());
+						getActiveWindow().document.execCommand('copy');
 					}
 					return;
 				}
@@ -485,7 +485,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 			// If the click was inside the selection, copy the selection to the clipboard.
 			if (insideSelection) {
-				services.clipboardService.writeText(selection.toString());
+				getActiveWindow().document.execCommand('copy');
 				props.positronConsoleInstance.focusInput();
 				return;
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -10,6 +10,7 @@ import './consoleInstance.css';
 import React, { KeyboardEvent, MouseEvent, UIEvent, useCallback, useEffect, useLayoutEffect, useRef, useState, WheelEvent } from 'react';
 
 // Other dependencies.
+import { getActiveWindow } from '../../../../../base/browser/dom.js';
 import * as nls from '../../../../../nls.js';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { ConsoleInstanceItems } from './consoleInstanceItems.js';
@@ -135,7 +136,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			run: () => {
 				// Copy the selection to the clipboard.
 				if (selection) {
-					services.clipboardService.writeText(selection.toString());
+					getActiveWindow().document.execCommand('copy');
 				}
 			}
 		});


### PR DESCRIPTION
Relates #10058 

The Console renders input and output using HTML, which sometimes will replace spaces with non-breaking spaces. When copying the string and subsequently pasting it back into the Console, the non-breaking space becomes an invalid character. Delegating to the document to perform the copy command results in a string with normal spaces.

The built-in copy command will convert the string, which might contain uncommon characters, back into what we expect.

VS Code's built-in terminal executes the same copy command when working with HTML contents, so there is prior art to using this method.

See: `xtermTerminal.copySelection()`

Another solution would be to handle the non-breaking space (0x00A0) on its own like so, but it does not seem like the best generalized solution with the assumption there are other characters that might be need to be replaced (e.g. maybe quotes?)

```ts
string.replace(/\u00A0/g, ' ')
```

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Copying commands in the console with spaces can now be pasted back into the console and executed

### QA Notes

I can only reproduce the reported bug when copying the expression using the context menu.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

@:console


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
