### PR TITLE
Connections: Use dropdown for option inputs with many/long options

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -108,3 +108,8 @@
 	align-items: center;
 	gap: 6px;
 }
+
+.create-connection-inputs > .labeled-input > label > .drop-down-list-box {
+	flex: 1;
+	min-width: 0;
+}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -249,13 +249,12 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 					title: option.title,
 					value: option.identifier
 				}));
-				const selectedId = defaultValue || options[0].identifier;
 
 				return <div className='labeled-input'><label className='label'>
 					<span className='label-text'>{label}</span>
 					<DropDownListBox
 						entries={entries}
-						selectedIdentifier={selectedId}
+						selectedIdentifier={defaultValue || options[0].identifier}
 						title={label}
 						onSelectionChanged={(item) => props.onChange(item.options.identifier)}
 					/>
@@ -266,7 +265,7 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 				<span className='label-text'>{label}</span>
 				<RadioGroup
 					entries={options.map(option => ({ options: option }))}
-					initialSelectionId={options[0].identifier}
+					initialSelectionId={defaultValue || options[0].identifier}
 					labelledBy={label}
 					name={label}
 					onSelectionChanged={(option) => props.onChange(option)}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -17,6 +17,8 @@ import Severity from '../../../../../../base/common/severity.js';
 import { IDriver, Input } from '../../../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { LabeledTextInput } from '../../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
 import { RadioGroup } from '../../../../../browser/positronComponents/positronModalDialog/components/radioGroup.js';
+import { DropDownListBox } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
+import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
 
@@ -201,6 +203,23 @@ interface FormElementProps {
 	onChange: (value: string) => void;
 }
 
+/**
+ * Determines whether to use a dropdown instead of radio buttons for option inputs.
+ * Uses dropdown when:
+ * - There are more than 3 options, OR
+ * - Any option title exceeds 30 characters
+ */
+const shouldUseDropdown = (options: { identifier: string; title: string }[]): boolean => {
+	const MAX_OPTIONS_FOR_RADIO = 3;
+	const MAX_TITLE_LENGTH = 30;
+
+	if (options.length > MAX_OPTIONS_FOR_RADIO) {
+		return true;
+	}
+
+	return options.some(option => option.title.length > MAX_TITLE_LENGTH);
+};
+
 const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 	const { label, value: defaultValue = '', type, options } = props.input;
 
@@ -215,21 +234,43 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 				></LabeledTextInput>
 			</div>;
 		case 'option':
+			if (!options || options.length === 0) {
+				return <div className='labeled-input'><label className='label'>
+					<span className='label-text'>{label}</span>
+					<p>
+						{(() => localize('positron.newConnectionModalDialog.createConnection.input.noOption', 'No options provided'))()}
+					</p>
+				</label></div>;
+			}
+
+			if (shouldUseDropdown(options)) {
+				const entries = options.map(option => new DropDownListBoxItem({
+					identifier: option.identifier,
+					title: option.title,
+					value: option.identifier
+				}));
+				const selectedId = defaultValue || options[0].identifier;
+
+				return <div className='labeled-input'><label className='label'>
+					<span className='label-text'>{label}</span>
+					<DropDownListBox
+						entries={entries}
+						selectedIdentifier={selectedId}
+						title={label}
+						onSelectionChanged={(item) => props.onChange(item.options.identifier)}
+					/>
+				</label></div>;
+			}
+
 			return <div className='labeled-input'><label className='label'>
 				<span className='label-text'>{label}</span>
-				{
-					options && options.length > 0 ?
-						<RadioGroup
-							entries={options.map(option => ({ options: option }))}
-							initialSelectionId={options[0].identifier}
-							labelledBy={label}
-							name={label}
-							onSelectionChanged={(option) => props.onChange(option)}
-						/>
-						: <p>
-							{(() => localize('positron.newConnectionModalDialog.createConnection.input.noOption', 'No options provided'))()}
-						</p>
-				}
+				<RadioGroup
+					entries={options.map(option => ({ options: option }))}
+					initialSelectionId={options[0].identifier}
+					labelledBy={label}
+					name={label}
+					onSelectionChanged={(option) => props.onChange(option)}
+				/>
 			</label></div>;
 		case 'string':
 		default:


### PR DESCRIPTION
## Summary

- Uses a dropdown instead of radio buttons for option inputs when there are more than 3 options or any option title exceeds 30 characters
- Adds CSS styling to make the dropdown fill available width

Addresses #11392

## Test plan

- Open a connection dialog with an option input that triggers the dropdown (e.g., edit `extensions/positron-connections/src/drivers.ts` and add a long title like `'integer64 with a very long description'` to one of the PostgreSQL driver options)
- Verify dropdown is displayed instead of radio buttons
- Verify dropdown fills the available width
- Revert the edit and verify radio buttons are still used for short options

🤖 Generated with [Claude Code](https://claude.com/claude-code)