### PR TITLE
Add optional `pinned` parameter (defaults to `true` i.e. not a preview editor) to OpenEditor RPC

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -13,20 +13,14 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
-
 from positron.positron_ipkernel import PositronIPyKernel, PositronShell
 from positron.ui import UiService
 from positron.ui_comm import ShowHtmlFileDestination, UiFrontendEvent
 from positron.utils import alias_home
 
 from .conftest import DummyComm
-from .utils import (
-    comm_open_message,
-    json_rpc_notification,
-    json_rpc_request,
-    json_rpc_response,
-    preserve_working_directory,
-)
+from .utils import (comm_open_message, json_rpc_notification, json_rpc_request,
+                    json_rpc_response, preserve_working_directory)
 
 try:
     import torch
@@ -114,7 +108,20 @@ def test_open_editor(ui_service: UiService, ui_comm: DummyComm) -> None:
 
     assert ui_comm.messages == [
         json_rpc_notification(
-            "open_editor", {"file": file, "line": line, "column": column, "kind": None}
+            "open_editor",
+            {"file": file, "line": line, "column": column, "kind": None, "pinned": True},
+        )
+    ]
+
+
+def test_open_editor_preview(ui_service: UiService, ui_comm: DummyComm) -> None:
+    file, line, column = "/Users/foo/bar/baz.py", 12, 34
+    ui_service.open_editor(file, line, column, pinned=False)
+
+    assert ui_comm.messages == [
+        json_rpc_notification(
+            "open_editor",
+            {"file": file, "line": line, "column": column, "kind": None, "pinned": False},
         )
     ]
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -13,14 +13,20 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+
 from positron.positron_ipkernel import PositronIPyKernel, PositronShell
 from positron.ui import UiService
 from positron.ui_comm import ShowHtmlFileDestination, UiFrontendEvent
 from positron.utils import alias_home
 
 from .conftest import DummyComm
-from .utils import (comm_open_message, json_rpc_notification, json_rpc_request,
-                    json_rpc_response, preserve_working_directory)
+from .utils import (
+    comm_open_message,
+    json_rpc_notification,
+    json_rpc_request,
+    json_rpc_response,
+    preserve_working_directory,
+)
 
 try:
     import torch

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -17,10 +17,17 @@ from comm.base_comm import BaseComm
 
 from ._vendor.pydantic import BaseModel
 from .positron_comm import CommMessage, PositronComm
-from .ui_comm import (CallMethodParams, CallMethodRequest, OpenEditorParams,
-                      ShowHtmlFileDestination, ShowHtmlFileParams,
-                      ShowUrlParams, UiBackendMessageContent, UiFrontendEvent,
-                      WorkingDirectoryParams)
+from .ui_comm import (
+    CallMethodParams,
+    CallMethodRequest,
+    OpenEditorParams,
+    ShowHtmlFileDestination,
+    ShowHtmlFileParams,
+    ShowUrlParams,
+    UiBackendMessageContent,
+    UiFrontendEvent,
+    WorkingDirectoryParams,
+)
 from .utils import JsonData, JsonRecord, alias_home, is_local_html_file
 
 if TYPE_CHECKING:
@@ -162,7 +169,7 @@ class UiService:
                 event = WorkingDirectoryParams(directory=str(alias_home(current_dir)))
                 self._send_event(name=UiFrontendEvent.WorkingDirectory, payload=event)
 
-    def open_editor(self, file: str, line: int, column: int, pinned: bool = True) -> None:
+    def open_editor(self, file: str, line: int, column: int, *, pinned: bool = True) -> None:
         event = OpenEditorParams(file=file, line=line, column=column, pinned=pinned)
         self._send_event(name=UiFrontendEvent.OpenEditor, payload=event)
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -17,17 +17,10 @@ from comm.base_comm import BaseComm
 
 from ._vendor.pydantic import BaseModel
 from .positron_comm import CommMessage, PositronComm
-from .ui_comm import (
-    CallMethodParams,
-    CallMethodRequest,
-    OpenEditorParams,
-    ShowHtmlFileDestination,
-    ShowHtmlFileParams,
-    ShowUrlParams,
-    UiBackendMessageContent,
-    UiFrontendEvent,
-    WorkingDirectoryParams,
-)
+from .ui_comm import (CallMethodParams, CallMethodRequest, OpenEditorParams,
+                      ShowHtmlFileDestination, ShowHtmlFileParams,
+                      ShowUrlParams, UiBackendMessageContent, UiFrontendEvent,
+                      WorkingDirectoryParams)
 from .utils import JsonData, JsonRecord, alias_home, is_local_html_file
 
 if TYPE_CHECKING:
@@ -169,8 +162,8 @@ class UiService:
                 event = WorkingDirectoryParams(directory=str(alias_home(current_dir)))
                 self._send_event(name=UiFrontendEvent.WorkingDirectory, payload=event)
 
-    def open_editor(self, file: str, line: int, column: int) -> None:
-        event = OpenEditorParams(file=file, line=line, column=column)
+    def open_editor(self, file: str, line: int, column: int, pinned: bool = True) -> None:
+        event = OpenEditorParams(file=file, line=line, column=column, pinned=pinned)
         self._send_event(name=UiFrontendEvent.OpenEditor, payload=event)
 
     def clear_console(self) -> None:

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -346,6 +346,10 @@ class OpenEditorParams(BaseModel):
 
     kind: Optional[OpenEditorKind] = Field(
         description="How to interpret the 'file' argument: as a file path or as a URI. If omitted, defaults to 'path'.",
+    )
+
+    pinned: Optional[StrictBool] = Field(
+        description="Whether to open the editor pinned (non-preview mode). If omitted, defaults to true.",
     )
 
 

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -62,6 +62,14 @@
 							"uri"
 						]
 					}
+				},
+				{
+					"name": "pinned",
+					"description": "Whether to open the editor pinned (non-preview mode). If omitted, defaults to true.",
+					"required": false,
+					"schema": {
+						"type": "boolean"
+					}
 				}
 			]
 		},

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -254,7 +254,10 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 
 				const editor: ITextResourceEditorInput = {
 					resource: file,
-					options: { selection: { startLineNumber: ed.line, startColumn: ed.column } }
+					options: {
+						selection: { startLineNumber: ed.line, startColumn: ed.column },
+						pinned: ed.pinned ?? true
+					}
 				};
 				this._editorService.openEditor(editor);
 			} else if (ev.name === UiFrontendEvent.OpenWorkspace) {

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -257,6 +257,12 @@ export interface OpenEditorParams {
 	 * omitted, defaults to 'path'.
 	 */
 	kind: OpenEditorKind;
+
+	/**
+	 * Whether to open the editor pinned (non-preview mode). If omitted,
+	 * defaults to true.
+	 */
+	pinned?: boolean;
 }
 
 /**
@@ -576,6 +582,12 @@ export interface OpenEditorEvent {
 	 * omitted, defaults to 'path'.
 	 */
 	kind?: OpenEditorKind;
+
+	/**
+	 * Whether to open the editor pinned (non-preview mode). If omitted,
+	 * defaults to true.
+	 */
+	pinned?: boolean;
 
 }
 
@@ -962,7 +974,7 @@ export class PositronUiComm extends PositronBaseComm {
 		super(instance, options);
 		this.onDidBusy = super.createEventEmitter('busy', ['busy']);
 		this.onDidClearConsole = super.createEventEmitter('clear_console', []);
-		this.onDidOpenEditor = super.createEventEmitter('open_editor', ['file', 'line', 'column', 'kind']);
+		this.onDidOpenEditor = super.createEventEmitter('open_editor', ['file', 'line', 'column', 'kind', 'pinned']);
 		this.onDidShowMessage = super.createEventEmitter('show_message', ['message']);
 		this.onDidPromptState = super.createEventEmitter('prompt_state', ['input_prompt', 'continuation_prompt']);
 		this.onDidWorkingDirectory = super.createEventEmitter('working_directory', ['directory']);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3673

I agree that using this `OpenEditor` event is a strong enough signal that we should default to a pinned, non-preview editor, but I did put it in an optional parameter for the method, in case we end up finding use cases that should _not_ open "for real". We'll eventually need to update this in ark as well, but there's no need to do it right away because we are providing a default.

### Release Notes

#### New Features

- R: opening a file via `rstudioapi::navigateToFile(path)` now opens a non-preview, pinned editor

#### Bug Fixes

- N/A


### QA Notes

If you use `rstudioapi::navigateToFile(path)` with a `path` for a real, existing file, you should get a pinned, non-preview, "for real" editor, not one of the preview editors with the italics title.
