### PR TITLE
Add back in our contributed defaults for pyright

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1003,7 +1003,9 @@
             "ruff.importStrategy": "useBundled",
             "[python]": {
                 "editor.inlayHints.enabled": "offUnlessPressed"
-            }
+            },
+            "pyright.disableLanguageServices": true,
+            "pyright.disableOrganizeImports": true
         },
         "debuggers": [
             {


### PR DESCRIPTION
Addresses #11011

This PR rolls back some of the changes in https://github.com/posit-dev/positron/pull/10647. 

I did **not** yet add back these:

```
            "python.analysis.autoImportCompletions": false,
            "python.analysis.typeCheckingMode": "off"
```

because those are just the default values as outlined here:
https://code.visualstudio.com/docs/python/settings-reference

Do we understand how those settings are used? Are they important? In my testing, I don't think they are a source of the super big changes in how, say, Pyright is acting.

This PR targets the **2025.12 release branch** and I will cherry-pick to `main` once this is reviewed and merged.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Add back in our contributed defaults for the Pyright extension


### QA Notes

If you have the Pyright extension installed (as almost all of our real users do, since we installed it for them) you should no longer get the super aggressive diagnostics that are contributed via the Pyright defaults.