### PR TITLE
e2e: update aria label for nb tests

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -29,7 +29,7 @@ export class PositronNotebooks extends Notebooks {
 	editorAtIndex = (index: number) => this.cell.nth(index).locator('.positron-cell-editor-monaco-widget textarea');
 	cell = this.code.driver.page.locator('[data-testid="notebook-cell"]');
 	codeCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Code cell"]');
-	markdownCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Markdown cell"]');
+	markdownCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Markdown cell - Press Enter to edit"]');
 	cellStatusSyncIcon = this.code.driver.page.locator('.cell-status-item-has-runnable .codicon-sync');
 	detectingKernelsText = this.code.driver.page.getByText(/detecting kernels/i);
 
@@ -74,7 +74,6 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async getCellContent(cellIndex: number): Promise<string[]> {
 		const cellType = await this.getCellType(cellIndex);
-
 		if (cellType === 'markdown') {
 			// Enter edit mode to ensure the monaco view-lines are present
 			const inEditMode = await this.cell.nth(cellIndex).getByRole('button', { name: 'View markdown' }).isVisible();
@@ -133,7 +132,7 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async getCellType(cellIndex: number): Promise<'code' | 'markdown'> {
 		const ariaLabel = await this.cell.nth(cellIndex).getAttribute('aria-label');
-		return ariaLabel === 'Markdown cell' ? 'markdown' : 'code';
+		return ariaLabel === 'Markdown cell - Press Enter to edit' ? 'markdown' : 'code';
 	}
 
 	// #endregion
@@ -565,6 +564,8 @@ export class PositronNotebooks extends Notebooks {
 	async expectCellContentAtIndexToBe(cellIndex: number, expectedContent: string | string[]): Promise<void> {
 		await test.step(`Expect cell ${cellIndex} content to be: ${expectedContent}`, async () => {
 			const actualContent = await this.getCellContent(cellIndex);
+			console.log(`Cell ${cellIndex} actual content:`, actualContent);
+			console.log(`Cell ${cellIndex} expected content:`, expectedContent);
 
 			if (Array.isArray(expectedContent)) {
 				// Compare arrays line by line

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -14,6 +14,7 @@ import { ACTIVE_STATUS_ICON, DISCONNECTED_STATUS_ICON, IDLE_STATUS_ICON, Session
 import { basename, relative } from 'path';
 
 const DEFAULT_TIMEOUT = 10000;
+const MARKDOWN_ARIA_LABEL = 'Markdown cell - Press Enter to edit';
 
 type MoreActionsMenuItems = 'Copy cell' | 'Cut cell' | 'Paste Cell Above' | 'Paste cell below' | 'Move cell down' | 'Move cell up' | 'Insert code cell above' | 'Insert code cell below';
 type EditorActionBarButtons = 'Markdown' | 'Code' | 'Clear Outputs' | 'Run All';
@@ -29,7 +30,7 @@ export class PositronNotebooks extends Notebooks {
 	editorAtIndex = (index: number) => this.cell.nth(index).locator('.positron-cell-editor-monaco-widget textarea');
 	cell = this.code.driver.page.locator('[data-testid="notebook-cell"]');
 	codeCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Code cell"]');
-	markdownCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Markdown cell - Press Enter to edit"]');
+	markdownCell = this.code.driver.page.locator(`[data-testid="notebook-cell"][aria-label="${MARKDOWN_ARIA_LABEL}"]`);
 	cellStatusSyncIcon = this.code.driver.page.locator('.cell-status-item-has-runnable .codicon-sync');
 	detectingKernelsText = this.code.driver.page.getByText(/detecting kernels/i);
 
@@ -132,7 +133,7 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async getCellType(cellIndex: number): Promise<'code' | 'markdown'> {
 		const ariaLabel = await this.cell.nth(cellIndex).getAttribute('aria-label');
-		return ariaLabel === 'Markdown cell - Press Enter to edit' ? 'markdown' : 'code';
+		return ariaLabel === MARKDOWN_ARIA_LABEL ? 'markdown' : 'code';
 	}
 
 	// #endregion
@@ -551,7 +552,7 @@ export class PositronNotebooks extends Notebooks {
 
 			expectedType === 'code'
 				? expect(ariaLabel).toBe('Code cell')
-				: expect(ariaLabel).toBe('Markdown cell');
+				: expect(ariaLabel).toBe(MARKDOWN_ARIA_LABEL);
 
 		});
 	}

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -564,8 +564,6 @@ export class PositronNotebooks extends Notebooks {
 	async expectCellContentAtIndexToBe(cellIndex: number, expectedContent: string | string[]): Promise<void> {
 		await test.step(`Expect cell ${cellIndex} content to be: ${expectedContent}`, async () => {
 			const actualContent = await this.getCellContent(cellIndex);
-			console.log(`Cell ${cellIndex} actual content:`, actualContent);
-			console.log(`Cell ${cellIndex} expected content:`, expectedContent);
 
 			if (Array.isArray(expectedContent)) {
 				// Compare arrays line by line


### PR DESCRIPTION
### Summary
The aria label for notebook cells has changed, which led to failures across the notebook tests. This PR updates the tests so they match the new label and run successfully again.

### QA Notes

@:positron-notebooks