### PR TITLE
[draft-experimental] basic marimo implementation/support

### DIFF
--- a/README-marimo.md
+++ b/README-marimo.md
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *---------------------------------------------------------------------------------------------*/
+
+ This will be deleted after successful implementation.
+
+
+Marimo integration (Phase 1)
+=================================
+
+This extension provides Phase 1 Marimo integration for Positron.
+
+Behavior:
+- Detects Marimo notebooks as `.py` files containing `import marimo`.
+- `positron.marimo.openInViewer` opens the file using `marimo edit <file>` in an integrated terminal (viewer-only; does not execute on open). **Note**: Currently, the user needs to manually click "Open in Viewer" to view the app. Automatic opening in the viewer is not yet implemented.
+- `positron.marimo.run` runs `marimo run <file>` in an integrated terminal (explicit run). A matching `positron.marimo.stop` command disposes the terminal to stop the session.
+
+Constraints:
+- Uses only the official `marimo` CLI binary available on PATH.
+- Does not embed any Marimo runtime, start background servers, or mutate files.
+- Uses `--headless` argument to prevent marimo from opening in the browser.
+- While copying text from `marimo` works (via `Cmd+C`), copy button functionality does not work.
+
+Error handling:
+- CLI detection failures and CLI errors are surfaced via error messages and an output channel. No silent retries are performed.
+
+Configuration:
+- `positron.marimo.viewerArgs`: array of extra args passed to `marimo edit` (for example `["--no-token"]` to avoid an access token being required by the viewer).
+- `positron.marimo.runArgs`: array of extra args passed to `marimo run`.
+
+Example: in your workspace settings.json
+
+```json
+"positron.marimo.viewerArgs": ["--no-token"],
+"positron.marimo.runArgs": []
+```

--- a/extensions/positron-notebooks/package.json
+++ b/extensions/positron-notebooks/package.json
@@ -12,15 +12,49 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onLanguage:python",
+    "onCommand:positron.marimo.openInViewer",
+    "onCommand:positron.marimo.run",
+    "onCommand:positron.marimo.stop"
   ],
   "contributes": {
     "commands": [
       {
         "command": "positronNotebookHelpers.convertImageToBase64",
         "title": "Convert Image to Base64"
+      },
+      {
+        "command": "positron.marimo.openInViewer",
+        "title": "Open in Marimo Viewer"
+      },
+      {
+        "command": "positron.marimo.run",
+        "title": "Run with Marimo"
+      },
+      {
+        "command": "positron.marimo.stop",
+        "title": "Stop Marimo Session"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Marimo",
+      "properties": {
+        "positron.marimo.viewerArgs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Extra args passed to 'marimo edit'"
+        },
+        "positron.marimo.runArgs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Extra args passed to 'marimo run'"
+        }
+      }
+    }
   },
   "main": "./out/extension.js",
   "scripts": {

--- a/extensions/positron-notebooks/src/extension.ts
+++ b/extensions/positron-notebooks/src/extension.ts
@@ -3,9 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import path from 'path';
+
+
 import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as path from 'path';
 import { readFile } from 'fs';
+import { readFile as fsReadFile } from 'fs/promises';
 
 // Make sure this matches the error message type defined where used
 // (src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx)
@@ -14,11 +18,106 @@ type CoversionErrorMsg = {
 	message: string;
 };
 
+/** Map from session key -> Terminal */
+const marimoSessions = new Map<string, vscode.Terminal>();
+
+let marimoOutput: vscode.OutputChannel | undefined;
+
+function findMarimoBinary(): string | null {
+	try {
+		if (process.platform === 'win32') {
+			const res = cp.spawnSync('where', ['marimo'], { encoding: 'utf8' });
+			if (res.status === 0 && res.stdout) {
+				const p = res.stdout.split(/\r?\n/)[0].trim();
+				return p || null;
+			}
+			return null;
+		} else {
+			const res = cp.spawnSync('which', ['marimo'], { encoding: 'utf8' });
+			if (res.status === 0 && res.stdout) {
+				const p = res.stdout.split(/\r?\n/)[0].trim();
+				return p || null;
+			}
+			return null;
+		}
+	} catch (err) {
+		return null;
+	}
+}
+
+async function getPositronRunAppApi(): Promise<any> {
+	const runAppExt = vscode.extensions.getExtension<any>('positron.positron-run-app');
+	if (!runAppExt) {
+		throw new Error('positron.positron-run-app extension not found');
+	}
+	return runAppExt.activate();
+}
+
+function quoteShellArg(arg: string): string {
+	if (process.platform === 'win32') {
+		return `"${arg.replace(/"/g, '\\"')}"`;
+	}
+	const escaped = arg.replace(/'/g, `'\\''`);
+	return `'${escaped}'`;
+}
+
+function buildMarimoCommand(kind: MarimoSessionKind, filePath: string, marimoPath: string): string {
+	const config = vscode.workspace.getConfiguration();
+	let viewerArgs = config.get<string[]>('positron.marimo.viewerArgs') || [];
+	const runArgs = config.get<string[]>('positron.marimo.runArgs') || [];
+
+	// TO-BE-DELETED_AFTER_CORRECT_IMPL: Crucial sanitization step: Ensure viewer opens without a token by default
+
+	//if (kind === 'edit' && !viewerArgs.includes('--no-token')) {
+	//	viewerArgs = [...viewerArgs, '--no-token'];
+	//}
+
+	// Crucial sanitization step: Ensure Marimo opens with --no-token and --headless flags by default
+	if (kind === 'edit') {
+		if (!viewerArgs.includes('--no-token')) {
+			viewerArgs = [...viewerArgs, '--no-token'];
+		}
+		if (!viewerArgs.includes('--headless')) {
+			viewerArgs = [...viewerArgs, '--headless'];
+		}
+	}
+	const args = kind === 'edit' ? viewerArgs : runArgs;
+
+	const quotedPath = quoteShellArg(filePath);
+	const quotedMarimo = quoteShellArg(marimoPath);
+
+	// Sanitize args: only allow simple flags/values (no newline/semicolons)
+	const safeArgs = args.map(a => String(a).replace(/\r|\n/g, ''));
+	const quotedArgs = safeArgs.map(a => quoteShellArg(a)).join(' ');
+
+	return kind === 'edit'
+		? `${quotedMarimo} edit ${quotedArgs ? quotedArgs + ' ' : ''}${quotedPath}`
+		: `${quotedMarimo} run ${quotedArgs ? quotedArgs + ' ' : ''}${quotedPath}`;
+}
+
 /**
- * Activates the extension.
- * @param context An ExtensionContext that contains the extention context.
+ * Map image file extension to MIME type.
  */
+const mimeTypeMap: Record<string, string> = {
+	png: 'image/png',
+	apng: 'image/apng',
+	avif: 'image/avif',
+	ico: 'image/vnd.microsoft.icon',
+	jpeg: 'image/jpeg',
+	jpg: 'image/jpeg',
+	gif: 'image/gif',
+	bmp: 'image/bmp',
+	webp: 'image/webp',
+	svg: 'image/svg+xml',
+	tiff: 'image/tiff',
+	tif: 'image/tiff',
+};
+
+type MarimoSessionKind = 'edit' | 'run';
+
 export function activate(context: vscode.ExtensionContext) {
+	marimoOutput = vscode.window.createOutputChannel('Marimo');
+	context.subscriptions.push(marimoOutput);
 	// Command that converts an image from the local file-system to a base64 string.
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
@@ -35,7 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
 					return;
 				}
 				try {
-					readFile(fullImagePath, (err, data) => {
+					readFile(fullImagePath, (err: NodeJS.ErrnoException | null, data?: Buffer) => {
 						if (err) {
 							resolve({
 								status: 'error',
@@ -51,33 +150,238 @@ export function activate(context: vscode.ExtensionContext) {
 						}
 					});
 				} catch (e) {
-					return {
-						type: 'error',
-						message: e instanceof Error ? e.message : `Error occured while converting image ${fullImagePath} to base64.`,
-					};
+					resolve({ status: 'error', message: e instanceof Error ? e.message : 'Unknown error' });
 				}
 			})
 		)
 	);
+
+	// Keep marimoSessions map up-to-date when terminals close.
+	const removeClosedTerminal = vscode.window.onDidCloseTerminal((terminal) => {
+		for (const [key, tracked] of marimoSessions.entries()) {
+			if (tracked === terminal) {
+				marimoSessions.delete(key);
+			}
+		}
+	});
+	context.subscriptions.push(removeClosedTerminal);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.marimo.openInViewer', () => startMarimoSession(context, marimoSessions, 'edit'))
+	);
+	// Run does NOT currently work, because (I believe) it'd require marimo engine for it to work.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.marimo.run', () => startMarimoSession(context, marimoSessions, 'run'))
+	);
+	// Stop implementation: we could borrow from the 'Stop' button in the Viewer pane for other apps.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.marimo.stop', () => stopMarimoSession(marimoSessions))
+	);
+
+	// We prefer to open localhost URLs in the Viewer by invoking the
+	// contributed opener 'positron.viewer' via `openExternal` when possible.
+	// NOTE: This is not working at the current state. It opens in the browser by default.
+	// However, if user Cmd+Click link and then press 'Open in Viewer' pane, then it is possible to open it.
+
+
+	// Provide CodeLens actions when a Python file imports marimo
+	class MarimoCodeLensProvider implements vscode.CodeLensProvider {
+		public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+			if (document.languageId !== 'python') {
+				return [];
+			}
+			const text = document.getText();
+			if (!isLikelyMarimoNotebook(text)) {
+				return [];
+			}
+			const top = new vscode.Range(0, 0, 0, 0);
+
+			// The implementation of this would need additional work and discussion.
+			// It requires passing the local host URI without the token, so that Viewer pane can open it.
+			// My intention would be for the Viewer pane to open this by default.
+			const openCmd: vscode.Command = {
+				title: 'Open in Marimo Viewer',
+				command: 'positron.marimo.openInViewer',
+				arguments: [document.uri],
+			};
+
+			// Run with Marimo is NOT intended to be functional now, because it'd require hooking up the Marimo engine behind the process.
+			// Out of Scope for Phase 1
+			const runCmd: vscode.Command = {
+				title: 'Run with Marimo',
+				command: 'positron.marimo.run',
+				arguments: [document.uri],
+			};
+			return [new vscode.CodeLens(top, openCmd), new vscode.CodeLens(top, runCmd)];
+		}
+	}
+
+	context.subscriptions.push(
+		vscode.languages.registerCodeLensProvider({ language: 'python', scheme: 'file' }, new MarimoCodeLensProvider())
+	);
 }
 
+export function deactivate() {
+	for (const term of marimoSessions.values()) {
+		try { term.dispose(); } catch (e) { }
+	}
+	marimoSessions.clear();
+}
 
-/**
- * Map image file extension to MIME type.
- *
- * Supports all the 'image' types from [this list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
- */
-const mimeTypeMap: Record<string, string> = {
-	png: 'image/png',
-	apng: 'image/apng',
-	avif: 'image/avif',
-	ico: 'image/vnd.microsoft.icon',
-	jpeg: 'image/jpeg',
-	jpg: 'image/jpeg',
-	gif: 'image/gif',
-	bmp: 'image/bmp',
-	webp: 'image/webp',
-	svg: 'image/svg+xml',
-	tiff: 'image/tiff',
-	tif: 'image/tiff',
-};
+async function startMarimoSession(
+	context: vscode.ExtensionContext,
+	marimoSessions: Map<string, vscode.Terminal>,
+	kind: MarimoSessionKind
+) {
+	let uri: vscode.Uri | undefined;
+	let text: string | undefined;
+	let contentSource: 'disk' | 'unsaved' = 'disk';
+
+	// if (arguments.length >= 4 && arguments[3]) { /* guard for unexpected calls */ }
+
+	// If caller passed a URI (via CodeLens or command argument), prefer it.
+	const maybeUri = (arguments && arguments[0]) as vscode.Uri | undefined;
+	if (maybeUri && maybeUri.scheme === 'file') {
+		uri = maybeUri;
+		try {
+			const doc = await vscode.workspace.openTextDocument(uri);
+			text = doc.getText();
+			contentSource = doc.isDirty ? 'unsaved' : 'disk';
+		} catch (e) {
+			try {
+				const bytes = await fsReadFile(uri.fsPath);
+				text = bytes.toString();
+				contentSource = 'disk';
+			} catch (err: any) {
+				void vscode.window.showErrorMessage(`Failed to read file: ${err?.message || String(err)}`);
+				return;
+			}
+		}
+	} else {
+		const target = await resolveMarimoTarget();
+		if (!target) {
+			return;
+		}
+		uri = target.uri;
+		text = target.text;
+		contentSource = target.contentSource;
+	}
+	if (!isLikelyMarimoNotebook(text)) {
+		void vscode.window.showErrorMessage(
+			'This file does not look like a Marimo notebook (no "import marimo" found).'
+		);
+		return;
+	}
+
+	const marimoPath = findMarimoBinary();
+	if (!marimoPath) {
+		void vscode.window.showErrorMessage('Marimo CLI not found. Please install Marimo and ensure it is on your PATH.');
+
+		// Log to output channel for diagnostics
+		try { marimoOutput?.appendLine('Marimo CLI not found on PATH'); } catch (e) { }
+		return;
+	}
+
+	const sessionKey = `${kind}:${uri.toString()}`;
+	const existing = marimoSessions.get(sessionKey);
+	if (existing) {
+		existing.show(true);
+		void vscode.window.showInformationMessage('Using existing Marimo session in the terminal.');
+		return;
+	}
+
+	const terminalName = `marimo ${kind}: ${path.basename(uri.fsPath)}`;
+	const terminal = vscode.window.createTerminal({
+		name: terminalName,
+		location: vscode.TerminalLocation.Panel,
+	});
+	marimoSessions.set(sessionKey, terminal);
+	context.subscriptions.push(terminal);
+
+	const command = buildMarimoCommand(kind, uri.fsPath, marimoPath);
+	// Log the command we are running to the output channel
+	try { marimoOutput?.appendLine(`> ${command}`); } catch (e) { }
+	terminal.sendText(command, true);
+	terminal.show(true);
+
+	// Viewer mode is terminal-driven (marimo edit opens a viewer).
+
+	const hint =
+		kind === 'edit'
+			? 'Opening Marimo viewer (no code executed). Use the terminal to stop it.'
+			: 'Running Marimo notebook. Use the terminal to stop it.';
+	void vscode.window.showInformationMessage(hint);
+
+	// If the document was unsaved, remind the user they are running the in-memory content.
+	if (contentSource === 'unsaved') {
+		void vscode.window.showWarningMessage(
+			'You ran an unsaved buffer. Save the file to keep Marimo in sync with future edits.'
+		);
+	}
+}
+
+async function stopMarimoSession(marimoSessions: Map<string, vscode.Terminal>) {
+	if (marimoSessions.size === 0) {
+		void vscode.window.showInformationMessage('No Marimo sessions are currently running.');
+		return;
+	}
+
+	const picks = Array.from(marimoSessions.entries()).map(([key, terminal]) => ({
+		label: terminal.name || key,
+		description: key.split(':')[0] === 'edit' ? 'viewer' : 'run',
+		target: terminal,
+		key,
+	}));
+
+	const choice = await vscode.window.showQuickPick(picks, {
+		placeHolder: 'Select a Marimo session to stop',
+	});
+
+	if (choice?.target) {
+		choice.target.dispose();
+		marimoSessions.delete(choice.key);
+		void vscode.window.showInformationMessage(`Stopped ${choice.description} session "${choice.label}".`);
+	}
+}
+
+function isLikelyMarimoNotebook(text: string): boolean {
+	const importRegex = /\bimport\s+marimo\b/;
+	const fromImportRegex = /\bfrom\s+marimo\s+import\b/;
+	return importRegex.test(text) || fromImportRegex.test(text);
+}
+
+async function resolveMarimoTarget(): Promise<{ uri: vscode.Uri; text: string; contentSource: 'disk' | 'unsaved' } | undefined> {
+	const activeEditor = vscode.window.activeTextEditor;
+	if (activeEditor?.document.languageId === 'python' && activeEditor.document.uri.scheme === 'file') {
+		return {
+			uri: activeEditor.document.uri,
+			text: activeEditor.document.getText(),
+			contentSource: activeEditor.document.isDirty ? 'unsaved' : 'disk',
+		};
+	}
+
+	const picked = await vscode.window.showOpenDialog({
+		canSelectFiles: true,
+		canSelectMany: false,
+		canSelectFolders: false,
+		filters: { Python: ['py'] },
+	});
+
+	if (!picked || picked.length === 0) {
+		return undefined;
+	}
+
+	const uri = picked[0];
+	if (uri.scheme !== 'file') {
+		void vscode.window.showErrorMessage('Only local Python files are supported for Marimo.');
+		return undefined;
+	}
+
+	try {
+		const bytes = await fsReadFile(uri.fsPath);
+		return { uri, text: bytes.toString(), contentSource: 'disk' };
+	} catch (e: any) {
+		void vscode.window.showErrorMessage(`Failed to read file: ${e?.message || String(e)}`);
+		return undefined;
+	}
+}

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -430,6 +430,13 @@
             },
             {
                 "category": "Python",
+                "command": "python.execMarimoInTerminal",
+                "icon": "$(play)",
+                "title": "%python.command.python.execMarimoInTerminal.title%",
+                "enablement": "pythonAppFramework == marimo"
+            },
+            {
+                "category": "Python",
                 "command": "python.execInConsole",
                 "icon": "$(play)",
                 "title": "%python.command.python.execInConsole.title%"

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -18,6 +18,7 @@
     "python.command.python.execFlaskInTerminal.title": "Run Flask App in Terminal",
     "python.command.python.execGradioInTerminal.title": "Run Gradio App in Terminal",
     "python.command.python.execStreamlitInTerminal.title": "Run Streamlit App in Terminal",
+    "python.command.python.execMarimoInTerminal.title": "Run Marimo App in Terminal",
     "python.command.python.debugDashInTerminal.title": "Debug Dash App in Terminal",
     "python.command.python.debugFastAPIInTerminal.title": "Debug FastAPI App in Terminal",
     "python.command.python.debugFlaskInTerminal.title": "Debug Flask App in Terminal",

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -64,10 +64,10 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
         Uri | string,
         (
             | {
-                  installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
-                  installPreReleaseVersion?: boolean;
-                  donotSync?: boolean;
-              }
+                installOnlyNewlyAddedFromExtensionPackVSIX?: boolean;
+                installPreReleaseVersion?: boolean;
+                donotSync?: boolean;
+            }
             | undefined
         ),
     ];
@@ -109,6 +109,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_Gradio_In_Terminal]: [];
     [Commands.Exec_Streamlit_In_Terminal]: [];
     [Commands.Exec_In_Console]: [];
+    [Commands.Exec_Marimo_In_Terminal]: [];
     [Commands.Focus_Positron_Console]: [];
     [Commands.Create_Pyproject_Toml]: [string | undefined];
     [Commands.InstallPackages]: [string[]];

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -38,7 +38,8 @@ export enum CommandSource {
     ui = 'ui',
     commandPalette = 'commandpalette',
 }
-
+//add marimo command here as well, jsut like streamlit
+// search codebase for where streamlit in terminal is used -- follow the path where it's being used and copy exact implementation
 export namespace Commands {
     export const ClearStorage = 'python.clearCacheAndReload';
     export const CreateNewFile = 'python.createNewFile';
@@ -58,6 +59,7 @@ export namespace Commands {
     export const Exec_Flask_In_Terminal = 'python.execFlaskInTerminal';
     export const Exec_Gradio_In_Terminal = 'python.execGradioInTerminal';
     export const Exec_Streamlit_In_Terminal = 'python.execStreamlitInTerminal';
+    export const Exec_Marimo_In_Terminal = 'python.execMarimoInTerminal'
     export const Exec_In_Console = 'python.execInConsole';
     export const Exec_Selection_In_Console = 'python.execSelectionInConsole';
     export const Debug_Dash_In_Terminal = 'python.debugDashInTerminal';
@@ -65,6 +67,7 @@ export namespace Commands {
     export const Debug_Flask_In_Terminal = 'python.debugFlaskInTerminal';
     export const Debug_Gradio_In_Terminal = 'python.debugGradioInTerminal';
     export const Debug_Streamlit_In_Terminal = 'python.debugStreamlitInTerminal';
+    export const Debug_Marimo_In_Terminal = 'python.debugMarimoInTerminal';
     // --- End Positron ---
     export const Exec_In_REPL = 'python.execInREPL';
     export const Exec_Selection_In_Django_Shell = 'python.execSelectionInDjangoShell';

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -61,6 +61,14 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197
             ['Local URL: {{APP_URL}}'],
         ),
+        registerExecCommand(
+            Commands.Exec_Marimo_In_Terminal,
+            'Marimo',
+            (_runtime, document, _urlPrefix) => getMarimoDebugConfig(document),
+            undefined,
+            undefined,
+            ['Local URL: {{APP_URL}}']
+        ),
         registerDebugCommand(
             Commands.Debug_Dash_In_Terminal,
             'Dash',
@@ -106,6 +114,14 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197
             ['Local URL: {{APP_URL}}'],
         ),
+        registerDebugCommand(
+            Commands.Debug_Marimo_In_Terminal,
+            'Marimo',
+            (_runtime, document, _urlPrefix) => getMarimoDebugConfig(document),
+            undefined,
+            undefined,
+            ['Local URL: {{APP_URL}}']
+        )
     );
 }
 
@@ -266,6 +282,11 @@ function getGradioDebugConfig(document: vscode.TextDocument): DebugConfiguration
 function getStreamlitDebugConfig(document: vscode.TextDocument): DebugConfiguration {
     const args = ['run', document.uri.fsPath, '--server.headless', 'true'];
     return { module: 'streamlit', args };
+}
+
+function getMarimoDebugConfig(document: vscode.TextDocument): DebugConfiguration {
+    const args = ['edit', document.uri.fsPath];
+    return { module: 'marimo', args };
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { executeCommand } from '../common/vscodeApis/commandApis';
 
 function getSupportedLibraries(): string[] {
-    const libraries: string[] = ['streamlit', 'dash', 'gradio', 'flask', 'fastapi'];
+    const libraries: string[] = ['streamlit', 'dash', 'gradio', 'flask', 'fastapi', 'marimo'];
     return libraries;
 }
 


### PR DESCRIPTION
# Marimo Integration Experiment (Phase 1)

Screenshot of recording I made. If interested, message me and I can provide the 4-min video.
<img width="1508" height="1035" alt="image" src="https://github.com/user-attachments/assets/bd11b8d6-3feb-4150-a7fe-a134d47e7029" />

This extension provides Phase 1 Marimo integration for Positron.

Behavior:
- Detects Marimo notebooks as `.py` files containing `import marimo`.
- `positron.marimo.openInViewer` opens the file using `marimo edit <file>` in an integrated terminal (viewer-only; does not execute on open). **Note**: Currently, the user needs to manually click "Open in Viewer" to view the app. Automatic opening in the viewer is not yet implemented, but I'm getting close to it. 
  - Currently, as a workaround, user could `Cmd+Click` the link and 'Open in the Viewer pane'.
- `positron.marimo.run` runs `marimo run <file>` in an integrated terminal (explicit run). A matching `positron.marimo.stop` command disposes the terminal to stop the session.

Constraints:
- Uses only the official `marimo` CLI binary available on PATH.
- Does not embed any Marimo runtime, start background servers, or mutate files.
- Uses `--headless` argument to prevent marimo from opening in the browser.
- While copying text from `marimo` works (via `Cmd+C`), copy button functionality does not work.

Error handling:
- CLI detection failures and CLI errors are surfaced via error messages and an output channel. No silent retries are performed.

Configuration:
- `positron.marimo.viewerArgs`: array of extra args passed to `marimo edit` (for example `["--no-token"]` to avoid an access token being required by the viewer).
- `positron.marimo.runArgs`: array of extra args passed to `marimo run`.