### PR TITLE
Assistant: ensure toolCalls/completions are set for all providers (#11045)

### DIFF
--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -68,6 +68,8 @@ class ErrorLanguageModel implements positron.ai.LanguageModelChatProvider {
 		defaults: {
 			name: 'Error Language Model',
 			model: 'error',
+			toolCalls: true,
+			completions: false,
 		},
 	};
 
@@ -121,6 +123,8 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 		defaults: {
 			name: 'Echo Language Model',
 			model: 'echo',
+			toolCalls: true,
+			completions: false,
 		},
 	};
 
@@ -708,6 +712,7 @@ class AnthropicAILanguageModel extends AILanguageModel implements positron.ai.La
 			name: DEFAULT_ANTHROPIC_MODEL_NAME,
 			model: DEFAULT_ANTHROPIC_MODEL_MATCH + '-latest',
 			toolCalls: true,
+			completions: false,
 			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.EnvVariable, key: 'ANTHROPIC_API_KEY', signedIn: false },
 		},
 	};
@@ -751,7 +756,7 @@ export class OpenAILanguageModel extends AILanguageModel implements positron.ai.
 			model: 'openai',
 			baseUrl: 'https://api.openai.com/v1',
 			toolCalls: true,
-			completions: true,
+			completions: false,
 		},
 	};
 
@@ -1087,6 +1092,7 @@ class OpenRouterLanguageModel extends AILanguageModel implements positron.ai.Lan
 			model: 'anthropic/claude-3.5-sonnet',
 			baseUrl: 'https://openrouter.ai/api/v1',
 			toolCalls: true,
+			completions: false,
 		},
 	};
 
@@ -1118,6 +1124,7 @@ class OllamaLanguageModel extends AILanguageModel implements positron.ai.Languag
 			model: 'qwen2.5-coder:7b',
 			baseUrl: 'http://localhost:11434/api',
 			toolCalls: false,
+			completions: false,
 			numCtx: 2048,
 		},
 	};
@@ -1150,6 +1157,7 @@ class AzureLanguageModel extends AILanguageModel implements positron.ai.Language
 			model: 'gpt-4o',
 			resourceName: undefined,
 			toolCalls: true,
+			completions: false,
 		},
 	};
 
@@ -1182,6 +1190,7 @@ class VertexLanguageModel extends AILanguageModel implements positron.ai.Languag
 			project: undefined,
 			location: undefined,
 			toolCalls: true,
+			completions: false,
 		},
 	};
 
@@ -1219,6 +1228,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 			name: 'Claude 4 Sonnet Bedrock',
 			model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
 			toolCalls: true,
+			completions: false,
 			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.Custom, message: 'Automatically configured using AWS credentials', signedIn: false },
 		},
 	};
@@ -1656,6 +1666,8 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 					name: model.source.provider.displayName,
 					model: model.source.defaults.model,
 					apiKey: apiKey,
+					toolCalls: model.source.defaults.toolCalls,
+					completions: model.source.defaults.completions,
 					autoconfigure: {
 						type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,
 						key: key,
@@ -1676,9 +1688,10 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 						name: model.source.provider.displayName,
 						model: model.source.defaults.model,
 						apiKey: result.token,
+						toolCalls: model.source.defaults.toolCalls,
+						completions: model.source.defaults.completions,
 						// Use baseUrl from autoconfigure result if available, otherwise fall back to defaults
 						...(result.baseUrl && { baseUrl: result.baseUrl }),
-						// pragma: allowlist nextline secret
 						autoconfigure: {
 							type: positron.ai.LanguageModelAutoconfigureType.Custom,
 							message: result.message,


### PR DESCRIPTION
### Summary

- cherry-picked from https://github.com/posit-dev/positron/pull/11045
- addresses https://github.com/posit-dev/positron/issues/11044

### Release Notes

#### Bug Fixes

- Assistant: fix issue preventing tool calls for Snowflake and Bedrock when using managed credentials (#11044)

### QA Notes

Reach out to me for some notes on testing this locally. Otherwise, the best testing environment is in a Workbench instance with AWS and/or Snowflake managed credentials set up.