### PR TITLE
Assistant: Fix case-insensitive model preference matching and add exact matching

### DIFF
--- a/extensions/positron-assistant/src/modelFilters.ts
+++ b/extensions/positron-assistant/src/modelFilters.ts
@@ -154,6 +154,7 @@ export function applyModelFilters(
 		log.debug(`[${providerName}] ${userSelectableCount} user-selectable models after applying system defaults (${nonSelectableCount} non-selectable): ${filteredModels.filter(m => m.isUserSelectable !== false).map(m => m.id).join(', ')}`);
 	}
 
+	// TODO: Consider refactoring so that selecting the default model only happens after filtering
 	// Check if the default model was filtered out
 	const hasDefault = filteredModels.some(m => m.isDefault);
 	if (!hasDefault && filteredModels.length > 0) {

--- a/extensions/positron-assistant/src/modelFilters.ts
+++ b/extensions/positron-assistant/src/modelFilters.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { log } from './extension.js';
 import { DEFAULT_SELECTABLE_PATTERNS } from './constants.js';
+import { markDefaultModel } from './modelResolutionHelpers.js';
 
 /**
  * Check if a model matches a user-defined filter pattern.
@@ -78,7 +79,8 @@ function regexMatch(pattern: string, text: string): boolean {
 export function applyModelFilters(
 	models: vscode.LanguageModelChatInformation[],
 	vendor: string,
-	providerName: string
+	providerName: string,
+	defaultMatch?: string
 ): vscode.LanguageModelChatInformation[] {
 	if (models.length === 0) {
 		log.debug(`[${providerName}] No models to filter.`);
@@ -150,6 +152,18 @@ export function applyModelFilters(
 		log.debug(`[${providerName}] 1 user-selectable model after applying system defaults (${nonSelectableCount} non-selectable): ${filteredModels.find(m => m.isUserSelectable !== false)?.id}`);
 	} else {
 		log.debug(`[${providerName}] ${userSelectableCount} user-selectable models after applying system defaults (${nonSelectableCount} non-selectable): ${filteredModels.filter(m => m.isUserSelectable !== false).map(m => m.id).join(', ')}`);
+	}
+
+	// Check if the default model was filtered out
+	const hasDefault = filteredModels.some(m => m.isDefault);
+	if (!hasDefault && filteredModels.length > 0) {
+		// Find the original default model that was filtered out for logging
+		const originalDefault = models.find(m => m.isDefault);
+		if (originalDefault) {
+			log.info(`[${providerName}] Configured default model '${originalDefault.id}' was filtered out; re-selecting default from remaining models.`);
+		}
+		// Re-select default from the filtered list
+		filteredModels = markDefaultModel(filteredModels, vendor, defaultMatch);
 	}
 
 	return filteredModels;

--- a/extensions/positron-assistant/src/modelResolutionHelpers.ts
+++ b/extensions/positron-assistant/src/modelResolutionHelpers.ts
@@ -31,42 +31,39 @@ export function getUserTokenLimits(): TokenLimits {
 }
 
 /**
- * Determines if a model should be marked as the default for a given provider.
+ * Finds the index of the best matching model for a pattern.
+ * Prefers exact ID or name match over partial match. Matching is case-insensitive.
  *
- * This function checks:
- * 1. User-configured default models for the provider
- * 2. Falls back to provider-specific default patterns
- *
- * @param provider The provider ID (e.g., 'anthropic-api', 'openai-compatible')
- * @param id The model ID to check
- * @param name Optional model display name to check against
- * @param defaultMatch Optional fallback pattern to match against (provider-specific)
- * @returns true if this model should be the default
+ * @param models Array of models to search
+ * @param pattern Pattern to match against model ID or name
+ * @returns Index of matching model, or -1 if no match
  */
-export function isDefaultUserModel(
-	provider: string,
-	id: string,
-	name?: string,
-	defaultMatch?: string
-): boolean {
-	const config = vscode.workspace.getConfiguration('positron.assistant');
-	const providerPreferences = config.get<Record<string, string>>('models.preference.byProvider');
+export function findMatchingModelIndex(
+	models: vscode.LanguageModelChatInformation[],
+	pattern: string
+): number {
+	const patternLower = pattern.toLowerCase();
+	let firstPartialMatchIndex = -1;
 
-	// Check user-configured default for this provider
-	const userDefault = providerPreferences[provider];
-	if (userDefault) {
-		const userDefaultLower = userDefault.toLowerCase();
-		if (id.toLowerCase().includes(userDefaultLower) || name?.toLowerCase().includes(userDefaultLower)) {
-			return true;
+	for (let i = 0; i < models.length; i++) {
+		const model = models[i];
+		const idLower = model.id.toLowerCase();
+		const nameLower = model.name?.toLowerCase() ?? '';
+
+		// Exact match on ID or name - use it immediately
+		if (idLower === patternLower || nameLower === patternLower) {
+			return i;
+		}
+
+		// Track first partial match (includes pattern in id or name)
+		if (firstPartialMatchIndex === -1) {
+			if (idLower.includes(patternLower) || nameLower.includes(patternLower)) {
+				firstPartialMatchIndex = i;
+			}
 		}
 	}
 
-	// Fall back to provider-specific default pattern if provided
-	if (defaultMatch) {
-		return id.toLowerCase().includes(defaultMatch.toLowerCase());
-	}
-
-	return false;
+	return firstPartialMatchIndex;
 }
 
 /**
@@ -190,9 +187,10 @@ export function createModelInfo(params: CreateModelInfoParams): vscode.LanguageM
 /**
  * Marks models as default, ensuring only one default per provider.
  *
- * This utility function standardizes default model selection across all providers.
- * It uses the isDefaultUserModel logic to determine which model should be default,
- * and ensures exactly one model is marked as default per provider.
+ * Priority order:
+ * 1. User-configured byProvider pattern (exact match preferred, then partial)
+ * 2. Provider-specific defaultMatch pattern (exact match preferred, then partial)
+ * 3. First model in list
  *
  * @param models Array of models to process
  * @param provider The provider ID (used for default model detection)
@@ -208,24 +206,30 @@ export function markDefaultModel(
 		return models;
 	}
 
-	// Mark models as default, ensuring only one default per provider
-	let hasDefault = false;
-	const updatedModels = models.map((model) => {
-		if (!hasDefault && isDefaultUserModel(provider, model.id, model.name, defaultMatch)) {
-			hasDefault = true;
-			return { ...model, isDefault: true };
-		} else {
-			return { ...model, isDefault: false };
-		}
-	});
+	// Get user-configured pattern for this provider
+	const config = vscode.workspace.getConfiguration('positron.assistant');
+	const providerPreferences = config.get<Record<string, string>>('models.preference.byProvider', {});
 
-	// If no models match the default criteria, make the first model the default
-	if (updatedModels.length > 0 && !hasDefault) {
-		updatedModels[0] = {
-			...updatedModels[0],
-			isDefault: true,
-		};
+	let defaultModelIndex = -1;
+
+	// Try user-configured pattern first
+	const userDefault = providerPreferences[provider];
+	if (userDefault) {
+		defaultModelIndex = findMatchingModelIndex(models, userDefault);
 	}
 
-	return updatedModels;
+	// Fall back to provider-specific defaultMatch
+	if (defaultModelIndex === -1 && defaultMatch) {
+		defaultModelIndex = findMatchingModelIndex(models, defaultMatch);
+	}
+
+	// Fall back to first model
+	if (defaultModelIndex === -1) {
+		defaultModelIndex = 0;
+	}
+
+	return models.map((model, index) => ({
+		...model,
+		isDefault: index === defaultModelIndex,
+	}));
 }

--- a/extensions/positron-assistant/src/modelResolutionHelpers.ts
+++ b/extensions/positron-assistant/src/modelResolutionHelpers.ts
@@ -55,14 +55,15 @@ export function isDefaultUserModel(
 	// Check user-configured default for this provider
 	const userDefault = providerPreferences[provider];
 	if (userDefault) {
-		if (id.includes(userDefault) || name?.includes(userDefault)) {
+		const userDefaultLower = userDefault.toLowerCase();
+		if (id.toLowerCase().includes(userDefaultLower) || name?.toLowerCase().includes(userDefaultLower)) {
 			return true;
 		}
 	}
 
 	// Fall back to provider-specific default pattern if provided
 	if (defaultMatch) {
-		return id.includes(defaultMatch);
+		return id.toLowerCase().includes(defaultMatch.toLowerCase());
 	}
 
 	return false;

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
@@ -94,6 +94,10 @@ export class AnthropicModelProvider extends ModelProvider implements positron.ai
 		return !!this._config.apiKey && this._config.apiKey.startsWith('sk-ant-');
 	}
 
+	protected override getDefaultMatch(): string {
+		return DEFAULT_ANTHROPIC_MODEL_MATCH;
+	}
+
 	override async resolveConnection(token: vscode.CancellationToken) {
 		// Keep custom implementation for API-specific connection testing
 		const timeoutMs = getProviderTimeoutMs();

--- a/extensions/positron-assistant/src/providers/base/modelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/modelProvider.ts
@@ -177,6 +177,19 @@ export abstract class ModelProvider implements positron.ai.LanguageModelChatProv
 	}
 
 	/**
+	 * Gets the default match pattern for this provider.
+	 *
+	 * This pattern is used by {@link markDefaultModel} to determine which model
+	 * should be marked as default when no user preference is configured.
+	 * Subclasses can override this to provide provider-specific defaults.
+	 *
+	 * @returns The default match pattern, or undefined to use first model as default
+	 */
+	protected getDefaultMatch(): string | undefined {
+		return this._config.model;
+	}
+
+	/**
 	 * Filters the available models based on user configuration and provider capabilities.
 	 *
 	 * This method applies configured filters to remove models that don't meet
@@ -190,7 +203,7 @@ export abstract class ModelProvider implements positron.ai.LanguageModelChatProv
 	 * @see {@link applyModelFilters} for filter implementation details
 	 */
 	protected filterModels(models: vscode.LanguageModelChatInformation[]): vscode.LanguageModelChatInformation[] {
-		return applyModelFilters(models, this.providerId, this.providerName);
+		return applyModelFilters(models, this.providerId, this.providerName, this.getDefaultMatch());
 	}
 
 	/**

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -617,7 +617,7 @@ suite('AnthropicModelProvider', () => {
 	suite('Model Resolution', () => {
 		let mockWorkspaceConfig: sinon.SinonStub;
 		let mockModelDefinitions: sinon.SinonStub;
-		let mockHelpers: { createModelInfo: sinon.SinonStub; isDefaultUserModel: sinon.SinonStub; markDefaultModel: sinon.SinonStub };
+		let mockHelpers: { createModelInfo: sinon.SinonStub; markDefaultModel: sinon.SinonStub };
 		let getConfigurationStub: sinon.SinonStub;
 
 		setup(() => {
@@ -633,7 +633,6 @@ suite('AnthropicModelProvider', () => {
 			// Mock helper functions
 			mockHelpers = {
 				createModelInfo: sinon.stub(helpersModule, 'createModelInfo'),
-				isDefaultUserModel: sinon.stub(helpersModule, 'isDefaultUserModel'),
 				markDefaultModel: sinon.stub(helpersModule, 'markDefaultModel')
 			};
 		});
@@ -643,7 +642,6 @@ suite('AnthropicModelProvider', () => {
 			getConfigurationStub.restore();
 			mockModelDefinitions.restore();
 			mockHelpers.createModelInfo.restore();
-			mockHelpers.isDefaultUserModel.restore();
 			mockHelpers.markDefaultModel.restore();
 		});
 

--- a/extensions/positron-assistant/src/test/modelFilters.test.ts
+++ b/extensions/positron-assistant/src/test/modelFilters.test.ts
@@ -17,6 +17,7 @@ suite('Model Filters', () => {
 		sinon.stub(vscode.workspace, 'getConfiguration').returns({
 			get: mockWorkspaceConfig
 		} as any);
+		mockWorkspaceConfig.withArgs('models.preference.byProvider', {}).returns({});
 	});
 
 	teardown(() => {
@@ -78,7 +79,9 @@ suite('Model Filters', () => {
 			const result = applyModelFilters(models, 'anthropic', 'Anthropic');
 
 			assert.strictEqual(result.length, models.length);
-			assert.deepStrictEqual(result, models);
+			const resultIds = result.map(m => m.id);
+			assert.ok(resultIds.includes('claude-sonnet-4.5'));
+			assert.ok(resultIds.includes('claude-opus-4'));
 		});
 
 		test('filters models using patterns', () => {
@@ -567,7 +570,6 @@ suite('Model Filters', () => {
 			// Filter out the default model (opus)
 			mockWorkspaceConfig.withArgs('unfilteredProviders', []).returns([]);
 			mockWorkspaceConfig.withArgs('models.include', []).returns(['sonnet', 'haiku']);
-			mockWorkspaceConfig.withArgs('models.preference.byProvider', {}).returns({});
 
 			const result = applyModelFilters(models, 'anthropic-api', 'Anthropic', 'claude-sonnet-4');
 
@@ -614,7 +616,6 @@ suite('Model Filters', () => {
 			// Filter includes the default model
 			mockWorkspaceConfig.withArgs('unfilteredProviders', []).returns([]);
 			mockWorkspaceConfig.withArgs('models.include', []).returns(['sonnet', 'haiku']);
-			mockWorkspaceConfig.withArgs('models.preference.byProvider', {}).returns({});
 
 			const result = applyModelFilters(models, 'anthropic-api', 'Anthropic', 'claude-haiku');
 
@@ -667,7 +668,6 @@ suite('Model Filters', () => {
 			// Filter out the default model, keep only gpt models
 			mockWorkspaceConfig.withArgs('unfilteredProviders', []).returns([]);
 			mockWorkspaceConfig.withArgs('models.include', []).returns(['gpt']);
-			mockWorkspaceConfig.withArgs('models.preference.byProvider', {}).returns({});
 
 			// defaultMatch is 'claude-sonnet' which won't match any remaining models
 			const result = applyModelFilters(models, 'mixed', 'Mixed', 'claude-sonnet');

--- a/extensions/positron-assistant/src/test/modelResolutionHelpers.test.ts
+++ b/extensions/positron-assistant/src/test/modelResolutionHelpers.test.ts
@@ -101,6 +101,41 @@ suite('Model Resolution Helpers', () => {
 
 			assert.strictEqual(result, false);
 		});
+
+		test('matches case-insensitively on model ID (lowercase preference)', () => {
+			const providerPreferences = { 'anthropic-api': 'sonnet' };
+			mockGetConfiguration.withArgs('models.preference.byProvider').returns(providerPreferences);
+
+			const result = isDefaultUserModel('anthropic-api', 'claude-SONNET-4-5', 'Claude Sonnet 4.5');
+
+			assert.strictEqual(result, true);
+		});
+
+		test('matches case-insensitively on model name (lowercase preference)', () => {
+			const providerPreferences = { 'anthropic-api': 'haiku' };
+			mockGetConfiguration.withArgs('models.preference.byProvider').returns(providerPreferences);
+
+			const result = isDefaultUserModel('anthropic-api', 'claude-haiku-4-5', 'Claude Haiku 4.5');
+
+			assert.strictEqual(result, true);
+		});
+
+		test('matches case-insensitively with uppercase preference', () => {
+			const providerPreferences = { 'anthropic-api': 'SONNET' };
+			mockGetConfiguration.withArgs('models.preference.byProvider').returns(providerPreferences);
+
+			const result = isDefaultUserModel('anthropic-api', 'claude-sonnet-4-5', 'Claude Sonnet 4.5');
+
+			assert.strictEqual(result, true);
+		});
+
+		test('matches case-insensitively on defaultMatch pattern', () => {
+			mockGetConfiguration.withArgs('models.preference.byProvider').returns({});
+
+			const result = isDefaultUserModel('anthropic-api', 'claude-SONNET-4-5', 'Claude Sonnet 4.5', 'sonnet');
+
+			assert.strictEqual(result, true);
+		});
 	});
 
 	suite('getMaxTokens', () => {
@@ -174,6 +209,7 @@ suite('Model Resolution Helpers', () => {
 			assert.strictEqual(resultInput, 250_000);
 			assert.strictEqual(resultOutput, 64_000);
 		});
+
 	});
 
 	suite('markDefaultModel', () => {

--- a/extensions/positron-assistant/src/test/openai.test.ts
+++ b/extensions/positron-assistant/src/test/openai.test.ts
@@ -40,6 +40,7 @@ suite('OpenAIModelProvider', () => {
 		// Mock the applyModelFilters import
 		mockWorkspaceConfig.withArgs('unfilteredProviders', []).returns([]);
 		mockWorkspaceConfig.withArgs('models.include', []).returns([]);
+		mockWorkspaceConfig.withArgs('models.preference.byProvider', {}).returns({});
 
 		openAIModel = new OpenAIModelProvider(mockConfig);
 	});

--- a/extensions/positron-assistant/src/test/openai.test.ts
+++ b/extensions/positron-assistant/src/test/openai.test.ts
@@ -104,7 +104,7 @@ suite('OpenAIModelProvider', () => {
 
 	suite('Model Resolution', () => {
 		let mockModelDefinitions: sinon.SinonStub;
-		let mockHelpers: { createModelInfo: sinon.SinonStub; isDefaultUserModel: sinon.SinonStub; markDefaultModel: sinon.SinonStub };
+		let mockHelpers: { createModelInfo: sinon.SinonStub; markDefaultModel: sinon.SinonStub };
 
 		setup(() => {
 			// Mock getAllModelDefinitions
@@ -113,7 +113,6 @@ suite('OpenAIModelProvider', () => {
 			// Mock helper functions
 			mockHelpers = {
 				createModelInfo: sinon.stub(helpersModule, 'createModelInfo'),
-				isDefaultUserModel: sinon.stub(helpersModule, 'isDefaultUserModel'),
 				markDefaultModel: sinon.stub(helpersModule, 'markDefaultModel')
 			};
 		});
@@ -122,7 +121,6 @@ suite('OpenAIModelProvider', () => {
 			// Restore specific stubs for this suite
 			mockModelDefinitions.restore();
 			mockHelpers.createModelInfo.restore();
-			mockHelpers.isDefaultUserModel.restore();
 			mockHelpers.markDefaultModel.restore();
 		});
 


### PR DESCRIPTION
Addresses #11188

The model preference matching in `positron.assistant.models.preference.byProvider` was case-sensitive, but intended to be case-insensitive. This fix converts strings to lowercase before comparison so users can configure `haiku` and have it correctly match `Claude Haiku 4.5`.

It also updates the pattern matching logic so that when multiple models for the provider match the pattern, an exact match is preferred if one exists. Otherwise, we revert to the first available.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix model preference matching by provider to be case-insensitive as documented (#11188)

### QA Notes

@:assistant

Confirm that configuring a model in the By Provider user setting selects a default model regardless of case.

Added 4 new test cases:
- Lowercase preference matching uppercase model ID
- Lowercase preference matching uppercase model name
- Uppercase preference matching lowercase model ID/name
- Case-insensitive `defaultMatch` pattern matching