### PR TITLE
python LS: add previews for dataframes/series in completion details

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -26,6 +26,7 @@ from positron._vendor.lsprotocol.types import (
     HoverParams,
     InitializeParams,
     InsertReplaceEdit,
+    MarkupContent,
     MarkupKind,
     NotebookCell,
     NotebookCellKind,
@@ -1039,8 +1040,8 @@ class TestCompletionItemResolve:
             assert resolved_item.documentation is not None
             doc_value = (
                 resolved_item.documentation.value
-                if hasattr(resolved_item.documentation, "value")
-                else str(resolved_item.documentation)
+                if isinstance(resolved_item.documentation, MarkupContent)
+                else resolved_item.documentation
             )
             assert expected_doc_contains in doc_value
 


### PR DESCRIPTION
Addresses part of https://github.com/posit-dev/positron/issues/11259. Adds previews for polars and pandas DataFrames and Series in the completion details.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

I think this looks a lot nicer now. To test it, put your cursor at the end and do Tab or Ctrl+Space. Then to expand the details, either click on the arrow that appears when you hover over the right side of the completion, or do Ctrl+Space again.

```py
import pandas as pd
import polars as pl

x = {'a':range(100),'b':[str(y) for y in range(100)]}
df1 = pd.DataFrame(x)
df2 = pl.DataFrame(x)
s1 = df1["a"]
s2 = df2["a"]

# Run the above first so we don't rely on static analysis.
# Now these completions should have previews!

df1
df1["
df2
df2["
s1
s2
```
