### PR TITLE
Clarify what `positron.r.saveAndRestoreWorkspace` does right now

### DIFF
--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -58,7 +58,7 @@
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",
 	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (restart Positron to apply)",
 	"r.configuration.restoreWorkspace.deprecationMessage": "This setting is deprecated and will be removed. Please use 'positron.r.saveAndRestoreWorkspace' instead.",
-	"r.configuration.saveAndRestoreWorkspace.description": "Save the workspace to `.RData` on exit, and restore on startup (restart Positron to apply)",
+	"r.configuration.saveAndRestoreWorkspace.description": "When restarting R, save the workspace to `.RData` and restore (restart Positron to apply)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",
 	"r.configuration.quietMode.description": "Run R in quiet mode, to suppress initial copyright and welcome messages (restart Positron to apply)",
 	"r.configuration.pipe": "String to insert as the pipe operator",


### PR DESCRIPTION
Addresses #10936 in that it clarifies what this setting does right now.

The plan is to merge this now, and then put #10936 into [Future](https://github.com/posit-dev/positron/milestone/5) for further work down the road.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

- N/A
