### PR TITLE
python LS: fix console hover for newer versions of Pyrefly

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -313,14 +313,14 @@ class HoverAdapter {
 			return undefined;
 		}
 		// --- Start Positron ---
-		// Filter out hovers that only contain "Unknown" text (possibly in a markdown code block).
+		// Filter out hovers that end with the text "Unknown" (possibly in a markdown code block).
 		// This is because that's the literal message Pyrefly sends when it has no useful hover info to provide.
 		const contentsText = extractPlainTextFromMarkdown(
 			value.contents
 				.map(c => typeof c === 'string' ? c : typeof c === 'object' && 'value' in c ? c.value : '')
 				.join('')
 		);
-		if (contentsText === 'Unknown') {
+		if (contentsText.endsWith('Unknown')) {
 			return undefined;
 		}
 		// --- End Positron ---


### PR DESCRIPTION
Addresses part of https://github.com/posit-dev/positron/issues/11259.

I noticed that hovering over certain namespace variables in the Console was returning e.g. `my_var: Unknown` in the hover, instead of the rich info our LS is supposed to provide. 

Instead of our LS being broken, I figured out that Pyrefly was contributing this hover, and in the core we're already deduplicating and preferring Pyrefly hovers in general. The bug was that we're searching for the specific text `Unknown` (which is what Pyrefly used to contribute when it has no useful info from static analysis). Newer versions of Pyrefly have changed this text slightly.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

In the console,
```py
>>> x = 123
>>> x
```
hovering over `x` should provide info about integers.
