### PR TITLE
python: add warning if >1 LS extension is installed

### DIFF
--- a/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
@@ -33,7 +33,7 @@ export class MultipleLanguageServersDiagnostic extends BaseDiagnostic {
         super(
             DiagnosticCodes.MultipleLanguageServersDiagnostic,
             message,
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Error,
             DiagnosticScope.Global,
             resource,
         );
@@ -73,7 +73,7 @@ export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsSer
             return [];
         }
 
-        const extensionList = JSON.stringify(detectedExtensions, null, 1);
+        const extensionList = detectedExtensions.join('", "');
         const message = LanguageService.multipleLanguageServersWarning.format(extensionList);
         return [new MultipleLanguageServersDiagnostic(message, resource)];
     }
@@ -90,6 +90,13 @@ export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsSer
 
         const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
         const options = [
+            {
+                prompt: Common.viewExtensions,
+                command: commandFactory.createCommand(diagnostic, {
+                    type: 'executeVSCCommand',
+                    options: 'workbench.view.extensions',
+                }),
+            },
             {
                 prompt: Common.doNotShowAgain,
                 command: commandFactory.createCommand(diagnostic, { type: 'ignore', options: DiagnosticScope.Global }),

--- a/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
@@ -61,7 +61,7 @@ export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsSer
     }
 
     public dispose(): void {
-        if (this.timeOut && typeof this.timeOut !== 'number') {
+        if (this.timeOut) {
             clearTimeout(this.timeOut);
             this.timeOut = undefined;
         }
@@ -121,7 +121,7 @@ export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsSer
     }
 
     protected async onDidChangeExtensions(): Promise<void> {
-        if (this.timeOut && typeof this.timeOut !== 'number') {
+        if (this.timeOut) {
             clearTimeout(this.timeOut);
             this.timeOut = undefined;
         }

--- a/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line max-classes-per-file
+import { inject, injectable, named } from 'inversify';
+import { DiagnosticSeverity } from 'vscode';
+import { IExtensions, IDisposableRegistry, Resource } from '../../../common/types';
+import { Common, LanguageService } from '../../../common/utils/localize';
+import { IServiceContainer } from '../../../ioc/types';
+import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
+import { IDiagnosticsCommandFactory } from '../commands/types';
+import { DiagnosticCodes } from '../constants';
+import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
+import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
+
+/**
+ * List of known Python language server extension IDs.
+ * These extensions may conflict with each other when multiple are enabled.
+ */
+const LANGUAGE_SERVER_EXTENSION_IDS = [
+    'astral-sh.ty',
+    'detachhead.basedpyright',
+    'kv9898.basedpyright',
+    'meta.pyrefly',
+    'ms-pyright.pyright',
+    'zuban.zubanls',
+];
+
+export class MultipleLanguageServersDiagnostic extends BaseDiagnostic {
+    constructor(message: string, resource: Resource) {
+        super(
+            DiagnosticCodes.MultipleLanguageServersDiagnostic,
+            message,
+            DiagnosticSeverity.Warning,
+            DiagnosticScope.Global,
+            resource,
+        );
+    }
+}
+
+export const MultipleLanguageServersDiagnosticServiceId = 'MultipleLanguageServersDiagnosticServiceId';
+
+@injectable()
+export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsService {
+    protected changeThrottleTimeout = 1000;
+
+    private timeOut?: NodeJS.Timeout | number;
+
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IExtensions) private readonly extensions: IExtensions,
+        @inject(IDiagnosticHandlerService)
+        @named(DiagnosticCommandPromptHandlerServiceId)
+        protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+    ) {
+        super([DiagnosticCodes.MultipleLanguageServersDiagnostic], serviceContainer, disposableRegistry, true, true);
+        this.addExtensionChangeHandler();
+    }
+
+    public dispose(): void {
+        if (this.timeOut && typeof this.timeOut !== 'number') {
+            clearTimeout(this.timeOut);
+            this.timeOut = undefined;
+        }
+    }
+
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
+        if (!this.hasMultipleLanguageServers()) {
+            return [];
+        }
+
+        return [new MultipleLanguageServersDiagnostic(LanguageService.multipleLanguageServersWarning, resource)];
+    }
+
+    protected async onHandle(diagnostics: IDiagnostic[]): Promise<void> {
+        if (diagnostics.length === 0 || !this.canHandle(diagnostics[0])) {
+            return;
+        }
+
+        const diagnostic = diagnostics[0];
+        if (await this.filterService.shouldIgnoreDiagnostic(diagnostic.code)) {
+            return;
+        }
+
+        const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
+        const options = [
+            {
+                prompt: Common.doNotShowAgain,
+                command: commandFactory.createCommand(diagnostic, { type: 'ignore', options: DiagnosticScope.Global }),
+            },
+        ];
+
+        await this.messageService.handle(diagnostic, {
+            commandPrompts: options,
+        });
+    }
+
+    private hasMultipleLanguageServers(): boolean {
+        let enabledCount = 0;
+
+        for (const extensionId of LANGUAGE_SERVER_EXTENSION_IDS) {
+            // VS Code's getExtension is case-insensitive by default
+            const extension = this.extensions.getExtension(extensionId);
+            if (extension !== undefined) {
+                enabledCount++;
+                if (enabledCount >= 2) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    protected addExtensionChangeHandler(): void {
+        const disposables = this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
+        disposables.push(this.extensions.onDidChange(() => this.onDidChangeExtensions()));
+    }
+
+    protected async onDidChangeExtensions(): Promise<void> {
+        if (this.timeOut && typeof this.timeOut !== 'number') {
+            clearTimeout(this.timeOut);
+            this.timeOut = undefined;
+        }
+        this.timeOut = setTimeout(() => {
+            this.timeOut = undefined;
+            this.diagnose(undefined)
+                .then((diagnostics) => this.handle(diagnostics))
+                .ignoreErrors();
+        }, this.changeThrottleTimeout);
+    }
+}

--- a/extensions/positron-python/src/client/application/diagnostics/constants.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/constants.ts
@@ -11,6 +11,8 @@ export enum DiagnosticCodes {
     // --- Start Positron ---
     // Add a new diagnostic code for unsupported Python versions
     UnsupportedPythonVersion = 'UnsupportedPythonVersion',
+    // and another for multiple language servers
+    MultipleLanguageServersDiagnostic = 'MultipleLanguageServersDiagnostic',
     // --- End Positron ---
     InvalidPythonPathInDebuggerSettingsDiagnostic = 'InvalidPythonPathInDebuggerSettingsDiagnostic',
     InvalidPythonPathInDebuggerLaunchDiagnostic = 'InvalidPythonPathInDebuggerLaunchDiagnostic',

--- a/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/serviceRegistry.ts
@@ -25,6 +25,10 @@ import {
 } from './checks/macPythonInterpreter';
 // --- Start Positron ---
 import { UnsupportedPythonVersionService, UnsupportedPythonVersionServiceId } from './checks/unsupportedPythonVersion';
+import {
+    MultipleLanguageServersDiagnosticService,
+    MultipleLanguageServersDiagnosticServiceId,
+} from './checks/multipleLanguageServers';
 // --- End Positron ---
 import {
     PowerShellActivationHackDiagnosticsService,
@@ -88,6 +92,13 @@ export function registerTypes(serviceManager: IServiceManager): void {
         IDiagnosticsService,
         UnsupportedPythonVersionService,
         UnsupportedPythonVersionServiceId,
+    );
+
+    // and another for multiple language servers
+    serviceManager.addSingleton<IDiagnosticsService>(
+        IDiagnosticsService,
+        MultipleLanguageServersDiagnosticService,
+        MultipleLanguageServersDiagnosticServiceId,
     );
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -43,6 +43,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [LSCommands.RestartLS]: [];
     // --- Start Positron ---
     [Commands.Show_Interpreter_Debug_Info]: [];
+    ['workbench.view.extensions']: [];
     // New command that opens the multisession interpreter picker
     ['workbench.action.language.runtime.selectSession']: [];
     // --- End Positron ---

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -73,6 +73,7 @@ export namespace Common {
     // --- Start Positron ---
     // Add a new button text
     export const selectNewSession = l10n.t('Select a new session');
+    export const viewExtensions = l10n.t('View Extensions');
     // --- End Positron ---
     export const openLaunch = l10n.t('Open launch.json');
     export const useCommandPrompt = l10n.t('Use Command Prompt');
@@ -189,7 +190,7 @@ export namespace LanguageService {
     );
     // --- Start Positron ---
     export const multipleLanguageServersWarning = l10n.t(
-        "More than one Python language server extension is enabled: {0}. You may experience duplicated static analysis behavior. Positron comes with Pyrefly by default; other extensions should work but are untested. It's recommended to uninstall or disable all but one.",
+        'More than one Python language server extension is enabled: "{0}". You may experience duplicated hovers/completions/etc. Positron comes with Pyrefly installed by default; other extensions should work but are untested.',
     );
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -190,7 +190,7 @@ export namespace LanguageService {
     );
     // --- Start Positron ---
     export const multipleLanguageServersWarning = l10n.t(
-        'More than one Python language server extension is enabled: "{0}". You may experience duplicated hovers/completions/etc. Positron comes with Pyrefly installed by default; other extensions should work but are untested.',
+        'More than one Python language server extension is enabled: "{0}". You may experience duplicated hovers, completions, etc. Positron comes with Pyrefly installed by default; other extensions should work but are untested.',
     );
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -189,7 +189,7 @@ export namespace LanguageService {
     );
     // --- Start Positron ---
     export const multipleLanguageServersWarning = l10n.t(
-        "More than one Python language server extension is enabled. You may experience duplicated static analysis behavior. It's recommended to uninstall or disable all but one.",
+        "More than one Python language server extension is enabled: {0}. You may experience duplicated static analysis behavior. Positron comes with Pyrefly by default; other extensions should work but are untested. It's recommended to uninstall or disable all but one.",
     );
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -187,6 +187,11 @@ export namespace LanguageService {
     export const reloadVSCodeIfSeachPathHasChanged = l10n.t(
         'Search paths have changed for this Python interpreter. Reload the extension to ensure that the IntelliSense works correctly.',
     );
+    // --- Start Positron ---
+    export const multipleLanguageServersWarning = l10n.t(
+        "More than one Python language server extension is enabled. You may experience duplicated static analysis behavior. It's recommended to uninstall or disable all but one.",
+    );
+    // --- End Positron ---
 }
 export namespace Interpreters {
     export const requireJupyter = l10n.t(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/10712. Adds a warning toast that pops up if you have more than one Python language server extension installed and enabled.

This doesn't explicitly tell you our recommendation to uninstall Pyright in the case when you've updated to 2025.12.0, have Pyright still installed, and now have Pyrefly bootstrapped, but instead it just recommends disabling/uninstalling one of them. Is that okay? I could add some special code for that if we're interested.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Warn users if they have more than one Python language server extension installed

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
The check should happen when
- the Python extension activates (upon restart of Positron or extensions)
- an extension is installed/uninstalled/enabled/disabled

unless you clicked "don't show again".
