### PR TITLE
Add validation support for connections drivers

### DIFF
--- a/extensions/positron-connections/src/drivers/bigquery.ts
+++ b/extensions/positron-connections/src/drivers/bigquery.ts
@@ -151,6 +151,9 @@ conn = bigquery.Client(credentials=credentials, project=${JSON.stringify(project
 			return { code, errorMessage: vscode.l10n.t('Project ID is required') };
 		}
 
+		if (keyfilePath === '') {
+			return { code, errorMessage: vscode.l10n.t('Service account keyfile path is required') };
+		}
 		return code;
 	}
 }

--- a/extensions/positron-connections/src/drivers/bigquery.ts
+++ b/extensions/positron-connections/src/drivers/bigquery.ts
@@ -78,7 +78,7 @@ export class PythonBigQueryDefaultCredentialsDriver extends PythonBigQueryDriver
 		]
 	};
 
-	generateCode(inputs: positron.ConnectionsInput[]): { valid: boolean; code: string; errorMessage?: string } {
+	generateCode(inputs: positron.ConnectionsInput[]): string | { code: string; errorMessage: string } {
 		const project = inputs.find(input => input.id === 'project')?.value ?? '';
 
 		const code = `from google.cloud import bigquery
@@ -90,14 +90,10 @@ conn = bigquery.Client(project=${JSON.stringify(project)})
 `;
 
 		if (project === '') {
-			return {
-				valid: false,
-				code,
-				errorMessage: 'Project ID is required'
-			};
+			return { code, errorMessage: 'Project ID is required' };
 		}
 
-		return { valid: true, code };
+		return code;
 	}
 }
 
@@ -139,7 +135,7 @@ export class PythonBigQueryServiceAccountDriver extends PythonBigQueryDriverBase
 		]
 	};
 
-	generateCode(inputs: positron.ConnectionsInput[]): { valid: boolean; code: string; errorMessage?: string } {
+	generateCode(inputs: positron.ConnectionsInput[]): string | { code: string; errorMessage: string } {
 		const project = inputs.find(input => input.id === 'project')?.value ?? '';
 		const keyfilePath = inputs.find(input => input.id === 'keyfile_path')?.value ?? '';
 
@@ -152,13 +148,9 @@ conn = bigquery.Client(credentials=credentials, project=${JSON.stringify(project
 `;
 
 		if (project === '') {
-			return {
-				valid: false,
-				code,
-				errorMessage: 'Project ID is required'
-			};
+			return { code, errorMessage: 'Project ID is required' };
 		}
 
-		return { valid: true, code };
+		return code;
 	}
 }

--- a/extensions/positron-connections/src/drivers/bigquery.ts
+++ b/extensions/positron-connections/src/drivers/bigquery.ts
@@ -78,16 +78,26 @@ export class PythonBigQueryDefaultCredentialsDriver extends PythonBigQueryDriver
 		]
 	};
 
-	generateCode(inputs: positron.ConnectionsInput[]) {
+	generateCode(inputs: positron.ConnectionsInput[]): { valid: boolean; code: string; errorMessage?: string } {
 		const project = inputs.find(input => input.id === 'project')?.value ?? '';
 
-		return `from google.cloud import bigquery
+		const code = `from google.cloud import bigquery
 
 # To configure credentials locally, run: gcloud auth application-default login
 # See: https://cloud.google.com/docs/authentication/provide-credentials-adc
 conn = bigquery.Client(project=${JSON.stringify(project)})
 %connection_show conn
 `;
+
+		if (project === '') {
+			return {
+				valid: false,
+				code,
+				errorMessage: 'Project ID is required'
+			};
+		}
+
+		return { valid: true, code };
 	}
 }
 
@@ -129,16 +139,26 @@ export class PythonBigQueryServiceAccountDriver extends PythonBigQueryDriverBase
 		]
 	};
 
-	generateCode(inputs: positron.ConnectionsInput[]) {
+	generateCode(inputs: positron.ConnectionsInput[]): { valid: boolean; code: string; errorMessage?: string } {
 		const project = inputs.find(input => input.id === 'project')?.value ?? '';
 		const keyfilePath = inputs.find(input => input.id === 'keyfile_path')?.value ?? '';
 
-		return `from google.cloud import bigquery
+		const code = `from google.cloud import bigquery
 from google.oauth2 import service_account
 
 credentials = service_account.Credentials.from_service_account_file(${JSON.stringify(keyfilePath)})
 conn = bigquery.Client(credentials=credentials, project=${JSON.stringify(project)})
 %connection_show conn
 `;
+
+		if (project === '') {
+			return {
+				valid: false,
+				code,
+				errorMessage: 'Project ID is required'
+			};
+		}
+
+		return { valid: true, code };
 	}
 }

--- a/extensions/positron-connections/src/drivers/bigquery.ts
+++ b/extensions/positron-connections/src/drivers/bigquery.ts
@@ -30,7 +30,7 @@ class PythonBigQueryDriverBase implements positron.ConnectionsDriver {
 			positron.RuntimeErrorBehavior.Continue
 		);
 		if (!exec) {
-			throw new Error('Failed to execute code');
+			throw new Error(vscode.l10n.t('Failed to execute code'));
 		}
 		return;
 	}
@@ -90,7 +90,7 @@ conn = bigquery.Client(project=${JSON.stringify(project)})
 `;
 
 		if (project === '') {
-			return { code, errorMessage: 'Project ID is required' };
+			return { code, errorMessage: vscode.l10n.t('Project ID is required') };
 		}
 
 		return code;
@@ -148,7 +148,7 @@ conn = bigquery.Client(credentials=credentials, project=${JSON.stringify(project
 `;
 
 		if (project === '') {
-			return { code, errorMessage: 'Project ID is required' };
+			return { code, errorMessage: vscode.l10n.t('Project ID is required') };
 		}
 
 		return code;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1652,8 +1652,9 @@ declare module 'positron' {
 
 		/**
 		 * Generates the connection code based on the inputs.
+		 * Returns a string for valid code, or an object with code and errorMessage if validation fails.
 		 */
-		generateCode?: (inputs: Array<ConnectionsInput>) => string | { valid: boolean; code: string; errorMessage?: string };
+		generateCode?: (inputs: Array<ConnectionsInput>) => string | { code: string; errorMessage: string };
 
 		/**
 		 * Connect session.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1652,7 +1652,25 @@ declare module 'positron' {
 
 		/**
 		 * Generates the connection code based on the inputs.
-		 * Returns a string for valid code, or an object with code and errorMessage if validation fails.
+		 *
+		 * @param inputs The current values of the connection inputs defined in metadata.
+		 * @returns Either a string containing valid connection code, or an object with:
+		 *   - `code`: The generated connection code. Should still be generated even when
+		 *     validation fails, so users can see and copy the partial code.
+		 *   - `errorMessage`: A user-facing message explaining the validation error,
+		 *     displayed in an error banner overlay on the code editor. The Connect
+		 *     button is disabled when an error message is present.
+		 *
+		 * @example
+		 * // Return valid code as a string
+		 * generateCode: (inputs) => `library(DBI)\ncon <- dbConnect(...)`
+		 *
+		 * @example
+		 * // Return validation error with generated code
+		 * generateCode: (inputs) => ({
+		 *   code: `library(bigrquery)\ncon <- dbConnect(...)`,
+		 *   errorMessage: 'Project ID is required'
+		 * })
 		 */
 		generateCode?: (inputs: Array<ConnectionsInput>) => string | { code: string; errorMessage: string };
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1653,7 +1653,7 @@ declare module 'positron' {
 		/**
 		 * Generates the connection code based on the inputs.
 		 */
-		generateCode?: (inputs: Array<ConnectionsInput>) => string;
+		generateCode?: (inputs: Array<ConnectionsInput>) => string | { valid: boolean; code: string; errorMessage?: string };
 
 		/**
 		 * Connect session.

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -154,7 +154,7 @@ export interface MainThreadConnectionsShape {
 }
 
 export interface ExtHostConnectionsShape {
-	$driverGenerateCode(driverId: string, inputs: Input[]): Promise<string>;
+	$driverGenerateCode(driverId: string, inputs: Input[]): Promise<string | { valid: boolean; code: string; errorMessage?: string }>;
 	$driverConnect(driverId: string, code: string): Promise<void>;
 	$driverCheckDependencies(driverId: string): Promise<boolean>;
 	$driverInstallDependencies(driverId: string): Promise<boolean>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -154,7 +154,7 @@ export interface MainThreadConnectionsShape {
 }
 
 export interface ExtHostConnectionsShape {
-	$driverGenerateCode(driverId: string, inputs: Input[]): Promise<string | { valid: boolean; code: string; errorMessage?: string }>;
+	$driverGenerateCode(driverId: string, inputs: Input[]): Promise<string | { code: string; errorMessage: string }>;
 	$driverConnect(driverId: string, code: string): Promise<void>;
 	$driverCheckDependencies(driverId: string): Promise<boolean>;
 	$driverInstallDependencies(driverId: string): Promise<boolean>;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -113,5 +113,5 @@
 
 /* Error state for code editor */
 .create-connection-code-editor.has-error {
-	border-left: 3px solid var(--vscode-inputValidation-errorBorder);
+	box-shadow: inset 3px 0 0 0 var(--vscode-inputValidation-errorBorder);
 }

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -128,6 +128,9 @@
 	color: var(--vscode-inputValidation-errorForeground);
 	transform-origin: bottom;
 	animation: growUp 0.2s ease-out;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 @keyframes growUp {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -136,6 +136,10 @@
 	gap: 6px;
 }
 
+.connection-error-message > .codicon.codicon-error {
+	color: var(--vscode-inputValidation-errorBorder);
+}
+
 @keyframes growUp {
 	from {
 		transform: scaleY(0);

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -58,10 +58,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-}
-
-.create-connection-footer > .default {
-	margin-left: auto;
+	justify-content: space-between;
 }
 
 .create-connection-inputs {
@@ -112,4 +109,9 @@
 .create-connection-inputs > .labeled-input > label > .drop-down-list-box {
 	flex: 1;
 	min-width: 0;
+}
+
+/* Error state for code editor */
+.create-connection-code-editor.has-error {
+	border-left: 3px solid var(--vscode-inputValidation-errorBorder);
 }

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -131,6 +131,9 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 @keyframes growUp {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -112,7 +112,7 @@
 }
 
 /* Error state for code editor */
-.create-connection-code-editor.has-error {
+.create-connection-code-editor {
 	position: relative;
 }
 
@@ -127,26 +127,23 @@
 	border-top: 1px solid var(--vscode-inputValidation-errorBorder);
 	color: var(--vscode-inputValidation-errorForeground);
 	transform-origin: bottom;
-	animation: growUp 0.2s ease-out;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	display: flex;
 	align-items: center;
 	gap: 6px;
+	transform: scaleY(0);
+	opacity: 0;
+	transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+.create-connection-code-editor.has-error .connection-error-message {
+	transform: scaleY(1);
+	opacity: 1;
 }
 
 .connection-error-message > .codicon.codicon-error {
 	color: var(--vscode-inputValidation-errorBorder);
 }
 
-@keyframes growUp {
-	from {
-		transform: scaleY(0);
-		opacity: 0;
-	}
-	to {
-		transform: scaleY(1);
-		opacity: 1;
-	}
-}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -113,5 +113,30 @@
 
 /* Error state for code editor */
 .create-connection-code-editor.has-error {
-	box-shadow: inset 3px 0 0 0 var(--vscode-inputValidation-errorBorder);
+	position: relative;
+}
+
+.connection-error-message {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	padding: 4px 8px;
+	font-size: 12px;
+	background-color: var(--vscode-inputValidation-errorBackground);
+	border-top: 1px solid var(--vscode-inputValidation-errorBorder);
+	color: var(--vscode-inputValidation-errorForeground);
+	transform-origin: bottom;
+	animation: growUp 0.2s ease-out;
+}
+
+@keyframes growUp {
+	from {
+		transform: scaleY(0);
+		opacity: 0;
+	}
+	to {
+		transform: scaleY(1);
+		opacity: 1;
+	}
 }

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -21,6 +21,9 @@ import { DropDownListBox } from '../../../../../browser/positronComponents/dropD
 import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
+import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 
 interface CreateConnectionProps {
 	readonly renderer: PositronModalReactRenderer;
@@ -143,7 +146,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			</SimpleCodeEditor>
 			{codeState?.errorMessage && (
 				<div className='connection-error-message'>
-					<span className='codicon codicon-error'></span>
+					<Icon icon={Codicon.error} />
 					{codeState.errorMessage}
 				</div>
 			)}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -133,7 +133,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			{(() => localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code"))()}
 		</div>
 
-		<div className={`create-connection-code-editor${codeState?.errorMessage ? ' has-error' : ''}`}>
+		<div className={positronClassNames('create-connection-code-editor', { 'has-error': codeState?.errorMessage })}>
 			<SimpleCodeEditor
 				ref={editorRef}
 				code={codeState?.code || ''}
@@ -172,7 +172,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				{(() => localize('positron.newConnectionModalDialog.createConnection.back', 'Back'))()}
 			</PositronButton>
 			<PositronButton
-				className={`button action-bar-button${!codeState?.errorMessage ? ' default' : ''}`}
+				className={`button action-bar-button`}
 				disabled={!codeState || !!codeState.errorMessage}
 				onPressed={onConnectHandler}
 			>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -137,7 +137,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			{(() => localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code"))()}
 		</div>
 
-		<div className={positronClassNames('create-connection-code-editor', { 'has-error': codeState?.errorMessage })}>
+		<div className={positronClassNames('create-connection-code-editor', { 'has-error': !!codeState?.errorMessage })}>
 			<SimpleCodeEditor
 				ref={editorRef}
 				code={codeState?.code || ''}
@@ -145,12 +145,10 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				language={languageId}
 			>
 			</SimpleCodeEditor>
-			{codeState?.errorMessage && (
-				<div className='connection-error-message'>
-					<Icon icon={Codicon.error} />
-					{codeState.errorMessage}
-				</div>
-			)}
+			<div className='connection-error-message'>
+				<Icon icon={Codicon.error} />
+				{codeState?.errorMessage}
+			</div>
 		</div>
 
 		<div className='create-connection-buttons'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -7,7 +7,7 @@
 import './createConnectionState.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { PositronButton } from '../../../../../../base/browser/ui/positronComponents/button/positronButton.js';
@@ -24,6 +24,7 @@ import { PositronModalReactRenderer } from '../../../../../../base/browser/posit
 import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { IEditorOptions } from '../../../../../../editor/common/config/editorOptions.js';
 
 interface CreateConnectionProps {
 	readonly renderer: PositronModalReactRenderer;
@@ -42,10 +43,10 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 	const [inputs, setInputs] = useState<Array<Input>>(metadata.inputs);
 	const [codeState, setCodeState] = useState<{ code: string; errorMessage?: string } | undefined>(undefined);
 
-	const editorOptions = useMemo(() => ({
+	const editorOptions: IEditorOptions = {
 		readOnly: true,
 		cursorBlinking: 'solid' as const
-	}), []);
+	};
 
 	useEffect(() => {
 		// Debounce the code generation to avoid unnecessary re-renders
@@ -130,7 +131,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			</h1>
 		</div>
 
-		<Form inputs={metadata.inputs} onInputsChange={setInputs}></Form>
+		<Form inputs={inputs} onInputsChange={setInputs}></Form>
 
 		<div className='create-connection-code-title'>
 			{(() => localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code"))()}
@@ -201,12 +202,9 @@ const Form = (props: PropsWithChildren<{ inputs: Input[], onInputsChange: (input
 			inputs.map((input) => {
 				return <FormElement key={input.id} input={input} onChange={(value) => {
 					onInputsChange(
-						inputs.map((i) => {
-							if (i.id === input.id) {
-								i.value = value;
-							}
-							return i;
-						})
+						inputs.map((i) =>
+							i.id === input.id ? { ...i, value } : i
+						)
 					);
 				}}></FormElement>;
 			})

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -37,7 +37,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 	const editorRef = useRef<SimpleCodeEditorWidget>(undefined!);
 
 	const [inputs, setInputs] = useState<Array<Input>>(metadata.inputs);
-	const [codeState, setCodeState] = useState<{ valid: boolean; code: string; errorMessage?: string } | undefined>(undefined);
+	const [codeState, setCodeState] = useState<{ code: string; errorMessage?: string } | undefined>(undefined);
 
 	const editorOptions = useMemo(() => ({
 		readOnly: true,
@@ -50,7 +50,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			if (generateCode) {
 				const result = await generateCode(inputs);
 				if (typeof result === 'string') {
-					setCodeState({ valid: true, code: result });
+					setCodeState({ code: result });
 				} else {
 					setCodeState(result);
 				}
@@ -133,7 +133,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			{(() => localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code"))()}
 		</div>
 
-		<div className={`create-connection-code-editor${codeState?.valid === false ? ' has-error' : ''}`}>
+		<div className={`create-connection-code-editor${codeState?.errorMessage ? ' has-error' : ''}`}>
 			<SimpleCodeEditor
 				ref={editorRef}
 				code={codeState?.code || ''}
@@ -141,7 +141,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				language={languageId}
 			>
 			</SimpleCodeEditor>
-			{codeState?.valid === false && codeState.errorMessage && (
+			{codeState?.errorMessage && (
 				<div className='connection-error-message'>{codeState.errorMessage}</div>
 			)}
 		</div>
@@ -169,8 +169,8 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				{(() => localize('positron.newConnectionModalDialog.createConnection.back', 'Back'))()}
 			</PositronButton>
 			<PositronButton
-				className={`button action-bar-button${codeState?.valid !== false ? ' default' : ''}`}
-				disabled={!codeState?.valid}
+				className={`button action-bar-button${!codeState?.errorMessage ? ' default' : ''}`}
+				disabled={!codeState || !!codeState.errorMessage}
 				onPressed={onConnectHandler}
 			>
 				{(() => localize('positron.newConnectionModalDialog.createConnection.connect', 'Connect'))()}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -45,7 +45,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 
 	const editorOptions: IEditorOptions = {
 		readOnly: true,
-		cursorBlinking: 'solid' as const
+		cursorBlinking: 'solid'
 	};
 
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -141,6 +141,9 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				language={languageId}
 			>
 			</SimpleCodeEditor>
+			{codeState?.valid === false && codeState.errorMessage && (
+				<div className='connection-error-message'>{codeState.errorMessage}</div>
+			)}
 		</div>
 
 		<div className='create-connection-buttons'>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -142,7 +142,10 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 			>
 			</SimpleCodeEditor>
 			{codeState?.errorMessage && (
-				<div className='connection-error-message'>{codeState.errorMessage}</div>
+				<div className='connection-error-message'>
+					<span className='codicon codicon-error'></span>
+					{codeState.errorMessage}
+				</div>
 			)}
 		</div>
 

--- a/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
+++ b/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
@@ -40,7 +40,7 @@ export interface IDriver {
 	metadata: IDriverMetadata;
 
 	// Generates the connection code based on the inputs.
-	generateCode?: (inputs: Array<Input>) => Promise<string>;
+	generateCode?: (inputs: Array<Input>) => Promise<string | { valid: boolean; code: string; errorMessage?: string }>;
 	// Connect session
 	connect?: (code: string) => Promise<void>;
 	// Checks if the dependencies for the driver are installed

--- a/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
+++ b/src/vs/workbench/services/positronConnections/common/interfaces/positronConnectionsDriver.ts
@@ -40,7 +40,8 @@ export interface IDriver {
 	metadata: IDriverMetadata;
 
 	// Generates the connection code based on the inputs.
-	generateCode?: (inputs: Array<Input>) => Promise<string | { valid: boolean; code: string; errorMessage?: string }>;
+	// Returns a string for valid code, or an object with code and errorMessage if validation fails.
+	generateCode?: (inputs: Array<Input>) => Promise<string | { code: string; errorMessage: string }>;
 	// Connect session
 	connect?: (code: string) => Promise<void>;
 	// Checks if the dependencies for the driver are installed


### PR DESCRIPTION
### Summary

Adds connection validation support, allowing drivers to return validation errors that are displayed inline in the connection modal with an animated error overlay.

<img width="699" height="626" alt="image" src="https://github.com/user-attachments/assets/91cc0a74-c789-40d6-9792-171ae3824122" />

### Release Notes

#### New Features

- Added validation support for connection drivers with inline error display

#### Bug Fixes
- N/A

### QA Notes

@:connections

1. Open the Connections pane and click "New Connection"
2. Select BigQuery (Application Default Credentials)
3. Clear the Project ID field and observe the error message appears
4. Enter a valid project ID and verify the error clears
5. Test the Service Account driver similarly with the keyfile path