### PR TITLE
e2e: add notebook keyboard edit mode tests

### DIFF
--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -9,6 +9,7 @@ import { HotKeys } from './hotKeys.js';
 import { QuickAccess } from './quickaccess.js';
 
 
+const DEBUG_TOOLBAR = '.debug-toolbar';
 const GLYPH_AREA = '.margin-view-overlays>:nth-child';
 const BREAKPOINT_GLYPH = '.monaco-editor .codicon-debug-breakpoint';
 const STOP = `.debug-toolbar .action-label[aria-label*="Stop"]`;
@@ -38,9 +39,11 @@ export class Debug {
 	get callStack(): Locator { return this.code.driver.page.locator(DEBUG_CALL_STACK); }
 	stackAtIndex = (index: number) => this.callStack.locator(`.monaco-list-row[data-index="${index}"]`);
 	debugPane: Locator;
+	debugToolbar: Locator;
 
 	constructor(private code: Code, private hotKeys: HotKeys, private quickaccess: QuickAccess) {
 		this.debugPane = this.code.driver.page.locator('.debug-pane');
+		this.debugToolbar = this.code.driver.page.locator(DEBUG_TOOLBAR);
 	}
 
 	async setBreakpointOnLine(lineNumber: number, index = 0): Promise<void> {
@@ -159,6 +162,15 @@ export class Debug {
 		await test.step(`Verify debug pane contains: ${variableLabel}`, async () => {
 			await expect(this.debugVariablesSection).toBeVisible();
 			await expect(this.code.driver.page.getByLabel(variableLabel)).toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: The debug toolbar is visible
+	 */
+	async expectDebugToolbarVisible(): Promise<void> {
+		await test.step('Verify debug toolbar is visible', async () => {
+			await expect(this.debugToolbar).toBeVisible();
 		});
 	}
 

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -89,4 +89,68 @@ test.describe('Notebook Edit Mode', {
 		await keyboard.type('new cell content');
 		await notebooksPositron.expectCellContentAtIndexToBe(3, 'new cell content');
 	});
+
+	// @seeM unskip me
+	test.skip("Move cells up and down with keyboard shortcuts", async function ({ app, r, }) {
+		const { notebooksPositron, debug } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create a new notebook with 2 cells
+		await notebooksPositron.newNotebook({ codeCells: 2 });
+
+		// Enter edit mode in cell 0
+		await notebooksPositron.selectCellAtIndex(0);
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
+
+		// Test: Move cell down: Alt+Down
+		await keyboard.press('Alt+ArrowDown');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 1', '# Cell 0']);
+
+		// Test: Move cell up: Alt+Up
+		await keyboard.press('Alt+ArrowUp');
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
+
+		// Test: Execute cell and select below: Shift+Enter
+		await keyboard.press('Shift+Enter');
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+
+		// Test: Execute cell or toggle editor: Cmd+Enter
+		await notebooksPositron.selectCellAtIndex(1);
+		const executeShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter';
+		await keyboard.press(executeShortcut);
+
+		// Test: Debug cell: Alt+Shift+Enter
+		await notebooksPositron.selectCellAtIndex(0);
+		await keyboard.press('Alt+Shift+Enter');
+		await debug.expectDebugToolbarVisible();
+	});
+
+	// @seeM unskip me
+	test.skip("Execute and debug cells with keyboard shortcuts", async function ({ app, r, }) {
+		const { notebooksPositron, debug } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+
+		// Create a new notebook with 2 cells
+		await notebooksPositron.newNotebook({ codeCells: 2 });
+
+		// Enter edit mode in cell 0
+		await notebooksPositron.selectCellAtIndex(0);
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+		await notebooksPositron.expectCellContentsToBe(['# Cell 0', '# Cell 1']);
+
+		// Test: Execute cell and select below: Shift+Enter
+		await keyboard.press('Shift+Enter');
+		await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+
+		// Test: Execute cell or toggle editor: Cmd+Enter
+		await notebooksPositron.selectCellAtIndex(1);
+		const executeShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter';
+		await keyboard.press(executeShortcut);
+
+		// Test: Debug cell: Alt+Shift+Enter
+		await notebooksPositron.selectCellAtIndex(0);
+		await keyboard.press('Alt+Shift+Enter');
+		await debug.expectDebugToolbarVisible();
+	});
 });


### PR DESCRIPTION
### Summary

This PR adds test coverage for some keyboard operations while in edit mode of Positron Notebooks cells.
Note: These tests are currently skipped because it depends on fix in this PR: https://github.com/posit-dev/positron/pull/11255


### QA Notes

Confirmed tests pass on branch with fix.