### PR TITLE
Set default terminal locale behavior to 'on'

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -316,7 +316,13 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 			localize('terminal.integrated.detectLocale.off', "Do not set the `$LANG` environment variable."),
 			localize('terminal.integrated.detectLocale.on', "Always set the `$LANG` environment variable.")
 		],
-		default: 'auto'
+		// --- Start Positron ---
+		// Default to 'on' to ensure consistent locale behavior across platforms,
+		// particularly for R which can produce different results with C/POSIX locales.
+		// See: https://github.com/posit-dev/positron/issues/11054
+		// default: 'auto'
+		default: 'on'
+		// --- End Positron ---
 	},
 	[TerminalSettingId.GpuAcceleration]: {
 		type: 'string',


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11054

This PR just changes the default value of `terminal.integrated.detectLocale` from `'auto'` to `'on'`. We believe this will ensure the `$LANG` environment variable is always set to a UTF-8 compliant locale (e.g., `en_US.UTF-8`), providing consistent behavior across platforms.

On macOS, Positron can inherit a different locale from its parent process, which causes inconsistent behavior. This affects both the integrated terminals and the Positron Console (R and Python sessions inherit environment from the parent Positron process).

With the `'auto'` default, R users on macOS were seeing:

```r
stringi::stri_locale_get()
#> [1] "en_US_POSIX"
```

When they expected:

```r
stringi::stri_locale_get()
#> [1] "en_US"
```

This difference affects string sorting and packages like tidytext, potentially causing reproducibility issues when the same code produces different results across operating systems.

For Python, IIUC this is pretty much also a good thing. From my research, I expect that this change:

- aligns with Python 3's default string handling expectations
- helps avoid potential `UnicodeEncodeError` issues that can occur with C/POSIX locales
- ensures consistent cross-platform behavior

This is a neutral-to-positive change for Python users, as most Python code already expects UTF-8 locales.

@:console @:win @:web

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Changed default for `terminal.integrated.detectLocale` to `'on'` to ensure consistent locale behavior, fixing issues where R and Python sessions could behave differently across platforms (#11054)

### QA Notes

1. On macOS, open Positron without any user settings override for `terminal.integrated.detectLocale`
2. Open the R Console and run:

```r
stringi::stri_locale_get()
Sys.getlocale()
```

3. Verify the locale is a proper locale (e.g., `en_US`) and not `en_US_POSIX` or `C`
4. Open a Terminal and run `locale` - verify `LANG` is set to a UTF-8 locale
5. For Python, run:

```python
import locale
locale.getlocale()
```

6. Verify consistent results across macOS, Windows, and Linux
