### PR TITLE
Positron Notebooks: show cell action bar on hover

### DIFF
--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -165,6 +165,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				disabled={options.disabled}
 				onPressed={e => {
 					dismiss();
+					options.onWillSelect?.();
 					if (options.commandId) {
 						services.commandService.executeCommand(options.commandId);
 					}

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
@@ -10,10 +10,18 @@ import { KeyboardModifiers } from '../../../../base/browser/ui/positronComponent
  */
 export interface CustomContextMenuItemOptions {
 	readonly commandId?: string;
+	/**
+	 * Called BEFORE the command executes. Similar to native ActionRunner's onWillRun.
+	 */
+	readonly onWillSelect?: () => void;
 	readonly checked?: boolean;
 	readonly icon?: string;
 	readonly label: string;
 	readonly disabled?: boolean;
+	/**
+	 * Called AFTER the command executes (or immediately if no commandId).
+	 * Similar to native ActionRunner's onDidRun.
+	 */
 	readonly onSelected: (e: KeyboardModifiers) => void;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -21,12 +21,12 @@
 	display: flex;
 	gap: var(--_positron-notebooks-cell-action-bar-button-gap);
 
+	/* Base state: action bar hidden by default */
+	visibility: hidden;
+
+	/* Always show action bar when cell is active (selected) */
 	&.visible {
 		visibility: visible;
-	}
-
-	&.hidden {
-		visibility: hidden;
 	}
 
 	.action-button {
@@ -75,4 +75,9 @@
 		width: 1px;
 		background-color: var(--vscode-positronNotebook-action-bar-border-color);
 	}
+}
+
+/* Show action bar when cell is hovered */
+.positron-notebook-cell:hover .positron-notebooks-cell-action-bar {
+	visibility: visible;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -75,7 +75,9 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 		{/* Dropdown menu for additional actions - only render if there are menu actions */}
 		{hasSubmenuActions ? (
 			<NotebookCellMoreActionsMenu
+				cell={cell}
 				hoverManager={instance.hoverManager}
+				instance={instance}
 				menuActions={submenuActions}
 			/>
 		) : null}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -58,7 +58,7 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	return <div
 		aria-hidden={!isActiveCell}
 		aria-label={localize('cellActions', 'Cell actions')}
-		className={`positron-notebooks-cell-action-bar ${isActiveCell ? 'visible' : 'hidden'}`}
+		className={`positron-notebooks-cell-action-bar ${isActiveCell ? 'visible' : ''}`}
 		role='toolbar'
 	>
 		{/* Render contributed main actions - will auto-update when registry changes */}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -32,6 +32,7 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	const contextKeyService = useCellScopedContextKeyService();
 
 	// State
+	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 	const isActiveCell = useObservedValue(cell.isActive);
 	const leftMenu = useMenu(MenuId.PositronNotebookCellActionBarLeft, contextKeyService);
 	const submenu = useMenu(MenuId.PositronNotebookCellActionBarSubmenu, contextKeyService);
@@ -58,7 +59,7 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	return <div
 		aria-hidden={!isActiveCell}
 		aria-label={localize('cellActions', 'Cell actions')}
-		className={`positron-notebooks-cell-action-bar ${isActiveCell ? 'visible' : ''}`}
+		className={`positron-notebooks-cell-action-bar ${isActiveCell || isMenuOpen ? 'visible' : ''}`}
 		role='toolbar'
 	>
 		{/* Render contributed main actions - will auto-update when registry changes */}
@@ -78,7 +79,9 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 				cell={cell}
 				hoverManager={instance.hoverManager}
 				instance={instance}
+				isMenuOpen={isMenuOpen}
 				menuActions={submenuActions}
+				setIsMenuOpen={setIsMenuOpen}
 			/>
 		) : null}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -15,9 +15,13 @@ import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/ac
 import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 
 interface NotebookCellMoreActionsMenuProps {
+	cell: IPositronNotebookCell;
 	hoverManager?: IHoverManager;
+	instance: IPositronNotebookInstance;
 	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][],
 }
 
@@ -28,7 +32,9 @@ const moreCellActions = localize('moreCellActions', 'More Cell Actions');
  * Encapsulates all dropdown menu logic including state management and menu display.
  */
 export function NotebookCellMoreActionsMenu({
+	cell,
 	hoverManager,
+	instance,
 	menuActions,
 }: NotebookCellMoreActionsMenuProps) {
 	const buttonRef = useRef<HTMLButtonElement>(null);
@@ -40,7 +46,7 @@ export function NotebookCellMoreActionsMenu({
 		}
 
 		try {
-			const entries = buildMoreActionsMenuItems(menuActions);
+			const entries = buildMoreActionsMenuItems(cell, menuActions, instance);
 
 			setIsMenuOpen(true);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -22,7 +22,9 @@ interface NotebookCellMoreActionsMenuProps {
 	cell: IPositronNotebookCell;
 	hoverManager?: IHoverManager;
 	instance: IPositronNotebookInstance;
+	isMenuOpen: boolean;
 	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][],
+	setIsMenuOpen: (isOpen: boolean) => void;
 }
 
 const moreCellActions = localize('moreCellActions', 'More Cell Actions');
@@ -35,10 +37,12 @@ export function NotebookCellMoreActionsMenu({
 	cell,
 	hoverManager,
 	instance,
+	isMenuOpen,
 	menuActions,
+	setIsMenuOpen,
 }: NotebookCellMoreActionsMenuProps) {
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+
 	const showMoreActionsMenu = () => {
 
 		if (!buttonRef.current) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -8,14 +8,28 @@ import { CustomContextMenuEntry } from '../../../../../../workbench/browser/posi
 import { CustomContextMenuSeparator } from '../../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
+import { CellSelectionType } from '../../selectionMachine.js';
 
 /**
  * Build the menu entries for the "more actions" dropdown menu.
  * This provides a clean extension point for adding new actions via the registry.
+ *
+ * Note: Like the CellActionButton component, we need to ensure the cell is selected
+ * before running any action. This is done via the onWillSelect callback which runs
+ * before the command is executed.
+ *
+ * @param cell The cell that the menu actions will operate on
+ * @param menuActions The grouped menu actions to display
+ * @param instance The notebook instance (needed to select cell before action runs)
  */
 export function buildMoreActionsMenuItems(
+	cell: IPositronNotebookCell,
 	menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][],
+	instance: IPositronNotebookInstance,
 ): CustomContextMenuEntry[] {
+
 	// Get the groups
 	const entriesByGroup = new Map<string, CustomContextMenuEntry[]>();
 	menuActions.forEach(([group, groupActions]) => {
@@ -26,6 +40,10 @@ export function buildMoreActionsMenuItems(
 			commandId: action.id,
 			label: action.label,
 			icon: ThemeIcon.isThemeIcon(action.item.icon) ? action.item.icon.id : undefined,
+			onWillSelect: () => {
+				// Select cell BEFORE command runs to keep notebook selection in sync
+				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+			},
 			onSelected: () => {
 				// No op as command is executed via the commandId argument
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Addresses #10942 

This PR includes changes so that a (1) cell action bar is shown when a user hovers over a cell  (2) ensures the cell being hovered over is treated as the selected cell for all cell actions in the cell action bar.

This PR fixes a behavioral discrepancy with how the icon buttons in the cell action bar behaved compared to the more menu items. Currently notebook actions operate on the active cell. When a user hovers over a cell and selects an icon button from the cell action bar, we ensure the cell selection state is updated so that cell is the active cell. For actions within the cell action bar's menu, we were not ensuring the cell selection state was updated prior to executing the command. This has been fixed so all cell actions update the selected cell to be the hovered cell prior to executing a command.

### Screenshots

**Cell Action Bar - Menu Items**

https://github.com/user-attachments/assets/fafc75b8-3368-41fc-859c-794536e5f314

**Cell Action Bar - Icon Buttons**

https://github.com/user-attachments/assets/d1a2959f-6e33-4933-896c-f120eadbca50


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
