### PR TITLE
e2e tests: Make sure session.start() always returns the Reticulate Python session

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -37,6 +37,7 @@ test.describe('Reticulate', {
 		// start new reticulate session
 		await sessions.start('pythonReticulate');
 		await sessions.expectSessionPickerToBe(RETICULATE_SESSION, 60000);
+		await sessions.expectStatusToBe(RETICULATE_SESSION, 'idle');
 
 		// restart reticulate session
 		await sessions.restart(RETICULATE_SESSION, {

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -5,6 +5,7 @@
 
 import { test, tags } from '../_test.setup';
 import { RETICULATE_SESSION, verifyReticulateFunctionality } from './helpers/verifyReticulateFunction.js';
+import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename
@@ -33,7 +34,7 @@ test.describe('Reticulate', {
 	test('R - Verify Reticulate Stop/Start Functionality', {
 		tag: [tags.ARK]
 	}, async function ({ app, r }) {
-		const { console, sessions, modals } = app.workbench;
+		const { sessions, modals } = app.workbench;
 
 		// start new reticulate session and verify functionality
 		const reticulateSession = await sessions.start('pythonReticulate');
@@ -44,7 +45,11 @@ test.describe('Reticulate', {
 		// stop reticulate session
 		await sessions.select(reticulateSession.id);
 		await sessions.delete(reticulateSession.id);
-		await console.waitForConsoleContents('exited', { timeout: 30000 });
+		// Deleting the Reticulate session will bring focus to the R session
+		expect(async () => {
+			const info = await sessions.getSelectedSessionInfo();
+			return info.language.toLowerCase() === 'r';
+		}).toPass();
 
 		// start reticulate session (again) and verify functionality
 		await sessions.start('pythonReticulate');


### PR DESCRIPTION
I think this will fix some flakiness in reticulate tests.

When starting a reticulate session, if no R session is already started, we'll start and R session and then the Reticulate Python session. It seems that `session.start` could return the R session ID, if the reticulate session didn't start fast enough, causing a few tests to break.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:reticulate @:web
