### PR TITLE
Connections pane: Fix expand button not appearing

### DIFF
--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
@@ -145,7 +145,7 @@ export class PositronConnectionsInstance extends BaseConnectionsInstance impleme
 	}
 
 	async getChildren() {
-		if (this._children === undefined) {
+		if (this._children === null || this._children === undefined) {
 			const children = await this.client.listObjects([]);
 			this._children = await Promise.all(children.map(async (item) => {
 				return await PositronConnectionItem.init(
@@ -437,7 +437,7 @@ class PositronConnectionItem implements IPositronConnectionItem {
 	}
 
 	async hasChildren() {
-		if (this._has_children === undefined) {
+		if (this._has_children === null || this._has_children === undefined) {
 			// Anything other than the 'field' type is said to have children.
 			this._has_children = this._kind !== 'field';
 		}
@@ -487,7 +487,7 @@ class PositronConnectionItem implements IPositronConnectionItem {
 	}
 
 	private async hasViewer() {
-		if (this._has_viewer === undefined) {
+		if (this._has_viewer === null || this._has_viewer === undefined) {
 			this._has_viewer = await this.instance.client.containsData(this.path);
 		}
 		return this._has_viewer;

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
@@ -110,7 +110,7 @@ export class PositronConnectionsService extends Disposable implements IPositronC
 		}
 
 		storedConnections.forEach((metadata) => {
-			if (metadata === null) {
+			if (metadata === null || metadata === undefined) {
 				return;
 			}
 

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsUtils.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsUtils.ts
@@ -53,7 +53,7 @@ async function flatten_items(items: IPositronConnectionItem[], expanded_entries:
 	const entries: IPositronConnectionEntry[] = [];
 	for (const item of items) {
 
-		const expanded = item.getChildren === undefined ?
+		const expanded = item.getChildren === null || item.getChildren === undefined ?
 			undefined :
 			expanded_entries.has(item.id);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

Fixes issue where the connections pane wouldn't show the expand icon on Windows and Linux.
I don't really understand what changed to cause `_has_children` to be initialized to `null` and then `=== undefined` wouldn't catch it.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:connections