### PR TITLE
Assistant: Remove testModels setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1316,8 +1316,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		} else if (!this.languageModelsService.currentProvider) {
 			// When Anthropic is the only supported provider, we can use a more specific message.
 			// TODO: remove this custom handling https://github.com/posit-dev/positron/issues/8301
-			const hasAdditionalModels = this.configurationService.getValue<boolean>('positron.assistant.testModels') ||
-				this.configurationService.getValue<string[]>('positron.assistant.enabledProviders')?.length > 0;
+			const hasAdditionalModels = this.configurationService.getValue<string[]>('positron.assistant.enabledProviders')?.length > 0;
 
 			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
 			const addLanguageModelMessage = hasAdditionalModels

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -190,11 +190,6 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 
 	getSupportedProviders(): string[] {
 		const providers = ['anthropic-api', 'copilot'];
-		const useTestModels = this._configurationService.getValue<boolean>('positron.assistant.testModels');
-
-		if (useTestModels) {
-			providers.push('amazon-bedrock', 'error', 'echo', 'google');
-		}
 		return providers;
 	}
 

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -7,9 +7,9 @@
   "files.simpleDialog.enable": true,
   "positron.importSettings.enable": false,
   "positron.assistant.enable": true,
-  "positron.assistant.testModels": true,
   "positron.assistant.enabledProviders": [
-    "openai-api"
+    "openai-api",
+    "echo"
   ],
   "posit.workbench.showWorkbenchFlaskHint": false
 }


### PR DESCRIPTION
Fixes #11003

## Summary

Removes the hidden `positron.assistant.testModels` setting which was causing confusion outside of testing. The setting was originally intended as a test shortcut but is no longer needed.

## Changes

- Removed references to `positron.assistant.testModels` from production code:
  - `src/vs/workbench/contrib/chat/browser/chatWidget.ts`
  - `src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts`
- Updated e2e test fixtures to use `positron.assistant.enabledProviders` instead:
  - Added `"echo"` provider to `test/e2e/fixtures/settings.json` to enable test providers

## Testing

Ran e2e tests for `positron-assistant`:
- 15 tests passed on `e2e-electron` (primary test platform)
- No new test failures introduced
- Pre-existing API key authentication test failures are unrelated to these changes

## QA Notes

The `echo` provider has been added to `enabledProviders` in test fixtures as requested, enabling the echo models for automated testing.