### PR TITLE
Fix keyboard shortcuts not working in cell editors

### DIFF
--- a/src/vs/platform/positronActionBar/browser/positronActionBarWidgetRegistry.ts
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarWidgetRegistry.ts
@@ -170,8 +170,9 @@ export interface IPositronActionBarWidgetRegistry {
 
 /**
  * Implementation of the Positron action bar widget registry.
+ * Exported for testing purposes - use the singleton `PositronActionBarWidgetRegistry` in production.
  */
-class PositronActionBarWidgetRegistryImpl implements IPositronActionBarWidgetRegistry {
+export class PositronActionBarWidgetRegistryImpl implements IPositronActionBarWidgetRegistry {
 	private widgets: IPositronActionBarWidgetDescriptor[] = [];
 
 	registerWidget(descriptor: IPositronActionBarWidgetDescriptor): IDisposable {

--- a/src/vs/platform/positronActionBar/test/browser/positronActionBarWidgetRegistry.test.ts
+++ b/src/vs/platform/positronActionBar/test/browser/positronActionBarWidgetRegistry.test.ts
@@ -7,14 +7,18 @@ import assert from 'assert';
 import sinon from 'sinon';
 import { MenuId } from '../../../actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../contextkey/common/contextkey.js';
-import { PositronActionBarWidgetRegistry, IPositronActionBarWidgetDescriptor } from '../../browser/positronActionBarWidgetRegistry.js';
+import { PositronActionBarWidgetRegistryImpl, IPositronActionBarWidgetDescriptor } from '../../browser/positronActionBarWidgetRegistry.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('PositronActionBarWidgetRegistry', () => {
+	let registry: PositronActionBarWidgetRegistryImpl;
 	let contextKeyService: IContextKeyService;
 	let contextMatchesRulesStub: sinon.SinonStub;
 
 	setup(() => {
+		// Create a fresh registry instance for each test to ensure isolation
+		registry = new PositronActionBarWidgetRegistryImpl();
+
 		// Create a mock context key service
 		contextMatchesRulesStub = sinon.stub().returns(true);
 		contextKeyService = {
@@ -34,9 +38,9 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable = PositronActionBarWidgetRegistry.registerWidget(descriptor);
+		const disposable = registry.registerWidget(descriptor);
 
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -55,10 +59,10 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable = PositronActionBarWidgetRegistry.registerWidget(descriptor);
+		const disposable = registry.registerWidget(descriptor);
 
 		// Widget should be present
-		let widgets = PositronActionBarWidgetRegistry.getWidgets(
+		let widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -66,7 +70,7 @@ suite('PositronActionBarWidgetRegistry', () => {
 
 		// Dispose and verify it's gone
 		disposable.dispose();
-		widgets = PositronActionBarWidgetRegistry.getWidgets(
+		widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -88,11 +92,11 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable1 = PositronActionBarWidgetRegistry.registerWidget(leftWidget);
-		const disposable2 = PositronActionBarWidgetRegistry.registerWidget(rightWidget);
+		const disposable1 = registry.registerWidget(leftWidget);
+		const disposable2 = registry.registerWidget(rightWidget);
 
 		// Should only get left widget
-		const leftWidgets = PositronActionBarWidgetRegistry.getWidgets(
+		const leftWidgets = registry.getWidgets(
 			MenuId.EditorActionsLeft,
 			contextKeyService
 		);
@@ -100,7 +104,7 @@ suite('PositronActionBarWidgetRegistry', () => {
 		assert.strictEqual(leftWidgets[0].id, 'left.widget');
 
 		// Should only get right widget
-		const rightWidgets = PositronActionBarWidgetRegistry.getWidgets(
+		const rightWidgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -127,15 +131,15 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable1 = PositronActionBarWidgetRegistry.registerWidget(alwaysVisible);
-		const disposable2 = PositronActionBarWidgetRegistry.registerWidget(conditionalWidget);
+		const disposable1 = registry.registerWidget(alwaysVisible);
+		const disposable2 = registry.registerWidget(conditionalWidget);
 
 		// Mock context key service to return false for conditional widget
 		contextMatchesRulesStub.callsFake((expr: any) => {
 			return expr === undefined; // Only match widgets without 'when' clause
 		});
 
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -157,12 +161,12 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable = PositronActionBarWidgetRegistry.registerWidget(descriptor);
+		const disposable = registry.registerWidget(descriptor);
 
 		// Mock context key service to return true (context matches)
 		contextMatchesRulesStub.returns(true);
 
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -195,11 +199,11 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable1 = PositronActionBarWidgetRegistry.registerWidget(widget300);
-		const disposable2 = PositronActionBarWidgetRegistry.registerWidget(widget100);
-		const disposable3 = PositronActionBarWidgetRegistry.registerWidget(widget200);
+		const disposable1 = registry.registerWidget(widget300);
+		const disposable2 = registry.registerWidget(widget100);
+		const disposable3 = registry.registerWidget(widget200);
 
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -236,11 +240,11 @@ suite('PositronActionBarWidgetRegistry', () => {
 			componentFactory: () => () => null
 		};
 
-		const disposable1 = PositronActionBarWidgetRegistry.registerWidget(widget1);
-		const disposable2 = PositronActionBarWidgetRegistry.registerWidget(widget2);
-		const disposable3 = PositronActionBarWidgetRegistry.registerWidget(widget3);
+		const disposable1 = registry.registerWidget(widget1);
+		const disposable2 = registry.registerWidget(widget2);
+		const disposable3 = registry.registerWidget(widget3);
 
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);
@@ -253,7 +257,7 @@ suite('PositronActionBarWidgetRegistry', () => {
 	});
 
 	test('getWidgets returns empty array for menuId with no widgets', () => {
-		const widgets = PositronActionBarWidgetRegistry.getWidgets(
+		const widgets = registry.getWidgets(
 			MenuId.EditorActionsRight,
 			contextKeyService
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -6,9 +6,7 @@
 import * as DOM from '../../../../base/browser/dom.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
-import { IContextKey, IContextKeyService, IScopedContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { IContextKey, IScopedContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { NotebookEditorContextKeys } from '../../notebook/browser/viewParts/notebookEditorWidgetContextKeys.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 
@@ -123,14 +121,12 @@ export function resetCellContextKeys(keys: IPositronNotebookCellContextKeys | un
  */
 export class PositronNotebookContextKeyManager extends Disposable {
 	//#region Private Properties
-	private _scopedInstantiationService?: IInstantiationService;
 	private readonly _containerDisposables = this._register(new DisposableStore());
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
 	constructor(
 		private readonly _notebookInstance: IPositronNotebookInstance,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 	}
@@ -142,8 +138,7 @@ export class PositronNotebookContextKeyManager extends Disposable {
 		this._containerDisposables.clear();
 		const disposables = this._containerDisposables;
 
-		const { scopedContextKeyService } = this._notebookInstance;
-		this._scopedInstantiationService = disposables.add(this._instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
+		const { scopedContextKeyService, scopedInstantiationService } = this._notebookInstance;
 
 		const positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(scopedContextKeyService);
 
@@ -151,7 +146,7 @@ export class PositronNotebookContextKeyManager extends Disposable {
 
 		// Create the manager for VSCode notebook editor context keys
 		// Extensions may depend on these familiar context keys
-		disposables.add(this._scopedInstantiationService.createInstance(NotebookEditorContextKeys, this._notebookInstance));
+		disposables.add(scopedInstantiationService.createInstance(NotebookEditorContextKeys, this._notebookInstance));
 
 		const focusTracker = disposables.add(DOM.trackFocus(container));
 		disposables.add(focusTracker.onDidFocus(() => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -15,6 +15,7 @@ import { RuntimeNotebookKernel } from '../../runtimeNotebookKernel/browser/runti
 import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
 import { IHoverManager } from '../../../../platform/hover/browser/hoverManager.js';
 import { IPositronNotebookContribution } from './positronNotebookExtensions.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 
 /**
  * Represents the possible states of a notebook's kernel connection
@@ -100,6 +101,11 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Observable of the DOM element that contains the entire notebook editor.
 	 */
 	readonly container: IObservable<HTMLElement | undefined>;
+
+	/**
+	 * Instantiation service scoped to this notebook instance.
+	 */
+	readonly scopedInstantiationService: IInstantiationService;
 
 	/**
 	 * The DOM element that contributions (such as the find widget) can render into.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -55,6 +55,7 @@ import { PixelRatio } from '../../../../base/browser/pixelRatio.js';
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { FontInfo } from '../../../../editor/common/config/fontInfo.js';
 import { createBareFontInfoFromRawSettings } from '../../../../editor/common/config/fontInfoFromSettings.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
 	textModel: NotebookTextModel;
@@ -164,6 +165,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	public readonly container = observableValue<HTMLElement | undefined>('positronNotebookContainer', undefined);
 
 	private _scopedContextKeyService: IContextKeyService | undefined;
+
+	private _scopedInstantiationService = this._register(new MutableDisposable<IInstantiationService>());
 
 	/**
 	 * Disposables for the editor container event listeners
@@ -307,6 +310,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			throw new Error('scopedContextKeyService is not available - attachView() must be called first');
 		}
 		return this._scopedContextKeyService;
+	}
+
+	get scopedInstantiationService(): IInstantiationService {
+		if (!this._scopedInstantiationService.value) {
+			throw new Error('scopedInstantiationService is not available - attachView() must be called first');
+		}
+		return this._scopedInstantiationService.value;
 	}
 
 	/**
@@ -1314,6 +1324,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this.detachView();
 		this.container.set(container, undefined);
 		this._scopedContextKeyService = scopedContextKeyService;
+		this._scopedInstantiationService.value = this._instantiationService.createChild(
+			new ServiceCollection([IContextKeyService, scopedContextKeyService]));
 		this._overlayContainer = overlayContainer;
 		this.contextManager.setContainer(editorContainer);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -56,7 +56,7 @@ import { NotebookAction2 } from './NotebookAction2.js';
 import './AskAssistantAction.js'; // Register AskAssistantAction
 import { CONTEXT_FIND_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
 
-const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
+export const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
 	POSITRON_NOTEBOOK_EDITOR_FOCUSED,
 	POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated(),
 	CONTEXT_FIND_INPUT_FOCUSED.toNegated(),

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -19,8 +19,8 @@ import { RuntimeExitReason } from '../../../services/languageRuntime/common/lang
 import { INotebookLanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IActiveNotebookEditor } from '../../notebook/browser/notebookBrowser.js';
 import { NOTEBOOK_KERNEL } from '../../notebook/common/notebookContextKeys.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../positronNotebook/browser/ContextKeysManager.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
+import { POSITRON_NOTEBOOK_COMMAND_MODE } from '../../positronNotebook/browser/positronNotebook.contribution.js';
 import { checkPositronNotebookEnabled } from '../../positronNotebook/browser/positronNotebookExperimentalConfig.js';
 import { PositronNotebookInstance } from '../../positronNotebook/browser/PositronNotebookInstance.js';
 import { usingPositronNotebooks } from '../../positronNotebook/common/positronNotebookCommon.js';
@@ -128,7 +128,7 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyChord(KeyCode.Digit0, KeyCode.Digit0),
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
 			},
 			menu: [
 				// VSCode notebooks

--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -175,6 +175,15 @@ export class Debug {
 	}
 
 	/**
+	 * Verify: The debug variable pane is visible
+	 */
+	async expectDebugVariablePaneVisible(): Promise<void> {
+		await test.step('Verify debug variable pane is visible', async () => {
+			await expect(this.debugVariablesSection).toBeVisible();
+		});
+	}
+
+	/**
 	 * Verify: The call stack is visible and contains the specified item at the specified position
 	 *
 	 * @param stackPosition The expected position (data-index) of the item in the call stack

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -91,7 +91,7 @@ test.describe('Notebook Edit Mode', {
 	});
 
 	test('Move cells up and down with keyboard shortcuts', async function ({ app, r, }) {
-		const { notebooksPositron, debug } = app.workbench;
+		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
 		// Create a new notebook with 2 cells
@@ -109,20 +109,6 @@ test.describe('Notebook Edit Mode', {
 		// Test: Move cell up: Alt+Up
 		await keyboard.press('Alt+ArrowUp');
 		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
-
-		// Test: Execute cell and select below: Shift+Enter
-		await keyboard.press('Shift+Enter');
-		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
-
-		// Test: Execute cell or toggle editor: Cmd+Enter
-		await notebooksPositron.selectCellAtIndex(1);
-		const executeShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter';
-		await keyboard.press(executeShortcut);
-
-		// Test: Debug cell: Alt+Shift+Enter
-		await notebooksPositron.selectCellAtIndex(0);
-		await keyboard.press('Alt+Shift+Enter');
-		await debug.expectDebugToolbarVisible();
 	});
 
 	test('Execute and debug cells with keyboard shortcuts', async function ({ app, r, }) {
@@ -135,20 +121,21 @@ test.describe('Notebook Edit Mode', {
 		// Enter edit mode in cell 0
 		await notebooksPositron.selectCellAtIndex(0);
 		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
-		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
 
 		// Test: Execute cell and select below: Shift+Enter
 		await keyboard.press('Shift+Enter');
+		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
 
 		// Test: Execute cell or toggle editor: Cmd+Enter
 		await notebooksPositron.selectCellAtIndex(1);
 		const executeShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter';
 		await keyboard.press(executeShortcut);
+		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }, { index: 1, order: 2 }]);
 
 		// Test: Debug cell: Alt+Shift+Enter
 		await notebooksPositron.selectCellAtIndex(0);
 		await keyboard.press('Alt+Shift+Enter');
-		await debug.expectDebugToolbarVisible();
+		await debug.expectDebugVariablePaneVisible();
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -90,8 +90,7 @@ test.describe('Notebook Edit Mode', {
 		await notebooksPositron.expectCellContentAtIndexToBe(3, 'new cell content');
 	});
 
-	// @seeM unskip me
-	test.skip("Move cells up and down with keyboard shortcuts", async function ({ app, r, }) {
+	test('Move cells up and down with keyboard shortcuts', async function ({ app, r, }) {
 		const { notebooksPositron, debug } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 
@@ -126,8 +125,7 @@ test.describe('Notebook Edit Mode', {
 		await debug.expectDebugToolbarVisible();
 	});
 
-	// @seeM unskip me
-	test.skip("Execute and debug cells with keyboard shortcuts", async function ({ app, r, }) {
+	test('Execute and debug cells with keyboard shortcuts', async function ({ app, r, }) {
 		const { notebooksPositron, debug } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 


### PR DESCRIPTION
Addresses #11254. Notebook cell actions stopped working in cell editors after the context key refactor in #11056.

The problem is that the `positronNotebookEditorFocused` context is not set inside cell editors, because the global instantiation service and context key service are used to instantiate the cell editor. We should instead use the notebook's scoped instantiation and context key services.

This was fixed in https://github.com/posit-dev/positron/pull/11175 but broke e2e tests and was reverted in #11056.

I think #11175 is the correct fix, and we needed one more fix that adjusts the `when` clause of `RuntimeNotebookKernelRestartAction` to `POSITRON_NOTEBOOK_COMMAND_MODE` so that it doesn't consume `0` keys inside cell editors.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web