### PR TITLE
Assistant: Validate tool schemas for OpenAI

### DIFF
--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -206,6 +206,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 			if (!input_schema.type) {
 				this.logger.warn(`Tool '${tool.name}' is missing input schema type; defaulting to 'object'`);
 				input_schema.type = 'object';
+				input_schema.properties = {};
 			}
 
 			acc[tool.name] = {

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -210,7 +210,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 			}
 
 			if (missingFields.length > 0) {
-				this.logger.warn(`Tool '${tool.name}' is missing input schema fields: ${missingFields.join(', ')}; using defaults`);
+				this.logger.trace(`Tool '${tool.name}' is missing input schema fields: ${missingFields.join(', ')}; using defaults`);
 			}
 
 			const input_schema: Record<string, any> = {


### PR DESCRIPTION
The `setupTools` method in `VercelModelProvider` already handled missing `type` fields by defaulting to `'object'`, but it didn't ensure the `properties` field existed. This fix adds a parallel check: when a schema has `type: 'object'` but no `properties` field, we default `properties` to an empty object `{}`.

This is a defensive fix that handles any tool with an incomplete schema, rather than requiring changes to all upstream tool definitions.

Addresses #10327

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- OpenAI now works in Assistant when `positron.assistant.alwaysIncludeCopilotTools` is enabled


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

1. Sign into both OpenAI and GitHub Copilot providers
2. Enable `positron.assistant.alwaysIncludeCopilotTools` setting
3. Send a request to an OpenAI model


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:assistant
