### PR TITLE
Assistant: update vision --> imageInput in model capabilities

### DIFF
--- a/extensions/positron-assistant/src/anthropic.ts
+++ b/extensions/positron-assistant/src/anthropic.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import Anthropic from '@anthropic-ai/sdk';
 import { getProviderTimeoutMs, ModelConfig, SecretStorage } from './config';
 import { isChatImagePart, isCacheBreakpointPart, parseCacheBreakpoint, processMessages, promptTsxPartToString } from './utils.js';
-import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
+import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, DEFAULT_MODEL_CAPABILITIES } from './constants.js';
 import { log, recordTokenUsage, recordRequestTokenUsage } from './extension.js';
 import { TokenUsage } from './tokens.js';
 import { getAllModelDefinitions } from './modelDefinitions.js';
@@ -46,11 +46,6 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 	tokenCount: number = 0;
 	modelListing: vscode.LanguageModelChatInformation[];
 
-	capabilities = {
-		vision: true,
-		toolCalling: true,
-		agentMode: true,
-	};
 
 	private readonly _client: Anthropic;
 
@@ -251,7 +246,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 				version: '',
 				provider: this.provider,
 				providerName: this.providerName,
-				capabilities: this.capabilities,
+				capabilities: DEFAULT_MODEL_CAPABILITIES,
 				defaultMaxInput: modelDef.maxInputTokens,
 				defaultMaxOutput: modelDef.maxOutputTokens
 			})
@@ -285,7 +280,7 @@ export class AnthropicLanguageModel implements positron.ai.LanguageModelChatProv
 							version: model.created_at,
 							provider: this.provider,
 							providerName: this.providerName,
-							capabilities: this.capabilities,
+							capabilities: DEFAULT_MODEL_CAPABILITIES,
 							defaultMaxInput: knownModel?.maxInputTokens,
 							defaultMaxOutput: knownModel?.maxOutputTokens
 						})

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -70,3 +70,20 @@ export const DEFAULT_MAX_CONNECTION_ATTEMPTS = 3;
  * Determines if the Posit Web environment is detected.
  */
 export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && vscode.env.uiKind === vscode.UIKind.Web;
+
+/**
+ * Extended capabilities interface for Positron language models.
+ * Extends the standard VSCode LanguageModelChatCapabilities with agentMode.
+ */
+export interface PositronLanguageModelCapabilities extends vscode.LanguageModelChatCapabilities {
+	readonly agentMode?: boolean;
+}
+
+/**
+ * Default capabilities for language models supporting image input, tool calling, and agent mode.
+ */
+export const DEFAULT_MODEL_CAPABILITIES: PositronLanguageModelCapabilities = {
+	imageInput: true,
+	toolCalling: true,
+	agentMode: true,
+} as const;

--- a/extensions/positron-assistant/src/modelResolutionHelpers.ts
+++ b/extensions/positron-assistant/src/modelResolutionHelpers.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { getAllModelDefinitions } from './modelDefinitions.js';
-import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, MIN_TOKEN_LIMIT } from './constants.js';
+import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, MIN_TOKEN_LIMIT, DEFAULT_MODEL_CAPABILITIES } from './constants.js';
 import { log } from './extension.js';
 
 /**
@@ -143,7 +143,7 @@ export interface CreateModelInfoParams {
 	/** The provider display name for logging */
 	providerName: string;
 	/** Model capabilities */
-	capabilities?: vscode.LanguageModelChatInformation['capabilities'];
+	capabilities?: vscode.LanguageModelChatCapabilities;
 	/** Optional default max input tokens (overrides model definition defaults) */
 	defaultMaxInput?: number;
 	/** Optional default max output tokens (overrides model definition defaults) */
@@ -168,7 +168,7 @@ export function createModelInfo(params: CreateModelInfoParams): vscode.LanguageM
 		version,
 		provider,
 		providerName,
-		capabilities = { vision: true, toolCalling: true, agentMode: true },
+		capabilities = DEFAULT_MODEL_CAPABILITIES,
 		defaultMaxInput,
 		defaultMaxOutput
 	} = params;

--- a/extensions/positron-assistant/src/models.ts
+++ b/extensions/positron-assistant/src/models.ts
@@ -19,7 +19,7 @@ import { processMessages, toAIMessage, isAuthorizationError } from './utils';
 import { AmazonBedrockProvider, createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AnthropicLanguageModel, DEFAULT_ANTHROPIC_MODEL_MATCH, DEFAULT_ANTHROPIC_MODEL_NAME } from './anthropic';
-import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, IS_RUNNING_ON_PWB } from './constants.js';
+import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, IS_RUNNING_ON_PWB, DEFAULT_MODEL_CAPABILITIES } from './constants.js';
 import { AssistantError, log, recordRequestTokenUsage, recordTokenUsage, registerModelWithAPI } from './extension.js';
 import { TokenUsage } from './tokens.js';
 import { BedrockClient, FoundationModelSummary, InferenceProfileSummary, ListFoundationModelsCommand, ListInferenceProfilesCommand } from '@aws-sdk/client-bedrock';
@@ -128,11 +128,6 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 		},
 	};
 
-	capabilities = {
-		vision: true,
-		toolCalling: true,
-		agentMode: true,
-	};
 
 	get providerName(): string {
 		return EchoLanguageModel.source.provider.displayName;
@@ -234,7 +229,7 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 			version: '1.0.0',
 			maxInputTokens: this.maxInputTokens,
 			maxOutputTokens: this.maxOutputTokens,
-			capabilities: this.capabilities,
+			capabilities: DEFAULT_MODEL_CAPABILITIES,
 			isDefault: true,
 			isUserSelectable: true,
 		}, {
@@ -244,7 +239,7 @@ class EchoLanguageModel implements positron.ai.LanguageModelChatProvider {
 			version: '1.0.0',
 			maxInputTokens: this.maxInputTokens,
 			maxOutputTokens: this.maxOutputTokens,
-			capabilities: this.capabilities,
+			capabilities: DEFAULT_MODEL_CAPABILITIES,
 			isUserSelectable: true,
 		}];
 		this.modelListing = models;
@@ -301,11 +296,6 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 
 	protected modelListing?: vscode.LanguageModelChatInformation[];
 
-	capabilities = {
-		vision: true,
-		toolCalling: true,
-		agentMode: true,
-	};
 
 	constructor(
 		protected readonly _config: ModelConfig,
@@ -661,7 +651,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 				version: this.aiProvider(model.identifier).specificationVersion,
 				provider: this.provider,
 				providerName: this.providerName,
-				capabilities: this.capabilities,
+				capabilities: DEFAULT_MODEL_CAPABILITIES,
 				defaultMaxInput: model.maxInputTokens ?? DEFAULT_MAX_TOKEN_INPUT,
 				defaultMaxOutput: model.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT
 			})
@@ -680,7 +670,7 @@ abstract class AILanguageModel implements positron.ai.LanguageModelChatProvider 
 			version: aiModel.specificationVersion,
 			provider: this._config.provider,
 			providerName: this.providerName,
-			capabilities: this.capabilities,
+			capabilities: DEFAULT_MODEL_CAPABILITIES,
 			defaultMaxInput: this._config.maxInputTokens,
 			defaultMaxOutput: this._config.maxOutputTokens
 		});
@@ -819,7 +809,7 @@ export class OpenAILanguageModel extends AILanguageModel implements positron.ai.
 				version: modelDef.identifier,
 				provider: this.provider,
 				providerName: this.providerName,
-				capabilities: this.capabilities,
+				capabilities: DEFAULT_MODEL_CAPABILITIES,
 				defaultMaxInput: modelDef.maxInputTokens ?? DEFAULT_MAX_TOKEN_INPUT,
 				defaultMaxOutput: modelDef.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT
 			})
@@ -845,7 +835,7 @@ export class OpenAILanguageModel extends AILanguageModel implements positron.ai.
 					version: model.id,
 					provider: this.provider,
 					providerName: this.providerName,
-					capabilities: this.capabilities,
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					defaultMaxInput: model.maxInputTokens ?? DEFAULT_MAX_TOKEN_INPUT,
 					defaultMaxOutput: model.maxOutputTokens ?? DEFAULT_MAX_TOKEN_OUTPUT
 				})
@@ -1447,7 +1437,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 				version: '',
 				provider: this.provider,
 				providerName: this.providerName,
-				capabilities: this.capabilities,
+				capabilities: DEFAULT_MODEL_CAPABILITIES,
 				defaultMaxInput: modelDef.maxInputTokens ?? AWSLanguageModel.DEFAULT_MAX_TOKENS_INPUT,
 				defaultMaxOutput: modelDef.maxOutputTokens ?? AWSLanguageModel.DEFAULT_MAX_TOKENS_OUTPUT
 			})
@@ -1495,7 +1485,7 @@ export class AWSLanguageModel extends AILanguageModel implements positron.ai.Lan
 					version: '',
 					provider: this.provider,
 					providerName: this.providerName,
-					capabilities: this.capabilities,
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					defaultMaxInput: AWSLanguageModel.DEFAULT_MAX_TOKENS_INPUT,
 					defaultMaxOutput: AWSLanguageModel.DEFAULT_MAX_TOKENS_OUTPUT
 				});

--- a/extensions/positron-assistant/src/posit.ts
+++ b/extensions/positron-assistant/src/posit.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import Anthropic from '@anthropic-ai/sdk';
 import { deleteConfiguration, ModelConfig, SecretStorage } from './config';
-import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT } from './constants.js';
+import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, DEFAULT_MODEL_CAPABILITIES } from './constants.js';
 import { log, recordRequestTokenUsage, recordTokenUsage } from './extension.js';
 import { isCacheControlOptions, toAnthropicMessages, toAnthropicSystem, toAnthropicToolChoice, toAnthropicTools, toTokenUsage } from './anthropic.js';
 import { getAllModelDefinitions } from './modelDefinitions.js';
@@ -32,11 +32,6 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 	/** The cancellation token for the current operation. */
 	private static _cancellationToken: vscode.CancellationTokenSource | null = null;
 
-	capabilities = {
-		vision: true,
-		toolCalling: true,
-		agentMode: true,
-	};
 
 	private readonly _anthropicClient: Anthropic;
 
@@ -483,7 +478,7 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 				version: '',
 				provider: this.provider,
 				providerName: this.providerName,
-				capabilities: this.capabilities,
+				capabilities: DEFAULT_MODEL_CAPABILITIES,
 				defaultMaxInput: modelDef.maxInputTokens,
 				defaultMaxOutput: modelDef.maxOutputTokens
 			})
@@ -509,7 +504,7 @@ export class PositLanguageModel implements positron.ai.LanguageModelChatProvider
 			version: this._context?.extension.packageJSON.version ?? '',
 			provider: this.provider,
 			providerName: this.providerName,
-			capabilities: this.capabilities,
+			capabilities: DEFAULT_MODEL_CAPABILITIES,
 			defaultMaxInput: this.maxInputTokens,
 			defaultMaxOutput: this.maxOutputTokens
 		});

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -10,6 +10,7 @@ import * as sinon from 'sinon';
 import { AnthropicLanguageModel, CacheControlOptions } from '../anthropic';
 import { ModelConfig } from '../config';
 import { EMPTY_TOOL_RESULT_PLACEHOLDER, languageModelCacheBreakpointPart } from '../utils.js';
+import { DEFAULT_MODEL_CAPABILITIES } from '../constants.js';
 import Anthropic from '@anthropic-ai/sdk';
 import { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream.js';
 import { mock } from './utils.js';
@@ -121,8 +122,20 @@ suite('AnthropicLanguageModel', () => {
 		messages: vscode.LanguageModelChatMessage2[],
 		options: vscode.ProvideLanguageModelChatResponseOptions = { requestInitiator: 'test', toolMode: vscode.LanguageModelChatToolMode.Auto },
 	) {
+		const mockModelInfo: vscode.LanguageModelChatInformation = {
+			id: 'claude-3-5-sonnet-20241022',
+			name: 'Claude 3.5 Sonnet',
+			family: 'anthropic-api',
+			version: '',
+			maxInputTokens: 200_000,
+			maxOutputTokens: 64_000,
+			capabilities: DEFAULT_MODEL_CAPABILITIES,
+			isDefault: true,
+			isUserSelectable: true
+		};
+
 		await model.provideLanguageModelChatResponse(
-			model,
+			mockModelInfo,
 			messages,
 			options,
 			progress,
@@ -647,7 +660,7 @@ suite('AnthropicLanguageModel', () => {
 					version: '',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: true,
 					isUserSelectable: true
 				};

--- a/extensions/positron-assistant/src/test/modelResolutionHelpers.test.ts
+++ b/extensions/positron-assistant/src/test/modelResolutionHelpers.test.ts
@@ -13,6 +13,7 @@ import {
 	getMaxTokens,
 	markDefaultModel
 } from '../modelResolutionHelpers.js';
+import { DEFAULT_MODEL_CAPABILITIES } from '../constants.js';
 
 suite('Model Resolution Helpers', () => {
 	let mockGetConfiguration: sinon.SinonStub;
@@ -185,7 +186,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 8_192,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -196,7 +197,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				}
@@ -224,7 +225,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 8_192,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -235,7 +236,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				}
@@ -260,7 +261,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 8_192,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -271,7 +272,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				}
@@ -296,7 +297,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 8_192,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -307,7 +308,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -318,7 +319,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 32_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				}
@@ -350,7 +351,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 100_000,
 					maxOutputTokens: 4_096,
-					capabilities: { vision: false, toolCalling: true, agentMode: false },
+					capabilities: { imageInput: false, toolCalling: true, agentMode: false },
 					isDefault: false,
 					isUserSelectable: true
 				}
@@ -367,7 +368,7 @@ suite('Model Resolution Helpers', () => {
 			assert.strictEqual(model.version, '1.0');
 			assert.strictEqual(model.maxInputTokens, 100_000);
 			assert.strictEqual(model.maxOutputTokens, 4_096);
-			assert.deepStrictEqual(model.capabilities, { vision: false, toolCalling: true, agentMode: false });
+			assert.deepStrictEqual(model.capabilities, { imageInput: false, toolCalling: true, agentMode: false });
 			assert.strictEqual(model.isDefault, true); // Should be marked as default (first/only model)
 			assert.strictEqual(model.isUserSelectable, true);
 		});
@@ -381,7 +382,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 8_192,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				},
@@ -392,7 +393,7 @@ suite('Model Resolution Helpers', () => {
 					version: '1.0',
 					maxInputTokens: 200_000,
 					maxOutputTokens: 64_000,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: false,
 					isUserSelectable: true
 				}

--- a/extensions/positron-assistant/src/test/openai.test.ts
+++ b/extensions/positron-assistant/src/test/openai.test.ts
@@ -11,6 +11,7 @@ import { OpenAILanguageModel } from '../models.js';
 import { ModelConfig } from '../config.js';
 import * as modelDefinitionsModule from '../modelDefinitions.js';
 import * as helpersModule from '../modelResolutionHelpers.js';
+import { DEFAULT_MODEL_CAPABILITIES } from '../constants.js';
 
 suite('OpenAILanguageModel', () => {
 	let mockWorkspaceConfig: sinon.SinonStub;
@@ -150,7 +151,7 @@ suite('OpenAILanguageModel', () => {
 					version: 'gpt-4',
 					maxInputTokens: 8192,
 					maxOutputTokens: 4096,
-					capabilities: { vision: true, toolCalling: true, agentMode: true },
+					capabilities: DEFAULT_MODEL_CAPABILITIES,
 					isDefault: true,
 					isUserSelectable: true
 				};


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/10686
- in the model capabilities, `vision` has since been changed to `imageInput`, likely in the last upstream merge or so
- this PR updates the capabilities to use `imageInput` instead, and also moves the default capabilities to a constant, since the same capabilities are applied to every model
- in the future, we may want to configure the capabilities at the model level, but for now, we'll use the same capabilities for everything

We can see the vision capability reflected in models view now, as well:

<img width="776" height="477" alt="image" src="https://github.com/user-attachments/assets/f6632855-e243-4325-be34-909a87925c55" />


### Release Notes

#### Bug Fixes

- Assistant: fix inaccurate tooltip indicating image attachments not supported (#10686)


### QA Notes

Updated assistant integration tests accordingly.

Could use a new E2E test to check that image attachments work!
