### PR TITLE
Fix New Connection modal not updating dynamically

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -7,7 +7,7 @@
 import './listDriversState.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 
 // Other dependencies.
 import { PositronButton } from '../../../../../../base/browser/ui/positronComponents/button/positronButton.js';
@@ -64,8 +64,8 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 		return () => disposable.dispose();
 	}, [runtimeSessionService, setLanguageId]);
 
-	// Compute filtered/grouped drivers during render
-	const driversByName = (() => {
+	// Compute filtered/grouped drivers, cached by drivers and languageId
+	const driversByName = useMemo(() => {
 		const filtered = languageId
 			? drivers.filter((driver) => driver.metadata.languageId === languageId)
 			: [];
@@ -80,7 +80,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 			}
 		}
 		return grouped;
-	})();
+	}, [drivers, languageId]);
 
 	const onDriverSelectedHandler = (drivers: IDriver[]) => {
 		props.onSelection(drivers);
@@ -157,9 +157,9 @@ const DriverListItem = (props: DriverListItemProps) => {
 	const { name, drivers, onSelect } = props;
 	const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
 
-	const icon = baseIcon 
-	    ? <img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> 
-	    : <div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
+	const icon = baseIcon
+		? <img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} />
+		: <div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
 	return <button
 		className='driver-list-item'
@@ -170,7 +170,7 @@ const DriverListItem = (props: DriverListItemProps) => {
 			<div className='driver-name'>
 				{name}
 			</div>
-			<div className='driver-button codicon codicon-chevron-right'/>
+			<div className='driver-button codicon codicon-chevron-right' />
 		</div>
 	</button>;
 };

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -123,29 +123,14 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 		<div className='driver-list'>
 			{
 				driversByName.size > 0 ?
-					[...driversByName].map(([name, drivers]) => {
-						// find the first icon
-						const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
-
-						const icon = baseIcon ?
-							<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
-							<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
-
-						return <button
+					[...driversByName].map(([name, drivers]) => (
+						<DriverListItem
 							key={name}
-							className='driver-list-item'
-							onClick={() => onDriverSelectedHandler(drivers)}
-						>
-							{icon}
-							<div className='driver-info'>
-								<div className='driver-name'>
-									{name}
-								</div>
-								<div className={`driver-button codicon codicon-chevron-right`}>
-								</div>
-							</div>
-						</button>;
-					}) :
+							drivers={drivers}
+							name={name}
+							onSelect={onDriverSelectedHandler}
+						/>
+					)) :
 					<div className='no-drivers'>
 						{(() => localize('positron.newConnectionModalDialog.listDrivers.noDrivers', "No drivers available"))()}
 					</div>
@@ -160,6 +145,35 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 			</PositronButton>
 		</div>
 	</div>;
+};
+
+interface DriverListItemProps {
+	readonly name: string;
+	readonly drivers: IDriver[];
+	readonly onSelect: (drivers: IDriver[]) => void;
+}
+
+const DriverListItem = (props: DriverListItemProps) => {
+	const { name, drivers, onSelect } = props;
+	const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
+
+	const icon = baseIcon ?
+		<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
+		<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
+
+	return <button
+		className='driver-list-item'
+		onClick={() => onSelect(drivers)}
+	>
+		{icon}
+		<div className='driver-info'>
+			<div className='driver-name'>
+				{name}
+			</div>
+			<div className='driver-button codicon codicon-chevron-right'>
+			</div>
+		</div>
+	</button>;
 };
 
 const getRegisteredLanguages = (services: PositronReactServices) => {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -7,7 +7,7 @@
 import './listDriversState.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { PositronButton } from '../../../../../../base/browser/ui/positronComponents/button/positronButton.js';
@@ -36,6 +36,12 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 
 	const { languageId, setLanguageId } = props;
 
+	// Use a ref to track languageId to avoid recreating the subscription on every change
+	const languageIdRef = useRef(languageId);
+	useEffect(() => {
+		languageIdRef.current = languageId;
+	}, [languageId]);
+
 	// Subscribe to driver changes
 	useEffect(() => {
 		const disposable = driverManager.onDidChangeDrivers(() => {
@@ -47,12 +53,12 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 	// Auto-select language when a console starts and no language is selected
 	useEffect(() => {
 		const disposable = runtimeSessionService.onDidStartRuntime((session) => {
-			if (!languageId) {
+			if (!languageIdRef.current) {
 				setLanguageId(session.runtimeMetadata.languageId);
 			}
 		});
 		return () => disposable.dispose();
-	}, [runtimeSessionService, languageId, setLanguageId]);
+	}, [runtimeSessionService, setLanguageId]);
 
 	const onDriverSelectedHandler = (drivers: IDriver[]) => {
 		props.onSelection(drivers);

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -157,9 +157,9 @@ const DriverListItem = (props: DriverListItemProps) => {
 	const { name, drivers, onSelect } = props;
 	const baseIcon = drivers[0].metadata.base64EncodedIconSvg;
 
-	const icon = baseIcon ?
-		<img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> :
-		<div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
+	const icon = baseIcon 
+	    ? <img alt='' className='driver-icon' src={`data:image/svg+xml;base64,${baseIcon}`} /> 
+	    : <div className='driver-icon codicon codicon-database' style={{ opacity: 0.5, fontSize: '24px' }}></div>;
 
 	return <button
 		className='driver-list-item'
@@ -170,8 +170,7 @@ const DriverListItem = (props: DriverListItemProps) => {
 			<div className='driver-name'>
 				{name}
 			</div>
-			<div className='driver-button codicon codicon-chevron-right'>
-			</div>
+			<div className='driver-button codicon codicon-chevron-right'/>
 		</div>
 	</button>;
 };

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
@@ -4,16 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IDriver } from '../common/interfaces/positronConnectionsDriver.js';
 import { IPositronConnectionsService } from '../common/interfaces/positronConnectionsService.js';
 
-export class PositronConnectionsDriverManager {
+export class PositronConnectionsDriverManager extends Disposable {
 	private readonly drivers: IDriver[] = [];
 
-	private readonly _onDidChangeDrivers = new Emitter<IDriver[]>();
+	private readonly _onDidChangeDrivers = this._register(new Emitter<IDriver[]>());
 	readonly onDidChangeDrivers: Event<IDriver[]> = this._onDidChangeDrivers.event;
 
-	constructor(readonly service: IPositronConnectionsService) { }
+	constructor(readonly service: IPositronConnectionsService) {
+		super();
+	}
 
 	registerDriver(driver: IDriver): void {
 		// Check that a driver with the same id does not already exist.

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
@@ -26,14 +26,14 @@ export class PositronConnectionsDriverManager extends Disposable {
 		} else {
 			this.drivers.push(driver);
 		}
-		this._onDidChangeDrivers.fire(this.drivers);
+		this._onDidChangeDrivers.fire([...this.drivers]);
 	}
 
 	removeDriver(driverId: string): void {
 		const index = this.drivers.findIndex(d => d.driverId === driverId);
 		if (index >= 0) {
 			this.drivers.splice(index, 1);
-			this._onDidChangeDrivers.fire(this.drivers);
+			this._onDidChangeDrivers.fire([...this.drivers]);
 		}
 	}
 

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
@@ -3,11 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { IDriver } from '../common/interfaces/positronConnectionsDriver.js';
 import { IPositronConnectionsService } from '../common/interfaces/positronConnectionsService.js';
 
 export class PositronConnectionsDriverManager {
 	private readonly drivers: IDriver[] = [];
+
+	private readonly _onDidChangeDrivers = new Emitter<IDriver[]>();
+	readonly onDidChangeDrivers: Event<IDriver[]> = this._onDidChangeDrivers.event;
 
 	constructor(readonly service: IPositronConnectionsService) { }
 
@@ -19,12 +23,14 @@ export class PositronConnectionsDriverManager {
 		} else {
 			this.drivers.push(driver);
 		}
+		this._onDidChangeDrivers.fire(this.drivers);
 	}
 
 	removeDriver(driverId: string): void {
 		const index = this.drivers.findIndex(d => d.driverId === driverId);
 		if (index > 0) {
 			this.drivers.splice(index, 1);
+			this._onDidChangeDrivers.fire(this.drivers);
 		}
 	}
 

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsDrivers.ts
@@ -21,7 +21,7 @@ export class PositronConnectionsDriverManager extends Disposable {
 	registerDriver(driver: IDriver): void {
 		// Check that a driver with the same id does not already exist.
 		const index = this.drivers.findIndex(d => d.driverId === driver.driverId);
-		if (index > 0) {
+		if (index >= 0) {
 			this.drivers[index] = driver;
 		} else {
 			this.drivers.push(driver);
@@ -31,7 +31,7 @@ export class PositronConnectionsDriverManager extends Disposable {
 
 	removeDriver(driverId: string): void {
 		const index = this.drivers.findIndex(d => d.driverId === driverId);
-		if (index > 0) {
+		if (index >= 0) {
 			this.drivers.splice(index, 1);
 			this._onDidChangeDrivers.fire(this.drivers);
 		}

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
@@ -42,7 +42,7 @@ export class PositronConnectionsService extends Disposable implements IPositronC
 	) {
 		super();
 
-		this.driverManager = new PositronConnectionsDriverManager(this);
+		this.driverManager = this._register(new PositronConnectionsDriverManager(this));
 
 		// Whenever a session starts, we'll register an observer that will create a ConnectionsInstance
 		// whenever a new connections client is created by the backend.


### PR DESCRIPTION
## Summary

- Add `onDidChangeDrivers` event to `PositronConnectionsDriverManager` that fires when drivers are registered or removed
- Update `ListDrivers` component to subscribe to driver changes and re-render the list
- Auto-select language when a console starts and no language is currently selected

Addresses #11306

## QA Notes

@:connections

- Open Positron fresh and immediately click "New Connection" before starting a console
- Start a Python or R console - verify the language auto-selects in the modal
- Verify driver list updates when drivers finish registering (without closing/reopening the modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)