### PR TITLE
Bump Ark to 0.1.227

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -969,7 +969,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.226"
+      "ark": "0.1.227"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -9,13 +9,11 @@ test.use({
 	suiteId: __filename
 });
 
-// FIXME: Disabled for https://github.com/posit-dev/positron/pull/11407 on windows
-test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS] }, () => {
+test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, () => {
 
 	test.afterEach(async ({ app }) => {
 		await app.workbench.sessions.deleteAll();
 	});
-
 
 	test('Verify Restart Extension Host command works - R', {
 		tag: [tags.ARK]


### PR DESCRIPTION
Fixes remaining breakpoints issues

- posit-dev/ark#1014
- posit-dev/ark#1015 
  Closes #11548
- posit-dev/ark#1016
  Addresses https://github.com/posit-dev/positron/issues/11558
- posit-dev/ark#1017 
- posit-dev/ark#1018
  Unskips test from #11497
- posit-dev/ark#1019



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:ark

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
