### PR TITLE
Update macOS runner to use 'macos-latest' in Python CI workflow

### DIFF
--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: 'macos-13'
+          - os: 'macos-latest'
             python: '3.9'
           - os: 'windows-latest'
             python: '3.10'


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/13046, MacOS 13 has been removed as a runner.  This updates the Python CI nightly job to use `macos-latest` instead.

### QA Notes
see CI run https://github.com/posit-dev/positron/actions/runs/20107846082

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
