### PR TITLE
Assistant: Add default model indicator in model picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -104,6 +104,15 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					run: () => { /* separator - no action */ }
 				} satisfies IActionWidgetDropdownAction);				// Add all models for this vendor
 				for (const model of vendorModels) {
+					// Check if this model is marked as the default for its provider
+					const isDefault = model.metadata.isDefault;
+					// Add "(default)" suffix to label if this is the default model
+					const label = isDefault ? `${model.metadata.name} (default)` : model.metadata.name;
+					// Add "(default)" to tooltip if this is the default model
+					const tooltip = isDefault
+						? localize('chat.defaultModel', "{0} (default)", model.metadata.tooltip ?? model.metadata.name)
+						: (model.metadata.tooltip ?? model.metadata.name);
+
 					actions.push({
 						id: model.metadata.id,
 						enabled: true,
@@ -112,8 +121,8 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 						category: { label: `vendor_${vendor}`, order: vendorOrder * 1000 },
 						class: undefined,
 						description: model.metadata.detail,
-						tooltip: model.metadata.tooltip ?? model.metadata.name,
-						label: model.metadata.name,
+						tooltip: tooltip,
+						label: label,
 						run: () => {
 							const previousModel = delegate.getCurrentModel();
 							telemetryService.publicLog2<ChatModelChangeEvent, ChatModelChangeClassification>('chat.modelChange', {

--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -70,6 +70,23 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 				modelsByVendor.get(vendor)!.push(model);
 			}
 
+			// Sort each vendor's models to place the default model first
+			// This improves UX by making the default model immediately visible
+			// without scrolling, especially for providers with long model lists
+			for (const [vendor, vendorModels] of modelsByVendor.entries()) {
+				// Find the default model for this vendor
+				const defaultModel = vendorModels.find(m => m.metadata.isDefault);
+
+				if (defaultModel) {
+					// Separate default from non-default models
+					const nonDefaultModels = vendorModels.filter(m => !m.metadata.isDefault);
+
+					// Place default first, followed by remaining models in original order
+					modelsByVendor.set(vendor, [defaultModel, ...nonDefaultModels]);
+				}
+				// If no default, keep original order
+			}
+
 			// Sort vendors for consistent ordering
 			const sortedVendors = Array.from(modelsByVendor.entries())
 				.sort((a, b) => {

--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -54,7 +54,7 @@ type ChatModelChangeEvent = {
 function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, telemetryService: ITelemetryService): IActionWidgetDropdownActionProvider {
 	// --- Start Positron ---
 	// The entire body of this function has been replaced to group models by
-	// vendor with separators
+	// vendor with separators, and to indicate default models in the list.
 	return {
 		getActions: () => {
 			const models = delegate.getModels();
@@ -70,6 +70,7 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 				modelsByVendor.get(vendor)!.push(model);
 			}
 
+			// --- Start "Mark default model" ---
 			// Sort each vendor's models to place the default model first
 			// This improves UX by making the default model immediately visible
 			// without scrolling, especially for providers with long model lists
@@ -86,6 +87,7 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 				}
 				// If no default, keep original order
 			}
+			// --- End "Mark default model" ---
 
 			// Sort vendors for consistent ordering
 			const sortedVendors = Array.from(modelsByVendor.entries())
@@ -121,6 +123,7 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					run: () => { /* separator - no action */ }
 				} satisfies IActionWidgetDropdownAction);				// Add all models for this vendor
 				for (const model of vendorModels) {
+					// --- Start "Mark default model" ---
 					// Check if this model is marked as the default for its provider
 					const isDefault = model.metadata.isDefault;
 					// Add "(default)" suffix to label if this is the default model
@@ -129,6 +132,7 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					const tooltip = isDefault
 						? localize('chat.defaultModel', "{0} (default)", model.metadata.tooltip ?? model.metadata.name)
 						: (model.metadata.tooltip ?? model.metadata.name);
+					// --- End "Mark default model" ---
 
 					actions.push({
 						id: model.metadata.id,
@@ -138,8 +142,10 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 						category: { label: `vendor_${vendor}`, order: vendorOrder * 1000 },
 						class: undefined,
 						description: model.metadata.detail,
+						// --- Start "Mark default model" ---
 						tooltip: tooltip,
 						label: label,
+						// --- End "Mark default model" ---
 						run: () => {
 							const previousModel = delegate.getCurrentModel();
 							telemetryService.publicLog2<ChatModelChangeEvent, ChatModelChangeClassification>('chat.modelChange', {

--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -70,7 +70,6 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 				modelsByVendor.get(vendor)!.push(model);
 			}
 
-			// --- Start "Mark default model" ---
 			// Sort each vendor's models to place the default model first
 			// This improves UX by making the default model immediately visible
 			// without scrolling, especially for providers with long model lists
@@ -87,7 +86,6 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 				}
 				// If no default, keep original order
 			}
-			// --- End "Mark default model" ---
 
 			// Sort vendors for consistent ordering
 			const sortedVendors = Array.from(modelsByVendor.entries())
@@ -123,7 +121,6 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					run: () => { /* separator - no action */ }
 				} satisfies IActionWidgetDropdownAction);				// Add all models for this vendor
 				for (const model of vendorModels) {
-					// --- Start "Mark default model" ---
 					// Check if this model is marked as the default for its provider
 					const isDefault = model.metadata.isDefault;
 					// Add "(default)" suffix to label if this is the default model
@@ -132,7 +129,6 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					const tooltip = isDefault
 						? localize('chat.defaultModel', "{0} (default)", model.metadata.tooltip ?? model.metadata.name)
 						: (model.metadata.tooltip ?? model.metadata.name);
-					// --- End "Mark default model" ---
 
 					actions.push({
 						id: model.metadata.id,
@@ -142,10 +138,8 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 						category: { label: `vendor_${vendor}`, order: vendorOrder * 1000 },
 						class: undefined,
 						description: model.metadata.detail,
-						// --- Start "Mark default model" ---
 						tooltip: tooltip,
 						label: label,
-						// --- End "Mark default model" ---
 						run: () => {
 							const previousModel = delegate.getCurrentModel();
 							telemetryService.publicLog2<ChatModelChangeEvent, ChatModelChangeClassification>('chat.modelChange', {


### PR DESCRIPTION
_originally opened by @cameronmpalmer in https://github.com/posit-dev/positron/pull/11189_

### Summary

This is a non-fork PR of https://github.com/posit-dev/positron/pull/11189 (because of the problems with our CI outlined in https://github.com/posit-dev/positron/issues/6628), with an additional commit to denote the default model indicator changes within an already code-fenced block.

- addresses https://github.com/posit-dev/positron/issues/11166

Adds a visual indicator showing which model is configured as the default for each provider in the Assistant model picker dropdown.

When a user has configured `positron.assistant.models.preference.byProvider`, the default model for each provider now displays with a "(default)" text suffix next to the model name.

Claude Sonnet 4.5 from Anthropic provider set as default:
<img width="357" height="315" alt="Screenshot 2026-01-08 at 1 42 31 PM" src="https://github.com/user-attachments/assets/098baa9c-c031-4cc2-a544-d27fd3591743" />

Claude Haiku 4.5 from Anthropic provider set as default:
<img width="359" height="314" alt="Screenshot 2026-01-08 at 1 42 07 PM" src="https://github.com/user-attachments/assets/48bf185b-7970-4c0c-a5ef-b1bdddce093f" />

Two providers each with default models set:
<img width="358" height="402" alt="Screenshot 2026-01-08 at 2 23 01 PM" src="https://github.com/user-attachments/assets/44969404-f0c8-4946-b433-781901b3cdae" />

#### Changes

- Modified `modelPickerActionItem.ts` to check `model.metadata.isDefault` property
- Added "(Default)" text suffix to model label when `isDefault` is true
- Enhanced tooltip to also show "(Default)" for consistency

#### Implementation Details

The implementation leverages the existing `isDefault` property that's already being set by the backend (`extensions/positron-assistant/src/modelResolutionHelpers.ts`) based on user preferences. No backend changes were needed.

### Release Notes

#### New Features

- Assistant: model picker now shows a "(Default)" indicator next to the model configured as default for each provider (#11166)


### QA Notes

Manually tested with:
- Setting `positron.assistant.models.preference.byProvider` with various models
- Switching between different defaults
- Multiple providers with different defaults
- Verified tooltip shows "(Default)" suffix