### PR TITLE
python LS: fix path completions on Windows

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -1015,9 +1015,8 @@ def _get_path_completions(
         remaining = entry_name[len(filename_prefix) :]
 
         if is_directory:
-            # Directories get trailing separator, no auto-close quote
-            # Windows: escape backslash for string literal
-            completion_text = remaining + "\\" + os.sep if os.name == "nt" else remaining + "/"
+            # Directories get trailing separator
+            completion_text = remaining + "/"
         else:
             # Files: auto-close quote if needed
             completion_text = remaining if has_closing_quote else remaining + quote_char

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -689,14 +689,6 @@ class TestCompletions:
         root_path: Optional[Path] = None,
         working_directory: Optional[str] = None,
     ):
-        # Replace separators for testing cross-platform.
-        source = source.replace("/", os.path.sep)
-
-        # On Windows, expect escaped backslashes in paths to avoid inserting invalid strings.
-        # See: https://github.com/posit-dev/positron/issues/3758.
-        if os.name == "nt":
-            expected_completion = expected_completion.replace("/", "\\" + os.path.sep)
-
         server = create_test_server(root_path=root_path, working_directory=working_directory)
         text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
         character = len(source) - chars_from_end


### PR DESCRIPTION
Addresses part of https://github.com/posit-dev/positron/issues/11259. Fixes path completions on Windows, which were using four backslashes as a separator. We can just use a forward slash; Python will know how to handle that on Windows.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Try completing nested directory paths on Windows and making sure Python can read the resulting file.
