### PR TITLE
[python/ci] replace miniconda with miniforge

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -357,10 +357,12 @@ jobs:
           }
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        shell: bash
         if: matrix.os == 'macos-latest' && matrix.test-suite == 'venv'
-        with:
-          python-version: "3.11"
+        run: |
+          curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+          source "${HOME}/conda/etc/profile.d/conda.sh"
 
       - name: Prepare conda for venv tests
         env:


### PR DESCRIPTION
With license changes to conda/miniconda, we want to move to miniforge, which is oss+community run. There's nothing in the github actions marketplace for miniforge ([one exists but is archived](https://github.com/conda-forge/setup-miniforge/tree/master)), so I wrote out their steps for installing the latest version in CI.

Miniforge is the community version of conda, which does not have the same licensing restrictions as miniconda and automatically uses to community-run package distributor conda-forge.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- https://github.com/posit-dev/positron/issues/11088 Use miniforge in Python CI.


### QA Notes

ci should be green