### PR TITLE
[python] do not consume `map` in Variables Pane

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1358,6 +1358,12 @@ def get_inspector(value: T) -> PositronInspector[T]:
         qualname = _get_simplified_qualname(value)
     inspector_cls = INSPECTOR_CLASSES.get(qualname)
 
+    # Guard: MapInspector should only be used for Mapping types, not map() iterators.
+    # Python's builtin map() has qualname 'map' which collides with the 'map' key
+    # intended for Mapping types like dict.
+    if inspector_cls is MapInspector and not isinstance(value, Mapping):
+        inspector_cls = None
+
     if inspector_cls is None:
         # Otherwise, look for an inspector by kind
         kind = _get_kind(value)


### PR DESCRIPTION
`map` was getting slurped up into the `MappingInspector`, which is supposed to be for _mappings_ like dicts and dataframes

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #9230 Fixes bug where Python's builtin `map` was eagerly consumed by the Variables pane.


### QA Notes

```python
def identity(x):
    print(x)
    return x

m = map(identity, range(10_000))
next(m)
```

should return 0 0