### PR TITLE
Notebooks: Change Markdown Renderer

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
@@ -73,13 +73,11 @@ export class MarkedKatexSupport {
 			const prop = style[i];
 			if (allowedProperties.includes(prop)) {
 				const value = style.getPropertyValue(prop);
-				// --- Start Positron ---
-				// Allow through lists of numbers with units (including %) or bare words like 'block'
+				// Allow through lists of numbers with units or bare words like 'block'
 				// Main goal is to block things like 'url()'.
-				if (/^(([\d\.\-]+[\w%]*\s?)+|\w+)$/.test(value)) {
+				if (/^(([\d\.\-]+\w*\s?)+|\w+)$/.test(value)) {
 					sanitizedProps.push(`${prop}: ${value}`);
 				}
-				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
@@ -73,11 +73,13 @@ export class MarkedKatexSupport {
 			const prop = style[i];
 			if (allowedProperties.includes(prop)) {
 				const value = style.getPropertyValue(prop);
-				// Allow through lists of numbers with units or bare words like 'block'
+				// --- Start Positron ---
+				// Allow through lists of numbers with units (including %) or bare words like 'block'
 				// Main goal is to block things like 'url()'.
-				if (/^(([\d\.\-]+\w*\s?)+|\w+)$/.test(value)) {
+				if (/^(([\d\.\-]+[\w%]*\s?)+|\w+)$/.test(value)) {
 					sanitizedProps.push(`${prop}: ${value}`);
 				}
+				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/domToReact.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/domToReact.tsx
@@ -7,6 +7,21 @@
 import React from 'react';
 
 /**
+ * DOM to React Conversion Utilities
+ *
+ * This module converts sanitized DOM nodes (from DOMPurify/safeSetInnerHtml) into React elements,
+ * enabling component overrides for specific HTML tags. This is part of the positron notebook markdown
+ * rendering pipeline:
+ *
+ * Markdown -> HTML string -> Sanitized DOM (DOMPurify) -> React tree (this module) -> Rendered output
+ *
+ * Key features:
+ * - Converts HTML attributes to React props (class -> className, style strings -> objects, etc.)
+ * - Supports component overrides (e.g., replacing <img> with DeferredImage component)
+ * - Handles complex DOM structures from KaTeX math rendering (MathML, SVG)
+ */
+
+/**
  * Component override map - allows replacing specific HTML tags with React components.
  */
 export interface ComponentOverrides {

--- a/src/vs/workbench/contrib/positronNotebook/browser/domToReact.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/domToReact.tsx
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+/**
+ * Component override map - allows replacing specific HTML tags with React components.
+ */
+export interface ComponentOverrides {
+	[tagName: string]: React.ComponentType<any>;
+}
+
+/**
+ * Counter for generating unique keys across the entire conversion process.
+ */
+let keyCounter = 0;
+
+/**
+ * Converts a container's children to an array of React elements.
+ * This is the main entry point for converting DOM from safeSetInnerHtml.
+ *
+ * @param container The container element (typically a div with rendered HTML inside)
+ * @param componentOverrides Map of tag names to React components
+ * @returns Array of React elements
+ */
+export function convertDomChildrenToReact(
+	container: HTMLElement,
+	componentOverrides: ComponentOverrides = {}
+): React.ReactElement[] {
+	// Reset key counter for each conversion
+	keyCounter = 0;
+
+	const elements: React.ReactElement[] = [];
+
+	for (let i = 0; i < container.childNodes.length; i++) {
+		const child = container.childNodes[i];
+		const converted = convertDomToReactWithCounter(child, componentOverrides);
+		if (converted !== null) {
+			// Wrap strings in a span to ensure we return React elements
+			if (typeof converted === 'string') {
+				elements.push(React.createElement('span', { key: `text-${keyCounter++}` }, converted));
+			} else {
+				elements.push(converted);
+			}
+		}
+	}
+
+	return elements;
+}
+
+/**
+ * Internal version of convertDomToReact that uses a global counter for unique keys.
+ */
+function convertDomToReactWithCounter(
+	node: Node,
+	componentOverrides: ComponentOverrides = {}
+): React.ReactElement | string | null {
+	// Handle text nodes
+	if (node.nodeType === Node.TEXT_NODE) {
+		return node.textContent || '';
+	}
+
+	// Handle comment nodes - skip them
+	if (node.nodeType === Node.COMMENT_NODE) {
+		return null;
+	}
+
+	// Handle element nodes
+	if (node.nodeType === Node.ELEMENT_NODE) {
+		const element = node as Element;
+		const tagName = element.tagName.toLowerCase();
+
+		// Convert HTML attributes to React props
+		const props = convertAttributesToProps(element);
+
+		// Convert child nodes recursively
+		const children: (React.ReactElement | string)[] = [];
+		for (let i = 0; i < element.childNodes.length; i++) {
+			const childNode = element.childNodes[i];
+			const converted = convertDomToReactWithCounter(childNode, componentOverrides);
+			if (converted !== null) {
+				children.push(converted);
+			}
+		}
+
+		// Add key prop for React list rendering
+		const key = `${tagName}-${keyCounter++}`;
+		const propsWithKey = { ...props, key };
+
+		// Check if there's a component override for this tag
+		if (componentOverrides[tagName]) {
+			const Component = componentOverrides[tagName];
+			// Pass children as array if present, otherwise pass nothing
+			if (children.length > 0) {
+				return React.createElement(Component, propsWithKey, ...children);
+			} else {
+				return React.createElement(Component, propsWithKey);
+			}
+		}
+
+		// Create standard React element
+		if (children.length > 0) {
+			return React.createElement(tagName, propsWithKey, ...children);
+		} else {
+			return React.createElement(tagName, propsWithKey);
+		}
+	}
+
+	// Unknown node type - skip it
+	return null;
+}
+
+/**
+ * Converts HTML element attributes to React props object.
+ * Handles special cases like class -> className, style parsing, etc.
+ *
+ * @param element The HTML element
+ * @returns Object with React props
+ */
+function convertAttributesToProps(element: Element): Record<string, any> {
+	const props: Record<string, any> = {};
+
+	// Convert all attributes
+	for (let i = 0; i < element.attributes.length; i++) {
+		const attr = element.attributes[i];
+		let propName = attr.name;
+		let propValue: any = attr.value;
+
+		// Handle special React prop names
+		if (propName === 'class') {
+			propName = 'className';
+		} else if (propName === 'for') {
+			propName = 'htmlFor';
+		} else if (propName === 'style') {
+			// Parse inline style string into object
+			propValue = parseStyleString(attr.value);
+		} else if (propName.startsWith('data-') || propName.startsWith('aria-')) {
+			// Keep data- and aria- attributes as-is
+			propName = propName;
+		} else if (propName.includes('-')) {
+			// Convert kebab-case to camelCase for other attributes
+			propName = kebabToCamelCase(propName);
+		}
+
+		props[propName] = propValue;
+	}
+
+	return props;
+}
+
+/**
+ * Parses an inline style string into a React style object.
+ *
+ * @param styleString The inline style string (e.g., "color: red; font-size: 14px")
+ * @returns React style object
+ */
+function parseStyleString(styleString: string): Record<string, string> {
+	const style: Record<string, string> = {};
+
+	if (!styleString || styleString.trim() === '') {
+		return style;
+	}
+
+	// Split by semicolon and parse each property
+	const declarations = styleString.split(';');
+	for (const declaration of declarations) {
+		const colonIndex = declaration.indexOf(':');
+		if (colonIndex === -1) {
+			continue;
+		}
+
+		const property = declaration.substring(0, colonIndex).trim();
+		const value = declaration.substring(colonIndex + 1).trim();
+
+		if (property && value) {
+			// Convert CSS property names to camelCase (e.g., font-size -> fontSize)
+			const camelProperty = kebabToCamelCase(property);
+			style[camelProperty] = value;
+		}
+	}
+
+	return style;
+}
+
+/**
+ * Converts kebab-case strings to camelCase.
+ *
+ * @param str The kebab-case string
+ * @returns The camelCase version
+ */
+function kebabToCamelCase(str: string): string {
+	return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.ts
@@ -9,6 +9,8 @@ import { tokenizeToString } from '../../../../editor/common/languages/textToHtml
 import * as marked from '../../../../base/common/marked/marked.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { slugify } from '../../markdown/browser/markedGfmHeadingIdPlugin.js';
+import { MarkedKatexSupport } from '../../markdown/browser/markedKatexSupport.js';
+import { getWindow } from '../../../../base/browser/dom.js';
 
 /**
  * Renders markdown with theme-aware syntax highlighting for Positron notebooks.
@@ -26,7 +28,14 @@ export async function renderNotebookMarkdown(
 	// This is scoped to each render call to ensure fresh state
 	const slugCounter = new Map<string, number>();
 
+	// Load KaTeX extension for LaTeX math rendering
+	const katexExtension = await MarkedKatexSupport.loadExtension(
+		getWindow(document),
+		{ throwOnError: false }
+	);
+
 	const m = new marked.Marked()
+		.use(katexExtension)  // Add KaTeX math support
 		.use(markedHighlight({
 			async: true,
 			async highlight(code: string, lang: string): Promise<string> {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
@@ -93,7 +93,8 @@ function useMarkdown(content: string): MarkdownRenderResults {
 }
 
 /**
- * Component that renders HTML with proper DOMPurify sanitization and React component overrides.
+ * Component that renders HTML with proper sanitization (via DOMPurify through safeSetInnerHtml)
+ * and support for React component overrides.
  *
  * This implementation:
  * 1. Uses safeSetInnerHtml with MarkedKatexSupport config to handle complex KaTeX math rendering
@@ -104,9 +105,7 @@ function useMarkdown(content: string): MarkdownRenderResults {
  * @returns React element containing the sanitized and converted HTML.
  */
 function MarkdownContent({ html }: { html: string }) {
-	const [reactElements, setReactElements] = React.useState<React.ReactElement[]>([]);
-
-	React.useEffect(() => {
+	const reactElements = React.useMemo(() => {
 		// Create a temporary container for DOM parsing
 		const tempContainer = document.createElement('div');
 
@@ -138,15 +137,13 @@ function MarkdownContent({ html }: { html: string }) {
 		safeSetInnerHtml(tempContainer, html, notebookSanitizerConfig);
 
 		// Convert the DOM tree to React elements with component overrides
-		const elements = convertDomChildrenToReact(
+		return convertDomChildrenToReact(
 			tempContainer,
 			{
 				img: DeferredImage,  // Enable local image conversion and remote SVG handling
 				a: NotebookLink,     // Enable proper link handling and anchor navigation
 			}
 		);
-
-		setReactElements(elements);
 	}, [html]);
 
 	return <>{reactElements}</>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/Markdown.tsx
@@ -10,14 +10,14 @@ import './Markdown.css';
 import React from 'react';
 
 // Other dependencies.
-import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
-import { DeferredImage } from './DeferredImage.js';
-import { NotebookLink } from './NotebookLink.js';
 import { localize } from '../../../../../nls.js';
 import { createCancelablePromise, raceTimeout } from '../../../../../base/common/async.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { renderNotebookMarkdown } from '../markdownRenderer.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
+import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
+import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
 
 /**
  * Component that render markdown content from a string.
@@ -72,12 +72,7 @@ function useMarkdown(content: string): MarkdownRenderResults {
 			}
 			setRenderedHtml({
 				status: 'success',
-				nodes: renderHtml(html, {
-					componentOverrides: {
-						img: DeferredImage,
-						a: (props) => <NotebookLink {...props} />
-					}
-				})
+				nodes: <MarkdownContent html={html} />
 			});
 		}).catch((error) => {
 			setRenderedHtml({
@@ -92,3 +87,30 @@ function useMarkdown(content: string): MarkdownRenderResults {
 	return renderedHtml;
 }
 
+/**
+ * Component that uses `domSanitize.safeSetInnerHtml` to render HTML.
+ * Uses MarkedKatexSupport.getSanitizerOptions() to get the appropriate sanitizer configuration
+ * that includes MathML and SVG tags/attributes required for KaTeX math rendering.
+ *
+ * This approach matches the chat pane markdown rendering approach.
+ *
+ * @param html: HTML string to render
+ * @returns React element containing the sanitized HTML.
+ */
+function MarkdownContent({ html }: { html: string }) {
+	const containerRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		if (containerRef.current) {
+			// Use MarkedKatexSupport helper to get sanitizer config with MathML/SVG support
+			const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
+				allowedTags: allowedMarkdownHtmlTags,
+				allowedAttributes: allowedMarkdownHtmlAttributes,
+			});
+
+			safeSetInnerHtml(containerRef.current, html, sanitizerConfig);
+		}
+	}, [html]);
+
+	return <div ref={containerRef} />;
+}


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/positron/pull/11167 that fully addresses https://github.com/posit-dev/positron/issues/10479 by changing the way we parse html for markdown rendering so we aren't mangling mathML/SVGs for LaTeX support.

When KaTeX support was added in https://github.com/posit-dev/positron/issues/10479, I discovered the custom HTML parser (`htmlParser.ts`) couldn't handle KaTeX's complex HTML/CSS output so matrices and symbols like sqrt were not being rendered. 

To fix this we needed to move away from the htmlParser. This branch now uses `DOMParser` and its `safeSetInnerHtml` method which can parse KaTeX HTML/CSS. We could render the HTML directly but that would mean we would lose the `DeferredImage` (lazy load images without blocking rendering) and `NotebookLink` (allow navigating to different pars of a notebook) component behavior.

To keep `DeferredImage`/`NotebookLink`  support, we need to take the parsed markdown HTML output and convert to react components (which will allow us to provide an override for image and link tags). We can't use the existing `renderHtml.tsx` path since the parsed markdown HTML output is quite different. A new `domToReact.tsx` file has been created which does what `renderHtml.tsx` but supports the output from `DOMParser`.

The bulk of the change includes moving away from `renderHtml.tsx` to `domToReact.tsx`. That should be heavily scrutinized. We could also consider some other alternative behavior for images and notebook links that would allow for simpler code?

### Screenshots

**Complex Math Expression Support**

<img width="1807" height="1062" alt="Screenshot 2026-01-07 at 3 24 17 PM" src="https://github.com/user-attachments/assets/8c81de5f-318e-4b22-9ed3-a0bd1871c0a7" />

<img width="1807" height="1062" alt="Screenshot 2026-01-07 at 3 24 50 PM" src="https://github.com/user-attachments/assets/d803599e-9166-4397-b33b-d57df8c78e5f" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

- verify that complex math expressions render as expected
- verify there are no regressions with markdown rendering

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
