### PR TITLE
Hide notebook console actions behind existing setting

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1072,7 +1072,7 @@ export function registerPositronConsoleActions() {
 						group: 'notebookConsole',
 						when: ContextKeyExpr.and(
 							ContextKeyExpr.equals('config.notebook.globalToolbar', true),
-							ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+							ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 						),
 						order: 1
 					}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1070,7 +1070,10 @@ export function registerPositronConsoleActions() {
 						// notebook console
 						id: MenuId.NotebookToolbar,
 						group: 'notebookConsole',
-						when: ContextKeyExpr.equals('config.notebook.globalToolbar', true),
+						when: ContextKeyExpr.and(
+							ContextKeyExpr.equals('config.notebook.globalToolbar', true),
+							ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+						),
 						order: 1
 					}
 				]

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1064,6 +1064,7 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
+				precondition: ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true),
 				menu: [
 					{
 						// Add an entry to the notebook toolbar to show the

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
@@ -38,9 +38,11 @@ export class ExecuteSelectionInConsoleAction extends Action2 {
 			icon: executeIcon,
 			f1: true,
 			// Only enable if the active editor is a notebook (Positron or built-in) and the notebook console actions setting is enabled
-			precondition: ContextKeyExpr.or(
-				ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-				ContextKeyExpr.equals('activeEditor', NOTEBOOK_EDITOR_ID),
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.or(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					ContextKeyExpr.equals('activeEditor', NOTEBOOK_EDITOR_ID),
+				),
 				ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 			),
 			// Show in the cell context menu, but only for code cells and when there's a selection

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
@@ -37,10 +37,11 @@ export class ExecuteSelectionInConsoleAction extends Action2 {
 			title: localize2('positronNotebookActions.executeSelectionInConsole', 'Execute Selection in Console'),
 			icon: executeIcon,
 			f1: true,
-			// Only enable if the active editor is a notebook (Positron or built-in)
+			// Only enable if the active editor is a notebook (Positron or built-in) and the notebook console actions setting is enabled
 			precondition: ContextKeyExpr.or(
 				ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 				ContextKeyExpr.equals('activeEditor', NOTEBOOK_EDITOR_ID),
+				ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 			),
 			// Show in the cell context menu, but only for code cells and when there's a selection
 			menu: [
@@ -53,7 +54,8 @@ export class ExecuteSelectionInConsoleAction extends Action2 {
 					group: CELL_TITLE_CELL_GROUP_ID,
 					when: ContextKeyExpr.and(
 						NOTEBOOK_CELL_TYPE.isEqualTo('code'),
-						EditorContextKeys.hasNonEmptySelection
+						EditorContextKeys.hasNonEmptySelection,
+						ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 					),
 				}
 			]

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1270,7 +1270,10 @@ registerAction2(class extends NotebookAction2 {
 			icon: ThemeIcon.fromId('terminal'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
-			precondition: ActiveNotebookHasRunningRuntime,
+			precondition: ContextKeyExpr.and(
+				ActiveNotebookHasRunningRuntime,
+				ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+			),
 			positronActionBarOptions: {
 				controlType: 'button',
 				displayTitle: true
@@ -1278,6 +1281,10 @@ registerAction2(class extends NotebookAction2 {
 			menu: {
 				id: MenuId.PositronNotebookKernelSubmenu,
 				order: 100,
+				when: ContextKeyExpr.and(
+					ActiveNotebookHasRunningRuntime,
+					ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+				)
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1272,7 +1272,7 @@ registerAction2(class extends NotebookAction2 {
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			precondition: ContextKeyExpr.and(
 				ActiveNotebookHasRunningRuntime,
-				ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+				ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 			),
 			positronActionBarOptions: {
 				controlType: 'button',
@@ -1283,7 +1283,7 @@ registerAction2(class extends NotebookAction2 {
 				order: 100,
 				when: ContextKeyExpr.and(
 					ActiveNotebookHasRunningRuntime,
-					ContextKeyExpr.equals('config.console.showNotebookConsoles', true)
+					ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true)
 				)
 			}
 		});

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -269,11 +269,19 @@ configurationRegistry.registerConfiguration({
 			'default': 1000,
 			markdownDescription: localize('console.scrollbackSize', "The number of console output items to display."),
 		},
-		// Whether to show notebook consoles
+		// Whether to automatically create consoles for notebook sessions
 		'console.showNotebookConsoles': {
 			type: 'boolean',
 			default: false,
-			markdownDescription: localize('console.showNotebookConsoles', "Whether to show consoles for open notebooks."),
+			markdownDescription: localize('console.showNotebookConsoles', "Controls whether consoles are automatically shown for open notebooks."),
+			tags: ['experimental'],
+		},
+		// Whether to show the notebook console actions in menus
+		'console.showNotebookConsoleActions': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize('console.showNotebookConsoleActions', "Controls whether notebook console actions are visible in notebook toolbars. When enabled, you can manually show or focus a notebook console using the 'Show Notebook Console' menu item."),
+			tags: ['experimental'],
 		}
 	}
 });

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -31,7 +31,6 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		// ensure when no kernel is selected, restart/shutdown are disabled
 		await notebooksPositron.kernel.expectMenuToContain([
 			{ label: 'Change Kernel', enabled: true },
-			{ label: 'Open Notebook Console', enabled: false },
 			{ label: 'Restart Kernel', enabled: false },
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
@@ -73,7 +72,6 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
 			{ label: 'Change Kernel', enabled: true },
-			{ label: 'Open Notebook Console', enabled: false },
 		]);
 
 		// re-start kernel from shutdown state and ensure state changes
@@ -175,8 +173,11 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		});
 	});
 
-	test('ensure notebook console attaches and terminates with active kernel', async function ({ app, sessions }) {
+	test('ensure notebook console attaches and terminates with active kernel', async function ({ app, sessions, settings }) {
 		const { notebooksPositron, console } = app.workbench;
+
+		// Enable the notebook console actions setting for this test
+		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
 
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
@@ -203,6 +204,9 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			kernelGroup: 'R',
 			status: 'disconnected'
 		});
+
+		// Disable the notebook console actions setting after this test
+		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 });
 


### PR DESCRIPTION
Addresses #9948

### Prior Behavior

When the `console.showNotebookConsoles` setting (Console -> Show Notebook Consoles) is enabled, a console instance gets automatically created for a notebook session (for built-in notebooks and Positron Notebooks). 

We also have two commands that allow a user to create/focus a console instance for a notebook session that we always showed. These actions did not depend on the `console.showNotebookConsoles` setting to be enabled to show up or work:
- `workbench.action.positronConsole.showNotebookConsole`: The "Show Notebook Console" command in the editor toolbar for built-in notebooks that users could select to show/focus a console for the current notebook session.
- `positronNotebook.showConsole`: The "Open Notebook Console" command in the kernel menu dropdown for Positron Notebooks that users could select to show/focus a console for the current notebook session.

There is also `positronNotebook.executeSelectionInConsole`: The "Notebook: Execute Selection In Console" menu item that lets you execute a highlighted portion from a notebook cell in the console for the current notebook. NOTE: The `Execute Selection in Console` doesn't ever show up in the Positron Notebook right-click menu. This is a known bug and unrelated to this change!

### New Behavior

This PR introduces a new setting called `console.showNotebookConsoleActions` that controls whether a user sees the commands described above.

The new behavior is as follows:
- Both OFF (default):
  - Console instances will NOT be automatically created for open notebooks. The "Show/Open Notebook Console" and "Notebook: Execute Selection In Console" menu items will NOT show up for notebooks.
- `console.showNotebookConsoleActions` ON only: 
  - Console instances will NOT be automatically created for open notebooks. The "Show/Open Notebook Console" and "Notebook: Execute Selection In Console"  menu items WILL show up for notebooks.
  - For users who want control over when a notebook console appear. They can manually trigger console creation when needed.
- `console.showNotebookConsoles` ON only: 
  - Console instances WILL BE automatically created for open notebooks. The "Show/Open Notebook Console" and "Notebook: Execute Selection In Console"  menu items will NOT show up for notebooks.
  - For users who want consoles for all notebooks and don't need the toolbar buttons cluttering their UI.
- Both ON:
  -  Console instances WILL BE automatically created for open notebooks. The "Show/Open Notebook Console" and "Notebook: Execute Selection In Console"  menu items WILL show up for notebooks.

Once this PR is merged, I'll leave a comment in https://github.com/posit-dev/positron/issues/3801 that introduced this change to let users know they will need to opt into the new setting to see the new commands.

### Screenshots

**BEFORE - setting OFF**

https://github.com/user-attachments/assets/b048c49c-281c-4312-8a14-8550b971b96f

**BEFORE - setting ON**

https://github.com/user-attachments/assets/9211a94b-c246-416d-a53c-332807a124a7

**AFTER - Both OFF**

https://github.com/user-attachments/assets/bb19b331-a65b-45d7-b64b-33d2f05f65ac

**AFTER - BOTH ON**

https://github.com/user-attachments/assets/1214c36d-0d6e-487e-b74a-87321ae23829

**AFTER - `console.showNotebookConsoles` ON**

https://github.com/user-attachments/assets/ae5d7219-9f99-4855-804a-ec7e42081acb

**AFTER - `console.showNotebookConsoleActions` ON**

https://github.com/user-attachments/assets/ec34edfc-9be2-4808-81fc-a1ead5c1d19d

https://github.com/user-attachments/assets/0cca0ca5-12dc-44ad-ac0d-c0e3cffd5148


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Following up on the shared notebook/console kernel feature ([#3801](https://github.com/posit-dev/positron/issues/3801)), notebook console action
  buttons are now hidden by default ([#9948](https://github.com/posit-dev/positron/issues/9948)). Enable **Console: Show Notebook Console Actions** to
  display "Show Notebook Console" option in notebook toolbars.

#### Bug Fixes

- N/A


### QA Notes

@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
