### PR TITLE
Code-sign Kallichore for Windows

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -181,7 +181,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.60"
+      "kallichore": "0.1.61"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
Picks up a new version of Kallichore that contains code signatures for Windows (see https://github.com/posit-dev/kallichore/pull/57 for original PR). Aside from the code signatures, this release should be functionally identical to 0.1.60.

Part of https://github.com/posit-dev/positron/issues/9962.