### PR TITLE
Add preview mode support for Data Explorer tabs

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -20,6 +20,8 @@ import { extname } from '../../../../base/common/resources.js';
 import { posix } from '../../../../base/common/path.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { DataExplorerPreviewEnabled } from '../../../services/positronDataExplorer/browser/positronDataExplorerSummary.js';
 
 /**
  * PositronDataExplorerContribution class.
@@ -36,6 +38,7 @@ class PositronDataExplorerContribution extends Disposable {
 	 * @param instantiationService The instantiation service.
 	 */
 	constructor(
+		@IConfigurationService configurationService: IConfigurationService,
 		@IEditorResolverService editorResolverService: IEditorResolverService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IPositronDataExplorerService dataExplorerService: IPositronDataExplorerService
@@ -51,6 +54,13 @@ class PositronDataExplorerContribution extends Disposable {
 		};
 
 		const createDataExplorerEditor: EditorInputFactoryFunction = ({ resource, options }) => {
+			// Determine pinned state based on preview setting.
+			// When preview is enabled, tabs open unpinned (in preview mode).
+			// See https://github.com/posit-dev/positron/issues/11289
+			// Note: We intentionally ignore options.pinned here to ensure our setting
+			// takes precedence over VS Code's default preview behavior for files.
+			const pinned = !DataExplorerPreviewEnabled(configurationService);
+
 			return {
 				editor: instantiationService.createInstance(
 					PositronDataExplorerEditorInput,
@@ -58,8 +68,7 @@ class PositronDataExplorerContribution extends Disposable {
 				),
 				options: {
 					...options,
-					// Fix for https://github.com/posit-dev/positron/issues/3362.
-					pinned: true
+					pinned
 				}
 			};
 		};

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -7,6 +7,7 @@ import { localize } from '../../../../nls.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../editor/common/editorService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -22,6 +23,7 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { URI } from '../../../../base/common/uri.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { DataExplorerPreviewEnabled } from './positronDataExplorerSummary.js';
 
 /**
  * DataExplorerRuntime class.
@@ -136,6 +138,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 */
 	constructor(
 		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
@@ -374,9 +377,13 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 
 		this.registerDataExplorerClient(languageName, dataExplorerClientInstance);
 
+		// Determine pinned state based on preview setting
+		const pinned = !DataExplorerPreviewEnabled(this._configurationService);
+
 		// Open an editor for the Positron data explorer client instance.
 		const editorPane = await this._editorService.openEditor({
-			resource: PositronDataExplorerUri.generate(dataExplorerClientInstance.identifier)
+			resource: PositronDataExplorerUri.generate(dataExplorerClientInstance.identifier),
+			options: { pinned }
 		});
 
 		// If the editor could not be opened, notify the user and return.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -92,7 +92,7 @@ configurationRegistry.registerConfiguration({ // for preview mode
 			default: false,
 			markdownDescription: localize(
 				'positron.dataExplorerEnablePreview',
-				'Controls whether Data Explorer tabs open in preview mode. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or interacting with the data pins the tab.'
+				'Controls whether preview mode is used for Data Explorer tabs, similar to `#workbench.editor.enablePreview#` for regular editors. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or interacting with the data pins the tab.'
 			),
 		},
 	},

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -92,7 +92,7 @@ configurationRegistry.registerConfiguration({ // for preview mode
 			default: false,
 			markdownDescription: localize(
 				'positron.dataExplorerEnablePreview',
-				'Controls whether preview mode is used for Data Explorer tabs, similar to `#workbench.editor.enablePreview#` for regular editors. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or interacting with the data pins the tab.'
+				'Controls whether preview mode is used for Data Explorer tabs, similar to `#workbench.editor.enablePreview#` for regular editors. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or clicking the \'Keep Open\' option in its label context menu pins the tab.'
 			),
 		},
 	},

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -89,7 +89,7 @@ configurationRegistry.registerConfiguration({ // for preview mode
 	properties: {
 		[DATA_EXPLORER_ENABLE_PREVIEW_KEY]: {
 			type: 'boolean',
-			default: true,
+			default: false,
 			markdownDescription: localize(
 				'positron.dataExplorerEnablePreview',
 				'Controls whether Data Explorer tabs open in preview mode. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or interacting with the data pins the tab.'

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -19,6 +19,8 @@ export const USE_DATA_EXPLORER_SUMMARY_COLLAPSED_KEY =
 	'dataExplorer.summaryCollapsed';
 export const USE_DATA_EXPLORER_SUMMARY_LAYOUT_KEY =
 	'dataExplorer.summaryLayout';
+export const DATA_EXPLORER_ENABLE_PREVIEW_KEY =
+	'dataExplorer.enablePreview';
 
 export function DataExplorerSummaryCollapseEnabled(
 	configurationService: IConfigurationService
@@ -38,6 +40,14 @@ export function DefaultDataExplorerSummaryLayout(
 	} else {
 		return PositronDataExplorerLayout.SummaryOnRight;
 	}
+}
+
+export function DataExplorerPreviewEnabled(
+	configurationService: IConfigurationService
+) {
+	return Boolean(
+		configurationService.getValue(DATA_EXPLORER_ENABLE_PREVIEW_KEY)
+	);
 }
 
 // Register the configuration setting
@@ -69,6 +79,20 @@ configurationRegistry.registerConfiguration({ // for summary layout
 			markdownDescription: localize(
 				'positron.dataExplorerSummaryLayout',
 				'Select the position of the Data Explorer Summary Panel (left or right).'
+			),
+		},
+	},
+});
+configurationRegistry.registerConfiguration({ // for preview mode
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[DATA_EXPLORER_ENABLE_PREVIEW_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.dataExplorerEnablePreview',
+				'Controls whether Data Explorer tabs open in preview mode. Preview tabs are shown in italics and are replaced by the next Data Explorer opened. Double-clicking or interacting with the data pins the tab.'
 			),
 		},
 	},


### PR DESCRIPTION
## Summary

Adds a new setting `dataExplorer.enablePreview` that controls whether Data Explorer tabs open in preview mode, addressing user feedback about tab clutter when clicking through multiple CSV files.

- When enabled (default): Data Explorer tabs open in preview mode (italicized tab name), and opening another Data Explorer replaces the previous preview tab
- When disabled: Data Explorer tabs open pinned (traditional behavior)

<img src="https://github.com/user-attachments/assets/5dee329e-16c9-4d0a-b267-8ef4c0bcf7c2" width=75%>


Addresses #11289

## QA Notes

@:data-explorer

### Testing Steps

1. **Preview mode enabled (default)**:
   - Open Settings, verify `dataExplorer.enablePreview` is checked (true)
   - Click a CSV file in the Explorer → tab should appear in italics
   - Click another CSV file → should replace the previous preview tab
   - Double-click the tab → should pin it (remove italics)

2. **Preview mode disabled**:
   - Open Settings, uncheck `dataExplorer.enablePreview`
   - Click a CSV file → tab should be pinned (no italics)
   - Click another CSV file → should open as a new pinned tab

3. **Runtime data frames**:
   - In Python/R console, view a data frame
   - Should respect the same preview setting

4. **Tab interactions**:
   - Right-click a preview tab → "Keep Open" should pin it
   - Verify parquet files also respect the setting