### PR TITLE
Assistant: Updates prompt for `/doc` command

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/commands/doc.md
+++ b/extensions/positron-assistant/src/md/prompts/commands/doc.md
@@ -4,6 +4,6 @@ mode: editor
 ---
 The user has asked you to generate documentation for the code in the Editor. Use the information in the code comments and the overall structure of the code to create comprehensive documentation. Be succinct but useful in your documentation. Follow standard documentation guidelines for language in which the code is written. If multiple documentation styles exist, use the one that already exists in the code.
 
-IMPORTANT: Only add or update documentation comments/docstrings. Do NOT modify, refactor, or restructure the existing code itself. The code logic, implementation, function signatures, variable names, and overall structure must remain exactly as they are. Your changes should be limited strictly to adding or improving documentation (comments, docstrings, JSDoc, etc.).
+Only add or update documentation comments/docstrings. Do not modify, refactor, or restructure the existing code itself.
 
 Respond with the code changes to add the documentation. You may provide at most one sentence of narrative.

--- a/extensions/positron-assistant/src/md/prompts/commands/doc.md
+++ b/extensions/positron-assistant/src/md/prompts/commands/doc.md
@@ -4,4 +4,6 @@ mode: editor
 ---
 The user has asked you to generate documentation for the code in the Editor. Use the information in the code comments and the overall structure of the code to create comprehensive documentation. Be succinct but useful in your documentation. Follow standard documentation guidelines for language in which the code is written. If multiple documentation styles exist, use the one that already exists in the code.
 
+IMPORTANT: Only add or update documentation comments/docstrings. Do NOT modify, refactor, or restructure the existing code itself. The code logic, implementation, function signatures, variable names, and overall structure must remain exactly as they are. Your changes should be limited strictly to adding or improving documentation (comments, docstrings, JSDoc, etc.).
+
 Respond with the code changes to add the documentation. You may provide at most one sentence of narrative.


### PR DESCRIPTION
Updates `/doc` command instructions to be more explicit about not touching anything but docs. Testing reliably shows expected behavior:

<img width="3120" height="1774" alt="Screenshot 2026-01-16 at 11 19 06 AM" src="https://github.com/user-attachments/assets/8b8c90dc-f242-455e-bb56-2e816bc1888b" />

Addresses #9170

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant's `/doc` command no longer modifies code logic, only comments/docstrings

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
