### PR TITLE
 Fix relative execution time not updating in notebook cell footer 

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellExecutionUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellExecutionUtils.ts
@@ -71,7 +71,7 @@ export function getRelativeTime(timestamp: number): string {
 			: localize('cellExecution.hoursAgo', '{0} hours ago', hours);
 	} else if (minutes > 0) {
 		return minutes === 1
-			? localize('cellExecution.minuteAgo', '1 minute ago')
+			? localize('cellExecution.minuteAgo', '1 min ago')
 			: localize('cellExecution.minutesAgo', '{0} mins ago', minutes);
 	} else {
 		return localize('cellExecution.justNow', 'Just now');

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellExecutionUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellExecutionUtils.ts
@@ -73,10 +73,6 @@ export function getRelativeTime(timestamp: number): string {
 		return minutes === 1
 			? localize('cellExecution.minuteAgo', '1 minute ago')
 			: localize('cellExecution.minutesAgo', '{0} mins ago', minutes);
-	} else if (seconds > 0) {
-		return seconds === 1
-			? localize('cellExecution.secondAgo', '1 second ago')
-			: localize('cellExecution.secondsAgo', '{0} seconds ago', seconds);
 	} else {
 		return localize('cellExecution.justNow', 'Just now');
 	}


### PR DESCRIPTION
Addresses #11573

This PR fixes the relative execution time display (e.g., "2 mins ago") in the notebook cell footer not updating over time. 

The `lastRunEndTime` value is set once after cell execution completes and never changes afterward. Since the cell footer component only re-rendered when this value changed, the relative time display would remain stuck at "Just now" indefinitely until another user action caused the cells in the notebook to re-render (e.g., adding a new cell to the notebook).                                                                   

This PR adds a 60-second interval that forces the component to re-render, recalculating the relative time from `getRelativeTime()`. To prevent unnecessary re-renders, the interval only triggers a re-render when the cell is visible in the viewport, using the existing `cell.isInViewport()` method.              
                                                                                                                                                          
I also removes the seconds-level granularity from `getRelativeTime()` since the update only occurs on a minute level.      

### Screenshot

Note: I edited the video to skip the 1 minute of waiting while we wait for the cell footer to update

https://github.com/user-attachments/assets/b5743bac-3116-4601-9a7c-39cf6ad390f5

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

**To verify execution time is being updated:**
1. Open a notebook with the Positron Notebook Editor                                                                                                      
2. Create a code cell with a simple statement (e.g.`print("hello")`)                                                                                    
3. Run the cell                                                                                                                                         
4. Observe the footer shows execution time of `Just now`                                                                                           
5. Wait 1-2 minutes                                                                                                                                     
6. The footer should update to `1 min ago`, then `2 mins ago`, etc. 

**To verify only visible cells are re-rendering the footer:**                                                                                                                      
1. Run several cells in a notebook                                                                                                                      
2. Scroll so the executed cells are out of view                                                                                                        
3. Wait 1+ minute                                                                                                                                       
4. Scroll back to view the hidden cells                                                                                                                 
5. The relative time should show the old elapsed time and then update the correct elapsed time when the next minute interval is hit

@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
