### PR TITLE
e2e test flake fix: add wait before verifying git status in new folder flow

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
@@ -40,6 +40,7 @@ test.describe('New Folder Flow: Empty Project', { tag: [tags.MODAL, tags.NEW_FOL
 		});
 
 		await newFolderFlow.verifyFolderCreation(folderName);
+		await app.code.wait(1000);
 		await verifyGitStatus(app);
 	});
 });


### PR DESCRIPTION
Adds a small delay after createing the new folder to let git initialize before the `git status` call.  It was failing because git wasn't initialized yet.


Running test 10x in CI: https://github.com/posit-dev/positron/actions/runs/21083514816/job/60642255471
note- the fails are flakes of Renv tests, I'll look at those separately

### QA Notes
@:new-folder-flow
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
