### PR TITLE
python: make warning more actionable

### DIFF
--- a/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/multipleLanguageServers.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,12 +89,17 @@ export class MultipleLanguageServersDiagnosticService extends BaseDiagnosticsSer
         }
 
         const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
+
+        // Create a search query for the detected language server extensions
+        const detectedExtensions = this.getDetectedLanguageServers();
+        const searchQuery = detectedExtensions.map((id) => `@id:${id}`).join(' ');
+
         const options = [
             {
                 prompt: Common.viewExtensions,
                 command: commandFactory.createCommand(diagnostic, {
-                    type: 'executeVSCCommand',
-                    options: 'workbench.view.extensions',
+                    type: 'executeVSCCommandWithArgs',
+                    options: { command: 'workbench.extensions.search', args: [searchQuery] },
                 }),
             },
             {

--- a/extensions/positron-python/src/client/application/diagnostics/commands/execVSCCommandWithArgs.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/commands/execVSCCommandWithArgs.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { ICommandNameArgumentTypeMapping } from '../../../common/application/commands';
+import { ICommandManager } from '../../../common/application/types';
+import { IServiceContainer } from '../../../ioc/types';
+import { sendTelemetryEvent } from '../../../telemetry';
+import { EventName } from '../../../telemetry/constants';
+import { IDiagnostic } from '../types';
+import { BaseDiagnosticCommand } from './base';
+
+export class ExecuteVSCCommandWithArgs extends BaseDiagnosticCommand {
+    constructor(
+        diagnostic: IDiagnostic,
+        private serviceContainer: IServiceContainer,
+        private commandName: keyof ICommandNameArgumentTypeMapping,
+        private commandArgs: any[],
+    ) {
+        super(diagnostic);
+    }
+    public async invoke(): Promise<void> {
+        sendTelemetryEvent(EventName.DIAGNOSTICS_ACTION, undefined, { commandName: this.commandName });
+        const cmdManager = this.serviceContainer.get<ICommandManager>(ICommandManager);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return cmdManager.executeCommand(this.commandName, ...(this.commandArgs as any)).then(() => undefined);
+    }
+}

--- a/extensions/positron-python/src/client/application/diagnostics/commands/factory.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/commands/factory.ts
@@ -7,6 +7,9 @@ import { inject, injectable } from 'inversify';
 import { IServiceContainer } from '../../../ioc/types';
 import { IDiagnostic, IDiagnosticCommand } from '../types';
 import { ExecuteVSCCommand } from './execVSCCommand';
+// --- Start Positron ---
+import { ExecuteVSCCommandWithArgs } from './execVSCCommandWithArgs';
+// --- End Positron ---
 import { IgnoreDiagnosticCommand } from './ignore';
 import { LaunchBrowserCommand } from './launchBrowser';
 import { CommandOptions, IDiagnosticsCommandFactory } from './types';
@@ -26,6 +29,16 @@ export class DiagnosticsCommandFactory implements IDiagnosticsCommandFactory {
             case 'executeVSCCommand': {
                 return new ExecuteVSCCommand(diagnostic, this.serviceContainer, options.options);
             }
+            // --- Start Positron ---
+            case 'executeVSCCommandWithArgs': {
+                return new ExecuteVSCCommandWithArgs(
+                    diagnostic,
+                    this.serviceContainer,
+                    options.options.command,
+                    options.options.args,
+                );
+            }
+            // --- End Positron ---
             default: {
                 throw new Error(`Unknown Diagnostic command commandType '${commandType}'`);
             }

--- a/extensions/positron-python/src/client/application/diagnostics/commands/types.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/commands/types.ts
@@ -3,14 +3,26 @@
 
 'use strict';
 
-import { CommandsWithoutArgs } from '../../../common/application/commands';
+// --- Start Positron ---
+import { CommandsWithoutArgs, ICommandNameArgumentTypeMapping } from '../../../common/application/commands';
+// --- End Positron ---
 import { DiagnosticScope, IDiagnostic, IDiagnosticCommand } from '../types';
 
 export type CommandOption<Type, Option> = { type: Type; options: Option };
 type LaunchBrowserOption = CommandOption<'launch', string>;
 type IgnoreDiagnosticOption = CommandOption<'ignore', DiagnosticScope>;
 type ExecuteVSCCommandOption = CommandOption<'executeVSCCommand', CommandsWithoutArgs>;
-export type CommandOptions = LaunchBrowserOption | IgnoreDiagnosticOption | ExecuteVSCCommandOption;
+// --- Start Positron ---
+type ExecuteVSCCommandWithArgsOption = CommandOption<
+    'executeVSCCommandWithArgs',
+    { command: keyof ICommandNameArgumentTypeMapping; args: any[] }
+>;
+export type CommandOptions =
+    | LaunchBrowserOption
+    | IgnoreDiagnosticOption
+    | ExecuteVSCCommandOption
+    | ExecuteVSCCommandWithArgsOption;
+// --- End Positron ---
 
 export const IDiagnosticsCommandFactory = Symbol('IDiagnosticsCommandFactory');
 

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -104,6 +104,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_In_Terminal_Icon]: [undefined, Uri];
     [Commands.Debug_In_Terminal]: [Uri];
     // --- Start Positron ---
+    ['workbench.extensions.search']: [string];
     [Commands.Exec_Dash_In_Terminal]: [];
     [Commands.Exec_FastAPI_In_Terminal]: [];
     [Commands.Exec_Flask_In_Terminal]: [];


### PR DESCRIPTION
Addresses #11282. Makes the "view extensions" button on the multiple language server warning more actionable by filtering the extension list down for you.

To do this, I had to add a bit more scaffolding in our extension to allow commands to run other commands with arguments.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

1. Ensure multiple language server extensions are installed, like pyrefly and pyright
2. Get the warning
3. Click the button
4. Only see the offending extensions
