### PR TITLE
python LS: fix parameter completion sorting

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -352,23 +352,28 @@ class TestCompletions:
 
         assert "a'" in labels or 'a"' in labels
 
-    @pytest.mark.xfail(reason="Parameter sorting needs verification after refactor")
-    def test_parameter_completions_appear_first(self) -> None:
-        """Test that parameter completions are sorted first."""
-        server = create_test_server()
-        text_document = create_text_document(
-            server,
-            TEST_DOCUMENT_URI,
-            """def f(x): pass
-f(""",
-        )
+    @pytest.mark.parametrize(
+        ("source", "expected_labels"),
+        [
+            ("f(", ["y=", "x=", "a", "f"]),
+            ("f(x", ["x=", "a", "f"]),
+            ("f(y", ["y=", "a", "f"]),
+            ("f(x=", ["a", "f"]),
+            ("f(y=", ["a", "f"]),
+            ("f(x=1,", ["y=", "a", "f"]),
+            ("f(y=1,", ["x=", "a", "f"]),
+        ],
+    )
+    def test_parameter_completions_sorting(self, source: str, expected_labels: list[str]) -> None:
+        """Test that parameter completions are sorted first when appropriate."""
+        server = create_test_server(namespace={"f": lambda y, x: y + x, "a": 1})
+        text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
 
         completions = self._completions(server, text_document)
         sorted_completions = sorted(completions, key=lambda c: c.sort_text or c.label)
         labels = [c.label for c in sorted_completions]
 
-        assert "x=" in labels
-        assert labels[0] == "x="
+        assert labels == expected_labels
 
     @pytest.mark.parametrize(
         ("source", "namespace", "character", "expected_labels"),
@@ -1024,35 +1029,3 @@ class TestNotebookFeatures:
         # Verify the basic structure - actual signature help may differ
         assert text_document.uri == cell_uris[1]
         assert len(cell_uris) == 2
-
-
-# --- Additional Completion Tests ---
-
-
-class TestAdditionalCompletions:
-    """Additional completion tests from the old test suite."""
-
-    def test_parameter_completions_appear_first(self) -> None:
-        """Test that parameter completions are sorted first."""
-        from positron.positron_lsp import _handle_completion
-
-        server = create_test_server()
-        text_document = create_text_document(
-            server,
-            TEST_DOCUMENT_URI,
-            "def f(x): pass\nf(",
-        )
-
-        line = len(text_document.lines) - 1
-        character = len(text_document.lines[line])
-        params = CompletionParams(
-            TextDocumentIdentifier(text_document.uri),
-            Position(line, character),
-        )
-        completion_list = _handle_completion(server, params)
-
-        if completion_list and completion_list.items:
-            sorted_completions = sorted(completion_list.items, key=lambda c: c.sort_text or c.label)
-            labels = [c.label for c in sorted_completions]
-            # Verify x= appears somewhere in the list
-            assert any("x" in label for label in labels)


### PR DESCRIPTION
Addresses part of https://github.com/posit-dev/positron/issues/11259.

Adds support for function parameter completions and ensures they're sorted correctly.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
Try completing all these and see if it makes sense
```
def asd(a, b, d, c):
    pass

# Note: execute the above first! Then try to complete these.
# If you don't execute it, right now they rely on static analysis which isn't as full-featured

asd(
asd(a
asd(a=
asd(a=1,
asd(a=1,c
asd(a=1,c=
asd(a=1,c=2,
```
etc

