### PR TITLE
Assistant: Autoconfigure provider state in configuration dialog

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -194,7 +194,7 @@ export async function showConfigurationDialog(context: vscode.ExtensionContext, 
 			})
 			.map(async (source) => {
 				// Handle autoconfigurable providers
-				if ('autoconfigure' in source.defaults && source.defaults.autoconfigure) {
+				if (!source.signedIn && 'autoconfigure' in source.defaults && source.defaults.autoconfigure) {
 					// Resolve environment variables
 					if (source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.EnvVariable) {
 						const envVarName = source.defaults.autoconfigure.key;


### PR DESCRIPTION
Autoconfiguration logic when opening the provider configuration dialog now takes into considering providers which are autoconfigurable, but have been manually configured previously. This prevents the autoconfiguration logic from marking these providers as unauthenticated.

Address #11537 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Provider authentication status is more reliable in Positron Assistant


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

Sign into either Bedrock or Snowflake manually. Close the model provider dialog & reopen. If the provider is shown as logged in, this PR works!

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant