### PR TITLE
Suppress debug status bar during R background debug sessions

### DIFF
--- a/extensions/positron-supervisor/src/DapComm.ts
+++ b/extensions/positron-supervisor/src/DapComm.ts
@@ -167,8 +167,7 @@ export class DapComm {
 			case 'start_debug': {
 				// Cancel any pending stop handler. We debounce these to avoid flickering.
 				this._stopDebug.cancel();
-				vscode.debug.setSuppressDebugToolbar(this.debugSession(), false);
-				vscode.debug.setSuppressDebugStatusbar(this.debugSession(), false);
+				vscode.debug.setDebugSessionForeground(this.debugSession(), true);
 				break;
 			}
 
@@ -177,8 +176,7 @@ export class DapComm {
 				// prevents flickering in the debug pane.
 				this._stopDebug.schedule(() => {
 					if (this._debugSession) {
-						vscode.debug.setSuppressDebugToolbar(this._debugSession, true);
-						vscode.debug.setSuppressDebugStatusbar(this._debugSession, true);
+						vscode.debug.setDebugSessionForeground(this._debugSession, false);
 					}
 				});
 				break;

--- a/extensions/positron-supervisor/src/DapComm.ts
+++ b/extensions/positron-supervisor/src/DapComm.ts
@@ -92,6 +92,7 @@ export class DapComm {
 
 		const debugOptions: vscode.DebugSessionOptions = {
 			suppressDebugToolbar: true,
+			suppressDebugStatusbar: true,
 		};
 
 		return new DapComm(
@@ -167,6 +168,7 @@ export class DapComm {
 				// Cancel any pending stop handler. We debounce these to avoid flickering.
 				this._stopDebug.cancel();
 				vscode.debug.setSuppressDebugToolbar(this.debugSession(), false);
+				vscode.debug.setSuppressDebugStatusbar(this.debugSession(), false);
 				break;
 			}
 
@@ -176,6 +178,7 @@ export class DapComm {
 				this._stopDebug.schedule(() => {
 					if (this._debugSession) {
 						vscode.debug.setSuppressDebugToolbar(this._debugSession, true);
+						vscode.debug.setSuppressDebugStatusbar(this._debugSession, true);
 					}
 				});
 				break;

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -354,6 +354,13 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 			this.debugService.setSessionSuppressDebugToolbar(session, suppress);
 		}
 	}
+
+	public $setSuppressDebugStatusbar(sessionId: DebugSessionUUID, suppress: boolean): void {
+		const session = this.debugService.getModel().getSession(sessionId);
+		if (session) {
+			this.debugService.setSessionSuppressDebugStatusbar(session, suppress);
+		}
+	}
 	// --- End Positron ---
 
 	public $customDebugAdapterRequest(sessionId: DebugSessionUUID, request: string, args: unknown): Promise<unknown> {

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -348,17 +348,10 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	}
 
 	// --- Start Positron ---
-	public $setSuppressDebugToolbar(sessionId: DebugSessionUUID, suppress: boolean): void {
+	public $setDebugSessionForeground(sessionId: DebugSessionUUID, foreground: boolean): void {
 		const session = this.debugService.getModel().getSession(sessionId);
 		if (session) {
-			this.debugService.setSessionSuppressDebugToolbar(session, suppress);
-		}
-	}
-
-	public $setSuppressDebugStatusbar(sessionId: DebugSessionUUID, suppress: boolean): void {
-		const session = this.debugService.getModel().getSession(sessionId);
-		if (session) {
-			this.debugService.setSessionSuppressDebugStatusbar(session, suppress);
+			this.debugService.setSessionForeground(session, foreground);
 		}
 	}
 	// --- End Positron ---

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1375,6 +1375,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean) {
 				return extHostDebugService.setSuppressDebugToolbar(session, suppress);
 			},
+			setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean) {
+				return extHostDebugService.setSuppressDebugStatusbar(session, suppress);
+			},
 			// --- End Positron ---
 			addBreakpoints(breakpoints: readonly vscode.Breakpoint[]) {
 				return extHostDebugService.addBreakpoints(breakpoints);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1372,11 +1372,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostDebugService.stopDebugging(session);
 			},
 			// --- Start Positron ---
-			setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean) {
-				return extHostDebugService.setSuppressDebugToolbar(session, suppress);
-			},
-			setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean) {
-				return extHostDebugService.setSuppressDebugStatusbar(session, suppress);
+			setDebugSessionForeground(session: vscode.DebugSession, foreground: boolean) {
+				return extHostDebugService.setDebugSessionForeground(session, foreground);
 			},
 			// --- End Positron ---
 			addBreakpoints(breakpoints: readonly vscode.Breakpoint[]) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1805,8 +1805,7 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 	$stopDebugging(sessionId: DebugSessionUUID | undefined): Promise<void>;
 	$setDebugSessionName(id: DebugSessionUUID, name: string): void;
 	// --- Start Positron ---
-	$setSuppressDebugToolbar(sessionId: DebugSessionUUID, suppress: boolean): void;
-	$setSuppressDebugStatusbar(sessionId: DebugSessionUUID, suppress: boolean): void;
+	$setDebugSessionForeground(sessionId: DebugSessionUUID, foreground: boolean): void;
 	// --- End Positron ---
 	$customDebugAdapterRequest(id: DebugSessionUUID, command: string, args: any): Promise<any>;
 	$getDebugProtocolBreakpoint(id: DebugSessionUUID, breakpoinId: string): Promise<DebugProtocol.Breakpoint | undefined>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1806,6 +1806,7 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 	$setDebugSessionName(id: DebugSessionUUID, name: string): void;
 	// --- Start Positron ---
 	$setSuppressDebugToolbar(sessionId: DebugSessionUUID, suppress: boolean): void;
+	$setSuppressDebugStatusbar(sessionId: DebugSessionUUID, suppress: boolean): void;
 	// --- End Positron ---
 	$customDebugAdapterRequest(id: DebugSessionUUID, command: string, args: any): Promise<any>;
 	$getDebugProtocolBreakpoint(id: DebugSessionUUID, breakpoinId: string): Promise<DebugProtocol.Breakpoint | undefined>;

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -54,8 +54,7 @@ export interface IExtHostDebugService extends ExtHostDebugServiceShape {
 	startDebugging(folder: vscode.WorkspaceFolder | undefined, nameOrConfig: string | vscode.DebugConfiguration, options: vscode.DebugSessionOptions): Promise<boolean>;
 	stopDebugging(session?: vscode.DebugSession): Promise<void>;
 	// --- Start Positron ---
-	setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void;
-	setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean): void;
+	setDebugSessionForeground(session: vscode.DebugSession, foreground: boolean): void;
 	// --- End Positron ---
 	registerDebugConfigurationProvider(type: string, provider: vscode.DebugConfigurationProvider, trigger: vscode.DebugConfigurationProviderTriggerKind): vscode.Disposable;
 	registerDebugAdapterDescriptorFactory(extension: IExtensionDescription, type: string, factory: vscode.DebugAdapterDescriptorFactory): vscode.Disposable;
@@ -506,12 +505,8 @@ export abstract class ExtHostDebugServiceBase extends DisposableCls implements I
 	}
 
 	// --- Start Positron ---
-	public setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void {
-		this._debugServiceProxy.$setSuppressDebugToolbar(session.id, suppress);
-	}
-
-	public setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean): void {
-		this._debugServiceProxy.$setSuppressDebugStatusbar(session.id, suppress);
+	public setDebugSessionForeground(session: vscode.DebugSession, foreground: boolean): void {
+		this._debugServiceProxy.$setDebugSessionForeground(session.id, foreground);
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -55,6 +55,7 @@ export interface IExtHostDebugService extends ExtHostDebugServiceShape {
 	stopDebugging(session?: vscode.DebugSession): Promise<void>;
 	// --- Start Positron ---
 	setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void;
+	setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean): void;
 	// --- End Positron ---
 	registerDebugConfigurationProvider(type: string, provider: vscode.DebugConfigurationProvider, trigger: vscode.DebugConfigurationProviderTriggerKind): vscode.Disposable;
 	registerDebugAdapterDescriptorFactory(extension: IExtensionDescription, type: string, factory: vscode.DebugAdapterDescriptorFactory): vscode.Disposable;
@@ -507,6 +508,10 @@ export abstract class ExtHostDebugServiceBase extends DisposableCls implements I
 	// --- Start Positron ---
 	public setSuppressDebugToolbar(session: vscode.DebugSession, suppress: boolean): void {
 		this._debugServiceProxy.$setSuppressDebugToolbar(session.id, suppress);
+	}
+
+	public setSuppressDebugStatusbar(session: vscode.DebugSession, suppress: boolean): void {
+		this._debugServiceProxy.$setSuppressDebugStatusbar(session.id, suppress);
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1020,6 +1020,11 @@ export class DebugService implements IDebugService {
 		}
 	}
 
+	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void {
+		session.setSuppressDebugStatusbar(suppress);
+		this._onDidChangeState.fire(this.state);
+	}
+
 	/**
 	 * Computes the debugUx value based on current state and session suppression.
 	 * Returns 'simple' (welcome view) when there's no foreground debug session.

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1000,8 +1000,9 @@ export class DebugService implements IDebugService {
 	}
 
 	// --- Start Positron ---
-	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void {
-		session.setSuppressDebugToolbar(suppress);
+	setSessionForeground(session: IDebugSession, foreground: boolean): void {
+		session.setSuppressDebugToolbar(!foreground);
+		session.setSuppressDebugStatusbar(!foreground);
 
 		// Update debugUx to show/hide welcome view based on suppression
 		const debugUxValue = this.computeDebugUxValue();
@@ -1012,17 +1013,12 @@ export class DebugService implements IDebugService {
 		this._onDidChangeState.fire(this.state);
 
 		// When bringing a session to the foreground, open the debug pane based on user settings
-		if (!suppress && !session.suppressDebugView) {
+		if (foreground && !session.suppressDebugView) {
 			const openDebug = this.configurationService.getValue<IDebugConfiguration>('debug').openDebug;
 			if (openDebug !== 'neverOpen') {
 				this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
 			}
 		}
-	}
-
-	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void {
-		session.setSuppressDebugStatusbar(suppress);
-		this._onDidChangeState.fire(this.state);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -240,6 +240,11 @@ export class DebugSession implements IDebugSession {
 		this._options.suppressDebugToolbar = value;
 		this._onDidChangeState.fire();
 	}
+
+	setSuppressDebugStatusbar(value: boolean): void {
+		this._options.suppressDebugStatusbar = value;
+		this._onDidChangeState.fire();
+	}
 	// --- End Positron ---
 
 	get suppressDebugView(): boolean {

--- a/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
@@ -113,11 +113,7 @@ export class StatusBarColorProvider implements IWorkbenchContribution {
 }
 
 export function isStatusbarInDebugMode(state: State, sessions: IDebugSession[]): boolean {
-	// --- Start Positron ---
-	// Also check suppressDebugToolbar for background sessions (e.g., permanent
-	// DAP session for R breakpoints) that shouldn't trigger debug mode styling.
-	if (state === State.Inactive || state === State.Initializing || sessions.every(s => s.suppressDebugStatusbar || s.suppressDebugToolbar || s.configuration?.noDebug)) {
-		// --- End Positron ---
+	if (state === State.Inactive || state === State.Initializing || sessions.every(s => s.suppressDebugStatusbar || s.configuration?.noDebug)) {
 		return false;
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
@@ -113,7 +113,11 @@ export class StatusBarColorProvider implements IWorkbenchContribution {
 }
 
 export function isStatusbarInDebugMode(state: State, sessions: IDebugSession[]): boolean {
-	if (state === State.Inactive || state === State.Initializing || sessions.every(s => s.suppressDebugStatusbar || s.configuration?.noDebug)) {
+	// --- Start Positron ---
+	// Also check suppressDebugToolbar for background sessions (e.g., permanent
+	// DAP session for R breakpoints) that shouldn't trigger debug mode styling.
+	if (state === State.Inactive || state === State.Initializing || sessions.every(s => s.suppressDebugStatusbar || s.suppressDebugToolbar || s.configuration?.noDebug)) {
+		// --- End Positron ---
 		return false;
 	}
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -443,6 +443,7 @@ export interface IDebugSession extends ITreeElement, IDisposable {
 
 	// --- Start Positron ---
 	setSuppressDebugToolbar(value: boolean): void;
+	setSuppressDebugStatusbar(value: boolean): void;
 	// --- End Positron ---
 
 	getSourceForUri(modelUri: uri): Source | undefined;
@@ -1384,6 +1385,10 @@ export interface IDebugService {
 	 * Sets the suppressDebugToolbar option for a running debug session.
 	 */
 	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void;
+	/**
+	 * Sets the suppressDebugStatusbar option for a running debug session.
+	 */
+	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void;
 	// --- End Positron ---
 
 	/**

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1382,13 +1382,10 @@ export interface IDebugService {
 
 	// --- Start Positron ---
 	/**
-	 * Sets the suppressDebugToolbar option for a running debug session.
+	 * Sets whether a debug session is in the foreground (actively debugging) or background.
+	 * Foreground sessions show the debug toolbar and status bar styling.
 	 */
-	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void;
-	/**
-	 * Sets the suppressDebugStatusbar option for a running debug session.
-	 */
-	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void;
+	setSessionForeground(session: IDebugSession, foreground: boolean): void;
 	// --- End Positron ---
 
 	/**

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -155,11 +155,7 @@ export class MockDebugService implements IDebugService {
 	}
 
 	// --- Start Positron ---
-	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void {
-		throw new Error('not implemented');
-	}
-
-	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void {
+	setSessionForeground(session: IDebugSession, foreground: boolean): void {
 		throw new Error('not implemented');
 	}
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -158,6 +158,10 @@ export class MockDebugService implements IDebugService {
 	setSessionSuppressDebugToolbar(session: IDebugSession, suppress: boolean): void {
 		throw new Error('not implemented');
 	}
+
+	setSessionSuppressDebugStatusbar(session: IDebugSession, suppress: boolean): void {
+		throw new Error('not implemented');
+	}
 	// --- End Positron ---
 
 	getModel(): IDebugModel {
@@ -306,6 +310,10 @@ export class MockSession implements IDebugSession {
 
 	// --- Start Positron ---
 	setSuppressDebugToolbar(value: boolean): void {
+		throw new Error('not implemented');
+	}
+
+	setSuppressDebugStatusbar(value: boolean): void {
 		throw new Error('not implemented');
 	}
 	// --- End Positron ---

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17302,6 +17302,14 @@ declare module 'vscode' {
 		 * @param suppress Whether to suppress the debug toolbar.
 		 */
 		export function setSuppressDebugToolbar(session: DebugSession, suppress: boolean): void;
+
+		/**
+		 * Sets whether the debug status bar styling should be suppressed during a running debug session.
+		 *
+		 * @param session The {@link DebugSession debug session} to modify.
+		 * @param suppress Whether to suppress the debug status bar styling.
+		 */
+		export function setSuppressDebugStatusbar(session: DebugSession, suppress: boolean): void;
 		// --- End Positron ---
 
 		/**

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17296,20 +17296,13 @@ declare module 'vscode' {
 
 		// --- Start Positron ---
 		/**
-		 * Sets whether the debug toolbar should be suppressed during a running debug session.
+		 * Sets whether a debug session is in the foreground (actively debugging) or background.
+		 * Foreground sessions show the debug toolbar and switch the status bar to debugging styling.
 		 *
 		 * @param session The {@link DebugSession debug session} to modify.
-		 * @param suppress Whether to suppress the debug toolbar.
+		 * @param foreground Whether the session should be in the foreground.
 		 */
-		export function setSuppressDebugToolbar(session: DebugSession, suppress: boolean): void;
-
-		/**
-		 * Sets whether the debug status bar styling should be suppressed during a running debug session.
-		 *
-		 * @param session The {@link DebugSession debug session} to modify.
-		 * @param suppress Whether to suppress the debug status bar styling.
-		 */
-		export function setSuppressDebugStatusbar(session: DebugSession, suppress: boolean): void;
+		export function setDebugSessionForeground(session: DebugSession, foreground: boolean): void;
 		// --- End Positron ---
 
 		/**


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11514

We now use the same approach for suppressing the debug statusbar as we implemented in https://github.com/posit-dev/positron/pull/11407 for suppressing the debug toolbar:

- Allow changing the option _during_ a debug session, rather than just at the start.
- We start the session with debug status bar set to false, and turn it on and off from the DAP comm based on whether R is actively debugging.

I've renamed the new API entry introduced in #11407 `vscode.debug.setSuppressDebugToolbar` to `vscode.debug.setDebugSessionForeground`. It is now in charge of flipping both the debug toolbar and the status bar.


https://github.com/user-attachments/assets/4ff511ac-7d67-49c9-a247-f4a2c1e7e67b



While researching this, I found an interesting extension: https://github.com/mathworks/MATLAB-extension-for-vscode/blob/main/src/debug/MatlabDebugger.ts

They have the same problem as R does, they need to start a debugging session early to receive breakpoint updates but only bring up the debug UI when actively debugging. Their solution was to first open a background session with all UI options (debug toolbar, debug status bar) turned off. When actively debugging, a new child DAP session is started with the UI options on. Changing the UI options seems simpler overall and may remove some UI edge cases (the background session might show up in the debug toolbar session stack), so I'm still happy with our approach.

We _could_ improve the notion of _foreground_ session developed in #11514 to also look for suppressed status bar rather than just suppressed debug toolbar. Likely not needed but just something to note for the future.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->


#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
