### PR TITLE
ci: bump reporter to 0.19.0

### DIFF
--- a/.github/actions/gen-report-dir/action.yml
+++ b/.github/actions/gen-report-dir/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Generate REPORT_DIR
       shell: bash
       run: |
-        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}"
+        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
 
         # Export REPORT_DIR for downstream steps
         echo "REPORT_DIR=$REPORT_DIR" >> $GITHUB_ENV

--- a/.github/actions/gen-report-dir/action.yml
+++ b/.github/actions/gen-report-dir/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: "https://d38p2avprg8il3.cloudfront.net"
   project:
-    description: "Playwright project name (e.g., e2e-electron, e2e-windows)"
+    description: "Playwright project name (e.g., e2e-electron, e2e-firefox). The app-type is extracted from after the first hyphen."
     required: true
 runs:
   using: "composite"
@@ -14,7 +14,44 @@ runs:
     - name: Generate REPORT_DIR
       shell: bash
       run: |
-        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.project }}"
+        # Strip "e2e-" prefix (or "***-" when masked) from project name
+        # e.g., "e2e-electron" → "electron", but "inspect-ai" stays as "inspect-ai"
+        APP_TYPE="${{ inputs.project }}"
+        APP_TYPE="${APP_TYPE#e2e-}"
+        APP_TYPE="${APP_TYPE#***-}"
+        echo "Extracted app-type: $APP_TYPE"
+
+        # Detect platform and distro to construct project name
+        # Format: apptype-platform[-distro]
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          PROJECT_NAME="${APP_TYPE}-windows"
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          PROJECT_NAME="${APP_TYPE}-mac"
+        elif [[ -f /etc/os-release ]]; then
+          # Parse Linux distro from os-release
+          OS_ID=$(grep "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"')
+          OS_ID_LIKE=$(grep "^ID_LIKE=" /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
+          case "$OS_ID" in
+            ubuntu) DISTRO="ubuntu" ;;
+            debian) DISTRO="debian" ;;
+            rhel|rocky|centos|fedora|almalinux) DISTRO="rhel" ;;
+            opensuse|opensuse-leap|opensuse-tumbleweed|sles) DISTRO="suse" ;;
+            *)
+              # Check ID_LIKE for derivatives
+              if [[ "$OS_ID_LIKE" == *"ubuntu"* ]]; then DISTRO="ubuntu"
+              elif [[ "$OS_ID_LIKE" == *"debian"* ]]; then DISTRO="debian"
+              elif [[ "$OS_ID_LIKE" == *"rhel"* || "$OS_ID_LIKE" == *"centos"* || "$OS_ID_LIKE" == *"fedora"* ]]; then DISTRO="rhel"
+              elif [[ "$OS_ID_LIKE" == *"suse"* || "$OS_ID_LIKE" == *"opensuse"* ]]; then DISTRO="suse"
+              else DISTRO="linux"
+              fi
+              ;;
+          esac
+          PROJECT_NAME="${APP_TYPE}-linux-${DISTRO}"
+        else
+          PROJECT_NAME="${APP_TYPE}-linux"
+        fi
+
+        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}-${PROJECT_NAME}"
 
         # Export REPORT_DIR for downstream steps
         echo "REPORT_DIR=$REPORT_DIR" >> $GITHUB_ENV

--- a/.github/actions/gen-report-dir/action.yml
+++ b/.github/actions/gen-report-dir/action.yml
@@ -5,13 +5,16 @@ inputs:
     description: "Base URL of the S3 bucket or CDN for the report"
     required: false
     default: "https://d38p2avprg8il3.cloudfront.net"
+  project:
+    description: "Playwright project name (e.g., e2e-electron, e2e-windows)"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Generate REPORT_DIR
       shell: bash
       run: |
-        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
+        REPORT_DIR="playwright-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.project }}"
 
         # Export REPORT_DIR for downstream steps
         echo "REPORT_DIR=$REPORT_DIR" >> $GITHUB_ENV

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: e2e-electron
 
       - name: Run Playwright Tests (Electron)
         shell: bash

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -192,6 +192,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: 🧪 Run Playwright Tests
         shell: bash

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: e2e-electron
 
       - name: 🧪 Run Playwright Tests - Electron
         shell: bash

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -192,6 +192,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: 🧪 Run Playwright Tests
         shell: bash

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -192,6 +192,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: 🧪 Run Playwright Tests
         shell: bash

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -399,6 +399,8 @@ jobs:
 
       - name: Generate Report Directory
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: Download all blob reports
         uses: actions/download-artifact@v7

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -246,6 +246,8 @@ jobs:
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: Alter AppArmor Restrictions for Playwright
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -541,6 +541,8 @@ jobs:
 
       - name: Generate Report Directory
         uses: ./.github/actions/gen-report-dir
+        with:
+          project: ${{ inputs.project }}
 
       - name: Download all blob reports
         uses: actions/download-artifact@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.14.0",
+        "@midleman/playwright-reporter": "^0.15.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.14.0.tgz",
-      "integrity": "sha512-o+3C7JQ02dujJmkgw1emn3GeeGX4n/CjwljyL0kVhZOQXqpMIYigY2O9qPQzZIe4IrwGTyGOM7XFUa5iz97INQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.15.0.tgz",
+      "integrity": "sha512-9VjXJLncJh47cdZeF8uZcfHr/ShZngO1yDXVpPa5VuJJbH4U9E7rdd5si17RkL5mzfJZPKFPl39MMwuBGDWSvA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.18.0",
+        "@midleman/playwright-reporter": "^0.19.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.18.0.tgz",
-      "integrity": "sha512-823ZYfYVd1Fxpimm+nF042nAH3TuxasyJBx1uUjn3ca/sCqadXSI6Gzz5IXiOdwHtv/feBt8qyQfvHlsvMnIkQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.19.0.tgz",
+      "integrity": "sha512-JQTzodzpTWNp5IWinRMliO3ZiEm8o3EHFGvBtZXvAio6balsWhNH8x+//GHMNa1hDiXJ0L/OwX2YufPHVlp4bA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.11.0",
+        "@midleman/playwright-reporter": "^0.12.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.11.0.tgz",
-      "integrity": "sha512-U0s+steF8ymUoJoIFqOTKlL27Lz84kP03w0qv49CT2Nr6gEj52FUDXcuG3gUUtSTHe1qiYvf9VTHbjfEn5SNWQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.12.0.tgz",
+      "integrity": "sha512-sKTL1/O14Vxa/OfLCsmOB/ZGcfHs9sH0O3dAShodM3/MUMPGqV8K4APf9rYUjG4m0XwOLZKeYGHmtLXGEwIxHg==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.7.0",
+        "@midleman/playwright-reporter": "^0.8.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.7.0.tgz",
-      "integrity": "sha512-ruVeYTgvPs/lj6vyyzFfYH/sCu44IFjoCrbT0+MziSTokXO2JU5mCbebaoYpSKR+apVXf0cda9oF1yblAMdrOw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.8.0.tgz",
+      "integrity": "sha512-XKtkah9G+HWrX1zm8lRNvnE23/JjOHZ3wpKgwb8xVwdHGOGJ/nxh2QspOsy71hZBI5cKSQMBaH/IO6jL6DLTkw==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.8.0",
+        "@midleman/playwright-reporter": "^0.10.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.8.0.tgz",
-      "integrity": "sha512-XKtkah9G+HWrX1zm8lRNvnE23/JjOHZ3wpKgwb8xVwdHGOGJ/nxh2QspOsy71hZBI5cKSQMBaH/IO6jL6DLTkw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.10.0.tgz",
+      "integrity": "sha512-JoQEwRjC75R0YV5llmBIQQlPQA3BbDNHs33DDZPXl+ZJWZqLuDVVQbbkGnjTTLPKHvQdkvAGOXrhmyV2VfsAOQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.10.0",
+        "@midleman/playwright-reporter": "^0.11.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.10.0.tgz",
-      "integrity": "sha512-JoQEwRjC75R0YV5llmBIQQlPQA3BbDNHs33DDZPXl+ZJWZqLuDVVQbbkGnjTTLPKHvQdkvAGOXrhmyV2VfsAOQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.11.0.tgz",
+      "integrity": "sha512-U0s+steF8ymUoJoIFqOTKlL27Lz84kP03w0qv49CT2Nr6gEj52FUDXcuG3gUUtSTHe1qiYvf9VTHbjfEn5SNWQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.15.0",
+        "@midleman/playwright-reporter": "^0.17.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.15.0.tgz",
-      "integrity": "sha512-9VjXJLncJh47cdZeF8uZcfHr/ShZngO1yDXVpPa5VuJJbH4U9E7rdd5si17RkL5mzfJZPKFPl39MMwuBGDWSvA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.17.0.tgz",
+      "integrity": "sha512-kzUs68LR0az5+kiMq79LyDyBUeDXynflDkamVlJnbFoU7HgFdgJIUgjQIVeV7DtIkVTAW8c0ucKPpPhzzSJBLA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.17.0",
+        "@midleman/playwright-reporter": "^0.18.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.17.0.tgz",
-      "integrity": "sha512-kzUs68LR0az5+kiMq79LyDyBUeDXynflDkamVlJnbFoU7HgFdgJIUgjQIVeV7DtIkVTAW8c0ucKPpPhzzSJBLA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.18.0.tgz",
+      "integrity": "sha512-823ZYfYVd1Fxpimm+nF042nAH3TuxasyJBx1uUjn3ca/sCqadXSI6Gzz5IXiOdwHtv/feBt8qyQfvHlsvMnIkQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock": "^3.914.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@midleman/playwright-reporter": "^0.12.0",
+        "@midleman/playwright-reporter": "^0.14.0",
         "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.12.0.tgz",
-      "integrity": "sha512-sKTL1/O14Vxa/OfLCsmOB/ZGcfHs9sH0O3dAShodM3/MUMPGqV8K4APf9rYUjG4m0XwOLZKeYGHmtLXGEwIxHg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.14.0.tgz",
+      "integrity": "sha512-o+3C7JQ02dujJmkgw1emn3GeeGX4n/CjwljyL0kVhZOQXqpMIYigY2O9qPQzZIe4IrwGTyGOM7XFUa5iz97INQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.18.0",
+    "@midleman/playwright-reporter": "^0.19.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.8.0",
+    "@midleman/playwright-reporter": "^0.10.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.10.0",
+    "@midleman/playwright-reporter": "^0.11.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.17.0",
+    "@midleman/playwright-reporter": "^0.18.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.7.0",
+    "@midleman/playwright-reporter": "^0.8.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.14.0",
+    "@midleman/playwright-reporter": "^0.15.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.12.0",
+    "@midleman/playwright-reporter": "^0.14.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.11.0",
+    "@midleman/playwright-reporter": "^0.12.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/client-bedrock": "^3.914.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@midleman/playwright-reporter": "^0.15.0",
+    "@midleman/playwright-reporter": "^0.17.0",
     "@parcel/watcher": "parcel-bundler/watcher#1ca032aa8339260a8a3bcf825c3a1a71e3e43542",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",


### PR DESCRIPTION
### Summary
* Bump to 0.19.0
* Workaround the masking that is occurring in our workflows: `e2e` --> `***`, this becomes problematic when generating predictable, unique URLs for sharded runs based on project name.

### QA Notes

n/a