### PR TITLE
Use new supervisor; restore default resource monitor

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -189,7 +189,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.62"
+      "kallichore": "0.1.63"
     }
   },
   "extensionDependencies": [

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -12,7 +12,5 @@
     "echo",
     "error"
   ],
-  "posit.workbench.showWorkbenchFlaskHint": false,
-  "kernelSupervisor.resourceUsagePollInterval": 0,
-  "console.showResourceMonitor": false
+  "posit.workbench.showWorkbenchFlaskHint": false
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11506; see full notes in https://github.com/posit-dev/kallichore/pull/59. 
