### PR TITLE
assistant: fix getPlot tool handling for openai-compatible providers

### DIFF
--- a/extensions/positron-assistant/src/openai-fetch-utils.ts
+++ b/extensions/positron-assistant/src/openai-fetch-utils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -91,11 +91,11 @@ export function fixPossiblyBrokenChatCompletionChunk(
 			const fixedFunctionType = hasEmptyType ? 'function' : toolCall.type || 'function';
 
 			if (isNoArgTool && hasEmptyArgs) {
-				log.debug(`[${providerName}] Converting empty tool arguments to '{}' for tool: ${name}`);
+				log.trace(`[${providerName}] Converting empty tool arguments to '{}' for tool: ${name}`);
 			}
 
 			if (hasEmptyType) {
-				log.debug(`[${providerName}] Converting empty tool type to 'function' for tool: ${name || '(unnamed)'}`);
+				log.trace(`[${providerName}] Converting empty tool type to 'function' for tool: ${name || '(unnamed)'}`);
 			}
 
 			return {
@@ -200,7 +200,7 @@ function transformRequestBody(init: RequestInit | undefined, providerName: strin
 		// Example error message without this fix:
 		// [OpenAI] [gpt-5]' Error in chat response: {"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error","param":"max_tokens","code":"unsupported_parameter"}}
 		if (requestBody.max_tokens !== undefined) {
-			log.debug(`[${providerName}] [DEBUG] Converting max_tokens (${requestBody.max_tokens}) to max_completion_tokens`);
+			log.trace(`[${providerName}] [DEBUG] Converting max_tokens (${requestBody.max_tokens}) to max_completion_tokens`);
 			requestBody.max_completion_tokens = requestBody.max_tokens;
 			delete requestBody.max_tokens;
 		}
@@ -213,7 +213,7 @@ function transformRequestBody(init: RequestInit | undefined, providerName: strin
 		if (requestBody.messages && Array.isArray(requestBody.messages)) {
 			for (const message of requestBody.messages) {
 				if (message.role === 'developer') {
-					log.debug(`[${providerName}] Converting 'developer' role to 'system' for compatibility`);
+					log.trace(`[${providerName}] Converting 'developer' role to 'system' for compatibility`);
 					message.role = 'system';
 				}
 			}
@@ -241,7 +241,7 @@ function transformRequestBody(init: RequestInit | undefined, providerName: strin
 			for (const tool of requestBody.tools) {
 				if (tool.function && tool.function.strict !== undefined) {
 					delete tool.function.strict;
-					log.debug(`[${providerName}] Removed 'strict' field from tool: ${tool.function.name}`);
+					log.trace(`[${providerName}] Removed 'strict' field from tool: ${tool.function.name}`);
 				}
 			}
 			log.trace(`[${providerName}] Tools payload: ${JSON.stringify(requestBody.tools)}`);

--- a/extensions/positron-assistant/src/providers/openai/openaiCompatibleProvider.ts
+++ b/extensions/positron-assistant/src/providers/openai/openaiCompatibleProvider.ts
@@ -45,6 +45,11 @@ import { createOpenAICompatibleFetch } from '../../openai-fetch-utils';
  * @see {@link ModelProvider} for base class documentation
  */
 export class OpenAICompatibleModelProvider extends OpenAIModelProvider implements positron.ai.LanguageModelChatProvider {
+	/**
+	 * OpenAI-compatible providers use /v1/chat/completions endpoint
+	 */
+	protected override usesChatCompletions = true;
+
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Chat,
 		provider: {

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -1,22 +1,24 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import * as ai from 'ai';
 import { JSONTree } from '@vscode/prompt-tsx';
-import { LanguageModelCacheBreakpoint, LanguageModelCacheBreakpointType, LanguageModelDataPartMimeType, PromptInstructionsReference, RuntimeSessionReference } from './types.js';
+import { LanguageModelCacheBreakpoint, LanguageModelCacheBreakpointType, LanguageModelDataPartMimeType, PromptInstructionsReference, RuntimeSessionReference, PositronAssistantToolName } from './types.js';
 import { log } from './extension.js';
 
 /**
  * Convert messages from VSCode Language Model format to Vercel AI format.
  *
  * @param messages The messages to convert.
+ * @param usesChatCompletions Whether to apply chat completions endpoint transformations.
  * @param bedrockCacheBreakpoint Whether to use Bedrock cache breakpoints.
  */
 export function toAIMessage(
 	messages: vscode.LanguageModelChatMessage2[],
+	usesChatCompletions: boolean = false,
 	bedrockCacheBreakpoint: boolean = false
 ): ai.ModelMessage[] {
 	// Gather all tool call references
@@ -75,12 +77,17 @@ export function toAIMessage(
 					if (!toolCall) {
 						log.warn(`[toAIMessage] Tool result with callId '${part.callId}' has no matching tool call in conversation history. Available tool calls: ${Object.keys(toolCalls).join(', ')}`);
 					}
-					const toolMessage = convertToolResultPartToAiToolMessage(part, toolCall);
-					if (cacheBreakpoint && bedrockCacheBreakpoint) {
-						cacheBreakpoint = false;
-						markBedrockCacheBreakpoint(toolMessage);
+
+					if (usesChatCompletions && toolCall?.name === PositronAssistantToolName.GetPlot) {
+						handleGetPlotToolResultForChatCompletions(part, toolCall, aiMessages);
+					} else {
+						const toolMessage = convertToolResultPartToAiToolMessage(part, toolCall);
+						if (cacheBreakpoint && bedrockCacheBreakpoint) {
+							cacheBreakpoint = false;
+							markBedrockCacheBreakpoint(toolMessage);
+						}
+						aiMessages.push(toolMessage);
 					}
-					aiMessages.push(toolMessage);
 				}
 			}
 
@@ -111,11 +118,8 @@ export function toAIMessage(
 				}
 			}
 			const aiMessage: ai.AssistantModelMessage = {
-
 				role: 'assistant',
-
 				content,
-
 			};
 
 			// If this is a cache breakpoint, note it in the message
@@ -181,13 +185,6 @@ function convertToolResultPartToAiToolMessage(
 	part: vscode.LanguageModelToolResultPart,
 	toolCall: vscode.LanguageModelToolCallPart,
 ): ai.ToolModelMessage {
-	// If experimental content is enabled for tool calls,
-	// that means tool results can contain images.
-
-	type ToolResultOutput =
-		| { type: 'text'; value: string }
-		| { type: 'content'; value: Array<{ type: 'text'; text: string } | { type: 'media'; data: string; mediaType: string }> };
-
 	const toolMessage: ai.ToolModelMessage = {
 		role: 'tool',
 		content: [
@@ -477,19 +474,6 @@ function stringifyPromptNodeJSON(node: JSONTree.PromptNodeJSON, strs: string[]):
 	}
 }
 
-// This type definition is from Vercel AI, but the type is not exported.
-type ToolResultContent = Array<
-	| {
-		type: 'text';
-		text: string;
-	}
-	| {
-		type: 'image';
-		data: string;
-		mimeType?: string;
-	}
->;
-
 /** Whether a chat request is from an inline editor context. */
 export function isTextEditRequest(request: vscode.ChatRequest):
 	request is vscode.ChatRequest & { location2: vscode.ChatRequestEditorData } {
@@ -619,4 +603,63 @@ export function isAuthorizationError(error: any): boolean {
 	return authPatterns.some(pattern =>
 		message.toLowerCase().includes(pattern.toLowerCase())
 	);
+}
+
+/**
+ * Handle getPlot tool results for OpenAI-compatible providers (chat completions endpoint).
+ *
+ * This creates both:
+ * 1. A proper tool result message (maintains tool call/result semantics for the model)
+ * 2. A separate user message with the image (ensures image compatibility with chat completions)
+ */
+function handleGetPlotToolResultForChatCompletions(
+	part: vscode.LanguageModelToolResultPart | vscode.LanguageModelToolResultPart2,
+	toolCall: vscode.LanguageModelToolCallPart,
+	aiMessages: ai.ModelMessage[]
+): void {
+	log.debug(`[handleGetPlotToolResultForChatCompletions] Processing getPlot tool result for OpenAI-compatible provider`);
+
+	// 1. Add proper tool result message with clear indication that image follows
+	const imageDataParts = part.content.filter(isChatImagePart);
+	const hasImage = imageDataParts.length > 0;
+
+	const toolResultText = hasImage
+		? 'Retrieved. Image follows.'
+		: part.content
+			.filter(p => p instanceof vscode.LanguageModelTextPart)
+			.map(p => (p as vscode.LanguageModelTextPart).value)
+			.join('') || 'No plot available';
+
+	const toolMessage: ai.ToolModelMessage = {
+		role: 'tool',
+		content: [{
+			type: 'tool-result',
+			toolCallId: part.callId,
+			toolName: toolCall.name,
+			output: { type: 'text' as const, value: toolResultText }
+		}]
+	};
+	aiMessages.push(toolMessage);
+
+	// 2. Add separate user message with image content (for compatibility)
+	if (hasImage) {
+		const imageUserMessage: ai.UserModelMessage = {
+			role: 'user',
+			content: [
+				{
+					type: 'text',
+					text: 'Here is the current active plot:'
+				},
+				...imageDataParts.map(imagePart => ({
+					type: 'image' as const,
+					image: (imagePart as vscode.LanguageModelDataPart).data,
+					mediaType: (imagePart as vscode.LanguageModelDataPart).mimeType
+				}))
+			]
+		};
+		aiMessages.push(imageUserMessage);
+		log.debug(`[handleGetPlotToolResultForChatCompletions] Added tool result message and user image message`);
+	} else {
+		log.debug(`[handleGetPlotToolResultForChatCompletions] Added tool result message (no image data)`);
+	}
 }


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/10759
- adds custom getPlot handling for openai-compatible providers, which require a different approach to returning the plot image due to the chat completions endpoint

#### Implementation notes

- Added a new `usesChatCompletions` property to the `VercelModelProvider` class to clearly indicate whether a provider uses the `/v1/chat/completions` endpoint, affecting how tool results are formatted and sent. This property is set to `true` for OpenAI-compatible providers. 
- Updated the `toAIMessage` utility to accept the `usesChatCompletions` flag and, when enabled, process "getPlot" tool results by sending both the tool call and tool result and a separate user message containing the image
    - I tried replacing the tool call/result with the user message, but that caused issues with GPT 5
    - keeping the tool call and result, while adding a user message with the actual plot image seems to work the best across providers and model families

### Release Notes

#### Bug Fixes

- Assistant: fix `getPlot` tool errors for openai-compatible providers (#10759) 

### QA Notes

- Manual testing, particularly with Snowflake and Custom Provider - OpenRouter are recommended
- Amazon Bedrock and OpenAI providers should continue to work
- Test Claude models and GPT models, as they may respond differently
    - GPT 4.1 and above recommended, and test a GPT 5 or above model as well

#### How to test

- Run the [plot hallucination script](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/assistant/plot-hallucination.r) in the Console
- In Chat with Agent mode, send `what is in the middle of the plot and what colour is it? use the get plot tool`
- Confirm that the model responds with the correct number and colour of the number based on what you see in the plots pane
- Start a new chat in between testing models

Here's what I've tested on this PR branch:

| Provider | Model | Notes |
|--------|--------|--------|
| Anthropic | Claude Opus 4.5 | ✅ correct number and colour |
| GitHub Copilot | any | Cannot test due to #10724 |
| Amazon Bedrock | Claude Opus 4.5 | ✅ correct number and colour |
| OpenAI | GPT 4.1 | ✅ correct number and colour |
| OpenAI | GPT 5.2 | ✅ correct number and colour |
| Custom Provider - OpenRouter | anthropic/claude-sonnet-4 | ✅ correct number and colour |
| Custom Provider - OpenRouter | openai/gpt-4.1 | ✅ correct number and colour |
| Custom Provider - OpenRouter | openai/gpt-5 | ✅ correct number and colour |
| Snowflake Cortex | Claude Sonnet 4 | ✅ correct number and colour |
| Snowflake Cortex | GPT 4.1 | ✅ correct number and colour |
| Snowflake Cortex | GPT 5 | ✅ correct number and colour |
