### PR TITLE
Add setting to toggle diff view for assistant notebook edits

### DIFF
--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -457,14 +457,18 @@ function createEditNotebookCellsTool(participantService: ParticipantService) {
 						// editorShown is true when editor is shown, false when preview is shown
 						const isMarkdownInPreview = cell.type === 'markdown' && cell.editorShown === false;
 
-						if (isMarkdownInPreview) {
-							// Use API-based approach for markdown cells in preview mode
+						// Check if diff view is enabled (defaults to true)
+						const showDiff = vscode.workspace.getConfiguration('positron.assistant.notebook').get('showDiff', true);
+
+						// Use direct update for: markdown in preview OR when diff view is disabled
+						if (isMarkdownInPreview || !showDiff) {
+							// Use API-based approach for direct updates
 							// This triggers visual feedback animation via handleAssistantCellModification
 							await positron.notebooks.updateCellContent(context.uri, cellIndex, content);
 
 							// The API call handles scrolling via handleAssistantCellModification
 							return new vscode.LanguageModelToolResult([
-								new vscode.LanguageModelTextPart(`Successfully updated markdown cell ${cellIndex} with visual feedback`)
+								new vscode.LanguageModelTextPart(`Successfully updated cell ${cellIndex}`)
 							]);
 						} else {
 							// Use native diff view for code cells and markdown cells in edit mode

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -23,6 +23,9 @@ export const POSITRON_NOTEBOOK_DELETION_SENTINEL_TIMEOUT_KEY = 'positron.assista
 // Configuration key for showing/hiding deletion sentinels
 export const POSITRON_NOTEBOOK_SHOW_DELETION_SENTINELS_KEY = 'positron.assistant.notebook.deletionSentinel.show';
 
+// Configuration key for showing diff view for assistant edits
+export const POSITRON_NOTEBOOK_ASSISTANT_SHOW_DIFF_KEY = 'positron.assistant.notebook.showDiff';
+
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
@@ -69,6 +72,15 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.assistant.notebook.deletionSentinel.show',
 				'Show deletion sentinels when cells are deleted. When disabled, cells are deleted immediately without undo placeholders.'
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
+		[POSITRON_NOTEBOOK_ASSISTANT_SHOW_DIFF_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.assistant.notebook.showDiff',
+				'Show diff view for AI assistant edits to notebook cells. When disabled, changes are applied directly without requiring approval.'
 			),
 			scope: ConfigurationScope.WINDOW,
 		},


### PR DESCRIPTION
Addresses #11417.

### Summary
Adds a new setting `positron.assistant.notebook.showDiff` that controls whether AI assistant edits to notebook cells show a diff view for approval or apply changes directly. When disabled, changes bypass the native diff interface and apply immediately with visual feedback animation.

This provides a persistent opt-out for users who find stacked diffs difficult to manage or prefer to review changes after the fact.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:assistant @:notebooks @:positron-notebooks

1. Open a notebook and start Positron Assistant
2. Verify the new setting exists: Settings → search "positron.assistant.notebook.showDiff"
3. With setting **enabled** (default):
   - Ask Assistant to edit a code cell
   - Verify native diff view appears requiring approval
4. With setting **disabled**:
   - Ask Assistant to edit a code cell
   - Verify changes apply directly without diff view
   - Verify visual feedback animation still appears
