### PR TITLE
Show add cell buttons above and below cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -14,7 +14,6 @@ import * as DOM from '../../../../base/browser/dom.js';
 import { useNotebookInstance } from './NotebookInstanceProvider.js';
 import { AddCellButtons } from './AddCellButtons.js';
 import { useObservedValue } from './useObservedValue.js';
-import { localize } from '../../../../nls.js';
 import { NotebookCodeCell } from './notebookCells/NotebookCodeCell.js';
 import { NotebookMarkdownCell } from './notebookCells/NotebookMarkdownCell.js';
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
@@ -66,15 +65,13 @@ export function PositronNotebookComponent() {
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			<div ref={containerRef} className='positron-notebook-cells-container'>
-				{notebookCells.length ?
-					notebookCells.map((cell, index) =>
-						<React.Fragment key={cell.handle}>
-							<NotebookCell cell={cell as PositronNotebookCellGeneral} />
-							<AddCellButtons index={index + 1} />
-						</React.Fragment>
-					) :
-					<div>{localize('noCells', 'No cells')}</div>
-				}
+				<AddCellButtons index={0} />
+				{notebookCells.map((cell, index) =>
+					<React.Fragment key={cell.handle}>
+						<NotebookCell cell={cell as PositronNotebookCellGeneral} />
+						<AddCellButtons index={index + 1} />
+					</React.Fragment>
+				)}
 			</div>
 			<ScreenReaderOnly className='notebook-announcements'>
 				{globalAnnouncement}

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -191,7 +191,8 @@ export class PositronNotebooks extends Notebooks {
 
 	/**
 	 * Action: Create a new Positron notebook.
-	 * @param numCellsToAdd - Number of cells to add after creating the notebook (default: 0).
+	 * @param codeCells - Number of code cells to create
+	 * @param markdownCells - Number of markdown cells to create
 	 */
 	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number; markdownCells?: number } = {}): Promise<void> {
 		await this.createNewNotebook();
@@ -344,7 +345,10 @@ export class PositronNotebooks extends Notebooks {
 
 			// Click the last "New Code Cell" button to add a cell at the end
 			await this.newCellButton.last().click();
-			await expect(this.cell).toHaveCount(newCellButtonCount + 1, { timeout: DEFAULT_TIMEOUT });
+			// The button count before adding the cell will match the new cell count after adding the cell.
+			// This is because there is one extra "New Code Cell" button at the beginning of the notebook.
+			// Ex: if there are 0 cells, there is 1 button; if there is 1 cell, there are 2 buttons, etc.
+			await expect(this.cell).toHaveCount(newCellButtonCount, { timeout: DEFAULT_TIMEOUT });
 		});
 	}
 


### PR DESCRIPTION
Addresses #10386 and #9923

The "Add Cell" buttons now show up on hover: above the first cell, between all cells, after the last cell, and when the notebook is empty. We no longer show the "No Cells" text when a notebook is empty.

**AFTER**

https://github.com/user-attachments/assets/3e835c91-03f6-4816-9af8-e49ab63eb6e3


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:positron-notebooks

