### PR TITLE
E2E test: fix layout related issues after change to notebook layout

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -36,7 +36,9 @@ test.describe('Headless Data Explorer', {
 }, () => {
 
 	test.beforeEach(async function ({ hotKeys }) {
-		await hotKeys.notebookLayout(); // Make data explorer larger
+		// Make data explorer larger
+		await hotKeys.notebookLayout();
+		await hotKeys.closeSecondarySidebar();
 	});
 
 	test.afterEach(async function ({ hotKeys }) {

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -135,10 +135,6 @@ test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS, tags.WIN, tags.WORKBENC
 			} catch (e) {
 				// No op if the sidebar isn't visible
 			}
-
-			// ------ Auxiliary Bar -------
-			// Should be collapsed
-			await expect(layouts.auxBar).not.toBeVisible();
 		});
 	});
 


### PR DESCRIPTION
A couple tests were broken after the secondary (auxiliary) side bar was added to the notebook layout.

### QA Notes

@:layouts @:data-explorer
