### PR TITLE
Assistant: Refines Copilot tool filtering in Ask mode

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -376,6 +376,17 @@ export function getEnabledTools(
 		// or if the user is signed into Copilot and has opted-in to always
 		// include Copilot tools.
 		const shouldIncludeCopilotTools = (usingCopilotModel || copilotEnabled && alwaysIncludeCopilotTools);
+
+		// Special filtering for Copilot tools in Ask mode.
+		if (copilotTool && isAskMode && !tool.tags.includes('vscode_codesearch')) {
+			// In Positron Ask mode with a non-Copilot model, only include
+			// Copilot tools that are tagged with 'vscode_codesearch' to allow
+			// use of code search functionality but *not* general Copilot tools.
+
+			// Adapted from extensions/positron-copilot-chat/src/extension/intents/node/askAgentIntent.ts:35
+			// Possibly revisit this logic in the future as Copilot evolves.
+			continue;
+		}
 
 		// Enable Copilot tools only if shouldIncludeCopilotTools is true; otherwise, enable if agent mode or tool is tagged 'positron-assistant'.
 		const enableTool = copilotTool

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -379,7 +379,7 @@ export function getEnabledTools(
 
 		// Special filtering for Copilot tools in Ask mode.
 		if (copilotTool && isAskMode && !tool.tags.includes('vscode_codesearch')) {
-			// In Positron Ask mode with a non-Copilot model, only include
+			// In Positron Ask mode, only include
 			// Copilot tools that are tagged with 'vscode_codesearch' to allow
 			// use of code search functionality but *not* general Copilot tools.
 


### PR DESCRIPTION
Copilot has special tool filtering in it's Ask mode agent, which only permits tools specified with the "vscode_codesearch" tag. This was ported to Assistant's tool filtering logic to prevent Copilot's mutable tools from being available in ask mode.

Addresses #10212


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant no longer can make edits when in Ask mode


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

Prompt Assistant to make edits to a file in Ask mode. It should not be able to. If you insist (e.g., "Edit the file yourself") it should report it's unable to.

Permutations:
- Assistant model
- Copilot model
- `positron.assistant.alwaysIncludeCopilotTools` on & off

Also ensure edits _can be made_ in Agent & Edit modes.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
