### PR TITLE
e2e test: R debugging with breakpoints 

### DIFF
--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -12,6 +12,7 @@ import { QuickAccess } from './quickaccess.js';
 const DEBUG_TOOLBAR = '.debug-toolbar';
 const GLYPH_AREA = '.margin-view-overlays>:nth-child';
 const BREAKPOINT_GLYPH = '.monaco-editor .codicon-debug-breakpoint';
+const BREAKPOINT_GLYPH_UNVERIFIED = '.monaco-editor .codicon-debug-breakpoint-unverified';
 const STOP = `.debug-toolbar .action-label[aria-label*="Stop"]`;
 
 const VIEWLET = 'div[id="workbench.view.debug"]';
@@ -51,6 +52,47 @@ export class Debug {
 			await expect(this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`)).toBeVisible();
 			await this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`).click({ position: { x: 5, y: 5 }, force: true });
 			await expect(this.code.driver.page.locator(BREAKPOINT_GLYPH).nth(index)).toBeVisible();
+		});
+	}
+
+	/**
+	 * Action: Set a breakpoint on a line and expect it to be initially unverified (gray)
+	 *
+	 * @param lineNumber The line number to set the breakpoint on
+	 * @param index The index of the breakpoint if multiple exist (default 0)
+	 */
+	async setUnverifiedBreakpointOnLine(lineNumber: number, index = 0): Promise<void> {
+		await test.step(`Debug: Set unverified breakpoint on line ${lineNumber}`, async () => {
+			await expect(this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`)).toBeVisible();
+			await this.code.driver.page.locator(`${GLYPH_AREA}(${lineNumber})`).click({ position: { x: 5, y: 5 }, force: true });
+			// For R breakpoints, initially expect the breakpoint to be unverified (gray)
+			await expect(
+				this.code.driver.page.locator(BREAKPOINT_GLYPH_UNVERIFIED).nth(index)
+					.or(this.code.driver.page.locator(BREAKPOINT_GLYPH).nth(index))
+			).toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: Wait for breakpoint to become verified (red)
+	 *
+	 * @param index The index of the breakpoint to check (default 0)
+	 * @param timeout Maximum time to wait for verification (default 30000ms)
+	 */
+	async expectBreakpointVerified(index = 0, timeout = 30000): Promise<void> {
+		await test.step(`Verify breakpoint ${index} is verified (red)`, async () => {
+			await expect(this.code.driver.page.locator(BREAKPOINT_GLYPH).nth(index)).toBeVisible({ timeout });
+		});
+	}
+
+	/**
+	 * Verify: Breakpoint is currently unverified (gray)
+	 *
+	 * @param index The index of the breakpoint to check (default 0)
+	 */
+	async expectBreakpointUnverified(index = 0): Promise<void> {
+		await test.step(`Verify breakpoint ${index} is unverified (gray)`, async () => {
+			await expect(this.code.driver.page.locator(BREAKPOINT_GLYPH_UNVERIFIED).nth(index)).toBeVisible();
 		});
 	}
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -253,8 +253,12 @@ test.describe('R Debugging', {
 		// Verify result appears in console
 		await console.waitForConsoleContents('[1] 15');
 
+		// Quit debugging
+		await page.keyboard.type('Q');
+		await page.keyboard.press('Enter');
+
 		// Verify we're back to normal prompt
-		await console.waitForReady('Browse[1]>');
+		await console.waitForReady('>');
 
 		// Clean up: clear the breakpoint
 		await debug.clearBreakpoints();

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -210,21 +210,52 @@ test.describe('R Debugging', {
 		await executeCode('R', 'fruit_avg(dat, "berry")', { waitForReady: false });
 		await console.waitForConsoleContents('Found 2 fruits!', { expectedCount: 2 });
 	});
+});
+
+// R Breakpoints - Tests for gutter-click breakpoints feature (#1766)
+// These tests verify the new R breakpoint support added in PR #11407
+test.describe('R Breakpoints', {
+	tag: [tags.DEBUG, tags.WEB, tags.WIN, tags.ARK]
+}, () => {
+	let breakpointSession: SessionMetaData;
+
+	test.beforeAll(async ({ sessions }) => {
+		breakpointSession = await sessions.start('r');
+	});
+
+	test.afterEach(async ({ app, page, hotKeys }) => {
+		// Focus the console
+		await app.workbench.console.focus();
+
+		// Exit debug mode if we're in it (send Q to quit)
+		const consoleContent = await app.workbench.console.activeConsole.textContent();
+		if (consoleContent?.includes('Browse[')) {
+			await page.keyboard.type('Q');
+			await page.keyboard.press('Enter');
+			await app.workbench.console.waitForReady('>');
+		}
+
+		// Clear breakpoints
+		await app.workbench.debug.clearBreakpoints();
+
+		// Close all editors (handles "Don't Save" dialog)
+		await hotKeys.closeAllEditors();
+
+		// Clear console
+		await app.workbench.console.clearButton.click();
+	});
 
 	test('R - Verify breakpoint set and hit via gutter click', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/1766' }]
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
 
-		// Open the test file
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
 
 		// Set a breakpoint on line 3 (inside the multiply_values function)
-		// Initially the breakpoint should be unverified (gray)
 		await debug.setUnverifiedBreakpointOnLine(3);
 
-		// Select all code and execute with Ctrl/Cmd+Enter to verify the breakpoint
-		// This sources the file and makes breakpoints verifiable
+		// Execute code with Ctrl/Cmd+Enter to verify the breakpoint
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
 
@@ -234,34 +265,21 @@ test.describe('R Debugging', {
 		// Call the function to trigger the breakpoint
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);
 
-		// Verify we hit the breakpoint - should enter browser mode
+		// Verify we hit the breakpoint
 		await debug.expectBrowserModeFrame(1);
-
-		// Verify debug toolbar is visible
 		await debug.expectDebugToolbarVisible();
-
-		// Verify current line indicator is visible
 		await debug.expectCurrentLineIndicatorVisible();
-
-		// Verify the call stack shows our function
 		await debug.expectCallStackAtIndex(0, 'multiply_values(');
 
-		// Continue execution to complete
+		// Continue and verify result
 		await page.keyboard.type('c');
 		await page.keyboard.press('Enter');
-
-		// Verify result appears in console
 		await console.waitForConsoleContents('[1] 15');
 
 		// Quit debugging
 		await page.keyboard.type('Q');
 		await page.keyboard.press('Enter');
-
-		// Verify we're back to normal prompt
 		await console.waitForReady('>');
-
-		// Clean up: clear the breakpoint
-		await debug.clearBreakpoints();
 	});
 
 	test('R - Verify breakpoints in dirty (unsaved) documents', {
@@ -269,50 +287,35 @@ test.describe('R Debugging', {
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
 
-		// Open the test file
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
-
-		// Set a breakpoint on line 3 (inside the multiply_values function)
 		await debug.setUnverifiedBreakpointOnLine(3);
 
-		// Execute code to verify the breakpoint
+		// Verify the breakpoint
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-
-		// Wait for the breakpoint to become verified (red)
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Edit the file to make it dirty (add a comment at the end)
-		// First, go to end of file
+		// Edit file to make it dirty
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+End' : 'Control+End');
 		await page.keyboard.press('Enter');
 		await page.keyboard.type('# test comment');
 
-		// Breakpoint should immediately become unverified (gray) after edit
+		// Breakpoint should become unverified after edit
 		await debug.expectBreakpointUnverified(0);
 
-		// Execute code again WITHOUT saving - breakpoint should become verified again
+		// Re-execute WITHOUT saving - breakpoint should re-verify
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-
-		// Wait for the breakpoint to become verified again
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Call the function to verify breakpoint still works
+		// Verify breakpoint still works
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);
-
-		// Verify we hit the breakpoint
 		await debug.expectBrowserModeFrame(1);
 
-		// Exit debugger
+		// Exit debugger and clean up
 		await page.keyboard.type('Q');
 		await page.keyboard.press('Enter');
 		await console.waitForReady('>');
-
-		// Clean up: clear breakpoints and revert file changes
-		await debug.clearBreakpoints();
-
-		// Undo the edit to restore original file state
 		await hotKeys.undo();
 		await hotKeys.undo();
 	});
@@ -322,40 +325,29 @@ test.describe('R Debugging', {
 	}, async ({ app, page, openFile, hotKeys, sessions }) => {
 		const { debug, console } = app.workbench;
 
-		// Start a second R session (first one was started in beforeAll)
-		// Use reuse: false to force creating a new session
+		// Start a second R session
 		const rSession2 = await sessions.start('r', { reuse: false });
 
-		// Switch back to the first R session (use ID since both have the same name)
-		await sessions.select(session.id);
+		// Switch back to first session (use ID since both have same name)
+		await sessions.select(breakpointSession.id);
 
-		// Open the test file
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
-
-		// Set a breakpoint on line 3
 		await debug.setUnverifiedBreakpointOnLine(3);
 
-		// Execute code to verify the breakpoint in Session 1
+		// Verify breakpoint in Session 1
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-
-		// Wait for the breakpoint to become verified (red) in Session 1
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Switch to Session 2 - breakpoint should become unverified
-		// (Session 2 hasn't sourced the code yet)
+		// Switch to Session 2 - breakpoint should be unverified
 		await sessions.select(rSession2.id);
-
-		// Breakpoint should be unverified in Session 2
 		await debug.expectBreakpointUnverified(0);
 
 		// Switch back to Session 1 - breakpoint should still be verified
-		await sessions.select(session.id);
-
-		// Breakpoint should still be verified in Session 1
+		await sessions.select(breakpointSession.id);
 		await debug.expectBreakpointVerified(0, 5000);
 
-		// Verify the breakpoint still works by triggering it
+		// Verify breakpoint still works
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);
 		await debug.expectBrowserModeFrame(1);
 
@@ -364,12 +356,9 @@ test.describe('R Debugging', {
 		await page.keyboard.press('Enter');
 		await console.waitForReady('>');
 
-		// Clean up
-		await debug.clearBreakpoints();
-
-		// Shutdown the second R session
+		// Shutdown second session
 		await sessions.select(rSession2.id);
-		await console.typeToConsole('q()', true);
+		await sessions.delete(rSession2.id);
 	});
 
 	test('R - Verify debug-specific console history', {
@@ -377,34 +366,28 @@ test.describe('R Debugging', {
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
 
-		// Type some normal commands first
+		// Type normal commands first
 		await console.typeToConsole('normal_x <- 1', true);
 		await console.typeToConsole('normal_y <- 2', true);
 
-		// Open file and set up a breakpoint to enter debug mode
+		// Set up breakpoint
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
 		await debug.setUnverifiedBreakpointOnLine(3);
-
-		// Execute code to verify the breakpoint
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Trigger the breakpoint
+		// Trigger breakpoint and type debug commands
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);
 		await debug.expectBrowserModeFrame(1);
-
-		// Type debug-specific commands
 		await console.typeToConsole('debug_var <- 100', true);
 		await console.typeToConsole('print(a)', true);
 		await app.code.wait(1000);
 
-		// Open history popup with Ctrl+R - should show only debug commands
+		// Ctrl+R should show debug commands
 		await page.keyboard.press('Control+R');
 		await console.waitForHistoryContents('debug_var <- 100');
 		await console.waitForHistoryContents('print(a)');
-
-		// Close history popup
 		await page.keyboard.press('Escape');
 
 		// Exit debugger
@@ -413,16 +396,11 @@ test.describe('R Debugging', {
 		await console.waitForReady('>');
 		await app.code.wait(1000);
 
-		// Open history popup with Ctrl+R - should show normal commands, not debug commands
+		// Ctrl+R should now show normal commands
 		await page.keyboard.press('Control+R');
 		await console.waitForHistoryContents('normal_x <- 1');
 		await console.waitForHistoryContents('normal_y <- 2');
-
-		// Close history popup
 		await page.keyboard.press('Escape');
-
-		// Clean up
-		await debug.clearBreakpoints();
 	});
 
 	test('R - Verify DAP disconnect/reconnect preserves breakpoints', {
@@ -430,30 +408,22 @@ test.describe('R Debugging', {
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
 
-		// Open the test file
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
-
-		// Set a breakpoint on line 3
 		await debug.setUnverifiedBreakpointOnLine(3);
 
-		// Execute code to verify the breakpoint
+		// Verify breakpoint
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-
-		// Wait for the breakpoint to become verified (red)
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Disconnect the DAP session with Shift+F5
+		// Disconnect DAP with Shift+F5
 		await page.keyboard.press('Shift+F5');
-
-		// Wait a moment for disconnect/reconnect cycle
 		await page.waitForTimeout(2000);
 
 		// Breakpoint should still be verified after auto-reconnect
-		// (DAP session auto-reconnects in background)
 		await debug.expectBreakpointVerified(0, 10000);
 
-		// Verify the breakpoint still works by triggering it
+		// Verify breakpoint still works
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);
 		await debug.expectBrowserModeFrame(1);
 
@@ -461,56 +431,39 @@ test.describe('R Debugging', {
 		await page.keyboard.type('Q');
 		await page.keyboard.press('Enter');
 		await console.waitForReady('>');
-
-		// Clean up
-		await debug.clearBreakpoints();
 	});
 
 	test('R - Verify editing file while at breakpoint invalidates breakpoints', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/1766' }]
-	}, async ({ app, page, openFile, hotKeys, sessions }) => {
+	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
 
-		// Open the test file
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
-
-		// Set a breakpoint on line 3
 		await debug.setUnverifiedBreakpointOnLine(3);
 
-		// Execute code to verify the breakpoint
+		// Verify breakpoint
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-
-		// Wait for the breakpoint to become verified (red)
 		await debug.expectBreakpointVerified(0, 30000);
 
-		// Trigger the breakpoint
+		// Trigger breakpoint
 		await debug.expectBrowserModeFrame(1);
 
-		// While stopped at the breakpoint, edit the file
-		// First focus the editor by selecting the tab, then add a comment at the end
+		// Edit file while at breakpoint
 		await app.workbench.editors.selectTab('breakpoint_test.r');
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+End' : 'Control+End');
 		await page.keyboard.press('Enter');
 		await page.keyboard.type('# edit while debugging');
 		await page.keyboard.press('Enter');
 
-		// Breakpoint should immediately become unverified (gray) after editing
+		// Breakpoint should become unverified
 		await debug.expectBreakpointUnverified(0);
 
-		// Continue execution - the invalidated breakpoint should NOT trigger again
-		// Focus the console first since we were editing the file
+		// Continue - invalidated breakpoint should NOT trigger again
 		await console.focus();
 		await page.keyboard.type('c', { delay: 100 });
 		await page.keyboard.press('Enter');
-
-		// Should return to normal prompt without hitting breakpoint again
 		await console.waitForReady('>');
-
-		// Clean up: clear breakpoints and undo the edit
-		await debug.clearBreakpoints();
-		await hotKeys.undo();
-		await hotKeys.undo();
 	});
 });
 

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -215,7 +215,7 @@ test.describe('R Debugging', {
 // R Breakpoints - Tests for gutter-click breakpoints feature (#1766)
 // These tests verify the new R breakpoint support added in PR #11407
 test.describe('R Breakpoints', {
-	tag: [tags.DEBUG, tags.WEB, tags.WIN, tags.ARK]
+	tag: [tags.DEBUG, tags.WIN, tags.ARK]
 }, () => {
 	let breakpointSession: SessionMetaData;
 
@@ -246,6 +246,7 @@ test.describe('R Breakpoints', {
 	});
 
 	test('R - Verify breakpoint set and hit via gutter click', {
+		tag: [tags.WEB],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/1766' }]
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
@@ -321,6 +322,7 @@ test.describe('R Breakpoints', {
 	});
 
 	test('R - Verify session switching preserves breakpoint state', {
+		tag: [tags.WEB],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/1766' }]
 	}, async ({ app, page, openFile, hotKeys, sessions }) => {
 		const { debug, console } = app.workbench;
@@ -362,6 +364,7 @@ test.describe('R Breakpoints', {
 	});
 
 	test('R - Verify debug-specific console history', {
+		tag: [tags.WEB],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11402' }]
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;
@@ -404,6 +407,7 @@ test.describe('R Breakpoints', {
 	});
 
 	test('R - Verify DAP disconnect/reconnect preserves breakpoints', {
+		tag: [tags.WEB],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/1766' }]
 	}, async ({ app, page, openFile, hotKeys }) => {
 		const { debug, console } = app.workbench;


### PR DESCRIPTION
Adds E2E tests for R breakpoint support (#1766) and related debug history fix (#11402).

Tests Added:
  - Test: R - Verify breakpoint set and hit via gutter click
  Description: Primary scenario: set breakpoint, execute with Ctrl+Enter, hit breakpoint
  - Test: R - Verify breakpoints in dirty (unsaved) documents
  Description: Editing invalidates breakpoints, re-executing re-verifies them
  - Test: R - Verify session switching preserves breakpoint state
  Description: Breakpoint verification is per-session
  - Test: R - Verify debug-specific console history
  Description: Ctrl+R shows debug vs normal history based on mode
  - Test: R - Verify DAP disconnect/reconnect preserves breakpoints
  Description: Shift+F5 disconnect auto-reconnects, preserving breakpoints
  - Test: R - Verify editing file while at breakpoint invalidates breakpoints
  Description: Editing while debugging invalidates breakpoints
  

Page Object Changes

  test/e2e/pages/debug.ts:
  - setUnverifiedBreakpointOnLine(lineNumber, index) - Sets breakpoint allowing initial unverified state
  - expectBreakpointVerified(index, timeout) - Waits for breakpoint to become verified (red)
  - expectBreakpointUnverified(index) - Verifies breakpoint is unverified (gray)
  - Added BREAKPOINT_GLYPH_UNVERIFIED selector for .codicon-debug-breakpoint-unverified

  Test Data

  - Added qa-example-content/workspaces/r-debugging/breakpoint_test.r (see https://github.com/posit-dev/qa-example-content/pull/104)

Note - there are places this could be optimized and consolidated, but I wanted to keep them all separate for now as it's a new feature and want to exercise things independently until it's been out for awhile. The 2 dirty file tests don't like web, so they are skipped for now. I will investigate those later, but wanted to get things running for now.


### QA Notes
@:debug @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
