### PR TITLE
Don't send non-file URIs on Cmd+Enter

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../nls.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { isString, assertType } from '../../../../base/common/types.js';
 import { Codicon } from '../../../../base/common/codicons.js';
@@ -124,9 +125,11 @@ async function executeCodeInConsole(
 		}
 	};
 
-	// If the document is dirty, send breakpoints to the debug adapter before executing code
+	// If the document is dirty, send breakpoints to the debug adapter before
+	// executing code. Only send for file URIs since DAP expects file paths, not
+	// URIs.
 	const documentUri = cursorLocation.uri;
-	if (textFileService.isDirty(documentUri)) {
+	if (documentUri.scheme === Schemas.file && textFileService.isDirty(documentUri)) {
 		await debugService.sendBreakpoints(documentUri, true);
 	}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11533

Fixes a Cmd+Enter issue. Evaluation now triggers a breakpoint update so that we can verify/inject them even in dirty docs. In untitled documents, this was causing a popup.

Report from @DavisVaughan:

> It seems like we have a fairly serious regression in Untitled R scripts in the latest daily
> 
> - Open an Untitled R script
> - Put in `1 + 1`
> - Try and Cmd + Enter to run that
> 
> Do you see a pop up that says Invalid path: untitled:Untitled-1?
> 
> I believe it is DAP related
> 

```
r-206c23de [R]   2026-01-26T14:02:53.726113Z TRACE  DAP: Got request: Request {
r-206c23de [R]     seq: 7,
r-206c23de [R]     command: SetBreakpoints(
r-206c23de [R]         SetBreakpointsArguments {
r-206c23de [R]             source: Source {
r-206c23de [R]                 name: Some(
r-206c23de [R]                     "Untitled-1",
r-206c23de [R]                 ),
r-206c23de [R]                 path: Some(
r-206c23de [R]                     "untitled:Untitled-1",
r-206c23de [R]                 ),
r-206c23de [R]                 source_reference: None,
r-206c23de [R]                 presentation_hint: None,
r-206c23de [R]                 origin: None,
r-206c23de [R]                 sources: None,
r-206c23de [R]                 adapter_data: None,
r-206c23de [R]                 checksums: None,
r-206c23de [R]             },
r-206c23de [R]             breakpoints: Some(
r-206c23de [R]                 [],
r-206c23de [R]             ),
r-206c23de [R]             lines: Some(
r-206c23de [R]                 [],
r-206c23de [R]             ),
r-206c23de [R]             source_modified: Some(
r-206c23de [R]                 true,
r-206c23de [R]             ),
r-206c23de [R]         },
r-206c23de [R]     ),
r-206c23de [R] }
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:236
r-206c23de [R] 
r-206c23de [R]   2026-01-26T14:02:53.726168Z ERROR  Failed to convert path to URI: 'untitled:Untitled-1'
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:345
r-206c23de [R] 
r-206c23de [R]   2026-01-26T14:02:53.726175Z TRACE  DAP: Responding to request: Response {
r-206c23de [R]     request_seq: 7,
r-206c23de [R]     success: false,
r-206c23de [R]     message: Some(
r-206c23de [R]         Error(
r-206c23de [R]             "Invalid path: untitled:Untitled-1",
r-206c23de [R]         ),
r-206c23de [R]     ),
r-206c23de [R]     body: None,
r-206c23de [R]     error: None,
r-206c23de [R] }
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:300
```


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

It looks like we're missing e2e tests for this.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
