### PR TITLE
Remove Anthropic/Copilot specific welcome view text

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1314,17 +1314,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			welcomeText = localize('positronAssistant.comingSoonMessage', "Positron Assistant is under development and is currently available as a preview feature of Positron.\n");
 			welcomeText += `\n\n[${enableAssistantMessage}](command:positron-assistant.enableAssistantSetting)`;
 		} else if (!this.languageModelsService.currentProvider) {
-			// When Anthropic is the only supported provider, we can use a more specific message.
-			// TODO: remove this custom handling https://github.com/posit-dev/positron/issues/8301
-			const hasAdditionalModels = this.configurationService.getValue<string[]>('positron.assistant.enabledProviders')?.length > 0;
-
 			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
-			const addLanguageModelMessage = hasAdditionalModels
-				? localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider")
-				: localize('positronAssistant.addLanguageModelMessageAnthropic', "Add a Chat Provider");
-			welcomeText = hasAdditionalModels
-				? localize('positronAssistant.welcomeMessage', "To use Positron Assistant you must first select and authenticate with a language model provider.\n")
-				: localize('positronAssistant.welcomeMessageAnthropic', "To use Positron Assistant Chat, you must first authenticate with Anthropic or Github.\n");
+			const addLanguageModelMessage = localize('positronAssistant.addLanguageModelMessage', "Add Language Model Provider");
+			welcomeText = localize('positronAssistant.welcomeMessage', "To use Positron Assistant, you must first select and authenticate with a language model provider.");
 			welcomeText += `\n\n[${addLanguageModelMessage}](command:positron-assistant.configureModels)`;
 		} else {
 			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11228

<img width="1524" height="884" alt="Screenshot 2026-01-12 at 1 54 23 PM" src="https://github.com/user-attachments/assets/ff6c219a-5a0e-4968-86d4-ba5a5447ce42" />

We don't use `firstLinkToButton` or have an alternative button option in this view (because of what we want to show when you do have a provider configured), so I decided not to link out to our docs from "you must first select and authenticate with a language model provider." I tried that at first, but it was fairly confusing above the link that brings up the modal. ("What do all these links do?!")

I did some searches in this area of the code base and do not see Anthropic or Copilot specifically mentioned in other inappropriate user-facing strings.

@:assistant

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

When you set up Positron Assistant, you should not see wording that indicates that Anthropic and Copilot are the only providers we support.
