### PR TITLE
Update notebook agent prompt to reinforce the need to verify structure of data

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -46,22 +46,24 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 </workflows>
 
 <data-verification>
-**CRITICAL: Verify data structure BEFORE writing analysis or visualization code**
+**Verify data structure before writing analysis or visualization code**
+
+Guessing column names or data shapes leads to runtime errors. Inspect data first to write correct code on the first attempt.
 
 When working with data of unknown structure:
-- **NEVER assume variable names, column names, shapes, or types.** Hallucinating data structure is a failure.
-- **ALWAYS verify first**: Use available inspection tools to see the data schema.
-- **Fallback to code**: If tools are insufficient, insert and execute a temporary inspection cell (e.g., `df.head()` or `colnames(df)`). **Wait for the output** to confirm the structure before writing your final analysis or plot code.
-- If you cannot verify structure, **stop and ask the user** for more information.
+- Do not assume variable names, column names, shapes, or types without verification.
+- Verify structure first: Use your available tools to inspect cell outputs or variable contents.
+- Fallback to code: If tools are insufficient, insert and execute a temporary inspection cell (e.g., `df.head()` or `colnames(df)`). The execution output is returned in the tool result—use it to inform your final code.
+- If structure cannot be verified, ask the user for more information.
 
 <anti-patterns>
-User: "plot the data":
+User: "plot the data"
 ❌ Guess `df['value']` / `df['date']`
-✓ Use tool to see columns → Use actual names in plot code
+✅ Inspect columns first, then use actual names in plot code
 
 User: "summarize revenue"
 ❌ Immediately use `df['revenue']`
-✓ Inspect → confirm exact column name (e.g. `Revenue`) → summarize
+✅ Inspect data, confirm exact column name (e.g., `Revenue`), then summarize
 </anti-patterns>
 </data-verification>
 

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -45,6 +45,26 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 **Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>
 
+<data-verification>
+**CRITICAL: Verify data structure BEFORE writing analysis or visualization code**
+
+When working with data of unknown structure:
+- **NEVER assume variable names, column names, shapes, or types.** Hallucinating data structure is a failure.
+- **ALWAYS verify first**: Use available inspection tools to see the data schema.
+- **Fallback to code**: If tools are insufficient, insert and execute a temporary inspection cell (e.g., `df.head()` or `colnames(df)`). **Wait for the output** to confirm the structure before writing your final analysis or plot code.
+- If you cannot verify structure, **stop and ask the user** for more information.
+
+<anti-patterns>
+User: "plot the data":
+❌ Guess `df['value']` / `df['date']`
+✓ Use tool to see columns → Use actual names in plot code
+
+User: "summarize revenue"
+❌ Immediately use `df['revenue']`
+✓ Inspect → confirm exact column name (e.g. `Revenue`) → summarize
+</anti-patterns>
+</data-verification>
+
 <critical-rules>
 - ALWAYS reference cells by their **zero-based index** (first cell = index 0, second cell = index 1, etc.)
 - Cell indices are shown in the notebook context (e.g., `<cell index="0">`, `<cell index="1">`)


### PR DESCRIPTION
Addresses #10855.

Adds a `<data-verification>` section to the notebook agent prompt that instructs the assistant to verify data structure before writing analysis or visualization code. This helps prevent the assistant from hallucinating column names or variable structures when working with unfamiliar data.

The new section emphasizes:
- Never assuming variable names, column names, shapes, or types
- Using inspection tools or temporary cells (e.g., `df.head()`) to verify structure first
- Waiting for output before writing final analysis code
- Asking the user when structure cannot be verified

This is a complementary fix to #10853 (single tool call to add and run cells), which was addressed in a previous PR.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Improved notebook assistant prompt to verify data structure before writing code that references columns or variables (#10855)

### QA Notes

@:notebooks @:assistant

1. Open a Positron Notebook with the pokemon dataset in the same folder
2. Ask Assistant: "help me determine whether Charizard is the best Pokemon using the pokemon.csv with pandas and seaborn"
3. Verify that Assistant inspects the data structure before writing visualization code
4. Verify that Assistant doesn't create cells with invalid column references
