### PR TITLE
Add support for R breakpoints

### DIFF
--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -373,27 +373,25 @@ export type CommBackendMessage =
  * Disposing the `DapComm` automatically disposes of the nested `Comm`.
  */
 export interface DapComm {
-    /** The `targetName` passed to the constructor. */
+    /** The `targetName` passed to `create()`. */
     readonly targetName: string;
 
-    /** The `debugType` passed to the constructor. */
+    /** The `debugType` passed to `create()`. */
     readonly debugType: string;
 
-    /** The `debugName` passed to the constructor. */
+    /** The `debugName` passed to `create()`. */
     readonly debugName: string;
 
     /**
      * The comm for the DAP.
      * Use it to receive messages or make notifications and requests.
-     * Defined after `createServerComm()` has been called.
      */
-    readonly comm?: Comm;
+    readonly comm: Comm;
 
     /**
      * The port on which the DAP server is listening.
-     * Defined after `createServerComm()` has been called.
      */
-    readonly serverPort?: number;
+    readonly port: number;
 
     /**
      * Handle a message received via `this.comm.receiver`.

--- a/extensions/positron-python/src/client/positron-supervisor.d.ts
+++ b/extensions/positron-python/src/client/positron-supervisor.d.ts
@@ -416,6 +416,12 @@ export interface DapComm {
      */
     handleMessage(msg: any): Promise<boolean>;
 
+    /** Connect to the DAP server. */
+    connect(): Promise<void>;
+
+    /** Disconnect from the DAP server. */
+    disconnect(): Promise<void>;
+
     /**
      * Dispose of the underlying comm.
      * Must be called if the DAP comm is no longer in use.

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -962,7 +962,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.223"
+      "ark": "posit-dev/ark@feature/breakpoints"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -710,7 +710,8 @@
         "type": "ark",
         "label": "R Debugger",
         "languages": ["r"],
-        "supportsUiLaunch": false
+        "supportsUiLaunch": false,
+        "sendBreakpointsOnAllSaves": true
       }
     ],
     "notebookRenderer": [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -962,7 +962,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "posit-dev/ark@feature/breakpoints"
+      "ark": "0.1.224"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -711,7 +711,8 @@
         "label": "R Debugger",
         "languages": ["r"],
         "supportsUiLaunch": false,
-        "sendBreakpointsOnAllSaves": true
+        "sendBreakpointsOnAllSaves": true,
+        "verifyBreakpointsInDirtyDocuments": true
       }
     ],
     "notebookRenderer": [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -700,6 +700,11 @@
         "when": "isRPackage"
       }
     ],
+    "breakpoints": [
+      {
+        "language": "r"
+      }
+    ],
     "debuggers": [
       {
         "type": "ark",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -86,6 +86,6 @@
 	"r.walkthrough.migrateFromRStudio.workspaces.description": "  \n[Open an existing folder](command:workbench.action.files.openFolder)",
 	"r.walkthrough.migrateFromRStudio.formatting.title": "Formatting your R code",
 	"r.walkthrough.migrateFromRStudio.formatting.description": "  \n[Configure Air to format on save](command:r.walkthrough.formatOnSave)",
-  "r.welcome.views.debugger.content": "Positron currently provides limited debugging support for R code, but you can use R's native debugging features in Positron.\n[Learn more](https://positron.posit.co/guide-r.html#debugging)"
+	"r.welcome.views.debugger.content": "Positron provides first-class debugging support for R\n[Learn more](https://positron.posit.co/guide-r.html#debugging)"
 
 }

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -381,27 +381,25 @@ export type CommBackendMessage =
  * Disposing the `DapComm` automatically disposes of the nested `Comm`.
  */
 export interface DapComm {
-	/** The `targetName` passed to the constructor. */
+	/** The `targetName` passed to `create()`. */
 	readonly targetName: string;
 
-	/** The `debugType` passed to the constructor. */
+	/** The `debugType` passed to `create()`. */
 	readonly debugType: string;
 
-	/** The `debugName` passed to the constructor. */
+	/** The `debugName` passed to `create()`. */
 	readonly debugName: string;
 
 	/**
 	 * The comm for the DAP.
 	 * Use it to receive messages or make notifications and requests.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly comm?: Comm;
+	readonly comm: Comm;
 
 	/**
 	 * The port on which the DAP server is listening.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly serverPort?: number;
+	readonly port: number;
 
 	/**
 	 * Handle a message received via `this.comm.receiver`.

--- a/extensions/positron-r/src/positron-supervisor.d.ts
+++ b/extensions/positron-r/src/positron-supervisor.d.ts
@@ -424,6 +424,12 @@ export interface DapComm {
 	 */
 	handleMessage(msg: any): Promise<boolean>;
 
+	/** Connect to the DAP server. */
+	connect(): Promise<void>;
+
+	/** Disconnect from the DAP server. */
+	disconnect(): Promise<void>;
+
 	/**
 	 * Dispose of the underlying comm.
 	 * Must be called if the DAP comm is no longer in use.

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -165,11 +165,11 @@ export class RSessionManager implements vscode.Disposable {
 	 * the safer `activateConsoleSession()`.
 	 */
 	private async activateSession(session: RSession, reason: string): Promise<void> {
-		await session.activateLsp(reason);
+		await session.activateServices(reason);
 	}
 
 	private async deactivateSession(session: RSession, reason: string): Promise<void> {
-		await session.deactivateLsp(reason);
+		await session.deactivateServices(reason);
 	}
 
 	/**

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -69,10 +69,6 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	/** The Jupyter kernel-based session implementing the Language Runtime API */
 	private _kernel?: JupyterLanguageRuntimeSession;
 
-	/** Returns the DAP comm, or undefined if not started */
-	private async dapComm(): Promise<DapComm | undefined> {
-		return this._dapComm;
-	}
 	private _dapComm?: Promise<DapComm>;
 
 	/** The emitter for language runtime messages */
@@ -772,7 +768,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 			await Promise.all([
 				this._activateLsp(),
-				this.dapComm().then(dap => dap?.connect()),
+				this._dapComm?.then(dap => dap.connect()),
 			]);
 		});
 	}
@@ -809,7 +805,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 			await Promise.all([
 				this._deactivateLsp(),
-				this.dapComm().then(dap => dap?.disconnect()),
+				this._dapComm?.then(dap => dap.disconnect()),
 			]);
 		});
 	}
@@ -966,7 +962,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		} else if (state === positron.RuntimeState.Exited) {
 			await Promise.all([
 				this.deactivateServices('session exited'),
-				this.dapComm().then(dap => dap?.dispose()),
+				this._dapComm?.then(dap => dap.dispose()),
 			]);
 		}
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -953,6 +953,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 		LOGGER.info('Exiting DAP loop');
 		dapComm?.dispose();
+		this._dapComm = undefined;
 	}
 
 	private async onStateChange(state: positron.RuntimeState): Promise<void> {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -925,9 +925,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	private async startDapMessageLoop(): Promise<void> {
 		LOGGER.info('Starting DAP loop');
 
-		let dapComm = undefined;
 		try {
-			dapComm = await this._dapComm;
+			const dapComm = await this._dapComm;
 			if (!dapComm?.comm) {
 				throw new Error('Must create comm before use');
 			}
@@ -948,7 +947,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 
 		LOGGER.info('Exiting DAP loop');
-		dapComm?.dispose();
+		(await this._dapComm)?.dispose();
 		this._dapComm = undefined;
 	}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -53,8 +53,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		return this._arkComm;
 	}
 
-	/** Queue for LSP events */
-	private _lspQueue: PQueue;
+	/** Queue for services (LSP and DAP) events */
+	private _servicesQueue: PQueue;
 
 	/**
 	 * Promise that resolves after LSP server activation is finished.
@@ -69,8 +69,11 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	/** The Jupyter kernel-based session implementing the Language Runtime API */
 	private _kernel?: JupyterLanguageRuntimeSession;
 
-	/** The DAP communication channel */
-	private _dapComm?: DapComm;
+	/** Returns the DAP comm, or undefined if not started */
+	private async dapComm(): Promise<DapComm | undefined> {
+		return this._dapComm;
+	}
+	private _dapComm?: Promise<DapComm>;
 
 	/** The emitter for language runtime messages */
 	private _messageEmitter =
@@ -124,7 +127,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		};
 
 		this._lsp = new ArkLsp(runtimeMetadata.languageVersion, metadata, this.dynState);
-		this._lspQueue = new PQueue({ concurrency: 1 });
+		this._servicesQueue = new PQueue({ concurrency: 1 });
 		this.onDidReceiveRuntimeMessage = this._messageEmitter.event;
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
 		this.onDidEndSession = this._exitEmitter.event;
@@ -374,7 +377,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 					vscode.LogLevel.Warning,
 				);
 			}
-			await this.deactivateLsp('restarting session');
+			await this.deactivateServices('restarting session');
 			return this._kernel.restart(workingDirectory);
 		} else {
 			throw new Error('Cannot restart; kernel not started');
@@ -385,7 +388,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		if (this._kernel) {
 			this._kernel.emitJupyterLog('Shutting down');
 			// Stop the LSP client before shutting down the kernel
-			await this.deactivateLsp('shutting down session');
+			await this.deactivateServices('shutting down session');
 			return this._kernel.shutdown(exitReason);
 		} else {
 			throw new Error('Cannot shutdown; kernel not started');
@@ -402,7 +405,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			// messages if we yank the kernel out from beneath it without
 			// warning.
 			await Promise.race([
-				this.deactivateLsp('force quitting session'),
+				this.deactivateServices('force quitting session'),
 				delay(250)
 			]);
 			return this._kernel.forceQuit();
@@ -740,101 +743,123 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	}
 
 	/**
-	 * Start the LSP
+	 * Activate services (LSP and DAP)
 	 *
-	 * Returns a promise that resolves when the LSP has been activated.
+	 * Returns a promise that resolves when the services have been activated.
 	 *
 	 * Should never be called within `RSession`, only a session manager
 	 * should call this.
 	 */
-	public async activateLsp(reason: string): Promise<void> {
+	public async activateServices(reason: string): Promise<void> {
 		this._kernel?.emitJupyterLog(
-			`Queuing LSP activation. Reason: ${reason}. ` +
-			`Queue size: ${this._lspQueue.size}, ` +
-			`pending: ${this._lspQueue.pending}`,
+			`Queueing services activation. Reason: ${reason}. ` +
+			`Queue size: ${this._servicesQueue.size}, ` +
+			`pending: ${this._servicesQueue.pending}`,
 			vscode.LogLevel.Debug,
 		);
-		return this._lspQueue.add(async () => {
+		return this._servicesQueue.add(async () => {
 			if (!this._kernel) {
-				LOGGER.warn('Cannot activate LSP; kernel not started');
+				LOGGER.warn('Cannot activate services; kernel not started');
 				return;
 			}
 
 			this._kernel.emitJupyterLog(
-				`LSP activation started. Reason: ${reason}. ` +
-				`Queue size: ${this._lspQueue.size}, ` +
-				`pending: ${this._lspQueue.pending}`,
+				`Services activation started. Reason: ${reason}. ` +
+				`Queue size: ${this._servicesQueue.size}, ` +
+				`pending: ${this._servicesQueue.pending}`,
 				vscode.LogLevel.Debug,
 			);
 
-			if (this._lsp.state !== ArkLspState.Stopped && this._lsp.state !== ArkLspState.Uninitialized) {
-				this._kernel.emitJupyterLog('LSP already active', vscode.LogLevel.Debug);
-				return;
-			}
-
-			this._kernel.emitJupyterLog('Starting Positron LSP server');
-
-			// Create the LSP comm, which also starts the LSP server.
-			// We await the server selected port (the server selects the
-			// port since it is in charge of binding to it, which avoids
-			// race conditions). We also use this promise to avoid restarting
-			// in the middle of initialization.
-			this._lspClientId = this._kernel.createPositronLspClientId();
-			this._lspStartingPromise = this._kernel.startPositronLsp(this._lspClientId, '127.0.0.1');
-			let port: number;
-			try {
-				port = await this._lspStartingPromise;
-			} catch (err) {
-				this._kernel.emitJupyterLog(`Error starting Positron LSP: ${err}`, vscode.LogLevel.Error);
-				return;
-			}
-
-			this._kernel.emitJupyterLog(`Starting Positron LSP client on port ${port}`);
-
-			await this._lsp.activate(port);
+			await Promise.all([
+				this._activateLsp(),
+				this.dapComm().then(dap => dap?.connect()),
+			]);
 		});
 	}
 
 	/**
-	 * Stops the LSP if it is running
+	 * Deactivate services (LSP and DAP)
 	 *
-	 * Returns a promise that resolves when the LSP has been deactivated.
+	 * Returns a promise that resolves when the services have been deactivated.
 	 *
-	 * The session manager is in charge of starting up the LSP, so
-	 * `activateLsp()` should never be called from `RSession`, but the session
-	 * itself may need to call `deactivateLsp()`. This is okay for now, the
-	 * important thing is that an LSP should only ever be started up by a
-	 * session manager to ensure that other LSPs are deactivated first.
+	 * The session manager is in charge of activating services, so
+	 * `activateServices()` should never be called from `RSession`, but
+	 * the session itself may need to call `deactivateServices()`. This
+	 * is okay for now, the important thing is that services should only ever
+	 * be activated by a session manager to ensure that other sessions are
+	 * deactivated first.
 	 *
 	 * Avoid calling `this._lsp.deactivate()` directly, use this instead
-	 * to enforce usage of the `_lspQueue`.
+	 * to enforce usage of the `_servicesQueue`.
 	 */
-	public async deactivateLsp(reason: string): Promise<void> {
+	public async deactivateServices(reason: string): Promise<void> {
 		this._kernel?.emitJupyterLog(
-			`Queuing LSP deactivation. Reason: ${reason}. ` +
-			`Queue size: ${this._lspQueue.size}, ` +
-			`pending: ${this._lspQueue.pending}`,
+			`Queueing services deactivation. Reason: ${reason}. ` +
+			`Queue size: ${this._servicesQueue.size}, ` +
+			`pending: ${this._servicesQueue.pending}`,
 			vscode.LogLevel.Debug,
 		);
-		return this._lspQueue.add(async () => {
+		return this._servicesQueue.add(async () => {
 			this._kernel?.emitJupyterLog(
-				`LSP deactivation started. Reason: ${reason}. ` +
-				`Queue size: ${this._lspQueue.size}, ` +
-				`pending: ${this._lspQueue.pending}`,
+				`Services deactivation started. Reason: ${reason}. ` +
+				`Queue size: ${this._servicesQueue.size}, ` +
+				`pending: ${this._servicesQueue.pending}`,
 				vscode.LogLevel.Debug,
 			);
-			if (this._lsp.state !== ArkLspState.Running) {
-				this._kernel?.emitJupyterLog('LSP already deactivated', vscode.LogLevel.Debug);
-				return;
-			}
-			this._kernel?.emitJupyterLog(`Stopping Positron LSP server`);
-			await this._lsp.deactivate();
-			if (this._lspClientId) {
-				this._kernel?.removeClient(this._lspClientId);
-				this._lspClientId = undefined;
-			}
-			this._kernel?.emitJupyterLog(`Positron LSP server stopped`, vscode.LogLevel.Debug);
+
+			await Promise.all([
+				this._deactivateLsp(),
+				this.dapComm().then(dap => dap?.disconnect()),
+			]);
 		});
+	}
+
+	private async _activateLsp(): Promise<void> {
+		if (!this._kernel) {
+			return;
+		}
+
+		if (this._lsp.state !== ArkLspState.Stopped && this._lsp.state !== ArkLspState.Uninitialized) {
+			this._kernel.emitJupyterLog('LSP already active', vscode.LogLevel.Debug);
+			return;
+		}
+
+		this._kernel.emitJupyterLog('Starting LSP');
+
+		// Create the LSP comm, which also starts the LSP server.
+		// We await the server selected port (the server selects the
+		// port since it is in charge of binding to it, which avoids
+		// race conditions). We also use this promise to avoid restarting
+		// in the middle of initialization.
+		this._lspClientId = this._kernel.createPositronLspClientId();
+		this._lspStartingPromise = this._kernel.startPositronLsp(this._lspClientId, '127.0.0.1');
+		let port: number;
+		try {
+			port = await this._lspStartingPromise;
+		} catch (err) {
+			this._kernel.emitJupyterLog(`Error starting Positron LSP: ${err}`, vscode.LogLevel.Error);
+			return;
+		}
+
+		this._kernel.emitJupyterLog(`Starting Positron LSP client on port ${port}`);
+
+		await this._lsp.activate(port);
+	}
+
+	private async _deactivateLsp(): Promise<void> {
+		if (this._lsp.state !== ArkLspState.Running) {
+			this._kernel?.emitJupyterLog('LSP already deactivated', vscode.LogLevel.Debug);
+			return;
+		}
+
+		this._kernel?.emitJupyterLog(`Stopping LSP`);
+		await this._lsp.deactivate();
+
+		if (this._lspClientId) {
+			this._kernel?.removeClient(this._lspClientId);
+			this._lspClientId = undefined;
+		}
+		this._kernel?.emitJupyterLog(`LSP stopped`, vscode.LogLevel.Debug);
 	}
 
 	/**
@@ -856,24 +881,30 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 * Start the DAP
 	 *
 	 * Returns a promise that resolves when the DAP has been activated.
-	 *
-	 * Unlike the LSP, the DAP can activate immediately. It is only actually
-	 * connected to a DAP client when a `start_debug` message is sent from the
-	 * foreground Ark session to Positron, so it won't interfere with any other
-	 * sessions by coming online.
+	 * Creates the DAP comm without connecting to the server.
+	 * Idempotent.
 	 */
 	private async startDap(): Promise<void> {
-		try {
-			if (!this._kernel) {
-				throw new Error('Kernel not started');
-			}
+		if (!this._kernel) {
+			LOGGER.error('Error starting DAP: Kernel not started');
+			return;
+		}
 
-			this._dapComm = await this._kernel.createDapComm('ark_dap', 'ark', 'Ark Positron R');
+		if (this._dapComm) {
+			await this._dapComm;
+			return;
+		}
+
+		try {
+			this._dapComm = this._kernel!.createDapComm('ark_dap', 'ark', 'Ark Positron R');
+			await this._dapComm;
 
 			// Not awaited: we're spawning an infinite async loop
 			this.startDapMessageLoop();
 		} catch (err) {
 			LOGGER.error(`Error starting DAP: ${err}`);
+			this._dapComm = undefined;
+			throw err;
 		}
 	}
 
@@ -898,15 +929,17 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	private async startDapMessageLoop(): Promise<void> {
 		LOGGER.info('Starting DAP loop');
 
+		let dapComm = undefined;
 		try {
-			if (!this._dapComm?.comm) {
+			dapComm = await this._dapComm;
+			if (!dapComm?.comm) {
 				throw new Error('Must create comm before use');
 			}
 
-			for await (const message of this._dapComm.comm.receiver) {
+			for await (const message of dapComm.comm.receiver) {
 				LOGGER.trace('Received DAP message:', JSON.stringify(message));
 
-				if (!await this._dapComm.handleMessage(message)) {
+				if (!await dapComm.handleMessage(message)) {
 					LOGGER.info(`Unknown DAP message: ${message.method}`);
 
 					if (message.kind === 'request') {
@@ -919,7 +952,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 
 		LOGGER.info('Exiting DAP loop');
-		this._dapComm?.dispose();
+		dapComm?.dispose();
 	}
 
 	private async onStateChange(state: positron.RuntimeState): Promise<void> {
@@ -931,8 +964,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			]);
 		} else if (state === positron.RuntimeState.Exited) {
 			await Promise.all([
-				this._dapComm?.dispose(),
-				this.deactivateLsp('session exited'),
+				this.deactivateServices('session exited'),
+				this.dapComm().then(dap => dap?.dispose()),
 			]);
 		}
 	}

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -381,27 +381,25 @@ export type CommBackendMessage =
  * Disposing the `DapComm` automatically disposes of the nested `Comm`.
  */
 export interface DapComm {
-	/** The `targetName` passed to the constructor. */
+	/** The `targetName` passed to `create()`. */
 	readonly targetName: string;
 
-	/** The `debugType` passed to the constructor. */
+	/** The `debugType` passed to `create()`. */
 	readonly debugType: string;
 
-	/** The `debugName` passed to the constructor. */
+	/** The `debugName` passed to `create()`. */
 	readonly debugName: string;
 
 	/**
 	 * The comm for the DAP.
 	 * Use it to receive messages or make notifications and requests.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly comm?: Comm;
+	readonly comm: Comm;
 
 	/**
 	 * The port on which the DAP server is listening.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly serverPort?: number;
+	readonly port: number;
 
 	/**
 	 * Handle a message received via `this.comm.receiver`.

--- a/extensions/positron-reticulate/src/positron-supervisor.d.ts
+++ b/extensions/positron-reticulate/src/positron-supervisor.d.ts
@@ -424,6 +424,12 @@ export interface DapComm {
 	 */
 	handleMessage(msg: any): Promise<boolean>;
 
+	/** Connect to the DAP server. */
+	connect(): Promise<void>;
+
+	/** Disconnect from the DAP server. */
+	disconnect(): Promise<void>;
+
 	/**
 	 * Dispose of the underlying comm.
 	 * Must be called if the DAP comm is no longer in use.

--- a/extensions/positron-supervisor/.zed/settings.json
+++ b/extensions/positron-supervisor/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+	"languages": {
+		"TypeScript": {
+			"tab_size": 4,
+			"hard_tabs": true,
+			"ensure_final_newline_on_save": true,
+			"remove_trailing_whitespace_on_save": true,
+			"format_on_save": "on",
+			"formatter": "language_server",
+			"code_actions_on_format": {
+				"source.fixAll.eslint": false
+			}
+		}
+	}
+}

--- a/extensions/positron-supervisor/src/DapComm.ts
+++ b/extensions/positron-supervisor/src/DapComm.ts
@@ -164,12 +164,15 @@ export class DapComm {
 			// When this happens, we attach automatically to the runtime
 			// with a synthetic configuration.
 			case 'start_debug': {
+				// Cancel any pending stop handler. We debounce these to avoid flickering.
 				this._stopDebug.cancel();
 				vscode.debug.setSuppressDebugToolbar(this.debugSession(), false);
 				break;
 			}
 
 			case 'stop_debug': {
+				// Debounce the stop handler in case we restart right away. This
+				// prevents flickering in the debug pane.
 				this._stopDebug.schedule(() => {
 					if (this._debugSession) {
 						vscode.debug.setSuppressDebugToolbar(this._debugSession, true);

--- a/extensions/positron-supervisor/src/DapComm.ts
+++ b/extensions/positron-supervisor/src/DapComm.ts
@@ -114,6 +114,11 @@ export class DapComm {
 			return this._startingSession;
 		}
 
+		this.session.emitJupyterLog(
+			`Connecting to DAP server on port ${this._port}`,
+			vscode.LogLevel.Info
+		);
+
 		this._startingSession = (async () => {
 			this._debugSession = await this.startDebugSession();
 			this._startingSession = undefined;
@@ -131,6 +136,12 @@ export class DapComm {
 		if (!session) {
 			return;
 		}
+
+		this.session.emitJupyterLog(
+			`Disconnecting from DAP server on port ${this._port}`,
+			vscode.LogLevel.Info
+		);
+
 		await vscode.debug.stopDebugging(session);
 	}
 

--- a/extensions/positron-supervisor/src/DapComm.ts
+++ b/extensions/positron-supervisor/src/DapComm.ts
@@ -12,64 +12,39 @@ import { JupyterLanguageRuntimeSession, Comm } from './positron-supervisor';
  * See `positron-supervisor.d.ts` for documentation.
  */
 export class DapComm {
-	public get comm(): Comm | undefined {
+	public get comm(): Comm {
 		return this._comm;
 	}
-	public get port(): number | undefined {
+	public get port(): number {
 		return this._port;
 	}
 
-	private _comm?: Comm;
-	private _port?: number;
 	private _debugSession?: vscode.DebugSession;
 	private _startingSession?: Promise<void>;
 	private connected = false;
+	private readonly disposables: vscode.Disposable[] = [];
+
+	// Message counter used for creating unique message IDs
 	private messageCounter = 0;
-	private msgStem: string;
-	private disposables: vscode.Disposable[] = [];
 
-	private config?: vscode.DebugConfiguration;
-	private debugOptions?: vscode.DebugSessionOptions;
+	// Random stem for messages
+	private readonly msgStem: string;
 
-	constructor(
-		private session: JupyterLanguageRuntimeSession,
+	private constructor(
+		private readonly session: JupyterLanguageRuntimeSession,
 		readonly targetName: string,
 		readonly debugType: string,
 		readonly debugName: string,
+		private readonly _comm: Comm,
+		private readonly _port: number,
+		private readonly config: vscode.DebugConfiguration,
+		private readonly debugOptions: vscode.DebugSessionOptions,
 	) {
-
-		// Generate 8 random hex characters for the message stem
 		this.msgStem = Math.random().toString(16).slice(2, 10);
-	}
-
-	async createComm(): Promise<void> {
-		// NOTE: Ideally we'd allow connecting to any network interface but the
-		// `debugServer` property passed in the configuration below needs to be
-		// localhost.
-		const host = '127.0.0.1';
-
-		const [comm, serverPort] = await this.session.createServerComm(this.targetName, host);
-
-		this._comm = comm;
-		this._port = serverPort;
-
-		this.session.emitJupyterLog(`Starting debug session for DAP server ${this.comm!.id}`);
-
-		this.config = {
-			type: this.debugType,
-			name: this.debugName,
-			request: 'attach',
-			debugServer: this.port,
-			internalConsoleOptions: 'neverOpen',
-		};
-
-		this.debugOptions = {
-			suppressDebugToolbar: true,
-		};
 
 		// Reconnect sessions automatically as long as we are "connected"
-		this.register(vscode.debug.onDidTerminateDebugSession(async (session) => {
-			if (session !== this._debugSession) {
+		this.register(vscode.debug.onDidTerminateDebugSession(async (terminatedSession) => {
+			if (terminatedSession !== this._debugSession) {
 				return;
 			}
 
@@ -90,11 +65,46 @@ export class DapComm {
 		}));
 	}
 
-	async connect() {
-		if (!this.config) {
-			throw new Error('Comm must be created before connecting');
-		}
+	static async create(
+		session: JupyterLanguageRuntimeSession,
+		targetName: string,
+		debugType: string,
+		debugName: string,
+	): Promise<DapComm> {
+		// NOTE: Ideally we'd allow connecting to any network interface but the
+		// `debugServer` property passed in the configuration below needs to be
+		// localhost.
+		const host = '127.0.0.1';
 
+		const [comm, serverPort] = await session.createServerComm(targetName, host);
+
+		session.emitJupyterLog(`Starting debug session for DAP server ${comm.id}`);
+
+		const config: vscode.DebugConfiguration = {
+			type: debugType,
+			name: debugName,
+			request: 'attach',
+			debugServer: serverPort,
+			internalConsoleOptions: 'neverOpen',
+		};
+
+		const debugOptions: vscode.DebugSessionOptions = {
+			suppressDebugToolbar: true,
+		};
+
+		return new DapComm(
+			session,
+			targetName,
+			debugType,
+			debugName,
+			comm,
+			serverPort,
+			config,
+			debugOptions,
+		);
+	}
+
+	async connect() {
 		this.connected = true;
 
 		if (this._debugSession) {
@@ -126,7 +136,6 @@ export class DapComm {
 
 	private debugSession(): vscode.DebugSession {
 		if (!this._debugSession) {
-			// We could try to reconnect here if session proves unstable for users
 			throw new Error('Debug session not initialized');
 		}
 		return this._debugSession;
@@ -183,7 +192,7 @@ export class DapComm {
 	private async startDebugSession(): Promise<vscode.DebugSession | undefined> {
 		const promise = new Promise<vscode.DebugSession | undefined>(resolve => {
 			const disposable = vscode.debug.onDidStartDebugSession(session => {
-				if (session.type === this.config!.type && session.name === this.config!.name) {
+				if (session.type === this.config.type && session.name === this.config.name) {
 					disposable.dispose();
 					resolve(session);
 				}
@@ -191,12 +200,12 @@ export class DapComm {
 		});
 
 		try {
-			if (!await vscode.debug.startDebugging(undefined, this.config!, this.debugOptions!)) {
+			if (!await vscode.debug.startDebugging(undefined, this.config, this.debugOptions)) {
 				throw new Error('Failed to start debug session');
 			}
 		} catch (err) {
 			this.session.emitJupyterLog(
-				`Can't start debug session for DAP server ${this.comm!.id}: ${err}`,
+				`Can't start debug session for DAP server ${this._comm.id}: ${err}`,
 				vscode.LogLevel.Warning
 			);
 			return undefined;
@@ -212,7 +221,6 @@ export class DapComm {
 
 	dispose(): void {
 		this.disposables.forEach(d => d.dispose());
-		this.disposables = [];
-		this._comm?.dispose();
+		this._comm.dispose();
 	}
 }

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -807,9 +807,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		debugType: string,
 		debugName: string,
 	): Promise<DapComm> {
-		const comm = new DapComm(this, targetName, debugType, debugName);
-		await comm.createComm();
-		return comm;
+		return DapComm.create(this, targetName, debugType, debugName);
 	}
 
 	/**

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -381,27 +381,25 @@ export type CommBackendMessage =
  * Disposing the `DapComm` automatically disposes of the nested `Comm`.
  */
 export interface DapComm {
-	/** The `targetName` passed to the constructor. */
+	/** The `targetName` passed to `create()`. */
 	readonly targetName: string;
 
-	/** The `debugType` passed to the constructor. */
+	/** The `debugType` passed to `create()`. */
 	readonly debugType: string;
 
-	/** The `debugName` passed to the constructor. */
+	/** The `debugName` passed to `create()`. */
 	readonly debugName: string;
 
 	/**
 	 * The comm for the DAP.
 	 * Use it to receive messages or make notifications and requests.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly comm?: Comm;
+	readonly comm: Comm;
 
 	/**
 	 * The port on which the DAP server is listening.
-	 * Defined after `createServerComm()` has been called.
 	 */
-	readonly serverPort?: number;
+	readonly port: number;
 
 	/**
 	 * Handle a message received via `this.comm.receiver`.

--- a/extensions/positron-supervisor/src/positron-supervisor.d.ts
+++ b/extensions/positron-supervisor/src/positron-supervisor.d.ts
@@ -424,6 +424,12 @@ export interface DapComm {
 	 */
 	handleMessage(msg: any): Promise<boolean>;
 
+	/** Connect to the DAP server. */
+	connect(): Promise<void>;
+
+	/** Disconnect from the DAP server. */
+	disconnect(): Promise<void>;
+
 	/**
 	 * Dispose of the underlying comm.
 	 * Must be called if the DAP comm is no longer in use.

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -347,6 +347,15 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 		session?.setName(name);
 	}
 
+	// --- Start Positron ---
+	public $setSuppressDebugToolbar(sessionId: DebugSessionUUID, suppress: boolean): void {
+		const session = this.debugService.getModel().getSession(sessionId);
+		if (session) {
+			this.debugService.setSessionSuppressDebugToolbar(session, suppress);
+		}
+	}
+	// --- End Positron ---
+
 	public $customDebugAdapterRequest(sessionId: DebugSessionUUID, request: string, args: unknown): Promise<unknown> {
 		const session = this.debugService.getModel().getSession(sessionId, true);
 		if (session) {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1371,6 +1371,11 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			stopDebugging(session?: vscode.DebugSession) {
 				return extHostDebugService.stopDebugging(session);
 			},
+			// --- Start Positron ---
+			setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean) {
+				return extHostDebugService.setSuppressDebugToolbar(session, suppress);
+			},
+			// --- End Positron ---
 			addBreakpoints(breakpoints: readonly vscode.Breakpoint[]) {
 				return extHostDebugService.addBreakpoints(breakpoints);
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1804,6 +1804,9 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 	$startDebugging(folder: UriComponents | undefined, nameOrConfig: string | IDebugConfiguration, options: IStartDebuggingOptions): Promise<boolean>;
 	$stopDebugging(sessionId: DebugSessionUUID | undefined): Promise<void>;
 	$setDebugSessionName(id: DebugSessionUUID, name: string): void;
+	// --- Start Positron ---
+	$setSuppressDebugToolbar(sessionId: DebugSessionUUID, suppress: boolean): void;
+	// --- End Positron ---
 	$customDebugAdapterRequest(id: DebugSessionUUID, command: string, args: any): Promise<any>;
 	$getDebugProtocolBreakpoint(id: DebugSessionUUID, breakpoinId: string): Promise<DebugProtocol.Breakpoint | undefined>;
 	$appendDebugConsole(value: string): void;

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -53,6 +53,9 @@ export interface IExtHostDebugService extends ExtHostDebugServiceShape {
 	removeBreakpoints(breakpoints0: readonly vscode.Breakpoint[]): Promise<void>;
 	startDebugging(folder: vscode.WorkspaceFolder | undefined, nameOrConfig: string | vscode.DebugConfiguration, options: vscode.DebugSessionOptions): Promise<boolean>;
 	stopDebugging(session?: vscode.DebugSession): Promise<void>;
+	// --- Start Positron ---
+	setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void;
+	// --- End Positron ---
 	registerDebugConfigurationProvider(type: string, provider: vscode.DebugConfigurationProvider, trigger: vscode.DebugConfigurationProviderTriggerKind): vscode.Disposable;
 	registerDebugAdapterDescriptorFactory(extension: IExtensionDescription, type: string, factory: vscode.DebugAdapterDescriptorFactory): vscode.Disposable;
 	registerDebugAdapterTrackerFactory(type: string, factory: vscode.DebugAdapterTrackerFactory): vscode.Disposable;
@@ -500,6 +503,12 @@ export abstract class ExtHostDebugServiceBase extends DisposableCls implements I
 	public stopDebugging(session?: vscode.DebugSession): Promise<void> {
 		return this._debugServiceProxy.$stopDebugging(session ? session.id : undefined);
 	}
+
+	// --- Start Positron ---
+	public setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void {
+		this._debugServiceProxy.$setSuppressDebugToolbar(session.id, suppress);
+	}
+	// --- End Positron ---
 
 	public registerDebugConfigurationProvider(type: string, provider: vscode.DebugConfigurationProvider, trigger: vscode.DebugConfigurationProviderTriggerKind): vscode.Disposable {
 

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -616,7 +616,16 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 				breakpointDecoration.range = newBreakpointRange;
 			}
 		});
-		if (!somethingChanged) {
+		// --- Start Positron ---
+		// Some debuggers need breakpoints re-sent on every file save, even if line
+		// numbers haven't changed. If so, we proceed to call `updateBreakpoints()`
+		// which queues this URI to send breakpoints on the next save.
+		const languageId = model.getLanguageId();
+		const shouldSendAnyway = this.debugService.getAdapterManager()
+			.shouldSendBreakpointsOnAllSaves(languageId);
+
+		if (!somethingChanged && !shouldSendAnyway) {
+			// --- End Positron ---
 			// nothing to do, my decorations did not change.
 			return;
 		}

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -7,6 +7,9 @@ import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../base/common/jsonSchema.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+// --- Start Positron ---
+import { URI } from '../../../../base/common/uri.js';
+// --- End Positron ---
 import Severity from '../../../../base/common/severity.js';
 import * as strings from '../../../../base/common/strings.js';
 import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
@@ -354,6 +357,16 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 			.filter(d => d.enabled && d.interestedInLanguage(languageId));
 		// Return true if at least one interested debugger wants breakpoints on all saves
 		return interestedDebuggers.some(d => d.sendBreakpointsOnAllSaves === true);
+	}
+
+	shouldVerifyBreakpointsInDirtyDocuments(uri: URI): boolean {
+		const languageId = this.languageService.guessLanguageIdByFilepathOrFirstLine(uri);
+		if (!languageId) {
+			return false;
+		}
+		const interestedDebuggers = this.debuggers
+			.filter(d => d.enabled && d.interestedInLanguage(languageId));
+		return interestedDebuggers.some(d => d.verifyBreakpointsInDirtyDocuments === true);
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -348,6 +348,13 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 		// Return true if at least one interested debugger supports UI launch
 		return interestedDebuggers.some(d => d.supportsUiLaunch !== false);
 	}
+
+	shouldSendBreakpointsOnAllSaves(languageId: string): boolean {
+		const interestedDebuggers = this.debuggers
+			.filter(d => d.enabled && d.interestedInLanguage(languageId));
+		// Return true if at least one interested debugger wants breakpoints on all saves
+		return interestedDebuggers.some(d => d.sendBreakpointsOnAllSaves === true);
+	}
 	// --- End Positron ---
 
 	async guessDebugger(gettingConfigurations: boolean): Promise<IGuessedDebugger | undefined> {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -995,6 +995,14 @@ export class DebugService implements IDebugService {
 
 		// Trigger toolbar update
 		this._onDidChangeState.fire(this.state);
+
+		// When bringing a session to the foreground, open the debug pane based on user settings
+		if (!suppress && !session.suppressDebugView) {
+			const openDebug = this.configurationService.getValue<IDebugConfiguration>('debug').openDebug;
+			if (openDebug !== 'neverOpen') {
+				this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
+			}
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -973,6 +973,15 @@ export class DebugService implements IDebugService {
 		return Promise.all(sessions.map(s => disconnect ? s.disconnect(undefined, suspend) : s.terminate()));
 	}
 
+	// --- Start Positron ---
+	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void {
+		session.setSuppressDebugToolbar(suppress);
+
+		// Trigger toolbar update
+		this._onDidChangeState.fire(this.state);
+	}
+	// --- End Positron ---
+
 	private async substituteVariables(launch: ILaunch | undefined, config: IConfig): Promise<IConfig | undefined> {
 		const dbg = this.adapterManager.getDebugger(config.type);
 		if (dbg) {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -649,8 +649,11 @@ export class DebugService implements IDebugService {
 		this._onWillNewSession.fire(session);
 
 		const openDebug = this.configurationService.getValue<IDebugConfiguration>('debug').openDebug;
-		// Open debug viewlet based on the visibility of the side bar and openDebug setting. Do not open for 'run without debug'
-		if (!configuration.resolved.noDebug && (openDebug === 'openOnSessionStart' || (openDebug !== 'neverOpen' && this.viewModel.firstSessionStart)) && !session.suppressDebugView) {
+		// --- Start Positron ---
+		// Open debug viewlet based on the visibility of the side bar and openDebug setting.
+		// Do not open for 'run without debug' or for background sessions (suppressDebugToolbar).
+		if (!configuration.resolved.noDebug && (openDebug === 'openOnSessionStart' || (openDebug !== 'neverOpen' && this.viewModel.firstSessionStart)) && !session.suppressDebugView && !session.suppressDebugToolbar) {
+			// --- End Positron ---
 			await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
 		}
 

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -235,6 +235,13 @@ export class DebugSession implements IDebugSession {
 		return this._options.suppressDebugToolbar ?? false;
 	}
 
+	// --- Start Positron ---
+	setSuppressDebugToolbar(value: boolean): void {
+		this._options.suppressDebugToolbar = value;
+		this._onDidChangeState.fire();
+	}
+	// --- End Positron ---
+
 	get suppressDebugView(): boolean {
 		return this._options.suppressDebugView ?? false;
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -240,10 +240,6 @@ export class DebugSession implements IDebugSession {
 		this._options.suppressDebugToolbar = value;
 		this._onDidChangeState.fire();
 	}
-
-	private get verifyBreakpointsInDirtyDocuments(): boolean {
-		return this.debugService.getAdapterManager().getDebugger(this.configuration.type)?.verifyBreakpointsInDirtyDocuments ?? false;
-	}
 	// --- End Positron ---
 
 	get suppressDebugView(): boolean {
@@ -519,9 +515,7 @@ export class DebugSession implements IDebugSession {
 				data.set(breakpointsToSend[i].getId(), response.body.breakpoints[i]);
 			}
 
-			// --- Start Positron ---
-			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-			// --- End Positron ---
+			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 		}
 	}
 
@@ -537,9 +531,7 @@ export class DebugSession implements IDebugSession {
 				for (let i = 0; i < fbpts.length; i++) {
 					data.set(fbpts[i].getId(), response.body.breakpoints[i]);
 				}
-				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-				// --- End Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 			}
 		}
 	}
@@ -568,9 +560,7 @@ export class DebugSession implements IDebugSession {
 					data.set(exbpts[i].getId(), response.body.breakpoints[i]);
 				}
 
-				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-				// --- End Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 			}
 		}
 	}
@@ -624,9 +614,7 @@ export class DebugSession implements IDebugSession {
 						data.set(dap.bp.getId(), response.body.breakpoints[i++]);
 					}
 				}
-				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-				// --- End Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 			}
 		}
 	}
@@ -643,9 +631,7 @@ export class DebugSession implements IDebugSession {
 				for (let i = 0; i < instructionBreakpoints.length; i++) {
 					data.set(instructionBreakpoints[i].getId(), response.body.breakpoints[i]);
 				}
-				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-				// --- End Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 			}
 		}
 	}
@@ -1282,9 +1268,7 @@ export class DebugSession implements IDebugSession {
 				}], false);
 				if (bps.length === 1) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[bps[0].getId(), event.body.breakpoint]]);
-					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-					// --- End Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 				}
 			}
 
@@ -1306,27 +1290,19 @@ export class DebugSession implements IDebugSession {
 						event.body.breakpoint.column = undefined;
 					}
 					const data = new Map<string, DebugProtocol.Breakpoint>([[breakpoint.getId(), event.body.breakpoint]]);
-					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-					// --- End Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 				}
 				if (functionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[functionBreakpoint.getId(), event.body.breakpoint]]);
-					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-					// --- End Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 				}
 				if (dataBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[dataBreakpoint.getId(), event.body.breakpoint]]);
-					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-					// --- End Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 				}
 				if (exceptionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[exceptionBreakpoint.getId(), event.body.breakpoint]]);
-					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
-					// --- End Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
 				}
 			}
 		}));
@@ -1506,9 +1482,7 @@ export class DebugSession implements IDebugSession {
 
 	private onDidExitAdapter(event?: AdapterEndEvent): void {
 		this.initialized = true;
-		// --- Start Positron ---
-		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined, this.verifyBreakpointsInDirtyDocuments);
-		// --- End Positron ---
+		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined);
 		this.shutdown();
 		this._onDidEndAdapter.fire(event);
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1390,7 +1390,10 @@ export class DebugSession implements IDebugSession {
 							}
 
 							if (thread.stoppedDetails && !token.isCancellationRequested) {
-								if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView) {
+								// --- Start Positron ---
+								// Also check suppressDebugToolbar for background sessions
+								if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView && !this.suppressDebugToolbar) {
+									// --- End Positron ---
 									await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
 								}
 

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -515,7 +515,10 @@ export class DebugSession implements IDebugSession {
 				data.set(breakpointsToSend[i].getId(), response.body.breakpoints[i]);
 			}
 
-			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+			// --- Start Positron ---
+			// Pass debugger type so Breakpoint can look up capabilities like verifyBreakpointsInDirtyDocuments
+			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+			// --- End Positron ---
 		}
 	}
 
@@ -531,7 +534,9 @@ export class DebugSession implements IDebugSession {
 				for (let i = 0; i < fbpts.length; i++) {
 					data.set(fbpts[i].getId(), response.body.breakpoints[i]);
 				}
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+				// --- Start Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				// --- End Positron ---
 			}
 		}
 	}
@@ -560,7 +565,9 @@ export class DebugSession implements IDebugSession {
 					data.set(exbpts[i].getId(), response.body.breakpoints[i]);
 				}
 
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+				// --- Start Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				// --- End Positron ---
 			}
 		}
 	}
@@ -614,7 +621,9 @@ export class DebugSession implements IDebugSession {
 						data.set(dap.bp.getId(), response.body.breakpoints[i++]);
 					}
 				}
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+				// --- Start Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				// --- End Positron ---
 			}
 		}
 	}
@@ -631,7 +640,9 @@ export class DebugSession implements IDebugSession {
 				for (let i = 0; i < instructionBreakpoints.length; i++) {
 					data.set(instructionBreakpoints[i].getId(), response.body.breakpoints[i]);
 				}
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+				// --- Start Positron ---
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				// --- End Positron ---
 			}
 		}
 	}
@@ -1268,7 +1279,9 @@ export class DebugSession implements IDebugSession {
 				}], false);
 				if (bps.length === 1) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[bps[0].getId(), event.body.breakpoint]]);
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+					// --- Start Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					// --- End Positron ---
 				}
 			}
 
@@ -1290,19 +1303,27 @@ export class DebugSession implements IDebugSession {
 						event.body.breakpoint.column = undefined;
 					}
 					const data = new Map<string, DebugProtocol.Breakpoint>([[breakpoint.getId(), event.body.breakpoint]]);
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+					// --- Start Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					// --- End Positron ---
 				}
 				if (functionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[functionBreakpoint.getId(), event.body.breakpoint]]);
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+					// --- Start Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					// --- End Positron ---
 				}
 				if (dataBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[dataBreakpoint.getId(), event.body.breakpoint]]);
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+					// --- Start Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					// --- End Positron ---
 				}
 				if (exceptionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[exceptionBreakpoint.getId(), event.body.breakpoint]]);
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data);
+					// --- Start Positron ---
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					// --- End Positron ---
 				}
 			}
 		}));
@@ -1482,7 +1503,9 @@ export class DebugSession implements IDebugSession {
 
 	private onDidExitAdapter(event?: AdapterEndEvent): void {
 		this.initialized = true;
-		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined);
+		// --- Start Positron ---
+		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined, this.configuration.type);
+		// --- End Positron ---
 		this.shutdown();
 		this._onDidEndAdapter.fire(event);
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -240,6 +240,10 @@ export class DebugSession implements IDebugSession {
 		this._options.suppressDebugToolbar = value;
 		this._onDidChangeState.fire();
 	}
+
+	private get verifyBreakpointsInDirtyDocuments(): boolean {
+		return this.debugService.getAdapterManager().getDebugger(this.configuration.type)?.verifyBreakpointsInDirtyDocuments ?? false;
+	}
 	// --- End Positron ---
 
 	get suppressDebugView(): boolean {
@@ -516,8 +520,7 @@ export class DebugSession implements IDebugSession {
 			}
 
 			// --- Start Positron ---
-			// Pass debugger type so Breakpoint can look up capabilities like verifyBreakpointsInDirtyDocuments
-			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+			this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 			// --- End Positron ---
 		}
 	}
@@ -535,7 +538,7 @@ export class DebugSession implements IDebugSession {
 					data.set(fbpts[i].getId(), response.body.breakpoints[i]);
 				}
 				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 				// --- End Positron ---
 			}
 		}
@@ -566,7 +569,7 @@ export class DebugSession implements IDebugSession {
 				}
 
 				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 				// --- End Positron ---
 			}
 		}
@@ -622,7 +625,7 @@ export class DebugSession implements IDebugSession {
 					}
 				}
 				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 				// --- End Positron ---
 			}
 		}
@@ -641,7 +644,7 @@ export class DebugSession implements IDebugSession {
 					data.set(instructionBreakpoints[i].getId(), response.body.breakpoints[i]);
 				}
 				// --- Start Positron ---
-				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+				this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 				// --- End Positron ---
 			}
 		}
@@ -1280,7 +1283,7 @@ export class DebugSession implements IDebugSession {
 				if (bps.length === 1) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[bps[0].getId(), event.body.breakpoint]]);
 					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 					// --- End Positron ---
 				}
 			}
@@ -1304,25 +1307,25 @@ export class DebugSession implements IDebugSession {
 					}
 					const data = new Map<string, DebugProtocol.Breakpoint>([[breakpoint.getId(), event.body.breakpoint]]);
 					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 					// --- End Positron ---
 				}
 				if (functionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[functionBreakpoint.getId(), event.body.breakpoint]]);
 					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 					// --- End Positron ---
 				}
 				if (dataBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[dataBreakpoint.getId(), event.body.breakpoint]]);
 					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 					// --- End Positron ---
 				}
 				if (exceptionBreakpoint) {
 					const data = new Map<string, DebugProtocol.Breakpoint>([[exceptionBreakpoint.getId(), event.body.breakpoint]]);
 					// --- Start Positron ---
-					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.configuration.type);
+					this.model.setBreakpointSessionData(this.getId(), this.capabilities, data, this.verifyBreakpointsInDirtyDocuments);
 					// --- End Positron ---
 				}
 			}
@@ -1504,7 +1507,7 @@ export class DebugSession implements IDebugSession {
 	private onDidExitAdapter(event?: AdapterEndEvent): void {
 		this.initialized = true;
 		// --- Start Positron ---
-		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined, this.configuration.type);
+		this.model.setBreakpointSessionData(this.getId(), this.capabilities, undefined, this.verifyBreakpointsInDirtyDocuments);
 		// --- End Positron ---
 		this.shutdown();
 		this._onDidEndAdapter.fire(event);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1076,6 +1076,7 @@ export interface IAdapterManager {
 	// --- Start Positron ---
 	someDebuggerInterestedInLanguageSupportsUiLaunch(language: string): boolean;
 	shouldSendBreakpointsOnAllSaves(languageId: string): boolean;
+	shouldVerifyBreakpointsInDirtyDocuments(uri: uri): boolean;
 	// --- End Positron ---
 	getDebugger(type: string): IDebuggerMetadata | undefined;
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -30,6 +30,10 @@ import { ITaskIdentifier } from '../../tasks/common/tasks.js';
 import { LiveTestResult } from '../../testing/common/testResult.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IView } from '../../../common/views.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+// --- End Positron ---
 
 export const VIEWLET_ID = 'workbench.view.debug';
 
@@ -108,6 +112,26 @@ export const CONTEXT_DISASSEMBLE_REQUEST_SUPPORTED = new RawContextKey<boolean>(
 export const CONTEXT_DISASSEMBLY_VIEW_FOCUS = new RawContextKey<boolean>('disassemblyViewFocus', false, { type: 'boolean', description: nls.localize('disassemblyViewFocus', "True when the Disassembly View is focused.") });
 export const CONTEXT_LANGUAGE_SUPPORTS_DISASSEMBLE_REQUEST = new RawContextKey<boolean>('languageSupportsDisassembleRequest', false, { type: 'boolean', description: nls.localize('languageSupportsDisassembleRequest', "True when the language in the current editor supports disassemble request.") });
 export const CONTEXT_FOCUSED_STACK_FRAME_HAS_INSTRUCTION_POINTER_REFERENCE = new RawContextKey<boolean>('focusedStackFrameHasInstructionReference', false, { type: 'boolean', description: nls.localize('focusedStackFrameHasInstructionReference', "True when the focused stack frame has instruction pointer reference.") });
+
+// --- Start Positron ---
+export const CONTEXT_DEBUG_TOOLBAR_SUPPRESSED = new RawContextKey<boolean>('debugToolbarSuppressed', false, { type: 'boolean', description: nls.localize('debugToolbarSuppressed', "True when the debug toolbar is suppressed by an extension.") });
+
+/**
+ * Returns true when there is an active "foreground" debug session, i.e., a
+ * debug session is active and the debug toolbar is not suppressed by an
+ * extension. This is useful for determining whether to use debug-specific
+ * behavior (like debug history) vs normal behavior.
+ *
+ * Note: This is independent from user preferences about toolbar visibility
+ * (`debug.toolBarLocation`). See `debugToolBar.ts` for implementation details.
+ */
+export function isDebugSessionWithToolbar(contextKeyService: IContextKeyService): boolean {
+	const debugState = CONTEXT_DEBUG_STATE.getValue(contextKeyService);
+	const isDebugActive = debugState !== undefined && debugState !== 'inactive';
+	const isSuppressed = CONTEXT_DEBUG_TOOLBAR_SUPPRESSED.getValue(contextKeyService) ?? false;
+	return isDebugActive && !isSuppressed;
+}
+// --- End Positron ---
 
 export const debuggerDisabledMessage = (debugType: string) => nls.localize('debuggerDisabled', "Configured debug type '{0}' is installed but not supported in this environment.", debugType);
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -201,6 +201,10 @@ export interface IDebuggerMetadata {
 	type: string;
 	strings?: { [key in DebuggerString]: string };
 	interestedInLanguage(languageId: string): boolean;
+	// --- Start Positron ---
+	// Whether this debugger can verify breakpoints in dirty (unsaved) documents
+	verifyBreakpointsInDirtyDocuments?: boolean;
+	// --- End Positron ---
 }
 
 export const enum State {
@@ -964,6 +968,9 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 
 	// Whether this debugger wants SetBreakpoints on every save (not just when positions change)
 	sendBreakpointsOnAllSaves?: boolean;
+
+	// Whether this debugger can verify breakpoints in dirty (unsaved) documents
+	verifyBreakpointsInDirtyDocuments?: boolean;
 	// --- End Positron ---
 
 	// debug configuration support

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -400,6 +400,10 @@ export interface IDebugSession extends ITreeElement, IDisposable {
 	readonly onDidChangeName: Event<string>;
 	getLabel(): string;
 
+	// --- Start Positron ---
+	setSuppressDebugToolbar(value: boolean): void;
+	// --- End Positron ---
+
 	getSourceForUri(modelUri: uri): Source | undefined;
 	getSource(raw?: DebugProtocol.Source): Source;
 
@@ -1325,6 +1329,13 @@ export interface IDebugService {
 	 * Stops the session. If no session is specified then all sessions are stopped.
 	 */
 	stopSession(session: IDebugSession | undefined, disconnect?: boolean, suspend?: boolean): Promise<void>;
+
+	// --- Start Positron ---
+	/**
+	 * Sets the suppressDebugToolbar option for a running debug session.
+	 */
+	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void;
+	// --- End Positron ---
 
 	/**
 	 * Makes unavailable all sources with the passed uri. Source will appear as grayed out in callstack view.

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -961,6 +961,9 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 	// --- Start Positron ---
 	// Whether this debugger supports launching from the Run and Debug UI
 	supportsUiLaunch?: boolean;
+
+	// Whether this debugger wants SetBreakpoints on every save (not just when positions change)
+	sendBreakpointsOnAllSaves?: boolean;
 	// --- End Positron ---
 
 	// debug configuration support
@@ -1065,6 +1068,7 @@ export interface IAdapterManager {
 	someDebuggerInterestedInLanguage(language: string): boolean;
 	// --- Start Positron ---
 	someDebuggerInterestedInLanguageSupportsUiLaunch(language: string): boolean;
+	shouldSendBreakpointsOnAllSaves(languageId: string): boolean;
 	// --- End Positron ---
 	getDebugger(type: string): IDebuggerMetadata | undefined;
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -125,11 +125,24 @@ export const CONTEXT_DEBUG_TOOLBAR_SUPPRESSED = new RawContextKey<boolean>('debu
  * Note: This is independent from user preferences about toolbar visibility
  * (`debug.toolBarLocation`). See `debugToolBar.ts` for implementation details.
  */
-export function isDebugSessionWithToolbar(contextKeyService: IContextKeyService): boolean {
+export function isForegroundDebugSession(contextKeyService: IContextKeyService): boolean {
 	const debugState = CONTEXT_DEBUG_STATE.getValue(contextKeyService);
 	const isDebugActive = debugState !== undefined && debugState !== 'inactive';
 	const isSuppressed = CONTEXT_DEBUG_TOOLBAR_SUPPRESSED.getValue(contextKeyService) ?? false;
 	return isDebugActive && !isSuppressed;
+}
+
+/**
+ * Returns the debug state when there's a foreground debug session, or 'inactive'
+ * otherwise. A foreground session is one where the debug toolbar is not suppressed
+ * by an extension (e.g., R's always-connected DAP for breakpoints is a background
+ * session).
+ */
+export function getForegroundDebugState(contextKeyService: IContextKeyService): string | undefined {
+	if (isForegroundDebugSession(contextKeyService)) {
+		return CONTEXT_DEBUG_STATE.getValue(contextKeyService);
+	}
+	return 'inactive';
 }
 // --- End Positron ---
 

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -70,6 +70,11 @@ export const debuggersExtPoint = extensionsRegistry.ExtensionsRegistry.registerE
 					type: 'boolean',
 					default: true
 				},
+				sendBreakpointsOnAllSaves: {
+					description: nls.localize('positron.extension.contributes.debuggers.sendBreakpointsOnAllSaves', "Whether this debugger should receive SetBreakpoints DAP events on every file save, even when breakpoint positions haven't changed. Defaults to false."),
+					type: 'boolean',
+					default: false
+				},
 				// --- End Positron ---
 				configurationSnippets: {
 					description: nls.localize('vscode.extension.contributes.debuggers.configurationSnippets', "Snippets for adding new configurations in \'launch.json\'."),
@@ -318,4 +323,3 @@ Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).re
 	},
 	renderer: new SyncDescriptor(DebuggersDataRenderer),
 });
-

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -75,6 +75,11 @@ export const debuggersExtPoint = extensionsRegistry.ExtensionsRegistry.registerE
 					type: 'boolean',
 					default: false
 				},
+				verifyBreakpointsInDirtyDocuments: {
+					description: nls.localize('positron.extension.contributes.debuggers.verifyBreakpointsInDirtyDocuments', "Whether this debugger can verify breakpoints in dirty (unsaved) documents. Set to true for debuggers that track source modifications internally and update breakpoint locations accordingly. Defaults to false."),
+					type: 'boolean',
+					default: false
+				},
 				// --- End Positron ---
 				configurationSnippets: {
 					description: nls.localize('vscode.extension.contributes.debuggers.configurationSnippets', "Snippets for adding new configurations in \'launch.json\'."),

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -328,3 +328,4 @@ Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).re
 	},
 	renderer: new SyncDescriptor(DebuggersDataRenderer),
 });
+

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -10,10 +10,6 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IDebugModel, IEvaluate, IExpression } from './debug.js';
-// --- Start Positron ---
-// eslint-disable-next-line no-duplicate-imports
-import { IDebugService } from './debug.js';
-// --- End Positron ---
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from './debugModel.js';
 import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
 import { mapValues } from '../../../../base/common/objects.js';
@@ -42,10 +38,7 @@ export class DebugStorage extends Disposable {
 		@IStorageService private readonly storageService: IStorageService,
 		@ITextFileService private readonly textFileService: ITextFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-		@ILogService private readonly logService: ILogService,
-		// --- Start Positron ---
-		@IDebugService private readonly debugService: IDebugService
-		// --- End Positron ---
+		@ILogService private readonly logService: ILogService
 	) {
 		super();
 		this.breakpoints = observableValue(this, this.loadBreakpoints());
@@ -85,9 +78,7 @@ export class DebugStorage extends Disposable {
 		try {
 			result = JSON.parse(this.storageService.get(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((breakpoint: ReturnType<Breakpoint['toJSON']>) => {
 				breakpoint.uri = URI.revive(breakpoint.uri);
-				// --- Start Positron ---
-				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, this.debugService, breakpoint.id);
-				// --- End Positron ---
+				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, breakpoint.id);
 			});
 		} catch (e) { }
 

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -10,6 +10,10 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IDebugModel, IEvaluate, IExpression } from './debug.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { IDebugService } from './debug.js';
+// --- End Positron ---
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from './debugModel.js';
 import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
 import { mapValues } from '../../../../base/common/objects.js';
@@ -38,7 +42,10 @@ export class DebugStorage extends Disposable {
 		@IStorageService private readonly storageService: IStorageService,
 		@ITextFileService private readonly textFileService: ITextFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
+		// --- Start Positron ---
+		@IDebugService private readonly debugService: IDebugService
+		// --- End Positron ---
 	) {
 		super();
 		this.breakpoints = observableValue(this, this.loadBreakpoints());
@@ -78,7 +85,9 @@ export class DebugStorage extends Disposable {
 		try {
 			result = JSON.parse(this.storageService.get(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((breakpoint: ReturnType<Breakpoint['toJSON']>) => {
 				breakpoint.uri = URI.revive(breakpoint.uri);
-				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, breakpoint.id);
+				// --- Start Positron ---
+				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, this.debugService, breakpoint.id);
+				// --- End Positron ---
 			});
 		} catch (e) { }
 

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -10,6 +10,10 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IDebugModel, IEvaluate, IExpression } from './debug.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { IDebugService } from './debug.js';
+// --- End Positron ---
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from './debugModel.js';
 import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
 import { mapValues } from '../../../../base/common/objects.js';
@@ -39,6 +43,9 @@ export class DebugStorage extends Disposable {
 		@ITextFileService private readonly textFileService: ITextFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ILogService private readonly logService: ILogService
+		// --- Start Positron ---
+		, @IDebugService private readonly debugService: IDebugService
+		// --- End Positron ---
 	) {
 		super();
 		this.breakpoints = observableValue(this, this.loadBreakpoints());
@@ -78,7 +85,9 @@ export class DebugStorage extends Disposable {
 		try {
 			result = JSON.parse(this.storageService.get(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((breakpoint: ReturnType<Breakpoint['toJSON']>) => {
 				breakpoint.uri = URI.revive(breakpoint.uri);
-				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, breakpoint.id);
+				// --- Start Positron ---
+				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, this.debugService, breakpoint.id);
+				// --- End Positron ---
 			});
 		} catch (e) { }
 

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -153,6 +153,10 @@ export class Debugger implements IDebugger, IDebuggerMetadata {
 	get sendBreakpointsOnAllSaves(): boolean {
 		return this.debuggerContribution.sendBreakpointsOnAllSaves === true; // Defaults to false
 	}
+
+	get verifyBreakpointsInDirtyDocuments(): boolean {
+		return this.debuggerContribution.verifyBreakpointsInDirtyDocuments === true; // Defaults to false
+	}
 	// --- End Positron ---
 
 	get when(): ContextKeyExpression | undefined {

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -149,6 +149,10 @@ export class Debugger implements IDebugger, IDebuggerMetadata {
 	get supportsUiLaunch(): boolean {
 		return this.debuggerContribution.supportsUiLaunch !== false; // Defaults to true
 	}
+
+	get sendBreakpointsOnAllSaves(): boolean {
+		return this.debuggerContribution.sendBreakpointsOnAllSaves === true; // Defaults to false
+	}
 	// --- End Positron ---
 
 	get when(): ContextKeyExpression | undefined {

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -448,10 +448,7 @@ suite('Debug - Breakpoints', () => {
 		const storage1 = disposables.add(new TestStorageService());
 		const debugStorage1 = disposables.add(new MockDebugStorage(storage1));
 		// eslint-disable-next-line local/code-no-any-casts
-		// --- Start Positron ---
-		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
-		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) }));
-		// --- End Positron ---
+		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
 
 		// 1. create breakpoints in the first model
 		const modelUri = uri.file('/myfolder/my file first.js');
@@ -467,10 +464,7 @@ suite('Debug - Breakpoints', () => {
 		// 2. hydrate a new model and ensure external breakpoints get applied
 		const storage2 = disposables.add(new TestStorageService());
 		// eslint-disable-next-line local/code-no-any-casts
-		// --- Start Positron ---
-		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
-		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) }));
-		// --- End Positron ---
+		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
 		storage2.store('debug.breakpoint', stored, StorageScope.WORKSPACE, StorageTarget.USER, /* external= */ true);
 		assert.deepStrictEqual(model2.getBreakpoints().map(b => b.getId()), model1.getBreakpoints().map(b => b.getId()));
 

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -448,7 +448,10 @@ suite('Debug - Breakpoints', () => {
 		const storage1 = disposables.add(new TestStorageService());
 		const debugStorage1 = disposables.add(new MockDebugStorage(storage1));
 		// eslint-disable-next-line local/code-no-any-casts
-		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
+		// --- Start Positron ---
+		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
+		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) }));
+		// --- End Positron ---
 
 		// 1. create breakpoints in the first model
 		const modelUri = uri.file('/myfolder/my file first.js');
@@ -464,7 +467,10 @@ suite('Debug - Breakpoints', () => {
 		// 2. hydrate a new model and ensure external breakpoints get applied
 		const storage2 = disposables.add(new TestStorageService());
 		// eslint-disable-next-line local/code-no-any-casts
-		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
+		// --- Start Positron ---
+		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
+		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) }));
+		// --- End Positron ---
 		storage2.store('debug.breakpoint', stored, StorageScope.WORKSPACE, StorageTarget.USER, /* external= */ true);
 		assert.deepStrictEqual(model2.getBreakpoints().map(b => b.getId()), model1.getBreakpoints().map(b => b.getId()));
 

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -448,7 +448,9 @@ suite('Debug - Breakpoints', () => {
 		const storage1 = disposables.add(new TestStorageService());
 		const debugStorage1 = disposables.add(new MockDebugStorage(storage1));
 		// eslint-disable-next-line local/code-no-any-casts
-		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
+		// --- Start Positron ---
+		const model1 = disposables.add(new DebugModel(debugStorage1, <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ shouldVerifyBreakpointsInDirtyDocuments: () => false }) }));
+		// --- End Positron ---
 
 		// 1. create breakpoints in the first model
 		const modelUri = uri.file('/myfolder/my file first.js');
@@ -464,7 +466,9 @@ suite('Debug - Breakpoints', () => {
 		// 2. hydrate a new model and ensure external breakpoints get applied
 		const storage2 = disposables.add(new TestStorageService());
 		// eslint-disable-next-line local/code-no-any-casts
-		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService()));
+		// --- Start Positron ---
+		const model2 = disposables.add(new DebugModel(disposables.add(new MockDebugStorage(storage2)), <any>{ isDirty: (e: any) => false }, mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ shouldVerifyBreakpointsInDirtyDocuments: () => false }) }));
+		// --- End Positron ---
 		storage2.store('debug.breakpoint', stored, StorageScope.WORKSPACE, StorageTarget.USER, /* external= */ true);
 		assert.deepStrictEqual(model2.getBreakpoints().map(b => b.getId()), model1.getBreakpoints().map(b => b.getId()));
 

--- a/src/vs/workbench/contrib/debug/test/browser/mockDebugModel.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/mockDebugModel.ts
@@ -18,5 +18,7 @@ export const mockUriIdentityService = new UriIdentityService(fileService);
 export function createMockDebugModel(disposable: Pick<DisposableStore, 'add'>): DebugModel {
 	const storage = disposable.add(new TestStorageService());
 	const debugStorage = disposable.add(new MockDebugStorage(storage));
-	return disposable.add(new DebugModel(debugStorage, upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), mockUriIdentityService, new NullLogService()));
+	// --- Start Positron ---
+	return disposable.add(new DebugModel(debugStorage, upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), mockUriIdentityService, new NullLogService(), <any>{ getAdapterManager: () => ({ shouldVerifyBreakpointsInDirtyDocuments: () => false }) }));
+	// --- End Positron ---
 }

--- a/src/vs/workbench/contrib/debug/test/browser/mockDebugModel.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/mockDebugModel.ts
@@ -11,9 +11,6 @@ import { ITextFileService } from '../../../../services/textfile/common/textfiles
 import { TestFileService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { DebugModel } from '../../common/debugModel.js';
 import { MockDebugStorage } from '../common/mockDebug.js';
-// --- Start Positron ---
-import { IDebugService, IAdapterManager } from '../../common/debug.js';
-// --- End Positron ---
 
 const fileService = new TestFileService();
 export const mockUriIdentityService = new UriIdentityService(fileService);
@@ -21,16 +18,5 @@ export const mockUriIdentityService = new UriIdentityService(fileService);
 export function createMockDebugModel(disposable: Pick<DisposableStore, 'add'>): DebugModel {
 	const storage = disposable.add(new TestStorageService());
 	const debugStorage = disposable.add(new MockDebugStorage(storage));
-	// --- Start Positron ---
-	// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
-	const mockDebugService = upcastPartial<IDebugService>({
-		getAdapterManager: () => upcastPartial<IAdapterManager>({
-			getDebugger: () => undefined,
-			someDebuggerInterestedInLanguage: () => false,
-			someDebuggerInterestedInLanguageSupportsUiLaunch: () => false,
-			shouldSendBreakpointsOnAllSaves: () => false
-		})
-	});
-	return disposable.add(new DebugModel(debugStorage, upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), mockUriIdentityService, new NullLogService(), mockDebugService));
-	// --- End Positron ---
+	return disposable.add(new DebugModel(debugStorage, upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), mockUriIdentityService, new NullLogService()));
 }

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -62,7 +62,9 @@ suite('DebugModel', () => {
 
 				const disposable = new DisposableStore();
 				const storage = disposable.add(new TestStorageService());
-				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService());
+				// --- Start Positron ---
+				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ shouldVerifyBreakpointsInDirtyDocuments: () => false }) });
+				// --- End Positron ---
 				disposable.add(model);
 
 				let top1Resolved = false;

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -62,7 +62,10 @@ suite('DebugModel', () => {
 
 				const disposable = new DisposableStore();
 				const storage = disposable.add(new TestStorageService());
-				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService());
+				// --- Start Positron ---
+				// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
+				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) });
+				// --- End Positron ---
 				disposable.add(model);
 
 				let top1Resolved = false;

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -62,10 +62,7 @@ suite('DebugModel', () => {
 
 				const disposable = new DisposableStore();
 				const storage = disposable.add(new TestStorageService());
-				// --- Start Positron ---
-				// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
-				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined, someDebuggerInterestedInLanguage: () => false, someDebuggerInterestedInLanguageSupportsUiLaunch: () => false, shouldSendBreakpointsOnAllSaves: () => false }) });
-				// --- End Positron ---
+				const model = new DebugModel(disposable.add(new MockDebugStorage(storage)), upcastPartial<ITextFileService>({ isDirty: (e: unknown) => false }), undefined!, new NullLogService());
 				disposable.add(model);
 
 				let top1Resolved = false;

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -154,6 +154,12 @@ export class MockDebugService implements IDebugService {
 		throw new Error('not implemented');
 	}
 
+	// --- Start Positron ---
+	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void {
+		throw new Error('not implemented');
+	}
+	// --- End Positron ---
+
 	getModel(): IDebugModel {
 		throw new Error('not implemented');
 	}
@@ -297,6 +303,12 @@ export class MockSession implements IDebugSession {
 	setName(name: string): void {
 		throw new Error('not implemented');
 	}
+
+	// --- Start Positron ---
+	setSuppressDebugToolbar(value: boolean): void {
+		throw new Error('not implemented');
+	}
+	// --- End Positron ---
 
 	getSourceForUri(modelUri: uri): Source {
 		throw new Error('not implemented');

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -704,9 +704,6 @@ export class MockDebugAdapter extends AbstractDebugAdapter {
 export class MockDebugStorage extends DebugStorage {
 
 	constructor(storageService: IStorageService) {
-		// --- Start Positron ---
-		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
-		super(storageService, undefined!, undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined }) });
-		// --- End Positron ---
+		super(storageService, undefined!, undefined!, new NullLogService());
 	}
 }

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -704,6 +704,9 @@ export class MockDebugAdapter extends AbstractDebugAdapter {
 export class MockDebugStorage extends DebugStorage {
 
 	constructor(storageService: IStorageService) {
-		super(storageService, undefined!, undefined!, new NullLogService());
+		// --- Start Positron ---
+		// Added mock IDebugService for verifyBreakpointsInDirtyDocuments capability lookup
+		super(storageService, undefined!, undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ getDebugger: () => undefined }) });
+		// --- End Positron ---
 	}
 }

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -704,6 +704,11 @@ export class MockDebugAdapter extends AbstractDebugAdapter {
 export class MockDebugStorage extends DebugStorage {
 
 	constructor(storageService: IStorageService) {
-		super(storageService, undefined!, undefined!, new NullLogService());
+		// --- Start Positron ---
+		// Old code:
+		// super(storageService, undefined!, undefined!, new NullLogService());
+		// eslint-disable-next-line local/code-no-any-casts
+		super(storageService, undefined!, undefined!, new NullLogService(), <any>{ getAdapterManager: () => ({ shouldVerifyBreakpointsInDirtyDocuments: () => false }) });
+		// --- End Positron ---
 	}
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -49,7 +49,7 @@ import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../serv
 import { localize } from '../../../../../nls.js';
 import { IFontOptions } from '../../../../browser/fontConfigurationManager.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { CONTEXT_DEBUG_STATE } from '../../../debug/common/debug.js';
+import { CONTEXT_DEBUG_STATE, isDebugSessionWithToolbar } from '../../../debug/common/debug.js';
 
 // Position enumeration.
 const enum Position {
@@ -98,18 +98,18 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	const shouldExecuteOnStartRef = useRef(false);
 
 	/**
-	 * Gets the appropriate history navigator based on the current debug state.
-	 * Uses the default navigator when debug state is 'inactive' or undefined,
-	 * and debug navigator for all other debug states.
+	 * Gets the appropriate history navigator based on whether a debug session
+	 * with toolbar is active. Uses the debug navigator when a session is active
+	 * with the toolbar visible, and the default navigator otherwise (including
+	 * when the debug toolbar is suppressed by an extension, e.g. positron-r).
 	 *
 	 * @returns The appropriate HistoryNavigator2 or undefined if none exists.
 	 */
 	const getHistoryNavigator = () => {
-		const debugState = CONTEXT_DEBUG_STATE.getValue(services.contextKeyService);
-		if (!debugState || debugState === 'inactive') {
-			return historyNavigatorRef.current;
+		if (isDebugSessionWithToolbar(services.contextKeyService)) {
+			return debugHistoryNavigatorRef.current;
 		}
-		return debugHistoryNavigatorRef.current;
+		return historyNavigatorRef.current;
 	};
 
 	/**
@@ -1076,7 +1076,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// If the code isn't empty and run interactively or non-interactively, add it to the history.
 			if (trimmedCode.length && (mode === RuntimeCodeExecutionMode.Interactive || mode === RuntimeCodeExecutionMode.NonInteractive)) {
 				const debugState = CONTEXT_DEBUG_STATE.getValue(services.contextKeyService);
-				const isDebugMode = debugState && debugState !== 'inactive';
+				const isDebugMode = isDebugSessionWithToolbar(services.contextKeyService);
 
 				// Creates an IInputHistoryEntry.
 				const createInputHistoryEntry = (): IInputHistoryEntry => ({

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -49,7 +49,7 @@ import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../serv
 import { localize } from '../../../../../nls.js';
 import { IFontOptions } from '../../../../browser/fontConfigurationManager.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { CONTEXT_DEBUG_STATE, isDebugSessionWithToolbar } from '../../../debug/common/debug.js';
+import { getForegroundDebugState, isForegroundDebugSession } from '../../../debug/common/debug.js';
 
 // Position enumeration.
 const enum Position {
@@ -106,7 +106,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	 * @returns The appropriate HistoryNavigator2 or undefined if none exists.
 	 */
 	const getHistoryNavigator = () => {
-		if (isDebugSessionWithToolbar(services.contextKeyService)) {
+		if (isForegroundDebugSession(services.contextKeyService)) {
 			return debugHistoryNavigatorRef.current;
 		}
 		return historyNavigatorRef.current;
@@ -555,12 +555,14 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			case KeyCode.KeyR: {
 				// When Ctrl-R is pressed, engage a reverse history search (like bash).
 				if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
+					const isDebugMode = isForegroundDebugSession(services.contextKeyService);
 					const entries =
 						services.executionHistoryService.getInputEntries(
 							props.positronConsoleInstance.runtimeMetadata.languageId
 						).filter(entry => {
-							// Filter out debug entries.
-							return !entry.debug || entry.debug === 'inactive';
+							// Show debug entries when in debug mode, non-debug entries otherwise.
+							const isDebugEntry = entry.debug && entry.debug !== 'inactive';
+							return isDebugMode ? isDebugEntry : !isDebugEntry;
 						});
 					engageHistoryBrowser(new HistoryInfixMatchStrategy(entries));
 					consumeEvent();
@@ -624,12 +626,14 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					// If the cmd or ctrl key is pressed, and the history
 					// browser is not up, engage the history browser with the
 					// prefix match strategy. This behavior mimics RStudio.
+					const isDebugMode = isForegroundDebugSession(services.contextKeyService);
 					const entries =
 						services.executionHistoryService.getInputEntries(
 							props.positronConsoleInstance.runtimeMetadata.languageId
 						).filter(entry => {
-							// Filter out debug entries.
-							return !entry.debug || entry.debug === 'inactive';
+							// Show debug entries when in debug mode, non-debug entries otherwise.
+							const isDebugEntry = entry.debug && entry.debug !== 'inactive';
+							return isDebugMode ? isDebugEntry : !isDebugEntry;
 						});
 					engageHistoryBrowser(new HistoryPrefixMatchStrategy(entries));
 					consumeEvent();
@@ -1075,14 +1079,12 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 			// If the code isn't empty and run interactively or non-interactively, add it to the history.
 			if (trimmedCode.length && (mode === RuntimeCodeExecutionMode.Interactive || mode === RuntimeCodeExecutionMode.NonInteractive)) {
-				const debugState = CONTEXT_DEBUG_STATE.getValue(services.contextKeyService);
-				const isDebugMode = isDebugSessionWithToolbar(services.contextKeyService);
+				const isDebugMode = isForegroundDebugSession(services.contextKeyService);
 
-				// Creates an IInputHistoryEntry.
 				const createInputHistoryEntry = (): IInputHistoryEntry => ({
 					when: new Date().getTime(),
 					input: trimmedCode,
-					debug: debugState
+					debug: getForegroundDebugState(services.contextKeyService)
 				});
 
 				// Add the history entry to the appropriate navigator based on debug state.

--- a/src/vs/workbench/services/positronHistory/common/languageInputHistory.ts
+++ b/src/vs/workbench/services/positronHistory/common/languageInputHistory.ts
@@ -8,7 +8,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { CONTEXT_DEBUG_STATE } from '../../../contrib/debug/common/debug.js';
+import { getForegroundDebugState } from '../../../contrib/debug/common/debug.js';
 import { IInputHistoryEntry, inputHistorySizeSettingId } from './executionHistoryService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
@@ -91,7 +91,7 @@ export class LanguageInputHistory extends Disposable {
 				const entry: IInputHistoryEntry = {
 					when: when,
 					input: languageRuntimeMessageInput.code,
-					debug: CONTEXT_DEBUG_STATE.getValue(this._contextKeyService)
+					debug: getForegroundDebugState(this._contextKeyService)
 				};
 				this._pendingEntries.push(entry);
 				this.delayedSave();

--- a/src/vs/workbench/services/positronHistory/common/sessionInputHistory.ts
+++ b/src/vs/workbench/services/positronHistory/common/sessionInputHistory.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.j
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { CONTEXT_DEBUG_STATE } from '../../../contrib/debug/common/debug.js';
+import { getForegroundDebugState } from '../../../contrib/debug/common/debug.js';
 import { IExecutionHistoryEntry, IInputHistoryEntry, INPUT_HISTORY_STORAGE_PREFIX } from './executionHistoryService.js';
 import { ILanguageRuntimeSession } from '../../runtimeSession/common/runtimeSessionService.js';
 
@@ -70,7 +70,7 @@ export class SessionInputHistory extends Disposable {
 			this._entries.push({
 				when: Date.now(),
 				input: message.code,
-				debug: CONTEXT_DEBUG_STATE.getValue(this._contextKeyService)
+				debug: getForegroundDebugState(this._contextKeyService)
 			});
 			this._dirty = true;
 			this.delayedSave();

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17294,6 +17294,16 @@ declare module 'vscode' {
 		 */
 		export function stopDebugging(session?: DebugSession): Thenable<void>;
 
+		// --- Start Positron ---
+		/**
+		 * Sets whether the debug toolbar should be suppressed during a running debug session.
+		 *
+		 * @param session The {@link DebugSession debug session} to modify.
+		 * @param suppress Whether to suppress the debug toolbar.
+		 */
+		export function setSuppressDebugToolbar(session: DebugSession, suppress: boolean): void;
+		// --- End Positron ---
+
 		/**
 		 * Add breakpoints.
 		 * @param breakpoints The breakpoints to add.

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -65,8 +65,8 @@ test.describe('R Debugging', {
 		await debug.expectBrowserModeFrame(1);
 
 		// Verify call stack order
-		await debug.expectCallStackAtIndex(0, 'inner()');
-		await debug.expectCallStackAtIndex(1, 'outer()');
+		await debug.expectCallStackAtIndex(0, 'inner(');
+		await debug.expectCallStackAtIndex(1, 'outer(');
 		await debug.expectCallStackAtIndex(2, '<global>');
 
 		// Verify the call stack redirects to correct data frame(s)
@@ -223,7 +223,7 @@ async function verifyDebugPane(app: Application) {
 async function verifyCallStack(app: Application) {
 	const { debug } = app.workbench;
 
-	await debug.expectCallStackAtIndex(0, 'fruit_avg()');
+	await debug.expectCallStackAtIndex(0, 'fruit_avg(');
 	await debug.expectCallStackAtIndex(1, '<global>');
 }
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -65,9 +65,9 @@ test.describe('R Debugging', {
 		await debug.expectBrowserModeFrame(1);
 
 		// Verify call stack order
-		await debug.expectCallStackAtIndex(0, 'inner()inner(x)');
-		await debug.expectCallStackAtIndex(1, 'outer(5)inner(x)');
-		await debug.expectCallStackAtIndex(2, '<global>outer(5)');
+		await debug.expectCallStackAtIndex(0, 'inner()');
+		await debug.expectCallStackAtIndex(1, 'outer()');
+		await debug.expectCallStackAtIndex(2, '<global>');
 
 		// Verify the call stack redirects to correct data frame(s)
 		await debug.selectCallStackAtIndex(0);
@@ -223,8 +223,8 @@ async function verifyDebugPane(app: Application) {
 async function verifyCallStack(app: Application) {
 	const { debug } = app.workbench;
 
-	await debug.expectCallStackAtIndex(0, 'fruit_avg()fruit_avg()2:');
-	await debug.expectCallStackAtIndex(1, '<global>fruit_avg(dat, "berry")');
+	await debug.expectCallStackAtIndex(0, 'fruit_avg()');
+	await debug.expectCallStackAtIndex(1, '<global>');
 }
 
 async function verifyVariableInConsole(app: Application, name: string, expectedText: string) {

--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -19,6 +19,9 @@ test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, ()
 	test('Verify Restart Extension Host command works - R', {
 		tag: [tags.ARK]
 	}, async function ({ app, r }) {
+		// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407
+		test.skip(process.platform === 'win32', 'Skip on Windows');
+
 		await app.workbench.quickaccess.runCommand('workbench.action.restartExtensionHost');
 		await app.workbench.console.waitForConsoleContents('Extensions restarting...');
 		await app.workbench.console.waitForReady('>');

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -110,10 +110,16 @@ test.describe('Notebook Edit Mode', {
 
 		// Create a new notebook with 2 cells
 		await notebooksPositron.newNotebook({ codeCells: 2 });
+		await notebooksPositron.kernel.select('Python');
 
 		// Enter edit mode in cell 0
 		await notebooksPositron.selectCellAtIndex(0);
 		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		// Needs an expression to break at
+		await keyboard.press('Enter');
+		await keyboard.type('1 + 1');
+		await app.workbench.quickaccess.runCommand('Debug: Toggle Breakpoint');
 
 		// Test: Execute cell and select below: Shift+Enter
 		await keyboard.press('Shift+Enter');


### PR DESCRIPTION
Branched from https://github.com/posit-dev/positron/pull/10815

Addresses https://github.com/posit-dev/positron/issues/1766
Addresses https://github.com/posit-dev/positron/issues/11402

Backend PR: https://github.com/posit-dev/ark/pull/1003

This PR implements the frontend side of breakpoint support for R in Positron. The backend now injects `browser()` calls at parse time, and verifies breakpoints during evaluation. This PR adds the infrastructure needed to:

**Maintain a permanent DAP session so breakpoints can be communicated to Ark**

- Properly distinguish between "foreground" debug sessions (user is actively debugging) and "background" debug sessions (DAP connected for breakpoint management). This is captured by a context key.
- Use that new notion to determine:
  - Which kind of console history to use (regular history or debug history).
  - Whether to focus the debug pane when a debug session starts (background Ark session should not focus)
  - Whether to show the welcome view in the debug pane (background sessions should not cause the welcome view to disappear)

**Notify Ark backend of active breakpoints in a timely manner**

- Because Ark does its own invalidation of breakpoints, we need the frontend to send breakpoints "on save" unconditionally (bypassing the internal check for invalidated breakpoints).
- Send breakpoints to the debug adapter before Cmd+Enter execution in dirty documents (since `sendBreakpointsOnAllSaves` only triggers on save)


## Permanent DAP session

Previously, the DAP session was only connected when a browser REPL was active. The R extension would send a `start_debug` notification to request Positron to connect with a DAP client. This is no longer the case: the DAP is now expected to always be connected so that the backend can receive notifications about breakpoint state at all time. This allows R to inject breakpoints in executed or sourced code, without requiring the user to enable a debug session first.

The `start_debug` and `stop_debug` messages sent via the Jupyter comm are now hints for showing/hiding the debug toolbar rather than session lifecycle events. When R enters the debugger, Ark sends `start_debug`; when it exits, it sends `stop_debug`. The DAP connection remains active throughout.


### DapComm refactoring

`DapComm` now uses a static factory pattern and manages reconnections automatically:
- Created via `DapComm.create()` which sets up the comm and configuration.
- `connect()` and `disconnect()` control the debug session lifecycle.
- Automatically reconnects when the debug session terminates (e.g., user disconnects via toolbar).
- The `start_debug` message now calls `setSuppressDebugToolbar(false)` instead of starting a new session.
- The `stop_debug` message suppresses the toolbar again. It is debounced by 100ms (via new `Debounced` utility) to prevent toolbar flickering when stepping through code.


### Multi-session

In case of multiple console sessions, only the DAP of the foreground session is connected. If all DAP sessions remained connected, then the verification status of breakpoints could be very surprising. A breakpoint verified in a background session but not the foreground session with which the user is working would appear as verified in the UI, even though there is no way the foreground session can break there.

To manage this, the R extension now manages LSP and DAP together through unified `activateServices()` and `deactivateServices()` methods (previously `activateLsp`/`deactivateLsp`). Both services are activated/deactivated in parallel through a shared queue, ensuring proper ordering during session switches.


## Foreground vs background debug sessions

With a permanent DAP connection, we need to distinguish between "foreground" debug sessions (user is actively debugging) and "background" sessions (DAP connected for breakpoint management only). This distinction affects several behaviors.


### `suppressDebugToolbar` as an indicator of background debug sessions

The main indication that there is an active foreground debug session is that the debug toolbar is shown, i.e. the `suppressDebugToolbar` property of the session is not set.

In VS Code, it is only possible to _start_ a session in background mode. I made Positron-only changes to allow extensions to flip the debug toolbar on and off. When R enters in a `browser()` state, a notification is sent to "unsuppress" the debug toolbar, i.e. bring the debug session to the foreground.

New extension API:

```ts
export function setSuppressDebugToolbar(session: DebugSession, suppress: boolean): void;
```

Allows extensions to toggle toolbar suppression on a running debug session. The R extension uses this to show the toolbar when entering the debugger and hide it when exiting.


### Context key and helpers

- `CONTEXT_DEBUG_TOOLBAR_SUPPRESSED` context key: `true` when all active debug sessions have `suppressDebugToolbar` set, which means the debug toolbar is not shown.
- `isForegroundDebugSession()` helper: returns `true` when a debug session is active AND the toolbar is not suppressed.
- `getForegroundDebugState()` helper: returns the debug state string only for foreground sessions, otherwise `'inactive'`.

Key distinction:
- User preferences like `debug.toolBarLocation: "docked"` do NOT affect the context key.
- Extension suppression via `suppressDebugToolbar` DOES affect the context key.


### Console history selection

The console maintains separate history navigators for debug vs normal sessions. Previously determined by `CONTEXT_DEBUG_STATE`, which didn't account for background sessions with suppressed debug toolbars.

Now uses new `isForegroundDebugSession()` helper for selecting the history navigator in `consoleInput.tsx`, and new `getForegroundDebugState()` for tagging history entries in `languageInputHistory.ts` and `sessionInputHistory.ts`. This ensures that only _foreground_ debug sessions cause commands to be logged in the debug-only history.


### Debug pane focus

When a debug session starts, VS Code normally focuses the debug pane. Background sessions (with `suppressDebugToolbar: true`) should not cause this focus change. The `debugUx` value computation now accounts for session suppression.


### Welcome view visibility

The debug welcome view should appear when there's no "foreground" debug session. Previously it would hide whenever any debug session was active, including background ones. We now check whether all sessions are suppressed and show the welcome view in that case.


## Timely breakpoint notifications

First of all, I regret having implementing this here, as this adds significant churn to this PR. This should have been implemented in another PR. Sorry for the extra cognitive load that implies for the review. Given the timeline, I would prefer to keep this here so I don't have to reconsider how verification works across frontend and backend.

The goal here is to avoid stepping through a stale view of an editor. To prevent this, VS Code has an internal mechanism of breakpoint invalidation. Basically if a breakpoint is on a line that was moved up or down, the breakpoint gets invalidated and a breakpoint updated is sent to the backend.

This invalidation is incomplete because if you change code _below_ a breakpoint, it will not get invalidated even though the file and source have changed and might lead to stale stepping. Since The Ark DAP lives alongside an LSP, we can do better: Take document-change notifications as an indication that the file is now stale and breakpoints are invalid. This approach works well but required changes to ensure that we receive breakpoint notifications event when VS Code think there is no need.

Furthermore, it's confusing for users having to save files so that breakpoint verification may work. Since we now have code execution gestures as a way of injecting/verifying breakpoints, I found that the UX was poor because of the need to save.

Two new mechanisms solve these:

1. The `sendBreakpointsOnAllSaves` debugger capability (described below) ensures Ark receives breakpoints on every file save, even when VS Code thinks breakpoints haven't been invalidated.

2. When executing code via Cmd+Enter in a dirty document, breakpoints haven't been sent since the last save. We now send them right before execution:

   ```positron/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
    if (textFileService.isDirty(documentUri)) {
        await debugService.sendBreakpoints(documentUri, true);
   }
   ```

   VS Code is not equipped by default to verify breakpoints in dirty documents though, so to make it respond to our verification notifications some changes were needed.

Two new debugger contribution properties allow extensions to opt into these behaviors.


### `sendBreakpointsOnAllSaves`

VS Code normally only sends `SetBreakpoints` DAP events on file save when breakpoint decorations have changed position. This optimization prevents unnecessary DAP traffic but doesn't work for Ark.

When `sendBreakpointsOnAllSaves: true`, the `somethingChanged` check in `breakpointEditorContribution.ts` is bypassed, ensuring breakpoints are sent on every save.

This required:
- Adding `shouldSendBreakpointsOnAllSaves(languageId)` method to `IAdapterManager`, which checks if any debugger interested in the language has the capability enabled
- Modifying `breakpointEditorContribution.ts` to call this method and bypass the early return when the capability is set


### `verifyBreakpointsInDirtyDocuments`

VS Code marks breakpoints as unverified when a file has unsaved changes, assuming unsaved changes invalidate breakpoint locations. However, Ark handles source modifications internally and can verify breakpoints even in dirty documents because:
- It receives `SetBreakpoints` with `sourceModified: true` on every save
- It receives `SetBreakpoints` when code is executed in dirty documents
- It tracks source state and updates breakpoint locations accordingly

When `verifyBreakpointsInDirtyDocuments: true`:
- The `Breakpoint.verified` getter trusts the adapter's verification status even when the file is dirty
- The breakpoint hover message defers to the adapter's message (or none) rather than showing the hardcoded "file is modified, please restart debug session" warning

To implement `verifyBreakpointsInDirtyDocuments`, the `Breakpoint` class needs to check whether the debugger supports this capability. This required changing VS Code files with the following fenced adjustments:

- Adding `IDebugService` to `Breakpoint`, `DebugModel`, and `DebugStorage` constructors
- Adding `shouldVerifyBreakpointsInDirtyDocuments(uri)` method to `IAdapterManager`, which checks if any debugger interested in the file's language has the capability enabled
- Modifying the `verified` and `message` getters in `Breakpoint` to call this method


## R extension changes

The `positron-r` extension's debugger contribution now includes:

```json
{
    "type": "ark",
    "label": "R Debugger",
    "languages": ["r"],
    "supportsUiLaunch": false,
    "sendBreakpointsOnAllSaves": true,
    "verifyBreakpointsInDirtyDocuments": true
}
```

And enables breakpoints for R files:

```json
"breakpoints": [
    { "language": "r" }
]
```

The debug welcome view message is also updated from "limited debugging support" to "first-class debugging support".


### Release Notes

#### New Features

- R gains support for breakpoints (posit-dev/positron#1766). In scripts, breakpoints are enabled after evaluation or sourcing. In packages, you need to install the latest version of pkgload (e.g. with `pak::pak("r-lib/pkgload")` and call `load_all()` to activate breakpoints.

#### Bug Fixes

- Ctrl+R and Cmd/Ctrl+Up now support debug-specific command histories (#11402).


### QA notes

See also notes in linked PR
https://github.com/posit-dev/ark/pull/1003

The main additional things to watch out for have to do with the background debug session that is now permanently connected to the frontend (should not affect existing UX related to console history or debug pane in any way), and with the way we validate (verify), invalidate, and revalidate breakpoints.

- **Dirty documents**: Editing a file should immediately invalidate all breakpoints (see also notes in linked PR). It should be possible to verify breakpoints by executing code in the dirty document _with and without saving the file_. Including _new_ breakpoints that were added after editing the document.
- **Console history**: Console commands emitted while a _foreground_ debug session is ongoing should go to debug history. Those emitted while a _background_ debug session is connected should go to normal history.
- Ctrl+R, Cmd+Up are now sensitive to whether a (foreground) debug session is active.
- **Debug pane focus**: Starting a new R console session should not focus the debug pane.
- **Welcome view** of the debug pane: Should show when no foreground debug session are ongoing, even with background debug session connected.
- **Toolbar visibility**: Should only appear when R is in browser REPL, i.e. an active foreground debug session. When the debug session is in the background, the debug toolbar should not be shown.
- **UI flickering** The debug toolbar and debug pane should not flicker when stepping through code (100ms debounce on `stop_debug`).
- **Session switching**: Breakpoint state preserved per session. Switching sessions back and forth should restore state.
- **Disconnect/reconnect**: Disconnecting via toolbar (Shift-F5) should auto-reconnect the DAP session (i.e. breakpoints are managed and can be verified/hit).

@:all
