### PR TITLE
Postpone executing `props.actions()` in the ActionBarMenuButton

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -57,8 +57,7 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 	const buttonRef = useRef<HTMLButtonElement>(undefined!);
 
 	// State hooks.
-	const [actions, setActions] = useState<readonly IAction[]>([]);
-	const [defaultAction, setDefaultAction] = useState<IAction | undefined>(undefined);
+	const [defaultActionId, setDefaultActionId] = useState<string | undefined>(undefined);
 
 	// Manage the aria-haspopup and aria-expanded attributes.
 	useEffect(() => {
@@ -79,8 +78,7 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 		const actions = await getActions();
 		const defaultAction = actions.find(action => action.checked);
 
-		setDefaultAction(defaultAction);
-		setActions(actions);
+		setDefaultActionId(defaultAction?.id);
 
 		return actions;
 	}, [getActions]);
@@ -97,6 +95,7 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 	 * @returns A Promise<void> that resolves when the menu is shown.
 	 */
 	const showMenu = async () => {
+		const actions = await getActions()
 		// Get the actions. If there are no actions, return.
 		if (!actions.length) {
 			return;
@@ -142,6 +141,8 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 					await showMenu();
 				} else {
 					// Run the preferred action.
+					const actions = await getActions();
+					const defaultAction = actions.find(action => action.id === defaultActionId);
 					defaultAction ? defaultAction.run() : actions[0].run();
 				}
 			}}


### PR DESCRIPTION
We want to execute the `props.actions` function as late as possible to ensure we have the most up-to-date data.

Previously, this component would execute the `prop.actions` function when the compenent was first rendered. It would then memoize the list of actions in a `React.useState`. This led to stale state, most especially with regard to the `enabled` property.

If we compute the list of actions at render-time, we have stronger guarantees that the rendered data is accurate.

This does not take into consideration the possibility that the command is disabled while the menu is visible, but that is unlikely an area of concern.

Relates #8728

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- If enabled, the menu item "New Folder from Git..." should be enabled the first time you open the menu.

### QA Notes

You can exercise this area of the code by enabling/disabling git from the settings.

@:top-action-bar