### PR TITLE
Add a new `CreateNotebook` tool for creating positron notebooks with assistant

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -832,8 +832,7 @@
         "toolReferenceName": "editNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
-          "positron-assistant",
-          "requires-notebook"
+          "positron-assistant"
         ],
         "inputSchema": {
           "type": "object",
@@ -900,8 +899,7 @@
         "toolReferenceName": "getNotebookCells",
         "canBeReferencedInPrompt": true,
         "tags": [
-          "positron-assistant",
-          "requires-notebook"
+          "positron-assistant"
         ],
         "inputSchema": {
           "type": "object",
@@ -927,6 +925,27 @@
           "required": [
             "operation"
           ]
+        }
+      },
+      {
+        "name": "createNotebook",
+        "displayName": "Create Notebook",
+        "modelDescription": "Create a new Jupyter notebook with the specified language kernel (Python or R). Use when the user wants to start a new notebook. After creation, use EditNotebookCells to add content.",
+        "toolReferenceName": "createNotebook",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": ["python", "r"],
+              "description": "The kernel language for the notebook"
+            }
+          },
+          "required": ["language"]
         }
       }
     ]

--- a/extensions/positron-assistant/src/test/tools/createNotebook.test.ts
+++ b/extensions/positron-assistant/src/test/tools/createNotebook.test.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import { createNotebookToolImpl } from '../../tools/createNotebook.js';
+
+suite('CreateNotebook Tool', () => {
+	let sandbox: sinon.SinonSandbox;
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	suite('prepareInvocation', () => {
+		test('prepares confirmation message for Python', async () => {
+			const prepared = await createNotebookToolImpl.prepareInvocation(
+				{ input: { language: 'python' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			assert.ok(prepared.confirmationMessages?.message.includes('Python'));
+			assert.ok(prepared.invocationMessage?.includes('Python'));
+		});
+
+		test('prepares confirmation message for R', async () => {
+			const prepared = await createNotebookToolImpl.prepareInvocation(
+				{ input: { language: 'r' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			assert.ok(prepared.confirmationMessages?.message.includes('R'));
+			assert.ok(prepared.invocationMessage?.includes('R'));
+		});
+	});
+
+	suite('invoke', () => {
+		test('rejects invalid language', async () => {
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'javascript' as any } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			assert.ok(textPart.value.includes('Invalid language'));
+		});
+
+		test('handles cancellation', async () => {
+			const tokenSource = new vscode.CancellationTokenSource();
+			tokenSource.cancel();
+
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'python' } },
+				tokenSource.token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			assert.ok(textPart.value.includes('cancelled'));
+		});
+
+		test('normalizes language to lowercase', async () => {
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand');
+			executeCommandStub.resolves();
+
+			// Mock positron.notebooks.getContext to return context after creation
+			const getContextStub = sandbox.stub(positron.notebooks, 'getContext');
+			getContextStub.onFirstCall().resolves(null); // Before creation
+			getContextStub.onSecondCall().resolves({ uri: 'test://notebook.ipynb' } as any); // After creation
+
+			await createNotebookToolImpl.invoke(
+				{ input: { language: 'PYTHON' as any } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			assert.ok(executeCommandStub.calledWith('ipynb.newUntitledIpynb', 'python'));
+		});
+
+		test('includes EditNotebookCells guidance when no prior notebook exists', async () => {
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand');
+			executeCommandStub.resolves();
+
+			// Mock positron.notebooks.getContext to return null initially (no notebook),
+			// then return context after creation
+			const getContextStub = sandbox.stub(positron.notebooks, 'getContext');
+			getContextStub.onFirstCall().resolves(null); // Before creation
+			getContextStub.onSecondCall().resolves({ uri: 'test://notebook.ipynb' } as any); // After creation
+
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'python' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			// Should include detailed EditNotebookCells guidance
+			assert.ok(textPart.value.includes('EditNotebookCells'));
+			assert.ok(textPart.value.includes('operation'));
+			assert.ok(textPart.value.includes('cellType'));
+		});
+
+		test('returns simple result when prior notebook exists', async () => {
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand');
+			executeCommandStub.resolves();
+
+			// Mock positron.notebooks.getContext to return context both times
+			// (notebook existed before and after creation)
+			const getContextStub = sandbox.stub(positron.notebooks, 'getContext');
+			getContextStub.resolves({ uri: 'test://notebook.ipynb' } as any);
+
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'python' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			// Should be a simple result without detailed instructions
+			assert.ok(textPart.value.includes('Created new python notebook'));
+			assert.ok(!textPart.value.includes('operation'));
+			assert.ok(!textPart.value.includes('cellType'));
+		});
+
+		test('handles context unavailable after creation', async () => {
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand');
+			executeCommandStub.resolves();
+
+			// Mock positron.notebooks.getContext to return null both times
+			const getContextStub = sandbox.stub(positron.notebooks, 'getContext');
+			getContextStub.resolves(null);
+
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'python' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			assert.ok(textPart.value.includes('context unavailable'));
+		});
+
+		test('handles command execution errors', async () => {
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand');
+			executeCommandStub.rejects(new Error('Command failed'));
+
+			// Mock positron.notebooks.getContext for the initial check
+			const getContextStub = sandbox.stub(positron.notebooks, 'getContext');
+			getContextStub.resolves(null);
+
+			const result = await createNotebookToolImpl.invoke(
+				{ input: { language: 'python' } },
+				new vscode.CancellationTokenSource().token
+			);
+
+			const textPart = result.content[0] as vscode.LanguageModelTextPart;
+			assert.ok(textPart.value.includes('Failed to create notebook'));
+			assert.ok(textPart.value.includes('Command failed'));
+		});
+	});
+});

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -11,6 +11,7 @@ import { ProjectTreeTool } from './tools/projectTreeTool.js';
 import { getWorkspaceGitChanges, GitRepoChangeKind } from './git.js';
 import { DocumentCreateTool } from './tools/documentCreate.js';
 import { registerNotebookTools } from './tools/notebookTools.js';
+import { CreateNotebookTool } from './tools/createNotebook.js';
 
 
 /**
@@ -364,6 +365,9 @@ export function registerAssistantTools(
 	// - UpdateNotebookCell: Update existing cell content
 	// - GetCellOutputs: Retrieve outputs from executed cells
 	registerNotebookTools(context, participantService);
+
+	// Register the CreateNotebook tool for creating new notebooks
+	context.subscriptions.push(CreateNotebookTool);
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/createNotebook.ts
+++ b/extensions/positron-assistant/src/tools/createNotebook.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { PositronAssistantToolName } from '../types.js';
+import { log } from '../extension.js';
+
+interface CreateNotebookInput {
+	language: 'python' | 'r';
+}
+
+/**
+ * CreateNotebook tool implementation.
+ */
+export const createNotebookToolImpl = {
+	prepareInvocation: async (options: { input: CreateNotebookInput }, _token: vscode.CancellationToken) => {
+		const { language } = options.input;
+		const langDisplay = language === 'python' ? 'Python' : 'R';
+
+		return {
+			invocationMessage: vscode.l10n.t('Creating {0} notebook', langDisplay),
+			confirmationMessages: {
+				title: vscode.l10n.t('Create Notebook'),
+				message: vscode.l10n.t('Create a new {0} notebook?', langDisplay)
+			},
+			pastTenseMessage: vscode.l10n.t('Created {0} notebook', langDisplay),
+		};
+	},
+
+	invoke: async (options: { input: CreateNotebookInput }, token: vscode.CancellationToken) => {
+		const { language } = options.input;
+
+		if (token.isCancellationRequested) {
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart('Operation cancelled')
+			]);
+		}
+
+		// Validate language
+		const lang = language?.toLowerCase();
+		if (lang !== 'python' && lang !== 'r') {
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Invalid language: "${language}". Must be "python" or "r".`)
+			]);
+		}
+
+		try {
+			// Check BEFORE creating whether there's already an active notebook
+			// context. This determines whether the system prompt likely
+			// included notebook tool instructions. This is not a perfect check
+			// but short of doing a lot of hacky work to get the full prompt,
+			// it's the best we can do. Worst case we double-instruct the
+			// assistant.
+			const hadNotebookBefore = !!(await positron.notebooks.getContext());
+
+			await vscode.commands.executeCommand('ipynb.newUntitledIpynb', lang);
+
+			// Brief wait for notebook to become active
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			const context = await positron.notebooks.getContext();
+			if (!context) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart('Notebook created but context unavailable. The notebook should be open in the editor.')
+				]);
+			}
+
+			// If there was already a notebook before, the system prompt likely
+			// included notebook tool instructions. Return a simple result.
+			if (hadNotebookBefore) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart(
+						`Created new ${lang} notebook. Use EditNotebookCells to add content.`
+					)
+				]);
+			}
+
+			// No notebook existed before, so the system prompt probably didn't
+			// include notebook instructions. Provide detailed guidance.
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(
+					`Created new ${lang} notebook.\n\n` +
+					`To add cells, use EditNotebookCells with:\n` +
+					`- operation: 'add'\n` +
+					`- cellType: 'code' or 'markdown'\n` +
+					`- index: -1 (append to end) or specific position\n` +
+					`- content: the cell content\n\n` +
+					`Example: {"operation":"add","cellType":"code","index":-1,"content":"print('Hello, world!')"}`
+				)
+			]);
+		} catch (error: unknown) {
+			const msg = error instanceof Error ? error.message : String(error);
+			log.error(`[CreateNotebook] Failed: ${msg}`);
+			return new vscode.LanguageModelToolResult([
+				new vscode.LanguageModelTextPart(`Failed to create notebook: ${msg}`)
+			]);
+		}
+	}
+};
+
+export const CreateNotebookTool = vscode.lm.registerTool<CreateNotebookInput>(
+	PositronAssistantToolName.CreateNotebook,
+	createNotebookToolImpl
+);

--- a/extensions/positron-assistant/src/tools/createNotebook.ts
+++ b/extensions/positron-assistant/src/tools/createNotebook.ts
@@ -18,8 +18,14 @@ interface CreateNotebookInput {
 export const createNotebookToolImpl = {
 	prepareInvocation: async (options: { input: CreateNotebookInput }, _token: vscode.CancellationToken) => {
 		const { language } = options.input;
-		const langDisplay = language === 'python' ? 'Python' : 'R';
 
+		// Normalize and validate language for consistent behavior with invoke
+		const lang = language?.toLowerCase();
+		if (lang !== 'python' && lang !== 'r') {
+			throw new Error(`Invalid language: "${language}". Must be "python" or "r".`);
+		}
+
+		const langDisplay = lang === 'python' ? 'Python' : 'R';
 		return {
 			invocationMessage: vscode.l10n.t('Creating {0} notebook', langDisplay),
 			confirmationMessages: {

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -491,7 +491,7 @@ export function serializeNotebookContext(
  *
  * @returns True if notebook mode is enabled, false otherwise
  */
-function isNotebookModeEnabled(): boolean {
+export function isNotebookModeEnabled(): boolean {
 	return vscode.workspace
 		.getConfiguration('positron.assistant.notebookMode')
 		.get('enable', false);

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -22,6 +22,7 @@ export enum PositronAssistantToolName {
 	RunNotebookCells = 'runNotebookCells',
 	EditNotebookCells = 'editNotebookCells',
 	GetNotebookCells = 'getNotebookCells',
+	CreateNotebook = 'createNotebook',
 }
 
 /**


### PR DESCRIPTION
Addresses #10443.

### Summary

Adds a new `CreateNotebook` tool to the Positron Assistant that allows users to create new Jupyter notebooks through natural language requests. Previously, users had to manually create a notebook through the UI before the assistant could help with notebook operations.

https://github.com/user-attachments/assets/2c6339e0-c594-4941-814b-c8f868c9cb56

The tool:
- Creates Python or R notebooks via the `ipynb.newUntitledIpynb` command
- Provides context-aware guidance: when no notebook was previously open, the tool result includes instructions on how to use `EditNotebookCells` to add content
- Enables same-turn workflows where users can say "Create a Python notebook and add a cell that prints hello world"

### Release Notes

#### New Features

- N/A



#### Bug Fixes

- N/A

### QA Notes

@:assistant @:positron-notebooks

1. Enable the notebook mode feature flag: `positron.assistant.notebookMode.enable`
2. Open Assistant in Edit or Agent mode (not Ask mode)
3. Test creating notebooks:
   - "Create a new Python notebook"
   - "Start an R notebook"
   - "Create a Python notebook and add a cell that prints hello world"
4. Verify the notebook opens with the correct kernel
5. For the combined request, verify cells are added in the same turn
