### PR TITLE
Add workflow to auto-trigger positron-api-pkg release

### DIFF
--- a/.github/workflows/trigger-api-pkg-release.yml
+++ b/.github/workflows/trigger-api-pkg-release.yml
@@ -1,0 +1,33 @@
+name: Trigger API Package Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-api-pkg-release:
+    runs-on: ubuntu-latest
+    # Only trigger for actual releases, not prereleases
+    if: ${{ !github.event.release.prerelease }}
+
+    steps:
+      - name: Trigger positron-api-pkg release
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.API_PKG_TRIGGER_TOKEN }}
+          repository: posit-dev/positron-api-pkg
+          event-type: positron-release
+          client-payload: >-
+            {
+              "ref": "${{ github.event.release.tag_name }}",
+              "positron_version": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}"
+            }
+
+      - name: Log trigger
+        run: |
+          echo "## API Package Release Triggered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Triggered release build for Positron ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check progress at: https://github.com/posit-dev/positron-api-pkg/actions" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trigger-api-pkg-release.yml
+++ b/.github/workflows/trigger-api-pkg-release.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   trigger-api-pkg-release:
     runs-on: ubuntu-latest
@@ -18,6 +20,7 @@ jobs:
           app-id: ${{ vars.POSITRON_BOT_APP_ID }}
           private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: positron-api-pkg
 
       - name: Trigger positron-api-pkg release
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/trigger-api-pkg-release.yml
+++ b/.github/workflows/trigger-api-pkg-release.yml
@@ -11,10 +11,18 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
 
     steps:
+      - name: Generate access token
+        id: access-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Trigger positron-api-pkg release
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.API_PKG_TRIGGER_TOKEN }}
+          token: ${{ steps.access-token.outputs.token }}
           repository: posit-dev/positron-api-pkg
           event-type: positron-release
           client-payload: >-


### PR DESCRIPTION
Addresses posit-dev/positron-builds#720.

### Summary

This PR adds a GitHub Actions workflow that automatically triggers the `@posit-dev/positron` npm package release whenever a new Positron release is published. This ensures the API package stays in sync with the IDE without requiring manual intervention.

The workflow:
- Triggers on `release.published` events (excluding prereleases)
- Generates a short-lived token via the **Positron Bot GitHub App** (scoped to `positron-api-pkg` only)
- Sends a `repository_dispatch` event to `posit-dev/positron-api-pkg`
- Passes the release tag and metadata in the payload
- Declares empty `permissions` for security hardening

This PR is paired with [posit-dev/positron-api-pkg#3](https://github.com/posit-dev/positron-api-pkg/pull/3) which adds support for receiving the `repository_dispatch` trigger.

### Release Notes

#### New Features
- Automatically trigger `@posit-dev/positron` npm package releases when Positron releases are published (posit-dev/positron-builds#720)

### QA Notes

**No new secrets required.** This workflow uses the existing Positron Bot GitHub App (`vars.POSITRON_BOT_APP_ID` / `secrets.POSITRON_BOT_PRIVATE_KEY`) which is already configured for cross-repo operations.

**Testing:**
1. The positron-api-pkg release pipeline was verified with a successful dry run and a real release (v0.2.4 published to npm on 2026-04-02).
2. Create a test prerelease in Positron and verify the workflow does NOT trigger.
3. Full integration test: Create an actual Positron release and verify the workflow triggers and completes successfully.