### PR TITLE
Data Explorer: Do not issue data explorer RPCs when editor tab is not active, do not compute profiles twice on schema updates

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -84,6 +84,12 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	private _hasMarkedInstanceVisible = false;
 
 	/**
+	 * Tracks whether setEditorVisible(false) has temporarily decremented the
+	 * ref-count. Prevents double-decrement when clearInput also fires.
+	 */
+	private _editorHiddenByVisibility = false;
+
+	/**
 	 * Gets the is focused context key.
 	 */
 	private readonly _isFocusedContextKey: IContextKey<boolean>;
@@ -456,14 +462,15 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	 */
 	override clearInput(): void {
 		// Mark the instance as not visible before disposing.
-		// This ensures that expensive operations are deferred while the tab is hidden.
+		// Skip decrement if setEditorVisible(false) already did it.
 		if (this._identifier && this._hasMarkedInstanceVisible) {
 			const instance = this._positronDataExplorerService.getInstance(this._identifier);
-			if (instance) {
+			if (instance && !this._editorHiddenByVisibility) {
 				instance.setVisible(false);
 			}
 		}
 		this._hasMarkedInstanceVisible = false;
+		this._editorHiddenByVisibility = false;
 
 		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();
@@ -479,6 +486,21 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	protected override setEditorVisible(visible: boolean): void {
 		// Call the base class's method.
 		super.setEditorVisible(visible);
+
+		if (!this._identifier || !this._hasMarkedInstanceVisible) {
+			return;
+		}
+		const instance = this._positronDataExplorerService.getInstance(this._identifier);
+		if (!instance) {
+			return;
+		}
+		if (!visible && !this._editorHiddenByVisibility) {
+			instance.setVisible(false);
+			this._editorHiddenByVisibility = true;
+		} else if (visible && this._editorHiddenByVisibility) {
+			instance.setVisible(true);
+			this._editorHiddenByVisibility = false;
+		}
 	}
 
 	//#endregion EditorPane Overrides

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -78,6 +78,12 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	private _identifier?: string;
 
 	/**
+	 * Tracks whether this editor has marked its data explorer instance visible.
+	 * Used to balance visibility calls when an instance is shared by multiple editors.
+	 */
+	private _hasMarkedInstanceVisible = false;
+
+	/**
 	 * Gets the is focused context key.
 	 */
 	private readonly _isFocusedContextKey: IContextKey<boolean>;
@@ -427,7 +433,10 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 
 				// Mark the instance as visible now that the editor is active.
 				// This will trigger any deferred refresh operations.
-				positronDataExplorerInstance.setVisible(true);
+				if (!this._hasMarkedInstanceVisible) {
+					positronDataExplorerInstance.setVisible(true);
+					this._hasMarkedInstanceVisible = true;
+				}
 			} else {
 				this._positronReactRenderer.render(
 					<PositronDataExplorerClosed
@@ -448,12 +457,13 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	override clearInput(): void {
 		// Mark the instance as not visible before disposing.
 		// This ensures that expensive operations are deferred while the tab is hidden.
-		if (this._identifier) {
+		if (this._identifier && this._hasMarkedInstanceVisible) {
 			const instance = this._positronDataExplorerService.getInstance(this._identifier);
 			if (instance) {
 				instance.setVisible(false);
 			}
 		}
+		this._hasMarkedInstanceVisible = false;
 
 		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -424,6 +424,10 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 						this._fileHasHeaderRowContextKey.set(hasHeaderRow)
 					)
 				);
+
+				// Mark the instance as visible now that the editor is active.
+				// This will trigger any deferred refresh operations.
+				positronDataExplorerInstance.setVisible(true);
 			} else {
 				this._positronReactRenderer.render(
 					<PositronDataExplorerClosed
@@ -442,6 +446,15 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	 * Clears the input.
 	 */
 	override clearInput(): void {
+		// Mark the instance as not visible before disposing.
+		// This ensures that expensive operations are deferred while the tab is hidden.
+		if (this._identifier) {
+			const instance = this._positronDataExplorerService.getInstance(this._identifier);
+			if (instance) {
+				instance.setVisible(false);
+			}
+		}
+
 		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -146,4 +146,12 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	 * The onDidChangeFileHasHeaderRow event.
 	 */
 	readonly onDidChangeFileHasHeaderRow: Event<boolean>;
+
+	/**
+	 * Sets the visibility state of the data explorer.
+	 * When not visible, expensive operations like data fetching and profile computation
+	 * are deferred until the explorer becomes visible again.
+	 * @param visible Whether the data explorer is currently visible.
+	 */
+	setVisible(visible: boolean): void;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -151,6 +151,8 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	 * Sets the visibility state of the data explorer.
 	 * When not visible, expensive operations like data fetching and profile computation
 	 * are deferred until the explorer becomes visible again.
+	 * Implementations may be reference-counted when multiple editors share
+	 * the same data explorer instance.
 	 * @param visible Whether the data explorer is currently visible.
 	 */
 	setVisible(visible: boolean): void;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -164,7 +164,8 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		// Create the table data data grid instance.
 		this._register(this._tableDataDataGridInstance = new TableDataDataGridInstance(
 			this._dataExplorerClientInstance,
-			this._tableDataCache
+			this._tableDataCache,
+			this._tableSummaryCache
 		));
 		// Add the onDidClose event handler.
 		this._register(this._dataExplorerClientInstance.onDidClose(() => {
@@ -482,6 +483,17 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 				)
 			);
 		}
+	}
+
+	/**
+	 * Sets the visibility state of the data explorer.
+	 * When not visible, expensive operations are deferred until visible again.
+	 * @param visible Whether the data explorer is currently visible.
+	 */
+	setVisible(visible: boolean): void {
+		// Propagate visibility to both data grid instances.
+		this._tableSchemaDataGridInstance.setVisible(visible);
+		this._tableDataDataGridInstance.setVisible(visible);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -123,6 +123,15 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 */
 	private _fileHasHeaderRow = true;
 
+	/**
+	 * The number of editor panes currently showing this instance.
+	 *
+	 * A single data explorer instance can be rendered by multiple editors
+	 * (for example, after splitting the editor). We only mark the internal
+	 * data grids hidden when the last visible editor detaches.
+	 */
+	private _visibleEditorCount = 0;
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -498,9 +507,31 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * @param visible Whether the data explorer is currently visible.
 	 */
 	setVisible(visible: boolean): void {
-		// Propagate visibility to both data grid instances.
-		this._tableSchemaDataGridInstance.setVisible(visible);
-		this._tableDataDataGridInstance.setVisible(visible);
+		if (visible) {
+			this._visibleEditorCount++;
+
+			// Instance was already visible from another editor.
+			if (this._visibleEditorCount > 1) {
+				return;
+			}
+
+			// Transitioned from hidden -> visible.
+			this._tableSchemaDataGridInstance.setVisible(true);
+			this._tableDataDataGridInstance.setVisible(true);
+			return;
+		}
+
+		// Guard against mismatched visibility calls.
+		this._visibleEditorCount = Math.max(0, this._visibleEditorCount - 1);
+
+		// Another editor is still showing this instance.
+		if (this._visibleEditorCount !== 0) {
+			return;
+		}
+
+		// Transitioned from visible -> hidden.
+		this._tableSchemaDataGridInstance.setVisible(false);
+		this._tableDataDataGridInstance.setVisible(false);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -164,8 +164,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		// Create the table data data grid instance.
 		this._register(this._tableDataDataGridInstance = new TableDataDataGridInstance(
 			this._dataExplorerClientInstance,
-			this._tableDataCache,
-			this._tableSummaryCache
+			this._tableDataCache
 		));
 		// Add the onDidClose event handler.
 		this._register(this._dataExplorerClientInstance.onDidClose(() => {
@@ -190,6 +189,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			this._tableDataDataGridInstance.onDidChangePinnedColumns(async pinnedColumns => {
 				// Update the pinned rows in the summary data grid instance.
 				await this._tableSchemaDataGridInstance.updatePinnedRows(pinnedColumns);
+			})
+		);
+
+		// Add the onDidSetRowFilters event handler.
+		// Refresh summary panel column profiles after row filters change.
+		this._register(
+			this._tableDataDataGridInstance.onDidSetRowFilters(async () => {
+				await this._tableSchemaDataGridInstance.fetchData(true);
 			})
 		);
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -7,6 +7,7 @@ import { localize } from '../../../../nls.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { TableDataCache } from '../common/tableDataCache.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { TableSummaryCache } from '../common/tableSummaryCache.js';
 import { TableDataDataGridInstance } from './tableDataDataGridInstance.js';
 import { PositronDataExplorerUri } from '../common/positronDataExplorerUri.js';
@@ -516,8 +517,8 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			}
 
 			// Transitioned from hidden -> visible.
-			this._tableSchemaDataGridInstance.setVisible(true);
-			this._tableDataDataGridInstance.setVisible(true);
+			this._tableSchemaDataGridInstance.setVisible(true).catch(onUnexpectedError);
+			this._tableDataDataGridInstance.setVisible(true).catch(onUnexpectedError);
 			return;
 		}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -167,6 +167,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Add the data explorer client onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async state => {
+			// If not visible, skip layout and sort key updates. Backend-
+			// initiated events will also fire onDidSchemaUpdate or
+			// onDidDataUpdate, which set the pending flags and will
+			// rebuild everything when we become visible again.
+			if (!this._visible) {
+				return;
+			}
+
 			await this.updateLayoutEntries(state);
 
 			// Rebuild sort keys on every backend state change to keep the

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -22,6 +22,7 @@ import { CustomContextMenuSeparator } from '../../../browser/positronComponents/
 import { MAX_ADVANCED_LAYOUT_ENTRY_COUNT } from '../../../browser/positronDataGrid/classes/layoutManager.js';
 import { PositronDataExplorerCommandId } from '../../../contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.js';
 import { InvalidateCacheFlags, TableDataCache, WidthCalculators } from '../common/tableDataCache.js';
+import { TableSummaryCache } from '../common/tableSummaryCache.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { BackendState, ColumnSchema, ExportFormat, RowFilter, SupportStatus } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { ClipboardData, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, MouseSelectionType, RowSelectionState } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
@@ -66,6 +67,33 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _onDidChangePinnedColumns = this._register(new Emitter<number[]>());
 
+	/**
+	 * Whether the data explorer is currently visible.
+	 * When not visible, expensive operations are deferred.
+	 */
+	private _visible = true;
+
+	/**
+	 * Whether a schema update is pending because we were not visible when it occurred.
+	 */
+	private _pendingSchemaUpdate = false;
+
+	/**
+	 * Whether a data update is pending because we were not visible when it occurred.
+	 */
+	private _pendingDataUpdate = false;
+
+	/**
+	 * Whether the initial data load has been completed.
+	 * Used to trigger initial load when first becoming visible.
+	 */
+	private _initialLoadComplete = false;
+
+	/**
+	 * Reference to the updateLayoutEntries function for use in setVisible().
+	 */
+	private _updateLayoutEntries!: (state?: BackendState) => Promise<void>;
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -74,10 +102,12 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Constructor.
 	 * @param _dataExplorerClientInstance The data explorer client instance.
 	 * @param _tableDataCache The table data cache.
+	 * @param _tableSummaryCache The table summary cache.
 	 */
 	constructor(
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _tableDataCache: TableDataCache,
+		private readonly _tableSummaryCache: TableSummaryCache,
 	) {
 		// Call the base class's constructor.
 		super({
@@ -115,7 +145,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		 * Updates the layout entries.
 		 * @param state The backend state, if known; otherwise, undefined.
 		 */
-		const updateLayoutEntries = async (state?: BackendState) => {
+		this._updateLayoutEntries = async (state?: BackendState) => {
 			// Get the backend state, if was not provided.
 			if (!state) {
 				state = await this._dataExplorerClientInstance.getBackendState();
@@ -179,43 +209,36 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Add the data explorer client onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
-			// Update the layout entries.
-			await updateLayoutEntries();
-
-			// Perform a soft reset.
-			this.softReset();
-
-			// Update the cache.
-			await this.fetchData(InvalidateCacheFlags.All);
+			// If not visible, defer the update until we become visible.
+			if (!this._visible) {
+				this._pendingSchemaUpdate = true;
+				return;
+			}
+			// Clear pending flags since we're doing the work now.
+			this._pendingSchemaUpdate = false;
+			this._pendingDataUpdate = false;
+			await this.handleSchemaUpdate();
 		}));
 
 		// Add the data explorer client onDidDataUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
-			// Update the layout entries.
-			await updateLayoutEntries();
-
-			// Update the cache.
-			await this.fetchData(InvalidateCacheFlags.Data);
+			// If not visible, defer the update until we become visible.
+			if (!this._visible) {
+				this._pendingDataUpdate = true;
+				return;
+			}
+			// Clear pending flag since we're doing the work now.
+			this._pendingDataUpdate = false;
+			await this.handleDataUpdate();
 		}));
 
 		// Add the data explorer client onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async state => {
-			// Update the layout entries.
-			await updateLayoutEntries(state);
+			await this._updateLayoutEntries(state);
+			this.rebuildSortKeysFromCache();
 
-			// Clear column sort keys.
-			this._columnSortKeys.clear();
-
-			// Update the column sort keys from the state.
-			state.sort_keys.forEach((key, sortIndex) => {
-				this._columnSortKeys.set(
-					key.column_index,
-					new ColumnSortKeyDescriptor(sortIndex, key.column_index, key.ascending)
-				);
-			});
-
-			// Fetch data.
-			await this.fetchData(InvalidateCacheFlags.Data);
+			// DISABLED: Fetching data here causes double-fetching in some scenarios.
+			// await this.fetchData(InvalidateCacheFlags.Data);
 		}));
 
 		// Add the table data cache onDidUpdate event handler.
@@ -305,18 +328,19 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Synchronize the backend state.
 		await this._dataExplorerClientInstance.updateBackendState();
 
-		// Get the first column layout entry and the first row layout entry. If they were found,
-		// update the cache.
+		// Update the cache with the visible data range, or invalidate with empty arrays
+		// if there's no visible data (e.g., zero rows after filtering).
 		const columnDescriptor = this.firstColumn;
 		const rowDescriptor = this.firstRow;
-		if (columnDescriptor && rowDescriptor) {
-			// Update the cache.
-			await this._tableDataCache.update({
-				invalidateCache: InvalidateCacheFlags.Data,
-				columnIndices: this._columnLayoutManager.getLayoutIndexes(this.horizontalScrollOffset, this.layoutWidth, OVERSCAN_FACTOR),
-				rowIndices: this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR)
-			});
-		}
+		await this._tableDataCache.update({
+			invalidateCache: InvalidateCacheFlags.Data,
+			columnIndices: columnDescriptor && rowDescriptor
+				? this._columnLayoutManager.getLayoutIndexes(this.horizontalScrollOffset, this.layoutWidth, OVERSCAN_FACTOR)
+				: [],
+			rowIndices: columnDescriptor && rowDescriptor
+				? this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR)
+				: []
+		});
 	}
 
 	/**
@@ -806,18 +830,31 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Synchronize the backend state.
 		await this._dataExplorerClientInstance.updateBackendState();
 
-		// Get the first column layout entry and the first row layout entry. If they were found,
-		// update the cache.
+		// Update layout entries to reflect the new row count after filtering.
+		// Note: The onDidUpdateBackendState handler also does this, but since the
+		// handler runs asynchronously we need to ensure it's done before we proceed.
+		await this._updateLayoutEntries();
+
+		// Update the data cache with the visible data range, or invalidate with empty arrays
+		// if there's no visible data (e.g., zero rows after filtering).
 		const columnDescriptor = this.firstColumn;
 		const rowDescriptor = this.firstRow;
-		if (columnDescriptor && rowDescriptor) {
-			// Update the cache.
-			await this._tableDataCache.update({
-				invalidateCache: InvalidateCacheFlags.Data,
-				columnIndices: this._columnLayoutManager.getLayoutIndexes(this.horizontalScrollOffset, this.layoutWidth, OVERSCAN_FACTOR),
-				rowIndices: this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR)
-			});
-		}
+		const columnIndices = columnDescriptor && rowDescriptor
+			? this._columnLayoutManager.getLayoutIndexes(this.horizontalScrollOffset, this.layoutWidth, OVERSCAN_FACTOR)
+			: [];
+		await this._tableDataCache.update({
+			invalidateCache: InvalidateCacheFlags.Data,
+			columnIndices,
+			rowIndices: columnDescriptor && rowDescriptor
+				? this._rowLayoutManager.getLayoutIndexes(this.verticalScrollOffset, this.layoutHeight, OVERSCAN_FACTOR)
+				: []
+		});
+
+		// Update the summary cache to refresh column profiles after filtering.
+		await this._tableSummaryCache.update({
+			invalidateCache: true,
+			columnIndices
+		});
 	}
 
 	/**
@@ -825,6 +862,83 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	isFeatureEnabled(status: SupportStatus): boolean {
 		return status === SupportStatus.Supported;
+	}
+
+	/**
+	 * Sets the visibility state.
+	 * When becoming visible with pending updates, triggers deferred refresh operations.
+	 * @param visible Whether the data explorer is currently visible.
+	 */
+	async setVisible(visible: boolean): Promise<void> {
+		const wasHidden = !this._visible;
+		this._visible = visible;
+
+		if (!visible) {
+			return;
+		}
+
+		// Initial load: first time becoming visible, no data loaded yet.
+		if (!this._initialLoadComplete) {
+			this._initialLoadComplete = true;
+			this._pendingSchemaUpdate = false;
+			this._pendingDataUpdate = false;
+			await this._updateLayoutEntries();
+			this.rebuildSortKeysFromCache();
+			await this.fetchData(InvalidateCacheFlags.All);
+			return;
+		}
+
+		// Deferred updates: becoming visible after being hidden with pending updates.
+		// Schema updates take precedence since they're more comprehensive.
+		if (wasHidden) {
+			if (this._pendingSchemaUpdate) {
+				this._pendingSchemaUpdate = false;
+				this._pendingDataUpdate = false;
+				await this.handleSchemaUpdate();
+			} else if (this._pendingDataUpdate) {
+				this._pendingDataUpdate = false;
+				await this.handleDataUpdate();
+			}
+		}
+	}
+
+	/**
+	 * Handles a schema update from the backend.
+	 */
+	private async handleSchemaUpdate(): Promise<void> {
+		await this._updateLayoutEntries();
+		this.rebuildSortKeysFromCache();
+		this.softReset();
+		await this.fetchData(InvalidateCacheFlags.All);
+	}
+
+	/**
+	 * Handles a data update from the backend.
+	 */
+	private async handleDataUpdate(): Promise<void> {
+		await this._updateLayoutEntries();
+		this.rebuildSortKeysFromCache();
+		await this.fetchData(InvalidateCacheFlags.Data);
+	}
+
+	/**
+	 * Rebuilds the column sort keys from the cached backend state.
+	 * Called after schema/data updates to sync sort keys with backend state.
+	 */
+	private rebuildSortKeysFromCache(): void {
+		const state = this._dataExplorerClientInstance.cachedBackendState;
+		if (!state) {
+			return;
+		}
+
+		// Clear and rebuild column sort keys from the cached state.
+		this._columnSortKeys.clear();
+		state.sort_keys.forEach((key, sortIndex) => {
+			this._columnSortKeys.set(
+				key.column_index,
+				new ColumnSortKeyDescriptor(sortIndex, key.column_index, key.ascending)
+			);
+		});
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -22,7 +22,6 @@ import { CustomContextMenuSeparator } from '../../../browser/positronComponents/
 import { MAX_ADVANCED_LAYOUT_ENTRY_COUNT } from '../../../browser/positronDataGrid/classes/layoutManager.js';
 import { PositronDataExplorerCommandId } from '../../../contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.js';
 import { InvalidateCacheFlags, TableDataCache, WidthCalculators } from '../common/tableDataCache.js';
-import { TableSummaryCache } from '../common/tableSummaryCache.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { BackendState, ColumnSchema, ExportFormat, RowFilter, SupportStatus } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { ClipboardData, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, MouseSelectionType, RowSelectionState } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
@@ -68,6 +67,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	private readonly _onDidChangePinnedColumns = this._register(new Emitter<number[]>());
 
 	/**
+	 * The onDidSetRowFilters event emitter.
+	 * Fired after row filters are applied so the coordinator can refresh
+	 * the summary panel's column profiles.
+	 */
+	private readonly _onDidSetRowFilters = this._register(new Emitter<void>());
+
+	/**
 	 * Whether the data explorer is currently visible.
 	 * When not visible, expensive operations are deferred.
 	 */
@@ -89,11 +95,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private _initialLoadComplete = false;
 
-	/**
-	 * Reference to the updateLayoutEntries function for use in setVisible().
-	 */
-	private _updateLayoutEntries!: (state?: BackendState) => Promise<void>;
-
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -102,12 +103,10 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Constructor.
 	 * @param _dataExplorerClientInstance The data explorer client instance.
 	 * @param _tableDataCache The table data cache.
-	 * @param _tableSummaryCache The table summary cache.
 	 */
 	constructor(
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _tableDataCache: TableDataCache,
-		private readonly _tableSummaryCache: TableSummaryCache,
 	) {
 		// Call the base class's constructor.
 		super({
@@ -141,72 +140,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		this._hoverManager = this._register(new PositronActionBarHoverManager(false, this._services.configurationService, this._services.hoverService));
 		this._hoverManager.setCustomHoverDelay(500);
 
-		/**
-		 * Updates the layout entries.
-		 * @param state The backend state, if known; otherwise, undefined.
-		 */
-		this._updateLayoutEntries = async (state?: BackendState) => {
-			// Get the backend state, if was not provided.
-			if (!state) {
-				state = await this._dataExplorerClientInstance.getBackendState();
-			}
-
-			// Notify the user if the dataset exceeds the advanced layout limits which will
-			// cause advanced features to be disabled to improve performance.
-			// See https://github.com/posit-dev/positron/issues/9265
-			const exceedsColumnLimit = await this.exceedsAdvancedLayoutLimits(state);
-			if (exceedsColumnLimit) {
-				const message = localize(
-					'positron.dataExplorer.largeDatasetNotificationColumns',
-					"Dataset '{0}' has {1} columns, which exceeds the size to fully support all features for the Data Explorer. Advanced features such as filtering, sorting, and row resizing will be disabled to improve performance.",
-					state.display_name,
-					state.table_shape.num_columns.toLocaleString()
-				);
-
-				// Show a sticky notification that persists until dismissed
-				this._services.notificationService.notify({
-					id: `dataExplorer.largeDataset.${this._dataExplorerClientInstance.identifier}`,
-					severity: Severity.Warning,
-					message: message,
-					sticky: true,
-					source: localize('positron.dataExplorer.source', 'Data Explorer')
-				});
-			}
-
-			// Calculate column widths.
-			const columnWidths = await this._tableDataCache.calculateColumnWidths(
-				this.minimumColumnWidth,
-				this.maximumColumnWidth
-			);
-
-			// Set the layout entries.
-			this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
-			this._rowLayoutManager.setEntries(state.table_shape.num_rows);
-
-			// For zero-row case (e.g., after filtering), ensure a full reset of scroll positions
-			if (state.table_shape.num_rows === 0) {
-				this._verticalScrollOffset = 0;
-				this._horizontalScrollOffset = 0;
-				// Force a layout recomputation and repaint
-				this.softReset();
-				this.fireOnDidUpdateEvent();
-			} else {
-				// Adjust the vertical scroll offset, if needed.
-				if (!this.firstRow) {
-					this._verticalScrollOffset = 0;
-				} else if (this._verticalScrollOffset > this.maximumVerticalScrollOffset) {
-					this._verticalScrollOffset = this.maximumVerticalScrollOffset;
-				}
-
-				// Adjust the horizontal scroll offset, if needed.
-				if (!this.firstColumn) {
-					this._horizontalScrollOffset = 0;
-				} else if (this._horizontalScrollOffset > this.maximumHorizontalScrollOffset) {
-					this._horizontalScrollOffset = this.maximumHorizontalScrollOffset;
-				}
-			}
-		};
-
 		// Add the data explorer client onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
 			// If not visible, defer the update until we become visible.
@@ -234,11 +167,19 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Add the data explorer client onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(async state => {
-			await this._updateLayoutEntries(state);
+			await this.updateLayoutEntries(state);
+
+			// Rebuild sort keys on every backend state change to keep the
+			// data grid's sort indicators in sync with the backend's sort
+			// state (e.g., sort keys may be affected by schema changes).
 			this.rebuildSortKeysFromCache();
 
-			// DISABLED: Fetching data here causes double-fetching in some scenarios.
-			// await this.fetchData(InvalidateCacheFlags.Data);
+			// Do not fetch data here. For backend-initiated events,
+			// onDidUpdateBackendState fires before onDidSchemaUpdate /
+			// onDidDataUpdate. Fetching here would compute data twice --
+			// once here and again in the schema/data handler.
+			// UI-initiated operations (setRowFilters, sortData) handle
+			// their own cache updates explicitly.
 		}));
 
 		// Add the table data cache onDidUpdate event handler.
@@ -782,6 +723,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	readonly onDidChangePinnedColumns = this._onDidChangePinnedColumns.event;
 
+	/**
+	 * The onDidSetRowFilters event.
+	 */
+	readonly onDidSetRowFilters = this._onDidSetRowFilters.event;
+
 	//#region Public Methods
 
 	/**
@@ -833,7 +779,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Update layout entries to reflect the new row count after filtering.
 		// Note: The onDidUpdateBackendState handler also does this, but since the
 		// handler runs asynchronously we need to ensure it's done before we proceed.
-		await this._updateLayoutEntries();
+		await this.updateLayoutEntries();
 
 		// Update the data cache with the visible data range, or invalidate with empty arrays
 		// if there's no visible data (e.g., zero rows after filtering).
@@ -850,11 +796,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				: []
 		});
 
-		// Update the summary cache to refresh column profiles after filtering.
-		await this._tableSummaryCache.update({
-			invalidateCache: true,
-			columnIndices
-		});
+		// Notify the coordinator to refresh the summary panel's column
+		// profiles now that the data cache has been updated.
+		this._onDidSetRowFilters.fire();
 	}
 
 	/**
@@ -882,7 +826,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			this._initialLoadComplete = true;
 			this._pendingSchemaUpdate = false;
 			this._pendingDataUpdate = false;
-			await this._updateLayoutEntries();
+			await this.updateLayoutEntries();
 			this.rebuildSortKeysFromCache();
 			await this.fetchData(InvalidateCacheFlags.All);
 			return;
@@ -903,10 +847,76 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Updates the layout entries.
+	 * @param state The backend state, if known; otherwise, undefined.
+	 */
+	private async updateLayoutEntries(state?: BackendState): Promise<void> {
+		// Get the backend state, if it was not provided.
+		if (!state) {
+			state = await this._dataExplorerClientInstance.getBackendState();
+		}
+
+		// Notify the user if the dataset exceeds the advanced layout limits which will
+		// cause advanced features to be disabled to improve performance.
+		// See https://github.com/posit-dev/positron/issues/9265
+		const exceedsColumnLimit = await this.exceedsAdvancedLayoutLimits(state);
+		if (exceedsColumnLimit) {
+			const message = localize(
+				'positron.dataExplorer.largeDatasetNotificationColumns',
+				"Dataset '{0}' has {1} columns, which exceeds the size to fully support all features for the Data Explorer. Advanced features such as filtering, sorting, and row resizing will be disabled to improve performance.",
+				state.display_name,
+				state.table_shape.num_columns.toLocaleString()
+			);
+
+			// Show a sticky notification that persists until dismissed
+			this._services.notificationService.notify({
+				id: `dataExplorer.largeDataset.${this._dataExplorerClientInstance.identifier}`,
+				severity: Severity.Warning,
+				message: message,
+				sticky: true,
+				source: localize('positron.dataExplorer.source', 'Data Explorer')
+			});
+		}
+
+		// Calculate column widths.
+		const columnWidths = await this._tableDataCache.calculateColumnWidths(
+			this.minimumColumnWidth,
+			this.maximumColumnWidth
+		);
+
+		// Set the layout entries.
+		this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
+		this._rowLayoutManager.setEntries(state.table_shape.num_rows);
+
+		// For zero-row case (e.g., after filtering), ensure a full reset of scroll positions
+		if (state.table_shape.num_rows === 0) {
+			this._verticalScrollOffset = 0;
+			this._horizontalScrollOffset = 0;
+			// Force a layout recomputation and repaint
+			this.softReset();
+			this.fireOnDidUpdateEvent();
+		} else {
+			// Adjust the vertical scroll offset, if needed.
+			if (!this.firstRow) {
+				this._verticalScrollOffset = 0;
+			} else if (this._verticalScrollOffset > this.maximumVerticalScrollOffset) {
+				this._verticalScrollOffset = this.maximumVerticalScrollOffset;
+			}
+
+			// Adjust the horizontal scroll offset, if needed.
+			if (!this.firstColumn) {
+				this._horizontalScrollOffset = 0;
+			} else if (this._horizontalScrollOffset > this.maximumHorizontalScrollOffset) {
+				this._horizontalScrollOffset = this.maximumHorizontalScrollOffset;
+			}
+		}
+	}
+
+	/**
 	 * Handles a schema update from the backend.
 	 */
 	private async handleSchemaUpdate(): Promise<void> {
-		await this._updateLayoutEntries();
+		await this.updateLayoutEntries();
 		this.rebuildSortKeysFromCache();
 		this.softReset();
 		await this.fetchData(InvalidateCacheFlags.All);
@@ -916,7 +926,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Handles a data update from the backend.
 	 */
 	private async handleDataUpdate(): Promise<void> {
-		await this._updateLayoutEntries();
+		await this.updateLayoutEntries();
 		this.rebuildSortKeysFromCache();
 		await this.fetchData(InvalidateCacheFlags.Data);
 	}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -168,8 +168,12 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			// Update layout entries and fetch data with cache invalidation.
 			await this.updateLayoutEntries(state);
 
-			// DISABLED: Fetching data here causes double-fetching in some scenarios.
-			// await this.fetchData(true);
+			// Do not fetch data here. For backend-initiated events,
+			// onDidUpdateBackendState fires before onDidSchemaUpdate /
+			// onDidDataUpdate. Fetching here would compute profiles
+			// twice -- once here and again in the schema/data handler.
+			// UI-initiated operations (setRowFilters, sortData) handle
+			// their own cache updates explicitly.
 		}));
 
 		// Add the table summary cache onDidUpdate event handler.

--- a/test/e2e/tests/data-explorer/data-explorer-split-editor.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-split-editor.test.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Data Explorer: Split Editor Visibility
+ *
+ * Verifies that a data explorer instance shared across multiple editor
+ * panes remains functional when one pane is closed. This guards against
+ * regressions where closing a split pane incorrectly hides the shared
+ * instance, causing the remaining pane to stop rendering data.
+ *
+ * Flow:
+ * - Open a data file in the data explorer
+ * - Split the editor so the same instance appears in two panes
+ * - Close one pane
+ * - Verify the remaining pane still renders data correctly
+ * - Apply a filter and verify the data updates
+ */
+
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Data Explorer - Split Editor', {
+	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
+}, () => {
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await app.workbench.dataExplorer.filters.clearAll();
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Data remains visible after closing one split pane', async function ({ app, openDataFile }) {
+		const { editors, dataExplorer, editorActionBar } = app.workbench;
+
+		// Open a parquet file in the data explorer.
+		await openDataFile('data-files/flights/flights.parquet');
+		const tabName = 'flights.parquet';
+		await editors.verifyTab(tabName, { isVisible: true, isSelected: true });
+		await dataExplorer.waitForIdle();
+
+		// Verify initial data renders.
+		await dataExplorer.grid.clickCell(0, 0);
+		await dataExplorer.grid.expectCellContentToBe({ rowIndex: 0, colIndex: 0, value: '2013' });
+
+		// Split the editor so the same data explorer shows in two panes.
+		await editorActionBar.clickButton('Split Editor Right');
+		await editorActionBar.verifySplitEditor('right', tabName);
+		// verifySplitEditor closes one of the split tabs, leaving one pane.
+
+		// Verify the remaining pane still renders data after the split
+		// pane was closed.
+		await dataExplorer.waitForIdle();
+		await dataExplorer.grid.clickCell(0, 0);
+		await dataExplorer.grid.expectCellContentToBe({ rowIndex: 0, colIndex: 0, value: '2013' });
+
+		// Verify that filtering still works, confirming the instance is
+		// fully functional (not in a deferred/hidden state).
+		await dataExplorer.filters.add({ columnName: 'month', condition: 'is equal to', value: '1' });
+		await dataExplorer.waitForIdle();
+		expect(await dataExplorer.grid.getRowCount()).toBe(27004);
+	});
+});


### PR DESCRIPTION
Addresses #2795, #4279.

### Changes

1. **Defer updates when tab is not visible**
   - Track visibility state in both grid instances (data and summary)
   - Defer schema, data, and backend-state updates until tab becomes active
   - Process deferred updates on visibility restore, with schema updates taking precedence

2. **Fix duplicate data fetching on backend events**
   - Backend fires `onDidUpdateBackendState` before `onDidSchemaUpdate`/`onDidDataUpdate`
   - Previously both handlers fetched data, causing double work
   - Now backend events are handled only by schema/data handlers
   - UI operations (`setRowFilters`, `sortData`) explicitly update caches

3. **Handle shared visibility across split editors**
   - Ref-count visible editors per instance so a single instance shared across split editors stays visible until the last editor detaches
   - Wire `setEditorVisible` into the ref-counting so editor group hide/show (not just tab switches) correctly defers work

4. **Catch unhandled promise rejections from grid `setVisible(true)`**
   - Async initial load failures on visibility restore are now caught via `onUnexpectedError`

5. **Guard `onDidUpdateBackendState` when hidden**
   - Skip `updateLayoutEntries` and `rebuildSortKeysFromCache` when the data grid is not visible, since companion schema/data events set pending flags that rebuild everything on re-show

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Data explorer does not do background computation in some cases when the tab is inactive.


### QA Notes

Since this PR was LLM-assisted, we'll just want to be careful to check for regressions in e2e tests.

@:data-explorer