### PR TITLE
E2E test: seeing if the notebook assistant tests are causing issues

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Notebook Assistant Features', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB]
+	tag: [tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ app, settings }) {


### PR DESCRIPTION
Checking if the Notebook Assistant Features tests are causing problems in CI

### QA Notes

@:rhel-web @:suse-web @:positron-notebooks