### PR TITLE
Fix "Initialize Git Repository" not working for Empty Project template

### DIFF
--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -414,6 +414,9 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 						this._handleGitIgnoreError(error);
 					});
 				break;
+			case FolderTemplate.EmptyProject:
+				// Empty projects don't need a .gitignore file
+				break;
 			default:
 				this._logService.error(
 					'Cannot determine .gitignore content for unknown folder template',
@@ -853,6 +856,9 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			case FolderTemplate.RProject:
 				tasks.add(NewFolderTask.R);
 				break;
+			case FolderTemplate.EmptyProject:
+				// Empty project doesn't have any language-specific tasks
+				break;
 			default:
 				this._logService.error(
 					'Cannot determine new folder tasks for unknown folder template',
@@ -865,9 +871,10 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			tasks.add(NewFolderTask.Git);
 		}
 
-		// Always create a new file in the new folder. This may be controlled by a folder config
-		// setting in the future.
-		tasks.add(NewFolderTask.CreateNewFile);
+		// Create a new file for language-specific templates. Empty projects don't create a file.
+		if (this._newFolderConfig.folderTemplate !== FolderTemplate.EmptyProject) {
+			tasks.add(NewFolderTask.CreateNewFile);
+		}
 
 		return tasks;
 	}

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
@@ -5,7 +5,7 @@
 
 import { FolderTemplate } from '../../infra';
 import { test, tags } from '../_test.setup';
-import { addRandomNumSuffix, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
+import { addRandomNumSuffix, verifyGitStatus, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
 	suiteId: __filename
@@ -26,5 +26,20 @@ test.describe('New Folder Flow: Empty Project', { tag: [tags.MODAL, tags.NEW_FOL
 
 		await newFolderFlow.verifyFolderCreation(folderName);
 		await verifyPyprojectTomlNotCreated(app);
+	});
+
+	test('Verify empty folder with git initialization', { tag: [tags.WIN] }, async function ({ app }) {
+		const { newFolderFlow } = app.workbench;
+		const folderName = addRandomNumSuffix('empty-project-git');
+
+		// Create a new empty project folder with git initialized
+		await newFolderFlow.createNewFolder({
+			folderTemplate,
+			folderName,
+			initGitRepo: true
+		});
+
+		await newFolderFlow.verifyFolderCreation(folderName);
+		await verifyGitStatus(app);
 	});
 });


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11161

The "Initialize Git Repository" checkbox in the New Folder from Template > Empty Project flow was not working. When creating an Empty Project with git initialization enabled, no git repository was created. The root cause was that `_getInitTasks()` had a switch statement where the empty project fell through to the default case, returning an empty set immediately so that `git init` was never executed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed "Initialize Git Repository" option not working for an empty project in the New Folder from Template flow (#11161)

### QA Notes

@:new-folder-flow

1. File > New Folder from Template
2. Select "Empty Project"
3. Check "Initialize Git repository"
4. Choose a location and create the folder
5. Open in New Window
6. In terminal, run `git status`
7. Verify the folder is a git repository (should show clean working tree, not "fatal: not a git repository")
8. Verify `README.md` exists with the folder name as the title
