### PR TITLE
E2E test: skip "Verify Restart Extension Host command works - Python" for now

### DIFF
--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -9,19 +9,17 @@ test.use({
 	suiteId: __filename
 });
 
-
-test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, () => {
+// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407 on windows
+test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS] }, () => {
 
 	test.afterEach(async ({ app }) => {
 		await app.workbench.sessions.deleteAll();
 	});
 
+
 	test('Verify Restart Extension Host command works - R', {
 		tag: [tags.ARK]
 	}, async function ({ app, r }) {
-		// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407
-		test.skip(process.platform === 'win32', 'Skip on Windows');
-
 		await app.workbench.quickaccess.runCommand('workbench.action.restartExtensionHost');
 		await app.workbench.console.waitForConsoleContents('Extensions restarting...');
 		await app.workbench.console.waitForReady('>');
@@ -30,9 +28,6 @@ test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, ()
 	});
 
 	test('Verify Restart Extension Host command works - Python', async function ({ app, python }) {
-		// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407
-		test.skip(process.platform === 'win32', 'Skip on Windows');
-
 		await app.workbench.quickaccess.runCommand('workbench.action.restartExtensionHost');
 		await app.workbench.console.waitForConsoleContents('Extensions restarting...');
 		await app.workbench.console.waitForReady('>>>');

--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -30,6 +30,9 @@ test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, ()
 	});
 
 	test('Verify Restart Extension Host command works - Python', async function ({ app, python }) {
+		// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407
+		test.skip(process.platform === 'win32', 'Skip on Windows');
+
 		await app.workbench.quickaccess.runCommand('workbench.action.restartExtensionHost');
 		await app.workbench.console.waitForConsoleContents('Extensions restarting...');
 		await app.workbench.console.waitForReady('>>>');


### PR DESCRIPTION
Skipping in addition to R test temporarily