### PR TITLE
e2e: notebook-editor test flake & upload json report

### DIFF
--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -418,44 +418,6 @@ jobs:
             --reporter=json \
             ../all-blob-reports
 
-      - name: Verify generated reports
-        working-directory: playwright-merge
-        run: |
-          # List all generated files
-          echo "Generated report files:"
-          ls -laR playwright-report/
-
-          # Verify .last-run.json
-          LAST_RUN_FILE="playwright-report/.last-run-${{ inputs.project }}.json"
-          if [ -f "$LAST_RUN_FILE" ]; then
-            FILE_SIZE=$(ls -lh "$LAST_RUN_FILE" | awk '{print $5}')
-            echo "✓ Generated $LAST_RUN_FILE ($FILE_SIZE)"
-            if command -v jq &> /dev/null; then
-              TEST_COUNT=$(jq '.testDurations | length' "$LAST_RUN_FILE")
-              TOTAL_DURATION=$(jq '[.testDurations[]] | add' "$LAST_RUN_FILE")
-              TOTAL_DURATION_SEC=$(echo "scale=1; $TOTAL_DURATION / 1000" | bc)
-              echo "  • Tests with duration data: $TEST_COUNT"
-              echo "  • Total test duration: ${TOTAL_DURATION_SEC}s"
-            fi
-          else
-            echo "⚠ No $LAST_RUN_FILE generated - patch may not be working correctly"
-          fi
-
-          # Verify JSON report
-          JSON_REPORT="playwright-report/results.json"
-          if [ -f "$JSON_REPORT" ]; then
-            FILE_SIZE=$(ls -lh "$JSON_REPORT" | awk '{print $5}')
-            echo "✓ Generated $JSON_REPORT ($FILE_SIZE)"
-            if command -v jq &> /dev/null; then
-              FAILED_COUNT=$(jq '[.. | .tests? // empty | .[] | select(.outcome == "unexpected")] | length' "$JSON_REPORT")
-              FLAKY_COUNT=$(jq '[.. | .tests? // empty | .[] | select(.outcome == "flaky")] | length' "$JSON_REPORT")
-              echo "  • Failed tests: $FAILED_COUNT"
-              echo "  • Flaky tests: $FLAKY_COUNT"
-            fi
-          else
-            echo "⚠ No $JSON_REPORT generated"
-          fi
-
       - name: Upload JSON report artifact
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -418,11 +418,34 @@ jobs:
             --reporter=json \
             ../all-blob-reports
 
+      - name: Verify generated reports
+        working-directory: playwright-merge
+        run: |
+          # List all generated files
+          echo "Generated report files:"
+          ls -laR playwright-report/
+
+          # Verify .last-run.json
+          LAST_RUN_FILE="playwright-report/.last-run-${{ inputs.project }}.json"
+          if [ -f "$LAST_RUN_FILE" ]; then
+            FILE_SIZE=$(ls -lh "$LAST_RUN_FILE" | awk '{print $5}')
+            echo "✓ Generated $LAST_RUN_FILE ($FILE_SIZE)"
+            if command -v jq &> /dev/null; then
+              TEST_COUNT=$(jq '.testDurations | length' "$LAST_RUN_FILE")
+              TOTAL_DURATION=$(jq '[.testDurations[]] | add' "$LAST_RUN_FILE")
+              TOTAL_DURATION_SEC=$(echo "scale=1; $TOTAL_DURATION / 1000" | bc)
+              echo "  • Tests with duration data: $TEST_COUNT"
+              echo "  • Total test duration: ${TOTAL_DURATION_SEC}s"
+            fi
+          else
+            echo "⚠ No $LAST_RUN_FILE generated - patch may not be working correctly"
+          fi
+
       - name: Upload JSON report artifact
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: playwright-json-report-${{ inputs.project }}
+          name: ${{ inputs.project }}-json
           path: playwright-merge/playwright-report/results.json
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -441,6 +441,30 @@ jobs:
             echo "⚠ No $LAST_RUN_FILE generated - patch may not be working correctly"
           fi
 
+          # Verify JSON report
+          JSON_REPORT="playwright-report/results.json"
+          if [ -f "$JSON_REPORT" ]; then
+            FILE_SIZE=$(ls -lh "$JSON_REPORT" | awk '{print $5}')
+            echo "✓ Generated $JSON_REPORT ($FILE_SIZE)"
+            if command -v jq &> /dev/null; then
+              FAILED_COUNT=$(jq '[.. | .tests? // empty | .[] | select(.outcome == "unexpected")] | length' "$JSON_REPORT")
+              FLAKY_COUNT=$(jq '[.. | .tests? // empty | .[] | select(.outcome == "flaky")] | length' "$JSON_REPORT")
+              echo "  • Failed tests: $FAILED_COUNT"
+              echo "  • Flaky tests: $FLAKY_COUNT"
+            fi
+          else
+            echo "⚠ No $JSON_REPORT generated"
+          fi
+
+      - name: Upload JSON report artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-json-report-${{ inputs.project }}
+          path: playwright-merge/playwright-report/results.json
+          retention-days: 7
+          if-no-files-found: warn
+
       - name: Upload HTML report to S3
         if: always()
         uses: ./.github/actions/upload-report-to-s3

--- a/test/e2e/tests/notebooks-positron/notebook-editor.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-editor.test.ts
@@ -29,35 +29,6 @@ test.describe('Positron Notebooks: Open & Save', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Switching between VS Code and Positron notebook editors works correctly', async function ({ app, hotKeys, settings }) {
-		const { notebooks, notebooksVscode, notebooksPositron } = app.workbench;
-
-		// Verify default behavior - VS Code notebook editor should be used when no association is set
-		// This tests the fallback behavior when positron.notebook.enabled=true but no explicit association exists
-		await notebooks.openNotebook(NOTEBOOK_PATH);
-		await notebooksVscode.expectToBeVisible();
-
-		// Configure Positron as the default notebook editor
-		// This sets workbench.editorAssociations to map *.ipynb files to the Positron notebook editor
-		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
-
-		// Verify that newly opened notebooks now use the Positron editor
-		// The same notebook file should now open with the Positron interface instead of VS Code
-		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
-		await notebooksPositron.expectToBeVisible();
-
-		// Reset to default configuration and verify VS Code editor is used again
-		// Close all editors first to ensure a clean state for the next test
-		await hotKeys.closeAllEditors();
-		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'default');
-
-		// Confirm that removing the association restores VS Code notebook editor
-		// This ensures the configuration change is properly applied and the fallback works
-		await notebooks.openNotebook(NOTEBOOK_PATH);
-		await notebooksVscode.expectToBeVisible();
-	});
-
-
 	test('Positron notebooks can open new untitled notebooks and saving works properly', { tag: [tags.WEB] },
 		async function ({ app, settings, runCommand, cleanup }) {
 			const { notebooks, notebooksPositron, quickInput, editors } = app.workbench;
@@ -131,5 +102,34 @@ test.describe('Positron Notebooks: Open & Save', {
 
 		// Additional verification: ensure the active tab is still the restored untitled notebook
 		await editors.waitForActiveTab(/^Untitled-\d+\.ipynb$/, true); // true = isDirty
+	});
+
+	// Intentionally moving this test to the end of the suite, because I think it causes flakes in the next test not always switching to Positron Notebooks
+	test('Switching between VS Code and Positron notebook editors works correctly', async function ({ app, hotKeys, settings }) {
+		const { notebooks, notebooksVscode, notebooksPositron } = app.workbench;
+
+		// Verify default behavior - VS Code notebook editor should be used when no association is set
+		// This tests the fallback behavior when positron.notebook.enabled=true but no explicit association exists
+		await notebooks.openNotebook(NOTEBOOK_PATH);
+		await notebooksVscode.expectToBeVisible();
+
+		// Configure Positron as the default notebook editor
+		// This sets workbench.editorAssociations to map *.ipynb files to the Positron notebook editor
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+
+		// Verify that newly opened notebooks now use the Positron editor
+		// The same notebook file should now open with the Positron interface instead of VS Code
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+		await notebooksPositron.expectToBeVisible();
+
+		// Reset to default configuration and verify VS Code editor is used again
+		// Close all editors first to ensure a clean state for the next test
+		await hotKeys.closeAllEditors();
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'default');
+
+		// Confirm that removing the association restores VS Code notebook editor
+		// This ensures the configuration change is properly applied and the fallback works
+		await notebooks.openNotebook(NOTEBOOK_PATH);
+		await notebooksVscode.expectToBeVisible();
 	});
 });


### PR DESCRIPTION
### Summary
I removed the web tag from the notebook-editor test because the settings changes don't always work as expected. We can always re-tag it after the feature becomes the default when it should be a non-issue.

### QA Notes

n/a
