### PR TITLE
Support rendering math expressions in notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
@@ -9,6 +9,8 @@ import { tokenizeToString } from '../../../../editor/common/languages/textToHtml
 import * as marked from '../../../../base/common/marked/marked.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { slugify } from '../../markdown/browser/markedGfmHeadingIdPlugin.js';
+import { MarkedKatexSupport } from '../../markdown/browser/markedKatexSupport.js';
+import { getWindow } from '../../../../base/browser/dom.js';
 
 /**
  * Renders markdown with theme-aware syntax highlighting for Positron notebooks.
@@ -26,7 +28,14 @@ export async function renderNotebookMarkdown(
 	// This is scoped to each render call to ensure fresh state
 	const slugCounter = new Map<string, number>();
 
+	// Load KaTeX extension for LaTeX math rendering
+	const katexExtension = await MarkedKatexSupport.loadExtension(
+		getWindow(document),
+		{ throwOnError: false }
+	);
+
 	const m = new marked.Marked()
+		.use(katexExtension)  // Add KaTeX math support
 		.use(markedHighlight({
 			async: true,
 			async highlight(code: string, lang: string): Promise<string> {


### PR DESCRIPTION
Addresses #10479 

This PR adds partial support for rendering LaTeX in positron notebooks by utilizing KaTeX to render the HTML. Using KaTeX in our markdown rendering flow gets us most of the way there when it comes to supporting math expressions. 

Because of our rendering pipeline which has an html parsing step, more complex expression support was not working. The root cause of this is `htmlParser.ts.parseHtml()` not knowing how to parse the HTML string returned by KaTeX.

We will need to move away from `htmlParser` if we want better support for all markdown rendering.

### Screenshots

The screenshots below show rendered math expressions next to built-in notebooks. The red boxes highlight the cases where math rendering isn't fully working.

<img width="1728" height="1084" alt="Screenshot 2025-12-29 at 12 33 07 PM" src="https://github.com/user-attachments/assets/c3cfc630-8f30-4d30-b60b-8d3f14b3c1c8" />

<img width="1728" height="1084" alt="Screenshot 2025-12-29 at 12 34 23 PM" src="https://github.com/user-attachments/assets/576df819-7c8c-4583-8425-44011cbe6bc1" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
