### PR TITLE
Reticulate: Recover tests

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -643,6 +643,24 @@ class PositronIPyKernel(IPythonKernel):
 
         return original_showwarning(message, category, filename, lineno, file, line)  # type: ignore reportAttributeAccessIssue
 
+    def pre_handler_hook(self):
+        # Override the default pre_handler_hook to add debug logging.
+        # The default logging in Ipykernel adds the exc_info=True which is causing
+        # huge tracebacks, specially in reticulate sessions - the pre_handler_hook and
+        # post_handler_hook always fail because they can't signal from a different thread.
+        # See: https://github.com/posit-dev/positron/issues/10953
+        try:
+            super().pre_handler_hook()
+        except Exception as e:
+            self.log.debug("Error in super().pre_handler_hook(): %s", e, exc_info=False)
+
+    def post_handler_hook(self):
+        # see the pre_handler_hook for details
+        try:
+            super().post_handler_hook()
+        except Exception as e:
+            self.log.debug("Error in super().post_handler_hook(): %s", e, exc_info=False)
+
 
 class PositronIPKernelApp(IPKernelApp):
     control_thread: ControlThread | None

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -14,7 +14,7 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
-test.describe.skip('Reticulate', {
+test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
 	test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/reticulate/reticulate-variables.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-variables.test.ts
@@ -12,7 +12,7 @@ test.use({
 // In order to run this test on Windows, I think we need to set the env var:
 // RETICULATE_PYTHON to the installed python path
 
-test.describe.skip('Reticulate - Variables pane support', {
+test.describe('Reticulate - Variables pane support', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
 	test('R - Verify Reticulate formats variables in the Variables pane', async function ({ app, sessions, logger }) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

This PR overrides the default `post_handler_hook` and `pre_handler_hook` in the IPyKernel instance, so that exceptions from executing it are not raised with `exc_info=True`.
Those hooks were added in https://github.com/ipython/ipykernel/pull/49 to allow customizing the signal behaviors.
Later, they started being executed in a try context and exceptions: https://github.com/ipython/ipykernel/pull/360
Their code hasn't changed in the last 10 years, so it seems safe to override them like this.

Addresses https://github.com/posit-dev/positron/issues/10953

The problem we are trying to solve described in #10953 is that in Reticulate sessions on Linux, some execute requests hang, causing the kernel to be completely unresponsive.

I'm not entirely sure why this fix works, but here's the hypothesis:

- The kernel receives an execute_request.
- The shell thread starts processing it and runs the `pre_handler_hook` which fails in reticulate (because you can't signal from the main thread)
- This causes a log message to be written with `self.log.debug("Unable to signal in pre_handler_hook:", exc_info=True)`
- Log messages are written to an `OutStream`, which will eventually [`flush`](https://github.com/ipython/ipykernel/blob/327589f5e0ed3759751daebb724b8f7d1a0e0c52/ipykernel/iostream.py#L587-L610). 
- Flushing needs to re-schedule to the IO thread and is a locking operation with a 10s timeout. This can cause hangs eg, we delay responding to rpc status messages, etc.

The hypothesis is that larger tracebacks, makes the IO thread queue larger, which makes more likely that flushing times out.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:reticulate @:web