### PR TITLE
Fix #11322: Better error messages when attempting to install extensions incompatible with the version of Positron

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -89,7 +89,7 @@ export function positronExtensionCompatibility(
 	}
 
 	// Check version compatibility for manifests with Positron engine requirements
-	if (productService?.positronVersion) {
+	if (productService?.positronVersion && extension.hasOwnProperty('engines')) {
 		const manifest = extension as IExtensionManifest;
 		if (manifest.engines?.positron) {
 			const validations = validatePositronExtensionManifest(

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -70,7 +70,7 @@ function isPositronExtensionCompatible(extension: { name: string; publisher: str
 
 /**
  * Check if an extension is compatible with Positron
- * @param extension Extension to check (gallery extension or manifest)
+ * @param extension Extension to check (gallery extension or manifest) - version checks are only done for manifests with Positron engine requirements
  * @param productService Product service to get current Positron version
  * @returns Compatibility result with optional reason if incompatible
  */
@@ -97,7 +97,7 @@ export function positronExtensionCompatibility(
 				productService.date,
 				URI.file(''), // extension not yet installed; pass empty URI
 				manifest,
-				false // extensionIsBuiltin is false, because installed extensions are always non-builtin
+				false // extensionIsBuiltin is set to false, because we are installing user requested extension, not a built-in one
 			);
 
 			// Return validation error if any exist (currently only one error is returned at a time)

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -27,7 +27,9 @@ import {
 import { areSameExtensions, ExtensionKey, getGalleryExtensionId, getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData, isMalicious } from './extensionManagementUtil.js';
 import { ExtensionType, IExtensionManifest, isApplicationScopedExtension, TargetPlatform } from '../../extensions/common/extensions.js';
 import { areApiProposalsCompatible } from '../../extensions/common/extensionValidator.js';
+// --- Start Positron ---
 import { validatePositronExtensionManifest } from '../../extensions/common/positronExtensionValidator.js';
+// --- End Positron ---
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';

--- a/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { positronExtensionCompatibility } from '../../common/abstractExtensionManagementService.js';
+import { IProductService } from '../../../product/common/productService.js';
+import { IExtensionManifest } from '../../../extensions/common/extensions.js';
+
+suite('Positron Extension Compatibility', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const mockProductService: IProductService = {
+		positronVersion: '2026.02.0',
+		version: '1.106.0',
+		date: '2026-01-10'
+	} as IProductService;
+
+	test('should reject blocked extension (ms-python.python)', () => {
+		const extension = {
+			name: 'python',
+			publisher: 'ms-python',
+			displayName: 'Python'
+		};
+
+		const result = positronExtensionCompatibility(extension, mockProductService);
+
+		assert.strictEqual(result.compatible, false);
+		assert.ok(result.reason);
+		assert.ok(result.reason.includes('conflicts with Positron built-in features'));
+		assert.ok(result.reason.includes('Python'));
+	});
+
+	test('should accept extension with compatible version requirement', () => {
+		const extensionManifest: IExtensionManifest = {
+			name: 'test-extension',
+			publisher: 'test-publisher',
+			displayName: 'Test Extension',
+			version: '1.0.0',
+			engines: {
+				positron: '^2025.1.0' // Compatible version requirement
+			}
+		} as IExtensionManifest;
+
+		const result = positronExtensionCompatibility(extensionManifest, mockProductService);
+
+		assert.strictEqual(result.compatible, true);
+		assert.strictEqual(result.reason, undefined);
+	});
+
+	test('should accept extension without engine requirements', () => {
+		const extension = {
+			name: 'simple-extension',
+			publisher: 'simple-publisher',
+			displayName: 'Simple Extension'
+		};
+
+		const result = positronExtensionCompatibility(extension, mockProductService);
+
+		assert.strictEqual(result.compatible, true);
+		assert.strictEqual(result.reason, undefined);
+	});
+
+	test('should report validation error for malformed Positron version syntax', () => {
+		// Test with an extension that has malformed Positron version syntax
+		const extensionManifest: IExtensionManifest = {
+			name: 'test-extension',
+			publisher: 'test-publisher',
+			displayName: 'Test Extension',
+			version: '1.0.0',
+			main: './main.js', // Must have main to trigger validation
+			engines: {
+				positron: 'invalid-version-syntax' // Malformed version will produce error
+			}
+		} as IExtensionManifest;
+
+		const result = positronExtensionCompatibility(extensionManifest, mockProductService);
+
+		assert.strictEqual(result.compatible, false);
+		assert.ok(result.reason);
+		// Should contain error about parsing the version
+		assert.ok(result.reason.includes('Could not parse'));
+	});
+
+	test('should handle missing ProductService gracefully', () => {
+		const extension = {
+			name: 'test-extension',
+			publisher: 'test-publisher',
+			displayName: 'Test Extension'
+		};
+
+		const result = positronExtensionCompatibility(extension, undefined);
+
+		assert.strictEqual(result.compatible, true);
+		assert.strictEqual(result.reason, undefined);
+	});
+
+	test('should handle different extension input types', () => {
+		// Test with basic extension object
+		const basicExtension = {
+			name: 'basic',
+			publisher: 'publisher'
+		};
+		let result = positronExtensionCompatibility(basicExtension, mockProductService);
+		assert.strictEqual(result.compatible, true);
+
+		// Test with gallery extension (using only required properties)
+		const galleryExtension = {
+			name: 'gallery',
+			publisher: 'publisher',
+			displayName: 'Gallery Extension'
+		};
+		result = positronExtensionCompatibility(galleryExtension, mockProductService);
+		assert.strictEqual(result.compatible, true);
+
+		// Test with manifest
+		const manifestExtension: IExtensionManifest = {
+			name: 'manifest',
+			publisher: 'publisher',
+			displayName: 'Manifest Extension',
+			version: '1.0.0'
+		} as IExtensionManifest;
+		result = positronExtensionCompatibility(manifestExtension, mockProductService);
+		assert.strictEqual(result.compatible, true);
+	});
+
+});

--- a/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
@@ -51,6 +51,27 @@ suite('Positron Extension Compatibility', () => {
 		assert.strictEqual(result.reason, undefined);
 	});
 
+	test('should reject extension that requires newer Positron version', () => {
+		const extensionManifest: IExtensionManifest = {
+			name: 'future-extension',
+			publisher: 'test-publisher',
+			displayName: 'Future Extension',
+			version: '1.0.0',
+			main: './main.js', // Must have main to trigger version validation
+			engines: {
+				positron: '^2027.01.0' // Requires newer version than 2026.02.0
+			}
+		} as IExtensionManifest;
+
+		const result = positronExtensionCompatibility(extensionManifest, mockProductService);
+
+		assert.strictEqual(result.compatible, false);
+		assert.ok(result.reason);
+		assert.ok(result.reason.includes('Extension is not compatible with Positron'));
+		assert.ok(result.reason.includes('2026.02.0'));
+		assert.ok(result.reason.includes('2027.01.0'));
+	});
+
 	test('should accept extension without engine requirements', () => {
 		const extension = {
 			name: 'simple-extension',

--- a/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -768,7 +768,21 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			],
 			icon: installWorkspaceRecommendedIcon,
 			run: async () => {
-				await this.extensionsWorkbenchService.updateAll();
+				// --- Start Positron ---
+				const results = await this.extensionsWorkbenchService.updateAll();
+
+				// Check for failures and report them
+				const failures = results.filter(r => r.error);
+				if (failures.length > 0) {
+					// Build error message showing which extensions failed and why
+					const failureMessages = failures
+						.map(f => `${f.identifier.id}: ${f.error?.message ?? 'Unknown error'}`)
+						.join('\n');
+
+					// Show error notification
+					throw new Error(localize('updateAllFailed', 'Failed to update some extensions:\n{0}', failureMessages));
+				}
+				// --- End Positron ---
 			}
 		});
 

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -769,6 +769,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			icon: installWorkspaceRecommendedIcon,
 			run: async () => {
 				// --- Start Positron ---
+				// await this.extensionsWorkbenchService.updateAll();
 				const results = await this.extensionsWorkbenchService.updateAll();
 
 				// Check for failures and report them

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -554,17 +554,22 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 	}
 
 	async installFromGallery(gallery: IGalleryExtension, installOptions?: InstallOptions, servers?: IExtensionManagementServer[]): Promise<ILocalExtension> {
+		// --- Start Positron ---
+		// Check compatibility using the manifest (which includes engines.positron if specified)
 		const manifest = await this.extensionGalleryService.getManifest(gallery, CancellationToken.None);
 		if (!manifest) {
 			throw new Error(localize('Manifest is not found', "Installing Extension {0} failed: Manifest is not found.", gallery.displayName || gallery.name));
 		}
 
-		// --- Start Positron ---
-		// Check compatibility using the manifest (which includes engines.positron if specified)
 		const compat = positronExtensionCompatibility(manifest, this.productService);
 		if (!compat.compatible) {
 			return Promise.reject(positronExtensionCompatibilityError(compat.reason));
 		}
+
+		// const manifest = await this.extensionGalleryService.getManifest(gallery, CancellationToken.None);
+		// if (!manifest) {
+		// 	throw new Error(localize('Manifest is not found', "Installing Extension {0} failed: Manifest is not found.", gallery.displayName || gallery.name));
+		// }
 		// --- End Positron ---
 
 		if (installOptions?.context?.[EXTENSION_INSTALL_SKIP_PUBLISHER_TRUST_CONTEXT] !== true) {

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -316,7 +316,7 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 
 	async installVSIX(vsix: URI, manifest: IExtensionManifest, options?: InstallOptions): Promise<ILocalExtension> {
 		// --- Start Positron ---
-		const compat = positronExtensionCompatibility(manifest);
+		const compat = positronExtensionCompatibility(manifest, this.productService);
 		if (!compat.compatible) {
 			return Promise.reject(positronExtensionCompatibilityError(compat.reason));
 		}
@@ -465,7 +465,7 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 		// Check Positron compatibility for all extensions
 		for (let i = 0; i < extensions.length; i++) {
 			const { extension, options } = extensions[i];
-			const compat = positronExtensionCompatibility(extension);
+			const compat = positronExtensionCompatibility(extension, this.productService);
 			if (!compat.compatible) {
 				results.set(extension.identifier.id.toLowerCase(), {
 					identifier: extension.identifier,
@@ -541,7 +541,7 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 
 	async installFromGallery(gallery: IGalleryExtension, installOptions?: InstallOptions, servers?: IExtensionManagementServer[]): Promise<ILocalExtension> {
 		// --- Start Positron ---
-		const compat = positronExtensionCompatibility(gallery);
+		const compat = positronExtensionCompatibility(gallery, this.productService);
 		if (!compat.compatible) {
 			return Promise.reject(positronExtensionCompatibilityError(compat.reason));
 		}

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -554,13 +554,12 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 	}
 
 	async installFromGallery(gallery: IGalleryExtension, installOptions?: InstallOptions, servers?: IExtensionManagementServer[]): Promise<ILocalExtension> {
-		// --- Start Positron ---
-		// Check compatibility using the manifest (which includes engines.positron if specified)
 		const manifest = await this.extensionGalleryService.getManifest(gallery, CancellationToken.None);
 		if (!manifest) {
 			throw new Error(localize('Manifest is not found', "Installing Extension {0} failed: Manifest is not found.", gallery.displayName || gallery.name));
 		}
-
+		// --- Start Positron ---
+		// Check compatibility using the manifest (which includes engines.positron if specified)
 		const compat = positronExtensionCompatibility(manifest, this.productService);
 		if (!compat.compatible) {
 			return Promise.reject(positronExtensionCompatibilityError(compat.reason));

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -565,11 +565,6 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 		if (!compat.compatible) {
 			return Promise.reject(positronExtensionCompatibilityError(compat.reason));
 		}
-
-		// const manifest = await this.extensionGalleryService.getManifest(gallery, CancellationToken.None);
-		// if (!manifest) {
-		// 	throw new Error(localize('Manifest is not found', "Installing Extension {0} failed: Manifest is not found.", gallery.displayName || gallery.name));
-		// }
 		// --- End Positron ---
 
 		if (installOptions?.context?.[EXTENSION_INSTALL_SKIP_PUBLISHER_TRUST_CONTEXT] !== true) {

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -436,6 +436,20 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 			return Promise.reject(`Invalid location ${extension.location.toString()}`);
 		}
 
+		// --- Start Positron ---
+		// Fetch manifest to check version compatibility before updating
+		const manifest = await this.extensionGalleryService.getManifest(gallery, CancellationToken.None);
+		if (!manifest) {
+			throw new Error(localize('Manifest is not found for update', "Updating Extension {0} failed: Manifest is not found.", gallery.displayName || gallery.name));
+		}
+
+		// Check Positron compatibility using the manifest
+		const compat = positronExtensionCompatibility(manifest, this.productService);
+		if (!compat.compatible) {
+			return Promise.reject(positronExtensionCompatibilityError(compat.reason));
+		}
+		// --- End Positron ---
+
 		const servers: IExtensionManagementServer[] = [];
 
 		// Update Language pack on local and remote servers


### PR DESCRIPTION
### Summary
Addresses #11322 by adding validation of the `engines.positron` field in extension manifests to provide clear, actionable error messages when users attempt to install or update incompatible extensions. Previously, when a user tried to install an extension with `engines.positron` set to a version newer than their current Positron installation, they would see a cryptic "Cannot read the extension" error. This was misleading because it suggested the extension file was corrupted rather than incompatible.

### Implementation Notes

#### 1. Enhanced Core Compatibility Function
**File:** `src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts`

- Updated `positronExtensionCompatibility()` to accept `productService` parameter for version checking. This parameter is needed in order to see the current running version of Positron.
- Integrated with `validatePositronExtensionManifest()` for version validation

#### 2. Installation Flow Updates
**File:** `src/vs/platform/extensionManagement/node/extensionManagementService.ts`

- **VSIX installations** (`installVSIX`): Validates local .vsix files before installation
- **Marketplace installations** (`installFromGallery`): Fetches and validates manifest before downloading
- **Bulk installations** (`installGalleryExtensions`): Validates all extensions in batch operations

#### 3. Update Flow Protection
- **Single updates** (`updateFromGallery`): Validates version compatibility before updating individual extensions
- **Bulk updates** (`src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts`): Enhanced "Update All Extensions" command to:
  - Capture all update operation results
  - Filter and report failures with clear messages
  - Show which specific extensions failed and why

#### 4. Test Coverage
**File:** `src/vs/platform/extensionManagement/test/common/positronExtensionCompatibility.test.ts` (new)

Added 7 test cases covering:
- ✅ Blocked extensions (existing functionality)
- ✅ Compatible version requirements
- ✅ Incompatible version requirements (newer Positron needed)
- ✅ Extensions without engine requirements (backward compatibility)
- ✅ Malformed version syntax handling
- ✅ Missing ProductService gracefully handled
- ✅ Different extension input types (basic/gallery/manifest)


#### Demonstration
The following video illustrates all the variations of this problem with the fix working correctly. (In this recording, Positron has been rigged to report version 2025.10.1 which mimics the setup reported in the original bug report)

https://github.com/user-attachments/assets/605b720f-4bc5-467d-9296-33a9d73a423a

### Release Notes
- N/A 

#### New Features
- N/A

#### Bug Fixes
- #11322 


### QA Notes

@:extensions

The demonstration video shows all the impacted use cases.  The following zip file contains the vsix files that were used for testing. 
[manual-test-extensions.zip](https://github.com/user-attachments/files/24576058/manual-test-extensions.zip)
