### PR TITLE
Positron Notebook: Actions to change cell type

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -262,6 +262,16 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	insertMarkdownCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
 
 	/**
+	 * Changes a cell to a different kind (code or markdown) and/or changes its language.
+	 * Cell content, metadata, and outputs are all preserved (outputs survive round-trip conversions).
+	 *
+	 * @param targetKind The target cell kind to convert to
+	 * @param targetLanguage Optional target language. If not provided, uses notebook default for code cells or 'markdown' for markdown cells
+	 * @param cell Optional cell to convert. If not provided, converts the currently active cell
+	 */
+	changeCellType(targetKind: CellKind, targetLanguage?: string, cell?: IPositronNotebookCell): void;
+
+	/**
 	 * Removes a cell from the notebook.
 	 *
 	 * @param cell Optional cell to delete. If not provided, deletes the currently active cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1093,6 +1093,98 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
+	 * Changes a cell to a different kind (code or markdown) and/or changes its language.
+	 * The cell content is preserved, but outputs are cleared when converting to markdown.
+	 * @param targetKind The target cell kind to convert to
+	 * @param targetLanguage Optional target language. If not provided, uses notebook default for code cells or 'markdown' for markdown cells
+	 * @param cellToConvert The cell to convert. If not provided, converts the currently active cell
+	 */
+	changeCellType(targetKind: CellKind, targetLanguage?: string, cellToConvert?: IPositronNotebookCell): void {
+		const cell = cellToConvert ?? getActiveCell(this.selectionStateMachine.state.get());
+
+		if (!cell) {
+			return;
+		}
+
+		this._assertTextModel();
+
+		const textModel = this.textModel;
+		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
+		const cellIndex = cell.index;
+
+		if (cellIndex < 0) {
+			return;
+		}
+
+		// Get the underlying cell model to access all properties
+		const cellModel = textModel.cells[cellIndex];
+		if (!cellModel) {
+			return;
+		}
+
+		// Determine the target language
+		const resolvedLanguage = targetLanguage ?? (targetKind === CellKind.Code ? this.language : 'markdown');
+
+		// Check if we only need a language change (same cell kind)
+		const needsKindChange = cell.kind !== targetKind;
+		const needsLanguageChange = cellModel.language !== resolvedLanguage;
+
+		if (!needsKindChange && !needsLanguageChange) {
+			return; // Nothing to do
+		}
+
+		// Preserve selection at the same index
+		const endSelections: ISelectionState = {
+			kind: SelectionStateType.Index,
+			focus: { start: cellIndex, end: cellIndex + 1 },
+			selections: [{ start: cellIndex, end: cellIndex + 1 }]
+		};
+
+		if (needsKindChange) {
+			// Replace the cell with a new cell of the target kind
+			// Preserve content, metadata, and outputs (outputs survive round-trip conversions)
+			textModel.applyEdits([
+				{
+					editType: CellEditType.Replace,
+					index: cellIndex,
+					count: 1,
+					cells: [
+						{
+							cellKind: targetKind,
+							language: resolvedLanguage,
+							mime: undefined,
+							outputs: cellModel.outputs,
+							metadata: cellModel.metadata,
+							source: cellModel.getValue()
+						}
+					]
+				}
+			],
+				true,
+				{
+					kind: SelectionStateType.Index,
+					focus: { start: cellIndex, end: cellIndex + 1 },
+					selections: [{ start: cellIndex, end: cellIndex + 1 }]
+				},
+				() => endSelections,
+				undefined,
+				computeUndoRedo
+			);
+		} else {
+			// Only language change needed
+			textModel.applyEdits([
+				{
+					editType: CellEditType.CellLanguage,
+					index: cellIndex,
+					language: resolvedLanguage
+				}
+			], true, undefined, () => undefined, undefined, computeUndoRedo);
+		}
+
+		this._onDidChangeContent.fire();
+	}
+
+	/**
 	 * Deletes a single cell from the notebook.
 	 * @param cellToDelete The cell to delete. If not provided, deletes the currently active cell
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1037,7 +1037,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				cells: [
 					{
 						cellKind: type,
-						language: this.language,
+						language: type === CellKind.Code ? this.language : 'markdown',
 						mime: undefined,
 						outputs: [],
 						metadata: undefined,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -71,6 +71,7 @@ export function useCellContextKeys(
 			const cellType = cell.kind;
 			keys.isCode.set(cellType === CellKind.Code);
 			keys.isMarkdown.set(cellType === CellKind.Markup);
+			keys.isRaw.set(cellType === CellKind.Code && cell.model.language === 'raw');
 			keys.isRunning.set(executionStatus === 'running');
 			keys.isPending.set(executionStatus === 'pending');
 			keys.isFirst.set(cell.index === 0);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -68,9 +68,10 @@ const POSITRON_NOTEBOOK_CATEGORY = localize2('positronNotebook.category', 'Noteb
 // Group IDs used to organize cell actions in menus and context menus
 enum PositronNotebookCellActionGroup {
 	Clipboard = '0_clipboard',
-	Insert = '1_insert',
-	Order = '2_order',
-	Execution = '3_execution',
+	CellType = '1_celltype',
+	Insert = '2_insert',
+	Order = '3_order',
+	Execution = '4_execution',
 }
 
 /**
@@ -1190,6 +1191,100 @@ registerAction2(class extends NotebookAction2 {
 	}
 });
 
+// Change to Code cell - y key (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToCode',
+			title: localize2('positronNotebook.cell.changeToCode', "Change to Code"),
+			icon: ThemeIcon.fromId('code'),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 10,
+				when: CELL_CONTEXT_KEYS.isCode.toNegated()
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 10,
+				when: CELL_CONTEXT_KEYS.isCode.toNegated()
+			}],
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.KeyY
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		// Change to code cell with kernel's default language
+		const kernelLanguage = notebook.kernel.get()?.supportedLanguages?.[0];
+		notebook.changeCellType(CellKind.Code, kernelLanguage);
+	}
+});
+
+// Change to Markdown cell - m key (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToMarkdown',
+			title: localize2('positronNotebook.cell.changeToMarkdown', "Change to Markdown"),
+			icon: ThemeIcon.fromId('markdown'),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 20,
+				when: CELL_CONTEXT_KEYS.isMarkdown.toNegated()
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 20,
+				when: CELL_CONTEXT_KEYS.isMarkdown.toNegated()
+			}],
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.KeyM
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeCellType(CellKind.Markup);
+	}
+});
+
+// Change to Raw cell - r key (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToRaw',
+			title: localize2('positronNotebook.cell.changeToRaw', "Change to Raw"),
+			icon: ThemeIcon.fromId('file-code'),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 30,
+				when: CELL_CONTEXT_KEYS.isRaw.toNegated()
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.CellType,
+				order: 30,
+				when: CELL_CONTEXT_KEYS.isRaw.toNegated()
+			}],
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.KeyR
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeCellType(CellKind.Code, 'raw');
+	}
+});
 
 //#endregion Cell Commands
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1202,12 +1202,12 @@ registerAction2(class extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 10,
-				when: CELL_CONTEXT_KEYS.isCode.toNegated()
+				when: ContextKeyExpr.or(CELL_CONTEXT_KEYS.isCode.toNegated(), CELL_CONTEXT_KEYS.isRaw)
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 10,
-				when: CELL_CONTEXT_KEYS.isCode.toNegated()
+				when: ContextKeyExpr.or(CELL_CONTEXT_KEYS.isCode.toNegated(), CELL_CONTEXT_KEYS.isRaw)
 			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_COMMAND_MODE,

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -450,7 +450,7 @@ export class PositronNotebooks extends Notebooks {
 	 * Action: Perform a cell action using keyboard shortcuts.
 	 * @param action - The action to perform: 'copy', 'cut', 'paste', 'undo', 'redo', 'delete', 'addCellBelow'.
 	 */
-	async performCellAction(action: 'copy' | 'cut' | 'paste' | 'undo' | 'redo' | 'delete' | 'addCellBelow'): Promise<void> {
+	async performCellAction(action: 'copy' | 'cut' | 'paste' | 'undo' | 'redo' | 'delete' | 'addCellBelow' | 'changeToCode' | 'changeToMarkdown' | 'changeToRaw'): Promise<void> {
 		await test.step(`Perform cell action: ${action}`, async () => {
 			// Note: We use direct keyboard shortcuts instead of hotKeys/clipboard helpers
 			// because Positron Notebooks uses Jupyter-style single-key shortcuts (C/X/V/Z)
@@ -476,6 +476,15 @@ export class PositronNotebooks extends Notebooks {
 					break;
 				case 'addCellBelow':
 					await this.code.driver.page.keyboard.press('KeyB');
+					break;
+				case 'changeToCode':
+					await this.code.driver.page.keyboard.press('KeyY');
+					break;
+				case 'changeToMarkdown':
+					await this.code.driver.page.keyboard.press('KeyM');
+					break;
+				case 'changeToRaw':
+					await this.code.driver.page.keyboard.press('KeyR');
 					break;
 				default:
 					throw new Error(`Unknown cell action: ${action}`);

--- a/test/e2e/tests/notebooks-positron/notebook-cell-type.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-type.test.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Cell Type', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Change cell type via command mode keyboard shortcuts', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const code = 'print("hello")';
+
+		await test.step('Create notebook and select Python kernel', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+		});
+
+		await test.step('Add code to cell and run it', async () => {
+			await notebooksPositron.addCodeToCell(0, code, { run: true });
+			await notebooksPositron.expectOutputAtIndex(0, ['hello']);
+		});
+
+		await test.step('Convert to markdown', async () => {
+			await notebooksPositron.performCellAction('changeToMarkdown');
+		});
+
+		await test.step('Verify cell is markdown and content preserved', async () => {
+			await notebooksPositron.expectCellTypeAtIndexToBe(0, 'markdown');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, code);
+		});
+
+		await test.step('Convert back to code', async () => {
+			await notebooksPositron.performCellAction('changeToCode');
+		});
+
+		await test.step('Verify cell is code, content preserved, and output restored', async () => {
+			await notebooksPositron.expectCellTypeAtIndexToBe(0, 'code');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, code);
+			await notebooksPositron.expectOutputAtIndex(0, ['hello']);
+		});
+	});
+});


### PR DESCRIPTION
Addresses #8599. This PR adds cell actions to change cell types between code, markdown, and raw. They can be accessed via Jupyter-style keyboard shortcuts (`y`, `m`, `r`) or in the more actions submenu of the cell action bar.

Also addresses #11446 by properly setting the language to `markdown` when adding markdown cells.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web