### PR TITLE
Try yet one more time to fix CLA for Snyk

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,7 @@ jobs:
             before we accept your contribution. You can sign the CLA by posting
             a comment on this PR saying:
 
-          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, posit-jenkins-enterprise[bot], github-actions[bot], Copilot, posit-snyk-bot
+          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, posit-jenkins-enterprise[bot], github-actions[bot], Copilot, snyk-bot
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
I tried making this work for the Snyk bot in https://github.com/posit-dev/positron/pull/11223, but then when https://github.com/posit-dev/positron/pull/11396 came in, it still failed! It turns out that the PR author is `posit-snyk-bot`, but the commit author is `snyk-bot`. The CLA action checks commit authors, not the PR author. 😩 

We didn't need to take https://github.com/posit-dev/positron/pull/11396 because the change is already in upstream, but hopefully this will set us up for next time we do need one of those PRs.