### PR TITLE
Positron notebooks | Empty outputs appearing bug fix

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -10,6 +10,11 @@
 
 	.positron-notebook-cell-outputs {
 		overflow: hidden;
+
+		&.no-outputs {
+			/* Dont show empty outputs at all */
+			display: none;
+		}
 	}
 
 	.positron-notebook-code-cell-outputs-inner {


### PR DESCRIPTION
This is a quick-followup to fix a small bug introduced in #11025 which addressed #10919,

Basically we modified the dom structure and the empty cell outputs got hidden because we were checking for them to literally be empty, but we always added a wrapper div in there to allow scrolling. 

It was broken like this:

<img width="310" height="137" alt="image" src="https://github.com/user-attachments/assets/52cc5f82-c028-4ce7-8b00-cf377248d05b" />

Now it looks like:

<img width="314" height="154" alt="image" src="https://github.com/user-attachments/assets/2139e825-9a81-444c-93c9-31d131f76ed2" />


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
