### PR TITLE
[python] look for web app creation before imports 

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -26,11 +26,11 @@ export function getFramework(text: string): string | undefined {
 
     // Define patterns for app creation for each framework
     const appCreationPatterns: Record<string, RegExp> = {
-        'dash': /\w+\s*=\s*(?:Dash|dash\.Dash)\(/i,
-        'flask': /\w+\s*=\s*(?:Flask|flask\.Flask)\(/i,
-        'streamlit': /st\.\w+\(|streamlit\.\w+\(/i, // More specific pattern for actual streamlit usage
-        'gradio': /\w+\s*=\s*(?:gr\.|gradio\.)/i,
-        'fastapi': /\w+\s*=\s*(?:FastAPI|fastapi\.FastAPI)\(/i,
+        dash: /\w+\s*=\s*(?:Dash|dash\.Dash)\(/i,
+        flask: /\w+\s*=\s*(?:Flask|flask\.Flask)\(/i,
+        streamlit: /st\.\w+\(|streamlit\.\w+\(/i, // More specific pattern for actual streamlit usage
+        gradio: /\w+\s*=\s*(?:gr\.|gradio\.)/i,
+        fastapi: /\w+\s*=\s*(?:FastAPI|fastapi\.FastAPI)\(/i,
     };
 
     // Check for app creation first (more reliable)

--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -23,6 +23,24 @@ export function detectWebApp(document: vscode.TextDocument): void {
 
 export function getFramework(text: string): string | undefined {
     const libraries = getSupportedLibraries();
+
+    // Define patterns for app creation for each framework
+    const appCreationPatterns: Record<string, RegExp> = {
+        'dash': /\w+\s*=\s*(?:Dash|dash\.Dash)\(/i,
+        'flask': /\w+\s*=\s*(?:Flask|flask\.Flask)\(/i,
+        'streamlit': /st\.\w+\(|streamlit\.\w+\(/i, // More specific pattern for actual streamlit usage
+        'gradio': /\w+\s*=\s*(?:gr\.|gradio\.)/i,
+        'fastapi': /\w+\s*=\s*(?:FastAPI|fastapi\.FastAPI)\(/i,
+    };
+
+    // Check for app creation first (more reliable)
+    for (const lib of libraries) {
+        if (libraries.includes(lib) && lib in appCreationPatterns && appCreationPatterns[lib].test(text)) {
+            return lib;
+        }
+    }
+
+    // Fall back to import detection
     const importPattern = new RegExp(`import\\s+(${libraries.join('|')})`, 'g');
     const fromImportPattern = new RegExp(`from\\s+(${libraries.join('|')})\\S*\\simport`, 'g');
     const importMatch = importPattern.exec(text);

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -11,56 +11,56 @@ import { detectWebApp, getFramework } from '../../client/positron/webAppContexts
 import { IDisposableRegistry } from '../../client/common/types';
 
 suite('Discover Web app frameworks', () => {
-    let document: vscode.TextDocument;
-    let executeCommandStub: sinon.SinonStub;
-    const disposables: IDisposableRegistry = [];
+	let document: vscode.TextDocument;
+	let executeCommandStub: sinon.SinonStub;
+	const disposables: IDisposableRegistry = [];
 
-    setup(() => {
-        executeCommandStub = sinon.stub(cmdApis, 'executeCommand');
-        document = {
-            getText: () => '',
-            languageId: 'python',
-        } as vscode.TextDocument;
-    });
+	setup(() => {
+		executeCommandStub = sinon.stub(cmdApis, 'executeCommand');
+		document = {
+			getText: () => '',
+			languageId: 'python',
+		} as vscode.TextDocument;
+	});
 
-    teardown(() => {
-        sinon.restore();
-        disposables.forEach((d) => d.dispose());
-    });
+	teardown(() => {
+		sinon.restore();
+		disposables.forEach((d) => d.dispose());
+	});
 
-    const texts = {
-        'import streamlit': 'streamlit',
-        'from fastapi import FastAPI': 'fastapi',
-        'import numpy': 'numpy',
-    };
-    Object.entries(texts).forEach(([text, framework]) => {
-        const expected = text.includes('numpy') ? undefined : framework;
-        test('should set context pythonAppFramework if application is found', () => {
-            document.getText = () => text;
-            detectWebApp(document);
+	const texts = {
+		'import streamlit': 'streamlit',
+		'from fastapi import FastAPI': 'fastapi',
+		'import numpy': 'numpy',
+	};
+	Object.entries(texts).forEach(([text, framework]) => {
+		const expected = text.includes('numpy') ? undefined : framework;
+		test('should set context pythonAppFramework if application is found', () => {
+			document.getText = () => text;
+			detectWebApp(document);
 
-            assert.ok(executeCommandStub.calledOnceWith('setContext', 'pythonAppFramework', expected));
-        });
-    });
+			assert.ok(executeCommandStub.calledOnceWith('setContext', 'pythonAppFramework', expected));
+		});
+	});
 
-    const frameworks = ['streamlit', 'gradio', 'flask', 'fastapi', 'numpy'];
-    frameworks.forEach((framework) => {
-        const expected = framework === 'numpy' ? undefined : framework;
-        test(`should detect ${expected}: import framework`, () => {
-            const text = `import ${framework}`;
-            const actual = getFramework(text);
+	const frameworks = ['streamlit', 'gradio', 'flask', 'fastapi', 'numpy'];
+	frameworks.forEach((framework) => {
+		const expected = framework === 'numpy' ? undefined : framework;
+		test(`should detect ${expected}: import framework`, () => {
+			const text = `import ${framework}`;
+			const actual = getFramework(text);
 
-            assert.strictEqual(actual, expected);
-        });
-        test(`should detect ${expected}: from framework.test import XYZ`, () => {
-            const text = `from ${framework}.test import XYZ`;
-            const actual = getFramework(text);
+			assert.strictEqual(actual, expected);
+		});
+		test(`should detect ${expected}: from framework.test import XYZ`, () => {
+			const text = `from ${framework}.test import XYZ`;
+			const actual = getFramework(text);
 
-            assert.strictEqual(actual, expected);
-        });
-        test(`should detect ${expected}: from framework import XYZ`, () => {
-            const text = `from ${framework} import XYZ`;
-            const actual = getFramework(text);
+			assert.strictEqual(actual, expected);
+		});
+		test(`should detect ${expected}: from framework import XYZ`, () => {
+			const text = `from ${framework} import XYZ`;
+			const actual = getFramework(text);
 
 			assert.strictEqual(actual, expected);
 		});
@@ -71,13 +71,8 @@ suite('Discover Web app frameworks', () => {
 		test('should detect Dash app when Flask is also imported', () => {
 			const code = `
 import flask
-import pandas as pd
 import plotly.express as px
 from dash import Dash, Input, Output, callback, dcc, html
-
-df = pd.read_csv(
-    "https://raw.githubusercontent.com/plotly/datasets/master/gapminder_unfiltered.csv"
-)
 
 app = Dash()
 `;

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -62,7 +62,85 @@ suite('Discover Web app frameworks', () => {
             const text = `from ${framework} import XYZ`;
             const actual = getFramework(text);
 
-            assert.strictEqual(actual, expected);
-        });
-    });
+			assert.strictEqual(actual, expected);
+		});
+	});
+
+	// Tests for app creation patterns
+	suite('App Creation Pattern Detection', () => {
+		test('should detect Dash app when Flask is also imported', () => {
+			const code = `
+import flask
+import pandas as pd
+import plotly.express as px
+from dash import Dash, Input, Output, callback, dcc, html
+
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/plotly/datasets/master/gapminder_unfiltered.csv"
+)
+
+app = Dash()
+`;
+			assert.strictEqual(getFramework(code), 'dash');
+		});
+
+		test('should detect Dash app with custom variable name', () => {
+			const code = `
+import flask
+from dash import Dash
+
+my_dashboard = Dash(__name__)
+`;
+			assert.strictEqual(getFramework(code), 'dash');
+		});
+
+		test('should detect Flask app with custom variable name', () => {
+			const code = `
+from flask import Flask
+
+web_service = Flask(__name__)
+
+@web_service.route('/')
+def hello_world():
+    return 'Hello, World!'
+`;
+			assert.strictEqual(getFramework(code), 'flask');
+		});
+
+		test('should detect FastAPI app with custom variable name', () => {
+			const code = `
+from fastapi import FastAPI
+
+api_service = FastAPI()
+
+@api_service.get("/")
+def read_root():
+    return {"Hello": "World"}
+`;
+			assert.strictEqual(getFramework(code), 'fastapi');
+		});
+
+		test('should detect Gradio app with custom variable name', () => {
+			const code = `
+import gradio as gr
+
+def greet(name):
+    return "Hello " + name + "!"
+
+interface = gr.Interface(fn=greet, inputs="text", outputs="text")
+`;
+			assert.strictEqual(getFramework(code), 'gradio');
+		});
+
+		test('should prioritize app creation over imports', () => {
+			const code = `
+import streamlit
+import flask
+import dash
+
+app = Dash(__name__)
+`;
+			assert.strictEqual(getFramework(code), 'dash');
+		});
+	});
 });

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -11,86 +11,86 @@ import { detectWebApp, getFramework } from '../../client/positron/webAppContexts
 import { IDisposableRegistry } from '../../client/common/types';
 
 suite('Discover Web app frameworks', () => {
-	let document: vscode.TextDocument;
-	let executeCommandStub: sinon.SinonStub;
-	const disposables: IDisposableRegistry = [];
+    let document: vscode.TextDocument;
+    let executeCommandStub: sinon.SinonStub;
+    const disposables: IDisposableRegistry = [];
 
-	setup(() => {
-		executeCommandStub = sinon.stub(cmdApis, 'executeCommand');
-		document = {
-			getText: () => '',
-			languageId: 'python',
-		} as vscode.TextDocument;
-	});
+    setup(() => {
+        executeCommandStub = sinon.stub(cmdApis, 'executeCommand');
+        document = {
+            getText: () => '',
+            languageId: 'python',
+        } as vscode.TextDocument;
+    });
 
-	teardown(() => {
-		sinon.restore();
-		disposables.forEach((d) => d.dispose());
-	});
+    teardown(() => {
+        sinon.restore();
+        disposables.forEach((d) => d.dispose());
+    });
 
-	const texts = {
-		'import streamlit': 'streamlit',
-		'from fastapi import FastAPI': 'fastapi',
-		'import numpy': 'numpy',
-	};
-	Object.entries(texts).forEach(([text, framework]) => {
-		const expected = text.includes('numpy') ? undefined : framework;
-		test('should set context pythonAppFramework if application is found', () => {
-			document.getText = () => text;
-			detectWebApp(document);
+    const texts = {
+        'import streamlit': 'streamlit',
+        'from fastapi import FastAPI': 'fastapi',
+        'import numpy': 'numpy',
+    };
+    Object.entries(texts).forEach(([text, framework]) => {
+        const expected = text.includes('numpy') ? undefined : framework;
+        test('should set context pythonAppFramework if application is found', () => {
+            document.getText = () => text;
+            detectWebApp(document);
 
-			assert.ok(executeCommandStub.calledOnceWith('setContext', 'pythonAppFramework', expected));
-		});
-	});
+            assert.ok(executeCommandStub.calledOnceWith('setContext', 'pythonAppFramework', expected));
+        });
+    });
 
-	const frameworks = ['streamlit', 'gradio', 'flask', 'fastapi', 'numpy'];
-	frameworks.forEach((framework) => {
-		const expected = framework === 'numpy' ? undefined : framework;
-		test(`should detect ${expected}: import framework`, () => {
-			const text = `import ${framework}`;
-			const actual = getFramework(text);
+    const frameworks = ['streamlit', 'gradio', 'flask', 'fastapi', 'numpy'];
+    frameworks.forEach((framework) => {
+        const expected = framework === 'numpy' ? undefined : framework;
+        test(`should detect ${expected}: import framework`, () => {
+            const text = `import ${framework}`;
+            const actual = getFramework(text);
 
-			assert.strictEqual(actual, expected);
-		});
-		test(`should detect ${expected}: from framework.test import XYZ`, () => {
-			const text = `from ${framework}.test import XYZ`;
-			const actual = getFramework(text);
+            assert.strictEqual(actual, expected);
+        });
+        test(`should detect ${expected}: from framework.test import XYZ`, () => {
+            const text = `from ${framework}.test import XYZ`;
+            const actual = getFramework(text);
 
-			assert.strictEqual(actual, expected);
-		});
-		test(`should detect ${expected}: from framework import XYZ`, () => {
-			const text = `from ${framework} import XYZ`;
-			const actual = getFramework(text);
+            assert.strictEqual(actual, expected);
+        });
+        test(`should detect ${expected}: from framework import XYZ`, () => {
+            const text = `from ${framework} import XYZ`;
+            const actual = getFramework(text);
 
-			assert.strictEqual(actual, expected);
-		});
-	});
+            assert.strictEqual(actual, expected);
+        });
+    });
 
-	// Tests for app creation patterns
-	suite('App Creation Pattern Detection', () => {
-		test('should detect Dash app when Flask is also imported', () => {
-			const code = `
+    // Tests for app creation patterns
+    suite('App Creation Pattern Detection', () => {
+        test('should detect Dash app when Flask is also imported', () => {
+            const code = `
 import flask
 import plotly.express as px
 from dash import Dash, Input, Output, callback, dcc, html
 
 app = Dash()
 `;
-			assert.strictEqual(getFramework(code), 'dash');
-		});
+            assert.strictEqual(getFramework(code), 'dash');
+        });
 
-		test('should detect Dash app with custom variable name', () => {
-			const code = `
+        test('should detect Dash app with custom variable name', () => {
+            const code = `
 import flask
 from dash import Dash
 
 my_dashboard = Dash(__name__)
 `;
-			assert.strictEqual(getFramework(code), 'dash');
-		});
+            assert.strictEqual(getFramework(code), 'dash');
+        });
 
-		test('should detect Flask app with custom variable name', () => {
-			const code = `
+        test('should detect Flask app with custom variable name', () => {
+            const code = `
 from flask import Flask
 
 web_service = Flask(__name__)
@@ -99,11 +99,11 @@ web_service = Flask(__name__)
 def hello_world():
     return 'Hello, World!'
 `;
-			assert.strictEqual(getFramework(code), 'flask');
-		});
+            assert.strictEqual(getFramework(code), 'flask');
+        });
 
-		test('should detect FastAPI app with custom variable name', () => {
-			const code = `
+        test('should detect FastAPI app with custom variable name', () => {
+            const code = `
 from fastapi import FastAPI
 
 api_service = FastAPI()
@@ -112,11 +112,11 @@ api_service = FastAPI()
 def read_root():
     return {"Hello": "World"}
 `;
-			assert.strictEqual(getFramework(code), 'fastapi');
-		});
+            assert.strictEqual(getFramework(code), 'fastapi');
+        });
 
-		test('should detect Gradio app with custom variable name', () => {
-			const code = `
+        test('should detect Gradio app with custom variable name', () => {
+            const code = `
 import gradio as gr
 
 def greet(name):
@@ -124,18 +124,18 @@ def greet(name):
 
 interface = gr.Interface(fn=greet, inputs="text", outputs="text")
 `;
-			assert.strictEqual(getFramework(code), 'gradio');
-		});
+            assert.strictEqual(getFramework(code), 'gradio');
+        });
 
-		test('should prioritize app creation over imports', () => {
-			const code = `
+        test('should prioritize app creation over imports', () => {
+            const code = `
 import streamlit
 import flask
 import dash
 
 app = Dash(__name__)
 `;
-			assert.strictEqual(getFramework(code), 'dash');
-		});
-	});
+            assert.strictEqual(getFramework(code), 'dash');
+        });
+    });
 });


### PR DESCRIPTION
Currently, we just look at `import XXX` or `from XXXX import XXXX` to decide if users are in a certain type of web app. This isn't the most reliable. This PR adds in a preliminary check of "has a user created the actual app object from a framework" rather than just relying on imports, which we keep as a backup.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #10258 Adjusted web app detection to look for app creation before imports.


### QA Notes

#10258 has a good example, and I've added a few others in unittests. Generally, creating apps with multiple imports and making sure we detect the one that is initialized by, eg, `app = Dash()` or `st.write("hello")`
