### PR TITLE
Fix title mixup with macOS native tabs

### DIFF
--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -199,10 +199,17 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 		options.fullscreenable = false; // enables simple fullscreen mode
 	}
 
-	const useNativeTabs = isMacintosh && windowSettings?.nativeTabs === true;
-	if (useNativeTabs) {
-		options.tabbingIdentifier = productService.nameShort; // this opts in to sierra tabs
-	}
+	// --- Start Positron ---
+	// Don't set `tabbingIdentifier` because it causes macOS to automatically group
+	// windows as tabs at creation time, before they have their proper titles. This
+	// leads to a tab title mixup. Instead, we explicitly call `addTabbedWindow()`
+	// in windowsMainService.ts. https://github.com/posit-dev/positron/issues/10488
+	//
+	// const useNativeTabs = isMacintosh && windowSettings?.nativeTabs === true;
+	// if (useNativeTabs) {
+	// 	options.tabbingIdentifier = productService.nameShort; // this opts in to sierra tabs
+	// }
+	// --- End Positron ---
 
 	const hideNativeTitleBar = !hasNativeTitlebar(configurationService, overrides?.forceNativeTitlebar ? TitlebarStyle.NATIVE : undefined);
 	if (hideNativeTitleBar) {

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -192,18 +192,37 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 
 	if (overrides?.disableFullscreen) {
 		options.fullscreen = false;
-	// --- Start Positron ---
-	// eslint-disable-next-line react-hooks/rules-of-hooks
+		// --- Start Positron ---
+		// eslint-disable-next-line react-hooks/rules-of-hooks
 	} else if (isMacintosh && !useNativeFullScreen(configurationService)) {
 		// --- End Positron ---
 		options.fullscreenable = false; // enables simple fullscreen mode
 	}
 
 	// --- Start Positron ---
-	// Don't set `tabbingIdentifier` because it causes macOS to automatically group
-	// windows as tabs at creation time, before they have their proper titles. This
-	// leads to a tab title mixup. Instead, we explicitly call `addTabbedWindow()`
-	// in windowsMainService.ts. https://github.com/posit-dev/positron/issues/10488
+	// In Positron, we do not rely on macOS's OS level setting
+	// "Prefer tabs when opening documents". This setting is what generally
+	// controls whether or not a new window is automatically grouped into
+	// a tab group at creation time, within a tab group name of
+	// `tabbingIdentifier`.
+	//
+	// Instead, we rely solely on `windowSettings?.nativeTabs`. If this is `true`,
+	// we assume the user definitely wants a native tab, regardless of the OS
+	// level setting, and we always call `addTabbedWindow()` in
+	// `windowsMainService.ts` to add the window as a tab "manually" after
+	// window creation.
+	//
+	// We have determined that a bug causing a mixup in tab titles was related to
+	// us doing both of the following:
+	// - Set `tabbingIdentifier` to let the OS auto-add the window as a tab
+	// - Call `addTabbedWindow()` to manually add the window as a tab
+	// And doing both has been shown to result in tab ordering problems:
+	// https://github.com/posit-dev/positron/issues/10488
+	// https://github.com/microsoft/vscode/issues/276577
+	//
+	// Because we always manually call `addTabbedWindow()` on any window
+	// that is going to be opened in a tab, we are able to fully disable
+	// `tabbingIdentifier` to work around this bug.
 	//
 	// const useNativeTabs = isMacintosh && windowSettings?.nativeTabs === true;
 	// if (useNativeTabs) {

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1563,8 +1563,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			// --- Start Positron ---
 			// Force opening in tabbed windows if `window.nativeTabs` is set to `true`.
 			// https://github.com/microsoft/vscode/issues/250042
-			const forceNewTabbedWindow = this.configurationService.getValue<boolean>('window.nativeTabs');
-			if (forceNewTabbedWindow || options.forceNewTabbedWindow) {
+			if (windowConfig?.nativeTabs || options.forceNewTabbedWindow) {
 				// --- End Positron ---
 				const activeWindow = this.getLastActiveWindow();
 				activeWindow?.addTabbedWindow(createdWindow);

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1559,16 +1559,16 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			});
 			mark('code/didCreateCodeWindow');
 
-			// Add as window tab if configured (macOS only)
 			// --- Start Positron ---
-			// Force opening in tabbed windows if `window.nativeTabs` is set to `true`.
-			// https://github.com/microsoft/vscode/issues/250042
-			const forceNewTabbedWindow = this.configurationService.getValue<boolean>('window.nativeTabs');
-			if (forceNewTabbedWindow || options.forceNewTabbedWindow) {
-				// --- End Positron ---
-				const activeWindow = this.getLastActiveWindow();
-				activeWindow?.addTabbedWindow(createdWindow);
-			}
+			// We do the following after the window is ready to fix
+			// https://github.com/posit-dev/positron/issues/10488
+			//
+			// // Add as window tab if configured (macOS only)
+			// if (options.forceNewTabbedWindow) {
+			// 	const activeWindow = this.getLastActiveWindow();
+			// 	activeWindow?.addTabbedWindow(createdWindow);
+			// }
+			// --- End Positron ---
 
 			// Add to our list of windows
 			this.windows.set(createdWindow.id, createdWindow);
@@ -1581,6 +1581,22 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 			// Window Events
 			const disposables = new DisposableStore();
+
+			// --- Start Positron ---
+			// Add as window tab if configured (macOS only)
+			// We wait for the window to be ready to fix a tab title mixup.
+			// https://github.com/posit-dev/positron/issues/10488
+			//
+			// Force opening in tabbed windows if `window.nativeTabs` is set to `true`.
+			// https://github.com/microsoft/vscode/issues/250042
+			const forceNewTabbedWindow = this.configurationService.getValue<boolean>('window.nativeTabs');
+			if (forceNewTabbedWindow || options.forceNewTabbedWindow) {
+				disposables.add(Event.once(createdWindow.onDidSignalReady)(() => {
+					this.getLastActiveWindow()?.addTabbedWindow(createdWindow);
+				}));
+			}
+			// --- End Positron ---
+
 			disposables.add(createdWindow.onDidSignalReady(() => this._onDidSignalReadyWindow.fire(createdWindow)));
 			disposables.add(Event.once(createdWindow.onDidClose)(() => this.onWindowClosed(createdWindow, disposables)));
 			disposables.add(Event.once(createdWindow.onDidDestroy)(() => this.onWindowDestroyed(createdWindow)));


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/10488

@DavisVaughan After toying around I found that this fixes the issue. I don't fully understand why though!

A title update coming asynchronously seems to be causing the issue when both automatic and manual management are at play. I don't know if it's a bug in Electron, macOS, an undocumented limitation, or if we do something wrong. Since in Positron our manual management is equivalent to the automatic (same behaviour no matter what the global macOS preference for tabs is), I just disabled the automatic management.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed issue causing a mixup in tab titles when native macOS tabs are enabled (https://github.com/posit-dev/positron/issues/10488).


### QA Notes

See reprex in linked issue. You need at least three tabs opened, and start from a tab on the left.

- Opening a new window should open a tab on the right. The tab title should match.
- Have like 4 tabs opened and restart Positron. The tabs should remain as tabs, with no title mixup.
- The above should work the same with the global macOS option set to either "never" or "always"

   <img width="466" height="73" alt="Screenshot 2026-01-13 at 23 47 56" src="https://github.com/user-attachments/assets/8000e00b-c8ff-44e1-86f7-bc1d908047f0" />

I've tested this on Tahoe but it would be nice to test on earlier macOS too.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
