### PR TITLE
Fix startup hang when installing bootstrap extensions after upgrade

### DIFF
--- a/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
@@ -194,6 +194,11 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 			this.reportClientOSInfo(telemetryService, logService);
 		});
 
+		// --- Start Positron ---
+		// Create the bootstrap extensions initializer separately so we can await its completion
+		const bootstrapInitializer = instantiationService.createInstance(PositronBootstrapExtensionsInitializer);
+		// --- End Positron ---
+
 		// Instantiate Contributions
 		this._register(combinedDisposable(
 			instantiationService.createInstance(CodeCacheCleaner, this.configuration.codeCachePath),
@@ -205,9 +210,13 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 			instantiationService.createInstance(UserDataProfilesCleaner),
 			// --- Start Positron ---
 			instantiationService.createInstance(DefaultExtensionsInitializer),
-			instantiationService.createInstance(PositronBootstrapExtensionsInitializer)
+			bootstrapInitializer
 			// --- End Positron ---
 		));
+
+		// --- Start Positron ---
+		await bootstrapInitializer.whenReady;
+		// --- End Positron ---
 	}
 
 	private async initServices(): Promise<IInstantiationService> {

--- a/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
@@ -227,7 +227,6 @@ export abstract class AbstractExtensionsProfileScannerService extends Disposable
 			let storedProfileExtensions: IStoredProfileExtension[] | undefined;
 			try {
 				const content = await this.fileService.readFile(file);
-				this.logService.info(`Parsing JSON from ${file.toString()} with contents ${content.value.toString()}`);
 				storedProfileExtensions = JSON.parse(content.value.toString().trim() || '[]');
 			} catch (error) {
 				this.logService.error(`Extensions profile: Failed to read extensions from ${file.toString()}`, getErrorMessage(error));

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -741,13 +741,16 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 	const { socketServer, instantiationService } = await setupServerServices(connectionToken, args, REMOTE_DATA_FOLDER, disposables);
 
 	// --- Start Positron ---
-	instantiationService.invokeFunction((accessor) => {
+	// Wait for bootstrap extensions to complete before continuing with server setup.
+	// This ensures the extension host will see the bootstrap extensions when it scans.
+	await instantiationService.invokeFunction(async (accessor) => {
 		const environmentService = accessor.get(INativeEnvironmentService);
 		const extensionManagementService = accessor.get(IExtensionManagementService);
 		const fileService = accessor.get(IFileService);
 		const productService = accessor.get(IProductService);
 		const logService = accessor.get(ILogService);
-		new PositronBootstrapExtensionsInitializer(environmentService, extensionManagementService, fileService, productService, logService);
+		const bootstrapInitializer = new PositronBootstrapExtensionsInitializer(environmentService, extensionManagementService, fileService, productService, logService);
+		await bootstrapInitializer.whenReady;
 	});
 	// --- End Positron ---
 


### PR DESCRIPTION
Addresses #11230.

After upgrading Positron, the console could hang on startup because bootstrap extensions were being installed asynchronously while the extension host scanned for extensions. This race condition caused the extension host to miss newly installed bootstrap extensions.

Key changes:
- Added `whenReady` promise with 30-second timeout to `PositronBootstrapExtensionsInitializer`
- Modified `sharedProcessMain.ts` to await bootstrap completion before continuing
- Modified `remoteExtensionHostAgentServer.ts` to await bootstrap completion for remote scenarios
- Cleaned up bootstrap extension logging: removed unhelpful noisy logs and moved verbose installation logs from `info` to `debug` level

A 30-second timeout prevents an indefinite hang. In my testing, the bootstrap extension installation completed in under a second when there were no new extensions to install and when all extensions needed to be installed. Slow network speeds will cause longer installs. We could consider checking if we are installing all extensions from scratch and use a longer timeout, or a shorter timeout when not starting from scratch.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed console startup hang when launching Positron for the first time after an upgrade (#11230)

### QA Notes

@:console @:extensions @:interpreter

To mimic an upgrade, delete `~/.positron/extensions/.version`. To create an environment where all extensions need to be installed, delete the directory `~/.positron/extensions`.