### PR TITLE
Show Profvis output in an editor tab

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -17,7 +17,7 @@ import pytest
 
 from positron.positron_ipkernel import PositronIPyKernel, PositronShell
 from positron.ui import UiService
-from positron.ui_comm import UiFrontendEvent, ShowHtmlFileDestination
+from positron.ui_comm import ShowHtmlFileDestination, UiFrontendEvent
 from positron.utils import alias_home
 
 from .conftest import DummyComm
@@ -66,7 +66,7 @@ def show_url_event(url: str) -> Dict[str, Any]:
     return json_rpc_notification(UiFrontendEvent.ShowUrl, {"url": url, "source": None})
 
 
-def show_html_file_event(path: str, *, destination: bool) -> Dict[str, Any]:
+def show_html_file_event(path: str, *, destination: str) -> Dict[str, Any]:
     return json_rpc_notification(
         "show_html_file", {"path": path, "destination": destination, "height": 0, "title": ""}
     )
@@ -178,12 +178,21 @@ def test_shutdown(ui_service: UiService, ui_comm: DummyComm) -> None:
         # Unix path
         (
             "file://hello/my/friend.html",
-            [show_html_file_event("file://hello/my/friend.html", destination=ShowHtmlFileDestination.Viewer)],
+            [
+                show_html_file_event(
+                    "file://hello/my/friend.html", destination=ShowHtmlFileDestination.Viewer
+                )
+            ],
         ),
         # Windows path
         (
             "file:///C:/Users/username/Documents/index.htm",
-            [show_html_file_event("file:///C:/Users/username/Documents/index.htm", destination=ShowHtmlFileDestination.Viewer)],
+            [
+                show_html_file_event(
+                    "file:///C:/Users/username/Documents/index.htm",
+                    destination=ShowHtmlFileDestination.Viewer,
+                )
+            ],
         ),
         # Not a local html file
         ("http://example.com/page.html", []),
@@ -315,5 +324,4 @@ webbrowser.open("file://file.html")
 
     params = ui_comm.messages[1]["data"]["params"]
     assert params["path"] == "file.html" if sys.platform == "win32" else "file://file.html"
-    assert params["destination"] is not "plot"
-
+    assert params["destination"] != "plot"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -66,9 +66,9 @@ def show_url_event(url: str) -> Dict[str, Any]:
     return json_rpc_notification(UiFrontendEvent.ShowUrl, {"url": url, "source": None})
 
 
-def show_html_file_event(path: str, *, is_plot: bool) -> Dict[str, Any]:
+def show_html_file_event(path: str, *, destination: bool) -> Dict[str, Any]:
     return json_rpc_notification(
-        "show_html_file", {"path": path, "is_plot": is_plot, "height": 0, "title": ""}
+        "show_html_file", {"path": path, "destination": destination, "height": 0, "title": ""}
     )
 
 
@@ -178,12 +178,12 @@ def test_shutdown(ui_service: UiService, ui_comm: DummyComm) -> None:
         # Unix path
         (
             "file://hello/my/friend.html",
-            [show_html_file_event("file://hello/my/friend.html", is_plot=False)],
+            [show_html_file_event("file://hello/my/friend.html", destination=ShowHtmlFileDestination.Viewer)],
         ),
         # Windows path
         (
             "file:///C:/Users/username/Documents/index.htm",
-            [show_html_file_event("file:///C:/Users/username/Documents/index.htm", is_plot=False)],
+            [show_html_file_event("file:///C:/Users/username/Documents/index.htm", destination=ShowHtmlFileDestination.Viewer)],
         ),
         # Not a local html file
         ("http://example.com/page.html", []),
@@ -233,7 +233,7 @@ show(p)
     assert len(ui_comm.messages) == 1
     params = ui_comm.messages[0]["data"]["params"]
     assert params["title"] == ""
-    assert params["is_plot"]
+    assert params["destination"] == "plot"
     assert params["height"] == 0
     # default behavior should be writing to temppath
     # not wherever the process is running (see patch.bokeh)
@@ -281,11 +281,11 @@ fig
     assert len(ui_comm.messages) == 2
     params = ui_comm.messages[0]["data"]["params"]
     assert params["title"] == ""
-    assert params["is_plot"]
+    assert params["destination"] == "plot"
     assert params["height"] == 0
     params = ui_comm.messages[1]["data"]["params"]
     assert params["title"] == ""
-    assert params["is_plot"]
+    assert params["destination"] == "plot"
     assert params["height"] == 0
 
 
@@ -296,7 +296,7 @@ def test_is_not_plot_url_events(
     """
     Test that opening a URL that is not a plot sends the expected UI events.
 
-    Checks that the `is_plot` parameter is not sent or is `False`.
+    Checks that the `destination` parameter is not set to "plot".
     """
     shell.run_cell(
         """\
@@ -311,8 +311,9 @@ webbrowser.open("file://file.html")
     assert len(ui_comm.messages) == 2
     params = ui_comm.messages[0]["data"]["params"]
     assert params["url"] == "http://127.0.0.1:8000"
-    assert "is_plot" not in params
+    assert "destination" not in params
 
     params = ui_comm.messages[1]["data"]["params"]
     assert params["path"] == "file.html" if sys.platform == "win32" else "file://file.html"
-    assert params["is_plot"] is False
+    assert params["destination"] is not "plot"
+

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -17,7 +17,7 @@ import pytest
 
 from positron.positron_ipkernel import PositronIPyKernel, PositronShell
 from positron.ui import UiService
-from positron.ui_comm import UiFrontendEvent
+from positron.ui_comm import UiFrontendEvent, ShowHtmlFileDestination
 from positron.utils import alias_home
 
 from .conftest import DummyComm

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -25,6 +25,7 @@ from .ui_comm import (
     ShowUrlParams,
     UiBackendMessageContent,
     UiFrontendEvent,
+    ShowHtmlFileDestination,
     WorkingDirectoryParams,
 )
 from .utils import JsonData, JsonRecord, alias_home, is_local_html_file
@@ -271,7 +272,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                         return True
         return False
 
-    def _send_show_html_event(self, url: str, destination: ShowHtmlFileDestination) -> bool:  # noqa: FBT001
+    def _send_show_html_event(self, url: str, destination: str) -> bool:  # noqa: FBT001
         if self._comm is None:
             logger.warning("No comm available to send ShowHtmlFile event")
             return False

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -21,11 +21,11 @@ from .ui_comm import (
     CallMethodParams,
     CallMethodRequest,
     OpenEditorParams,
+    ShowHtmlFileDestination,
     ShowHtmlFileParams,
     ShowUrlParams,
     UiBackendMessageContent,
     UiFrontendEvent,
-    ShowHtmlFileDestination,
     WorkingDirectoryParams,
 )
 from .utils import JsonData, JsonRecord, alias_home, is_local_html_file
@@ -239,7 +239,11 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
             # Send bokeh plots to the plots pane.
             # Identify bokeh plots by checking the stack for the bokeh.io.showing.show function.
             # This is not great but currently the only information we have.
-            destination = ShowHtmlFileDestination.Plot if self._is_module_function("bokeh.io.showing", "show") else ShowHtmlFileDestination.Viewer
+            destination = (
+                ShowHtmlFileDestination.Plot
+                if self._is_module_function("bokeh.io.showing", "show")
+                else ShowHtmlFileDestination.Viewer
+            )
 
             return self._send_show_html_event(url, destination)
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -276,7 +276,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                         return True
         return False
 
-    def _send_show_html_event(self, url: str, destination: str) -> bool:  # noqa: FBT001
+    def _send_show_html_event(self, url: str, destination: str) -> bool:
         if self._comm is None:
             logger.warning("No comm available to send ShowHtmlFile event")
             return False

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -232,21 +232,21 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         if not self._comm:
             return False
 
-        is_plot = False
+        destination = ShowHtmlFileDestination.Viewer
         # If url is pointing to an HTML file, route to the ShowHtmlFile comm
         if is_local_html_file(url):
             # Send bokeh plots to the plots pane.
             # Identify bokeh plots by checking the stack for the bokeh.io.showing.show function.
             # This is not great but currently the only information we have.
-            is_plot = self._is_module_function("bokeh.io.showing", "show")
+            destination = ShowHtmlFileDestination.Plot if self._is_module_function("bokeh.io.showing", "show") else ShowHtmlFileDestination.Viewer
 
-            return self._send_show_html_event(url, is_plot)
+            return self._send_show_html_event(url, destination)
 
         for addr in _localhosts:
             if addr in url:
                 is_plot = self._is_module_function("plotly.basedatatypes")
                 if is_plot:
-                    return self._send_show_html_event(url, is_plot)
+                    return self._send_show_html_event(url, ShowHtmlFileDestination.Plot)
                 else:
                     event = ShowUrlParams(url=url)
                     self._comm.send_event(name=UiFrontendEvent.ShowUrl, payload=event.dict())
@@ -271,7 +271,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                         return True
         return False
 
-    def _send_show_html_event(self, url: str, is_plot: bool) -> bool:  # noqa: FBT001
+    def _send_show_html_event(self, url: str, destination: ShowHtmlFileDestination) -> bool:  # noqa: FBT001
         if self._comm is None:
             logger.warning("No comm available to send ShowHtmlFile event")
             return False
@@ -283,7 +283,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                 path=url,
                 # Use the URL's title.
                 title="",
-                is_plot=is_plot,
+                destination=destination,
                 # No particular height is required.
                 height=0,
             ).dict(),

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -35,6 +35,19 @@ class OpenEditorKind(str, enum.Enum):
 
 
 @enum.unique
+class ShowHtmlFileDestination(str, enum.Enum):
+    """
+    Possible values for Destination in ShowHtmlFile
+    """
+
+    Plot = "plot"
+
+    Viewer = "viewer"
+
+    Editor = "editor"
+
+
+@enum.unique
 class PreviewSourceType(str, enum.Enum):
     """
     Possible values for Type in PreviewSource
@@ -569,8 +582,8 @@ class ShowHtmlFileParams(BaseModel):
         description="A title to be displayed in the viewer. May be empty, and can be superseded by the title in the HTML file.",
     )
 
-    is_plot: StrictBool = Field(
-        description="Whether the HTML file is a plot-like object",
+    destination: ShowHtmlFileDestination = Field(
+        description="Where the file should be shown in Positron: as an interactive plot, in the viewer pane, or in a new editor tab.",
     )
 
     height: StrictInt = Field(

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -955,7 +955,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.220"
+      "ark": "0.1.221"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -514,10 +514,15 @@
 					}
 				},
 				{
-					"name": "is_plot",
-					"description": "Whether the HTML file is a plot-like object",
+					"name": "destination",
+					"description": "Where the file should be shown in Positron: as an interactive plot, in the viewer pane, or in a new editor tab.",
 					"schema": {
-						"type": "boolean"
+						"type": "string",
+						"enum": [
+							"plot",
+							"viewer",
+							"editor"
+						]
 					}
 				},
 				{

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -30,7 +30,7 @@ import { decodeBase64 } from '../../../../base/common/buffer.js';
 import { SavePlotOptions, showSavePlotModalDialog } from './modalDialogs/savePlotModalDialog.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { localize } from '../../../../nls.js';
-import { UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
+import { ShowHtmlFileDestination, UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
 import { IShowHtmlUriEvent } from '../../../services/languageRuntime/common/languageRuntimeUiClient.js';
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { NotebookOutputPlotClient } from './notebookOutputPlotClient.js';
@@ -241,7 +241,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			// If we have a new HTML file to show, turn it into a webview plot.
 			if (event.event.name === UiFrontendEvent.ShowHtmlFile) {
 				const data = event.event.data as IShowHtmlUriEvent;
-				if (data.event.is_plot) {
+				if (data.event.destination === ShowHtmlFileDestination.Plot) {
 					await this.createWebviewPlot(event.session_id, data);
 				}
 			}

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -16,7 +16,7 @@ import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../servic
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { PreviewUrl } from './previewUrl.js';
-import { ShowHtmlFileEvent, ShowUrlEvent, UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
+import { ShowHtmlFileDestination, ShowHtmlFileEvent, ShowUrlEvent, UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { isLocalhost } from '../../positronHelp/browser/utils.js';
@@ -88,7 +88,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 
 				if (e.event.name === UiFrontendEvent.ShowHtmlFile) {
 					const data = e.event.data as IShowHtmlUriEvent;
-					if (!data.event.is_plot) {
+					if (data.event.destination === ShowHtmlFileDestination.Viewer) {
 						this.handleShowHtmlFileEvent(session, data);
 					}
 				} else {
@@ -321,7 +321,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		const evt: ShowHtmlFileEvent = {
 			height: 0,
 			title: basename(htmlpath),
-			is_plot: false,
+			destination: ShowHtmlFileDestination.Viewer,
 			path: htmlpath,
 		};
 

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -28,6 +28,8 @@ import { basename } from '../../../../base/common/path.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { localize } from '../../../../nls.js';
 
 /**
  * Positron preview service; keeps track of the set of active previews and
@@ -56,6 +58,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@IOpenerService private readonly _openerService: IOpenerService,
+		@INotificationService private readonly _notificationService: INotificationService,
 		@IPositronNotebookOutputWebviewService private readonly _notebookOutputWebviewService: IPositronNotebookOutputWebviewService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IEditorService private readonly _editorService: IEditorService
@@ -90,6 +93,10 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 					const data = e.event.data as IShowHtmlUriEvent;
 					if (data.event.destination === ShowHtmlFileDestination.Viewer) {
 						this.handleShowHtmlFileEvent(session, data);
+					} else if (data.event.destination === ShowHtmlFileDestination.Editor) {
+						this.openEditor(data.uri, data.event.title).catch(err => {
+							this._notificationService.error(localize('positronPreviewFailedToOpenHtmlFileInEditor', "Failed to open {1} in editor: {0}", data.uri.toString(), err.message));
+						});
 					}
 				} else {
 					this.handleShowUrlEvent(session, e.event.data as ShowUrlEvent);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -6,7 +6,7 @@
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IRuntimeClientInstance, RuntimeClientState } from './languageRuntimeClientInstance.js';
-import { BusyEvent, ClearConsoleEvent, UiFrontendEvent, OpenEditorEvent, OpenWorkspaceEvent, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent, ShowUrlEvent, SetEditorSelectionsEvent, ShowHtmlFileEvent, OpenWithSystemEvent, ClearWebviewPreloadsEvent } from './positronUiComm.js';
+import { BusyEvent, ClearConsoleEvent, UiFrontendEvent, OpenEditorEvent, OpenWorkspaceEvent, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent, ShowUrlEvent, SetEditorSelectionsEvent, ShowHtmlFileEvent, OpenWithSystemEvent, ClearWebviewPreloadsEvent, ShowHtmlFileDestination } from './positronUiComm.js';
 import { PositronUiCommInstance } from './positronUiCommInstance.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -175,17 +175,17 @@ export class UiClientInstance extends Disposable {
 				// Start an HTML proxy server for the file
 				const uri = await this.startHtmlProxyServer(e.path);
 
-				if (isWeb) {
+				if (isWeb && e.destination === ShowHtmlFileDestination.Plot) {
 					// In Web mode, we can't show interactive plots in the Plots
-					// pane.
-					e.is_plot = false;
-				} else if (e.is_plot) {
+					// pane, so show them in the Viewer tab instead.
+					e.destination = ShowHtmlFileDestination.Viewer;
+				} else if (e.destination === ShowHtmlFileDestination.Plot) {
 					// Check the configuration to see if we should open the plot
-					// in the Viewer tab. If so, clear the `is_plot` flag so that
+					// in the Viewer tab. If so, update the destination so that
 					// we open the file in the Viewer.
 					const openInViewer = this._configurationService.getValue<boolean>(POSITRON_PREVIEW_PLOTS_IN_VIEWER);
 					if (openInViewer) {
-						e.is_plot = false;
+						e.destination = ShowHtmlFileDestination.Viewer;
 					}
 				}
 

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -207,6 +207,15 @@ export enum OpenEditorKind {
 }
 
 /**
+ * Possible values for Destination in ShowHtmlFile
+ */
+export enum ShowHtmlFileDestination {
+	Plot = 'plot',
+	Viewer = 'viewer',
+	Editor = 'editor'
+}
+
+/**
  * Possible values for Type in PreviewSource
  */
 export enum PreviewSourceType {
@@ -503,9 +512,10 @@ export interface ShowHtmlFileParams {
 	title: string;
 
 	/**
-	 * Whether the HTML file is a plot-like object
+	 * Where the file should be shown in Positron: as an interactive plot, in
+	 * the viewer pane, or in a new editor tab.
 	 */
-	is_plot: boolean;
+	destination: ShowHtmlFileDestination;
 
 	/**
 	 * The desired height of the HTML viewer, in pixels. The special value 0
@@ -666,9 +676,10 @@ export interface ShowHtmlFileEvent {
 	title: string;
 
 	/**
-	 * Whether the HTML file is a plot-like object
+	 * Where the file should be shown in Positron: as an interactive plot, in
+	 * the viewer pane, or in a new editor tab.
 	 */
-	is_plot: boolean;
+	destination: ShowHtmlFileDestination;
 
 	/**
 	 * The desired height of the HTML viewer, in pixels. The special value 0
@@ -958,7 +969,7 @@ export class PositronUiComm extends PositronBaseComm {
 		this.onDidOpenWorkspace = super.createEventEmitter('open_workspace', ['path', 'new_window']);
 		this.onDidSetEditorSelections = super.createEventEmitter('set_editor_selections', ['selections']);
 		this.onDidShowUrl = super.createEventEmitter('show_url', ['url', 'source']);
-		this.onDidShowHtmlFile = super.createEventEmitter('show_html_file', ['path', 'title', 'is_plot', 'height']);
+		this.onDidShowHtmlFile = super.createEventEmitter('show_html_file', ['path', 'title', 'destination', 'height']);
 		this.onDidOpenWithSystem = super.createEventEmitter('open_with_system', ['path']);
 		this.onDidClearWebviewPreloads = super.createEventEmitter('clear_webview_preloads', []);
 	}


### PR DESCRIPTION
This change adds a small feature that opens Profvis output in an editor tab in Positron, similar to how Profvis output is treated in RStudio.

<img width="1194" height="1091" alt="image" src="https://github.com/user-attachments/assets/ae402c78-0a75-4d2e-9536-e076fe88e8cc" />

Requires https://github.com/posit-dev/ark/pull/988. This is a breaking change in the UI comm protocol, so the merges must be coordinated. 

Addresses https://github.com/posit-dev/positron/issues/3269.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Show Profvis (R profiler) output in the editor (#3269)

#### Bug Fixes

- N/A


### QA Notes

- The Profvis website has many examples you can try
- Profvis isn't very good about responding to resizes and renders at a fairly fixed size regardless of the editor tab dimensions
- Compare behavior to RStudio

