### PR TITLE
Start supervisor without resource monitoring

### DIFF
--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -388,7 +388,9 @@ async function startKernelSupervisor() {
 	// Start the supervisor process.
 	process.stdout.write(`\nStarting Positron Kernel Supervisor (${supervisorPath})...\n`);
 	const supervisorProcess = spawn(supervisorPath, [
-		'--connection-file', connectionFile, '--log-file', logFile,]);
+		'--connection-file', connectionFile,
+		'--log-file', logFile,
+		'--resource-sample-interval', '0']);
 	supervisorProcess.stdout.on('data', (data) => {
 		process.stdout.write(data);
 	});

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -12,5 +12,7 @@
     "echo",
     "error"
   ],
-  "posit.workbench.showWorkbenchFlaskHint": false
+  "posit.workbench.showWorkbenchFlaskHint": false,
+  "kernelSupervisor.resourceUsagePollInterval": 0,
+  "console.showResourceMonitor": false
 }


### PR DESCRIPTION
There is currently an issue with the Chromium tests that causes them to leak hundreds of node, chrome, etc. processes. Because the new kernel resource monitor frequently enumerates the system process table (and the process table grows unbounded, and instances of the kernel supervisor are _also_ leaked), an $O(n^2)$ behavior ensues that eventually exhausts CPU resources on the CI runner such that new tests take > 1 minute to start and time out.

To help mitigate this problem, this change:

- starts the supervisor without resource monitoring, until Positron tells it to start monitoring
- runs the CI tests without monitoring for now (we should turn this back on once we have made the supervisor's behavior more efficient and the test cleanup more thorough)

E2E run: 
https://github.com/posit-dev/positron/actions/runs/21011629444