### PR TITLE
e2e Tests: Assistant default model setting

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -294,14 +294,14 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 		}).toPass({ timeout: 30000 });
 
 		// Only sign out of Anthropic if we signed in with API key
-		if (process.env.ANTHROPIC_KEY) {
-			await expect(async () => {
-				await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-				await app.workbench.assistant.selectModelProvider('anthropic-api');
-				await app.workbench.assistant.clickSignOutButton();
-				await app.workbench.assistant.clickCloseButton();
-			}).toPass({ timeout: 30000 });
-		}
+		// if (process.env.ANTHROPIC_KEY) {
+		// 	await expect(async () => {
+		// 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
+		// 		await app.workbench.assistant.selectModelProvider('anthropic-api');
+		// 		await app.workbench.assistant.clickSignOutButton();
+		// 		await app.workbench.assistant.clickCloseButton();
+		// 	}).toPass({ timeout: 30000 });
+		// }
 	});
 
 	/**
@@ -318,6 +318,16 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 				'echo': 'Echo Language Model v2'
 			}
 		}, { reload: true });
+
+		// Only sign out of Anthropic if we signed in with API key
+		if (process.env.ANTHROPIC_KEY) {
+			await expect(async () => {
+				await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
+				await app.workbench.assistant.selectModelProvider('anthropic-api');
+				await app.workbench.assistant.clickSignOutButton();
+				await app.workbench.assistant.clickCloseButton();
+			}).toPass({ timeout: 30000 });
+		}
 
 		await expect(async () => {
 			await app.workbench.assistant.pickModel();

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -261,17 +261,6 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 	test.beforeAll('Enable Assistant and sign in to providers', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 
-		// Only sign in to Anthropic if ANTHROPIC_KEY is provided
-		// Otherwise, assume already signed in via another method (e.g., OAuth)
-		// if (process.env.ANTHROPIC_KEY) {
-		// 	await app.workbench.assistant.clickAddModelButton();
-		// 	await app.workbench.assistant.selectModelProvider('anthropic-api');
-		// 	await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
-		// 	await app.workbench.assistant.clickSignInButton();
-		// 	await app.workbench.assistant.verifySignOutButtonVisible();
-		// 	await app.workbench.assistant.clickCloseButton();
-		// }
-
 		// Sign in to Echo provider
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
 		await app.workbench.assistant.selectModelProvider('echo');
@@ -308,7 +297,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 	 * Test Case 2: Multiple Providers with Different Defaults
 	 * Verifies that when a user configures default models for multiple providers:
 	 * 1. Each provider shows its respective default model with "(default)" suffix
-	 * 2. Each default model appears first in its vendor group
+	 * 2. Each default model appears first in its provider group
 	 */
 	test('Verify default model indicators and ordering for multiple providers', async function ({ app, settings }) {
 		// Configure defaults for both Anthropic and Echo providers
@@ -319,6 +308,8 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 			}
 		}, { reload: true });
 
+		// Only sign in to Anthropic if ANTHROPIC_KEY is provided
+		// Otherwise, assume already signed in via another method (e.g., OAuth)
 		if (process.env.ANTHROPIC_KEY) {
 			await app.workbench.assistant.clickAddModelButton();
 			await app.workbench.assistant.selectModelProvider('anthropic-api');

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -263,14 +263,14 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 
 		// Only sign in to Anthropic if ANTHROPIC_KEY is provided
 		// Otherwise, assume already signed in via another method (e.g., OAuth)
-		if (process.env.ANTHROPIC_KEY) {
-			await app.workbench.assistant.clickAddModelButton();
-			await app.workbench.assistant.selectModelProvider('anthropic-api');
-			await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
-			await app.workbench.assistant.clickSignInButton();
-			await app.workbench.assistant.verifySignOutButtonVisible();
-			await app.workbench.assistant.clickCloseButton();
-		}
+		// if (process.env.ANTHROPIC_KEY) {
+		// 	await app.workbench.assistant.clickAddModelButton();
+		// 	await app.workbench.assistant.selectModelProvider('anthropic-api');
+		// 	await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
+		// 	await app.workbench.assistant.clickSignInButton();
+		// 	await app.workbench.assistant.verifySignOutButtonVisible();
+		// 	await app.workbench.assistant.clickCloseButton();
+		// }
 
 		// Sign in to Echo provider
 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
@@ -294,14 +294,14 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 		}).toPass({ timeout: 30000 });
 
 		// Only sign out of Anthropic if we signed in with API key
-		// if (process.env.ANTHROPIC_KEY) {
-		// 	await expect(async () => {
-		// 		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		// 		await app.workbench.assistant.selectModelProvider('anthropic-api');
-		// 		await app.workbench.assistant.clickSignOutButton();
-		// 		await app.workbench.assistant.clickCloseButton();
-		// 	}).toPass({ timeout: 30000 });
-		// }
+		if (process.env.ANTHROPIC_KEY) {
+			await expect(async () => {
+				await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
+				await app.workbench.assistant.selectModelProvider('anthropic-api');
+				await app.workbench.assistant.clickSignOutButton();
+				await app.workbench.assistant.clickCloseButton();
+			}).toPass({ timeout: 30000 });
+		}
 	});
 
 	/**
@@ -319,14 +319,13 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 			}
 		}, { reload: true });
 
-		// Only sign out of Anthropic if we signed in with API key
 		if (process.env.ANTHROPIC_KEY) {
-			await expect(async () => {
-				await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-				await app.workbench.assistant.selectModelProvider('anthropic-api');
-				await app.workbench.assistant.clickSignOutButton();
-				await app.workbench.assistant.clickCloseButton();
-			}).toPass({ timeout: 30000 });
+			await app.workbench.assistant.clickAddModelButton();
+			await app.workbench.assistant.selectModelProvider('anthropic-api');
+			await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
+			await app.workbench.assistant.clickSignInButton();
+			await app.workbench.assistant.verifySignOutButtonVisible();
+			await app.workbench.assistant.clickCloseButton();
 		}
 
 		await expect(async () => {


### PR DESCRIPTION
Add tests for Positron Assistant default model settings.. added in https://github.com/posit-dev/positron/issues/11166


### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
