### PR TITLE
Update activity badge of debug pane according to count of foreground sessions

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -998,6 +998,9 @@ export class DebugService implements IDebugService {
 
 	// --- Start Positron ---
 	private updateActivityBadge(): void {
+		// Positron: The following line is the only change. We added a check for
+		// `suppressDebugToolbar`. Old code:
+		// const numberOfSessions = this.model.getSessions().filter(s => !s.parentSession).length;
 		const numberOfSessions = this.model.getSessions().filter(s => !s.parentSession && !s.suppressDebugToolbar).length;
 		this.activity?.dispose();
 		if (numberOfSessions > 0) {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -179,14 +179,11 @@ export class DebugService implements IDebugService {
 			this.debugStorage.storeDebugUxState(debugUxValue);
 		}));
 		this.disposables.add(this.model.onDidChangeCallStack(() => {
-			const numberOfSessions = this.model.getSessions().filter(s => !s.parentSession).length;
-			this.activity?.dispose();
-			if (numberOfSessions > 0) {
-				const viewContainer = this.viewDescriptorService.getViewContainerByViewId(CALLSTACK_VIEW_ID);
-				if (viewContainer) {
-					this.activity = this.activityService.showViewContainerActivity(viewContainer.id, { badge: new NumberBadge(numberOfSessions, n => n === 1 ? nls.localize('1activeSession', "1 active session") : nls.localize('nActiveSessions', "{0} active sessions", n)) });
-				}
-			}
+			// --- Start Positron ---
+			// The implementation of this handler is called in two different places in Positron.
+			// When this impl changes, please update the following method accordingly.
+			this.updateActivityBadge();
+			// --- End Positron ---
 		}));
 
 		this.disposables.add(editorService.onDidActiveEditorChange(() => {
@@ -1000,6 +997,17 @@ export class DebugService implements IDebugService {
 	}
 
 	// --- Start Positron ---
+	private updateActivityBadge(): void {
+		const numberOfSessions = this.model.getSessions().filter(s => !s.parentSession && !s.suppressDebugToolbar).length;
+		this.activity?.dispose();
+		if (numberOfSessions > 0) {
+			const viewContainer = this.viewDescriptorService.getViewContainerByViewId(CALLSTACK_VIEW_ID);
+			if (viewContainer) {
+				this.activity = this.activityService.showViewContainerActivity(viewContainer.id, { badge: new NumberBadge(numberOfSessions, n => n === 1 ? nls.localize('1activeSession', "1 active session") : nls.localize('nActiveSessions', "{0} active sessions", n)) });
+			}
+		}
+	}
+
 	setSessionForeground(session: IDebugSession, foreground: boolean): void {
 		session.setSuppressDebugToolbar(!foreground);
 		session.setSuppressDebugStatusbar(!foreground);
@@ -1008,6 +1016,9 @@ export class DebugService implements IDebugService {
 		const debugUxValue = this.computeDebugUxValue();
 		this.debugUx.set(debugUxValue);
 		this.debugStorage.storeDebugUxState(debugUxValue);
+
+		// Update activity badge to reflect foreground/background change
+		this.updateActivityBadge();
 
 		// Trigger toolbar update
 		this._onDidChangeState.fire(this.state);

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -181,7 +181,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(this.model.onDidChangeCallStack(() => {
 			// --- Start Positron ---
 			// The implementation of this handler is called in two different places in Positron.
-			// When this impl changes, please update the following method accordingly.
+			// If the VS Code impl changes, please update the following method accordingly.
 			this.updateActivityBadge();
 			// --- End Positron ---
 		}));


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11557

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

The activity badge of the debug pane should reflect the number of active _foreground_ debug sessions.

- When R starts up, count is zero (no red badge)
- When debugging, count is one
- When leaving the debugger via Shift-F5 or `Q`, count is zero
- When leaving the debugger via F10 or `n` (that's another code path), count is zero

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
