### PR TITLE
ci: fix npm install retry logic to properly detect and retry on failure

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -201,6 +201,8 @@ jobs:
           # Note: test/e2e is installed in separate step below (not cached, always runs)
           # See https://github.com/posit-dev/positron/issues/3481 for why retry is needed (windows-process-tree failures)
           command: |
+            set -e  # Exit immediately if any command fails
+
             # Pre-install build directory (required by postinstall for gulp-merge-json)
             npm --prefix build ci --no-audit --no-fund --fetch-timeout 120000
 
@@ -217,6 +219,8 @@ jobs:
           retry_wait_seconds: 10
           shell: bash
           command: |
+            set -e  # Exit immediately if any command fails
+
             # Download platform-specific binaries for Windows
             # Wrapped in retry due to occasional GitHub API timeouts
             cd extensions

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -78,6 +78,8 @@ jobs:
           retry_wait_seconds: 5
           shell: bash
           command: |
+            set -e  # Exit immediately if any command fails
+
             # Install node-gyp (required by some packages)
             npm i --global node-gyp
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -82,6 +82,8 @@ jobs:
           retry_wait_seconds: 5
           shell: bash
           command: |
+            set -e  # Exit immediately if any command fails
+
             # Capture file tree before npm install (for cache validation)
             find . -type f -o -type l | grep -v "node_modules/" | sort > /tmp/files-before-npm-install.txt
 


### PR DESCRIPTION
### Summary
Our retries weren’t actually happening in workflows if the installation of dependencies fails for any reason. This should fix that.

### QA Notes

@:win