### PR TITLE
e2e: remove canvas dep

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -208,21 +208,11 @@ jobs:
             echo "Downloading Kallichore binary..."
             cd ../positron-supervisor && npm rebuild --foreground-scripts
 
-      - name: Install E2E test dependencies
-        run: npm --prefix test/e2e ci --no-audit --no-fund
-
-      - name: Compile E2E Tests
-        run: npm --prefix test/e2e run compile
-
       - name: Compile Positron and Download Electron
         run: npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron x64"
 
       - name: Install Playwright browsers
         run: npm run playwright-install
-
-      # Downloads Builtin Extensions (needed for integration & e2e testing)
-      - shell: bash
-        run: npm run prelaunch
 
       - name: 💾 Save caches
         if: ${{ inputs.save_cache && matrix.shard == 1 }}
@@ -238,6 +228,16 @@ jobs:
           package-locks-hash: ${{ steps.restore-caches.outputs.package-locks-hash }}
           node-version: ${{ steps.restore-caches.outputs.node-version }}
           playwright-version: ${{ steps.restore-caches.outputs.playwright-version }}
+
+      - name: Install E2E test dependencies
+        run: npm --prefix test/e2e ci --no-audit --no-fund
+
+      - name: Compile E2E Tests
+        run: npm --prefix test/e2e run compile
+
+      # Downloads Builtin Extensions (needed for integration & e2e testing)
+      - shell: bash
+        run: npm run prelaunch
 
       - name: Download Python requirements file
         id: download-python-reqs

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -173,7 +173,7 @@ jobs:
           #   both hit OR both miss      → filter='' (install all or skip via parent condition)
           POSITRON_EXTENSIONS_FILTER: ${{ (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit == 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true' && 'stable') || (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit == 'true' && 'volatile') || '' }}
         with:
-          timeout_minutes: 45
+          timeout_minutes: 60
           max_attempts: 3
           retry_wait_seconds: 5
           shell: bash

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.722.0",
-    "canvas": "^3.0.0",
     "mkdirp": "^1.0.4",
     "ncp": "^2.0.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
### Summary

This PR fixes a Windows build failure caused by canvas@3.0.0, which lacks prebuilt binaries for Node 22 and cannot be built on Windows without GTK/Cairo. The dependency only appeared to work previously due to stale CI caches. Removing canvas from package.json allows resemblejs to fall back to its bundled canvas@2.11.2. This issue was surfaced by recent CI cache improvements, which exposed a latent dependency bug that had been masked by stale artifacts.
  
### QA Notes

@:win @:plots