### PR TITLE
Set "search.followSymlinks" to false to fix massive slowdowns

### DIFF
--- a/positron.code-workspace
+++ b/positron.code-workspace
@@ -6,5 +6,8 @@
 		{
 			"path": "./extensions/positron-python"
 		}
-	]
+	],
+	"settings": {
+		"search.followSymlinks": false
+    }
 }


### PR DESCRIPTION
I think this solves the really terrible problems I've had lately with dev builds and the incremental file watchers. It does not change the fairly high memory usage (i.e. `gulp watch-client` still uses 5+ GB of RAM) but it does solve the extremely intense slowdowns I was experiencing. I was seeing a zillion `rg` processes, as [described here](https://github.com/microsoft/vscode/issues/98594) and in some other issues around you can find, including for Cursor and the other forks.

You can't apply this to one of the folders in a multiroot workspace, but you can do it for the multiroot workspace as a whole. If this isn't a good idea, I will just keep it in my user settings. 😅 

I used Claude to tell me what symlinks we have, and it says this:

> There are 844 symlinks in the project. They fall into a few categories:
> 
>   1. node_modules/.bin/ symlinks (the vast majority)
> 
>   node_modules/.bin/gulp -> ../gulp/bin/gulp.js
>   node_modules/.bin/tsc -> ../typescript/bin/tsc
>   When you npm install, npm creates symlinks in .bin/ folders that point to executable scripts in installed packages. This is how commands like gulp, tsc, mocha etc. become available. There are hundreds of these across the main node_modules and various nested ones in test/, extensions/, etc.
> 
>   2. macOS framework symlinks (in .build/electron/)
> 
>   Electron Framework.framework/Versions/Current -> A
>   Electron Framework.framework/Electron Framework -> Versions/Current/...
>   These are standard macOS framework bundle structures. Frameworks use symlinks to point to the "current" version of libraries.
> 
>   What "not following symlinks" means practically
> 
>   With search.followSymlinks: false:
>   - When you search for text in files, VS Code won't traverse into symlinked directories
>   - It won't follow those .bin/ symlinks into the actual package source files
>   - It won't search through the Electron framework internals
> 
>   This is almost always what you want because:
>   - You don't want to search inside node_modules package internals anyway
>   - Following symlinks can cause the same file to be indexed multiple times
>   - It can slow down file watching significantly in large projects
> 
>   Your actual source code has no symlinks, so your searches will work exactly the same for the code you care about.