### PR TITLE
[python] update streamlit web app detection regex

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -27,7 +27,7 @@ export function getFramework(text: string): string | undefined {
 
     // Define patterns for app creation for each framework
     const appCreationPatterns: Record<string, RegExp> = {
-        streamlit: /st\.\w+\(|streamlit\.\w+\(/i, // More specific pattern for actual streamlit usage
+        streamlit: /\bst\.\w+\(|streamlit\.\w+\(/i, // More specific pattern for actual streamlit usage
         dash: /\w+\s*=\s*(?:Dash|dash\.Dash)\(/i,
         gradio: /\w+\s*=\s*(?:gr\.|gradio\.)/i,
         flask: /\w+\s*=\s*(?:Flask|flask\.Flask)\(/i,
@@ -51,8 +51,8 @@ export function getFramework(text: string): string | undefined {
         // Check for app creation
         const hasAppCreation = appCreationPatterns[lib].test(text);
 
-        // If we have both app creation and import, return immediately (highest priority)
-        if (hasAppCreation && importMatch) {
+        // If we have both app creation and import for the same library, return immediately (highest priority)
+        if (hasAppCreation && importMatch === lib) {
             traceInfo(`Detected web app framework: ${lib} (with app creation)`);
             return lib;
         }

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -137,5 +137,34 @@ app = Dash(__name__)
 `;
             assert.strictEqual(getFramework(code), 'dash');
         });
+
+        test('should only match app creation when import is for the same library', () => {
+            // Has Flask import but Dash-like app creation pattern - should return flask (import match)
+            // since the app creation pattern doesn't match the imported library
+            const code = `
+from flask import Flask
+
+app = Dash(__name__)
+`;
+            assert.strictEqual(getFramework(code), 'flask');
+        });
+
+        test('should detect FastAPI app with matching import and app creation', () => {
+            const code = `
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+@app.middleware("http")                                                     
+async def logging_middleware(request: Request, call_next):                  
+  req_body = await request.body()  
+`;
+            assert.strictEqual(getFramework(code), 'fastapi');
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -139,8 +139,6 @@ app = Dash(__name__)
         });
 
         test('should only match app creation when import is for the same library', () => {
-            // Has Flask import but Dash-like app creation pattern - should return flask (import match)
-            // since the app creation pattern doesn't match the imported library
             const code = `
 from flask import Flask
 


### PR DESCRIPTION
Addresses problem in https://github.com/posit-dev/positron/discussions/11453 where the `st.` in `request.` was being treated as streamlit code.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Update Streamlit web app detection regex.


### QA Notes

web app should be detected as FastAPI in the play button (note this app does not actually run, just checking the detection)

```python
from fastapi import FastAPI

app = FastAPI()


@app.get("/")
def read_root():
    return {"Hello": "World"}

@app.middleware("http")                                                     
async def logging_middleware(request: Request, call_next):                  
  req_body = await request.body()  

```