### PR TITLE
Monkey-patch Plotly browser renderer to use temp files for HTML output

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/patch/plotly.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/plotly.py
@@ -57,7 +57,7 @@ def patch_plotly_browser_renderer(session_mode: "SessionMode") -> None:
         )
         return
 
-    def positron_open_html_in_browser(html: str, using=None, new=0, autoraise=True) -> None:
+    def positron_open_html_in_browser(html: str, using=None, new=0, autoraise=True) -> None:  # noqa: ARG001, FBT002
         """
         Replacement for Plotly's open_html_in_browser that writes to a temp file.
 

--- a/extensions/positron-python/python_files/posit/positron/patch/plotly.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/plotly.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2026 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/patch/plotly.py
+++ b/extensions/positron-python/python_files/posit/positron/patch/plotly.py
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+"""
+Patches for Plotly to improve the experience in Positron.
+
+The main issue is that Plotly's browser renderer uses a single-use local server
+that shuts down immediately after serving content. This causes problems with
+Positron's "Open in Browser" feature because the server is gone by the time the
+user clicks the button.
+
+We patch the renderer to write HTML to a temp file instead of starting a server,
+which allows the content to be reopened at any time.
+"""
+
+import logging
+import tempfile
+import webbrowser
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..session_mode import SessionMode
+
+logger = logging.getLogger(__name__)
+
+
+def patch_plotly_browser_renderer(session_mode: "SessionMode") -> None:
+    """
+    Patch Plotly's browser renderer to write HTML to a temp file.
+
+    This replaces the default behavior of starting a local server with writing
+    to a temp file, which solves the "Open in Browser" issue where the server
+    is gone by the time the user wants to reopen the plot.
+
+    Args:
+        session_mode: The mode that the kernel application was started in.
+    """
+    from ..session_mode import SessionMode
+
+    if session_mode == SessionMode.NOTEBOOK:
+        # Don't patch in notebook mode - notebooks handle plots differently
+        return
+
+    try:
+        from plotly.io import _base_renderers
+    except ImportError:
+        # Plotly not installed
+        return
+
+    # Check if the function we need to patch exists
+    if not hasattr(_base_renderers, "open_html_in_browser"):
+        logger.warning(
+            "Could not find plotly.io._base_renderers.open_html_in_browser to patch. "
+            "Plotly plots may not work correctly with 'Open in Browser'."
+        )
+        return
+
+    def positron_open_html_in_browser(html: str, using=None, new=0, autoraise=True) -> None:
+        """
+        Replacement for Plotly's open_html_in_browser that writes to a temp file.
+
+        Instead of starting a single-use server, we write the HTML to a temp file
+        and open that. This allows the plot to be reopened later via "Open in Browser".
+
+        Args:
+            html: The HTML string to display.
+            using: Which browser to use (passed to webbrowser, but we ignore it).
+            new: Browser window behavior (passed to webbrowser, but we ignore it).
+            autoraise: Whether to raise the browser window (passed to webbrowser, but we ignore it).
+        """
+        # Write HTML to a temp file
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".html",
+            prefix="positron_plotly_",
+            delete=False,
+            encoding="utf-8",
+        ) as f:
+            f.write(html)
+            temp_path = f.name
+
+        # Open the temp file in the browser (which Positron will intercept)
+        webbrowser.open(f"file://{temp_path}")
+
+    # Replace the function
+    _base_renderers.open_html_in_browser = positron_open_html_in_browser
+    logger.debug("Patched plotly.io._base_renderers.open_html_in_browser")

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -38,6 +38,7 @@ from .lsp import LSPService
 from .patch.bokeh import handle_bokeh_output, patch_bokeh_no_access
 from .patch.haystack import patch_haystack_is_in_jupyter
 from .patch.holoviews import set_holoviews_extension
+from .patch.plotly import patch_plotly_browser_renderer
 from .plots import PlotsService
 from .session_mode import SessionMode
 from .ui import UiService
@@ -534,6 +535,9 @@ class PositronIPyKernel(IPythonKernel):
 
         # Patch haystack-ai to ensure is_in_jupyter() returns True in Positron
         patch_haystack_is_in_jupyter()
+
+        # Patch plotly to write HTML to temp file instead of starting a server
+        patch_plotly_browser_renderer(self.session_mode)
 
     @property
     def kernel_info(self):

--- a/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_plotly.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_plotly.py
@@ -1,0 +1,100 @@
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+import os
+import tempfile
+
+from positron.patch.plotly import patch_plotly_browser_renderer
+from positron.session_mode import SessionMode
+
+
+def test_patch_plotly_browser_renderer():
+    """
+    Test that the plotly browser renderer patch writes HTML to a temp file.
+
+    The patch replaces Plotly's open_html_in_browser function to write to a
+    temp file instead of starting a local server. This allows "Open in Browser"
+    to work after the plot is first displayed.
+    """
+    # Apply the patch
+    patch_plotly_browser_renderer(SessionMode.CONSOLE)
+
+    # Import after patching to get the patched version
+    from plotly.io import _base_renderers
+
+    # The patched function should be our replacement
+    assert _base_renderers.open_html_in_browser.__name__ == "positron_open_html_in_browser"
+
+
+def test_patch_writes_temp_file():
+    """
+    Test that the patched function actually writes HTML to a temp file.
+    """
+    # Apply the patch
+    patch_plotly_browser_renderer(SessionMode.CONSOLE)
+
+    from plotly.io import _base_renderers
+
+    # Create some test HTML
+    test_html = "<html><body><h1>Test Plot</h1></body></html>"
+
+    # Mock webbrowser.open to capture what URL is opened
+    import webbrowser
+    opened_urls = []
+    original_open = webbrowser.open
+
+    def mock_open(url):
+        opened_urls.append(url)
+        return True
+
+    webbrowser.open = mock_open
+
+    try:
+        # Call the patched function (signature: html, using=None, new=0, autoraise=True)
+        _base_renderers.open_html_in_browser(test_html)
+
+        # Should have opened one URL
+        assert len(opened_urls) == 1
+
+        # URL should be a file:// URL
+        url = opened_urls[0]
+        assert url.startswith("file://"), f"Expected file:// URL, got: {url}"
+
+        # Extract and verify the file exists
+        file_path = url.replace("file://", "")
+        assert os.path.isfile(file_path), f"Temp file should exist: {file_path}"
+
+        # Verify the content
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+        assert content == test_html
+
+        # Verify it's in the temp directory
+        assert tempfile.gettempdir() in file_path or "/var/folders" in file_path
+
+    finally:
+        webbrowser.open = original_open
+
+
+def test_patch_skipped_in_notebook_mode():
+    """
+    Test that the patch is not applied in notebook mode.
+    """
+    try:
+        from plotly.io import _base_renderers
+
+        # Get the original function name
+        original_name = _base_renderers.open_html_in_browser.__name__
+
+        # Apply the patch in notebook mode
+        patch_plotly_browser_renderer(SessionMode.NOTEBOOK)
+
+        # Function should be unchanged (or at least not our patched version if
+        # a previous test already patched it in console mode)
+        # Note: This test may pass trivially if run after other tests that patch in console mode
+        # The important thing is that notebook mode doesn't cause errors
+    except ImportError:
+        # Plotly not installed, skip
+        pass

--- a/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_plotly.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_plotly.py
@@ -70,7 +70,7 @@ def test_patch_writes_temp_file():
         assert content == test_html
 
         # Verify it's in the temp directory
-        assert tempfile.gettempdir() in str(file_path) or "/var/folders" in str(file_path)
+        assert tempfile.gettempdir() in str(file_path)
 
     finally:
         webbrowser.open = original_open

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -299,10 +299,7 @@ fig
         assert path.endswith(".html"), f"Expected .html file, got: {path}"
         # On Windows, the path is a raw file path (e.g., C:\...), while on other
         # platforms it's a file:// URL. Extract the actual file path accordingly.
-        if path.startswith("file://"):
-            file_path = Path(path.replace("file://", ""))
-        else:
-            file_path = Path(path)
+        file_path = Path(path.replace("file://", "")) if path.startswith("file://") else Path(path)
         assert file_path.is_file(), f"Cached HTML file should exist: {file_path}"
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict
-from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -298,11 +297,13 @@ fig
         path = params["path"]
         assert not path.startswith("http"), f"Expected file path, got URL: {path}"
         assert path.endswith(".html"), f"Expected .html file, got: {path}"
-        # The path should be a file:// URL pointing to the temp file
-        assert path.startswith("file://"), f"Expected file:// URL, got: {path}"
-        # Extract the actual file path and verify it exists
-        file_path = path.replace("file://", "")
-        assert os.path.isfile(file_path), f"Cached HTML file should exist: {file_path}"
+        # On Windows, the path is a raw file path (e.g., C:\...), while on other
+        # platforms it's a file:// URL. Extract the actual file path accordingly.
+        if path.startswith("file://"):
+            file_path = Path(path.replace("file://", ""))
+        else:
+            file_path = Path(path)
+        assert file_path.is_file(), f"Cached HTML file should exist: {file_path}"
 
 
 def test_is_not_plot_url_events(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -266,7 +266,6 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
 def test_plotly_show_sends_events(
     shell: PositronShell,
     ui_comm: DummyComm,
-    mock_handle_request: Mock,
 ) -> None:
     """Test that showing a Plotly plot sends the expected UI events when using `fig.show()` and `fig`."""
     shell.run_cell(
@@ -286,16 +285,24 @@ fig.show()
 fig
 """
     )
-    mock_handle_request.assert_called()
     assert len(ui_comm.messages) == 2
-    params = ui_comm.messages[0]["data"]["params"]
-    assert params["title"] == ""
-    assert params["destination"] == "plot"
-    assert params["height"] == 0
-    params = ui_comm.messages[1]["data"]["params"]
-    assert params["title"] == ""
-    assert params["destination"] == "plot"
-    assert params["height"] == 0
+
+    # Both fig.show() and fig should send events with cached HTML files
+    for i in range(2):
+        params = ui_comm.messages[i]["data"]["params"]
+        assert params["title"] == ""
+        assert params["destination"] == "plot"
+        assert params["height"] == 0
+        # Plotly HTML should be cached to a temp file (not a localhost URL)
+        # so that "Open in Browser" works after Plotly's single-use server shuts down
+        path = params["path"]
+        assert not path.startswith("http"), f"Expected file path, got URL: {path}"
+        assert path.endswith(".html"), f"Expected .html file, got: {path}"
+        # The path should be a file:// URL pointing to the temp file
+        assert path.startswith("file://"), f"Expected file:// URL, got: {path}"
+        # Extract the actual file path and verify it exists
+        file_path = path.replace("file://", "")
+        assert os.path.isfile(file_path), f"Cached HTML file should exist: {file_path}"
 
 
 def test_is_not_plot_url_events(

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -236,14 +236,12 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         destination = ShowHtmlFileDestination.Viewer
         # If url is pointing to an HTML file, route to the ShowHtmlFile comm
         if is_local_html_file(url):
-            # Send bokeh plots to the plots pane.
-            # Identify bokeh plots by checking the stack for the bokeh.io.showing.show function.
-            # This is not great but currently the only information we have.
-            destination = (
-                ShowHtmlFileDestination.Plot
-                if self._is_module_function("bokeh.io.showing", "show")
-                else ShowHtmlFileDestination.Viewer
-            )
+            # Send bokeh and plotly plots to the plots pane.
+            # Identify them by checking the stack for their respective modules/functions.
+            if self._is_module_function("bokeh.io.showing", "show"):
+                destination = ShowHtmlFileDestination.Plot
+            elif self._is_module_function("plotly.basedatatypes"):
+                destination = ShowHtmlFileDestination.Plot
 
             return self._send_show_html_event(url, destination)
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -238,7 +238,9 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         if is_local_html_file(url):
             # Send bokeh and plotly plots to the plots pane.
             # Identify them by checking the stack for their respective modules/functions.
-            if self._is_module_function("bokeh.io.showing", "show") or self._is_module_function("plotly.basedatatypes"):
+            if self._is_module_function("bokeh.io.showing", "show") or self._is_module_function(
+                "plotly.basedatatypes"
+            ):
                 destination = ShowHtmlFileDestination.Plot
 
             return self._send_show_html_event(url, destination)

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -238,9 +238,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         if is_local_html_file(url):
             # Send bokeh and plotly plots to the plots pane.
             # Identify them by checking the stack for their respective modules/functions.
-            if self._is_module_function("bokeh.io.showing", "show"):
-                destination = ShowHtmlFileDestination.Plot
-            elif self._is_module_function("plotly.basedatatypes"):
+            if self._is_module_function("bokeh.io.showing", "show") or self._is_module_function("plotly.basedatatypes"):
                 destination = ShowHtmlFileDestination.Plot
 
             return self._send_show_html_event(url, destination)


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7741

This PR fixes the "Open in Browser" functionality for Plotly plots by monkey-patching Plotly's browser renderer to write HTML to a temp file instead of starting a single-use local server. The root cause of the issue was that Plotly's `browser` renderer starts an HTTP server that only serves one request before shutting down. When Positron displayed the plot in the Plots pane, that single request was consumed, so clicking "Open in Browser" later would fail with a proxy error because the server was already gone.

The fix patches `plotly.io._base_renderers.open_html_in_browser` to write the HTML directly to a temp file and open that via a `file://` URL. This approach is consistent with how we handle other libraries like Bokeh, and the temp file persists so the plot can be reopened at any time. 

I also updated `ui.py` to detect Plotly in the local HTML file path so plots are routed to the Plots pane rather than the Viewer.

@:plots

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Python: fixed proxy error when opening Plotly plots in an external browser


### QA Notes

If you've got a couple of Plotly plots, like this:

```python
import plotly.express as px

fig1 = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig1

df = px.data.gapminder()
fig2 = px.scatter(df.query("year==2007"), 
    x="gdpPercap", y="lifeExp",
    size="pop", color="continent",
    hover_name="country", log_x=True, size_max=60)
fig2.show()
```

then you should be able to open either one in an external browser via the "Open plot in new window" button. You should also see Python Plotly plots work correctly in the new-ish auxiliary window Plots Gallery.