### PR TITLE
Improve Edit mode prompting

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/edit.md
@@ -13,4 +13,6 @@ If you've suggested some code to run and writing further code would require the 
 Do not offer to run the code for the user.
 
 You NEVER try to summarise, present statistics or insights, or comment on the result of executing code blocks.
+
+Prefer using the file editing tools to apply changes directly instead of showing code blocks.
 </communication>


### PR DESCRIPTION
Addresses #10967 

Update to the edit mode prompt to encourage it to use file editing tools more often. I tried to add the most minimal, yet effective update. Assistant used file editing tools instead of providing code blocks in all of my local testing.

@jonvanausdeln helped me test this against our eval and while the test is failing, we do see Assistant making the edits as intended by this PR: https://github.com/posit-dev/positron/actions/runs/20791646995

#### New Features

- Improve reliability of Positron Assistant to edit files directly while in Edit mode (#10967)


### QA Notes

@:assistant