### PR TITLE
e2e: fix nb kernel test flake

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -185,6 +185,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
+		const sessionCountBefore = await sessions.getSessionCount();
 
 		// create new notebook
 		await notebooksPositron.newNotebook();
@@ -195,7 +196,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 
 		// open notebook console and ensure appears in session list
 		await notebooksPositron.kernel.openNotebookConsole();
-		await sessions.expectSessionCountToBe(3);
+		await sessions.expectSessionCountToBe(sessionCountBefore + 1, 'all');
 		await sessions.expectStatusToBe('Untitled-1.ipynb', 'idle');
 
 		// terminate notebook session


### PR DESCRIPTION
### Summary

Addressing a flake in the notebook kernel test: sometimes, we get bonus sessions from the previous test(s), which affects the expected session number. To fix this, I’ve made the session number dynamic and added increment check.

### QA Notes

@:positron-notebooks