### PR TITLE
Positron Notebooks - Fix inline chat regressions

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -83,6 +83,12 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly editor: IObservable<ICodeEditor | undefined>;
 
 	/**
+	 * Observable for the cell's code editor widget.
+	 * Use this when you need to track changes to the editor (e.g., when the editor is attached/detached).
+	 */
+	readonly editorObservable: IObservable<ICodeEditor | undefined>;
+
+	/**
 	 * Current cell outputs as an observable.
 	 * Returns undefined for markdown cells (which have no outputs).
 	 * Code cells override this to return their outputs observable.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -42,7 +42,9 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	abstract readonly kind: CellKind;
 	private _container: HTMLElement | undefined;
 	private readonly _execution = observableValue<INotebookCellExecution | undefined, void>('cellExecution', undefined);
-	public readonly editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
+	protected readonly _editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
+	public readonly editorObservable: IObservable<ICodeEditor | undefined> = this._editor;
+	public readonly editor: IObservable<ICodeEditor | undefined> = this._editor;
 	protected readonly _internalMetadata;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
 	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;
@@ -119,7 +121,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	get currentEditor(): ICodeEditor | undefined {
-		return this.editor.get();
+		return this._editor.get();
 	}
 
 	get uri(): URI {
@@ -192,11 +194,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	attachEditor(editor: CodeEditorWidget): void {
-		this.editor.set(editor, undefined);
+		this._editor.set(editor, undefined);
 	}
 
 	detachEditor(): void {
-		this.editor.set(undefined, undefined);
+		this._editor.set(undefined, undefined);
 	}
 
 	deltaModelDecorations(oldDecorations: readonly string[], newDecorations: readonly IModelDeltaDecoration[]): string[] {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
@@ -33,11 +33,16 @@ export class PositronNotebookEditorControl extends Disposable implements ICompos
 	) {
 		super();
 
-		// Update the active code editor when the notebook selection state changes.
+		// Update the active code editor when the notebook selection state changes
+		// OR when the active cell's editor changes (e.g., when a markdown cell's editor is attached).
 		this._register(autorun(reader => {
 			const selectionStateMachine = this._notebookInstance.selectionStateMachine;
 			const state = selectionStateMachine.state.read(reader);
-			this._activeCodeEditor = getActiveCell(state)?.currentEditor;
+			const activeCell = getActiveCell(state);
+			// Read from the editorObservable to track changes to the editor itself.
+			// This ensures we update when the editor is attached/detached (e.g., markdown cells
+			// entering edit mode) - not just when the selection state changes.
+			this._activeCodeEditor = activeCell?.editorObservable.read(reader);
 		}));
 	}
 


### PR DESCRIPTION
Addresses #11159 and #10475.

### Summary

This PR fixes two related issues with inline chat in Positron notebooks:

1. **Inline chat not activating in markdown cells** (#10475): When editing a markdown cell, pressing `Cmd+I` wouldn't trigger inline chat because `PositronNotebookEditorControl.activeCodeEditor` wasn't being updated when the cell's editor was attached. The `autorun` only tracked selection state changes, not the editor observable - so when React mounted the editor widget *after* the state changed, the control still reported `undefined`.

2. **Inline chat lacking notebook context** (#11159): The Positron Assistant extension needed to properly detect when inline chat was invoked within a notebook context to provide cell-aware responses.

### Technical Changes

- Added `editorObservable` to `IPositronNotebookCell` interface to expose the cell's editor as a trackable observable
- Updated `PositronNotebookEditorControl` to read from `editorObservable.read(reader)` instead of just the `editor` getter, ensuring the autorun re-fires when editors are attached/detached
- Updated `notebookUtils.ts` to properly detect inline chat context via `request.location2`

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed inline chat (`Cmd+I`) not activating when editing markdown cells in Positron notebooks (#10475)
- Fixed inline chat not having notebook context when invoked from notebook cells (#11159)

### QA Notes

@:positron-notebooks @:assistant

**Test 1: Markdown cell inline chat**
1. Open a notebook with a markdown cell
2. Double-click the markdown cell to enter edit mode
3. Press `Cmd+I` (or `Ctrl+I` on Windows/Linux)
4. Verify inline chat opens and responds appropriately

**Test 2: Code cell inline chat with context**
1. Open a notebook with a code cell containing some code
2. Click into the code cell
3. Press `Cmd+I` and ask "What can you tell me about this cell?"
4. Verify the assistant has context about the cell contents
