### PR TITLE
claude: add new qa-verify skill

### DIFF
--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -212,9 +212,9 @@ The generated guides follow this structure:
 ```markdown
 # Verification Guide
 ### [Issue Title]<br>
-**Issue:** #[number]<br>
+**Issue:** [#number](https://github.com/posit-dev/positron/issues/[number])<br>
 **Type:** Bug | Feature | Documentation | Maintenance<br>
-**PR:** #[number]<br>
+**Primary PR:** [#number](https://github.com/posit-dev/positron/pull/[number])<br>
 **Component:** [area label]<br>
 **Generated:** [timestamp]<br>
 

--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -210,12 +210,13 @@ The script:
 The generated guides follow this structure:
 
 ```markdown
-# Verification Guide: [Issue Title]
-
-**Issue:** #[number]
-**PR:** #[number]
-**Component:** [area label]
-**Generated:** [timestamp]
+# Verification Guide
+### [Issue Title]<br>
+**Issue:** #[number]<br>
+**Type:** Bug | Feature | Documentation | Maintenance<br>
+**PR:** #[number]<br>
+**Component:** [area label]<br>
+**Generated:** [timestamp]<br>
 
 ---
 

--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -21,6 +21,25 @@ Use this skill when:
 - Working in the Positron repository
 - Access to the posit-dev/positron repository
 
+## Execution Mode
+
+**CRITICAL: This skill MUST run non-interactively without ANY prompts.**
+
+- **NEVER use `AskUserQuestion`** - The skill always writes to a safe output directory (`.claude/skills/positron-qa-verify/output/`)
+- **Version auto-detection is best-effort** - If it fails, silently use empty values. The user can fill them in manually.
+- **All operations must complete quickly** - Fail fast if data cannot be retrieved within reasonable timeouts
+- **No permission requests** - Reading issue data, writing markdown files, and running version detection do not require special permissions
+
+**Performance requirements:**
+- Version detection must complete in ≤4 seconds total (enforced by script timeouts)
+- If version detection times out or fails, continue without error messages
+- Never attempt interactive detection methods (no manual path prompts, no user input)
+
+**Windows compatibility:**
+- The `detect_versions.sh` script handles Windows paths via Git Bash/MSYS/PowerShell
+- Falls back gracefully if Positron installation path cannot be found
+- Uses multiple detection methods to maximize success rate across platforms
+
 ## Input
 
 Provide an issue number or URL. Examples:
@@ -32,7 +51,19 @@ Provide an issue number or URL. Examples:
 
 I'll analyze the issue and generate a verification guide following these steps:
 
-### Step 1: Fetch Issue Details
+### Performance Optimization Strategy
+
+**CRITICAL: Use parallel execution wherever possible to minimize latency.**
+
+- **Step 1 & 2 run in parallel** - Issue details and PR search are independent
+- **Step 3 fetches run in parallel** - Related PRs/issues are fetched concurrently
+- **Step 4 checks size first** - Only fetch diff for small PRs (<500 lines)
+
+Total time savings: ~40-50% faster than sequential execution (5-8s vs 10-15s typical)
+
+### Step 1: Fetch Issue Details (Parallel with Step 2)
+
+**MUST RUN IN PARALLEL** with Step 2 using a single message with multiple Bash tool calls.
 
 Using `gh issue view`, I'll retrieve:
 - Issue title and description
@@ -41,7 +72,9 @@ Using `gh issue view`, I'll retrieve:
 - Labels and metadata
 - Linked issues
 
-### Step 2: Identify Related PR(s)
+### Step 2: Identify Related PR(s) (Parallel with Step 1)
+
+**MUST RUN IN PARALLEL** with Step 1 using a single message with multiple Bash tool calls.
 
 I'll automatically detect the PR that fixes this issue by:
 1. Looking for PR references in issue comments (e.g., "Fixed in #1234")
@@ -52,12 +85,19 @@ If multiple PRs are found, I'll analyze all of them.
 
 ### Step 3: Analyze PR Context
 
-For each PR, I'll fetch:
+**OPTIMIZATION:** Fetch primary PR details first, then fetch all related PRs/issues in parallel.
+
+For the primary PR, I'll fetch:
 - PR description and summary
 - All PR comments (often contain testing notes)
-- Related PRs mentioned (e.g., in ark or other repos)
+- **Additions and deletions counts** (needed for Step 4 size check)
+- Related PRs/issues mentioned in the body
+
+Then, for all related PRs/issues referenced, I'll fetch them **in parallel using multiple Bash tool calls in a single message**.
 
 ### Step 4: Review Code Changes (Conditionally)
+
+**OPTIMIZATION:** Check PR size from Step 3 data (additions + deletions) BEFORE fetching diff.
 
 **For small PRs (< 500 lines changed):**
 - I'll use `gh pr diff` to review actual code changes
@@ -67,8 +107,9 @@ For each PR, I'll fetch:
   - Whether the fix is focused or touches multiple areas
 
 **For large PRs (>= 500 lines):**
-- I'll skip detailed code review
+- I'll skip detailed code review (don't fetch diff at all)
 - Focus on PR description and comments instead
+- Saves 1-5 seconds by avoiding large diff download
 
 ### Step 5: Extract Linked Issues and Scenarios
 
@@ -97,7 +138,8 @@ I'll create a markdown file in `.claude/skills/positron-qa-verify/output/` with:
    - Helps understand what might break again
 
 4. **Test Scenarios**
-   - Checkboxes for each scenario with nested bullets (not numbered steps)
+   - Scenario titles use checkmarks (✓) for visual organization
+   - Test steps within scenarios use checkboxes (- [ ]) for tracking progress
    - Primary scenario (the main repro steps from the issue)
    - Edge cases (from comments, PR review, code analysis) with "Why test:" rationale
    - Regression checks (related functionality to verify still works)
@@ -114,9 +156,15 @@ I'll create a markdown file in `.claude/skills/positron-qa-verify/output/` with:
    - Link to PR(s)
    - Links to related issues
 
-### Step 7: Offer Verification Comment Template (Optional)
+### Step 7: Offer Verification Comment Template (User-Triggered)
 
-After generating the guide, I'll ask if you want help creating a verification comment to post on the issue after testing.
+After generating the guide, I'll offer to create a verification comment template. **Only if you accept** will I run the version detection script and generate the template.
+
+**Workflow:**
+1. Generate verification guide
+2. Offer: "Would you like me to generate a verification comment template?"
+3. If yes → Run `detect_versions.sh` to auto-detect versions
+4. Generate template and copy to clipboard
 
 For single scenario tests (only 1 test, no edge cases or regressions), I'll use a simple format:
 
@@ -156,16 +204,22 @@ OS Version(s): [OS]
 [links or paths to e2e tests, or n/a]
 ```
 
-**Note:** The verification comment uses plain bullets. Checkboxes are only in the verification guide for tracking during testing.
+**Note:** The verification comment uses plain bullets. Checkmarks (✓) and checkboxes (- [ ]) are only in the verification guide for visual organization and progress tracking during testing.
 
 The template will be pre-filled with:
 - Test scenarios extracted and condensed from the verification guide
 - Grouped format used by default for better readability (unless only 1 scenario)
-- **Positron Version automatically detected** from installed application
-- **OS Version automatically detected** from your system
+- **Positron Version automatically detected** from installed application (using `scripts/detect_versions.sh`)
+- **OS Version automatically detected** from your system (using `scripts/detect_versions.sh`)
 - Ready to paste - you can adjust versions if you tested on multiple systems
 
-**The template will be automatically copied to your clipboard** (on macOS/Linux using `pbcopy`/`xclip`, on Windows using `clip`), making it easy to paste directly into the GitHub issue after you complete testing.
+**Version detection is best-effort and silent:**
+- **Only runs when you request the comment template** (not during initial guide generation)
+- Uses the `detect_versions.sh` script with 3-second timeouts per detection
+- If detection fails, empty values are used (you can fill them in manually)
+- Never prompts or shows errors - fails fast and silent
+
+**The template will be automatically copied to your clipboard** (on macOS/Linux using `pbcopy`/`xclip`, on Windows using `clip`) when you accept the offer, making it easy to paste directly into the GitHub issue after you complete testing.
 
 ## Output Format
 
@@ -188,7 +242,53 @@ I'll respond with:
 2. Path to the generated verification guide
 3. Key highlights (number of scenarios, any blockers, etc.)
 
-## Helper Script
+## Implementation Examples
+
+### Example 1: Parallel Execution of Steps 1 & 2
+
+**Do this (FAST - ~2 seconds):**
+
+Single message with multiple Bash tool calls running in parallel:
+- `gh issue view <number>` fetches issue details
+- `gh pr list --search "<number>"` searches for related PRs
+
+**Saves ~1-2 seconds** compared to sequential execution.
+
+### Example 2: Parallel Fetch of Related PRs/Issues
+
+**Do this (FAST - ~2 seconds):**
+
+After identifying related PRs/issues from PR body (e.g., #10625, #10753), fetch them all in parallel with a single message containing multiple Bash tool calls.
+
+**Don't do this (SLOW - ~6 seconds):**
+
+Sequential fetches of each related PR/issue one at a time.
+
+**Saves ~2-4 seconds** depending on number of related items.
+
+### Example 3: Check PR Size Before Fetching Diff
+
+**Do this (FAST):**
+
+1. Get PR with `--json additions,deletions` in Step 3
+2. Calculate total: `additions + deletions`
+3. Only fetch diff if `< 500 lines`
+
+**Example:**
+```bash
+# Already have from Step 3:
+# "additions": 9, "deletions": 3
+# Total: 12 lines (< 500, so fetch diff)
+gh pr diff 11251
+```
+
+**Don't do this (SLOW):**
+
+Always fetch diff, then check size after.
+
+**Saves ~1-5 seconds** on large PRs by avoiding unnecessary diff downloads.
+
+## Helper Scripts
 
 ### `scripts/analyze_issue.sh`
 
@@ -204,6 +304,40 @@ The script:
 - Extracts linked issues from comments
 - Calculates PR size to determine if code review is needed
 - Outputs structured JSON for parsing
+
+### `scripts/detect_versions.sh`
+
+This script performs fast, silent version detection:
+
+```bash
+# Usage:
+./scripts/detect_versions.sh
+
+# With debug output:
+DEBUG=1 ./scripts/detect_versions.sh
+```
+
+The script:
+- Detects Positron version and build number from `product.json`
+- Detects OS version using platform-specific commands
+- Has 3-second timeout per detection (max 4 seconds total)
+- **Never prompts or shows errors** - always outputs valid JSON
+- Fails gracefully with empty values if detection fails
+
+Output format:
+```json
+{
+  "positronVersion": "2026.02.0",
+  "positronBuild": "10",
+  "osVersion": "macOS 26.2",
+  "detectionStatus": "success"
+}
+```
+
+Detection status values:
+- `"success"` - Both Positron and OS versions detected
+- `"partial"` - Only one version detected
+- `"failed"` - No versions detected
 
 ## Verification Guide Template
 
@@ -231,16 +365,33 @@ The generated guides follow this structure:
 ## Test Scenarios
 
 ### Primary Scenario
-[Main repro steps from issue]
+
+✓ **[Scenario title]**
+
+**Setup:** (if needed)
+- [ ] Setup step one
+- [ ] Setup step two
+
+**Test Steps:**
+- [ ] Step one
+- [ ] Step two
 
 **Expected:** [What should happen]
 **Previously:** [What was broken]
 
 ### Edge Cases
-[Additional scenarios from comments/analysis]
+
+✓ **[Edge case scenario title]**
+
+**_Why test:_** [Brief explanation]
+
+- [ ] Step one
+- [ ] Step two
 
 ### Regression Checks
-[Related functionality to verify]
+
+- [ ] [What to verify]
+- [ ] [Another thing to verify]
 
 ## Testing Context
 

--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: positron-qa-verify
+description: Generates clear, actionable verification guides for QA testing of Positron bug fixes and features
+---
+
+# Positron QA Verify
+
+This skill analyzes GitHub issues and their associated PRs to generate comprehensive verification guides for manual QA testing. It extracts the essential information from issues, comments, linked PRs, and code changes to produce clear test scenarios.
+
+## When to Use This Skill
+
+Use this skill when:
+- You're assigned a ticket from the QA verification board (https://github.com/orgs/posit-dev/projects/2/views/8)
+- You need to understand what to test for a specific bug fix or feature
+- You want to extract test scenarios from an issue and its related PRs
+- You need to identify all edge cases and related scenarios mentioned in comments
+
+## Prerequisites
+
+- GitHub CLI (`gh`) installed and authenticated
+- Working in the Positron repository
+- Access to the posit-dev/positron repository
+
+## Input
+
+Provide an issue number or URL. Examples:
+- `4567`
+- `#4567`
+- `https://github.com/posit-dev/positron/issues/4567`
+
+## Workflow
+
+I'll analyze the issue and generate a verification guide following these steps:
+
+### Step 1: Fetch Issue Details
+
+Using `gh issue view`, I'll retrieve:
+- Issue title and description
+- Reporter's repro steps
+- All comments (which often contain additional test scenarios)
+- Labels and metadata
+- Linked issues
+
+### Step 2: Identify Related PR(s)
+
+I'll automatically detect the PR that fixes this issue by:
+1. Looking for PR references in issue comments (e.g., "Fixed in #1234")
+2. Checking for timeline events linking PRs
+3. Using `gh pr list` with issue filter if needed
+
+If multiple PRs are found, I'll analyze all of them.
+
+### Step 3: Analyze PR Context
+
+For each PR, I'll fetch:
+- PR description and summary
+- All PR comments (often contain testing notes)
+- Related PRs mentioned (e.g., in ark or other repos)
+
+### Step 4: Review Code Changes (Conditionally)
+
+**For small PRs (< 500 lines changed):**
+- I'll use `gh pr diff` to review actual code changes
+- This helps identify:
+  - Edge cases to test
+  - Related functionality that might be affected
+  - Whether the fix is focused or touches multiple areas
+
+**For large PRs (>= 500 lines):**
+- I'll skip detailed code review
+- Focus on PR description and comments instead
+
+### Step 5: Extract Linked Issues and Scenarios
+
+I'll search comments for:
+- References to other issues (`#1234`)
+- Additional test scenarios mentioned by team members
+- Edge cases discovered during PR review
+- Platform-specific considerations (macOS, Windows, Linux)
+
+### Step 6: Generate Verification Guide
+
+I'll create a markdown file in `.claude/skills/positron-qa-verify/output/` with:
+
+1. **Issue Summary**
+   - Brief explanation of the problem
+   - User impact (why this matters)
+   - Affected component/area
+
+2. **Root Cause** (if identifiable)
+   - What was causing the issue
+   - Only included if clearly stated in PR or obvious from small diff
+   - Helps understand what might break again
+
+3. **Test Scenarios**
+   - Primary scenario (the main repro steps from the issue)
+   - Edge cases (from comments, PR review, code analysis)
+   - Regression checks (related functionality to verify still works)
+   - Platform-specific scenarios if mentioned
+
+4. **Testing Context**
+   - Environment requirements (Python/R version, specific packages, etc.)
+   - Setup steps (if any)
+   - Expected vs actual behavior
+   - Related PRs to be aware of
+
+5. **References**
+   - Link to original issue
+   - Link to PR(s)
+   - Links to related issues
+
+### Step 7: Offer Verification Comment Template (Optional)
+
+After generating the guide, I'll ask if you want help creating a verification comment to post on the issue after testing.
+
+For single scenario tests (only 1 test, no edge cases or regressions), I'll use a simple format:
+
+```markdown
+### Verified Fixed
+Positron Version(s): [version]
+OS Version(s): [OS]
+
+### Test scenario(s)
+- [Single scenario]
+
+### Link(s) to test cases run or created:
+[links or paths to e2e tests, or n/a]
+```
+
+For everything else (2+ scenarios, or any edge cases/regressions), I'll use a grouped format for better readability:
+
+```markdown
+### Verified Fixed
+Positron Version(s): [version]
+OS Version(s): [OS]
+
+### Test scenario(s)
+
+**Primary scenario:**
+- [Main test scenario]
+
+**Edge cases:**
+- [Edge case 1]
+- [Edge case 2]
+
+**Regression checks:**
+- [Regression check 1]
+- [Regression check 2]
+
+### Link(s) to test cases run or created:
+[links or paths to e2e tests, or n/a]
+```
+
+**Note:** The verification comment uses plain bullets. Checkboxes are only in the verification guide for tracking during testing.
+
+The template will be pre-filled with:
+- Test scenarios extracted and condensed from the verification guide
+- Grouped format used by default for better readability (unless only 1 scenario)
+- **Positron Version automatically detected** from installed application
+- **OS Version automatically detected** from your system
+- Ready to paste - you can adjust versions if you tested on multiple systems
+
+**The template will be automatically copied to your clipboard** (on macOS/Linux using `pbcopy`/`xclip`, on Windows using `clip`), making it easy to paste directly into the GitHub issue after you complete testing.
+
+## Output Format
+
+The verification guide is saved as a markdown file:
+
+```
+.claude/skills/positron-qa-verify/output/verify-issue-{number}-{timestamp}.md
+```
+
+Example filename: `verify-issue-4567-20260108-153045.md`
+
+## Example Usage
+
+```
+User: /qa-verify 4567
+```
+
+I'll respond with:
+1. A summary of what I found
+2. Path to the generated verification guide
+3. Key highlights (number of scenarios, any blockers, etc.)
+
+## Helper Script
+
+### `scripts/analyze_issue.sh`
+
+This script orchestrates the data gathering:
+
+```bash
+# Usage:
+./scripts/analyze_issue.sh <issue-number>
+```
+
+The script:
+- Fetches issue and PR data using `gh` CLI
+- Extracts linked issues from comments
+- Calculates PR size to determine if code review is needed
+- Outputs structured JSON for parsing
+
+## Verification Guide Template
+
+The generated guides follow this structure:
+
+```markdown
+# Verification Guide: [Issue Title]
+
+**Issue:** #[number]
+**PR:** #[number]
+**Component:** [area label]
+**Generated:** [timestamp]
+
+---
+
+## Issue Summary
+
+[2-3 sentences explaining the problem and user impact]
+
+## Root Cause
+
+[1-2 sentences if identifiable, otherwise "See PR for technical details"]
+
+## Test Scenarios
+
+### Primary Scenario
+[Main repro steps from issue]
+
+**Expected:** [What should happen]
+**Previously:** [What was broken]
+
+### Edge Cases
+[Additional scenarios from comments/analysis]
+
+### Regression Checks
+[Related functionality to verify]
+
+## Testing Context
+
+**Environment:**
+- Positron version: [if specified]
+- OS: [if relevant]
+- Language: Python/R [version if specified]
+
+**Setup:**
+[Any required setup steps]
+
+**Related PRs:**
+- [Links to related PRs with brief description]
+
+## References
+
+- Issue: [link]
+- PR: [link]
+- Related: [links to other issues]
+
+---
+*Generated by positron-qa-verify skill*
+```
+
+## Tips for Effective Verification
+
+- **Start with the primary scenario** - Always test the exact repro steps from the issue first
+- **Check edge cases** - Comments often reveal additional scenarios discovered during development
+- **Test on relevant platforms** - If issue mentions "macOS only", prioritize that platform
+- **Verify related functionality** - Small fixes sometimes have unintended side effects
+- **Look for performance notes** - PRs sometimes mention performance implications
+
+## Advanced Features
+
+### Multiple PRs
+
+If an issue has multiple related PRs (e.g., backend + frontend changes):
+- I'll analyze all of them
+- The guide will note which scenarios relate to which PR
+- Testing order may be suggested if one depends on another
+
+### Linked Issues
+
+When comments reference other issues:
+- I'll fetch those issue titles
+- Include relevant context in the verification guide
+- Help you understand if they should be tested together
+
+### Code Analysis Insights
+
+For small PRs where I review the code:
+- I'll note if changes are isolated or touch multiple areas
+- Highlight any test files modified (what the developers tested)
+- Identify configuration changes that might affect behavior
+
+## Limitations
+
+- Cannot automatically execute tests (manual verification only)
+- Code analysis is limited to small PRs to save time
+- Relies on quality of issue description and PR comments
+- May miss verbal discussions not captured in GitHub
+
+## Integration with QA Workflow
+
+This skill integrates with the typical QA verification workflow:
+
+1. **Sign up for ticket** on the QA board
+2. **Run `/qa-verify [issue-number]`** to generate guide
+3. **Review the generated markdown** to understand what to test
+4. **Perform manual verification** following the scenarios
+5. **Update ticket status** based on results
+
+The generated guides serve as:
+- A checklist during testing
+- Documentation of what was verified
+- Reference for future related issues
+
+## Success Criteria
+
+A successful verification guide should:
+- Clearly explain the issue and its impact
+- Provide specific, actionable test scenarios
+- Include relevant edge cases from comments/analysis
+- List required environment/setup details
+- Reference all related issues and PRs
+- Be concise but complete (no fluff, all substance)
+
+---
+
+Remember: This skill generates the testing plan. You still need to execute the manual verification yourself!

--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -82,29 +82,34 @@ I'll search comments for:
 
 I'll create a markdown file in `.claude/skills/positron-qa-verify/output/` with:
 
-1. **Issue Summary**
-   - Brief explanation of the problem
-   - User impact (why this matters)
-   - Affected component/area
+1. **Ticket Type** (Bug, Feature, Documentation, Maintenance)
+   - Helps set testing expectations
+   - Determines whether Root Cause section is included
 
-2. **Root Cause** (if identifiable)
+2. **Issue Summary**
+   - What changed or what was broken
+   - User impact (why this matters)
+   - Uses H4 subsections for readability
+
+3. **Root Cause** (Bugs only)
    - What was causing the issue
-   - Only included if clearly stated in PR or obvious from small diff
+   - Only included for bug fixes when clearly stated in PR
    - Helps understand what might break again
 
-3. **Test Scenarios**
+4. **Test Scenarios**
+   - Checkboxes for each scenario with nested bullets (not numbered steps)
    - Primary scenario (the main repro steps from the issue)
-   - Edge cases (from comments, PR review, code analysis)
+   - Edge cases (from comments, PR review, code analysis) with "Why test:" rationale
    - Regression checks (related functionality to verify still works)
    - Platform-specific scenarios if mentioned
 
-4. **Testing Context**
+5. **Testing Context**
    - Environment requirements (Python/R version, specific packages, etc.)
    - Setup steps (if any)
    - Expected vs actual behavior
    - Related PRs to be aware of
 
-5. **References**
+6. **References**
    - Link to original issue
    - Link to PR(s)
    - Links to related issues

--- a/.claude/skills/positron-qa-verify/references/verification_guide.md
+++ b/.claude/skills/positron-qa-verify/references/verification_guide.md
@@ -11,35 +11,75 @@ This document provides guidance for generating effective QA verification guides 
 
 ## Guide Structure
 
+### 0. Header with Ticket Type
+
+**Purpose:** Immediately identify what kind of issue this is to set expectations for testing approach.
+
+**Format:**
+```markdown
+**Issue:** #12345
+**Type:** Bug | Feature | Documentation | Maintenance
+**Primary PR:** #12346
+**Component:** [Component Name]
+**Generated:** [timestamp]
+```
+
+**Ticket Types:**
+- **Bug**: Something broken that needs fixing → Include Root Cause section
+- **Feature**: New functionality being added → Skip Root Cause section
+- **Documentation**: Docs updates → Adjust testing focus
+- **Maintenance**: Refactoring, tech debt → May have limited user-facing testing
+
 ### 1. Issue Summary
 
 **Purpose:** Give the tester immediate context about what they're verifying.
 
-**Should include:**
-- What was broken or missing
-- How it affects users
-- Which component/area is involved
+**Format:** Use H4 subsections for better readability:
 
-**Good example:**
-```
+**Bug fix example:**
+```markdown
+## Issue Summary
+
+#### What Was Broken
 The Data Explorer's scrollbars would snap back to position 0 when dragging on Safari.
-This made it impossible to navigate large dataframes on Safari, forcing users to use
-keyboard navigation or switch browsers. Affects the Data Explorer component.
+
+#### User Impact
+Users couldn't navigate large dataframes on Safari, forcing them to:
+- Use keyboard navigation instead
+- Switch to a different browser
+- Avoid working with large datasets
 ```
 
-**Bad example:**
-```
-There was a bug in the Data Explorer that needed to be fixed.
+**Feature example:**
+```markdown
+## Issue Summary
+
+#### What Changed
+Added support for Microsoft SQL Server databases to the Connections Pane using Python connectors.
+
+#### User Impact
+Python users working with SQL Server can now:
+- Inspect databases directly in Positron
+- Browse database objects without external tools
+- View table structures and schemas
 ```
 
-### 2. Root Cause (Optional)
+**Formatting rules:**
+- **Bugs**: Use "What Was Broken" to emphasize the problem
+- **Features**: Use "What Changed" to emphasize the addition
+- **Always use bullets** in User Impact for easy scanning
+- Keep it concise (2-4 bullets max)
+
+### 2. Root Cause (Bugs Only)
 
 **When to include:**
+- **Only for bug fixes** (Type: Bug)
 - PR explicitly states the cause
 - Small PR diff makes it obvious
 - Understanding the cause helps identify test scenarios
 
 **When to skip:**
+- **Always skip for Features, Documentation, or Maintenance**
 - Large refactors where cause is complex
 - PR doesn't clearly explain it
 - Not relevant to testing approach
@@ -67,24 +107,39 @@ The main reproduction steps from the issue. Always test this first.
 ```markdown
 ### Primary Scenario
 
-[Step-by-step reproduction from the issue]
+- [ ] **[Scenario title]**
 
-**Expected:** [What should happen now]
-**Previously:** [What was broken before the fix]
+   **Setup:** (if needed)
+   - Setup step one
+   - Setup step two
+
+   **Test Steps:**
+   - Step one
+   - Step two
+   - Step three
+
+   **Expected:** [What should happen now]
+   **Previously:** [What was broken before the fix]
 ```
 
 **Example:**
 ```markdown
 ### Primary Scenario
 
-1. Open Positron on Safari
-2. Create a large dataframe: `df = pd.DataFrame({'col': range(10000)})`
-3. View in Data Explorer
-4. Drag the scrollbar down to row 5000
-5. Release the scrollbar
+- [ ] **Scrollbar maintains position on Safari**
 
-**Expected:** Scrollbar stays at position, showing rows around 5000
-**Previously:** Scrollbar snapped back to 0, showing first rows
+   **Setup:**
+   - Open Positron on Safari
+   - Create a large dataframe: `df = pd.DataFrame({'col': range(10000)})`
+   - View in Data Explorer
+
+   **Test Steps:**
+   - Drag the scrollbar down to row 5000
+   - Release the scrollbar
+   - Verify scrollbar position
+
+   **Expected:** Scrollbar stays at position, showing rows around 5000
+   **Previously:** Scrollbar snapped back to 0, showing first rows
 ```
 
 #### Edge Cases
@@ -99,30 +154,35 @@ Additional scenarios from:
 ```markdown
 ### Edge Cases
 
-#### [Scenario name]
-[Steps]
+- [ ] **[Scenario name]**
 
-**Why test:** [Brief explanation of what this verifies]
+   **_Why test:_** [Brief explanation of what this verifies]
+
+   - Step one
+   - Step two
+   - Step three
 ```
 
 **Example:**
 ```markdown
 ### Edge Cases
 
-#### Horizontal scrollbar
-1. Create wide dataframe: `df = pd.DataFrame({f'col{i}': range(100) for i in range(50)})`
-2. View in Data Explorer
-3. Drag horizontal scrollbar
-4. Release
+- [ ] **Horizontal scrollbar**
 
-**Why test:** Ensures fix works for both scroll directions
+   **_Why test:_** Ensures fix works for both scroll directions
 
-#### Rapid scrolling
-1. Open large dataframe in Data Explorer
-2. Rapidly drag scrollbar up and down multiple times
-3. Release at various positions
+   - Create wide dataframe: `df = pd.DataFrame({f'col{i}': range(100) for i in range(50)})`
+   - View in Data Explorer
+   - Drag horizontal scrollbar
+   - Release
 
-**Why test:** Stress tests the event handler under rapid input
+- [ ] **Rapid scrolling**
+
+   **_Why test:_** Stress tests the event handler under rapid input
+
+   - Open large dataframe in Data Explorer
+   - Rapidly drag scrollbar up and down multiple times
+   - Release at various positions
 ```
 
 #### Regression Checks

--- a/.claude/skills/positron-qa-verify/references/verification_guide.md
+++ b/.claude/skills/positron-qa-verify/references/verification_guide.md
@@ -1,0 +1,774 @@
+# Verification Guide Reference
+
+This document provides guidance for generating effective QA verification guides from GitHub issues and PRs.
+
+## Core Principles
+
+1. **Be actionable** - Every scenario should be testable
+2. **Be specific** - No vague instructions like "test the feature"
+3. **Be complete** - Cover the main scenario, edge cases, and regressions
+4. **Be concise** - Respect the tester's time, no fluff
+
+## Guide Structure
+
+### 1. Issue Summary
+
+**Purpose:** Give the tester immediate context about what they're verifying.
+
+**Should include:**
+- What was broken or missing
+- How it affects users
+- Which component/area is involved
+
+**Good example:**
+```
+The Data Explorer's scrollbars would snap back to position 0 when dragging on Safari.
+This made it impossible to navigate large dataframes on Safari, forcing users to use
+keyboard navigation or switch browsers. Affects the Data Explorer component.
+```
+
+**Bad example:**
+```
+There was a bug in the Data Explorer that needed to be fixed.
+```
+
+### 2. Root Cause (Optional)
+
+**When to include:**
+- PR explicitly states the cause
+- Small PR diff makes it obvious
+- Understanding the cause helps identify test scenarios
+
+**When to skip:**
+- Large refactors where cause is complex
+- PR doesn't clearly explain it
+- Not relevant to testing approach
+
+**Good example:**
+```
+The virtual scrolling logic was using the wrong event handler for Safari's
+scroll events, causing position to reset on each drag.
+```
+
+**Bad example:**
+```
+The code was wrong and now it's fixed.
+```
+
+### 3. Test Scenarios
+
+This is the most important section. Break down into subsections:
+
+#### Primary Scenario
+
+The main reproduction steps from the issue. Always test this first.
+
+**Format:**
+```markdown
+### Primary Scenario
+
+[Step-by-step reproduction from the issue]
+
+**Expected:** [What should happen now]
+**Previously:** [What was broken before the fix]
+```
+
+**Example:**
+```markdown
+### Primary Scenario
+
+1. Open Positron on Safari
+2. Create a large dataframe: `df = pd.DataFrame({'col': range(10000)})`
+3. View in Data Explorer
+4. Drag the scrollbar down to row 5000
+5. Release the scrollbar
+
+**Expected:** Scrollbar stays at position, showing rows around 5000
+**Previously:** Scrollbar snapped back to 0, showing first rows
+```
+
+#### Edge Cases
+
+Additional scenarios from:
+- Comments on the issue
+- PR review comments
+- Code analysis (for small PRs)
+- Your inference based on the fix
+
+**Format:**
+```markdown
+### Edge Cases
+
+#### [Scenario name]
+[Steps]
+
+**Why test:** [Brief explanation of what this verifies]
+```
+
+**Example:**
+```markdown
+### Edge Cases
+
+#### Horizontal scrollbar
+1. Create wide dataframe: `df = pd.DataFrame({f'col{i}': range(100) for i in range(50)})`
+2. View in Data Explorer
+3. Drag horizontal scrollbar
+4. Release
+
+**Why test:** Ensures fix works for both scroll directions
+
+#### Rapid scrolling
+1. Open large dataframe in Data Explorer
+2. Rapidly drag scrollbar up and down multiple times
+3. Release at various positions
+
+**Why test:** Stress tests the event handler under rapid input
+```
+
+#### Regression Checks
+
+Things to verify still work that might have been affected by the fix.
+
+**Format:**
+```markdown
+### Regression Checks
+
+- [ ] [What to verify]
+- [ ] [Another thing to verify]
+```
+
+**Example:**
+```markdown
+### Regression Checks
+
+- [ ] Scrollbar works normally on Chrome and Firefox
+- [ ] Keyboard navigation (arrow keys) still works
+- [ ] Mouse wheel scrolling still works
+- [ ] Scrollbar position persists when switching between tabs
+```
+
+### 4. Testing Context
+
+**Environment requirements:**
+- Specific OS/browser if issue is platform-specific
+- Language version (Python/R) if relevant
+- Required packages or extensions
+- Positron version if specified
+
+**Setup steps:**
+- Any required configuration
+- Files to create
+- Extensions to enable
+
+**Example:**
+```markdown
+## Testing Context
+
+**Environment:**
+- Safari browser (any version)
+- Any OS with Safari support (macOS, iOS)
+- Python or R (issue affects both)
+
+**Setup:**
+No special setup required. Any dataframe with >100 rows will work.
+
+**Related PRs:**
+- #8931 - Adds tests for Safari scrolling behavior
+```
+
+### 5. References
+
+Always include:
+- Link to original issue
+- Link to PR(s)
+- Links to related issues mentioned
+
+**Format:**
+```markdown
+## References
+
+- Issue: https://github.com/posit-dev/positron/issues/8930
+- PR: https://github.com/posit-dev/positron/pull/8931
+- Related: #7234 (Chrome scrolling issue)
+```
+
+## Writing Tips
+
+### Extracting Test Scenarios from Comments
+
+Comments often contain gold:
+
+**Look for patterns like:**
+- "Also happens when..."
+- "Same issue with..."
+- "We should also test..."
+- "Edge case: ..."
+- "What about...?"
+
+**Example comment:**
+```
+"Also happens when you use the horizontal scrollbar. And if you scroll quickly
+multiple times it gets worse."
+```
+
+**Extracted scenarios:**
+- Test horizontal scrollbar (in addition to vertical)
+- Test rapid repeated scrolling
+
+### Extracting from PR Descriptions
+
+**Look for:**
+- "This also fixes..." (additional scenarios)
+- "Changes include..." (areas to test)
+- "Note that..." (edge cases or limitations)
+- Testing notes or QA sections
+
+**Example PR description:**
+```
+Fixes the scrollbar snap issue on Safari by updating the event handler.
+
+This also improves scrolling performance on all browsers.
+
+Note: This doesn't affect the fixed-position headers, which use a different
+scrolling mechanism.
+```
+
+**Extracted info:**
+- Primary: Safari scrollbar fix
+- Bonus: Performance improvement to verify on all browsers
+- Regression: Check that headers still work
+
+### Code Analysis Tips (for small PRs)
+
+When reviewing diffs for small PRs:
+
+**Look for:**
+- Which files changed (indicates affected areas)
+- Test files added/modified (what did developers test?)
+- Configuration changes (environment implications)
+- Multiple functions touched (broader impact)
+
+**Example diff insights:**
+```
+Files changed:
+- src/vs/workbench/contrib/dataExplorer/browser/virtualScroll.ts
+- src/vs/workbench/contrib/dataExplorer/test/virtualScroll.test.ts
+
+Insight: Changes are isolated to virtual scrolling component.
+         Tests were added for the specific scenario.
+         Should focus testing on scrolling, not broader Data Explorer features.
+```
+
+## Common Pitfalls to Avoid
+
+### ❌ Vague Scenarios
+
+**Bad:**
+```
+Test that the Data Explorer works correctly
+```
+
+**Good:**
+```
+1. Open dataframe with 10,000 rows
+2. Scroll to row 5,000
+3. Verify position holds and no snap-back occurs
+```
+
+### ❌ Missing Context
+
+**Bad:**
+```
+Verify the scrollbar fix
+```
+
+**Good:**
+```
+**Environment:** Safari browser on macOS
+**Expected:** Scrollbar stays in position after dragging
+**Previously:** Scrollbar snapped back to 0
+```
+
+### ❌ Too Many Assumptions
+
+**Bad:**
+```
+Test the obvious scrolling scenarios
+```
+
+**Good:**
+```
+### Test Scenarios
+1. Vertical scrollbar drag
+2. Horizontal scrollbar drag
+3. Rapid scrolling
+4. Scroll then switch tabs
+```
+
+### ❌ Ignoring Comments
+
+**Don't just use the issue body** - comments often contain:
+- Additional reproduction steps
+- Edge cases discovered during debugging
+- Platform-specific notes
+- Related issues
+
+Always read all comments before generating scenarios.
+
+### ❌ Overcomplicated Root Cause
+
+**Bad:**
+```
+The issue was caused by a race condition in the virtual DOM reconciliation
+algorithm when Safari's scroll event coalescing triggered a re-render before
+the state had propagated through the React fiber tree...
+```
+
+**Good:**
+```
+Safari's scroll events were handled differently, causing position to reset.
+```
+
+Or just skip it if too complex.
+
+## Examples
+
+### Example 1: Simple Bug Fix
+
+**Issue:** Console crashes when printing None in Python
+
+**Good verification guide:**
+```markdown
+# Verification Guide: Console crashes when printing None in Python
+
+**Issue:** #4567
+**PR:** #4589
+**Component:** Console
+
+---
+
+## Issue Summary
+
+Printing `None` in the Python console causes Positron to crash. This affects
+any code that prints None values, making the console unusable for common
+debugging workflows.
+
+## Root Cause
+
+The console's output renderer didn't handle None values, attempting to call
+.toString() on undefined.
+
+## Test Scenarios
+
+### Primary Scenario
+
+1. Open Positron with Python
+2. In the console, type: `print(None)`
+3. Press Enter
+
+**Expected:** Console prints "None" and remains functional
+**Previously:** Positron crashed
+
+### Edge Cases
+
+#### None in variables
+```python
+x = None
+print(x)
+```
+
+#### None in lists
+```python
+items = [1, None, 3]
+print(items)
+```
+
+#### Multiple None values
+```python
+print(None, None, None)
+```
+
+### Regression Checks
+
+- [ ] Printing other falsy values works (0, False, "", [])
+- [ ] Printing normal values still works
+- [ ] Console error handling works for real errors
+
+## Testing Context
+
+**Environment:**
+- Python 3.x (any version)
+- No special setup required
+
+## References
+
+- Issue: https://github.com/posit-dev/positron/issues/4567
+- PR: https://github.com/posit-dev/positron/pull/4589
+```
+
+### Example 2: Feature with Multiple Scenarios
+
+**Issue:** Add keyboard shortcut for running selected code
+
+**Good verification guide:**
+```markdown
+# Verification Guide: Add keyboard shortcut for running selected code
+
+**Issue:** #3456
+**PR:** #3478
+**Component:** Editor
+
+---
+
+## Issue Summary
+
+Users can now run selected code using Cmd+Enter (Ctrl+Enter on Windows/Linux).
+Previously, running selected code required right-clicking or using the Run menu.
+This makes running code snippets much faster.
+
+## Test Scenarios
+
+### Primary Scenario
+
+1. Open a Python or R file
+2. Select a few lines of code
+3. Press Cmd+Enter (or Ctrl+Enter)
+
+**Expected:** Selected code runs in the console
+**Previously:** Shortcut was not available
+
+### Edge Cases
+
+#### Single line selection
+1. Click in a line (cursor only, no selection)
+2. Press Cmd+Enter
+
+**Expected:** Current line runs
+
+#### Multiple selections (from PR comments)
+1. Make multiple selections (Cmd+click)
+2. Press Cmd+Enter
+
+**Expected:** All selections run in order
+
+#### Partial line selection
+1. Select part of a line (e.g., just the function name)
+2. Press Cmd+Enter
+
+**Expected:** Only selected text runs
+
+#### No active console (from PR review)
+1. Close all console sessions
+2. Select code and press Cmd+Enter
+
+**Expected:** New console starts and code runs
+
+### Regression Checks
+
+- [ ] Run menu still works
+- [ ] Right-click context menu still works
+- [ ] Cmd+Enter behavior in console REPL unchanged (runs current command)
+- [ ] Other keyboard shortcuts still work
+
+## Testing Context
+
+**Environment:**
+- Python or R file editor
+- Both Python and R should be tested
+
+**Related PRs:**
+- #3479 - Adds the same shortcut for notebooks
+
+## References
+
+- Issue: https://github.com/posit-dev/positron/issues/3456
+- PR: https://github.com/posit-dev/positron/pull/3478
+- Related: #3479 (notebooks implementation)
+```
+
+## Checklist for Complete Guides
+
+Before finalizing a verification guide, ensure:
+
+- [ ] Issue summary clearly explains the problem and impact
+- [ ] Primary scenario includes exact repro steps
+- [ ] Edge cases are specific and testable
+- [ ] Regression checks cover related functionality
+- [ ] Environment requirements are listed
+- [ ] All comments from issue have been reviewed
+- [ ] PR description has been analyzed
+- [ ] Related issues are referenced
+- [ ] Each scenario has clear expected vs actual behavior
+- [ ] No vague instructions like "test it works"
+- [ ] Root cause included only if helpful for testing
+- [ ] Links to issue, PR, and related issues are present
+
+## Success Metrics
+
+A good verification guide should enable a QA tester to:
+1. Understand what was broken and why it matters (< 30 seconds)
+2. Execute the primary test scenario (< 5 minutes)
+3. Identify and test edge cases (< 15 minutes)
+4. Verify no regressions occurred (< 10 minutes)
+
+Total time investment: ~30 minutes to generate a thorough verification guide that saves hours of back-and-forth clarification.
+
+## Verification Comment Templates
+
+After completing manual verification, QA testers typically post a standardized comment on the issue to confirm the fix. The skill can help generate this comment template.
+
+### Standard Format
+
+For single scenario tests (only 1 test total, no edge cases or regressions), use a simple format:
+
+```markdown
+### Verified Fixed
+Positron Version(s): [version]
+OS Version(s): [OS]
+
+### Test scenario(s)
+- [Single scenario description]
+
+### Link(s) to test cases run or created:
+[links or paths to e2e tests, or n/a]
+```
+
+For everything else (2+ scenarios, or has edge cases/regressions), use grouped format for better readability:
+
+```markdown
+### Verified Fixed
+Positron Version(s): [version]
+OS Version(s): [OS]
+
+### Test scenario(s)
+
+**Primary scenario:**
+- [Main test scenario]
+
+**Edge cases:**
+- [Edge case 1]
+- [Edge case 2]
+- [Edge case 3]
+
+**Regression checks:**
+- [Regression 1]
+- [Regression 2]
+
+### Link(s) to test cases run or created:
+[links or paths to e2e tests, or n/a]
+```
+
+**Important distinction:**
+- **Verification guide** (`.md` file for testing): Uses checkboxes `- [ ]` so QA can track progress
+- **Verification comment** (posted to GitHub): Uses plain bullets `-` for the final report
+
+### Generating the Template
+
+The skill should:
+1. Extract test scenarios from the verification guide
+2. **Use grouped format by default** unless there's only 1 scenario total
+3. Condense verbose scenario descriptions into concise bullets
+4. **Auto-detect Positron version** from installed application
+5. **Auto-detect OS version** from the system
+6. Pre-fill with "n/a" for test case links unless e2e tests were mentioned
+
+**Format decision rule:**
+- Only 1 scenario (no edge cases, no regressions) → Simple format
+- Everything else → Grouped format
+
+**Positron Version Detection:**
+- Look for `product.json` in standard installation paths
+- Extract `positronVersion` and `positronBuildNumber` fields
+- Format as: `{version} build {buildNumber}` (e.g., "2026.02.0 build 10")
+- If detection fails, leave blank for manual entry
+
+**OS Version Detection:**
+- macOS: Use `sw_vers -productVersion` (e.g., "macOS 14.5")
+- Linux: Parse `/etc/os-release` for distribution name and version
+- Windows: Use `ver` command output
+- Fallback: Use `uname` output if above methods fail
+
+### Example 1: Single Scenario (Simple Format)
+
+For issue #2345 (Fix typo in help text):
+
+```markdown
+### Verified Fixed
+Positron Version(s): 2026.01.0 build 123
+OS Version(s): macOS 14.5
+
+### Test scenario(s)
+- Verify typo is corrected in Help pane
+
+### Link(s) to test cases run or created:
+n/a
+```
+
+Note: This uses simple format because there's truly only one thing to test. Most issues will have edge cases or regressions and should use grouped format.
+
+### Example 2: Longer Bug Fix (Grouped Format)
+
+For issue #4567 (Console crashes when printing None):
+
+```markdown
+### Verified Fixed
+Positron Version(s): 2026.01.0 build 123
+OS Version(s): macOS 14.5
+
+### Test scenario(s)
+
+**Primary scenario:**
+- Print None directly in console
+
+**Edge cases:**
+- Print None stored in variable
+- Print None in lists
+- Print multiple None values
+
+**Regression checks:**
+- Other falsy values still work (0, False, "", [])
+- Normal printing still works
+- Console error handling works for real errors
+
+### Link(s) to test cases run or created:
+n/a
+```
+
+### Example 3: Feature with Platform Testing (Grouped Format)
+
+For issue #3456 (Keyboard shortcut for running code):
+
+```markdown
+### Verified Fixed
+Positron Version(s): 2026.01.0 build 123
+OS Version(s): macOS 14.5, Windows 11
+
+### Test scenario(s)
+
+**Primary scenario:**
+- Run selected code with Cmd/Ctrl+Enter in Python and R files
+
+**Edge cases:**
+- Run single line with cursor only (no selection)
+- Run multiple selections
+- Run partial line selection
+- Run code when no console is active (creates new console)
+
+**Regression checks:**
+- Run menu still works
+- Right-click context menu still works
+- Cmd+Enter in console REPL unchanged
+
+### Link(s) to test cases run or created:
+n/a
+```
+
+### Example 4: With E2E Tests (Grouped Format)
+
+For issue #8930 (Safari scrollbar fix):
+
+```markdown
+### Verified Fixed
+Positron Version(s): 2026.01.0 build 123
+OS Version(s): macOS 14.5 (Safari 17.2)
+
+### Test scenario(s)
+
+**Primary scenario:**
+- Drag vertical scrollbar in Data Explorer on Safari, verify no snap-back to position 0
+
+**Edge cases:**
+- Drag horizontal scrollbar
+- Rapid scrolling multiple times
+- Scroll then switch tabs and return
+
+**Regression checks:**
+- Scrollbar works on Chrome and Firefox
+- Keyboard navigation still works
+- Mouse wheel scrolling still works
+
+### Link(s) to test cases run or created:
+test/e2e/tests/data-explorer/scrolling.test.ts
+```
+
+### Tips for Generating Comments
+
+**Choose the right format:**
+- **Default to grouped format** - it's clearer and more scannable
+- Only use simple format for truly single-scenario tests (no edge cases, no regressions)
+- Group by: Primary scenario → Edge cases → Regression checks
+
+**Extract scenarios systematically:**
+- Start with primary scenario (the main test from the issue)
+- Add each edge case as a bullet under "Edge cases"
+- Include regression checks as bullets under "Regression checks"
+- Combine very similar scenarios into one bullet
+
+**Format consistently:**
+- Use action verbs ("Verify", "Test", "Check")
+- Keep bullets concise but specific
+- Each bullet should be one clear test action
+- For edge cases: Place "Why test:" explanation immediately after the title, before the steps
+
+**Handle version/OS fields:**
+- **Positron Version(s)**: Auto-detect from installed application using `product.json` file
+  - macOS: `/Applications/Positron.app/Contents/Resources/app/product.json`
+  - Linux: Common paths like `/usr/share/positron/resources/app/product.json` or `~/.local/share/positron/`
+  - Windows: `C:\Program Files\Positron\resources\app\product.json`
+  - Format: `{positronVersion} build {positronBuildNumber}` (e.g., "2026.02.0 build 10")
+- **OS Version(s)**: Auto-detect from system using `sw_vers` (macOS), `/etc/os-release` (Linux), or `ver` (Windows)
+- User can adjust values if testing on multiple systems or if auto-detection fails
+- For multi-platform testing, user can add additional versions (comma-separated)
+
+**Test case links:**
+- Default to "n/a" unless e2e tests mentioned in PR
+- If PR added/modified test files, include those paths
+- If tester created new e2e tests, they'll fill this in
+
+### Anti-Patterns
+
+**Don't:**
+- Include setup steps in scenarios (those aren't test scenarios)
+- List expected/actual behavior (comment format is just scenario list)
+- Include references or links (those are in the issue already)
+- Add QA notes or explanations (just the scenario bullets)
+
+**Example of what NOT to do:**
+
+```markdown
+### Test scenario(s)
+- Setup: Create two environments, one with pandas and one without
+- Expected: Diagnostics should toggle
+- See issue #6936 for more details
+- This was fixed in Pyrefly 0.45.0
+```
+
+**Correct version (grouped format):**
+
+```markdown
+### Test scenario(s)
+
+**Primary scenario:**
+- Switch between sessions with/without pandas, verify diagnostics toggle
+
+**Edge cases:**
+- Rapid switching between multiple sessions
+- Different import patterns (full, specific, aliased)
+- Semantic highlighting also updates
+```
+
+### Workflow Integration
+
+After generating the verification guide:
+
+1. User performs manual testing following the guide
+2. User asks for verification comment
+3. Skill generates comment template with **auto-detected Positron and OS versions** and **copies it to clipboard**
+4. User pastes into GitHub issue comment box (versions already filled in!)
+5. User adjusts versions if testing was done on multiple systems
+6. User adds e2e test links if applicable (usually pre-filled with "n/a" or detected test paths)
+7. User posts comment and updates issue status
+
+This completes the QA verification workflow.
+
+**Note:** Testing notes (like "pay attention to X") should be included in the verification guide for manual testing, but should NOT be included in the verification comment template.

--- a/.claude/skills/positron-qa-verify/references/verification_guide.md
+++ b/.claude/skills/positron-qa-verify/references/verification_guide.md
@@ -9,6 +9,13 @@ This document provides guidance for generating effective QA verification guides 
 3. **Be complete** - Cover the main scenario, edge cases, and regressions
 4. **Be concise** - Respect the tester's time, no fluff
 
+## Formatting Convention
+
+- **Scenario titles** use checkmarks `✓ **Title**` for visual organization
+- **Test steps** use checkboxes `- [ ] Step` for tracking progress during testing
+- **Regression checks** use checkboxes `- [ ] Check` as they are individual items to verify
+- This format makes it easy to see the overall structure while checking off steps as you test
+
 ## Guide Structure
 
 ### 0. Header with Ticket Type
@@ -109,39 +116,39 @@ The main reproduction steps from the issue. Always test this first.
 ```markdown
 ### Primary Scenario
 
-- [ ] **[Scenario title]**
+✓ **[Scenario title]**
 
-   **Setup:** (if needed)
-   - Setup step one
-   - Setup step two
+**Setup:** (if needed)
+- [ ] Setup step one
+- [ ] Setup step two
 
-   **Test Steps:**
-   - Step one
-   - Step two
-   - Step three
+**Test Steps:**
+- [ ] Step one
+- [ ] Step two
+- [ ] Step three
 
-   **Expected:** [What should happen now]
-   **Previously:** [What was broken before the fix]
+**Expected:** [What should happen now]
+**Previously:** [What was broken before the fix]
 ```
 
 **Example:**
 ```markdown
 ### Primary Scenario
 
-- [ ] **Scrollbar maintains position on Safari**
+✓ **Scrollbar maintains position on Safari**
 
-   **Setup:**
-   - Open Positron on Safari
-   - Create a large dataframe: `df = pd.DataFrame({'col': range(10000)})`
-   - View in Data Explorer
+**Setup:**
+- [ ] Open Positron on Safari
+- [ ] Create a large dataframe: `df = pd.DataFrame({'col': range(10000)})`
+- [ ] View in Data Explorer
 
-   **Test Steps:**
-   - Drag the scrollbar down to row 5000
-   - Release the scrollbar
-   - Verify scrollbar position
+**Test Steps:**
+- [ ] Drag the scrollbar down to row 5000
+- [ ] Release the scrollbar
+- [ ] Verify scrollbar position
 
-   **Expected:** Scrollbar stays at position, showing rows around 5000
-   **Previously:** Scrollbar snapped back to 0, showing first rows
+**Expected:** Scrollbar stays at position, showing rows around 5000
+**Previously:** Scrollbar snapped back to 0, showing first rows
 ```
 
 #### Edge Cases
@@ -156,35 +163,35 @@ Additional scenarios from:
 ```markdown
 ### Edge Cases
 
-- [ ] **[Scenario name]**
+✓ **[Scenario name]**
 
-   **_Why test:_** [Brief explanation of what this verifies]
+**_Why test:_** [Brief explanation of what this verifies]
 
-   - Step one
-   - Step two
-   - Step three
+- [ ] Step one
+- [ ] Step two
+- [ ] Step three
 ```
 
 **Example:**
 ```markdown
 ### Edge Cases
 
-- [ ] **Horizontal scrollbar**
+✓ **Horizontal scrollbar**
 
-   **_Why test:_** Ensures fix works for both scroll directions
+**_Why test:_** Ensures fix works for both scroll directions
 
-   - Create wide dataframe: `df = pd.DataFrame({f'col{i}': range(100) for i in range(50)})`
-   - View in Data Explorer
-   - Drag horizontal scrollbar
-   - Release
+- [ ] Create wide dataframe: `df = pd.DataFrame({f'col{i}': range(100) for i in range(50)})`
+- [ ] View in Data Explorer
+- [ ] Drag horizontal scrollbar
+- [ ] Release
 
-- [ ] **Rapid scrolling**
+✓ **Rapid scrolling**
 
-   **_Why test:_** Stress tests the event handler under rapid input
+**_Why test:_** Stress tests the event handler under rapid input
 
-   - Open large dataframe in Data Explorer
-   - Rapidly drag scrollbar up and down multiple times
-   - Release at various positions
+- [ ] Open large dataframe in Data Explorer
+- [ ] Rapidly drag scrollbar up and down multiple times
+- [ ] Release at various positions
 ```
 
 #### Regression Checks
@@ -426,28 +433,34 @@ The console's output renderer didn't handle None values, attempting to call
 
 ### Primary Scenario
 
-1. Open Positron with Python
-2. In the console, type: `print(None)`
-3. Press Enter
+✓ **Print None in console**
+
+**Test Steps:**
+- [ ] Open Positron with Python
+- [ ] In the console, type: `print(None)`
+- [ ] Press Enter
 
 **Expected:** Console prints "None" and remains functional
 **Previously:** Positron crashed
 
 ### Edge Cases
 
-#### None in variables
+✓ **None in variables**
+
 ```python
 x = None
 print(x)
 ```
 
-#### None in lists
+✓ **None in lists**
+
 ```python
 items = [1, None, 3]
 print(items)
 ```
 
-#### Multiple None values
+✓ **Multiple None values**
+
 ```python
 print(None, None, None)
 ```
@@ -496,36 +509,47 @@ This makes running code snippets much faster.
 
 ### Primary Scenario
 
-1. Open a Python or R file
-2. Select a few lines of code
-3. Press Cmd+Enter (or Ctrl+Enter)
+✓ **Run selected code with keyboard shortcut**
+
+**Test Steps:**
+- [ ] Open a Python or R file
+- [ ] Select a few lines of code
+- [ ] Press Cmd+Enter (or Ctrl+Enter)
 
 **Expected:** Selected code runs in the console
 **Previously:** Shortcut was not available
 
 ### Edge Cases
 
-#### Single line selection
-1. Click in a line (cursor only, no selection)
-2. Press Cmd+Enter
+✓ **Single line selection**
+
+**Test Steps:**
+- [ ] Click in a line (cursor only, no selection)
+- [ ] Press Cmd+Enter
 
 **Expected:** Current line runs
 
-#### Multiple selections (from PR comments)
-1. Make multiple selections (Cmd+click)
-2. Press Cmd+Enter
+✓ **Multiple selections** (from PR comments)
+
+**Test Steps:**
+- [ ] Make multiple selections (Cmd+click)
+- [ ] Press Cmd+Enter
 
 **Expected:** All selections run in order
 
-#### Partial line selection
-1. Select part of a line (e.g., just the function name)
-2. Press Cmd+Enter
+✓ **Partial line selection**
+
+**Test Steps:**
+- [ ] Select part of a line (e.g., just the function name)
+- [ ] Press Cmd+Enter
 
 **Expected:** Only selected text runs
 
-#### No active console (from PR review)
-1. Close all console sessions
-2. Select code and press Cmd+Enter
+✓ **No active console** (from PR review)
+
+**Test Steps:**
+- [ ] Close all console sessions
+- [ ] Select code and press Cmd+Enter
 
 **Expected:** New console starts and code runs
 
@@ -625,8 +649,8 @@ OS Version(s): [OS]
 ```
 
 **Important distinction:**
-- **Verification guide** (`.md` file for testing): Uses checkboxes `- [ ]` so QA can track progress
-- **Verification comment** (posted to GitHub): Uses plain bullets `-` for the final report
+- **Verification guide** (`.md` file for testing): Uses checkmarks `- ✓` for scenario titles and checkboxes `- [ ]` for steps so QA can track progress
+- **Verification comment** (posted to GitHub): Uses plain bullets `-` for the final report (no checkmarks or checkboxes)
 
 ### Generating the Template
 
@@ -643,16 +667,22 @@ The skill should:
 - Everything else → Grouped format
 
 **Positron Version Detection:**
-- Look for `product.json` in standard installation paths
-- Extract `positronVersion` and `positronBuildNumber` fields
+- Use the `scripts/detect_versions.sh` helper script
+- Script checks standard installation paths for `product.json`
+- Extracts `positronVersion` and `positronBuildNumber` fields
 - Format as: `{version} build {buildNumber}` (e.g., "2026.02.0 build 10")
+- Has 3-second timeout - fails fast and silent if not found
 - If detection fails, leave blank for manual entry
 
 **OS Version Detection:**
-- macOS: Use `sw_vers -productVersion` (e.g., "macOS 14.5")
-- Linux: Parse `/etc/os-release` for distribution name and version
-- Windows: Use `ver` command output
-- Fallback: Use `uname` output if above methods fail
+- Use the `scripts/detect_versions.sh` helper script
+- macOS: Uses `sw_vers -productVersion` (e.g., "macOS 14.5")
+- Linux: Parses `/etc/os-release` for distribution name and version
+- Windows: Uses PowerShell or systeminfo
+- Has 3-second timeout - fails fast and silent
+- Fallback: Uses `uname` output if above methods fail
+
+**Important: Version detection must never prompt the user or block execution. If detection fails, silently use empty values.**
 
 ### Example 1: Single Scenario (Simple Format)
 
@@ -827,14 +857,21 @@ test/e2e/tests/data-explorer/scrolling.test.ts
 
 After generating the verification guide:
 
-1. User performs manual testing following the guide
-2. User asks for verification comment
-3. Skill generates comment template with **auto-detected Positron and OS versions** and **copies it to clipboard**
-4. User pastes into GitHub issue comment box (versions already filled in!)
-5. User adjusts versions if testing was done on multiple systems
-6. User adds e2e test links if applicable (usually pre-filled with "n/a" or detected test paths)
-7. User posts comment and updates issue status
+1. Skill offers to generate verification comment template
+2. User performs manual testing following the guide
+3. **When ready, user accepts the offer** (e.g., responds "yes" or "generate the verification comment")
+4. **Only then:** Skill runs `scripts/detect_versions.sh` to auto-detect Positron and OS versions (silent, 4-second max)
+5. Skill generates comment template with detected versions and **copies it to clipboard**
+6. User pastes into GitHub issue comment box (versions already filled in!)
+7. User adjusts versions if testing was done on multiple systems or if auto-detection failed
+8. User adds e2e test links if applicable (usually pre-filled with "n/a" or detected test paths)
+9. User posts comment and updates issue status
 
 This completes the QA verification workflow.
 
-**Note:** Testing notes (like "pay attention to X") should be included in the verification guide for manual testing, but should NOT be included in the verification comment template.
+**Important:**
+- Verification comment generation is **offered but user-triggered** - skill waits for explicit acceptance
+- Version detection **only runs after user accepts** - not during initial guide generation
+- Version detection is **best-effort, silent and fast** (max 4 seconds) - never prompts, never blocks
+- If version detection fails, empty values are used - user fills them in manually
+- Testing notes (like "pay attention to X") should be in the verification guide, NOT in the comment template

--- a/.claude/skills/positron-qa-verify/references/verification_guide.md
+++ b/.claude/skills/positron-qa-verify/references/verification_guide.md
@@ -17,11 +17,13 @@ This document provides guidance for generating effective QA verification guides 
 
 **Format:**
 ```markdown
-**Issue:** #12345
-**Type:** Bug | Feature | Documentation | Maintenance
-**Primary PR:** #12346
-**Component:** [Component Name]
-**Generated:** [timestamp]
+# Verification Guide
+### [Issue Title]<br>
+**Issue:** #12345<br>
+**Type:** Bug | Feature | Documentation | Maintenance<br>
+**Primary PR:** #12346<br>
+**Component:** [Component Name]<br>
+**Generated:** [timestamp]<br>
 ```
 
 **Ticket Types:**
@@ -399,11 +401,13 @@ Or just skip it if too complex.
 
 **Good verification guide:**
 ```markdown
-# Verification Guide: Console crashes when printing None in Python
-
-**Issue:** #4567
-**PR:** #4589
-**Component:** Console
+# Verification Guide
+### Console crashes when printing None in Python<br>
+**Issue:** #4567<br>
+**Type:** Bug<br>
+**PR:** #4589<br>
+**Component:** Console<br>
+**Generated:** [timestamp]<br>
 
 ---
 
@@ -472,11 +476,13 @@ print(None, None, None)
 
 **Good verification guide:**
 ```markdown
-# Verification Guide: Add keyboard shortcut for running selected code
-
-**Issue:** #3456
-**PR:** #3478
-**Component:** Editor
+# Verification Guide
+### Add keyboard shortcut for running selected code<br>
+**Issue:** #3456<br>
+**Type:** Feature<br>
+**PR:** #3478<br>
+**Component:** Editor<br>
+**Generated:** [timestamp]<br>
 
 ---
 

--- a/.claude/skills/positron-qa-verify/references/verification_guide.md
+++ b/.claude/skills/positron-qa-verify/references/verification_guide.md
@@ -19,9 +19,9 @@ This document provides guidance for generating effective QA verification guides 
 ```markdown
 # Verification Guide
 ### [Issue Title]<br>
-**Issue:** #12345<br>
+**Issue:** [#12345](https://github.com/posit-dev/positron/issues/12345)<br>
 **Type:** Bug | Feature | Documentation | Maintenance<br>
-**Primary PR:** #12346<br>
+**Primary PR:** [#12346](https://github.com/posit-dev/positron/pull/12346)<br>
 **Component:** [Component Name]<br>
 **Generated:** [timestamp]<br>
 ```
@@ -403,9 +403,9 @@ Or just skip it if too complex.
 ```markdown
 # Verification Guide
 ### Console crashes when printing None in Python<br>
-**Issue:** #4567<br>
+**Issue:** [#4567](https://github.com/posit-dev/positron/issues/4567)<br>
 **Type:** Bug<br>
-**PR:** #4589<br>
+**Primary PR:** [#4589](https://github.com/posit-dev/positron/pull/4589)<br>
 **Component:** Console<br>
 **Generated:** [timestamp]<br>
 
@@ -478,9 +478,9 @@ print(None, None, None)
 ```markdown
 # Verification Guide
 ### Add keyboard shortcut for running selected code<br>
-**Issue:** #3456<br>
+**Issue:** [#3456](https://github.com/posit-dev/positron/issues/3456)<br>
 **Type:** Feature<br>
-**PR:** #3478<br>
+**Primary PR:** [#3478](https://github.com/posit-dev/positron/pull/3478)<br>
 **Component:** Editor<br>
 **Generated:** [timestamp]<br>
 

--- a/.claude/skills/positron-qa-verify/scripts/analyze_issue.sh
+++ b/.claude/skills/positron-qa-verify/scripts/analyze_issue.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# analyze_issue.sh - Gather issue and PR data for QA verification
+#
+# Usage: ./analyze_issue.sh <issue-number>
+#
+# This script fetches comprehensive data about an issue and its related PRs
+# to help generate verification guides for QA testing.
+
+set -euo pipefail
+
+ISSUE_NUMBER="$1"
+REPO="posit-dev/positron"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Analyzing issue #${ISSUE_NUMBER}...${NC}"
+
+# Function to get PR size (lines changed)
+get_pr_size() {
+	local pr_number="$1"
+	gh pr view "$pr_number" --repo "$REPO" --json additions,deletions --jq '.additions + .deletions' 2>/dev/null || echo "0"
+}
+
+# 1. Fetch issue details
+echo -e "${YELLOW}Fetching issue details...${NC}"
+ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,body,comments,url,labels,author,createdAt 2>/dev/null)
+
+if [ $? -ne 0 ] || [ -z "$ISSUE_JSON" ]; then
+	echo -e "${RED}Failed to fetch issue #${ISSUE_NUMBER}${NC}"
+	exit 1
+fi
+
+ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url')
+ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r '.labels[].name' | paste -sd ',' - || echo "")
+
+echo "Title: $ISSUE_TITLE"
+echo "URL: $ISSUE_URL"
+echo "Labels: $ISSUE_LABELS"
+
+# 2. Extract comments
+echo -e "\n${YELLOW}Analyzing comments...${NC}"
+COMMENTS_JSON=$(echo "$ISSUE_JSON" | jq '.comments')
+COMMENT_COUNT=$(echo "$COMMENTS_JSON" | jq 'length')
+echo "Found $COMMENT_COUNT comments"
+
+# 3. Find linked PRs - simple approach using issue view
+echo -e "\n${YELLOW}Detecting linked PRs...${NC}"
+
+# Get PRs that mention this issue
+LINKED_PRS=$(gh pr list --repo "$REPO" --search "$ISSUE_NUMBER" --state all --json number --jq '.[].number' 2>/dev/null || echo "")
+
+# Also extract from body and comments text
+ALL_PR_REFS=$(echo "$ISSUE_BODY" | grep -oE '#[0-9]+' | sed 's/#//' || echo "")
+COMMENT_PR_REFS=$(echo "$COMMENTS_JSON" | jq -r '.[].body // ""' | grep -oE '#[0-9]+' | sed 's/#//' || echo "")
+
+# Combine and deduplicate
+ALL_PRS=$(echo -e "${LINKED_PRS}\n${ALL_PR_REFS}\n${COMMENT_PR_REFS}" | sort -u | grep -E '^[0-9]+$' | head -20 || echo "")
+
+if [ -z "$ALL_PRS" ]; then
+	echo -e "${YELLOW}No PRs found linked to this issue${NC}"
+	PR_LIST="[]"
+else
+	echo -e "${GREEN}Found potential PR(s): $(echo "$ALL_PRS" | tr '\n' ' ')${NC}"
+
+	# 4. Fetch PR details for each
+	PR_LIST="["
+	FIRST=true
+
+	for PR_NUM in $ALL_PRS; do
+		echo -e "\n${YELLOW}Checking PR #${PR_NUM}...${NC}"
+
+		# Verify this is actually a PR (not just an issue reference)
+		PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPO" --json title,body,url,state,comments,author,mergedAt,number 2>/dev/null || echo "")
+
+		if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+			echo -e "${YELLOW}  #${PR_NUM} is not a PR, skipping${NC}"
+			continue
+		fi
+
+		PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
+		PR_SIZE=$(get_pr_size "$PR_NUM")
+
+		echo "  Title: $PR_TITLE"
+		echo "  Size: $PR_SIZE lines changed"
+		echo "  Should review code: $([ "$PR_SIZE" -lt 500 ] && echo 'Yes' || echo 'No (too large)')"
+
+		# Add to JSON array
+		if [ "$FIRST" = true ]; then
+			FIRST=false
+		else
+			PR_LIST="${PR_LIST},"
+		fi
+
+		PR_LIST="${PR_LIST}$(echo "$PR_JSON" | jq -c ". + {size: $PR_SIZE, shouldReviewCode: $([ "$PR_SIZE" -lt 500 ] && echo 'true' || echo 'false')}")"
+	done
+
+	PR_LIST="${PR_LIST}]"
+fi
+
+# 5. Extract referenced issues
+echo -e "\n${YELLOW}Finding related issues...${NC}"
+BODY_ISSUES=$(echo "$ISSUE_BODY" | grep -oE '#[0-9]+' | sed 's/#//' | grep -v "^${ISSUE_NUMBER}$" || echo "")
+COMMENT_ISSUES=$(echo "$COMMENTS_JSON" | jq -r '.[].body // ""' | grep -oE '#[0-9]+' | sed 's/#//' | grep -v "^${ISSUE_NUMBER}$" || echo "")
+RELATED_ISSUES=$(echo -e "${BODY_ISSUES}\n${COMMENT_ISSUES}" | sort -u | grep -E '^[0-9]+$' | head -20 || echo "")
+
+if [ -n "$RELATED_ISSUES" ]; then
+	echo -e "${GREEN}Found related issues: $(echo "$RELATED_ISSUES" | tr '\n' ' ')${NC}"
+else
+	echo "No related issues found"
+fi
+
+# 6. Build final JSON output
+echo -e "\n${YELLOW}Building analysis output...${NC}"
+
+OUTPUT_JSON=$(jq -n \
+	--arg title "$ISSUE_TITLE" \
+	--arg url "$ISSUE_URL" \
+	--arg body "$ISSUE_BODY" \
+	--arg labels "$ISSUE_LABELS" \
+	--arg number "$ISSUE_NUMBER" \
+	--argjson comments "$COMMENTS_JSON" \
+	--argjson prs "$PR_LIST" \
+	--arg related "$(echo "$RELATED_ISSUES" | tr '\n' ',' | sed 's/,$//')" \
+	'{
+		issue: {
+			number: $number,
+			title: $title,
+			url: $url,
+			body: $body,
+			labels: $labels,
+			commentCount: ($comments | length)
+		},
+		comments: $comments,
+		prs: $prs,
+		relatedIssues: ($related | split(",") | map(select(length > 0)))
+	}'
+)
+
+# Output the JSON
+echo "$OUTPUT_JSON"
+
+echo -e "\n${GREEN}Analysis complete!${NC}"

--- a/.claude/skills/positron-qa-verify/scripts/detect_versions.sh
+++ b/.claude/skills/positron-qa-verify/scripts/detect_versions.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+# detect_versions.sh - Fast, silent version detection for Positron and OS
+#
+# This script attempts to auto-detect:
+# 1. Positron version and build number
+# 2. OS version
+#
+# DESIGN PRINCIPLES:
+# - Fast: Each detection has a 3-second timeout, max 6 seconds total
+# - Silent: Never prints errors, never prompts, only outputs JSON
+# - Fail-safe: If detection fails, returns empty values (not errors)
+# - Cross-platform: Works on macOS, Linux, Windows (Git Bash/PowerShell)
+#
+# Output format: JSON with keys:
+# - positronVersion: string or empty
+# - positronBuild: string or empty
+# - osVersion: string or empty
+# - detectionStatus: "success", "partial", or "failed"
+
+set +e  # Don't exit on errors
+set -u  # But do error on undefined variables
+set -o pipefail
+
+# Timeout for each detection attempt (seconds)
+TIMEOUT=2
+
+# Colors for debug output (only used if DEBUG=1)
+if [ "${DEBUG:-0}" = "1" ]; then
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	NC='\033[0m'
+else
+	RED=''
+	GREEN=''
+	YELLOW=''
+	NC=''
+fi
+
+debug() {
+	if [ "${DEBUG:-0}" = "1" ]; then
+		echo -e "${YELLOW}[DEBUG]${NC} $1" >&2
+	fi
+}
+
+# Detect platform
+detect_platform() {
+	case "$(uname -s)" in
+		Darwin*) echo "macos" ;;
+		Linux*) echo "linux" ;;
+		CYGWIN*|MINGW*|MSYS*) echo "windows" ;;
+		*) echo "unknown" ;;
+	esac
+}
+
+PLATFORM=$(detect_platform)
+debug "Platform: $PLATFORM"
+
+# Function to run command with timeout (silent on failure)
+run_with_timeout() {
+	local timeout=$1
+	shift
+	local cmd="$@"
+
+	debug "Running: $cmd"
+
+	# Try with timeout command if available, otherwise just run directly
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$timeout" bash -c "$cmd" 2>/dev/null
+	elif command -v gtimeout >/dev/null 2>&1; then
+		# macOS with coreutils installed
+		gtimeout "$timeout" bash -c "$cmd" 2>/dev/null
+	else
+		# No timeout available, just run directly (risky but better than nothing)
+		eval "$cmd" 2>/dev/null
+	fi
+	return $?
+}
+
+# Detect Positron version
+detect_positron_version() {
+	local product_json=""
+	local positron_version=""
+	local positron_build=""
+
+	# List of paths to check (in order of likelihood)
+	case "$PLATFORM" in
+		macos)
+			paths=(
+				"/Applications/Positron.app/Contents/Resources/app/product.json"
+				"$HOME/Applications/Positron.app/Contents/Resources/app/product.json"
+			)
+			;;
+		linux)
+			paths=(
+				"/usr/share/positron/resources/app/product.json"
+				"/opt/positron/resources/app/product.json"
+				"$HOME/.local/share/positron/resources/app/product.json"
+				"$HOME/positron/resources/app/product.json"
+			)
+			;;
+		windows)
+			# Convert Windows paths for Git Bash/MSYS
+			localappdata="${LOCALAPPDATA:-$HOME/AppData/Local}"
+			programfiles="${PROGRAMFILES:-/c/Program Files}"
+			programfilesx86="${PROGRAMFILES(X86):-/c/Program Files (x86)}"
+
+			paths=(
+				"$localappdata/Programs/Positron/resources/app/product.json"
+				"$programfiles/Positron/resources/app/product.json"
+				"$programfilesx86/Positron/resources/app/product.json"
+			)
+			;;
+		*)
+			paths=()
+			;;
+	esac
+
+	# Try each path with timeout
+	for path in "${paths[@]}"; do
+		debug "Checking path: $path"
+
+		# Check if file exists quickly (no timeout needed)
+		if [ -f "$path" ]; then
+			debug "File exists, reading..."
+
+			# Read and parse JSON with timeout
+			if command -v jq >/dev/null 2>&1; then
+				local result=$(run_with_timeout $TIMEOUT "cat '$path' | jq -r '{positronVersion:.positronVersion, positronBuildNumber:.positronBuildNumber}'")
+
+				if [ $? -eq 0 ] && [ -n "$result" ]; then
+					positron_version=$(echo "$result" | jq -r '.positronVersion // empty' 2>/dev/null)
+					positron_build=$(echo "$result" | jq -r '.positronBuildNumber // empty' 2>/dev/null)
+
+					if [ -n "$positron_version" ] && [ "$positron_version" != "null" ]; then
+						debug "Found version: $positron_version build $positron_build"
+						break
+					fi
+				fi
+			else
+				# Fallback: try to extract without jq (less reliable)
+				local result=$(run_with_timeout $TIMEOUT "grep -E 'positronVersion|positronBuildNumber' '$path' | head -2")
+
+				if [ $? -eq 0 ] && [ -n "$result" ]; then
+					positron_version=$(echo "$result" | grep positronVersion | sed -E 's/.*"positronVersion"[^"]*"([^"]+)".*/\1/' | head -1)
+					positron_build=$(echo "$result" | grep positronBuildNumber | sed -E 's/.*"positronBuildNumber"[^"]*"?([^",]+)"?.*/\1/' | head -1)
+
+					if [ -n "$positron_version" ]; then
+						debug "Found version (no jq): $positron_version build $positron_build"
+						break
+					fi
+				fi
+			fi
+		fi
+	done
+
+	# Output results (even if empty)
+	echo "$positron_version"
+	echo "$positron_build"
+}
+
+# Detect OS version
+detect_os_version() {
+	local os_version=""
+
+	case "$PLATFORM" in
+		macos)
+			debug "Detecting macOS version..."
+			os_version=$(run_with_timeout $TIMEOUT "sw_vers -productVersion 2>/dev/null | head -1")
+			if [ -n "$os_version" ]; then
+				os_version="macOS $os_version"
+			fi
+			;;
+		linux)
+			debug "Detecting Linux version..."
+			# Try /etc/os-release first (standard)
+			if [ -f /etc/os-release ]; then
+				local name=$(run_with_timeout $TIMEOUT "grep -E '^NAME=' /etc/os-release | cut -d'=' -f2 | tr -d '\"' | head -1")
+				local version=$(run_with_timeout $TIMEOUT "grep -E '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '\"' | head -1")
+
+				if [ -n "$name" ]; then
+					os_version="$name"
+					if [ -n "$version" ]; then
+						os_version="$os_version $version"
+					fi
+				fi
+			fi
+
+			# Fallback to uname
+			if [ -z "$os_version" ]; then
+				os_version=$(run_with_timeout $TIMEOUT "uname -sr 2>/dev/null")
+			fi
+			;;
+		windows)
+			debug "Detecting Windows version..."
+			# Try multiple methods for Windows
+
+			# Method 1: PowerShell command (if available)
+			if command -v powershell.exe >/dev/null 2>&1; then
+				local win_version=$(run_with_timeout $TIMEOUT "powershell.exe -NoProfile -Command '[System.Environment]::OSVersion.VersionString' 2>/dev/null | tr -d '\r'")
+				if [ -n "$win_version" ]; then
+					os_version="$win_version"
+				fi
+			fi
+
+			# Method 2: Try systeminfo (slower, skip if we have version)
+			if [ -z "$os_version" ] && command -v systeminfo >/dev/null 2>&1; then
+				local win_name=$(run_with_timeout $TIMEOUT "systeminfo 2>/dev/null | grep -E 'OS Name' | cut -d':' -f2 | sed 's/^[[:space:]]*//' | head -1")
+				if [ -n "$win_name" ]; then
+					os_version="$win_name"
+				fi
+			fi
+
+			# Fallback: uname (less informative on Windows)
+			if [ -z "$os_version" ]; then
+				os_version=$(run_with_timeout $TIMEOUT "uname -sr 2>/dev/null")
+			fi
+			;;
+		*)
+			os_version=$(run_with_timeout $TIMEOUT "uname -sr 2>/dev/null")
+			;;
+	esac
+
+	# Trim whitespace
+	os_version=$(echo "$os_version" | xargs 2>/dev/null)
+
+	debug "OS Version: $os_version"
+	echo "$os_version"
+}
+
+# Main detection logic
+main() {
+	debug "Starting version detection..."
+
+	# Detect Positron version (returns two lines)
+	local positron_output=$(detect_positron_version)
+	local positron_version=$(echo "$positron_output" | sed -n '1p')
+	local positron_build=$(echo "$positron_output" | sed -n '2p')
+
+	# Detect OS version
+	local os_version=$(detect_os_version)
+
+	# Determine detection status
+	local status="failed"
+	if [ -n "$positron_version" ] && [ -n "$os_version" ]; then
+		status="success"
+	elif [ -n "$positron_version" ] || [ -n "$os_version" ]; then
+		status="partial"
+	fi
+
+	# Output JSON (always valid, even if empty)
+	cat <<-EOF
+	{
+	  "positronVersion": "${positron_version:-}",
+	  "positronBuild": "${positron_build:-}",
+	  "osVersion": "${os_version:-}",
+	  "detectionStatus": "$status"
+	}
+	EOF
+
+	debug "Detection complete: $status"
+}
+
+# Run main function
+main

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pwb-version
 !.claude/skills/
 !.claude/hooks/
 !.claude/settings.json
+.claude/skills/positron-qa-verify/output/
 
 .Rproj.user
 /playwright-report/


### PR DESCRIPTION
Adds a new Claude Code skill to streamline the QA verification workflow for the Positron team.

### Summary

This PR introduces the `positron-qa-verify` skill, which automates the tedious process of extracting verification requirements from GitHub issues. The skill analyzes issues, PRs, comments, and code changes to generate comprehensive verification guides for manual QA testing.

**Key features:**
- Analyzes GitHub issues and automatically detects related PRs
- Extracts test scenarios from issue descriptions, comments, and PR reviews
- Reviews code changes for small PRs (<500 lines) to identify edge cases
- Generates structured verification guides with checkboxes for tracking
- Creates verification comment templates with auto-detected Positron and OS versions
- Automatically copies verification comments to clipboard

**Workflow integration:**
```bash
/qa-verify 12345
```

The skill generates two outputs:
1. **Verification guide** (`.md` file with checkboxes) - used during testing to track progress
2. **Verification comment** (optional) - autogenerated with testing summary and OS/Positron versions auto-detected

### QA Notes

This is a new Claude Code skill that doesn't directly change Positron functionality. To verify:

1. Run the skill with a completed issue:
```bash
/qa-verify 11254
```

2. Verify it generates a verification guide in `.claude/skills/positron-qa-verify/output/`

3. When prompted, generate a verification comment and verify:
   - Positron version is auto-detected
   - OS version is auto-detected
   - Test scenarios are grouped (Primary, Edge cases, Regression checks)
   - Comment is copied to clipboard

4. Review the generated guide and verify:
   - Has checkboxes for tracking
   - Includes edge cases from comments/analysis
   - Includes root cause analysis when identifiable
