### PR TITLE
Add missing CSS keyframes so spinners are animated

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -87,7 +87,13 @@
 }
 
 .connections-items-container .animate-spin {
-	animation: spin 1s linear infinite;
+	animation: connections-spin 1s linear infinite;
+}
+
+@keyframes connections-spin {
+	100% {
+		transform: rotate(360deg);
+	}
 }
 
 .connections-item.selected {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.css
@@ -2,3 +2,13 @@
  *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+.animate-spin {
+	animation: runtime-spin 1.5s linear infinite;
+}
+
+@keyframes runtime-spin {
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
@@ -63,10 +63,8 @@ export const RuntimeStatusIcon = ({ status }: RuntimeStatusIconProps) => {
 	const colorId = statusToIconColor[status];
 	const color = asCssVariable(colorId);
 	return <Icon
+		className={status === RuntimeStatus.Active ? 'animate-spin' : undefined}
 		icon={icon}
-		style={{
-			animation: status === RuntimeStatus.Active ? 'spin 2s linear infinite' : undefined,
-			color,
-		}}
+		style={{ color }}
 	/>
 };


### PR DESCRIPTION
This is a pre-req to #11162 which fixes a CSS `@keyframes` inheritance issue I noticed. 

I noticed that the `running` status icon in the console pane, positron notebooks kernel popup, and connections pane was using a `spin` animation keyframe that was defined in the `CellExecutionInfoPopup.css`. That file will be deleted in an upcoming PR which would cause the spinning animation to stop working for the console pane, positron notebook kernel menu, and connections pane schema view.

`runtimeStatus.css` and `schemaNavigation.css` have `animation: spin 1s linear infinite;` defined but rely on the `spin` animation keyframes defined in `CellExecutionInfoPopup.css`. This inheritance is quite fragile so to avoid regressions with spinners in the future (because of a deleted file) I've updated each css file to have its own uniquely named `@keyframe` that can be referenced by the `animation` property.

I did do some poking in the codebase to see if there was a reusable keyframe for animating spinners and I did run across `src/vs/base/browser/ui/codicons/codicon/codicon-modifiers.css` which has:
```
@keyframes codicon-spin {
	100% {
		transform:rotate(360deg);
	}
}

.codicon-sync.codicon-modifier-spin,
.codicon-loading.codicon-modifier-spin,
.codicon-gear.codicon-modifier-spin,
.codicon-notebook-state-executing.codicon-modifier-spin {
	/* Use steps to throttle FPS to reduce CPU usage */
	animation: codicon-spin 1.5s steps(30) infinite;
}
```

This looks to be a centralized location for adding a spin animation to certain codicons! An element with `className='codicon-loading codicon-modifier-spin'` would get the spinning animation style because of the `.codicon-loading.codicon-modifier-spin` compound selector.

We could consider moving all spinner animation styles into this file but I am a bit worried about the discoverability of this file for folks. Curious what other folks think! 

### Screenshots

**BEFORE - all spinners using keyframes from a positron notebook file 😬**

https://github.com/user-attachments/assets/9d6dd665-8c26-4c0b-92f1-fcfcf1f7edf8


**AFTER - each file has its own `@keyframes` now**

https://github.com/user-attachments/assets/fe86dca7-227d-4b06-8f4d-1a0af233672a


https://github.com/user-attachments/assets/df9923dd-911e-4dd0-84bd-5a8477252f8e



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks
@:connections
@:sessions
@:console

For testing, we should make sure that the `running` icon spins in the console tab and positron notebook kernel menu. This can e done by clicking the "restart" icon button in the console tab or the "restart kernel" option from the positron notebook kernel menu.

For testing the connections pane, we can use the same testing steps as in https://github.com/posit-dev/positron/issues/10835. 

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
