### PR TITLE
Improve notification for explicit "Check for Updates"

### DIFF
--- a/product.json
+++ b/product.json
@@ -2,7 +2,7 @@
 	"companyName": "Posit Software, PBC",
 	"nameShort": "Positron",
 	"nameLong": "Positron",
-	"positronVersion": "2026.01.0",
+	"positronVersion": "2024.11.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/product.json
+++ b/product.json
@@ -2,7 +2,7 @@
 	"companyName": "Posit Software, PBC",
 	"nameShort": "Positron",
 	"nameLong": "Positron",
-	"positronVersion": "2024.11.0",
+	"positronVersion": "2026.01.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -421,6 +421,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		// if (!this.shouldShowNotification()) {
 		// Always show notification for manual checks, otherwise respect the throttle
 		if (!this.explicitCheck && !this.shouldShowNotification()) {
+			// --- End Positron ---
 			return;
 		}
 
@@ -447,7 +448,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			// --- Start Positron ---
 			// { priority: NotificationPriority.OPTIONAL }
 			{
-				priority: this.explicitCheck ? NotificationPriority.URGENT : NotificationPriority.DEFAULT,
+				priority: this.explicitCheck ? NotificationPriority.URGENT : NotificationPriority.OPTIONAL,
 				sticky: this.explicitCheck
 			}
 			// --- End Positron ---

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -307,11 +307,21 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 					const currentVersion = parseVersion(this.productService.version);
 					const nextVersion = parseVersion(productVersion);
 					this.majorMinorUpdateAvailableContextKey.set(Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion)));
-					this.onUpdateReady(state.update);
+					try {
+						console.log('[Positron Update] About to call this.onUpdateReady - method exists?', typeof this.onUpdateReady, this.onUpdateReady);
+						this.onUpdateReady(state.update);
+						console.log('[Positron Update] Returned from this.onUpdateReady');
+					} catch (e) {
+						console.error('[Positron Update] Exception calling onUpdateReady:', e);
+					}
 				} else {
 					console.log('[Positron Update] State Ready but no version at all!');
 					// Still try to show notification without version
-					this.onUpdateReady(state.update);
+					try {
+						this.onUpdateReady(state.update);
+					} catch (e) {
+						console.error('[Positron Update] Exception calling onUpdateReady (no version):', e);
+					}
 				}
 
 				// Reset explicitCheck after showing the Ready notification

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -255,7 +255,6 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				if (state.explicit) {
 					this.explicitCheck = true;
 				}
-				console.log('[Positron Update] CheckingForUpdates - state.explicit:', state.explicit, 'this.explicitCheck:', this.explicitCheck);
 				break;
 			// --- End Positron ---
 
@@ -269,20 +268,17 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				// Only reset explicit check flag if we actually returned to idle (no update available)
 				// Keep it true if we're in an update flow (downloading, ready, etc.)
 				if (this.state.type === StateType.CheckingForUpdates) {
-					console.log('[Positron Update] Returning to Idle after check - resetting explicitCheck to false');
 					this.explicitCheck = false;
 				}
 				// --- End Positron ---
 				break;
 
 			case StateType.AvailableForDownload:
-				console.log('[Positron Update] State: AvailableForDownload - explicitCheck:', this.explicitCheck);
 				this.onUpdateAvailable(state.update);
 				break;
 
 			// --- Start Positron ---
 			case StateType.Downloading:
-				console.log('[Positron Update] State: Downloading - explicitCheck:', this.explicitCheck);
 				// With auto-update, we go directly from CheckingForUpdates to Downloading
 				// Show notification for explicit checks since they never see AvailableForDownload
 				if (this.explicitCheck) {
@@ -296,14 +292,11 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				break;
 
 			case StateType.Ready: {
-				console.log('[Positron Update] State: Ready - explicitCheck:', this.explicitCheck);
-				console.log('[Positron Update] State Ready - update.productVersion:', state.update.productVersion, 'update.version:', state.update.version);
 				// --- Start Positron ---
 				// const productVersion = state.update.productVersion;
 				// Use version fallback like we do elsewhere
 				const productVersion = state.update.productVersion || state.update.version;
 				if (productVersion) {
-					console.log('[Positron Update] Ready - calling onUpdateReady with version:', productVersion);
 					// --- Start Positron ---
 					// Try to set major/minor update context, but don't let it block showing the notification
 					try {
@@ -312,27 +305,21 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 						const isMajorMinor = Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion));
 						this.majorMinorUpdateAvailableContextKey.set(isMajorMinor);
 					} catch (e) {
-						console.log('[Positron Update] Could not parse versions for major/minor check, skipping:', e);
 						// Just set to false if we can't determine
 						this.majorMinorUpdateAvailableContextKey.set(false);
 					}
 					// --- End Positron ---
-					console.log('[Positron Update] About to call this.onUpdateReady');
 					this.onUpdateReady(state.update);
-					console.log('[Positron Update] Returned from this.onUpdateReady');
 				} else {
-					console.log('[Positron Update] State Ready but no version at all!');
 					// Still try to show notification without version
 					try {
 						this.onUpdateReady(state.update);
 					} catch (e) {
-						console.error('[Positron Update] Exception calling onUpdateReady (no version):', e);
 					}
 				}
 
 				// Reset explicitCheck after showing the Ready notification
 				// The manual check flow is now complete
-				console.log('[Positron Update] Ready notification shown, resetting explicitCheck to false');
 				this.explicitCheck = false;
 				// --- End Positron ---
 				break;
@@ -380,7 +367,6 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 
 	// --- Start Positron ---
 	private onUpdateDownloading(): void {
-		console.log('[Positron Update] onUpdateDownloading called - explicitCheck:', this.explicitCheck);
 		// Show notification when downloading starts (macOS auto-update flow)
 		this.notificationService.notify({
 			severity: Severity.Info,
@@ -469,19 +455,13 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 
 	// windows and mac
 	private onUpdateReady(update: IUpdate): void {
-		console.log('========== [Positron Update] onUpdateReady ENTRY POINT ==========');
-		console.log('[Positron Update] onUpdateReady called - explicitCheck:', this.explicitCheck);
-		console.log('[Positron Update] onUpdateReady - isMacintosh:', isMacintosh, 'isWindows:', isWindows);
 		// --- Start Positron ---
 		// Always show for: Windows system-wide installs OR manual checks
 		// Otherwise respect the throttle
 		const isWindowsSystemWide = isWindows && this.productService.target !== 'user';
-		console.log('[Positron Update] onUpdateReady - isWindowsSystemWide:', isWindowsSystemWide, 'shouldShowNotification:', this.shouldShowNotification());
 		if (!isWindowsSystemWide && !this.explicitCheck && !this.shouldShowNotification()) {
-			console.log('[Positron Update] Skipping onUpdateReady - not explicit and throttled');
 			return;
 		}
-		console.log('[Positron Update] onUpdateReady - PASSED throttle check, will show notification');
 		// --- End Positron ---
 
 		const actions = [{
@@ -506,7 +486,6 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		const message = productVersion
 			? nls.localize('updateReadyWithVersions', "{0} {1} update is now ready. Restart to apply.", this.productService.nameLong, productVersion)
 			: nls.localize('updateAvailableAfterRestart', "Restart {0} to apply the latest update.", this.productService.nameLong);
-		console.log('[Positron Update] Showing Ready notification:', message);
 		// --- End Positron ---
 
 		// windows user fast updates and mac

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -304,22 +304,22 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				const productVersion = state.update.productVersion || state.update.version;
 				if (productVersion) {
 					console.log('[Positron Update] Ready - calling onUpdateReady with version:', productVersion);
-					console.log('[Positron Update] Step 1: About to parseVersion(this.productService.version)');
-					const currentVersion = parseVersion(this.productService.version);
-					console.log('[Positron Update] Step 2: currentVersion:', currentVersion);
-					const nextVersion = parseVersion(productVersion);
-					console.log('[Positron Update] Step 3: nextVersion:', nextVersion);
-					const isMajorMinor = Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion));
-					console.log('[Positron Update] Step 4: isMajorMinor:', isMajorMinor);
-					this.majorMinorUpdateAvailableContextKey.set(isMajorMinor);
-					console.log('[Positron Update] Step 5: Set context key');
+					// --- Start Positron ---
+					// Try to set major/minor update context, but don't let it block showing the notification
 					try {
-						console.log('[Positron Update] About to call this.onUpdateReady');
-						this.onUpdateReady(state.update);
-						console.log('[Positron Update] Returned from this.onUpdateReady');
+						const currentVersion = parseVersion(this.productService.version);
+						const nextVersion = parseVersion(productVersion);
+						const isMajorMinor = Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion));
+						this.majorMinorUpdateAvailableContextKey.set(isMajorMinor);
 					} catch (e) {
-						console.error('[Positron Update] Exception calling onUpdateReady:', e);
+						console.log('[Positron Update] Could not parse versions for major/minor check, skipping:', e);
+						// Just set to false if we can't determine
+						this.majorMinorUpdateAvailableContextKey.set(false);
 					}
+					// --- End Positron ---
+					console.log('[Positron Update] About to call this.onUpdateReady');
+					this.onUpdateReady(state.update);
+					console.log('[Positron Update] Returned from this.onUpdateReady');
 				} else {
 					console.log('[Positron Update] State Ready but no version at all!');
 					// Still try to show notification without version

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -304,11 +304,17 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				const productVersion = state.update.productVersion || state.update.version;
 				if (productVersion) {
 					console.log('[Positron Update] Ready - calling onUpdateReady with version:', productVersion);
+					console.log('[Positron Update] Step 1: About to parseVersion(this.productService.version)');
 					const currentVersion = parseVersion(this.productService.version);
+					console.log('[Positron Update] Step 2: currentVersion:', currentVersion);
 					const nextVersion = parseVersion(productVersion);
-					this.majorMinorUpdateAvailableContextKey.set(Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion)));
+					console.log('[Positron Update] Step 3: nextVersion:', nextVersion);
+					const isMajorMinor = Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion));
+					console.log('[Positron Update] Step 4: isMajorMinor:', isMajorMinor);
+					this.majorMinorUpdateAvailableContextKey.set(isMajorMinor);
+					console.log('[Positron Update] Step 5: Set context key');
 					try {
-						console.log('[Positron Update] About to call this.onUpdateReady - method exists?', typeof this.onUpdateReady, this.onUpdateReady);
+						console.log('[Positron Update] About to call this.onUpdateReady');
 						this.onUpdateReady(state.update);
 						console.log('[Positron Update] Returned from this.onUpdateReady');
 					} catch (e) {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -297,7 +297,9 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				// Use version fallback like we do elsewhere
 				const productVersion = state.update.productVersion || state.update.version;
 				if (productVersion) {
-					// --- Start Positron ---
+					// const currentVersion = parseVersion(this.productService.version);
+					// const nextVersion = parseVersion(productVersion);
+					// this.majorMinorUpdateAvailableContextKey.set(Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion)));
 					// Try to set major/minor update context, but don't let it block showing the notification
 					try {
 						const currentVersion = parseVersion(this.productService.version);
@@ -308,7 +310,6 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 						// Just set to false if we can't determine
 						this.majorMinorUpdateAvailableContextKey.set(false);
 					}
-					// --- End Positron ---
 					this.onUpdateReady(state.update);
 				} else {
 					// Still try to show notification without version

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -297,15 +297,20 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 
 			case StateType.Ready: {
 				console.log('[Positron Update] State: Ready - explicitCheck:', this.explicitCheck);
-				const productVersion = state.update.productVersion;
+				console.log('[Positron Update] State Ready - update.productVersion:', state.update.productVersion, 'update.version:', state.update.version);
+				// --- Start Positron ---
+				// const productVersion = state.update.productVersion;
+				// Use version fallback like we do elsewhere
+				const productVersion = state.update.productVersion || state.update.version;
 				if (productVersion) {
+					console.log('[Positron Update] Ready - calling onUpdateReady with version:', productVersion);
 					const currentVersion = parseVersion(this.productService.version);
 					const nextVersion = parseVersion(productVersion);
 					this.majorMinorUpdateAvailableContextKey.set(Boolean(currentVersion && nextVersion && isMajorMinorUpdate(currentVersion, nextVersion)));
 					this.onUpdateReady(state.update);
-					// --- Start Positron ---
 				} else {
-					console.log('[Positron Update] State Ready but no productVersion, calling onUpdateReady anyway');
+					console.log('[Positron Update] State Ready but no version at all!');
+					// Still try to show notification without version
 					this.onUpdateReady(state.update);
 				}
 

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -453,17 +453,20 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 
 	// windows and mac
 	private onUpdateReady(update: IUpdate): void {
+		console.log('========== [Positron Update] onUpdateReady ENTRY POINT ==========');
 		console.log('[Positron Update] onUpdateReady called - explicitCheck:', this.explicitCheck);
+		console.log('[Positron Update] onUpdateReady - isMacintosh:', isMacintosh, 'isWindows:', isWindows);
 		// --- Start Positron ---
-		// if (!(isWindows && this.productService.target !== 'user') && !this.shouldShowNotification()) {
 		// Always show for: Windows system-wide installs OR manual checks
 		// Otherwise respect the throttle
 		const isWindowsSystemWide = isWindows && this.productService.target !== 'user';
+		console.log('[Positron Update] onUpdateReady - isWindowsSystemWide:', isWindowsSystemWide, 'shouldShowNotification:', this.shouldShowNotification());
 		if (!isWindowsSystemWide && !this.explicitCheck && !this.shouldShowNotification()) {
 			console.log('[Positron Update] Skipping onUpdateReady - not explicit and throttled');
-			// --- End Positron ---
 			return;
 		}
+		console.log('[Positron Update] onUpdateReady - PASSED throttle check, will show notification');
+		// --- End Positron ---
 
 		const actions = [{
 			label: nls.localize('updateNow', "Update Now"),


### PR DESCRIPTION
Addresses #10186

NOTE TO SELF: must revert 79b42994bc4ec64ebf2a4dbeb20d4bda49c1b6c6 before merging

This PR makes changes in the update flow to keep track of whether a check was explicitly done by a user (as opposed to the behind-the-scenes automatic checking). It does not align exactly with what is outlined in https://github.com/posit-dev/positron/issues/10186 as "expected behavior" because AFAICT that would be _extremely_ difficult with how the Electron updating/downloading/etc works. 

Instead, for the Electron auto-updating that is used on macOS and system Windows install, what happens here when you manually do "Check for Updates" is first a notification that there _is_ an update (not sticky, dismisses itself after a bit):

<img width="1451" height="1114" alt="Screenshot 2025-12-14 at 8 52 50 PM" src="https://github.com/user-attachments/assets/739315ae-41df-4f4b-9406-d77e734bf8a0" />

And then later, a notification that the update is downloaded and you can restart (sticky):

<img width="1451" height="1114" alt="Screenshot 2025-12-14 at 8 53 04 PM" src="https://github.com/user-attachments/assets/e4214c72-afe2-4653-91e1-454c63dcc79f" />



### Release Notes

#### New Features

- Improved user feedback when "Check for Updates" is manually triggered

#### Bug Fixes

- N/A


### QA Notes

On macOS and Windows, when you explicitly call "Check for Updates..." either from the gear icon in the lower left or the command palette _Positron: Check for Updates..._ you should get immediate feedback that an update either is or is not available. The feedback that it _is_ available is what is new here.

If an update _is_ available, the download will start and then you should get a notification that you can restart to apply the update once it's ready.

The behind-the-scenes updating (not triggered by a user) should work the same as before.

This PR does not involve any changes to what happens on Linux, since there is no real auto-updating for Linux. We could improve that as well, but this PR only changes what happens related to the Electron auto-updating process when triggered by an explicit user action.
