### PR TITLE
Set background color for settings markdown code blocks

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -602,6 +602,7 @@
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown code {
 	line-height: 15px;
+	background-color: var(--vscode-textPreformat-background);
 	/** For some reason, this is needed, otherwise <code> will take up 20px height */
 	font-family: var(--monaco-monospace-font);
 	font-size: 11px;

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -602,11 +602,11 @@
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown code {
 	line-height: 15px;
-	background-color: var(--vscode-textPreformat-background);
 	/** For some reason, this is needed, otherwise <code> will take up 20px height */
 	font-family: var(--monaco-monospace-font);
 	font-size: 11px;
 	color: var(--vscode-textPreformat-foreground);
+	background-color: var(--vscode-textPreformat-background);
 	padding: 1px 3px;
 	border-radius: 4px;
 }


### PR DESCRIPTION
The background color was not set for some reason. Use the theme color to ensure it adjusts for the theme. This uses the same css properties as vscode itself.

Relates #8434

Example screenshots using high contrast themes and the default Positron themes:

<img width="648" height="140" alt="Screenshot 2025-12-12 at 4 12 38 PM" src="https://github.com/user-attachments/assets/3b726fa4-16c4-4cc9-966a-1540c1ba77bf" />
<img width="657" height="146" alt="Screenshot 2025-12-12 at 4 12 34 PM" src="https://github.com/user-attachments/assets/a0de4911-aa94-4c28-9380-95fd9ec0c971" />
<img width="693" height="190" alt="Screenshot 2025-12-12 at 4 12 23 PM" src="https://github.com/user-attachments/assets/cf8ae62f-deb0-484a-84e0-a33ae8d5636e" />
<img width="715" height="197" alt="Screenshot 2025-12-12 at 4 12 18 PM" src="https://github.com/user-attachments/assets/99e5eec0-14ed-4337-b187-6adfffd897f5" />

This is an example screenshot without this change using the Positron Light theme, notice that there is no background for the code blocks:

<img width="652" height="146" alt="Screenshot 2025-12-12 at 4 15 26 PM" src="https://github.com/user-attachments/assets/cf92299a-81e9-48c3-ba42-99724a81ef98" />



### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Use theme background color for code blocks in settings markdown

### QA Notes

Notice that without this PR, the background is never set. Without changing the theme, we can see that this fix works. When switching to the high contrast themes, the colors just become more obvious.

@:vscode-settings