### PR TITLE
ci: use windows runner for windows merge report job

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -490,7 +490,7 @@ jobs:
     timeout-minutes: 10
     if: ${{ !cancelled() }}
     needs: [e2e-windows-run]
-    runs-on: ubuntu-latest-4x
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Summary
This PR resolves the issue of displaying the entire file path for the PW HTML reports and GH summary. The problem arose because the reports were merged using an Ubuntu runner when the tests were executed in a Windows container.

#### Before
<img width="1045" height="340" alt="Screenshot 2026-01-06 at 2 22 26 PM" src="https://github.com/user-attachments/assets/025633f2-8287-475f-8b14-6040c2ec63b0" />
<img width="1012" height="321" alt="Screenshot 2026-01-06 at 2 22 19 PM" src="https://github.com/user-attachments/assets/2d244042-8933-4972-a564-4d222620e673" />

#### After
It passed, so I only have the GH Summary view.
<img width="546" height="149" alt="Screenshot 2026-01-06 at 2 23 41 PM" src="https://github.com/user-attachments/assets/016175c5-c760-41e6-a12c-d513647cd229" />

### QA Notes

@:win