### PR TITLE
Add a subtle drop shadow to the breakcrumb bar when the notebook editor is scrolled at all to make visually more distinct.

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -48,6 +48,7 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	position: relative;
 
 	p,
 	h1,
@@ -78,4 +79,15 @@
 
 	height: 100%;
 	overflow: auto;
+}
+
+.positron-notebook .scroll-decoration {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 6px;
+	z-index: 10;
+	pointer-events: none;
+	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -38,8 +38,19 @@ export function PositronNotebookComponent() {
 	const [globalAnnouncement, setGlobalAnnouncement] = React.useState<string>('');
 	const previousCellCount = React.useRef<number>(notebookCells.length);
 
+	// Track scroll position for scroll decoration
+	const [isScrolled, setIsScrolled] = React.useState(false);
+
+	// TODO: Track find widget visibility for scroll decoration
+	// When the find widget is implemented, add state here to track visibility
+	// and include it in the showDecoration condition below.
+
 	React.useEffect(() => {
 		notebookInstance.setCellsContainer(containerRef.current);
+		// Initial scroll check
+		if (containerRef.current) {
+			setIsScrolled(containerRef.current.scrollTop > 0);
+		}
 	}, [notebookInstance]);
 
 	// Track cell count changes and announce to screen readers
@@ -58,13 +69,27 @@ export function PositronNotebookComponent() {
 		previousCellCount.current = currentCount;
 	}, [notebookCells.length]);
 
-	// Observe scroll events and fire to notebook instance
+	// Observe scroll events and fire to notebook instance, also track scroll position
 	useScrollObserver(containerRef, React.useCallback(() => {
 		notebookInstance.fireScrollEvent();
+		setIsScrolled((containerRef.current?.scrollTop ?? 0) > 0);
 	}, [notebookInstance]));
+
+	// TODO: Observe find widget visibility from context key service
+	// When the find widget is implemented, add an effect here to observe
+
+	// Determine if scroll decoration should be shown
+	const showDecoration = isScrolled;
 
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
+			{showDecoration && (
+				<div
+					aria-hidden='true'
+					className='scroll-decoration'
+					role='presentation'
+				/>
+			)}
 			<div ref={containerRef} className='positron-notebook-cells-container'>
 				{notebookCells.length ?
 					notebookCells.map((cell, index) =>


### PR DESCRIPTION
Just a quick PR to bring up the style of the breadcrumb bar to match the existing editors. 

Other editors have no drop shadow on the breadcrumb bar when the editor is scrolled all the way to the top, then when the user scrolls they add a subtle drop-shadow border to create visual separation. Positron notebooks just never had a border which did look a bit funky when things dissapeared behind a plain white (in the case of light mode) band. 

Here we add some css logic and hook into existing scroll tracking to recreate this behavior. 

I also added some comments on where we can add logic to enable the border at other times like when the find widget is implemented for #11056.

### Text editor behavior when not scrolled

<img width="680" height="256" alt="image" src="https://github.com/user-attachments/assets/7d9ce8f7-4314-46a6-ad31-1b6562672668" />


### Text editor behavior on scroll

<img width="684" height="171" alt="image" src="https://github.com/user-attachments/assets/0e1a3f61-fd9b-41bc-86ad-1809e0b0f938" />


### Old behavior on scroll

<img width="681" height="232" alt="image" src="https://github.com/user-attachments/assets/675a8584-08e2-4aeb-9507-26737b36089b" />



### New behavior on scroll

<img width="672" height="178" alt="image" src="https://github.com/user-attachments/assets/fe4ae1d0-7869-4c25-ad8b-b68ff452e0d6" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
