### PR TITLE
Add eslint rule to prevent clickable divs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ pluginHeader.rules.header.meta.schema = false;
 import globals from 'globals';
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
+import pluginJsxA11y from 'eslint-plugin-jsx-a11y';
 // --- End Positron ---
 
 const ignores = fs.readFileSync(path.join(import.meta.dirname, '.eslint-ignore'), 'utf8')
@@ -138,9 +139,8 @@ export default tseslint.config(
 		],
 		plugins: {
 			'react': pluginReact,
-			// @ts-ignore
-			// This shows up with a red squiggly in the editor, but it works.
 			'react-hooks': pluginReactHooks,
+			'jsx-a11y': pluginJsxA11y,
 		},
 		settings: {
 			react: {
@@ -169,7 +169,9 @@ export default tseslint.config(
 					'reservedFirst': true,
 					'shorthandFirst': true
 				}
-			]
+			],
+			// Do not allow non-interactive elements to have interactive handlers
+			'jsx-a11y/no-static-element-interactions': 'error',
 		},
 	},
 	// --- End Positron ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
         "eslint-formatter-compact": "^8.40.0",
         "eslint-plugin-header": "3.1.1",
         "eslint-plugin-jsdoc": "^50.3.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-mocha": "^10.4.3",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -5936,6 +5937,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -6297,6 +6308,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -6401,6 +6419,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
@@ -6424,6 +6452,16 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/b4a": {
@@ -7901,6 +7939,13 @@
         "type": "^1.0.1"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -9058,6 +9103,43 @@
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.5.0",
@@ -14211,6 +14293,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -19203,6 +19305,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "eslint-formatter-compact": "^8.40.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^50.3.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.1.0",


### PR DESCRIPTION
## Description 

This PR addresses a part of #11249 by adding a linting rule to catch instances of onClick handlers attached to `<div>` elements which is a common pattern I've seen in the codebase. Clickable `<div>` elements are not semantically correct and creates accessibility/UI issues. These elements should either use proper semantic HTML (like `<button>`) or have appropriate ARIA roles and keyboard event handlers.

This PR adds a new dev dependency to the repository which allows us to add linting for accessibility rules: [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) 

The plugin does static evaluations of the TSX code. The [jsx-a11y/no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md) rule prevents interactive handlers (`onClick`, `onMouseDown`, etc) on non-interactive elements without proper ARIA roles. This should flag all the instances of `<div onClick={...}>` without role attributes.

By adding this rule, we can prevent further instances of clickable divs. We can then start addressing all of the files that are failing this rule in the future as we come across the files during our work.

## Usage

When you open a file that is failing this rule, you will see a message like "Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element." under the "Problems" tab. A red squiggly under the problematic code will show up:

<img width="1840" height="1106" alt="image" src="https://github.com/user-attachments/assets/f368a509-982f-4493-a18c-a7f9af9252d6" />

-- 

To see all the places where this rule is failing, you can run:
`npm run eslint -- --format=compact 2>&1 | grep "no-static-element-interactions"`

The current list of files that are failing this rule in Core:
- src/vs/base/browser/ui/positronComponents/scrollable/Scrollable.tsx
- src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
- src/vs/workbench/browser/positronComponents/positronModalDialog/components/draggableTitleBar.tsx
- src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.tsx
- src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
- src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
- src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
- src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
- src/vs/workbench/contrib/positronHistory/browser/components/historySeparator.tsx
- src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeletionSentinel.tsx
- src/vs/workbench/contrib/positronNotebook/browser/notebookCells/ExecutionStatusBadge.tsx
- src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
- src/vs/workbench/contrib/positronPlots/browser/components/plotGalleryThumbnail.tsx
- src/vs/workbench/contrib/positronVariables/browser/components/variableGroup.tsx
- src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
- src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.tsx
- src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
- src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
- src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
- src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
- src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
- src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
This PR just adds a new dev dependency to the code base and shouldn't effect performance or behavior of any builds. We can do some basic verification to make sure the app works, but there isn't anything specific to test here.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
