### PR TITLE
Bump Ark to 0.1.226

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -969,7 +969,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.225"
+      "ark": "0.1.226"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1010
  Addresses https://github.com/posit-dev/ark/issues/1006
- https://github.com/posit-dev/ark/pull/992
  Addresses https://github.com/posit-dev/positron/issues/5024



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed a deadlock occuring when stepping rapidly in the debugger (https://github.com/posit-dev/positron/issues/5024).
- Fixed regression where evaluating empty lines was no longer interpreted as stepping to next expression in the debugger (https://github.com/posit-dev/ark/issues/1006).


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
