### PR TITLE
Assistant: Fix for Bedrock & autoconfiguration logic

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -312,9 +312,7 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 	// Register the new model FIRST, before saving configuration
 	try {
 		await registerModel(newConfig, context, storage);
-		// Only save to persistent state for non-autoconfigured models
-		// Autoconfigured models (e.g., Copilot, env var based) are managed
-		// externally
+		// Update persistent storage with new configuration
 		await context.globalState.update(
 			'positron.assistant.models',
 			[...existingConfigs, newConfig]

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -157,7 +157,9 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 	const registeredModels = context.globalState.get<Array<StoredModelConfig>>('positron.assistant.models');
 	// Auto-configured models (e.g., env var based or managed credentials) stored in memory
 	// But exclude any that are already registered manually
-	const autoconfiguredModels = getAutoconfiguredModels().filter(m => !registeredModels.some(rm => rm.provider === m.provider));
+	// Use a Set for O(1) lookup instead of Array.some() which is O(n)
+	const registeredProviderIds = new Set(registeredModels?.map(rm => rm.provider));
+	const autoconfiguredModels = getAutoconfiguredModels().filter(m => !registeredProviderIds.has(m.provider));
 	const allProviders = [...getModelProviders(), ...completionModels];
 
 	// Build a map of provider IDs to their autoconfigure functions

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -274,9 +274,6 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 	// Create unique ID for the configuration
 	const id = randomUUID();
 
-	// Check if this provider uses autoconfiguration (should not be saved to persistent state)
-	// Some models such as Anthropic can use either autoconfiguration or manual configuration;
-	// if an apiKey is provided, treat it as manual configuration
 
 	// Filter out sources that use autoconfiguration for required field validation
 	sources = sources.filter(source => source.defaults.autoconfigure === undefined);

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -309,6 +309,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 
 
 	// Register the new model FIRST, before saving configuration
+	// Note: Autoconfigurable providers are registered upon extension activation, so don't need to be handled here.
+	// Likewise, the configuration dialog hides affordances to login/logout for autoconfigured models, so we'd never reach this state.
 	try {
 		await registerModel(newConfig, context, storage);
 		// Update persistent storage with new configuration
@@ -369,7 +371,10 @@ async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources:
 				throw new Error(vscode.l10n.t('OAuth sign-in is not supported for provider {0}', userConfig.provider));
 		}
 
-		await saveModel(userConfig, sources, storage, context);
+		// Special case: Copilot handles saving its own configuration internally
+		if (userConfig.provider !== 'copilot-auth') {
+			await saveModel(userConfig, sources, storage, context);
+		}
 
 		PositronAssistantApi.get().notifySignIn(userConfig.provider);
 

--- a/extensions/positron-assistant/src/copilot.ts
+++ b/extensions/positron-assistant/src/copilot.ts
@@ -187,7 +187,7 @@ export class CopilotModelProvider extends ModelProvider {
 			id: 'copilot-auth',
 			displayName: 'GitHub Copilot'
 		},
-		supportedOptions: ['oauth'],
+		supportedOptions: ['oauth', 'autoconfigure'],
 		defaults: {
 			name: 'GitHub Copilot',
 			model: 'github-copilot',


### PR DESCRIPTION
Changes related to autoconfiguration related to recent Copilot auth changes led to undesirable behavior with providers that can be manually or automatically configured. Now, models that can _optionally_ be autoconfigured but are manually configured get saved across Positron restarts.

Addresses #11390

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant: Amazon Bedrock providers stay enabled across restarts of Positron


### QA Notes

Attempt to manually add Bedrock as a provider. Restart Positron & observe that it remains registered.

Additionally, ensure Copilot stays registered in between restarts.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
