### PR TITLE
Bump bundled Quarto to 1.8.27

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -129,7 +129,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.7.32';
+    const version = '1.8.27';
     (0, fancy_log_1.default)(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -98,7 +98,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.7.32';
+	const version = '1.8.27';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
It's been a loooooong time since we did this, and it's a pretty good time relative to our release cycle.

@:quarto
@:r-markdown


### Release Notes

#### New Features

- Updated bundled Quarto to 1.8.27, the current release version

#### Bug Fixes

- N/A


### QA Notes

I added the tags for Quarto and `.Rmd`, but we'll want to spot check the various Quarto workflows. I am thinking probably the PR tests don't actually re-bundle? In which case we'll want to do some spot checks in the next daily build.
