### PR TITLE
Fix race condition causing kernels not to start when a notebook is opened

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1117,7 +1117,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// If there is a pending shutdown request for this notebook, return the existing promise.
 		const shuttingDownPromise = this._shuttingDownNotebooksByNotebookUri.get(notebookUri);
 		if (shuttingDownPromise && !shuttingDownPromise.isSettled) {
-			this._logService.debug(`Notebook ${notebookUri.toString()} is already shutting down. Returning existing promise`);
+			this._logService.info(`Notebook ${notebookUri.toString()} is already shutting down. Returning existing promise`);
 			return shuttingDownPromise.p;
 		}
 
@@ -1135,7 +1135,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Get the session to shutdown.
 		const session = await this.getActiveOrStartingNotebook(notebookUri);
 		if (!session) {
-			this._logService.debug(
+			this._logService.info(
 				`Aborting shutdown request for notebook ${notebookUri.toString()}. ` +
 				`No active session found`
 			);


### PR DESCRIPTION
Related to #9695. Fixes a race condition where notebook kernels don't automatically start when opening a notebook after a window reload. When a notebook is created before runtimes finish registering, the kernel selection event fires but the kernel doesn't yet exist, silently skipping session startup.

The fix defers kernel selection startups. When runtimes register, any pending selections are processed and sessions are started.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web

We haven't been able to repro this locally yet, so we'll have to monitor e2e tests over the next while.