### PR TITLE
E2E test: see if notebook action bar is problematic

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-action-bar.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Action Bar Behavior', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {


### PR DESCRIPTION
Seeing if the Positron Notebooks: Action Bar Behavior tests are causing CI problems

### QA Notes

@:rhel-web @:suse-web @:positron-notebooks
