### PR TITLE
Update Shiny extension, add test for interrupt button

### DIFF
--- a/product.json
+++ b/product.json
@@ -268,8 +268,8 @@
 		},
 		{
 			"name": "posit.shiny",
-			"version": "1.3.2",
-			"sha256sum": "c030931ff473103523c5ec167cbadc377737bdaa2ab7a09005fa1cda390cc19a",
+			"version": "1.3.3",
+			"sha256sum": "c2424225bd73ad848fd9c4380e1a632a5dea0a63b32ca8335f448555ce4f9c11",
 			"repo": "https://github.com/posit-dev/shiny-vscode",
 			"metadata": {
 				"id": "7ffa9a66-85ab-44de-ab80-2eecce45b0fe",

--- a/test/e2e/tests/shiny/shiny.test.ts
+++ b/test/e2e/tests/shiny/shiny.test.ts
@@ -19,7 +19,7 @@ test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tag
 		await app.workbench.viewer.refreshViewer();
 	});
 
-	test('Python - Verify Basic Shiny App', async function ({ app, python }) {
+	test('Python - Verify Basic Shiny App', async function ({ app, page, python }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
 		await app.workbench.quickaccess.runCommand('shiny.python.runApp');
 		const headerLocator = app.web
@@ -34,6 +34,12 @@ test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tag
 			}
 			await expect(headerLocator).toHaveText('Restaurant tipping', { timeout: 20000 });
 		}).toPass({ timeout: 60000 });
+
+		// Verify the interrupt button is visible and works
+		const interruptButton = page.locator('.positron-action-bar').getByRole('button', { name: 'Interrupt execution' });
+		await expect(interruptButton).toBeVisible({ timeout: 10000 });
+		await interruptButton.click();
+		await expect(interruptButton).not.toBeVisible({ timeout: 5000 });
 	});
 
 	test('R - Verify Basic Shiny App', {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11246

@:apps
@:viewer
@:web

### Release Notes

#### New Features

- Added new button to interrupt a running Shiny app from the Viewer pane

#### Bug Fixes

- N/A


### QA Notes

With this update, when you press the "play" button on a Shiny app (R or Python), you should see a new button pop up on the Viewer pane, similar to what we had in https://github.com/posit-dev/positron/pull/10625 for Streamlit and Dash and such.

- If you click the button, it should stop the app from running (similar to if you stopped it from the terminal)
- Having another terminal focused or active should not interfere with the button behavior; the button should act like it is connected exactly to the process running the app

