### PR TITLE
Positron nb create notebook test fix

### DIFF
--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -432,7 +432,7 @@ function createEditNotebookCellsTool(participantService: ParticipantService) {
 							]);
 						}
 
-						// Get the cell to retrieve its URI
+						// Get the cell to retrieve its URI and editor state
 						const cell: positron.notebooks.NotebookCell | undefined = await positron.notebooks.getCell(context.uri, cellIndex);
 						if (!cell) {
 							return new vscode.LanguageModelToolResult([
@@ -440,27 +440,45 @@ function createEditNotebookCellsTool(participantService: ParticipantService) {
 							]);
 						}
 
-						// Get the response stream from the participant service
-						const { response } = getChatRequestData(options.chatRequestId, participantService);
+						// Check if this is a markdown cell in preview mode
+						// editorShown is true when editor is shown, false when preview is shown
+						const isMarkdownInPreview = cell.type === 'markdown' && cell.editorShown === false;
 
-						// Apply the edit directly via response.textEdit()
-						// cell.id is the cell document URI string
-						const cellDocUri = vscode.Uri.parse(cell.id);
-						const cellDoc = await vscode.workspace.openTextDocument(cellDocUri);
-						const currentContent = cellDoc.getText();
+						if (isMarkdownInPreview) {
+							// Use API-based approach for markdown cells in preview mode
+							// This triggers visual feedback animation via handleAssistantCellModification
+							await positron.notebooks.updateCellContent(context.uri, cellIndex, content);
 
-						// Only create edit if content actually changed
-						if (currentContent !== content) {
-							const edit = new vscode.TextEdit(
-								new vscode.Range(0, 0, cellDoc.lineCount, 0),
-								content
-							);
-							response.textEdit(cellDocUri, edit);
+							// The API call handles scrolling via handleAssistantCellModification
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart(`Successfully updated markdown cell ${cellIndex} with visual feedback`)
+							]);
+						} else {
+							// Use native diff view for code cells and markdown cells in edit mode
+							const { response } = getChatRequestData(options.chatRequestId, participantService);
+
+							// Apply the edit directly via response.textEdit()
+							// cell.id is the cell document URI string
+							const cellDocUri = vscode.Uri.parse(cell.id);
+							const cellDoc = await vscode.workspace.openTextDocument(cellDocUri);
+							const currentContent = cellDoc.getText();
+
+							// Only create edit if content actually changed
+							if (currentContent !== content) {
+								const edit = new vscode.TextEdit(
+									new vscode.Range(0, 0, cellDoc.lineCount, 0),
+									content
+								);
+								response.textEdit(cellDocUri, edit);
+							}
+
+							// Trigger scroll-to behavior for native diff edits
+							await positron.notebooks.scrollToCellIfNeeded(context.uri, cellIndex);
+
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart(`Successfully proposed edit to cell ${cellIndex}`)
+							]);
 						}
-
-						return new vscode.LanguageModelToolResult([
-							new vscode.LanguageModelTextPart(`Successfully proposed edit to cell ${cellIndex}`)
-						]);
 					}
 
 					case 'delete': {

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -349,6 +349,7 @@ if (!context) {
 **All notebook tools use zero-based indices to reference cells:**
 - First cell = index 0, second cell = index 1, etc.
 - Tools accept `cellIndex` (single cell) or `cellIndices` (array of cells) parameters
+- Delete operations use `cellIndices` array (can delete single or multiple cells in one call)
 - The assistant must remember that indices shift when adding or deleting cells:
   - Adding cell at index N: cells N+ shift to N+1, N+2, etc.
   - Deleting cell at index N: cells N+1+ shift down to N, N+1, etc.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2592,6 +2592,13 @@ declare module 'positron' {
 		export function deleteCell(notebookUri: string, cellIndex: number): Thenable<void>;
 
 		/**
+		 * Delete multiple cells from a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Array of cell indices to delete
+		 */
+		export function deleteCells(notebookUri: string, cellIndices: number[]): Thenable<void>;
+
+		/**
 		 * Update the content of a cell in a notebook
 		 * @param notebookUri URI of the notebook
 		 * @param cellIndex Index of the cell to update

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2538,6 +2538,12 @@ declare module 'positron' {
 			 * Only present for code cells
 			 */
 			lastRunEndTime?: number;
+
+			/**
+			 * For markdown cells only: whether the editor is shown (true) or preview is shown (false).
+			 * This property is undefined for code cells.
+			 */
+			editorShown?: boolean;
 		}
 
 		/**
@@ -2632,5 +2638,13 @@ declare module 'positron' {
 		 *                 Must be a valid permutation containing each index from 0 to cellCount-1 exactly once.
 		 */
 		export function reorderCells(notebookUri: string, newOrder: number[]): Thenable<void>;
+
+		/**
+		 * Scroll to a cell if it's out of view and auto-follow is enabled.
+		 * Respects the `positron.notebook.assistant.autoFollow` setting.
+		 * @param notebookUri The notebook URI as a string
+		 * @param cellIndex The index of the cell to scroll to
+		 */
+		export function scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Thenable<void>;
 	}
 }

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -14,6 +14,7 @@ import { getNotebookInstanceFromActiveEditorPane } from '../../../contrib/positr
 import { CellSelectionType, getSelectedCells } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, CellEditType } from '../../../contrib/notebook/common/notebookCommon.js';
+import { cellToCellDtoForRestore } from '../../../contrib/positronNotebook/browser/cellClipboardUtils.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { encodeBase64 } from '../../../../base/common/buffer.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -239,16 +240,14 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 
 		const cellToDelete = cells[cellIndex];
 
-		// Capture cell content before deletion
-		const cellContent = cellToDelete.getContent();
-		const cellKind = cellToDelete.kind;
-		const language = cellToDelete.isCodeCell() ? cellToDelete.model.language : undefined;
+		// Capture complete cell data before deletion (outputs omitted for memory)
+		const cellData = cellToCellDtoForRestore(cellToDelete);
 
-		// Delete the cell immediately
+		// Delete the cell
 		instance.deleteCell(cellToDelete);
 
-		// Add sentinel with cell content for preview
-		instance.addDeletionSentinel(cellIndex, cellContent, cellKind, language);
+		// Add sentinel with complete cell data
+		instance.addDeletionSentinel(cellIndex, cellData);
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -427,6 +427,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostNotebookFeatures.deleteCell(notebookUri, cellIndex);
 			},
 
+			async deleteCells(notebookUri: string, cellIndices: number[]): Promise<void> {
+				return extHostNotebookFeatures.deleteCells(notebookUri, cellIndices);
+			},
+
 			async updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void> {
 				return extHostNotebookFeatures.updateCellContent(notebookUri, cellIndex, content);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -92,7 +92,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior, observer, sessionId): Thenable<Record<string, any>> {
+			executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior, observer, sessionId): Thenable<Record<string, unknown>> {
 				const extensionId = extension.identifier.value;
 				return extHostLanguageRuntime.executeCode(languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, observer, sessionId);
 			},
@@ -231,7 +231,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		const methods: typeof positron.methods = {
 			// This takes a string to avoid making `positron.d.ts` depend on the UI comm types
-			call(method: string, params: Record<string, any>): Thenable<any> {
+			call(method: string, params: Record<string, unknown>): Thenable<unknown> {
 				return extHostMethods.call(extension.identifier.value, method as UiFrontendRequest, params);
 			},
 			lastActiveEditorContext(): Thenable<positron.EditorContext | null> {
@@ -396,7 +396,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 					executionOrder: cell.executionOrder,
 					lastRunSuccess: cell.lastRunSuccess,
 					lastExecutionDuration: cell.lastExecutionDuration,
-					lastRunEndTime: cell.lastRunEndTime
+					lastRunEndTime: cell.lastRunEndTime,
+					editorShown: cell.editorShown
 				}));
 			},
 
@@ -440,6 +441,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 			async reorderCells(notebookUri: string, newOrder: number[]): Promise<void> {
 				return extHostNotebookFeatures.reorderCells(notebookUri, newOrder);
+			},
+
+			async scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void> {
+				return extHostNotebookFeatures.scrollToCellIfNeeded(notebookUri, cellIndex);
 			}
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -228,6 +228,7 @@ export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$runCells(notebookUri: string, cellIndices: number[]): Promise<void>;
 	$addCell(notebookUri: string, type: NotebookCellType, index: number, content: string): Promise<number>;
 	$deleteCell(notebookUri: string, cellIndex: number): Promise<void>;
+	$deleteCells(notebookUri: string, cellIndices: number[]): Promise<void>;
 	$updateCellContent(notebookUri: string, cellIndex: number, content: string): Promise<void>;
 	$getCellOutputs(notebookUri: string, cellIndex: number): Promise<INotebookCellOutputDTO[]>;
 	$moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -60,7 +60,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$getSessionDynState(sessionId: string): Promise<LanguageRuntimeDynState>;
 	$getSessionVariables(sessionId: string, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
 	$querySessionTables(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<QueryTableSummaryResult>>;
-	$callMethod(sessionId: string, method: string, args: any[]): Thenable<any>;
+	$callMethod(sessionId: string, method: string, args: unknown[]): Thenable<unknown>;
 	$emitLanguageRuntimeMessage(sessionId: string, handled: boolean, message: SerializableObjectWithBuffers<ILanguageRuntimeMessage>): void;
 	$emitLanguageRuntimeState(sessionId: string, clock: number, state: RuntimeState): void;
 	$emitLanguageRuntimeExit(sessionId: string, exit: ILanguageRuntimeExit): void;
@@ -79,15 +79,15 @@ export interface ExtHostLanguageRuntimeShape {
 	$openResource(handle: number, resource: URI | string): Promise<boolean>;
 	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, executionId?: string): void;
 	$isCodeFragmentComplete(handle: number, code: string): Promise<RuntimeCodeFragmentStatus>;
-	$createClient(handle: number, id: string, type: RuntimeClientType, params: any, metadata?: any): Promise<void>;
+	$createClient(handle: number, id: string, type: RuntimeClientType, params: unknown, metadata?: unknown): Promise<void>;
 	$listClients(handle: number, type?: RuntimeClientType): Promise<Record<string, string>>;
 	$removeClient(handle: number, id: string): void;
-	$sendClientMessage(handle: number, client_id: string, message_id: string, message: any): void;
+	$sendClientMessage(handle: number, client_id: string, message_id: string, message: unknown): void;
 	$replyToPrompt(handle: number, id: string, response: string): void;
 	$setWorkingDirectory(handle: number, directory: string): Promise<void>;
 	$interruptLanguageRuntime(handle: number): Promise<void>;
 	$restartSession(handle: number, workingDirectory?: string): Promise<void>;
-	$callMethod(handle: number, method: string, args: any[]): Thenable<any>;
+	$callMethod(handle: number, method: string, args: unknown[]): Thenable<unknown>;
 	$shutdownLanguageRuntime(handle: number, exitReason: RuntimeExitReason): Promise<void>;
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$showOutputLanguageRuntime(handle: number, channel?: LanguageRuntimeSessionChannel): void;
@@ -232,6 +232,7 @@ export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$getCellOutputs(notebookUri: string, cellIndex: number): Promise<INotebookCellOutputDTO[]>;
 	$moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void>;
 	$reorderCells(notebookUri: string, newOrder: number[]): Promise<void>;
+	$scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -114,5 +114,15 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	async reorderCells(notebookUri: string, newOrder: number[]): Promise<void> {
 		return this._proxy.$reorderCells(notebookUri, newOrder);
 	}
+
+	/**
+	 * Scrolls to a cell if it's out of view and auto-follow is enabled.
+	 * Respects the `positron.notebook.assistant.autoFollow` setting.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIndex The index of the cell to scroll to.
+	 */
+	async scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void> {
+		return this._proxy.$scrollToCellIfNeeded(notebookUri, cellIndex);
+	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -76,6 +76,15 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	}
 
 	/**
+	 * Deletes multiple cells from a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIndices Array of cell indices to delete.
+	 */
+	async deleteCells(notebookUri: string, cellIndices: number[]): Promise<void> {
+		return this._proxy.$deleteCells(notebookUri, cellIndices);
+	}
+
+	/**
 	 * Updates the content of a cell in a notebook.
 	 * @param notebookUri The URI of the notebook as a string.
 	 * @param cellIndex The index of the cell to update.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -6,7 +6,7 @@
 import { IObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { CellKind as NotebookCellKind } from '../../notebook/common/notebookCommon.js';
+import { CellKind as NotebookCellKind, ICellDto2 } from '../../notebook/common/notebookCommon.js';
 import { SelectionStateMachine } from './selectionMachine.js';
 import { Event } from '../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
@@ -20,7 +20,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 
 /**
  * Represents a deletion sentinel - a temporary placeholder shown where cells were deleted.
- * Sentinels display a red fade animation and provide an undo button.
+ * Sentinels display a red fade animation and provide a restore button.
  */
 export interface IDeletionSentinel {
 	/** Unique identifier for the sentinel */
@@ -29,12 +29,14 @@ export interface IDeletionSentinel {
 	originalIndex: number;
 	/** Timestamp when the sentinel was created */
 	timestamp: number;
-	/** The content of the deleted cell (first few lines for preview) */
-	cellContent: string;
+	/** Preview content for display (first few lines) */
+	previewContent: string;
 	/** The type of cell that was deleted */
 	cellKind: NotebookCellKind;
 	/** The language of the cell (for code cells) */
 	language?: string;
+	/** Complete cell data for restoration (outputs omitted to save memory) */
+	cellData: ICellDto2;
 }
 
 /**
@@ -405,11 +407,15 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	/**
 	 * Add a deletion sentinel at the specified cell index.
 	 * @param cellIndex The index where the cell was deleted
-	 * @param cellContent The content of the deleted cell
-	 * @param cellKind The type of cell that was deleted
-	 * @param language The language of the cell (for code cells)
+	 * @param cellData The complete cell data for potential restoration
 	 */
-	addDeletionSentinel(cellIndex: number, cellContent: string, cellKind: NotebookCellKind, language?: string): void;
+	addDeletionSentinel(cellIndex: number, cellData: ICellDto2): void;
+
+	/**
+	 * Restores a deleted cell from its sentinel data.
+	 * @param sentinel The deletion sentinel containing cell data to restore
+	 */
+	restoreCell(sentinel: IDeletionSentinel): void;
 
 	/**
 	 * Remove a deletion sentinel by its ID.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -181,9 +181,11 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	 * Temporarily highlight the cell with a flash animation to draw attention.
 	 * The highlight animation is controlled by CSS and automatically completes.
 	 * Calling this method multiple times in quick succession will restart the animation.
+	 * @param operationType Optional type of operation for specific styling ('add', 'delete', or 'modify')
+	 * @param maxWaitMs Maximum time to wait for container in milliseconds. Defaults to 100ms for modify, 500ms for add.
 	 * @returns Promise that resolves to true if the highlight was successfully added, false otherwise.
 	 */
-	highlightTemporarily(): Promise<boolean>;
+	highlightTemporarily(operationType?: 'add' | 'delete' | 'modify', maxWaitMs?: number): Promise<boolean>;
 
 	/**
 	 * Apply notebook editor options to this cell. Used by the IDE to select and/or reveal the cell.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -38,6 +38,8 @@
 	--vscode-positronNotebook-action-bar-inset: calc(
 		var(--vscode-positronNotebook-action-bar-h) / 2
 	);
+	--_positron-notebook-cell-gap: 4px;
+	--_positron-notebook-add-cell-buttons-height: 26px; /* Icon 18px + padding 8px */
 
 	/* Misc variables */
 	--vscode-positronNotebook-border: 1px solid
@@ -85,7 +87,7 @@
 	padding-inline: 1rem;
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: var(--_positron-notebook-cell-gap);
 
 	height: 100%;
 	overflow: auto;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -105,7 +105,6 @@ export function PositronNotebookComponent() {
 							{sentinelsBeforeCell.map(sentinel => (
 								<DeletionSentinel
 									key={sentinel.id}
-									commandService={services.commandService}
 									configurationService={services.configurationService}
 									sentinel={sentinel}
 								/>
@@ -119,7 +118,6 @@ export function PositronNotebookComponent() {
 				{deletionSentinels.filter(s => s.originalIndex >= notebookCells.length).map(sentinel => (
 					<DeletionSentinel
 						key={sentinel.id}
-						commandService={services.commandService}
 						configurationService={services.configurationService}
 						sentinel={sentinel}
 					/>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -27,6 +27,8 @@ import { ScreenReaderOnly } from '../../../../base/browser/ui/positronComponents
 import { createBareFontInfoFromRawSettings } from '../../../../editor/common/config/fontInfoFromSettings.js';
 import { useContextKeyValue } from './useContextKeyValue.js';
 import { CONTEXT_FIND_WIDGET_VISIBLE } from '../../../../editor/contrib/find/browser/findModel.js';
+import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
+import { IDeletionSentinel } from './IPositronNotebookInstance.js';
 
 
 export function PositronNotebookComponent() {
@@ -95,33 +97,7 @@ export function PositronNotebookComponent() {
 			)}
 			<div ref={containerRef} className='positron-notebook-cells-container'>
 				<AddCellButtons index={0} />
-				{notebookCells.map((cell, index) => {
-					// Find sentinels that should appear before this cell
-					const sentinelsBeforeCell = deletionSentinels.filter(s => s.originalIndex === index);
-
-					return (
-						<React.Fragment key={cell.handle}>
-							{/* Render any sentinels that belong at this position */}
-							{sentinelsBeforeCell.map(sentinel => (
-								<DeletionSentinel
-									key={sentinel.id}
-									configurationService={services.configurationService}
-									sentinel={sentinel}
-								/>
-							))}
-							<NotebookCell cell={cell as PositronNotebookCellGeneral} />
-							<AddCellButtons index={index + 1} />
-						</React.Fragment>
-					);
-				})}
-				{/* Render sentinels at the end if cells were deleted from the end */}
-				{deletionSentinels.filter(s => s.originalIndex >= notebookCells.length).map(sentinel => (
-					<DeletionSentinel
-						key={sentinel.id}
-						configurationService={services.configurationService}
-						sentinel={sentinel}
-					/>
-				))}
+				{renderCellsAndSentinels(notebookCells, deletionSentinels, services)}
 			</div>
 			<ScreenReaderOnly className='notebook-announcements'>
 				{globalAnnouncement}
@@ -129,6 +105,78 @@ export function PositronNotebookComponent() {
 		</div>
 	);
 }
+
+/**
+ * Renders cells and sentinels in the correct order.
+ * Sentinels are positioned based on their originalIndex relative to
+ * the cumulative position in the rendered notebook.
+ *
+ * Algorithm:
+ * 1. Sort sentinels by originalIndex for efficient processing
+ * 2. Track currentOriginalIndex as we iterate through cells
+ * 3. Before rendering each cell, insert all sentinels with originalIndex <= currentOriginalIndex
+ * 4. Increment currentOriginalIndex for both cells and sentinels
+ * 5. After all cells, render any remaining sentinels
+ *
+ * Example: If cells 2 and 3 are deleted from [0, 1, 2, 3, 4]:
+ * - Remaining cells: [0, 1, 4]
+ * - Sentinels: [{originalIndex: 2}, {originalIndex: 3}]
+ * - Result: 0, 1, sentinel(2), sentinel(3), 4
+ */
+function renderCellsAndSentinels(
+	cells: IPositronNotebookCell[],
+	sentinels: readonly IDeletionSentinel[],
+	services: any
+): React.ReactElement[] {
+	const elements: React.ReactElement[] = [];
+	let currentOriginalIndex = 0;
+
+	// Sort sentinels by originalIndex for efficient processing
+	const sortedSentinels = [...sentinels].sort((a, b) => a.originalIndex - b.originalIndex);
+	let sentinelIndex = 0;
+
+	cells.forEach((cell, cellArrayIndex) => {
+		// Render all sentinels that should appear before this cell
+		while (sentinelIndex < sortedSentinels.length &&
+			sortedSentinels[sentinelIndex].originalIndex <= currentOriginalIndex) {
+			const sentinel = sortedSentinels[sentinelIndex];
+			elements.push(
+				<DeletionSentinel
+					key={sentinel.id}
+					configurationService={services.configurationService}
+					sentinel={sentinel}
+				/>
+			);
+			sentinelIndex++;
+			currentOriginalIndex++;
+		}
+
+		// Render the cell
+		elements.push(
+			<React.Fragment key={cell.handle}>
+				<NotebookCell cell={cell as PositronNotebookCellGeneral} />
+				<AddCellButtons index={cellArrayIndex + 1} />
+			</React.Fragment>
+		);
+		currentOriginalIndex++;
+	});
+
+	// Render any remaining sentinels at the end
+	while (sentinelIndex < sortedSentinels.length) {
+		const sentinel = sortedSentinels[sentinelIndex];
+		elements.push(
+			<DeletionSentinel
+				key={sentinel.id}
+				configurationService={services.configurationService}
+				sentinel={sentinel}
+			/>
+		);
+		sentinelIndex++;
+	}
+
+	return elements;
+}
+
 /**
  * Get css properties for fonts in the notebook.
  * @returns A css properties object that sets css variables associated with fonts in the notebook.

--- a/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts
@@ -7,27 +7,59 @@ import { ICellDto2 } from '../../notebook/common/notebookCommon.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
- * Converts a Positron notebook cell to ICellDto2 format for clipboard storage.
- * This preserves all cell data without creating standalone text models.
+ * Options for controlling what cell data is preserved during conversion.
  */
-export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
+interface CellDtoOptions {
+	/** Include cell outputs (images, plots, etc.) - can be large */
+	includeOutputs?: boolean;
+	/** Include cell metadata (mime, tags, execution info, collapse state) */
+	includeMetadata?: boolean;
+}
+
+/**
+ * Base function for converting a Positron notebook cell to ICellDto2 format.
+ * Use the specialized functions `cellToCellDto2` or `cellToCellDtoForRestore` instead.
+ */
+function cellToCellDtoBase(cell: IPositronNotebookCell, options: CellDtoOptions): ICellDto2 {
 	const cellModel = cell.model;
 
 	return {
 		source: cell.getContent(),
 		language: cellModel.language,
-		mime: undefined,
+		mime: options.includeMetadata ? cellModel.mime : undefined,
 		cellKind: cellModel.cellKind,
-		outputs: cellModel.outputs.map(output => ({
-			outputId: output.outputId,
-			outputs: output.outputs.map(item => ({
-				mime: item.mime,
-				data: item.data
+		outputs: options.includeOutputs
+			? cellModel.outputs.map(output => ({
+				outputId: output.outputId,
+				outputs: output.outputs.map(item => ({
+					mime: item.mime,
+					data: item.data
+				}))
 			}))
-		})),
-		metadata: {},
-		internalMetadata: {},
-		collapseState: undefined
+			: [],
+		metadata: options.includeMetadata ? cellModel.metadata : {},
+		internalMetadata: options.includeMetadata ? cellModel.internalMetadata : {},
+		collapseState: options.includeMetadata ? cellModel.collapseState : undefined
 	};
+}
+
+/**
+ * Converts a Positron notebook cell to ICellDto2 format for clipboard storage.
+ * Preserves outputs for pasting but omits metadata.
+ */
+export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
+	return cellToCellDtoBase(cell, { includeOutputs: true, includeMetadata: false });
+}
+
+/**
+ * Converts a Positron notebook cell to ICellDto2 format for restoration.
+ * Preserves metadata for faithful restoration but omits outputs to save memory.
+ *
+ * Note: Outputs are intentionally omitted to avoid memory concerns with large outputs
+ * (images, plots, DataFrames). To add output restoration later, change the options to:
+ * { includeOutputs: true, includeMetadata: true }
+ */
+export function cellToCellDtoForRestore(cell: IPositronNotebookCell): ICellDto2 {
+	return cellToCellDtoBase(cell, { includeOutputs: false, includeMetadata: true });
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
@@ -85,7 +85,7 @@
 	gap: 8px;
 }
 
-.deletion-sentinel-undo,
+.deletion-sentinel-restore,
 .deletion-sentinel-dismiss {
 	min-width: 50px;
 	padding: 2px 8px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
@@ -5,7 +5,7 @@
 
 .deletion-sentinel {
 	position: relative;
-	margin-left: 12px; /* Match cell left margin */
+	margin-left: 19px; /* 12px base + 7px to align with cell content area (no selection bar) */
 	/* Match spacing that AddCellButtons provides between live cells */
 	margin-bottom: calc(
 		var(--_positron-notebook-add-cell-buttons-height) +
@@ -41,24 +41,12 @@
 	z-index: 2;
 }
 
-/* Left selection bar - greyed out version */
-.deletion-sentinel-selection-bar {
-	width: 7px;
-	background-color: var(--vscode-editorWidget-border);
-	opacity: 0.5;
-	border-top-left-radius: var(--vscode-positronNotebook-cell-radius);
-	border-bottom-left-radius: var(--vscode-positronNotebook-cell-radius);
-	flex-shrink: 0;
-}
-
 /* Main cell container */
 .deletion-sentinel-cell-container {
 	flex: 1;
 	background: var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background));
 	border: var(--vscode-positronNotebook-border);
-	border-left: none;
-	border-top-right-radius: var(--vscode-positronNotebook-cell-radius);
-	border-bottom-right-radius: var(--vscode-positronNotebook-cell-radius);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
 	opacity: 0.6; /* Make the whole cell look faded */
 	overflow: hidden;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.deletion-sentinel {
+	position: relative;
+	margin-left: 12px; /* Match cell left margin */
+	/* Match spacing that AddCellButtons provides between live cells */
+	margin-bottom: calc(
+		var(--_positron-notebook-add-cell-buttons-height) +
+			var(--_positron-notebook-cell-gap)
+	);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+	animation: sentinel-slide-in 0.3s ease-out;
+}
+
+/* Red deletion flash animation overlay */
+.deletion-sentinel-flash {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: var(--vscode-diffEditor-removedLineBackground, var(--vscode-diffEditor-removedTextBackground));
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+	pointer-events: none;
+	animation: deletion-flash-fade 2s ease-in-out forwards;
+	z-index: 1;
+}
+
+@keyframes deletion-flash-fade {
+	0% { opacity: 0; }
+	25% { opacity: 0.3; }
+	100% { opacity: 0; }
+}
+
+.deletion-sentinel-content {
+	position: relative;
+	display: flex;
+	z-index: 2;
+}
+
+/* Left selection bar - greyed out version */
+.deletion-sentinel-selection-bar {
+	width: 7px;
+	background-color: var(--vscode-editorWidget-border);
+	opacity: 0.5;
+	border-top-left-radius: var(--vscode-positronNotebook-cell-radius);
+	border-bottom-left-radius: var(--vscode-positronNotebook-cell-radius);
+	flex-shrink: 0;
+}
+
+/* Main cell container */
+.deletion-sentinel-cell-container {
+	flex: 1;
+	background: var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background));
+	border: var(--vscode-positronNotebook-border);
+	border-left: none;
+	border-top-right-radius: var(--vscode-positronNotebook-cell-radius);
+	border-bottom-right-radius: var(--vscode-positronNotebook-cell-radius);
+	opacity: 0.6; /* Make the whole cell look faded */
+	overflow: hidden;
+}
+
+/* Header section with message and actions */
+.deletion-sentinel-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 6px 12px;
+	background: var(--vscode-notifications-background);
+	border-bottom: 1px solid var(--vscode-widget-border);
+	gap: 12px;
+}
+
+.deletion-sentinel-message {
+	color: var(--vscode-foreground);
+	font-size: 12px;
+	opacity: 0.8;
+}
+
+.deletion-sentinel-actions {
+	display: flex;
+	gap: 8px;
+}
+
+.deletion-sentinel-undo,
+.deletion-sentinel-dismiss {
+	min-width: 50px;
+	padding: 2px 8px;
+	font-size: 11px;
+}
+
+/* Code preview section */
+.deletion-sentinel-code-preview {
+	padding: 8px 16px;
+	min-height: 2em;
+	max-height: 4.5em; /* Roughly 3 lines */
+	overflow: hidden;
+	position: relative;
+	font-family: var(
+		--vscode-positronNotebook-text-output-font-family,
+		var(--monaco-monospace-font)
+	);
+	font-size: var(--vscode-positronNotebook-text-output-font-size);
+}
+
+/* Fade out effect for truncated content */
+.deletion-sentinel-code-preview::after {
+	content: '';
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: 1.5em;
+	background: linear-gradient(
+		to bottom,
+		transparent,
+		var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background))
+	);
+	pointer-events: none;
+}
+
+/* Code/content preview - plain greyed-out text */
+.deletion-sentinel-code-preview .deletion-sentinel-code-text {
+	margin: 0;
+	white-space: pre;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	opacity: 0.7;
+	color: var(--vscode-foreground);
+}
+
+/* Empty cell placeholder */
+.deletion-sentinel-code-preview .empty-cell-placeholder {
+	font-style: italic;
+	opacity: 0.5;
+	color: var(--vscode-foreground);
+}
+
+@keyframes sentinel-slide-in {
+	from {
+		opacity: 0;
+		transform: translateY(-8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+/* High contrast theme support */
+.hc-black .deletion-sentinel-cell-container,
+.hc-light .deletion-sentinel-cell-container {
+	border: 2px solid var(--vscode-widget-border);
+	opacity: 0.8;
+}
+
+.hc-black .deletion-sentinel-flash,
+.hc-light .deletion-sentinel-flash {
+	background-color: transparent;
+	border: 2px solid var(--vscode-diffEditor-removedLineBackground, var(--vscode-editorOverviewRuler-deletedForeground));
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+	.deletion-sentinel {
+		animation: none;
+	}
+	.deletion-sentinel-flash {
+		animation: none;
+		opacity: 0;
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './DeletionSentinel.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { IDeletionSentinel } from '../IPositronNotebookInstance.js';
+import { ActionButton } from '../utilityComponents/ActionButton.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { POSITRON_NOTEBOOK_DELETION_SENTINEL_TIMEOUT_KEY } from '../positronNotebookExperimentalConfig.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+
+interface DeletionSentinelProps {
+	sentinel: IDeletionSentinel;
+	commandService: ICommandService;
+	configurationService: IConfigurationService;
+}
+
+export const DeletionSentinel: React.FC<DeletionSentinelProps> = ({
+	sentinel,
+	commandService,
+	configurationService
+}) => {
+	const instance = useNotebookInstance();
+	const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
+
+	React.useEffect(() => {
+		// Auto-dismiss after timeout (configured via settings)
+		const timeout = configurationService.getValue<number>(POSITRON_NOTEBOOK_DELETION_SENTINEL_TIMEOUT_KEY) ?? 10000;
+
+		if (timeout > 0) {
+			timeoutRef.current = setTimeout(() => {
+				instance.removeDeletionSentinel(sentinel.id);
+			}, timeout);
+		}
+
+		return () => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, [sentinel.id, instance, configurationService]);
+
+	const handleUndo = async () => {
+		// Clear timeout
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
+		// Trigger undo command
+		await commandService.executeCommand('undo');
+
+		// Remove sentinel
+		instance.removeDeletionSentinel(sentinel.id);
+	};
+
+	const handleDismiss = () => {
+		instance.removeDeletionSentinel(sentinel.id);
+	};
+
+	const cellType = sentinel.cellKind === CellKind.Code ? 'Code' : 'Markdown';
+
+	return (
+		<div className="deletion-sentinel positron-notebook-cell">
+			<div className="deletion-sentinel-flash" />
+			<div className="deletion-sentinel-content">
+				{/* Left selection bar area */}
+				<div className="deletion-sentinel-selection-bar" />
+
+				{/* Main cell content */}
+				<div className="deletion-sentinel-cell-container">
+					{/* Header with cell info and actions */}
+					<div className="deletion-sentinel-header">
+						<span className="deletion-sentinel-message">
+							{localize('notebook.cellDeleted', "{0} cell {1} deleted", cellType, sentinel.originalIndex + 1)}
+						</span>
+						<div className="deletion-sentinel-actions">
+							<ActionButton
+								ariaLabel={localize('notebook.undo', "Undo")}
+								className="deletion-sentinel-undo"
+								onPressed={handleUndo}
+							>
+								{localize('notebook.undo', "Undo")}
+							</ActionButton>
+							<ActionButton
+								ariaLabel={localize('notebook.dismiss', "Dismiss")}
+								className="deletion-sentinel-dismiss"
+								onPressed={handleDismiss}
+							>
+								{localize('notebook.dismiss', "Dismiss")}
+							</ActionButton>
+						</div>
+					</div>
+
+					{/* Code preview - displayed as plain greyed-out text */}
+					<div className="deletion-sentinel-code-preview">
+						{sentinel.cellContent ? (
+							<pre className="deletion-sentinel-code-text">
+								{sentinel.cellContent}
+							</pre>
+						) : (
+							<div className="empty-cell-placeholder">
+								{localize('notebook.emptyCell', "(empty cell)")}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx
@@ -69,9 +69,6 @@ export const DeletionSentinel: React.FC<DeletionSentinelProps> = ({
 		<div className="deletion-sentinel positron-notebook-cell">
 			<div className="deletion-sentinel-flash" />
 			<div className="deletion-sentinel-content">
-				{/* Left selection bar area */}
-				<div className="deletion-sentinel-selection-bar" />
-
 				{/* Main cell content */}
 				<div className="deletion-sentinel-cell-container">
 					{/* Header with cell info and actions */}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -170,14 +170,15 @@
 	position: relative;
 }
 
-.positron-notebook-cell.assistant-highlight::before {
+.positron-notebook-cell.assistant-highlight::after {
 	content: "";
 	position: absolute;
 	inset: 0;
 	background-color: var(--vscode-button-background);
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 	pointer-events: none;
-	z-index: 0;
+	/* Must be higher than cell content (action bar is z-index: 10) to be visible as overlay */
+	z-index: 15;
 	opacity: 0;
 	animation: assistant-flash 1.5s ease-in-out;
 	animation-fill-mode: forwards;
@@ -188,13 +189,29 @@
 	25%, 75% { opacity: 0.2; }
 }
 
-/* Use border-based highlight for high contrast themes instead of background overlay */
-.hc-black .positron-notebook-cell.assistant-highlight::before,
-.hc-light .positron-notebook-cell.assistant-highlight::before {
+/* Operation-specific highlight colors - all use the same animation */
+.positron-notebook-cell.assistant-highlight.assistant-highlight-add::after {
+	background-color: var(--vscode-diffEditor-insertedLineBackground, var(--vscode-diffEditor-insertedTextBackground));
+}
+
+.positron-notebook-cell.assistant-highlight.assistant-highlight-modify::after {
+	background-color: var(--vscode-button-background);
+}
+
+/* Note: Delete animation moved to sentinel implementation in Phase 5 */
+
+/* High contrast theme variants - use border instead of background overlay */
+.hc-black .positron-notebook-cell.assistant-highlight::after,
+.hc-light .positron-notebook-cell.assistant-highlight::after {
 	background-color: transparent;
 	border: 2px solid var(--vscode-focusBorder);
 	animation: assistant-flash-hc 1.5s ease-in-out;
 	animation-fill-mode: forwards;
+}
+
+.hc-black .positron-notebook-cell.assistant-highlight.assistant-highlight-add::after,
+.hc-light .positron-notebook-cell.assistant-highlight.assistant-highlight-add::after {
+	border-color: var(--vscode-diffEditor-insertedLineBackground, var(--vscode-editorOverviewRuler-addedForeground));
 }
 
 @keyframes assistant-flash-hc {
@@ -202,8 +219,9 @@
 	25%, 75% { opacity: 1; }
 }
 
+/* Accessibility - disable animations for users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
-	.positron-notebook-cell.assistant-highlight::before {
+	.positron-notebook-cell.assistant-highlight::after {
 		animation: none;
 		opacity: 0;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
@@ -31,7 +31,8 @@ export function getNotebookInstanceFromEditorPane(editorPane?: IEditorPane): IPo
 		return undefined;
 	}
 
-	// Extract the notebook instance from the editor
-	const activeNotebook = (editorPane as PositronNotebookEditor).notebookInstance;
+	// Extract the notebook instance from the editor.
+	// The cast to IPositronNotebookInstance is safe because PositronNotebookInstance implements the interface.
+	const activeNotebook = (editorPane as PositronNotebookEditor).notebookInstance as IPositronNotebookInstance | undefined;
 	return activeNotebook;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookExperimentalConfig.ts
@@ -18,6 +18,9 @@ export const POSITRON_NOTEBOOK_ENABLED_KEY = 'positron.notebook.enabled';
 // Configuration key for assistant auto-follow setting
 export const POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY = 'positron.notebook.assistant.autoFollow';
 
+// Configuration key for deletion sentinel timeout setting
+export const POSITRON_NOTEBOOK_DELETION_SENTINEL_TIMEOUT_KEY = 'positron.notebook.deletionSentinel.timeout';
+
 /**
  * Retrieves the value of the configuration setting that determines whether to enable
  * the Positron Notebook editor.
@@ -57,6 +60,16 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.notebook.assistant.autoFollow',
 				'Automatically scroll to cells modified by the AI assistant. When enabled, cells modified outside the viewport will be automatically scrolled into view and highlighted.'
+			),
+		},
+		[POSITRON_NOTEBOOK_DELETION_SENTINEL_TIMEOUT_KEY]: {
+			type: 'number',
+			default: 10000,
+			minimum: 0,
+			maximum: 60000,
+			markdownDescription: localize(
+				'positron.notebook.deletionSentinel.timeout',
+				'Time in milliseconds before deletion sentinels auto-dismiss (0 to disable auto-dismiss).'
 			),
 		},
 	},

--- a/thoughts/shared/plans/2026-01-07-fix-deletion-sentinel-undo.md
+++ b/thoughts/shared/plans/2026-01-07-fix-deletion-sentinel-undo.md
@@ -1,8 +1,28 @@
-# Fix Deletion Sentinel Undo Button Implementation Plan
+# Fix Deletion Sentinel - Restore Button Implementation Plan
 
 ## Overview
 
-The undo button on the deletion sentinel (visual feedback for deleted notebook cells) currently behaves the same as the dismiss button - it removes the sentinel but doesn't actually restore the deleted cell. This is because the undo command may not succeed if there's nothing to undo, but the sentinel is removed regardless.
+The "Undo" button on the deletion sentinel (visual feedback for deleted notebook cells) currently behaves the same as the dismiss button - it removes the sentinel but doesn't actually restore the deleted cell. This is because the undo command may not succeed if there's nothing to undo, but the sentinel is removed regardless.
+
+**Key Insight**: The VS Code undo/redo service only supports undoing the most recent operation (`undo(resource)`), not targeting specific elements. This means if the user deletes multiple cells or performs other operations after deletion, clicking "undo" on a specific sentinel won't restore that particular cell.
+
+## Solution: "Restore" Instead of "Undo"
+
+We will change the approach from "undo" to "restore":
+- Store the complete cell data (content, type, language, metadata) when creating the sentinel
+- **Note**: Outputs are intentionally omitted in the initial implementation to avoid memory concerns with large outputs. The design allows easy addition of output restoration later.
+- The button directly re-inserts the cell at a smart position, bypassing the undo stack
+- This allows users to selectively restore any deleted cell, regardless of what other operations have occurred
+
+### Benefits:
+- **Predictable**: Click restore on cell 3's sentinel → cell 3 is restored
+- **Selective**: Users can choose which cells to restore when multiple are deleted
+- **Independent**: Works regardless of undo stack state
+
+### Trade-offs:
+- Restoration creates a new cell (new handle), not technically "undoing"
+- If user presses Ctrl+Z after restore, it undoes the restoration (expected behavior)
+- The original deletion remains in the undo stack
 
 ## Current State Analysis
 
@@ -11,117 +31,194 @@ When the AI assistant deletes a cell, it creates a deletion sentinel that shows:
 - An "Undo" button that should restore the cell
 - A "Dismiss" button that removes the sentinel
 
-### Key Discoveries:
-- The undo button executes the 'undo' command but doesn't verify success (`DeletionSentinel.tsx:60`)
-- The sentinel is removed immediately after the command, regardless of outcome (`DeletionSentinel.tsx:63`)
-- There's no automatic cleanup of sentinels when cells are restored through global undo
-- The undo stack may be empty or may contain unrelated operations
+### Key Files:
+- `src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts` - IDeletionSentinel interface
+- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts` - addDeletionSentinel, removeDeletionSentinel
+- `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx` - React component
+- `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts` - $deleteCell API
 
-### Root Cause:
-The deletion sentinel is created AFTER the cell deletion is complete, which means:
-1. The undo stack already has the deletion operation when the sentinel is created
-2. BUT if the user performs other operations after deletion, those go on the undo stack
-3. When clicking the sentinel's undo button, it undoes the LAST operation, not necessarily the deletion
+### Existing Patterns:
+- `cellToCellDto2()` in `cellClipboardUtils.ts` - converts cell to serializable format
+- `pasteCells()` in `PositronNotebookInstance.ts` - inserts cells using `textModel.applyEdits`
+
+### Current Gap in cellToCellDto2:
+The existing `cellToCellDto2()` function does NOT capture important metadata:
+```typescript
+// Current implementation loses:
+mime: undefined,           // Should be: cellModel.mime
+metadata: {},              // Should be: cellModel.metadata (cell tags, custom properties)
+internalMetadata: {},      // Should be: cellModel.internalMetadata (execution order, timing, success)
+collapseState: undefined   // Should be: cellModel.collapseState (UI collapse state)
+```
+
+This needs to be fixed for proper cell restoration (see Phase 1).
 
 ## Desired End State
 
 After implementation:
-1. The undo button should only restore the specific deleted cell it represents
-2. The sentinel should only be removed if the cell was successfully restored
-3. The fix should handle cases where the undo stack has changed since deletion
-4. Global undo operations should also clean up relevant sentinels
+1. The "Restore" button restores the specific deleted cell it represents
+2. Multiple sentinels can be restored in any order
+3. The sentinel is removed after successful restoration
+4. Global undo (Ctrl+Z) that happens to restore a deleted cell also cleans up the corresponding sentinel
 
 ### Success Verification:
 - Delete a cell via AI assistant → sentinel appears
-- Click undo button on sentinel → cell is restored and sentinel disappears
-- Delete a cell, perform other operations, click undo on sentinel → cell is restored (not the other operations)
+- Click "Restore" button on sentinel → cell is restored at original position and sentinel disappears
+- Delete cells 3, 5, and 7 → click restore on cell 5's sentinel → only cell 5 is restored
+- Delete a cell, perform other operations, click "Restore" → cell is still restored correctly
 - Delete a cell, use global Ctrl+Z → cell is restored AND sentinel is automatically removed
 
 ## What We're NOT Doing
 
-- Not changing the visual design of deletion sentinels
+- Not changing the visual design of deletion sentinels (beyond button label)
 - Not modifying the timeout behavior
 - Not changing how AI assistant triggers deletions
 - Not implementing a custom undo stack
 
-## Implementation Approach
+---
 
-We need to make the deletion sentinel's undo operation more intelligent by:
-1. Storing the actual undo element reference when creating the sentinel
-2. Using that specific element for targeted undo
-3. Verifying restoration success before removing the sentinel
-4. Automatically cleaning up sentinels when cells are restored via any undo path
-
-## Phase 1: Store Undo Element with Sentinel
+## Phase 1: Store Full Cell Data with Sentinel
 
 ### Overview
-Capture and store the undo element created by the deletion operation so we can undo it specifically.
+Update the sentinel interface and creation to store complete cell data for restoration. This includes:
+1. Creating a new `cellToCellDtoForRestore()` function that captures all metadata (but omits outputs for now)
+2. Updating the sentinel interface to store this data
+3. Adding the restore functionality
+
+### Design Decision: Outputs Omitted Initially
+Outputs are intentionally omitted to avoid memory concerns with large outputs (images, plots, DataFrames). The design allows easy addition later by:
+- Changing `outputs: []` to `outputs: cellModel.outputs.map(...)` in the capture function
+- No other changes needed - the ICellDto2 structure already supports outputs
+- Make sure to add a comment in the code explaining this decision for future maintainers.
 
 ### Changes Required:
 
-#### 1. Update IDeletionSentinel Interface
+#### 1. Refactor cellToCellDto2 with Base Function
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts`
+**Changes**: Refactor existing function into a base function with options, then expose two specialized functions for clipboard and restore use cases.
+
+```typescript
+/**
+ * Options for controlling what cell data is preserved during conversion.
+ */
+interface CellDtoOptions {
+	/** Include cell outputs (images, plots, etc.) - can be large */
+	includeOutputs?: boolean;
+	/** Include cell metadata (mime, tags, execution info, collapse state) */
+	includeMetadata?: boolean;
+}
+
+/**
+ * Base function for converting a Positron notebook cell to ICellDto2 format.
+ * Use the specialized functions `cellToCellDto2` or `cellToCellDtoForRestore` instead.
+ */
+function cellToCellDtoBase(cell: IPositronNotebookCell, options: CellDtoOptions): ICellDto2 {
+	const cellModel = cell.model;
+
+	return {
+		source: cell.getContent(),
+		language: cellModel.language,
+		mime: options.includeMetadata ? cellModel.mime : undefined,
+		cellKind: cellModel.cellKind,
+		outputs: options.includeOutputs
+			? cellModel.outputs.map(output => ({
+				outputId: output.outputId,
+				outputs: output.outputs.map(item => ({
+					mime: item.mime,
+					data: item.data
+				}))
+			}))
+			: [],
+		metadata: options.includeMetadata ? cellModel.metadata : {},
+		internalMetadata: options.includeMetadata ? cellModel.internalMetadata : {},
+		collapseState: options.includeMetadata ? cellModel.collapseState : undefined
+	};
+}
+
+/**
+ * Converts a Positron notebook cell to ICellDto2 format for clipboard storage.
+ * Preserves outputs for pasting but omits metadata.
+ */
+export function cellToCellDto2(cell: IPositronNotebookCell): ICellDto2 {
+	return cellToCellDtoBase(cell, { includeOutputs: true, includeMetadata: false });
+}
+
+/**
+ * Converts a Positron notebook cell to ICellDto2 format for restoration.
+ * Preserves metadata for faithful restoration but omits outputs to save memory.
+ *
+ * To add output restoration later, change to: { includeOutputs: true, includeMetadata: true }
+ */
+export function cellToCellDtoForRestore(cell: IPositronNotebookCell): ICellDto2 {
+	return cellToCellDtoBase(cell, { includeOutputs: false, includeMetadata: true });
+}
+```
+
+**Why this approach?** Using a base function with options:
+- Centralizes the cell-to-DTO conversion logic
+- Makes it easy to adjust what's preserved for each use case
+- Allows future expansion (e.g., adding output restoration by changing one flag)
+- Keeps the existing `cellToCellDto2` behavior unchanged for clipboard operations
+
+**Implementation note:** Add a file-level comment or JSDoc explaining why outputs are omitted for restore (memory concerns) and how to enable them in the future by changing the options flag.
+
+#### 2. Update IDeletionSentinel Interface
 **File**: `src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts`
-**Changes**: Add undo element reference to the interface
+**Changes**: Add cell data for restoration
 
 ```typescript
+import { ICellDto2, CellKind } from '../../notebook/common/notebookCommon.js';
+
 export interface IDeletionSentinel {
+	/** Unique identifier for the sentinel */
 	id: string;
+	/** The original index where the cell was deleted */
 	originalIndex: number;
+	/** Timestamp when the sentinel was created */
 	timestamp: number;
-	cellContent: string;
+	/** Preview content for display (first few lines) */
+	previewContent: string;
+	/** The type of cell that was deleted */
 	cellKind: CellKind;
+	/** The language of the cell (for code cells) */
 	language?: string;
-	undoElement?: IUndoRedoElement; // Add this line
+	/** Complete cell data for restoration (outputs omitted to save memory) */
+	cellData: ICellDto2;
 }
 ```
 
-#### 2. Capture Undo Element During Deletion
-**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
-**Changes**: Store the last undo element after deletion
+#### 3. Update addDeletionSentinel Signature
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts`
+**Changes**: Update method signature in interface
 
 ```typescript
-// In the deleteCell method, after the deleteCells call:
-deleteCell(cellToDelete?: IPositronNotebookCell): IUndoRedoElement | undefined {
-	const cell = cellToDelete ?? getActiveCell(this.selectionStateMachine.state.get());
-
-	if (!cell) {
-		return undefined;
-	}
-
-	// Get the undo stack before deletion
-	const undoElements = this.undoRedoService.getElements(this.uri);
-	const pastStackHeight = undoElements.past.length;
-
-	this.deleteCells([cell]);
-
-	// Get the new undo element created by the deletion
-	const newUndoElements = this.undoRedoService.getElements(this.uri);
-	if (newUndoElements.past.length > pastStackHeight) {
-		return newUndoElements.past[newUndoElements.past.length - 1];
-	}
-
-	return undefined;
-}
+/**
+ * Add a deletion sentinel at the specified cell index.
+ * @param cellIndex The index where the cell was deleted
+ * @param cellData The complete cell data for potential restoration
+ */
+addDeletionSentinel(cellIndex: number, cellData: ICellDto2): void;
 ```
 
-#### 3. Pass Undo Element to Sentinel
+#### 4. Update addDeletionSentinel Implementation
 **File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
-**Changes**: Update addDeletionSentinel to accept undo element
+**Changes**: Store full cell data and generate preview
 
 ```typescript
-addDeletionSentinel(originalIndex: number, cellContent: string, cellKind: CellKind, language?: string, undoElement?: IUndoRedoElement): void {
-	// Truncate content to first 3 lines for preview
-	const lines = cellContent.split('\n');
-	const truncatedContent = lines.slice(0, 3).join('\n');
+addDeletionSentinel(cellIndex: number, cellData: ICellDto2): void {
+	// Generate preview content (first 3 lines)
+	const lines = cellData.source.split('\n');
+	const previewContent = lines.slice(0, 3).join('\n');
+	const truncated = lines.length > 3;
 
 	const sentinel: IDeletionSentinel = {
-		id: `sentinel-${Date.now()}-${originalIndex}`,
-		originalIndex,
+		id: `sentinel-${Date.now()}-${cellIndex}`,
+		originalIndex: cellIndex,
 		timestamp: Date.now(),
-		cellContent: truncatedContent,
-		cellKind,
-		language,
-		undoElement // Store the undo element
+		previewContent: truncated ? previewContent + '\n...' : previewContent,
+		cellKind: cellData.cellKind,
+		language: cellData.language,
+		cellData  // Store complete data for restoration
 	};
 
 	const current = this._deletionSentinels.get();
@@ -129,11 +226,68 @@ addDeletionSentinel(originalIndex: number, cellContent: string, cellKind: CellKi
 }
 ```
 
-#### 4. Update AI Assistant Integration
-**File**: `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts`
-**Changes**: Capture and pass undo element
+#### 5. Add restoreCell Method
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
+**Changes**: Add method to restore a cell from sentinel data
 
 ```typescript
+/**
+ * Restores a deleted cell from its sentinel data.
+ * @param sentinel The deletion sentinel containing cell data to restore
+ */
+restoreCell(sentinel: IDeletionSentinel): void {
+	this._assertTextModel();
+
+	const textModel = this.textModel;
+	const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
+
+	// Clamp insertion index to valid range (handles case where notebook was modified)
+	const maxIndex = textModel.cells.length;
+	const insertIndex = Math.min(sentinel.originalIndex, maxIndex);
+
+	const focusRange = { start: insertIndex, end: insertIndex + 1 };
+
+	textModel.applyEdits([
+		{
+			editType: CellEditType.Replace,
+			index: insertIndex,
+			count: 0,
+			cells: [sentinel.cellData]
+		}
+	],
+		true, // synchronous - ensures operations are serialized
+		{ kind: SelectionStateType.Index, focus: focusRange, selections: [focusRange] },
+		() => ({ kind: SelectionStateType.Index, focus: focusRange, selections: [focusRange] }),
+		undefined,
+		computeUndoRedo
+	);
+
+	this._onDidChangeContent.fire();
+
+	// Remove the sentinel after successful restoration
+	this.removeDeletionSentinel(sentinel.id);
+}
+```
+
+#### 6. Update Interface to Expose restoreCell
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts`
+**Changes**: Add method to interface
+
+```typescript
+/**
+ * Restores a deleted cell from its sentinel data.
+ * @param sentinel The deletion sentinel containing cell data to restore
+ */
+restoreCell(sentinel: IDeletionSentinel): void;
+```
+
+#### 7. Update AI Assistant Integration
+**File**: `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts`
+**Changes**: Use cellToCellDtoForRestore to capture full cell data
+
+```typescript
+import { cellToCellDtoForRestore } from '../../../contrib/positronNotebook/browser/cellClipboardUtils.js';
+
 async $deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
 	const instance = this._getInstanceByUri(notebookUri);
 	if (!instance) {
@@ -147,16 +301,14 @@ async $deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
 
 	const cellToDelete = cells[cellIndex];
 
-	// Capture cell content before deletion
-	const cellContent = cellToDelete.getContent();
-	const cellKind = cellToDelete.kind;
-	const language = cellToDelete.isCodeCell() ? cellToDelete.model.language : undefined;
+	// Capture complete cell data before deletion (outputs omitted for memory)
+	const cellData = cellToCellDtoForRestore(cellToDelete);
 
-	// Delete the cell and capture the undo element
-	const undoElement = instance.deleteCell(cellToDelete);
+	// Delete the cell
+	instance.deleteCell(cellToDelete);
 
-	// Add sentinel with cell content and undo element
-	instance.addDeletionSentinel(cellIndex, cellContent, cellKind, language, undoElement);
+	// Add sentinel with complete cell data
+	instance.addDeletionSentinel(cellIndex, cellData);
 }
 ```
 
@@ -165,69 +317,58 @@ async $deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
 #### Automated Verification:
 - [ ] TypeScript compilation passes: `npm run compile`
 - [ ] No linting errors: `npm run lint`
-- [ ] Unit tests pass: `npm test`
 
 #### Manual Verification:
 - [ ] Deletion sentinels still appear when AI assistant deletes cells
-- [ ] Sentinel data structure contains undo element reference
+- [ ] Sentinel displays correct preview content
 - [ ] No regressions in basic deletion functionality
 
 ---
 
-## Phase 2: Implement Targeted Undo in Sentinel
+## Phase 2: Update Sentinel Component to Use Restore
 
 ### Overview
-Update the deletion sentinel component to use the stored undo element for targeted restoration.
+Update the DeletionSentinel React component to call `restoreCell` instead of the undo command.
 
 ### Changes Required:
 
 #### 1. Update DeletionSentinel Component
 **File**: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx`
-**Changes**: Implement targeted undo with verification
+**Changes**: Replace undo with restore, update button label
 
 ```typescript
-const handleUndo = async () => {
-	// Clear timeout
+const handleRestore = () => {
+	// Clear auto-dismiss timeout
 	if (timeoutRef.current) {
 		clearTimeout(timeoutRef.current);
 	}
 
-	try {
-		// Check if we have a specific undo element for this deletion
-		if (sentinel.undoElement) {
-			// Get the undo/redo service
-			const undoRedoService = commandService._getService(IUndoRedoService);
-
-			// Check if the element is still in the undo stack
-			const elements = undoRedoService.getElements(instance.uri);
-			const elementInStack = elements.past.includes(sentinel.undoElement);
-
-			if (elementInStack) {
-				// Undo this specific element
-				await undoRedoService.undoTo(instance.uri, sentinel.undoElement);
-				// Remove sentinel after successful undo
-				instance.removeDeletionSentinel(sentinel.id);
-				return;
-			}
-		}
-
-		// Fallback: Try general undo if no specific element or not in stack
-		// This handles the case where user may have already partially undone
-		const cellsBefore = instance.cells.get().length;
-		await commandService.executeCommand('undo');
-		const cellsAfter = instance.cells.get().length;
-
-		// Only remove sentinel if a cell was actually restored
-		if (cellsAfter > cellsBefore) {
-			instance.removeDeletionSentinel(sentinel.id);
-		} else {
-			// Show a message that undo is not available
-			console.warn('Unable to undo cell deletion - operation may have already been undone');
-		}
-	} catch (error) {
-		console.error('Failed to undo cell deletion:', error);
-	}
+	// Restore the cell (this also removes the sentinel)
+	instance.restoreCell(sentinel);
 };
+
+// In the JSX, update the button:
+<ActionButton
+	ariaLabel={localize('notebook.restore', "Restore")}
+	className="deletion-sentinel-restore"
+	onPressed={handleRestore}
+>
+	{localize('notebook.restore', "Restore")}
+</ActionButton>
+```
+
+#### 2. Update CSS Class (if needed)
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.css`
+**Changes**: Rename `.deletion-sentinel-undo` to `.deletion-sentinel-restore` (or keep both for compatibility)
+
+#### 3. Update Sentinel Display to Use previewContent
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx`
+**Changes**: Use `sentinel.previewContent` instead of `sentinel.cellContent`
+
+```typescript
+<pre className="deletion-sentinel-code-text">
+	{sentinel.previewContent}
+</pre>
 ```
 
 ### Success Criteria:
@@ -237,73 +378,67 @@ const handleUndo = async () => {
 - [ ] Component renders without errors
 
 #### Manual Verification:
-- [ ] Clicking undo on sentinel restores the specific deleted cell
-- [ ] Sentinel is only removed if restoration succeeds
-- [ ] Works correctly even after other operations are performed
-- [ ] Fallback behavior works when undo element is not available
+- [ ] Button displays "Restore" label
+- [ ] Clicking "Restore" restores the cell at the correct position
+- [ ] Sentinel is removed after restore
+- [ ] Multiple sentinels can be restored in any order
+- [ ] Restore works correctly even after other operations
 
 ---
 
 ## Phase 3: Auto-cleanup Sentinels on Global Undo
 
 ### Overview
-Automatically remove deletion sentinels when cells are restored through any undo path (Ctrl+Z, menu, etc.).
+When the user performs a global undo (Ctrl+Z) that happens to restore a deleted cell, automatically clean up the corresponding sentinel.
 
 ### Changes Required:
 
 #### 1. Track Cell Restoration in _syncCells
 **File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
-**Changes**: Detect restored cells and clean up sentinels
+**Changes**: Detect restored cells and clean up matching sentinels by comparing content
 
 ```typescript
-private _syncCells(): void {
+private _syncCells() {
 	this._assertTextModel();
+	const modelCells = this.textModel.cells;
 
-	const textModel = this.textModel;
-	const modelCells = textModel.cells;
+	// ... existing cell mapping logic ...
 
-	// Create map of existing cells before sync
-	const existingCellsMap = new Map<number, IPositronNotebookCell>();
-	for (const cell of this.cells.get()) {
-		existingCellsMap.set(cell.model.handle, cell);
-	}
-
-	// Track indices of newly appearing cells
-	const restoredIndices: number[] = [];
-
-	// Build the new cells array
-	const newCells: IPositronNotebookCell[] = [];
-	modelCells.forEach((modelCell, index) => {
-		let cell = existingCellsMap.get(modelCell.handle);
-		if (cell) {
-			cell.setIndex(index);
-			existingCellsMap.delete(modelCell.handle);
-		} else {
-			cell = this.cellAt(index);
-			// This is a newly appearing cell (could be from undo)
-			restoredIndices.push(index);
-		}
-		newCells.push(cell);
-	});
-
-	// Get the current operation type
 	const currentOp = this.getAndResetCurrentOperation();
 
-	// Clean up sentinels for restored cells during undo
-	if (currentOp === NotebookOperationType.Undo && restoredIndices.length > 0) {
-		const sentinels = this._deletionSentinels.get();
-		const remainingSentinels = sentinels.filter(sentinel => {
-			// Remove sentinels whose original index matches restored cells
-			return !restoredIndices.includes(sentinel.originalIndex);
-		});
-
-		if (remainingSentinels.length < sentinels.length) {
-			this._deletionSentinels.set(remainingSentinels, undefined);
-		}
+	// Check for sentinel cleanup when cells are added during undo
+	if (currentOp === NotebookOperationType.Undo) {
+		this._cleanupSentinelsForRestoredCells(newlyAddedCells);
 	}
 
-	// Rest of the existing _syncCells logic...
-	// [existing code continues]
+	// ... rest of existing logic ...
+}
+
+/**
+ * Cleans up sentinels for cells that have been restored via undo.
+ * Matches by comparing cell content since handles change on restoration.
+ */
+private _cleanupSentinelsForRestoredCells(restoredCells: IPositronNotebookCell[]): void {
+	if (restoredCells.length === 0) {
+		return;
+	}
+
+	const sentinels = this._deletionSentinels.get();
+	if (sentinels.length === 0) {
+		return;
+	}
+
+	// Build a set of restored cell contents for quick lookup
+	const restoredContents = new Set(restoredCells.map(cell => cell.getContent()));
+
+	// Remove sentinels whose cell content matches a restored cell
+	const remainingSentinels = sentinels.filter(sentinel => {
+		return !restoredContents.has(sentinel.cellData.source);
+	});
+
+	if (remainingSentinels.length < sentinels.length) {
+		this._deletionSentinels.set(remainingSentinels, undefined);
+	}
 }
 ```
 
@@ -311,7 +446,7 @@ private _syncCells(): void {
 
 #### Automated Verification:
 - [ ] TypeScript compilation passes: `npm run compile`
-- [ ] Existing notebook tests still pass: `npm run test`
+- [ ] Existing notebook tests still pass
 
 #### Manual Verification:
 - [ ] Delete cell via AI, use Ctrl+Z → cell restored AND sentinel removed
@@ -321,146 +456,52 @@ private _syncCells(): void {
 
 ---
 
-## Phase 4: Add E2E Tests
-
-### Overview
-Add comprehensive end-to-end tests to verify the fix works correctly.
-
-### Changes Required:
-
-#### 1. Add Deletion Sentinel Undo Test
-**File**: `test/e2e/tests/notebooks-positron/notebook-deletion-sentinel.test.ts` (new file)
-**Changes**: Create comprehensive test suite
-
-```typescript
-import { test, expect } from '@playwright/test';
-import { Application } from '../../application';
-
-test.describe('Notebook Deletion Sentinels', () => {
-	let app: Application;
-
-	test.beforeEach(async ({ page }) => {
-		app = new Application(page);
-		await app.notebook.createNewNotebook();
-	});
-
-	test('undo button on sentinel restores deleted cell', async () => {
-		// Add a cell with content
-		await app.notebook.addCodeCell();
-		await app.notebook.typeInCell(0, 'print("test cell")');
-
-		// Delete via AI assistant (simulate)
-		await app.notebook.deleteCell(0, { viaAssistant: true });
-
-		// Verify sentinel appears
-		const sentinel = await app.page.locator('.deletion-sentinel');
-		await expect(sentinel).toBeVisible();
-
-		// Click undo on sentinel
-		await sentinel.locator('.deletion-sentinel-undo').click();
-
-		// Verify cell is restored
-		const cellContent = await app.notebook.getCellContent(0);
-		expect(cellContent).toBe('print("test cell")');
-
-		// Verify sentinel is removed
-		await expect(sentinel).not.toBeVisible();
-	});
-
-	test('global undo removes sentinel automatically', async () => {
-		// Add and delete a cell
-		await app.notebook.addCodeCell();
-		await app.notebook.typeInCell(0, 'print("test")');
-		await app.notebook.deleteCell(0, { viaAssistant: true });
-
-		// Verify sentinel appears
-		const sentinel = await app.page.locator('.deletion-sentinel');
-		await expect(sentinel).toBeVisible();
-
-		// Use global undo
-		await app.page.keyboard.press('ControlOrMeta+z');
-
-		// Verify cell is restored and sentinel removed
-		const cellContent = await app.notebook.getCellContent(0);
-		expect(cellContent).toBe('print("test")');
-		await expect(sentinel).not.toBeVisible();
-	});
-
-	test('undo after other operations still works', async () => {
-		// Setup: Create two cells
-		await app.notebook.addCodeCell();
-		await app.notebook.typeInCell(0, 'cell 1');
-		await app.notebook.addCodeCell();
-		await app.notebook.typeInCell(1, 'cell 2');
-
-		// Delete first cell via assistant
-		await app.notebook.deleteCell(0, { viaAssistant: true });
-
-		// Perform another operation (edit remaining cell)
-		await app.notebook.typeInCell(0, ' edited');
-
-		// Click undo on sentinel (should restore deleted cell, not undo edit)
-		const sentinel = await app.page.locator('.deletion-sentinel');
-		await sentinel.locator('.deletion-sentinel-undo').click();
-
-		// Verify: First cell restored, second cell still edited
-		expect(await app.notebook.getCellContent(0)).toBe('cell 1');
-		expect(await app.notebook.getCellContent(1)).toBe('cell 2 edited');
-
-		// Sentinel should be gone
-		await expect(sentinel).not.toBeVisible();
-	});
-});
-```
-
-### Success Criteria:
-
-#### Automated Verification:
-- [ ] All new tests pass: `npx playwright test notebook-deletion-sentinel.test.ts`
-- [ ] No regressions in existing tests: `npx playwright test notebooks-positron/`
-- [ ] Tests cover all edge cases
-
-#### Manual Verification:
-- [ ] Tests accurately reflect user experience
-- [ ] Test failures provide clear diagnostic information
-
----
-
 ## Testing Strategy
-
-### Unit Tests:
-- Test sentinel creation with undo element
-- Test undo element retrieval from undo service
-- Test sentinel cleanup logic in _syncCells
-
-### Integration Tests:
-- Test full flow from AI deletion to undo restoration
-- Test interaction between multiple sentinels
-- Test timeout vs manual dismissal vs undo
 
 ### Manual Testing Steps:
 1. Open a notebook with multiple cells
 2. Use AI assistant to delete a cell in the middle
 3. Verify sentinel appears with correct preview
-4. Click undo button → verify cell restored and sentinel removed
-5. Delete another cell, edit a different cell, then click undo on sentinel
-6. Verify only the deleted cell is restored
-7. Delete a cell, use Ctrl+Z → verify automatic sentinel cleanup
-8. Delete multiple cells → verify multiple sentinels work correctly
+4. Click "Restore" button → verify cell restored and sentinel removed
+5. Delete cells 3, 5, and 7 → verify 3 sentinels appear
+6. Click restore on cell 5's sentinel → verify only cell 5 is restored
+7. Verify sentinels for cells 3 and 7 are still present
+8. Delete a cell, use Ctrl+Z → verify automatic sentinel cleanup
+9. Delete a cell, perform other edits, click restore → verify cell still restores correctly
 
 ## Performance Considerations
 
-- Storing undo element references has minimal memory impact
-- Sentinel cleanup during _syncCells is O(n) where n is number of sentinels
-- No performance regression expected for normal notebook operations
+- **Outputs omitted**: Cell data capture intentionally omits outputs to avoid memory issues with large outputs (images, plots, DataFrames). Design allows easy addition later.
+- **Lightweight metadata**: The metadata we capture (internalMetadata, metadata, collapseState) is typically ~200-500 bytes per cell, negligible overhead.
+- Sentinel cleanup during _syncCells is O(n*m) where n=sentinels, m=restored cells (acceptable given small n,m)
+- Auto-dismiss timeout (default 10 seconds) limits how long sentinels consume memory
+
+## Edge Cases and Known Limitations
+
+### Handled Edge Cases:
+1. **Invalid insertion index**: If notebook is modified and original index is invalid, we clamp to the valid range (cell inserted at end if original position no longer exists)
+2. **Race conditions between restores**: `applyEdits` with `synchronous: true` ensures operations are serialized
+3. **Cell identity**: Restored cells get new handles/URIs (this is by design, same as paste behavior)
+
+### Known Limitations:
+1. **Outputs not restored**: Restored cells have empty outputs. User can re-execute to regenerate.
+2. **Content-based sentinel cleanup**: Global undo cleanup matches by cell content, which could have edge cases with duplicate cell content.
+3. **No sentinel recreation on restoration undo**: If user restores a cell then presses Ctrl+Z, the sentinel doesn't reappear.
+
+### Future Improvements (if needed):
+- Add output restoration with configurable size limits
+- Improve sentinel cleanup to use timestamp correlation in addition to content matching
 
 ## Migration Notes
 
-No migration needed - the change is backward compatible. Existing sentinels without undo elements will use the fallback behavior.
+This change is backward compatible:
+- The sentinel interface is extended, not changed incompatibly
+- Existing behavior (dismiss button, auto-timeout) remains unchanged
+- The "Undo" button becomes "Restore" with clearer semantics
 
 ## References
 
 - Original issue: User report of undo button not working
 - Related code: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx`
-- Undo/redo system: `src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts`
+- Cell clipboard utils: `src/vs/workbench/contrib/positronNotebook/browser/cellClipboardUtils.ts`
 - AI integration: `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts`

--- a/thoughts/shared/plans/2026-01-07-fix-deletion-sentinel-undo.md
+++ b/thoughts/shared/plans/2026-01-07-fix-deletion-sentinel-undo.md
@@ -1,0 +1,466 @@
+# Fix Deletion Sentinel Undo Button Implementation Plan
+
+## Overview
+
+The undo button on the deletion sentinel (visual feedback for deleted notebook cells) currently behaves the same as the dismiss button - it removes the sentinel but doesn't actually restore the deleted cell. This is because the undo command may not succeed if there's nothing to undo, but the sentinel is removed regardless.
+
+## Current State Analysis
+
+When the AI assistant deletes a cell, it creates a deletion sentinel that shows:
+- A preview of the deleted cell content
+- An "Undo" button that should restore the cell
+- A "Dismiss" button that removes the sentinel
+
+### Key Discoveries:
+- The undo button executes the 'undo' command but doesn't verify success (`DeletionSentinel.tsx:60`)
+- The sentinel is removed immediately after the command, regardless of outcome (`DeletionSentinel.tsx:63`)
+- There's no automatic cleanup of sentinels when cells are restored through global undo
+- The undo stack may be empty or may contain unrelated operations
+
+### Root Cause:
+The deletion sentinel is created AFTER the cell deletion is complete, which means:
+1. The undo stack already has the deletion operation when the sentinel is created
+2. BUT if the user performs other operations after deletion, those go on the undo stack
+3. When clicking the sentinel's undo button, it undoes the LAST operation, not necessarily the deletion
+
+## Desired End State
+
+After implementation:
+1. The undo button should only restore the specific deleted cell it represents
+2. The sentinel should only be removed if the cell was successfully restored
+3. The fix should handle cases where the undo stack has changed since deletion
+4. Global undo operations should also clean up relevant sentinels
+
+### Success Verification:
+- Delete a cell via AI assistant → sentinel appears
+- Click undo button on sentinel → cell is restored and sentinel disappears
+- Delete a cell, perform other operations, click undo on sentinel → cell is restored (not the other operations)
+- Delete a cell, use global Ctrl+Z → cell is restored AND sentinel is automatically removed
+
+## What We're NOT Doing
+
+- Not changing the visual design of deletion sentinels
+- Not modifying the timeout behavior
+- Not changing how AI assistant triggers deletions
+- Not implementing a custom undo stack
+
+## Implementation Approach
+
+We need to make the deletion sentinel's undo operation more intelligent by:
+1. Storing the actual undo element reference when creating the sentinel
+2. Using that specific element for targeted undo
+3. Verifying restoration success before removing the sentinel
+4. Automatically cleaning up sentinels when cells are restored via any undo path
+
+## Phase 1: Store Undo Element with Sentinel
+
+### Overview
+Capture and store the undo element created by the deletion operation so we can undo it specifically.
+
+### Changes Required:
+
+#### 1. Update IDeletionSentinel Interface
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts`
+**Changes**: Add undo element reference to the interface
+
+```typescript
+export interface IDeletionSentinel {
+	id: string;
+	originalIndex: number;
+	timestamp: number;
+	cellContent: string;
+	cellKind: CellKind;
+	language?: string;
+	undoElement?: IUndoRedoElement; // Add this line
+}
+```
+
+#### 2. Capture Undo Element During Deletion
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
+**Changes**: Store the last undo element after deletion
+
+```typescript
+// In the deleteCell method, after the deleteCells call:
+deleteCell(cellToDelete?: IPositronNotebookCell): IUndoRedoElement | undefined {
+	const cell = cellToDelete ?? getActiveCell(this.selectionStateMachine.state.get());
+
+	if (!cell) {
+		return undefined;
+	}
+
+	// Get the undo stack before deletion
+	const undoElements = this.undoRedoService.getElements(this.uri);
+	const pastStackHeight = undoElements.past.length;
+
+	this.deleteCells([cell]);
+
+	// Get the new undo element created by the deletion
+	const newUndoElements = this.undoRedoService.getElements(this.uri);
+	if (newUndoElements.past.length > pastStackHeight) {
+		return newUndoElements.past[newUndoElements.past.length - 1];
+	}
+
+	return undefined;
+}
+```
+
+#### 3. Pass Undo Element to Sentinel
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
+**Changes**: Update addDeletionSentinel to accept undo element
+
+```typescript
+addDeletionSentinel(originalIndex: number, cellContent: string, cellKind: CellKind, language?: string, undoElement?: IUndoRedoElement): void {
+	// Truncate content to first 3 lines for preview
+	const lines = cellContent.split('\n');
+	const truncatedContent = lines.slice(0, 3).join('\n');
+
+	const sentinel: IDeletionSentinel = {
+		id: `sentinel-${Date.now()}-${originalIndex}`,
+		originalIndex,
+		timestamp: Date.now(),
+		cellContent: truncatedContent,
+		cellKind,
+		language,
+		undoElement // Store the undo element
+	};
+
+	const current = this._deletionSentinels.get();
+	this._deletionSentinels.set([...current, sentinel], undefined);
+}
+```
+
+#### 4. Update AI Assistant Integration
+**File**: `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts`
+**Changes**: Capture and pass undo element
+
+```typescript
+async $deleteCell(notebookUri: string, cellIndex: number): Promise<void> {
+	const instance = this._getInstanceByUri(notebookUri);
+	if (!instance) {
+		throw new Error(`No notebook found with URI: ${notebookUri}`);
+	}
+
+	const cells = instance.cells.get();
+	if (cellIndex < 0 || cellIndex >= cells.length) {
+		throw new Error(`Cell not found at index: ${cellIndex}`);
+	}
+
+	const cellToDelete = cells[cellIndex];
+
+	// Capture cell content before deletion
+	const cellContent = cellToDelete.getContent();
+	const cellKind = cellToDelete.kind;
+	const language = cellToDelete.isCodeCell() ? cellToDelete.model.language : undefined;
+
+	// Delete the cell and capture the undo element
+	const undoElement = instance.deleteCell(cellToDelete);
+
+	// Add sentinel with cell content and undo element
+	instance.addDeletionSentinel(cellIndex, cellContent, cellKind, language, undoElement);
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compilation passes: `npm run compile`
+- [ ] No linting errors: `npm run lint`
+- [ ] Unit tests pass: `npm test`
+
+#### Manual Verification:
+- [ ] Deletion sentinels still appear when AI assistant deletes cells
+- [ ] Sentinel data structure contains undo element reference
+- [ ] No regressions in basic deletion functionality
+
+---
+
+## Phase 2: Implement Targeted Undo in Sentinel
+
+### Overview
+Update the deletion sentinel component to use the stored undo element for targeted restoration.
+
+### Changes Required:
+
+#### 1. Update DeletionSentinel Component
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx`
+**Changes**: Implement targeted undo with verification
+
+```typescript
+const handleUndo = async () => {
+	// Clear timeout
+	if (timeoutRef.current) {
+		clearTimeout(timeoutRef.current);
+	}
+
+	try {
+		// Check if we have a specific undo element for this deletion
+		if (sentinel.undoElement) {
+			// Get the undo/redo service
+			const undoRedoService = commandService._getService(IUndoRedoService);
+
+			// Check if the element is still in the undo stack
+			const elements = undoRedoService.getElements(instance.uri);
+			const elementInStack = elements.past.includes(sentinel.undoElement);
+
+			if (elementInStack) {
+				// Undo this specific element
+				await undoRedoService.undoTo(instance.uri, sentinel.undoElement);
+				// Remove sentinel after successful undo
+				instance.removeDeletionSentinel(sentinel.id);
+				return;
+			}
+		}
+
+		// Fallback: Try general undo if no specific element or not in stack
+		// This handles the case where user may have already partially undone
+		const cellsBefore = instance.cells.get().length;
+		await commandService.executeCommand('undo');
+		const cellsAfter = instance.cells.get().length;
+
+		// Only remove sentinel if a cell was actually restored
+		if (cellsAfter > cellsBefore) {
+			instance.removeDeletionSentinel(sentinel.id);
+		} else {
+			// Show a message that undo is not available
+			console.warn('Unable to undo cell deletion - operation may have already been undone');
+		}
+	} catch (error) {
+		console.error('Failed to undo cell deletion:', error);
+	}
+};
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compilation passes: `npm run compile`
+- [ ] Component renders without errors
+
+#### Manual Verification:
+- [ ] Clicking undo on sentinel restores the specific deleted cell
+- [ ] Sentinel is only removed if restoration succeeds
+- [ ] Works correctly even after other operations are performed
+- [ ] Fallback behavior works when undo element is not available
+
+---
+
+## Phase 3: Auto-cleanup Sentinels on Global Undo
+
+### Overview
+Automatically remove deletion sentinels when cells are restored through any undo path (Ctrl+Z, menu, etc.).
+
+### Changes Required:
+
+#### 1. Track Cell Restoration in _syncCells
+**File**: `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts`
+**Changes**: Detect restored cells and clean up sentinels
+
+```typescript
+private _syncCells(): void {
+	this._assertTextModel();
+
+	const textModel = this.textModel;
+	const modelCells = textModel.cells;
+
+	// Create map of existing cells before sync
+	const existingCellsMap = new Map<number, IPositronNotebookCell>();
+	for (const cell of this.cells.get()) {
+		existingCellsMap.set(cell.model.handle, cell);
+	}
+
+	// Track indices of newly appearing cells
+	const restoredIndices: number[] = [];
+
+	// Build the new cells array
+	const newCells: IPositronNotebookCell[] = [];
+	modelCells.forEach((modelCell, index) => {
+		let cell = existingCellsMap.get(modelCell.handle);
+		if (cell) {
+			cell.setIndex(index);
+			existingCellsMap.delete(modelCell.handle);
+		} else {
+			cell = this.cellAt(index);
+			// This is a newly appearing cell (could be from undo)
+			restoredIndices.push(index);
+		}
+		newCells.push(cell);
+	});
+
+	// Get the current operation type
+	const currentOp = this.getAndResetCurrentOperation();
+
+	// Clean up sentinels for restored cells during undo
+	if (currentOp === NotebookOperationType.Undo && restoredIndices.length > 0) {
+		const sentinels = this._deletionSentinels.get();
+		const remainingSentinels = sentinels.filter(sentinel => {
+			// Remove sentinels whose original index matches restored cells
+			return !restoredIndices.includes(sentinel.originalIndex);
+		});
+
+		if (remainingSentinels.length < sentinels.length) {
+			this._deletionSentinels.set(remainingSentinels, undefined);
+		}
+	}
+
+	// Rest of the existing _syncCells logic...
+	// [existing code continues]
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compilation passes: `npm run compile`
+- [ ] Existing notebook tests still pass: `npm run test`
+
+#### Manual Verification:
+- [ ] Delete cell via AI, use Ctrl+Z → cell restored AND sentinel removed
+- [ ] Delete multiple cells, undo all → all sentinels cleaned up
+- [ ] Non-deletion undos don't affect sentinels
+- [ ] Sentinel cleanup doesn't interfere with other undo operations
+
+---
+
+## Phase 4: Add E2E Tests
+
+### Overview
+Add comprehensive end-to-end tests to verify the fix works correctly.
+
+### Changes Required:
+
+#### 1. Add Deletion Sentinel Undo Test
+**File**: `test/e2e/tests/notebooks-positron/notebook-deletion-sentinel.test.ts` (new file)
+**Changes**: Create comprehensive test suite
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { Application } from '../../application';
+
+test.describe('Notebook Deletion Sentinels', () => {
+	let app: Application;
+
+	test.beforeEach(async ({ page }) => {
+		app = new Application(page);
+		await app.notebook.createNewNotebook();
+	});
+
+	test('undo button on sentinel restores deleted cell', async () => {
+		// Add a cell with content
+		await app.notebook.addCodeCell();
+		await app.notebook.typeInCell(0, 'print("test cell")');
+
+		// Delete via AI assistant (simulate)
+		await app.notebook.deleteCell(0, { viaAssistant: true });
+
+		// Verify sentinel appears
+		const sentinel = await app.page.locator('.deletion-sentinel');
+		await expect(sentinel).toBeVisible();
+
+		// Click undo on sentinel
+		await sentinel.locator('.deletion-sentinel-undo').click();
+
+		// Verify cell is restored
+		const cellContent = await app.notebook.getCellContent(0);
+		expect(cellContent).toBe('print("test cell")');
+
+		// Verify sentinel is removed
+		await expect(sentinel).not.toBeVisible();
+	});
+
+	test('global undo removes sentinel automatically', async () => {
+		// Add and delete a cell
+		await app.notebook.addCodeCell();
+		await app.notebook.typeInCell(0, 'print("test")');
+		await app.notebook.deleteCell(0, { viaAssistant: true });
+
+		// Verify sentinel appears
+		const sentinel = await app.page.locator('.deletion-sentinel');
+		await expect(sentinel).toBeVisible();
+
+		// Use global undo
+		await app.page.keyboard.press('ControlOrMeta+z');
+
+		// Verify cell is restored and sentinel removed
+		const cellContent = await app.notebook.getCellContent(0);
+		expect(cellContent).toBe('print("test")');
+		await expect(sentinel).not.toBeVisible();
+	});
+
+	test('undo after other operations still works', async () => {
+		// Setup: Create two cells
+		await app.notebook.addCodeCell();
+		await app.notebook.typeInCell(0, 'cell 1');
+		await app.notebook.addCodeCell();
+		await app.notebook.typeInCell(1, 'cell 2');
+
+		// Delete first cell via assistant
+		await app.notebook.deleteCell(0, { viaAssistant: true });
+
+		// Perform another operation (edit remaining cell)
+		await app.notebook.typeInCell(0, ' edited');
+
+		// Click undo on sentinel (should restore deleted cell, not undo edit)
+		const sentinel = await app.page.locator('.deletion-sentinel');
+		await sentinel.locator('.deletion-sentinel-undo').click();
+
+		// Verify: First cell restored, second cell still edited
+		expect(await app.notebook.getCellContent(0)).toBe('cell 1');
+		expect(await app.notebook.getCellContent(1)).toBe('cell 2 edited');
+
+		// Sentinel should be gone
+		await expect(sentinel).not.toBeVisible();
+	});
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] All new tests pass: `npx playwright test notebook-deletion-sentinel.test.ts`
+- [ ] No regressions in existing tests: `npx playwright test notebooks-positron/`
+- [ ] Tests cover all edge cases
+
+#### Manual Verification:
+- [ ] Tests accurately reflect user experience
+- [ ] Test failures provide clear diagnostic information
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Test sentinel creation with undo element
+- Test undo element retrieval from undo service
+- Test sentinel cleanup logic in _syncCells
+
+### Integration Tests:
+- Test full flow from AI deletion to undo restoration
+- Test interaction between multiple sentinels
+- Test timeout vs manual dismissal vs undo
+
+### Manual Testing Steps:
+1. Open a notebook with multiple cells
+2. Use AI assistant to delete a cell in the middle
+3. Verify sentinel appears with correct preview
+4. Click undo button → verify cell restored and sentinel removed
+5. Delete another cell, edit a different cell, then click undo on sentinel
+6. Verify only the deleted cell is restored
+7. Delete a cell, use Ctrl+Z → verify automatic sentinel cleanup
+8. Delete multiple cells → verify multiple sentinels work correctly
+
+## Performance Considerations
+
+- Storing undo element references has minimal memory impact
+- Sentinel cleanup during _syncCells is O(n) where n is number of sentinels
+- No performance regression expected for normal notebook operations
+
+## Migration Notes
+
+No migration needed - the change is backward compatible. Existing sentinels without undo elements will use the fallback behavior.
+
+## References
+
+- Original issue: User report of undo button not working
+- Related code: `src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx`
+- Undo/redo system: `src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts`
+- AI integration: `src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts`


### PR DESCRIPTION
## Summary

Fixes flaky `CreateNotebook` tool tests introduced in #11260. The tests were failing because the `onDidChangeActiveNotebookEditor` event was not mocked, causing the Promise in the implementation to timeout after 5 seconds.

The fix:
- Adds a `mockNotebookEditorActivation()` helper function that properly mocks the event listener
- Uses `setImmediate` to defer the callback until after the `disposable` variable is assigned (preventing "undefined.dispose()" errors)
- Mocks `activeNotebookEditor` to prevent the race condition check from interfering

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:assistant

This is a test-only change. Verify the extension tests pass:

```bash
npm run test-extension -- -l positron-assistant --grep "CreateNotebook"
```

All 9 CreateNotebook tests should pass consistently without the 5-second timeout delay.
