### PR TITLE
Ensure Positron notebook ai features dont show up if assistant is globally disabled. 

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.ts
@@ -100,6 +100,7 @@ export class AskAssistantAction extends NotebookAction2 {
 				order: 50,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					ContextKeyExpr.has('config.positron.assistant.enable'),
 					ContextKeyExpr.has('config.positron.assistant.notebookMode.enable')
 				)
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1381,6 +1381,7 @@ registerAction2(class extends NotebookAction2 {
 				order: 55, // After Ask Assistant (50)
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					ContextKeyExpr.has('config.positron.assistant.enable'),
 					ContextKeyExpr.has('config.positron.assistant.notebookMode.enable')
 				)
 			}

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Assistant Features', {
+	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB]
+}, () => {
+
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.beforeEach(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.setNotebookEditor(settings, 'positron');
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Notebook AI features hidden when assistant disabled', async function ({ app, settings, page }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		// Disable assistant features
+		await settings.set({
+			'positron.assistant.enable': false,
+			'positron.assistant.notebookMode.enable': false
+		});
+
+		// Create a new notebook with a cell that produces an error
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.kernel.select('Python');
+
+		// Add a code cell with intentional error using proper pattern
+		await notebooksPositron.addCodeToCell(0, 'invalid_function()', { run: true });
+
+		// Wait for execution to complete
+		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
+
+		// Wait for error output to appear
+		await page.waitForSelector('.notebook-error', { timeout: 10000 });
+
+		// Verify Ask Assistant button is NOT visible in toolbar
+		const askAssistantButton = page.getByRole('button', { name: 'Ask Assistant', exact: true });
+		await expect(askAssistantButton).not.toBeVisible();
+
+		// Verify Fix/Explain buttons are NOT visible in error cell
+		const fixButton = page.getByRole('button', { name: /Ask assistant to fix/i });
+		const explainButton = page.getByRole('button', { name: /Ask assistant to explain/i });
+		await expect(fixButton).not.toBeVisible();
+		await expect(explainButton).not.toBeVisible();
+	});
+
+	test('Notebook AI features visible when assistant enabled', async function ({ app, settings, page }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		// Enable assistant features (notebook mode requires master switch)
+		await settings.set({
+			'positron.assistant.enable': true,
+			'positron.assistant.notebookMode.enable': true
+		});
+
+		// Create a new notebook with a cell that produces an error
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.kernel.select('Python');
+
+		// Add a code cell with intentional error using proper pattern
+		await notebooksPositron.addCodeToCell(0, 'invalid_function()', { run: true });
+
+		// Wait for execution to complete
+		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
+
+		// Wait for error output to appear
+		await page.waitForSelector('.notebook-error', { timeout: 10000 });
+
+		// Verify Ask Assistant button IS visible in toolbar
+		const askAssistantButton = page.getByRole('button', { name: 'Ask Assistant', exact: true });
+		await expect(askAssistantButton).toBeVisible();
+
+		// Verify Fix/Explain buttons ARE visible in error cell
+		const fixButton = page.getByRole('button', { name: /Ask assistant to fix/i });
+		const explainButton = page.getByRole('button', { name: /Ask assistant to explain/i });
+		await expect(fixButton).toBeVisible();
+		await expect(explainButton).toBeVisible();
+	});
+
+	test('Follow Assistant toggle only visible when both assistant settings enabled', async function ({ app, settings, page }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		// Test 1: Disable assistant - Follow Assistant should not be visible
+		await settings.set({
+			'positron.assistant.enable': false,
+			'positron.assistant.notebookMode.enable': false
+		});
+
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+
+		// Follow Assistant has eye icon and toggles assistant auto-follow
+		const followAssistantDisabled = page.getByRole('button', { name: /[Ff]ollow.*[Aa]ssistant/i });
+		await expect(followAssistantDisabled).not.toBeVisible();
+
+		// Test 2: Enable master switch but not notebook mode - should still not be visible
+		await settings.set({
+			'positron.assistant.enable': true,
+			'positron.assistant.notebookMode.enable': false
+		});
+
+		// Reload to apply settings
+		await page.reload();
+		await notebooksPositron.expectToBeVisible();
+
+		const followAssistantPartial = page.getByRole('button', { name: /[Ff]ollow.*[Aa]ssistant/i });
+		await expect(followAssistantPartial).not.toBeVisible();
+
+		// Test 3: Enable both - should be visible
+		await settings.set({
+			'positron.assistant.enable': true,
+			'positron.assistant.notebookMode.enable': true
+		});
+
+		// Reload to apply settings
+		await page.reload();
+		await notebooksPositron.expectToBeVisible();
+
+		const followAssistantEnabled = page.getByRole('button', { name: /[Ff]ollow.*[Aa]ssistant/i });
+		await expect(followAssistantEnabled).toBeVisible();
+	});
+});


### PR DESCRIPTION
Addresses #11229.

This PR ensures notebook AI features respect the master `positron.assistant.enable` setting. Previously, notebook-specific AI features (Ask Assistant button, Fix/Explain error buttons, Follow Assistant toggle) only checked `positron.assistant.notebookMode.enable`. Now they require both settings to be enabled.

The fix adds `config.positron.assistant.enable` to the `when` context for the Ask Assistant action and Follow Assistant toggle, ensuring these features are hidden when the master assistant setting is disabled.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:assistant

1. Open Settings and set `positron.assistant.enable` to `false`
2. Open a notebook and run a cell with an error (e.g., `invalid_function()`)
3. Verify the "Ask Assistant" toolbar button is NOT visible
4. Verify the "Fix"/"Explain" buttons on the error output are NOT visible
5. Enable `positron.assistant.enable` and `positron.assistant.notebookMode.enable`
6. Verify all assistant features now appear
