### PR TITLE
e2e fix: fix welcome message in walkthrough test

### DIFF
--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -54,7 +54,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 				'Migrating from RStudio to Positron',
 				'Get Started with Jupyter Notebooks',
 				'Get Started with Posit Publisher',
-				'Get Started with the Positron Notebook Editor in Alpha'
+				'Explore the Positron Notebook in Alpha'
 			]);
 		});
 

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -54,7 +54,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 				'Migrating from RStudio to Positron',
 				'Get Started with Jupyter Notebooks',
 				'Get Started with Posit Publisher',
-				'Explore the Positron Notebook in Alpha'
+				'Explore the Positron Notebook Editor in Alpha'
 			]);
 		});
 

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -44,7 +44,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await hotKeys.reloadWindow();
 
 			await welcome.expectWalkthroughsToHaveCount(3);
-			await welcome.expectWalkthroughsToContain(['Migrating from VSCode to Positron', 'Migrating from RStudio to Positron', 'Get Started with the Positron Notebook Editor in Alpha']);
+			await welcome.expectWalkthroughsToContain(['Migrating from VSCode to Positron', 'Migrating from RStudio to Positron', 'Explore the Positron Notebook Editor in Alpha']);
 
 			await welcome.walkthroughSection.getByText('More...').click();
 			await quickInput.expectTitleBarToHaveText('Open Walkthrough...');


### PR DESCRIPTION
Update the welcome walkthrough test with the new language for the Notebook alpha

https://github.com/posit-dev/positron/pull/11545 Added the new entry, but the text changed in the course of review and didn't make it into the test.

### QA Notes
@:welcome
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
