### PR TITLE
Remove windows tag from test for empty folder with git initialization

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
@@ -28,7 +28,7 @@ test.describe('New Folder Flow: Empty Project', { tag: [tags.MODAL, tags.NEW_FOL
 		await verifyPyprojectTomlNotCreated(app);
 	});
 
-	test('Verify empty folder with git initialization', { tag: [tags.WIN] }, async function ({ app }) {
+	test('Verify empty folder with git initialization', async function ({ app }) {
 		const { newFolderFlow } = app.workbench;
 		const folderName = addRandomNumSuffix('empty-project-git');
 


### PR DESCRIPTION
New empty-folder test was failing on widows because we can't get to the terminal on windows in playwright.

- Removed the windows tag


### QA Notes
@:new-folder-flow
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
