### PR TITLE
e2e: address air test flake & bump ext

### DIFF
--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -23,7 +23,7 @@ on:
       grep:
         required: false
         description: "Only run tests matching this regex. Supports tags (comma-separated), titles, filenames. Confirm pattern matching locally with: npx playwright test --grep=<regex>"
-        default: "search.test"
+        default: "/search.test"
         type: string
       notify_on:
         description: "Slack notification on:"
@@ -57,7 +57,7 @@ jobs:
       allow_soft_fail: false
       shards: 1
       matrix: '{"shard":[1]}'
-      grep: ${{ inputs.grep && inputs.grep || 'search.test' }}
+      grep: ${{ inputs.grep && inputs.grep || '/search.test' }}
 
   e2e-webkit:
     name: e2e
@@ -71,7 +71,7 @@ jobs:
       allow_soft_fail: false
       shards: 1
       matrix: '{"shard":[1]}'
-      grep: ${{ inputs.grep && inputs.grep || 'search.test' }}
+      grep: ${{ inputs.grep && inputs.grep || '/search.test' }}
 
   e2e-edge:
     name: e2e
@@ -85,7 +85,7 @@ jobs:
       allow_soft_fail: false
       shards: 1
       matrix: '{"shard":[1]}'
-      grep: ${{ inputs.grep && inputs.grep || 'search.test' }}
+      grep: ${{ inputs.grep && inputs.grep || '/search.test' }}
 
   slack-notify:
     if: always()

--- a/product.json
+++ b/product.json
@@ -229,7 +229,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.27.9",
+			"version": "1.28.0",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",
@@ -268,8 +268,8 @@
 		},
 		{
 			"name": "posit.shiny",
-			"version": "1.3.2",
-			"sha256sum": "c030931ff473103523c5ec167cbadc377737bdaa2ab7a09005fa1cda390cc19a",
+			"version": "1.3.3",
+			"sha256sum": "c2424225bd73ad848fd9c4380e1a632a5dea0a63b32ca8335f448555ce4f9c11",
 			"repo": "https://github.com/posit-dev/shiny-vscode",
 			"metadata": {
 				"id": "7ffa9a66-85ab-44de-ab80-2eecce45b0fe",

--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -108,5 +108,9 @@
     {
         "key": "cmd+l c",
         "command": "workbench.action.positronPlots.clear" // Clear Plots
+    },
+    {
+        "key": "cmd+l f",
+        "command": "editor.action.formatDocument" // Format Document
     }
 ]

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -279,6 +279,13 @@ export class HotKeys {
 		return this.pressHotKeys('Cmd+L C', 'Clear Plots');
 	}
 
+	// -----------------------
+	// ---   Formatting	   ---
+	// -----------------------
+	public formatDocument() {
+		return this.pressHotKeys('Cmd+L F', 'Format Document');
+	}
+
 	/**
 	 * Press the hotkeys.
 	 * Note: Supports multiple key sequences separated by spaces.

--- a/test/e2e/tests/extensions/air.test.ts
+++ b/test/e2e/tests/extensions/air.test.ts
@@ -16,16 +16,10 @@ test.describe('Extensions', {
 
 	test('Verify AIR extension basic functionality', {
 		tag: [tags.ARK]
-	}, async function ({ app, openFile, runCommand }) {
+	}, async function ({ app, openFile, hotKeys }) {
 
 		await openFile('workspaces/r-formatting/bad-formatting.r');
-
-		// hotKeys approach fails on Ubuntu as key combination is
-		// overriden by Positron
-		await runCommand('command:editor.action.formatDocument', { keepOpen: true });
-		await app.workbench.quickInput.waitForQuickInputOpened();
-		await app.workbench.quickInput.selectQuickInputElementContaining('Air');
-		await app.workbench.quickInput.waitForQuickInputClosed();
+		await hotKeys.formatDocument(); // Air is default for R document formatting
 
 		await app.workbench.editor.waitForEditorContents('bad-formatting.r', (contents: string) => {
 			return contents.includes(formattedFile);


### PR DESCRIPTION
### Summary
A few small fixes to e2e tests:
* an adjustment to the air.test.ts to prevent a flake with using commands (as seen in last night's run)
* adjusting the grep pattern for cross browser tests. it was including a new positron notebook test which isn't compatible yet
* bumping out of date bootstrap extensions

### QA Notes

@:extensions @:web @:win
