### PR TITLE
remote ssh: respect `serverInstallPath` for data and extensions dirs

### DIFF
--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -467,7 +467,7 @@ if [[ -z $SERVER_RUNNING_PROCESS ]]; then
 	SERVER_CONNECTION_TOKEN="${crypto.randomUUID()}"
 	echo $SERVER_CONNECTION_TOKEN > $SERVER_TOKENFILE
 
-	$SERVER_SCRIPT --start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms &> $SERVER_LOGFILE &
+	$SERVER_SCRIPT --start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --server-data-dir $SERVER_DATA_DIR --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms &> $SERVER_LOGFILE &
 	echo $! > $SERVER_PIDFILE
 else
 	echo "Server script is already running $SERVER_SCRIPT"


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11370. When adding the `serverInstallPath` setting in https://github.com/posit-dev/positron/pull/10017, I forgot to forward it on to the server script. So some stuff was still being put in `~/.positron-server` no matter what the setting looked like. This fixes that issue.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- The `remoteSSH.serverInstallPath` setting now puts all server data in the specified directory, instead of just the server binary. BREAKING CHANGE: if you were using a custom `serverInstallPath` and don't want to lose application state, make sure to move the files on your remote host in `~/.positron-server` to that custom path.


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
As usual if you do a dev build, you'll have to serve a REH binary that exists, because it won't be able to find one from the CDN.