### PR TITLE
Improve notebook layout and apply automatically in new Jupyter folders

### DIFF
--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -64,6 +64,25 @@ export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 						}
 					}
 
+					// TODO: we may want to allow the user to select an already existing folder
+					// and then create the folder in that folder. We will need to handle if the
+					// folder is the same as the current workspace folder in the active window
+					// or if the new folder directory is already open in another window.
+
+					// If the folder is new, set its trust state to trusted.
+					if (!existingFolder) {
+						renderer.services.workspaceTrustManagementService.setUrisTrust([folder], true);
+					}
+
+					// Any context-dependent work needs to be done before opening the folder
+					// because the extension host gets destroyed when a new folder is opened,
+					// whether the folder is opened in a new window or in the existing window.
+					// Ask the user where to open the new folder and open it.
+					result.openInNewWindow = await showChooseNewFolderWindowModalDialog(
+						folder.path,
+						result.openInNewWindow,
+					);
+
 					// Create the new folder configuration.
 					const newFolderConfig: NewFolderConfiguration = {
 						folderScheme: folder.scheme,
@@ -80,29 +99,20 @@ export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 						condaPythonVersion: result.condaPythonVersion,
 						uvPythonVersion: result.uvPythonVersion,
 						useRenv: result.useRenv,
+						openInNewWindow: result.openInNewWindow,
 					};
-
-					// TODO: we may want to allow the user to select an already existing folder
-					// and then create the folder in that folder. We will need to handle if the
-					// folder is the same as the current workspace folder in the active window
-					// or if the new folder directory is already open in another window.
 
 					// Store the new folder configuration.
 					renderer.services.positronNewFolderService.storeNewFolderConfig(newFolderConfig);
 
-					// If the folder is new, set its trust state to trusted.
-					if (!existingFolder) {
-						renderer.services.workspaceTrustManagementService.setUrisTrust([folder], true);
-					}
-
-					// Any context-dependent work needs to be done before opening the folder
-					// because the extension host gets destroyed when a new folder is opened,
-					// whether the folder is opened in a new window or in the existing window.
-					// Ask the user where to open the new folder and open it.
-					showChooseNewFolderWindowModalDialog(
-						folder.path,
+					// Open the folder in the selected window.
+					await renderer.services.commandService.executeCommand(
+						'vscode.openFolder',
 						folder,
-						result.openInNewWindow
+						{
+							forceNewWindow: result.openInNewWindow,
+							forceReuseWindow: !result.openInNewWindow
+						}
 					);
 				}}
 				renderer={renderer}

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -74,10 +74,7 @@ export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 						renderer.services.workspaceTrustManagementService.setUrisTrust([folder], true);
 					}
 
-					// Any context-dependent work needs to be done before opening the folder
-					// because the extension host gets destroyed when a new folder is opened,
-					// whether the folder is opened in a new window or in the existing window.
-					// Ask the user where to open the new folder and open it.
+					// Ask the user where to open the new folder.
 					result.openInNewWindow = await showChooseNewFolderWindowModalDialog(
 						folder.path,
 						result.openInNewWindow,
@@ -105,6 +102,9 @@ export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 					// Store the new folder configuration.
 					renderer.services.positronNewFolderService.storeNewFolderConfig(newFolderConfig);
 
+					// Any context-dependent work needs to be done before opening the folder
+					// because the extension host gets destroyed when a new folder is opened,
+					// whether the folder is opened in a new window or in the existing window.
 					// Open the folder in the selected window.
 					await renderer.services.commandService.executeCommand(
 						'vscode.openFolder',

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronNotebookLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronNotebookLayout.ts
@@ -36,10 +36,20 @@ export const positronNotebookLayout: PositronLayoutInfo = {
 			hideIfBelowMinSize: true,
 		},
 		[Parts.AUXILIARYBAR_PART]: {
-			hidden: true,
 			size: '20%',
-			minSize: 180,
-		},
+			hidden: false,
+			viewContainers: [
+				{
+					id: 'workbench.panel.positronSession',
+					opened: true,
+					views: [
+						{
+							id: 'workbench.panel.positronVariables',
+						},
+					]
+				},
+			]
+		}
 	},
 };
 

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -101,6 +101,7 @@ export interface NewFolderConfiguration {
 	readonly condaPythonVersion: string | undefined;
 	readonly uvPythonVersion: string | undefined;
 	readonly useRenv: boolean | undefined;
+	readonly openInNewWindow: boolean;
 }
 
 /**

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -25,32 +25,37 @@ export enum NewFolderStartupPhase {
 	Initializing = 'initializing',
 
 	/**
-	 * Phase 2: The new folder is awaiting trust. If the workspace is not trusted, we cannot proceed with
+	 * Phase 2: The new folder is applying the appropriate layout for the folder template.
+	 * This phase occurs before trust is granted since layout changes don't require trust.
+	 */
+	ApplyLayout = 'applyLayout',
+
+	/**
+	 * Phase 3: The new folder is awaiting trust. If the workspace is not trusted, we cannot proceed with
 	 * initialization. The new folder service stays at `AwaitingTrust` until workspace trust is granted.
 	 */
 	AwaitingTrust = 'awaitingTrust',
 
 	/**
-	 * Phase 3: The new folder is running initialization tasks provided by extensions, such as creating the
+	 * Phase 4: The new folder is running initialization tasks provided by extensions, such as creating the
 	 * appropriate unsaved new file, initializing the git repository, etc., and starting the user-selected
 	 * interpreter.
 	*/
 	CreatingFolder = 'creatingFolder',
 
 	/**
-	 * Phase 4: The affiliated runtime for the new folder is starting.
+	 * Phase 5: The affiliated runtime for the new folder is starting.
 	 */
 	RuntimeStartup = 'runtimeStartup',
 
 	/**
-	 * Phase 5: The new folder is running post-initialization tasks that require the interpreter to be
+	 * Phase 6: The new folder is running post-initialization tasks that require the interpreter to be
 	 * ready, such as running renv::init() in R.
 	 */
-
 	PostInitialization = 'postInitialization',
 
 	/**
-	 * Phase 6: The new folder has been initialized.
+	 * Phase 7: The new folder has been initialized.
 	 */
 	Complete = 'complete',
 }

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -916,6 +916,16 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			// We're in the new folder window, so we can clear the config from the storage service.
 			this.clearNewFolderConfig();
 
+			// Apply notebook layout if this is a Jupyter Notebook template opened in a new window.
+			// When opened in the current window, we preserve the user's existing layout.
+			if (this._newFolderConfig.folderTemplate === FolderTemplate.JupyterNotebook &&
+				this._newFolderConfig.openInNewWindow) {
+				this._logService.debug('[New folder startup] Applying notebook layout for Jupyter Notebook folder template in new window');
+				this._commandService.executeCommand('workbench.action.positronNotebookLayout').catch((error) => {
+					this._logService.error('[New folder startup] Error applying notebook layout:', error);
+				});
+			}
+
 			this._startupPhase.set(
 				NewFolderStartupPhase.AwaitingTrust,
 				undefined

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -167,6 +167,24 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 	//#region Private Methods
 
 	/**
+	 * Applies the appropriate layout for the folder template.
+	 * This is called before awaiting trust since layout changes don't require trust.
+	 */
+	private async _applyLayout(): Promise<void> {
+		if (!this._newFolderConfig) {
+			return;
+		}
+
+		// Apply notebook layout if this is a Jupyter Notebook template opened in a new window.
+		// When opened in the current window, we preserve the user's existing layout.
+		if (this._newFolderConfig.folderTemplate === FolderTemplate.JupyterNotebook &&
+			this._newFolderConfig.openInNewWindow) {
+			this._logService.debug('[New folder startup] Applying notebook layout for Jupyter Notebook folder template in new window');
+			await this._commandService.executeCommand('workbench.action.positronNotebookLayout');
+		}
+	}
+
+	/**
 	 * Parses the new folder configuration from the storage service and returns it.
 	 * @returns The new folder configuration.
 	 */
@@ -916,15 +934,14 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			// We're in the new folder window, so we can clear the config from the storage service.
 			this.clearNewFolderConfig();
 
-			// Apply notebook layout if this is a Jupyter Notebook template opened in a new window.
-			// When opened in the current window, we preserve the user's existing layout.
-			if (this._newFolderConfig.folderTemplate === FolderTemplate.JupyterNotebook &&
-				this._newFolderConfig.openInNewWindow) {
-				this._logService.debug('[New folder startup] Applying notebook layout for Jupyter Notebook folder template in new window');
-				this._commandService.executeCommand('workbench.action.positronNotebookLayout').catch((error) => {
-					this._logService.error('[New folder startup] Error applying notebook layout:', error);
-				});
-			}
+			// Apply layout before awaiting trust since layout changes don't require trust.
+			this._startupPhase.set(
+				NewFolderStartupPhase.ApplyLayout,
+				undefined
+			);
+			this._applyLayout().catch((error) => {
+				this._logService.error('[New folder startup] Error applying layout:', error);
+			});
 
 			this._startupPhase.set(
 				NewFolderStartupPhase.AwaitingTrust,


### PR DESCRIPTION
Addresses #10663:

1. Notebook layout now shows the variables pane & minimizes the plots pane (screenshots below)
2. Automatically set notebook layout when creating a new folder with the Jupyter template in a new window - current window uses the default layout

Current layout:

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/0af0e677-3cf9-4f55-a77a-dd1be8c4432b" />

New layout:

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/32101e0f-8598-41ba-a802-9a24f7d1678d" />

Notebook layout is applied in new Jupyter folder in new window:

https://github.com/user-attachments/assets/c01f653e-a589-461e-9dd4-eb09191b0f5e

Notebook layout is not applied in new Jupyter folder in current window:

https://github.com/user-attachments/assets/60c7ce05-3898-46df-9822-204e6d76d2c6

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web

1. Run the View: Notebook Layout command
2. Verify that the left bar is 20%, right is 20%, variables pane is showing, plots pane is minimized, and console pane is collapsed

---

1. Create a new folder using the Jupyter template, in a new window
2. Verify that the notebook layout is applied (see previous verification)

---

1. Create a new folder using the Jupyter template, in the current window
2. Verify that the notebook layout is not applied