### PR TITLE
Just skip diagnostics for Quarto virtual docs

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -142,9 +142,12 @@ export class PythonLsp implements vscode.Disposable {
         // https://github.com/quarto-dev/quarto/issues/855
         this._clientOptions.middleware = {
             handleDiagnostics(uri, diagnostics, next) {
-                const baseName = path.basename(uri.fsPath);
-                if (VDOC_PATTERN.test(baseName)) {
-                    return;
+                // Only check file URIs because vdocs are files on disk
+                if (uri.scheme === 'file') {
+                    const baseName = path.basename(uri.fsPath);
+                    if (VDOC_PATTERN.test(baseName)) {
+                        return;
+                    }
                 }
                 return next(uri, diagnostics);
             },

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -150,9 +150,12 @@ export class ArkLsp implements vscode.Disposable {
 					}
 					// Disable diagnostics for Quarto virtual documents:
 					// https://github.com/quarto-dev/quarto/issues/855
-					const baseName = path.basename(uri.fsPath);
-					if (VDOC_PATTERN.test(baseName)) {
-						return undefined;
+					// Only check file URIs because vdocs are files on disk
+					if (uri.scheme === 'file') {
+						const baseName = path.basename(uri.fsPath);
+						if (VDOC_PATTERN.test(baseName)) {
+							return undefined;
+						}
 					}
 					return next(uri, diagnostics);
 				},

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -1,10 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import * as path from 'path';
 import { PromiseHandles, timeout } from './util';
 import { RStatementRangeProvider } from './statement-range';
 import { LOGGER } from './extension';
@@ -22,6 +23,9 @@ import { Socket } from 'net';
 import { RHelpTopicProvider } from './help';
 import { R_DOCUMENT_SELECTORS } from './provider';
 import { VirtualDocumentProvider } from './virtual-documents';
+
+// Regex to match Quarto virtual document files: .vdoc.[uuid].[ext]
+const VDOC_PATTERN = /^\.vdoc\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\w+$/i;
 
 /**
  * Global output channel for R LSP sessions
@@ -142,6 +146,12 @@ export class ArkLsp implements vscode.Disposable {
 					// Disable diagnostics for Assistant code confirmation widgets:
 					// https://github.com/posit-dev/positron/issues/7750
 					if (uri.scheme === 'assistant-code-confirmation-widget') {
+						return undefined;
+					}
+					// Disable diagnostics for Quarto virtual documents:
+					// https://github.com/quarto-dev/quarto/issues/855
+					const baseName = path.basename(uri.fsPath);
+					if (VDOC_PATTERN.test(baseName)) {
 						return undefined;
 					}
 					return next(uri, diagnostics);


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto/issues/855 along with the many linked issues there, most of which were reported here in Positron and not on the Quarto repo.

This PR filters out diagnostics from Quarto virtual document (`.vdoc`) files in Positron's R and Python language servers. It feels a little gross to be making this kind of change _here_ and not in the Quarto extension but after digging into it for a while this week, I think this is the best option for now, as long as the Quarto extension uses these literal temp files on disk. Also, it turns out this is a problem only in Positron, not in VS Code, so maybe that's a reason to feel more OK with this.

Virtual documents are temporary files that Quarto creates to provide language features (completion, hover, formatting) for code blocks embedded in `.qmd` files. When Quarto calls `workspace.openTextDocument()` on these temp files, Positron broadcasts the document open event to **all** registered language extensions. Positron's R and Python language servers then analyze these files and publish diagnostics to the Problems panel. These diagnostics persist even after the vdoc files are deleted! In the long term, there may be other options for the Quarto extension to use other than these literal temp files on disk, but for now, this is what we've got.

I already added diagnostic filtering to the Quarto extension in [quarto-dev/quarto#832](https://github.com/quarto-dev/quarto/pull/832), but that middleware only intercepts diagnostics flowing through the **Quarto LSP client**. It cannot intercept diagnostics published by other language extensions through their own diagnostic collections.

Since Positron's language servers independently analyze any `.py` or `.R` file that gets opened (including vdoc temp files) they publish diagnostics through their own channels that bypass Quarto's middleware entirely. This problem only occurs in Positron, not in VS Code, so something about the tighter integration with the LSP and console in Positron is making us generate these. I do not think that _external_ extensions like Ruff are a source of these problems based on looking at the reports and my own experimentation, just our internal LSPs.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed spurious diagnostics from Quarto virtual documents appearing in Problems pane (https://github.com/quarto-dev/quarto/issues/855)

### QA Notes

@:quarto @:problems

1. Open a Quarto document (`.qmd`) containing Python and/or R code blocks
2. Make sure you have a console going that matches the language of the code cells
3. Add intentional syntax errors in code blocks (e.g., incomplete or bad expressions such as `x = {"x1": 1, "x2": 2 "x3": 3, "x4": 4}`)
4. Trigger language features (hover, completion, or save the file)
5. Verify that no diagnostics appear in the Problems panel for `.vdoc.*` files
