### PR TITLE
Add back in our contributed defaults for pyright

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1003,7 +1003,9 @@
             "ruff.importStrategy": "useBundled",
             "[python]": {
                 "editor.inlayHints.enabled": "offUnlessPressed"
-            }
+            },
+            "pyright.disableLanguageServices": true,
+            "pyright.disableOrganizeImports": true
         },
         "debuggers": [
             {


### PR DESCRIPTION
### Summary

- cherry-picked from #11053
- addresses #11011

### Release Notes

#### Bug Fixes

- Add back in our contributed defaults for the Pyright extension

### QA Notes

If you have the Pyright extension installed (as almost all of our real users do, since we installed it for them) you should no longer get the super aggressive diagnostics that are contributed via the Pyright defaults.