### PR TITLE
Fix Windows postinstall launching Positron with silent option

### DIFF
--- a/build/win32/positron.iss
+++ b/build/win32/positron.iss
@@ -85,7 +85,7 @@ Name: "addcontextmenufiles"; Description: "{cm:AddContextMenuFiles,{#NameShort}}
 Name: "addcontextmenufolders"; Description: "{cm:AddContextMenuFolders,{#NameShort}}"; GroupDescription: "{cm:Other}"; Flags: unchecked; Check: not (IsWindows11OrLater and QualityIsInsiders)
 Name: "associatewithfiles"; Description: "{cm:AssociateWithFiles,{#NameShort}}"; GroupDescription: "{cm:Other}"
 Name: "addtopath"; Description: "{cm:AddToPath}"; GroupDescription: "{cm:Other}"
-Name: "runcode"; Description: "{cm:RunAfter,{#NameShort}}"; GroupDescription: "{cm:Other}"; Check: WizardSilent
+Name: "runcode"; Description: "{cm:RunAfter,{#NameShort}}"; GroupDescription: "{cm:Other}"; Check: WizardSilent and IsBackgroundUpdate
 
 [Dirs]
 Name: "{app}"; AfterInstall: DisableAppDirInheritance


### PR DESCRIPTION
Address #10843 

The task needs to run in silent mode for updates. There is an existing check on background updates where it looks for a marker file to signal that an update is in progress. This occurs with the `/update` option that Positron passes to the installer in an update scenario.

For a typical admin install, they may script the installation or run it from command line. The silent option wasn't enough to prevent launching Positron. Adding the background update check restricts it to the update scenario.

Note: there is also the `[Run]` section that can launch Positron but it is the option at the end of the wizard installation.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Windows installer launching Positron when run in silent mode


### QA Notes
* Installer should respect the option to launch Positron at the end of the install
* Running the installer from the command line in silent mode should not run Positron
* The auto-update should re-launch Positron after initiating the "Restart to Update"