### PR TITLE
ci: fix windows prelaunch order for caching

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -214,6 +214,16 @@ jobs:
       - name: Install Playwright browsers
         run: npm run playwright-install
 
+      - name: Install E2E test dependencies
+        run: npm --prefix test/e2e ci --no-audit --no-fund
+
+      - name: Compile E2E Tests
+        run: npm --prefix test/e2e run compile
+
+      # Downloads Builtin Extensions (needed for integration & e2e testing)
+      - shell: bash
+        run: npm run prelaunch
+
       - name: 💾 Save caches
         if: ${{ inputs.save_cache && matrix.shard == 1 }}
         uses: ./.github/actions/save-build-caches
@@ -228,16 +238,6 @@ jobs:
           package-locks-hash: ${{ steps.restore-caches.outputs.package-locks-hash }}
           node-version: ${{ steps.restore-caches.outputs.node-version }}
           playwright-version: ${{ steps.restore-caches.outputs.playwright-version }}
-
-      - name: Install E2E test dependencies
-        run: npm --prefix test/e2e ci --no-audit --no-fund
-
-      - name: Compile E2E Tests
-        run: npm --prefix test/e2e run compile
-
-      # Downloads Builtin Extensions (needed for integration & e2e testing)
-      - shell: bash
-        run: npm run prelaunch
 
       - name: Download Python requirements file
         id: download-python-reqs


### PR DESCRIPTION
### Summary

  Fixes Windows builtins cache by correcting step order in e2e workflow.

  **Root cause:** Cache save attempted before `npm run prelaunch`, resulting in:
  Warning: Path(s) specified in the action for caching do(es) not exist

  **Fix:** Move cache save step after prelaunch so `.build/builtInExtensions/` exists when saving.

### QA Notes
Confirmed that builtin cache saved for windows run without error.

@:win
