### PR TITLE
Connections pane multiple drivers

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1508,8 +1508,15 @@ declare module 'positron' {
 		languageId: string;
 		/**
 		 * A human-readable name for the driver.
+		 * The name is also used to group drivers for the same database provider. For instance,
+		 * if there are multiple different ways to connect to the same database.
 		 */
 		name: string;
+		/**
+		 * A human-readable description for the driver.
+		 * Used specially when disambiguating drivers with the same name.
+		 */
+		description?: string;
 		/**
 		 * The base64-encoded SVG icon for the driver.
 		 */

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
@@ -18,6 +18,7 @@ import { CreateConnection } from './newConnectionModalDialog/createConnectionSta
 import { ListDrivers } from './newConnectionModalDialog/listDriversState.js';
 import { IDriver } from '../../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
+import { ListDriversDetails } from './newConnectionModalDialog/listDriversDetailsState.js';
 
 const NEW_CONNECTION_MODAL_DIALOG_WIDTH = 700;
 const NEW_CONNECTION_MODAL_DIALOG_HEIGHT = 630;
@@ -36,8 +37,21 @@ interface NewConnectionModalDialogProps {
 	readonly renderer: PositronModalReactRenderer;
 }
 
+
 const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDialogProps>) => {
-	const [selectedDriver, setSelectedDriver] = useState<IDriver | undefined>();
+
+	enum ModalStateKind {
+		ListDrivers,
+		CreateConnection,
+		SelectDriverDetails
+	}
+
+	type ModalState = { kind: ModalStateKind.ListDrivers } |
+	{ kind: ModalStateKind.CreateConnection, driver: IDriver, previous: ModalState } |
+	{ kind: ModalStateKind.SelectDriverDetails, drivers: IDriver[], previous: ModalState };
+
+	const [modalState, setModalState] = useState<ModalState>({ kind: ModalStateKind.ListDrivers });
+
 	// If threre is a foreground session, use its language ID as the preferred language id.
 	const [languageId, setLanguageId] = useState<string | undefined>(
 		props.renderer.services.runtimeSessionService.foregroundSession?.runtimeMetadata.languageId
@@ -49,8 +63,19 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 
 	const backHandler = () => {
 		// When hitting back, reset the language ID to the previously selected language id
-		setLanguageId(selectedDriver?.metadata.languageId);
-		setSelectedDriver(undefined);
+		switch (modalState.kind) {
+			case ModalStateKind.CreateConnection:
+				setLanguageId(modalState.driver.metadata.languageId);
+				setModalState(modalState.previous);
+				break;
+			case ModalStateKind.SelectDriverDetails:
+				setLanguageId(modalState.drivers[0].metadata.languageId);
+				setModalState(modalState.previous);
+				break;
+			case ModalStateKind.ListDrivers:
+				// no-op
+				break;
+		}
 	};
 
 	return <PositronModalDialog
@@ -62,19 +87,39 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 	>
 		<div className='connections-new-connection-modal'>
 			<ContentArea>
-				{
-					selectedDriver ?
-						<CreateConnection
-							renderer={props.renderer}
-							selectedDriver={selectedDriver}
-							onBack={backHandler}
-							onCancel={cancelHandler} /> :
-						<ListDrivers
-							languageId={languageId}
-							setLanguageId={setLanguageId}
-							onCancel={cancelHandler}
-							onSelection={(driver) => setSelectedDriver(driver)}
-						/>}
+				{(() => {
+					switch (modalState.kind) {
+						case ModalStateKind.CreateConnection:
+							return <CreateConnection
+								renderer={props.renderer}
+								selectedDriver={modalState.driver}
+								onBack={backHandler}
+								onCancel={cancelHandler} />;
+						case ModalStateKind.ListDrivers:
+							return <ListDrivers
+								languageId={languageId}
+								setLanguageId={setLanguageId}
+								onCancel={cancelHandler}
+								onSelection={(drivers) => {
+									if (drivers.length === 1) {
+										// if there's a single driver with that name, we don't need to filter out
+										// anything
+										setModalState({ kind: ModalStateKind.CreateConnection, driver: drivers[0], previous: modalState });
+									} else {
+										// otherwise we set the state the user to select the driver details
+										setModalState({ kind: ModalStateKind.SelectDriverDetails, drivers, previous: modalState });
+									}
+								}} />;
+						case ModalStateKind.SelectDriverDetails:
+							return <ListDriversDetails
+								drivers={modalState.drivers}
+								onBack={backHandler}
+								onCancel={cancelHandler}
+								onDriverSelected={(driver) => {
+									setModalState({ kind: ModalStateKind.CreateConnection, driver, previous: modalState });
+								}} />;
+					}
+				})()}
 			</ContentArea>
 		</div>
 	</PositronModalDialog>;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
@@ -52,7 +52,7 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 
 	const [modalState, setModalState] = useState<ModalState>({ kind: ModalStateKind.ListDrivers });
 
-	// If threre is a foreground session, use its language ID as the preferred language id.
+	// If there is a foreground session, use its language ID as the preferred language id.
 	const [languageId, setLanguageId] = useState<string | undefined>(
 		props.renderer.services.runtimeSessionService.foregroundSession?.runtimeMetadata.languageId
 	);
@@ -106,7 +106,7 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 										// anything
 										setModalState({ kind: ModalStateKind.CreateConnection, driver: drivers[0], previous: modalState });
 									} else {
-										// otherwise we set the state the user to select the driver details
+										// otherwise we set the state the user to the user select the driver details
 										setModalState({ kind: ModalStateKind.SelectDriverDetails, drivers, previous: modalState });
 									}
 								}} />;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
@@ -29,7 +29,7 @@
 
 .connections-new-connection-list-drivers-details > .footer {
 	grid-row: 3;
-	display:inline-flex;
+	display: inline-flex;
 }
 
 .connections-new-connection-list-drivers-details > .footer > .button {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.connections-new-connection-list-drivers-details {
+	display: grid;
+	gap: 10px;
+	grid-template-rows: 36px 1fr 32px;
+	height: 100%;
+}
+
+.connections-new-connection-list-drivers-details > .header {
+	grid-row: 1;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+.connections-new-connection-list-drivers-details > .header > .title {
+	flex-grow: 1;
+}
+
+.connections-new-connection-list-drivers-details > .header > .icon {
+	margin-left: 10px;
+	height: 24px;
+	width: 24px;
+}
+
+.connections-new-connection-list-drivers-details > .footer {
+	grid-row: 3;
+	display:inline-flex;
+}
+
+.connections-new-connection-list-drivers-details > .footer > .button {
+	padding: 0 15px;
+}
+
+.connections-new-connection-list-drivers-details > .footer > .right {
+	margin-left: auto;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list {
+	grid-row: 2;
+	height: 100%;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-positronVariables-border);
+	overflow-y: auto;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item {
+	display: grid;
+	grid-template-columns: auto;
+	gap: 2px;
+	align-items: center;
+	padding: 0px 5px;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item > .driver-info {
+	grid-column: 1;
+	display: grid;
+	grid-template-columns: max-content 1fr 26px;
+	gap: 4px;
+	align-items: center;
+
+	height: 40px;
+	padding-left: 6px;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item:not(:last-child) > .driver-info {
+	border-bottom: 1px solid var(--vscode-positronVariables-border);
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item > .driver-info > .driver-description {
+	grid-column: 1;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item > .driver-info > .driver-inputs {
+	grid-column: 2;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item > .driver-info > .driver-button {
+	grid-column: 3;
+}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.css
@@ -49,11 +49,16 @@
 }
 
 .connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item {
+	background: transparent;
+	border: none;
+	color: inherit;
 	display: grid;
 	grid-template-columns: auto;
 	gap: 2px;
 	align-items: center;
 	padding: 0px 5px;
+	text-align: left;
+	cursor: pointer;
 }
 
 .connections-new-connection-list-drivers-details > .drivers-list > .driver-list-item > .driver-info {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './listDriversDetailsState.css';
+
+
+// React.
+import React, { PropsWithChildren } from 'react';
+import { IDriver, Input } from '../../../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
+import { localize } from '../../../../../../nls.js';
+import { PositronButton } from '../../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+
+
+interface ListDriversDetailsProps {
+	readonly drivers: IDriver[];
+	readonly onDriverSelected: (driver: IDriver) => void;
+	readonly onBack: () => void;
+	readonly onCancel: () => void;
+}
+
+export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsProps>) => {
+	const driver = props.drivers;
+
+	// drivers must be length > 1
+	if (driver.length <= 1) {
+		throw new Error('ListDriversDetails requires more than one driver');
+	}
+
+	const name = driver[0].metadata.name;
+	const summarizeInputs = (inputs: Input[]): React.ReactNode => {
+		if (inputs.length === 0) {
+			return localize(
+				'positron.connections.newConnectionModalDialog.listDriversDetails.noInputs',
+				'No inputs required'
+			);
+		}
+
+		const labels = inputs.map(input => input.label).filter((label): label is string => Boolean(label));
+		return labels.join(', ');
+	};
+
+	return <div className='connections-new-connection-list-drivers-details'>
+		<div className='header'>
+			<h1 className='title'>
+				{localize(
+					'positron.connections.newConnectionModalDialog.listDriversDetails.title',
+					'Multiple drivers found for {0}',
+					name
+				)}
+			</h1>
+			<div className='icon'>
+				{driver[0].metadata.base64EncodedIconSvg ? <img
+					src={`data:image/svg+xml;base64,${driver[0].metadata.base64EncodedIconSvg}`}
+				/> : null}
+			</div>
+		</div>
+		<div className='drivers-list'>
+			{driver.map((driver) => (
+				<div key={driver.driverId} className='driver-list-item'>
+					<div className='driver-info' onMouseDown={() => props.onDriverSelected(driver)}>
+						<div className='driver-description'>
+							{driver.metadata.description ?? localize(
+								'positron.connections.newConnectionModalDialog.listDriversDetails.noDescription',
+								'No description available'
+							)}
+							{':'}
+						</div>
+						<div className='driver-inputs'>
+							<small>
+								{'('}
+								{summarizeInputs(driver.metadata.inputs)}
+								{')'}
+							</small>
+						</div>
+						<div className={`driver-button codicon codicon-chevron-right`}>
+						</div>
+					</div>
+				</div>
+			))}
+		</div>
+		<div className='footer'>
+			<PositronButton
+				className='button action-bar-button'
+				onPressed={props.onBack}
+			>
+				{(() => localize('positron.resumeConnectionModalDialog.back', "Back"))()}
+			</PositronButton>
+			<PositronButton
+				className='button action-bar-button right'
+				onPressed={props.onCancel}
+			>
+				{(() => localize('positron.resumeConnectionModalDialog.cancel', "Cancel"))()}
+			</PositronButton>
+		</div>
+	</div>;
+}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -47,7 +47,7 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 			<h1 className='title'>
 				{localize(
 					'positron.connections.newConnectionModalDialog.listDriversDetails.title',
-					'Multiple drivers found for {0}',
+					'Select a driver for {0}',
 					name
 				)}
 			</h1>
@@ -62,10 +62,12 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 				<div key={driver.driverId} className='driver-list-item'>
 					<div className='driver-info' onMouseDown={() => props.onDriverSelected(driver)}>
 						<div className='driver-description'>
-							{driver.metadata.description ?? localize(
-								'positron.connections.newConnectionModalDialog.listDriversDetails.noDescription',
-								'No description available'
-							)}
+							<strong>
+								{driver.metadata.description ?? localize(
+									'positron.connections.newConnectionModalDialog.listDriversDetails.noDescription',
+									'No description available'
+								)}
+							</strong>
 							{':'}
 						</div>
 						<div className='driver-inputs'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -8,10 +8,11 @@ import './listDriversDetailsState.css';
 
 
 // React.
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { IDriver, Input } from '../../../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { localize } from '../../../../../../nls.js';
 import { PositronButton } from '../../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 
 
 interface ListDriversDetailsProps {
@@ -22,11 +23,23 @@ interface ListDriversDetailsProps {
 }
 
 export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsProps>) => {
+	const services = usePositronReactServicesContext();
 	const drivers = props.drivers;
+	const { onBack } = props;
 
 	// drivers must be length > 1
+	useEffect(() => {
+		if (drivers.length <= 1) {
+			services.notificationService.error(localize(
+				'positron.connections.newConnectionModalDialog.listDriversDetails.invalidDriverSelection',
+				'Unable to show driver details. Please select a driver again.'
+			));
+			onBack();
+		}
+	}, [drivers, onBack, services]);
+
 	if (drivers.length <= 1) {
-		throw new Error('ListDriversDetails requires more than one driver');
+		return null;
 	}
 
 	const name = drivers[0].metadata.name;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -60,8 +60,14 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 		</div>
 		<div className='drivers-list'>
 			{drivers.map((driver) => (
-				<div key={driver.driverId} className='driver-list-item'>
-					<div className='driver-info' onMouseDown={() => props.onDriverSelected(driver)}>
+				<div
+					key={driver.driverId}
+					className='driver-list-item'
+					role='button'
+					tabIndex={0}
+					onClick={() => props.onDriverSelected(driver)}
+				>
+					<div className='driver-info'>
 						<div className='driver-description'>
 							<strong>
 								{driver.metadata.description ?? localize(

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -60,11 +60,9 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 		</div>
 		<div className='drivers-list'>
 			{drivers.map((driver) => (
-				<div
+				<button
 					key={driver.driverId}
 					className='driver-list-item'
-					role='button'
-					tabIndex={0}
 					onClick={() => props.onDriverSelected(driver)}
 				>
 					<div className='driver-info'>
@@ -87,7 +85,7 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 						<div className={`driver-button codicon codicon-chevron-right`}>
 						</div>
 					</div>
-				</div>
+				</button>
 			))}
 		</div>
 		<div className='footer'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -80,12 +80,10 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 				>
 					<div className='driver-info'>
 						<div className='driver-description'>
-							<strong>
-								{driver.metadata.description ?? localize(
-									'positron.connections.newConnectionModalDialog.listDriversDetails.noDescription',
-									'No description available'
-								)}
-							</strong>
+							{driver.metadata.description ?? localize(
+								'positron.connections.newConnectionModalDialog.listDriversDetails.noDescription',
+								'No description available'
+							)}
 							{':'}
 						</div>
 						<div className='driver-inputs'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -22,14 +22,14 @@ interface ListDriversDetailsProps {
 }
 
 export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsProps>) => {
-	const driver = props.drivers;
+	const drivers = props.drivers;
 
 	// drivers must be length > 1
-	if (driver.length <= 1) {
+	if (drivers.length <= 1) {
 		throw new Error('ListDriversDetails requires more than one driver');
 	}
 
-	const name = driver[0].metadata.name;
+	const name = drivers[0].metadata.name;
 	const summarizeInputs = (inputs: Input[]): React.ReactNode => {
 		if (inputs.length === 0) {
 			return localize(
@@ -52,13 +52,14 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 				)}
 			</h1>
 			<div className='icon'>
-				{driver[0].metadata.base64EncodedIconSvg ? <img
-					src={`data:image/svg+xml;base64,${driver[0].metadata.base64EncodedIconSvg}`}
+				{drivers[0].metadata.base64EncodedIconSvg ? <img
+					alt='' // decorative image
+					src={`data:image/svg+xml;base64,${drivers[0].metadata.base64EncodedIconSvg}`}
 				/> : null}
 			</div>
 		</div>
 		<div className='drivers-list'>
-			{driver.map((driver) => (
+			{drivers.map((driver) => (
 				<div key={driver.driverId} className='driver-list-item'>
 					<div className='driver-info' onMouseDown={() => props.onDriverSelected(driver)}>
 						<div className='driver-description'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
@@ -70,11 +70,17 @@
 }
 
 .driver-list-item {
+	background: transparent;
+	border: none;
+	color: inherit;
 	display: grid;
 	grid-template-columns: 24px auto;
 	gap: 2px;
 	align-items: center;
 	padding: 0px 5px;
+	text-align: left;
+	width: 100%;
+	cursor: pointer;
 }
 
 .driver-list-item > .driver-icon {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.css
@@ -28,10 +28,10 @@
 
 .connections-new-connection-list-drivers > .driver-list {
 	grid-row: 3;
+	height: 100%;
 	border-radius: 4px;
 	border: 1px solid var(--vscode-positronVariables-border);
 	overflow-y: auto;
-	height: 100%;
 }
 
 .connections-new-connection-list-drivers > .footer {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -97,11 +97,9 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 							<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
 							<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
-						return <div
+						return <button
 							key={name}
 							className='driver-list-item'
-							role='button'
-							tabIndex={0}
 							onClick={() => onDriverSelectedHandler(drivers)}
 						>
 							{icon}
@@ -112,7 +110,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 								<div className={`driver-button codicon codicon-chevron-right`}>
 								</div>
 							</div>
-						</div>;
+						</button>;
 					}) :
 					<div className='no-drivers'>
 						{(() => localize('positron.newConnectionModalDialog.listDrivers.noDrivers', "No drivers available"))()}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -94,7 +94,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 						const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
 
 						const icon = baseIcon ?
-							<img className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
+							<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
 							<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
 						return <div key={name} className='driver-list-item'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -97,9 +97,15 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 							<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
 							<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
-						return <div key={name} className='driver-list-item'>
+						return <div
+							key={name}
+							className='driver-list-item'
+							role='button'
+							tabIndex={0}
+							onClick={() => onDriverSelectedHandler(drivers)}
+						>
 							{icon}
-							<div className='driver-info' onMouseDown={() => onDriverSelectedHandler(drivers)}>
+							<div className='driver-info'>
 								<div className='driver-name'>
 									{name}
 								</div>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -21,7 +21,7 @@ import { PositronReactServices } from '../../../../../../base/browser/positronRe
 
 interface ListDriversProps {
 	readonly onCancel: () => void;
-	readonly onSelection: (driver: IDriver) => void;
+	readonly onSelection: (drivers: IDriver[]) => void;
 	readonly languageId?: string;
 	readonly setLanguageId: (languageId: string) => void;
 }
@@ -29,16 +29,28 @@ interface ListDriversProps {
 export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 	const services = usePositronReactServicesContext();
 
-	const onDriverSelectedHandler = (driver: IDriver) => {
-		props.onSelection(driver);
+	const onDriverSelectedHandler = (drivers: IDriver[]) => {
+		props.onSelection(drivers);
 	};
 
 	const { languageId, setLanguageId } = props;
 	const driverManager = services.positronConnectionsService.driverManager;
 
-	const drivers = languageId ?
-		driverManager.getDrivers().filter(driver => driver.metadata.languageId === languageId) :
-		[];
+	const drivers = languageId
+		? driverManager
+			.getDrivers()
+			.filter((driver) => driver.metadata.languageId === languageId)
+		: [];
+
+	// group drivers by name such that we only display a single driver per name
+	const driversByName: Map<string, IDriver[]> = new Map();
+	for (const driver of drivers) {
+		if (!driversByName.get(driver.metadata.name)) {
+			driversByName.set(driver.metadata.name, [driver]);
+		} else {
+			driversByName.get(driver.metadata.name)?.push(driver);
+		}
+	}
 
 	const onLanguageChangeHandler = (lang: string) => {
 		setLanguageId(lang);
@@ -76,17 +88,20 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 		</div>
 		<div className='driver-list'>
 			{
-				drivers.length > 0 ?
-					drivers.map(driver => {
-						const icon = driver.metadata.base64EncodedIconSvg ?
-							<img className='driver-icon' src={`data:image/svg+xml;base64,${driver.metadata.base64EncodedIconSvg}`} /> :
+				driversByName.size > 0 ?
+					[...driversByName].map(([name, drivers]) => {
+						// find the first icon
+						const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
+
+						const icon = baseIcon ?
+							<img className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
 							<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
-						return <div key={driver.driverId} className='driver-list-item'>
+						return <div key={name} className='driver-list-item'>
 							{icon}
-							<div className='driver-info' onMouseDown={() => onDriverSelectedHandler(driver)}>
+							<div className='driver-info' onMouseDown={() => onDriverSelectedHandler(drivers)}>
 								<div className='driver-name'>
-									{driver.metadata.name}
+									{name}
 								</div>
 								<div className={`driver-button codicon codicon-chevron-right`}>
 								</div>

--- a/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
+++ b/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
@@ -22,6 +22,8 @@ export interface IDriverMetadata {
 	languageId: string;
 	// A human-readable name for the driver.
 	name: string;
+	// A human-readable description for the driver.
+	description?: string;
 	// The base64-encoded SVG icon for the driver.
 	base64EncodedIconSvg?: string;
 	// The inputs required to create a connection.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11082

For instance, we now register a few different options for Spark connections in R, each with its own inputs:

<img width="698" height="630" alt="image" src="https://github.com/user-attachments/assets/053fb96a-6167-486e-aa82-ec257f69cefb" />



### Release Notes


#### New Features

- Extensions can now register multiple database drivers with the same name and get them rendered as options when creating a new database connection in the connections pane. (https://github.com/posit-dev/positron/issues/11082)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
