### PR TITLE
Claude UI component guidelines

### DIFF
--- a/.claude/ui-components.md
+++ b/.claude/ui-components.md
@@ -6,16 +6,14 @@ This prompt provides context for working with Positron's reusable UI components,
 
 Always search before creating new UI controls:
 
-```bash
-# Find React components in Positron directories
-Glob: **/positron**/components/*.tsx
-Glob: **/positronComponents/**/*.tsx
+**Find React components in Positron directories:**
+- Glob: `**/positron**/components/*.tsx`
+- Glob: `**/positronComponents/**/*.tsx`
 
-# Search for specific control types
-Grep: "toggle" --glob "*.tsx" --glob "*positron*"
-Grep: "ScreenReaderOnly" --type tsx
-Grep: "Modal" --glob "*positron*.tsx"
-```
+**Search for specific control types:**
+- Grep: `"toggle"` with glob `*.tsx` and `*positron*`
+- Grep: `"ScreenReaderOnly"` with type `tsx`
+- Grep: `"Modal"` with glob `*positron*.tsx`
 
 ## Component Categories
 
@@ -67,11 +65,8 @@ For custom controls needing hidden native inputs, search for `ScreenReaderOnly` 
 ```
 
 ### Finding CSS Patterns
-```bash
-# Search for similar styling patterns
-Grep: "\.toggle" --glob "*.css" --glob "*positron*"
-Grep: "\.button" --glob "*.css" --glob "*positron*"
-```
+- Grep: `"\.toggle"` with glob `*.css` and `*positron*`
+- Grep: `"\.button"` with glob `*.css` and `*positron*`
 
 ## Common Patterns
 
@@ -87,12 +82,10 @@ Look for existing modal implementations to understand the framework pattern.
 
 ### Feature-Specific Components
 Each Positron feature has its own components directory. Search by feature name:
-```bash
-Glob: **/positronDataExplorer/**/components/*.tsx
-Glob: **/positronVariables/**/components/*.tsx
-Glob: **/positronPlots/**/components/*.tsx
-Glob: **/positronConsole/**/components/*.tsx
-```
+- Glob: `**/positronDataExplorer/**/components/*.tsx`
+- Glob: `**/positronVariables/**/components/*.tsx`
+- Glob: `**/positronPlots/**/components/*.tsx`
+- Glob: `**/positronConsole/**/components/*.tsx`
 
 ## Tips
 

--- a/.claude/ui-components.md
+++ b/.claude/ui-components.md
@@ -1,0 +1,103 @@
+# Positron UI Components Context
+
+This prompt provides context for working with Positron's reusable UI components, patterns, and styling conventions.
+
+## Finding Existing Components
+
+Always search before creating new UI controls:
+
+```bash
+# Find React components in Positron directories
+Glob: **/positron**/components/*.tsx
+Glob: **/positronComponents/**/*.tsx
+
+# Search for specific control types
+Grep: "toggle" --glob "*.tsx" --glob "*positron*"
+Grep: "ScreenReaderOnly" --type tsx
+Grep: "Modal" --glob "*positron*.tsx"
+```
+
+## Component Categories
+
+### Action Bar Controls
+Search: `Glob: **/positronActionBar/**/components/*.tsx`
+
+Toolbar controls like buttons, toggles, filters, and menu triggers.
+
+**Context Requirement:** Action bar components use `useRegisterWithActionBar` hook requiring `PositronActionBarContext`. They cannot be used directly in modals or dialogs—search for the CSS patterns and copy styling instead.
+
+### Base UI Primitives
+Search: `Glob: **/positronComponents/**/*.tsx`
+
+Low-level reusable primitives including buttons, accessibility helpers (`ScreenReaderOnly`), splitters, and progress indicators.
+
+### Modal and Popup Components
+Search: `Grep: "positronModal" --type tsx`
+
+Dialog and popover frameworks. Look for `ModalDialog` and `ModalPopup` patterns.
+
+## CSS Patterns
+
+### Conditional Class Names
+Search for `positronClassNames` usage:
+```typescript
+import { positronClassNames } from 'vs/base/common/positronUtilities';
+
+const className = positronClassNames(
+    'base-class',
+    { 'active': isActive, 'disabled': isDisabled }
+);
+```
+
+### Accessibility: Visually Hidden Inputs
+For custom controls needing hidden native inputs, search for `ScreenReaderOnly` or use this CSS pattern:
+
+```css
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+```
+
+### Finding CSS Patterns
+```bash
+# Search for similar styling patterns
+Grep: "\.toggle" --glob "*.css" --glob "*positron*"
+Grep: "\.button" --glob "*.css" --glob "*positron*"
+```
+
+## Common Patterns
+
+### Modal Dialogs
+Search: `Grep: "positronModalDialog" --type tsx`
+
+Look for existing modal implementations to understand the framework pattern.
+
+### Action Bar Integration
+1. Search for `PositronActionBarContextProvider` to check if parent provides context
+2. If context available, reuse action bar components
+3. If no context (e.g., in modals), copy CSS patterns from action bar stylesheets
+
+### Feature-Specific Components
+Each Positron feature has its own components directory. Search by feature name:
+```bash
+Glob: **/positronDataExplorer/**/components/*.tsx
+Glob: **/positronVariables/**/components/*.tsx
+Glob: **/positronPlots/**/components/*.tsx
+Glob: **/positronConsole/**/components/*.tsx
+```
+
+## Tips
+
+1. **Search before creating**: Many controls already exist in slightly different forms
+2. **Copy CSS, not components**: When context requirements prevent component reuse
+3. **Check similar features**: Look at how other Positron features implement similar UI
+4. **Use semantic HTML**: Prefer native elements with custom styling over div soup
+5. **Follow naming conventions**: Positron components use `positron` prefix in directory and file names

--- a/.claude/ui-components.md
+++ b/.claude/ui-components.md
@@ -42,8 +42,8 @@ Grep: "DropDownListBox" type:tsx
 ## Key Components
 
 ### Buttons
-- **`Button`** (`button/button.tsx`) - Styled button with hover/tooltip support, uses native `<button>`
-- **`PositronButton`** (`button/positronButton.tsx`) - Intentionally unstyled, uses `<div>`, for custom styling needs
+- **`Button`** (`button/button.tsx`) - **Preferred for new code.** Uses native `<button>` element for proper semantic HTML. Has minimal/reset styling (transparent background, no border) so it works well for custom styling. Supports hover/tooltip via `hoverManager`.
+- **`PositronButton`** (`button/positronButton.tsx`) - Legacy, uses `<div>`. Prefer `Button`.
 
 ### Modal Components
 Located in `positronModalDialog/components/`:

--- a/.claude/ui-components.md
+++ b/.claude/ui-components.md
@@ -1,43 +1,65 @@
-# Positron UI Components Context
+# Positron UI Components
 
-This prompt provides context for working with Positron's reusable UI components, patterns, and styling conventions.
+Context for working with Positron's reusable UI components.
 
-## Finding Existing Components
+## Core Principles
 
-Always search before creating new UI controls:
+1. **Search before creating** - Many controls already exist
+2. **Understand context requirements** - Some components need specific React contexts
+3. **Ask when unclear** - When facing subjective decisions about component reuse or styling, ask the developer
 
-**Find React components in Positron directories:**
-- Glob: `**/positron**/components/*.tsx`
-- Glob: `**/positronComponents/**/*.tsx`
+## Component Locations
 
-**Search for specific control types:**
-- Grep: `"toggle"` with glob `*.tsx` and `*positron*`
-- Grep: `"ScreenReaderOnly"` with type `tsx`
-- Grep: `"Modal"` with glob `*positron*.tsx`
+| Location | Contains |
+|----------|----------|
+| `src/vs/base/browser/ui/positronComponents/` | Base primitives (Button, Scrollable, ScreenReaderOnly, splitters) |
+| `src/vs/workbench/browser/positronComponents/` | Workbench components (modals, dropdowns, popups) |
+| `src/vs/workbench/browser/positronComponents/positronModalDialog/components/` | Modal sub-components (Checkbox, RadioGroup, LabeledTextInput, etc.) |
+| `src/vs/workbench/contrib/positron*/` | Feature-specific components (data explorer, console, plots, etc.) |
+| `src/vs/workbench/browser/positronActionBar/` | Action bar controls (require context) |
 
-## Component Categories
+## Context Requirements
 
-### Action Bar Controls
-Search: `Glob: **/positronActionBar/**/components/*.tsx`
+**Action bar components** (`positronActionBar/`) use `useRegisterWithActionBar` hook requiring `PositronActionBarContext`. They cannot be used directly in modals or dialogs.
 
-Toolbar controls like buttons, toggles, filters, and menu triggers.
+**For buttons in modals:** Use the base `Button` component from `vs/base/browser/ui/positronComponents/button/button.tsx` with `action-bar-button` CSS class. Modal styles already define these classes.
 
-**Context Requirement:** Action bar components use `useRegisterWithActionBar` hook requiring `PositronActionBarContext`. They cannot be used directly in modals or dialogs—search for the CSS patterns and copy styling instead.
+## Finding Components
 
-### Base UI Primitives
-Search: `Glob: **/positronComponents/**/*.tsx`
+Start with glob patterns in these directories:
+```
+**/positronComponents/**/*.tsx
+**/positronModalDialog/components/*.tsx
+**/positronActionBar/**/components/*.tsx
+```
 
-Low-level reusable primitives including buttons, accessibility helpers (`ScreenReaderOnly`), splitters, and progress indicators.
+Search for specific control types:
+```
+Grep: "Checkbox" glob:*positron*.tsx
+Grep: "DropDownListBox" type:tsx
+```
 
-### Modal and Popup Components
-Search: `Grep: "positronModal" --type tsx`
+## Key Components
 
-Dialog and popover frameworks. Look for `ModalDialog` and `ModalPopup` patterns.
+### Buttons
+- **`Button`** (`button/button.tsx`) - Styled button with hover/tooltip support, uses native `<button>`
+- **`PositronButton`** (`button/positronButton.tsx`) - Intentionally unstyled, uses `<div>`, for custom styling needs
+
+### Modal Components
+Located in `positronModalDialog/components/`:
+- `Checkbox`, `RadioGroup`, `RadioButton` - Form controls
+- `LabeledTextInput`, `LabeledFolderInput` - Text inputs with labels
+- `OkCancelActionBar`, `OkActionBar` - Dialog button bars
+- `ContentArea`, `VerticalStack`, `VerticalSpacer` - Layout helpers
+
+### Other Primitives
+- `DropDownListBox` - Select/dropdown inputs
+- `Scrollable` - Scrollable container
+- `ScreenReaderOnly` - Accessibility helper for visually hidden content
 
 ## CSS Patterns
 
-### Conditional Class Names
-Search for `positronClassNames` usage:
+Conditional class names:
 ```typescript
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 
@@ -47,50 +69,14 @@ const className = positronClassNames(
 );
 ```
 
-### Accessibility: Visually Hidden Inputs
-For custom controls needing hidden native inputs, search for `ScreenReaderOnly` or use this CSS pattern:
+## When to Ask the Developer
 
-```css
-.visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-```
+- Multiple similar components exist - which pattern to follow?
+- Unclear whether to reuse existing component or create new
+- Styling/UX subjective choices (button placement, labels, etc.)
+- Component seems close but not quite right - modify or create new?
 
-### Finding CSS Patterns
-- Grep: `"\.toggle"` with glob `*.css` and `*positron*`
-- Grep: `"\.button"` with glob `*.css` and `*positron*`
-
-## Common Patterns
-
-### Modal Dialogs
-Search: `Grep: "positronModalDialog" --type tsx`
-
-Look for existing modal implementations to understand the framework pattern.
-
-### Action Bar Integration
-1. Search for `PositronActionBarContextProvider` to check if parent provides context
-2. If context available, reuse action bar components
-3. If no context (e.g., in modals), copy CSS patterns from action bar stylesheets
-
-### Feature-Specific Components
-Each Positron feature has its own components directory. Search by feature name:
-- Glob: `**/positronDataExplorer/**/components/*.tsx`
-- Glob: `**/positronVariables/**/components/*.tsx`
-- Glob: `**/positronPlots/**/components/*.tsx`
-- Glob: `**/positronConsole/**/components/*.tsx`
-
-## Tips
-
-1. **Search before creating**: Many controls already exist in slightly different forms
-2. **Copy CSS, not components**: When context requirements prevent component reuse
-3. **Check similar features**: Look at how other Positron features implement similar UI
-4. **Use semantic HTML**: Prefer native elements with custom styling over div soup
-5. **Follow naming conventions**: Positron components use `positron` prefix in directory and file names
+Examples:
+- "I found similar controls in DataExplorer and Variables - which pattern should I follow?"
+- "Should I reuse DropDownListBox or create a custom select for this use case?"
+- "This could use the existing Checkbox or a simpler native input - preference?"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,20 @@ This ensures consistent, scriptable access to GitHub data and integrates well wi
 - WebView-based UI components for data science workflows
 - Kernel-based execution for Python and R interpreters
 
+## UI Component Reuse
+
+When implementing UI controls, search existing components before creating new:
+- `src/vs/platform/positronActionBar/browser/components/` - ActionBarToggle, ActionBarButton, etc.
+- `src/vs/base/browser/ui/positronComponents/` - ScreenReaderOnly, Button, splitters
+- `src/vs/workbench/browser/positronComponents/` - Modal dialogs, popover
+
+**Important:** Action bar components (e.g., ActionBarToggle) use `useRegisterWithActionBar` hook requiring `PositronActionBarContext`. They cannot be used directly in modals or other contexts - copy the CSS styling instead.
+
+### CSS Patterns
+- Use `ScreenReaderOnly` component or visually-hidden CSS (`clip: rect(0,0,0,0)`) for accessible hidden inputs
+- Use `positronClassNames` from `vs/base/common/positronUtilities.ts` for conditional class names
+- Match existing patterns by searching CSS files for similar components
+
 ## Directory Structure
 
 - `src/` - Core VS Code source with Positron modifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,17 +219,13 @@ This ensures consistent, scriptable access to GitHub data and integrates well wi
 
 ## UI Component Reuse
 
-When implementing UI controls, search existing components before creating new:
-- `src/vs/platform/positronActionBar/browser/components/` - ActionBarToggle, ActionBarButton, etc.
-- `src/vs/base/browser/ui/positronComponents/` - ScreenReaderOnly, Button, splitters
-- `src/vs/workbench/browser/positronComponents/` - Modal dialogs, popover
+Before creating new UI controls, search existing Positron components:
+- Glob: `**/positron**/components/*.tsx`, `**/positronComponents/**/*.tsx`
+- Key directories: `positronActionBar`, `positronComponents`, `positronModalDialog`
 
-**Important:** Action bar components (e.g., ActionBarToggle) use `useRegisterWithActionBar` hook requiring `PositronActionBarContext`. They cannot be used directly in modals or other contexts - copy the CSS styling instead.
+**Constraint:** Action bar components require `PositronActionBarContext` and can't be used directly in modals—copy CSS patterns instead.
 
-### CSS Patterns
-- Use `ScreenReaderOnly` component or visually-hidden CSS (`clip: rect(0,0,0,0)`) for accessible hidden inputs
-- Use `positronClassNames` from `vs/base/common/positronUtilities.ts` for conditional class names
-- Match existing patterns by searching CSS files for similar components
+For comprehensive patterns and examples, read `.claude/ui-components.md`.
 
 ## Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ Positron is a next-generation data science IDE built on VS Code, designed for Py
 ps aux | grep -E "npm.*watch-(client|extensions|e2e)d" | grep -v grep
 ```
 
+**NEVER run direct TypeScript compilation** (`npx tsc`, `tsc --noEmit`, etc.) on this project—it's too large and will fail or hang. The background daemons handle all compilation. If you need to verify code compiles:
+1. Check daemon status first
+2. Ask the user about any compilation errors shown by daemons
+
 **Essential workflows:**
 - **Launching Positron**: Read `.claude/launch-positron.md` for non-blocking launch protocol
 - **Build system**: Read `.claude/build-system.md` for detailed daemon management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,8 +223,6 @@ Before creating new UI controls, search existing Positron components:
 - Glob: `**/positron**/components/*.tsx`, `**/positronComponents/**/*.tsx`
 - Key directories: `positronActionBar`, `positronComponents`, `positronModalDialog`
 
-**Constraint:** Action bar components require `PositronActionBarContext` and can't be used directly in modals—copy CSS patterns instead.
-
 For comprehensive patterns and examples, read `.claude/ui-components.md`.
 
 ## Directory Structure


### PR DESCRIPTION
Adds Claude Code development guidelines to CLAUDE.md based on lessons learned during recent development work. Also adds the referenced-but-not-existant `ui-components.md` file. 

### Summary

Two additions:

1. **TypeScript compilation warning** - Explicitly warns against running `npx tsc` or `tsc --noEmit` directly, as the codebase is too large and will fail or hang. Points to the background daemons instead. For whatever reason this finally worked for me after lots of other attempts to get claude to stop running tsc directly. 

2. **UI component reuse guidelines** - Documents common UI component locations and gotchas discovered while implementing notebook assistant features. Attempts to not be too attached to current code structure and emphasizes that claude should check with the developer before making any unclear choices about reuse etc..

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

Documentation only - no functional changes.
