### PR TITLE
E2E flake: soft fail session-rename on windows only.

### DIFF
--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Sessions: Rename', {
-	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL],
+	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS],
 	annotation: [
 		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7692' },
 		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6843' }
@@ -21,7 +21,9 @@ test.describe('Sessions: Rename', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	test('Validate can rename sessions and name persists', async function ({ sessions, runCommand }) {
+	test('Validate can rename sessions and name persists', {
+		tag: process.platform === 'win32' ? [tags.SOFT_FAIL] : [] //only soft fail on windows since this is marked as critical and only flakey on windows.
+	}, async function ({ sessions, runCommand }) {
 		const [pySession, pySessionAlt, rSession, rSessionAlt] = await sessions.start(['python', 'pythonAlt', 'r', 'rAlt']);
 
 		// Rename sessions

--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Sessions: Rename', {
-	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS],
+	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS, tags.CRITICAL],
 	annotation: [
 		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7692' },
 		{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6843' }


### PR DESCRIPTION
The session-rename test occasionally flakes on windows only.  Soft failing for now and we can revist later when we audit.

These tests are also marked critical, so only soft-failing on windows as it's the place it occasionally fails.

### QA Notes
@:win
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
