### PR TITLE
python: let users name venv in new project wizard

### DIFF
--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -120,7 +120,7 @@ export async function createPythonRuntimeMetadata(
         const venvDir = path.dirname(path.dirname(interpreter.path)); // Go up from python to bin/Scripts, then to .venv
         const projectDir = path.dirname(venvDir); // Go up from .venv to project
         const projectName = path.basename(projectDir);
-        if (projectName && !projectName.startsWith('.')) {
+        if (projectName) {
             envName = projectName;
         }
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -13,328 +13,331 @@ import { getOSType, OSType } from '../../../common/utils/platform';
 import { createCondaScript } from '../../../common/process/internal/scripts';
 import { Common, CreateEnv } from '../../../common/utils/localize';
 import {
-	ExistingCondaAction,
-	deleteEnvironment,
-	getCondaBaseEnv,
-	getPathEnvVariableForConda,
-	pickExistingCondaAction,
-	pickPythonVersion,
+    ExistingCondaAction,
+    deleteEnvironment,
+    getCondaBaseEnv,
+    getPathEnvVariableForConda,
+    pickExistingCondaAction,
+    pickPythonVersion,
 } from './condaUtils';
 import { getPrefixCondaEnvPath, showErrorMessageWithLogs } from '../common/commonUtils';
 import { MultiStepAction, MultiStepNode, withProgress } from '../../../common/vscodeApis/windowApis';
 import { EventName } from '../../../telemetry/constants';
 import { sendTelemetryEvent } from '../../../telemetry';
 import {
-	CondaProgressAndTelemetry,
-	CONDA_ENV_CREATED_MARKER,
-	CONDA_ENV_EXISTING_MARKER,
+    CondaProgressAndTelemetry,
+    CONDA_ENV_CREATED_MARKER,
+    CONDA_ENV_EXISTING_MARKER,
 } from './condaProgressAndTelemetry';
 import { splitLines } from '../../../common/stringUtils';
 import {
-	CreateEnvironmentOptions,
-	CreateEnvironmentResult,
-	CreateEnvironmentProvider,
+    CreateEnvironmentOptions,
+    CreateEnvironmentResult,
+    CreateEnvironmentProvider,
 } from '../proposed.createEnvApis';
 import { shouldDisplayEnvCreationProgress } from './hideEnvCreation';
 import { noop } from '../../../common/utils/misc';
 
-function generateCommandArgs(version?: string, options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal): string[] {
-	let addGitIgnore = true;
-	let installPackages = true;
-	if (options) {
-		addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
-		installPackages = options?.installPackages !== undefined ? options.installPackages : true;
-	}
+function generateCommandArgs(
+    version?: string,
+    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+): string[] {
+    let addGitIgnore = true;
+    let installPackages = true;
+    if (options) {
+        addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
+        installPackages = options?.installPackages !== undefined ? options.installPackages : true;
+    }
 
-	const command: string[] = [createCondaScript()];
+    const command: string[] = [createCondaScript()];
 
-	if (addGitIgnore) {
-		command.push('--git-ignore');
-	}
+    if (addGitIgnore) {
+        command.push('--git-ignore');
+    }
 
-	if (installPackages) {
-		command.push('--install');
-	}
+    if (installPackages) {
+        command.push('--install');
+    }
 
-	if (version) {
-		command.push('--python');
-		command.push(version);
-	}
+    if (version) {
+        command.push('--python');
+        command.push(version);
+    }
 
-	// --- Start Positron ---
-	if (options?.envName) {
-		command.push('--name', options.envName);
-	}
-	// --- End Positron ---
+    // --- Start Positron ---
+    if (options?.envName) {
+        command.push('--name', options.envName);
+    }
+    // --- End Positron ---
 
-	return command;
+    return command;
 }
 
 function getCondaEnvFromOutput(output: string): string | undefined {
-	try {
-		const envPath = output
-			.split(/\r?\n/g)
-			.map((s) => s.trim())
-			.filter((s) => s.startsWith(CONDA_ENV_CREATED_MARKER) || s.startsWith(CONDA_ENV_EXISTING_MARKER))[0];
-		if (envPath.includes(CONDA_ENV_CREATED_MARKER)) {
-			return envPath.substring(CONDA_ENV_CREATED_MARKER.length);
-		}
-		return envPath.substring(CONDA_ENV_EXISTING_MARKER.length);
-	} catch (ex) {
-		traceError('Parsing out environment path failed.');
-		return undefined;
-	}
+    try {
+        const envPath = output
+            .split(/\r?\n/g)
+            .map((s) => s.trim())
+            .filter((s) => s.startsWith(CONDA_ENV_CREATED_MARKER) || s.startsWith(CONDA_ENV_EXISTING_MARKER))[0];
+        if (envPath.includes(CONDA_ENV_CREATED_MARKER)) {
+            return envPath.substring(CONDA_ENV_CREATED_MARKER.length);
+        }
+        return envPath.substring(CONDA_ENV_EXISTING_MARKER.length);
+    } catch (ex) {
+        traceError('Parsing out environment path failed.');
+        return undefined;
+    }
 }
 
 async function createCondaEnv(
-	workspace: WorkspaceFolder,
-	command: string,
-	args: string[],
-	progress: CreateEnvironmentProgress,
-	token?: CancellationToken,
+    workspace: WorkspaceFolder,
+    command: string,
+    args: string[],
+    progress: CreateEnvironmentProgress,
+    token?: CancellationToken,
 ): Promise<string> {
-	progress.report({
-		message: CreateEnv.Conda.creating,
-	});
+    progress.report({
+        message: CreateEnv.Conda.creating,
+    });
 
-	const deferred = createDeferred<string>();
-	const pathEnv = getPathEnvVariableForConda(command);
-	traceLog('Running Conda Env creation script: ', [command, ...args]);
-	const { proc, out, dispose } = execObservable(command, args, {
-		mergeStdOutErr: true,
-		token,
-		cwd: workspace.uri.fsPath,
-		env: {
-			PATH: pathEnv,
-			// --- Start Positron ---
-			PW_TEST: process.env.PW_TEST,
-			// --- End Positron ---
-		},
-	});
+    const deferred = createDeferred<string>();
+    const pathEnv = getPathEnvVariableForConda(command);
+    traceLog('Running Conda Env creation script: ', [command, ...args]);
+    const { proc, out, dispose } = execObservable(command, args, {
+        mergeStdOutErr: true,
+        token,
+        cwd: workspace.uri.fsPath,
+        env: {
+            PATH: pathEnv,
+            // --- Start Positron ---
+            PW_TEST: process.env.PW_TEST,
+            // --- End Positron ---
+        },
+    });
 
-	const progressAndTelemetry = new CondaProgressAndTelemetry(progress);
-	let condaEnvPath: string | undefined;
-	out.subscribe(
-		(value) => {
-			const output = splitLines(value.out).join('\r\n');
-			traceLog(output.trimEnd());
-			if (output.includes(CONDA_ENV_CREATED_MARKER) || output.includes(CONDA_ENV_EXISTING_MARKER)) {
-				condaEnvPath = getCondaEnvFromOutput(output);
-			}
-			progressAndTelemetry.process(output);
-		},
-		async (error) => {
-			traceError('Error while running conda env creation script: ', error);
-			deferred.reject(error);
-		},
-		() => {
-			dispose();
-			if (proc?.exitCode !== 0) {
-				traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
-				deferred.reject(
-					progressAndTelemetry.getLastError() || `Conda env creation failed with exitCode: ${proc?.exitCode}`,
-				);
-			} else {
-				deferred.resolve(condaEnvPath);
-			}
-		},
-	);
-	return deferred.promise;
+    const progressAndTelemetry = new CondaProgressAndTelemetry(progress);
+    let condaEnvPath: string | undefined;
+    out.subscribe(
+        (value) => {
+            const output = splitLines(value.out).join('\r\n');
+            traceLog(output.trimEnd());
+            if (output.includes(CONDA_ENV_CREATED_MARKER) || output.includes(CONDA_ENV_EXISTING_MARKER)) {
+                condaEnvPath = getCondaEnvFromOutput(output);
+            }
+            progressAndTelemetry.process(output);
+        },
+        async (error) => {
+            traceError('Error while running conda env creation script: ', error);
+            deferred.reject(error);
+        },
+        () => {
+            dispose();
+            if (proc?.exitCode !== 0) {
+                traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
+                deferred.reject(
+                    progressAndTelemetry.getLastError() || `Conda env creation failed with exitCode: ${proc?.exitCode}`,
+                );
+            } else {
+                deferred.resolve(condaEnvPath);
+            }
+        },
+    );
+    return deferred.promise;
 }
 
 function getExecutableCommand(condaBaseEnvPath: string): string {
-	if (getOSType() === OSType.Windows) {
-		// Both Miniconda3 and Anaconda3 have the following structure:
-		// Miniconda3 (or Anaconda3)
-		//  |- python.exe     <--- this is the python that we want.
-		return path.join(condaBaseEnvPath, 'python.exe');
-	}
-	// On non-windows machines:
-	// miniconda (or miniforge or anaconda3)
-	// |- bin
-	//     |- python   <--- this is the python that we want.
-	return path.join(condaBaseEnvPath, 'bin', 'python');
+    if (getOSType() === OSType.Windows) {
+        // Both Miniconda3 and Anaconda3 have the following structure:
+        // Miniconda3 (or Anaconda3)
+        //  |- python.exe     <--- this is the python that we want.
+        return path.join(condaBaseEnvPath, 'python.exe');
+    }
+    // On non-windows machines:
+    // miniconda (or miniforge or anaconda3)
+    // |- bin
+    //     |- python   <--- this is the python that we want.
+    return path.join(condaBaseEnvPath, 'bin', 'python');
 }
 
 async function createEnvironment(
-	// --- Start Positron ---
-	options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+    // --- Start Positron ---
+    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
 ): Promise<CreateEnvironmentResult | undefined> {
-	// --- End Positron ---
-	const conda = await getCondaBaseEnv();
-	if (!conda) {
-		return undefined;
-	}
+    // --- End Positron ---
+    const conda = await getCondaBaseEnv();
+    if (!conda) {
+        return undefined;
+    }
 
-	let workspace: WorkspaceFolder | undefined;
-	const workspaceStep = new MultiStepNode(
-		undefined,
-		async (context?: MultiStepAction) => {
-			try {
-				workspace = (await pickWorkspaceFolder(undefined, context)) as WorkspaceFolder | undefined;
-			} catch (ex) {
-				if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-					return ex;
-				}
-				throw ex;
-			}
+    let workspace: WorkspaceFolder | undefined;
+    const workspaceStep = new MultiStepNode(
+        undefined,
+        async (context?: MultiStepAction) => {
+            try {
+                workspace = (await pickWorkspaceFolder(undefined, context)) as WorkspaceFolder | undefined;
+            } catch (ex) {
+                if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                    return ex;
+                }
+                throw ex;
+            }
 
-			if (workspace === undefined) {
-				traceError('Workspace was not selected or found for creating conda environment.');
-				return MultiStepAction.Cancel;
-			}
-			traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating conda environment.`);
-			return MultiStepAction.Continue;
-		},
-		undefined,
-	);
+            if (workspace === undefined) {
+                traceError('Workspace was not selected or found for creating conda environment.');
+                return MultiStepAction.Cancel;
+            }
+            traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating conda environment.`);
+            return MultiStepAction.Continue;
+        },
+        undefined,
+    );
 
-	let existingCondaAction: ExistingCondaAction | undefined;
-	const existingEnvStep = new MultiStepNode(
-		workspaceStep,
-		async (context?: MultiStepAction) => {
-			if (workspace && context === MultiStepAction.Continue) {
-				try {
-					existingCondaAction = await pickExistingCondaAction(workspace);
-					return MultiStepAction.Continue;
-				} catch (ex) {
-					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-						return ex;
-					}
-					throw ex;
-				}
-			} else if (context === MultiStepAction.Back) {
-				return MultiStepAction.Back;
-			}
-			return MultiStepAction.Continue;
-		},
-		undefined,
-	);
-	workspaceStep.next = existingEnvStep;
+    let existingCondaAction: ExistingCondaAction | undefined;
+    const existingEnvStep = new MultiStepNode(
+        workspaceStep,
+        async (context?: MultiStepAction) => {
+            if (workspace && context === MultiStepAction.Continue) {
+                try {
+                    existingCondaAction = await pickExistingCondaAction(workspace);
+                    return MultiStepAction.Continue;
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
+                    }
+                    throw ex;
+                }
+            } else if (context === MultiStepAction.Back) {
+                return MultiStepAction.Back;
+            }
+            return MultiStepAction.Continue;
+        },
+        undefined,
+    );
+    workspaceStep.next = existingEnvStep;
 
-	let version: string | undefined;
-	const versionStep = new MultiStepNode(
-		workspaceStep,
-		async (context) => {
-			// --- Start Positron ---
-			if (existingCondaAction === ExistingCondaAction.Create && options?.condaPythonVersion) {
-				version = options.condaPythonVersion;
-			} else if (
-				// --- End Positron ---
-				existingCondaAction === ExistingCondaAction.Recreate ||
-				existingCondaAction === ExistingCondaAction.Create
-			) {
-				try {
-					version = await pickPythonVersion();
-				} catch (ex) {
-					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-						return ex;
-					}
-					throw ex;
-				}
-				if (version === undefined) {
-					traceError('Python version was not selected for creating conda environment.');
-					return MultiStepAction.Cancel;
-				}
-				traceInfo(`Selected Python version ${version} for creating conda environment.`);
-			} else if (existingCondaAction === ExistingCondaAction.UseExisting) {
-				if (context === MultiStepAction.Back) {
-					return MultiStepAction.Back;
-				}
-			}
+    let version: string | undefined;
+    const versionStep = new MultiStepNode(
+        workspaceStep,
+        async (context) => {
+            // --- Start Positron ---
+            if (existingCondaAction === ExistingCondaAction.Create && options?.condaPythonVersion) {
+                version = options.condaPythonVersion;
+            } else if (
+                // --- End Positron ---
+                existingCondaAction === ExistingCondaAction.Recreate ||
+                existingCondaAction === ExistingCondaAction.Create
+            ) {
+                try {
+                    version = await pickPythonVersion();
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
+                    }
+                    throw ex;
+                }
+                if (version === undefined) {
+                    traceError('Python version was not selected for creating conda environment.');
+                    return MultiStepAction.Cancel;
+                }
+                traceInfo(`Selected Python version ${version} for creating conda environment.`);
+            } else if (existingCondaAction === ExistingCondaAction.UseExisting) {
+                if (context === MultiStepAction.Back) {
+                    return MultiStepAction.Back;
+                }
+            }
 
-			return MultiStepAction.Continue;
-		},
-		undefined,
-	);
-	existingEnvStep.next = versionStep;
+            return MultiStepAction.Continue;
+        },
+        undefined,
+    );
+    existingEnvStep.next = versionStep;
 
-	const action = await MultiStepNode.run(workspaceStep);
-	if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-		throw action;
-	}
+    const action = await MultiStepNode.run(workspaceStep);
+    if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+        throw action;
+    }
 
-	if (workspace) {
-		if (existingCondaAction === ExistingCondaAction.Recreate) {
-			sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-				environmentType: 'conda',
-				status: 'triggered',
-			});
-			if (await deleteEnvironment(workspace, getExecutableCommand(conda))) {
-				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-					environmentType: 'conda',
-					status: 'deleted',
-				});
-			} else {
-				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-					environmentType: 'conda',
-					status: 'failed',
-				});
-				throw MultiStepAction.Cancel;
-			}
-		} else if (existingCondaAction === ExistingCondaAction.UseExisting) {
-			sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
-				environmentType: 'conda',
-			});
-			return { path: getPrefixCondaEnvPath(workspace), workspaceFolder: workspace };
-		}
-	}
+    if (workspace) {
+        if (existingCondaAction === ExistingCondaAction.Recreate) {
+            sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                environmentType: 'conda',
+                status: 'triggered',
+            });
+            if (await deleteEnvironment(workspace, getExecutableCommand(conda))) {
+                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                    environmentType: 'conda',
+                    status: 'deleted',
+                });
+            } else {
+                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                    environmentType: 'conda',
+                    status: 'failed',
+                });
+                throw MultiStepAction.Cancel;
+            }
+        } else if (existingCondaAction === ExistingCondaAction.UseExisting) {
+            sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
+                environmentType: 'conda',
+            });
+            return { path: getPrefixCondaEnvPath(workspace), workspaceFolder: workspace };
+        }
+    }
 
-	const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
-		progress.report({
-			message: CreateEnv.statusStarting,
-		});
+    const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
+        progress.report({
+            message: CreateEnv.statusStarting,
+        });
 
-		let envPath: string | undefined;
-		try {
-			sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
-				environmentType: 'conda',
-				pythonVersion: version,
-			});
-			if (workspace) {
-				envPath = await createCondaEnv(
-					workspace,
-					getExecutableCommand(conda),
-					generateCommandArgs(version, options),
-					progress,
-					token,
-				);
+        let envPath: string | undefined;
+        try {
+            sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
+                environmentType: 'conda',
+                pythonVersion: version,
+            });
+            if (workspace) {
+                envPath = await createCondaEnv(
+                    workspace,
+                    getExecutableCommand(conda),
+                    generateCommandArgs(version, options),
+                    progress,
+                    token,
+                );
 
-				if (envPath) {
-					return { path: envPath, workspaceFolder: workspace };
-				}
+                if (envPath) {
+                    return { path: envPath, workspaceFolder: workspace };
+                }
 
-				throw new Error('Failed to create conda environment. See Output > Python for more info.');
-			} else {
-				throw new Error('A workspace is needed to create conda environment');
-			}
-		} catch (ex) {
-			traceError(ex);
-			showErrorMessageWithLogs(CreateEnv.Conda.errorCreatingEnvironment);
-			return { error: ex as Error };
-		}
-	};
+                throw new Error('Failed to create conda environment. See Output > Python for more info.');
+            } else {
+                throw new Error('A workspace is needed to create conda environment');
+            }
+        } catch (ex) {
+            traceError(ex);
+            showErrorMessageWithLogs(CreateEnv.Conda.errorCreatingEnvironment);
+            return { error: ex as Error };
+        }
+    };
 
-	if (!shouldDisplayEnvCreationProgress()) {
-		const token = new CancellationTokenSource();
-		try {
-			return await createEnvInternal({ report: noop }, token.token);
-		} finally {
-			token.dispose();
-		}
-	}
+    if (!shouldDisplayEnvCreationProgress()) {
+        const token = new CancellationTokenSource();
+        try {
+            return await createEnvInternal({ report: noop }, token.token);
+        } finally {
+            token.dispose();
+        }
+    }
 
-	return withProgress(
-		{
-			location: ProgressLocation.Notification,
-			title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
-			cancellable: true,
-		},
-		async (
-			progress: CreateEnvironmentProgress,
-			token: CancellationToken,
-		): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
-	);
+    return withProgress(
+        {
+            location: ProgressLocation.Notification,
+            title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
+            cancellable: true,
+        },
+        async (
+            progress: CreateEnvironmentProgress,
+            token: CancellationToken,
+        ): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
+    );
 }
 
 // --- Start Positron ---
@@ -342,16 +345,16 @@ export const CONDA_PROVIDER_ID = `${PVSC_EXTENSION_ID}:conda`;
 // --- End Positron ---
 
 export function condaCreationProvider(): CreateEnvironmentProvider {
-	return {
-		createEnvironment,
-		name: 'Conda',
+    return {
+        createEnvironment,
+        name: 'Conda',
 
-		description: CreateEnv.Conda.providerDescription,
+        description: CreateEnv.Conda.providerDescription,
 
-		// --- Start Positron ---
-		id: CONDA_PROVIDER_ID,
-		// --- End Positron ---
+        // --- Start Positron ---
+        id: CONDA_PROVIDER_ID,
+        // --- End Positron ---
 
-		tools: ['Conda'],
-	};
+        tools: ['Conda'],
+    };
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -40,7 +40,9 @@ import { noop } from '../../../common/utils/misc';
 
 function generateCommandArgs(
     version?: string,
+    // --- Start Positron ---
     options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+    // --- End Positron ---
 ): string[] {
     let addGitIgnore = true;
     let installPackages = true;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -13,322 +13,328 @@ import { getOSType, OSType } from '../../../common/utils/platform';
 import { createCondaScript } from '../../../common/process/internal/scripts';
 import { Common, CreateEnv } from '../../../common/utils/localize';
 import {
-    ExistingCondaAction,
-    deleteEnvironment,
-    getCondaBaseEnv,
-    getPathEnvVariableForConda,
-    pickExistingCondaAction,
-    pickPythonVersion,
+	ExistingCondaAction,
+	deleteEnvironment,
+	getCondaBaseEnv,
+	getPathEnvVariableForConda,
+	pickExistingCondaAction,
+	pickPythonVersion,
 } from './condaUtils';
 import { getPrefixCondaEnvPath, showErrorMessageWithLogs } from '../common/commonUtils';
 import { MultiStepAction, MultiStepNode, withProgress } from '../../../common/vscodeApis/windowApis';
 import { EventName } from '../../../telemetry/constants';
 import { sendTelemetryEvent } from '../../../telemetry';
 import {
-    CondaProgressAndTelemetry,
-    CONDA_ENV_CREATED_MARKER,
-    CONDA_ENV_EXISTING_MARKER,
+	CondaProgressAndTelemetry,
+	CONDA_ENV_CREATED_MARKER,
+	CONDA_ENV_EXISTING_MARKER,
 } from './condaProgressAndTelemetry';
 import { splitLines } from '../../../common/stringUtils';
 import {
-    CreateEnvironmentOptions,
-    CreateEnvironmentResult,
-    CreateEnvironmentProvider,
+	CreateEnvironmentOptions,
+	CreateEnvironmentResult,
+	CreateEnvironmentProvider,
 } from '../proposed.createEnvApis';
 import { shouldDisplayEnvCreationProgress } from './hideEnvCreation';
 import { noop } from '../../../common/utils/misc';
 
-function generateCommandArgs(version?: string, options?: CreateEnvironmentOptions): string[] {
-    let addGitIgnore = true;
-    let installPackages = true;
-    if (options) {
-        addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
-        installPackages = options?.installPackages !== undefined ? options.installPackages : true;
-    }
+function generateCommandArgs(version?: string, options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal): string[] {
+	let addGitIgnore = true;
+	let installPackages = true;
+	if (options) {
+		addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
+		installPackages = options?.installPackages !== undefined ? options.installPackages : true;
+	}
 
-    const command: string[] = [createCondaScript()];
+	const command: string[] = [createCondaScript()];
 
-    if (addGitIgnore) {
-        command.push('--git-ignore');
-    }
+	if (addGitIgnore) {
+		command.push('--git-ignore');
+	}
 
-    if (installPackages) {
-        command.push('--install');
-    }
+	if (installPackages) {
+		command.push('--install');
+	}
 
-    if (version) {
-        command.push('--python');
-        command.push(version);
-    }
+	if (version) {
+		command.push('--python');
+		command.push(version);
+	}
 
-    return command;
+	// --- Start Positron ---
+	if (options?.envName) {
+		command.push('--name', options.envName);
+	}
+	// --- End Positron ---
+
+	return command;
 }
 
 function getCondaEnvFromOutput(output: string): string | undefined {
-    try {
-        const envPath = output
-            .split(/\r?\n/g)
-            .map((s) => s.trim())
-            .filter((s) => s.startsWith(CONDA_ENV_CREATED_MARKER) || s.startsWith(CONDA_ENV_EXISTING_MARKER))[0];
-        if (envPath.includes(CONDA_ENV_CREATED_MARKER)) {
-            return envPath.substring(CONDA_ENV_CREATED_MARKER.length);
-        }
-        return envPath.substring(CONDA_ENV_EXISTING_MARKER.length);
-    } catch (ex) {
-        traceError('Parsing out environment path failed.');
-        return undefined;
-    }
+	try {
+		const envPath = output
+			.split(/\r?\n/g)
+			.map((s) => s.trim())
+			.filter((s) => s.startsWith(CONDA_ENV_CREATED_MARKER) || s.startsWith(CONDA_ENV_EXISTING_MARKER))[0];
+		if (envPath.includes(CONDA_ENV_CREATED_MARKER)) {
+			return envPath.substring(CONDA_ENV_CREATED_MARKER.length);
+		}
+		return envPath.substring(CONDA_ENV_EXISTING_MARKER.length);
+	} catch (ex) {
+		traceError('Parsing out environment path failed.');
+		return undefined;
+	}
 }
 
 async function createCondaEnv(
-    workspace: WorkspaceFolder,
-    command: string,
-    args: string[],
-    progress: CreateEnvironmentProgress,
-    token?: CancellationToken,
+	workspace: WorkspaceFolder,
+	command: string,
+	args: string[],
+	progress: CreateEnvironmentProgress,
+	token?: CancellationToken,
 ): Promise<string> {
-    progress.report({
-        message: CreateEnv.Conda.creating,
-    });
+	progress.report({
+		message: CreateEnv.Conda.creating,
+	});
 
-    const deferred = createDeferred<string>();
-    const pathEnv = getPathEnvVariableForConda(command);
-    traceLog('Running Conda Env creation script: ', [command, ...args]);
-    const { proc, out, dispose } = execObservable(command, args, {
-        mergeStdOutErr: true,
-        token,
-        cwd: workspace.uri.fsPath,
-        env: {
-            PATH: pathEnv,
-            // --- Start Positron ---
-            PW_TEST: process.env.PW_TEST,
-            // --- End Positron ---
-        },
-    });
+	const deferred = createDeferred<string>();
+	const pathEnv = getPathEnvVariableForConda(command);
+	traceLog('Running Conda Env creation script: ', [command, ...args]);
+	const { proc, out, dispose } = execObservable(command, args, {
+		mergeStdOutErr: true,
+		token,
+		cwd: workspace.uri.fsPath,
+		env: {
+			PATH: pathEnv,
+			// --- Start Positron ---
+			PW_TEST: process.env.PW_TEST,
+			// --- End Positron ---
+		},
+	});
 
-    const progressAndTelemetry = new CondaProgressAndTelemetry(progress);
-    let condaEnvPath: string | undefined;
-    out.subscribe(
-        (value) => {
-            const output = splitLines(value.out).join('\r\n');
-            traceLog(output.trimEnd());
-            if (output.includes(CONDA_ENV_CREATED_MARKER) || output.includes(CONDA_ENV_EXISTING_MARKER)) {
-                condaEnvPath = getCondaEnvFromOutput(output);
-            }
-            progressAndTelemetry.process(output);
-        },
-        async (error) => {
-            traceError('Error while running conda env creation script: ', error);
-            deferred.reject(error);
-        },
-        () => {
-            dispose();
-            if (proc?.exitCode !== 0) {
-                traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
-                deferred.reject(
-                    progressAndTelemetry.getLastError() || `Conda env creation failed with exitCode: ${proc?.exitCode}`,
-                );
-            } else {
-                deferred.resolve(condaEnvPath);
-            }
-        },
-    );
-    return deferred.promise;
+	const progressAndTelemetry = new CondaProgressAndTelemetry(progress);
+	let condaEnvPath: string | undefined;
+	out.subscribe(
+		(value) => {
+			const output = splitLines(value.out).join('\r\n');
+			traceLog(output.trimEnd());
+			if (output.includes(CONDA_ENV_CREATED_MARKER) || output.includes(CONDA_ENV_EXISTING_MARKER)) {
+				condaEnvPath = getCondaEnvFromOutput(output);
+			}
+			progressAndTelemetry.process(output);
+		},
+		async (error) => {
+			traceError('Error while running conda env creation script: ', error);
+			deferred.reject(error);
+		},
+		() => {
+			dispose();
+			if (proc?.exitCode !== 0) {
+				traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
+				deferred.reject(
+					progressAndTelemetry.getLastError() || `Conda env creation failed with exitCode: ${proc?.exitCode}`,
+				);
+			} else {
+				deferred.resolve(condaEnvPath);
+			}
+		},
+	);
+	return deferred.promise;
 }
 
 function getExecutableCommand(condaBaseEnvPath: string): string {
-    if (getOSType() === OSType.Windows) {
-        // Both Miniconda3 and Anaconda3 have the following structure:
-        // Miniconda3 (or Anaconda3)
-        //  |- python.exe     <--- this is the python that we want.
-        return path.join(condaBaseEnvPath, 'python.exe');
-    }
-    // On non-windows machines:
-    // miniconda (or miniforge or anaconda3)
-    // |- bin
-    //     |- python   <--- this is the python that we want.
-    return path.join(condaBaseEnvPath, 'bin', 'python');
+	if (getOSType() === OSType.Windows) {
+		// Both Miniconda3 and Anaconda3 have the following structure:
+		// Miniconda3 (or Anaconda3)
+		//  |- python.exe     <--- this is the python that we want.
+		return path.join(condaBaseEnvPath, 'python.exe');
+	}
+	// On non-windows machines:
+	// miniconda (or miniforge or anaconda3)
+	// |- bin
+	//     |- python   <--- this is the python that we want.
+	return path.join(condaBaseEnvPath, 'bin', 'python');
 }
 
 async function createEnvironment(
-    // --- Start Positron ---
-    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+	// --- Start Positron ---
+	options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
 ): Promise<CreateEnvironmentResult | undefined> {
-    // --- End Positron ---
-    const conda = await getCondaBaseEnv();
-    if (!conda) {
-        return undefined;
-    }
+	// --- End Positron ---
+	const conda = await getCondaBaseEnv();
+	if (!conda) {
+		return undefined;
+	}
 
-    let workspace: WorkspaceFolder | undefined;
-    const workspaceStep = new MultiStepNode(
-        undefined,
-        async (context?: MultiStepAction) => {
-            try {
-                workspace = (await pickWorkspaceFolder(undefined, context)) as WorkspaceFolder | undefined;
-            } catch (ex) {
-                if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                    return ex;
-                }
-                throw ex;
-            }
+	let workspace: WorkspaceFolder | undefined;
+	const workspaceStep = new MultiStepNode(
+		undefined,
+		async (context?: MultiStepAction) => {
+			try {
+				workspace = (await pickWorkspaceFolder(undefined, context)) as WorkspaceFolder | undefined;
+			} catch (ex) {
+				if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+					return ex;
+				}
+				throw ex;
+			}
 
-            if (workspace === undefined) {
-                traceError('Workspace was not selected or found for creating conda environment.');
-                return MultiStepAction.Cancel;
-            }
-            traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating conda environment.`);
-            return MultiStepAction.Continue;
-        },
-        undefined,
-    );
+			if (workspace === undefined) {
+				traceError('Workspace was not selected or found for creating conda environment.');
+				return MultiStepAction.Cancel;
+			}
+			traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating conda environment.`);
+			return MultiStepAction.Continue;
+		},
+		undefined,
+	);
 
-    let existingCondaAction: ExistingCondaAction | undefined;
-    const existingEnvStep = new MultiStepNode(
-        workspaceStep,
-        async (context?: MultiStepAction) => {
-            if (workspace && context === MultiStepAction.Continue) {
-                try {
-                    existingCondaAction = await pickExistingCondaAction(workspace);
-                    return MultiStepAction.Continue;
-                } catch (ex) {
-                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                        return ex;
-                    }
-                    throw ex;
-                }
-            } else if (context === MultiStepAction.Back) {
-                return MultiStepAction.Back;
-            }
-            return MultiStepAction.Continue;
-        },
-        undefined,
-    );
-    workspaceStep.next = existingEnvStep;
+	let existingCondaAction: ExistingCondaAction | undefined;
+	const existingEnvStep = new MultiStepNode(
+		workspaceStep,
+		async (context?: MultiStepAction) => {
+			if (workspace && context === MultiStepAction.Continue) {
+				try {
+					existingCondaAction = await pickExistingCondaAction(workspace);
+					return MultiStepAction.Continue;
+				} catch (ex) {
+					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+						return ex;
+					}
+					throw ex;
+				}
+			} else if (context === MultiStepAction.Back) {
+				return MultiStepAction.Back;
+			}
+			return MultiStepAction.Continue;
+		},
+		undefined,
+	);
+	workspaceStep.next = existingEnvStep;
 
-    let version: string | undefined;
-    const versionStep = new MultiStepNode(
-        workspaceStep,
-        async (context) => {
-            // --- Start Positron ---
-            if (existingCondaAction === ExistingCondaAction.Create && options?.condaPythonVersion) {
-                version = options.condaPythonVersion;
-            } else if (
-                // --- End Positron ---
-                existingCondaAction === ExistingCondaAction.Recreate ||
-                existingCondaAction === ExistingCondaAction.Create
-            ) {
-                try {
-                    version = await pickPythonVersion();
-                } catch (ex) {
-                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                        return ex;
-                    }
-                    throw ex;
-                }
-                if (version === undefined) {
-                    traceError('Python version was not selected for creating conda environment.');
-                    return MultiStepAction.Cancel;
-                }
-                traceInfo(`Selected Python version ${version} for creating conda environment.`);
-            } else if (existingCondaAction === ExistingCondaAction.UseExisting) {
-                if (context === MultiStepAction.Back) {
-                    return MultiStepAction.Back;
-                }
-            }
+	let version: string | undefined;
+	const versionStep = new MultiStepNode(
+		workspaceStep,
+		async (context) => {
+			// --- Start Positron ---
+			if (existingCondaAction === ExistingCondaAction.Create && options?.condaPythonVersion) {
+				version = options.condaPythonVersion;
+			} else if (
+				// --- End Positron ---
+				existingCondaAction === ExistingCondaAction.Recreate ||
+				existingCondaAction === ExistingCondaAction.Create
+			) {
+				try {
+					version = await pickPythonVersion();
+				} catch (ex) {
+					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+						return ex;
+					}
+					throw ex;
+				}
+				if (version === undefined) {
+					traceError('Python version was not selected for creating conda environment.');
+					return MultiStepAction.Cancel;
+				}
+				traceInfo(`Selected Python version ${version} for creating conda environment.`);
+			} else if (existingCondaAction === ExistingCondaAction.UseExisting) {
+				if (context === MultiStepAction.Back) {
+					return MultiStepAction.Back;
+				}
+			}
 
-            return MultiStepAction.Continue;
-        },
-        undefined,
-    );
-    existingEnvStep.next = versionStep;
+			return MultiStepAction.Continue;
+		},
+		undefined,
+	);
+	existingEnvStep.next = versionStep;
 
-    const action = await MultiStepNode.run(workspaceStep);
-    if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-        throw action;
-    }
+	const action = await MultiStepNode.run(workspaceStep);
+	if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+		throw action;
+	}
 
-    if (workspace) {
-        if (existingCondaAction === ExistingCondaAction.Recreate) {
-            sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                environmentType: 'conda',
-                status: 'triggered',
-            });
-            if (await deleteEnvironment(workspace, getExecutableCommand(conda))) {
-                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                    environmentType: 'conda',
-                    status: 'deleted',
-                });
-            } else {
-                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                    environmentType: 'conda',
-                    status: 'failed',
-                });
-                throw MultiStepAction.Cancel;
-            }
-        } else if (existingCondaAction === ExistingCondaAction.UseExisting) {
-            sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
-                environmentType: 'conda',
-            });
-            return { path: getPrefixCondaEnvPath(workspace), workspaceFolder: workspace };
-        }
-    }
+	if (workspace) {
+		if (existingCondaAction === ExistingCondaAction.Recreate) {
+			sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+				environmentType: 'conda',
+				status: 'triggered',
+			});
+			if (await deleteEnvironment(workspace, getExecutableCommand(conda))) {
+				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+					environmentType: 'conda',
+					status: 'deleted',
+				});
+			} else {
+				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+					environmentType: 'conda',
+					status: 'failed',
+				});
+				throw MultiStepAction.Cancel;
+			}
+		} else if (existingCondaAction === ExistingCondaAction.UseExisting) {
+			sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
+				environmentType: 'conda',
+			});
+			return { path: getPrefixCondaEnvPath(workspace), workspaceFolder: workspace };
+		}
+	}
 
-    const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
-        progress.report({
-            message: CreateEnv.statusStarting,
-        });
+	const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
+		progress.report({
+			message: CreateEnv.statusStarting,
+		});
 
-        let envPath: string | undefined;
-        try {
-            sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
-                environmentType: 'conda',
-                pythonVersion: version,
-            });
-            if (workspace) {
-                envPath = await createCondaEnv(
-                    workspace,
-                    getExecutableCommand(conda),
-                    generateCommandArgs(version, options),
-                    progress,
-                    token,
-                );
+		let envPath: string | undefined;
+		try {
+			sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
+				environmentType: 'conda',
+				pythonVersion: version,
+			});
+			if (workspace) {
+				envPath = await createCondaEnv(
+					workspace,
+					getExecutableCommand(conda),
+					generateCommandArgs(version, options),
+					progress,
+					token,
+				);
 
-                if (envPath) {
-                    return { path: envPath, workspaceFolder: workspace };
-                }
+				if (envPath) {
+					return { path: envPath, workspaceFolder: workspace };
+				}
 
-                throw new Error('Failed to create conda environment. See Output > Python for more info.');
-            } else {
-                throw new Error('A workspace is needed to create conda environment');
-            }
-        } catch (ex) {
-            traceError(ex);
-            showErrorMessageWithLogs(CreateEnv.Conda.errorCreatingEnvironment);
-            return { error: ex as Error };
-        }
-    };
+				throw new Error('Failed to create conda environment. See Output > Python for more info.');
+			} else {
+				throw new Error('A workspace is needed to create conda environment');
+			}
+		} catch (ex) {
+			traceError(ex);
+			showErrorMessageWithLogs(CreateEnv.Conda.errorCreatingEnvironment);
+			return { error: ex as Error };
+		}
+	};
 
-    if (!shouldDisplayEnvCreationProgress()) {
-        const token = new CancellationTokenSource();
-        try {
-            return await createEnvInternal({ report: noop }, token.token);
-        } finally {
-            token.dispose();
-        }
-    }
+	if (!shouldDisplayEnvCreationProgress()) {
+		const token = new CancellationTokenSource();
+		try {
+			return await createEnvInternal({ report: noop }, token.token);
+		} finally {
+			token.dispose();
+		}
+	}
 
-    return withProgress(
-        {
-            location: ProgressLocation.Notification,
-            title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
-            cancellable: true,
-        },
-        async (
-            progress: CreateEnvironmentProgress,
-            token: CancellationToken,
-        ): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
-    );
+	return withProgress(
+		{
+			location: ProgressLocation.Notification,
+			title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
+			cancellable: true,
+		},
+		async (
+			progress: CreateEnvironmentProgress,
+			token: CancellationToken,
+		): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
+	);
 }
 
 // --- Start Positron ---
@@ -336,16 +342,16 @@ export const CONDA_PROVIDER_ID = `${PVSC_EXTENSION_ID}:conda`;
 // --- End Positron ---
 
 export function condaCreationProvider(): CreateEnvironmentProvider {
-    return {
-        createEnvironment,
-        name: 'Conda',
+	return {
+		createEnvironment,
+		name: 'Conda',
 
-        description: CreateEnv.Conda.providerDescription,
+		description: CreateEnv.Conda.providerDescription,
 
-        // --- Start Positron ---
-        id: CONDA_PROVIDER_ID,
-        // --- End Positron ---
+		// --- Start Positron ---
+		id: CONDA_PROVIDER_ID,
+		// --- End Positron ---
 
-        tools: ['Conda'],
-    };
+		tools: ['Conda'],
+	};
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -47,8 +47,9 @@ async function createUvVenv(
         cwd: workspace.uri.fsPath,
     });
 
-    const venvPath = `${workspace.uri.fsPath}${os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
-        }`;
+    const venvPath = `${workspace.uri.fsPath}${
+        os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
+    }`;
 
     out.subscribe(
         (value) => {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -36,10 +36,8 @@ async function createUvVenv(
         message: CreateEnv.Venv.creating,
     });
     const command = 'uv';
-    // --- Start Positron ---
     const targetDir = envName ?? '.venv';
     const argv = ['venv', targetDir, '--no-project', '--seed', '-p', version];
-    // --- End Positron ---
 
     const deferred = createDeferred<string | undefined>();
     traceLog('Running uv venv creation script: ', [command, ...argv]);
@@ -49,11 +47,9 @@ async function createUvVenv(
         cwd: workspace.uri.fsPath,
     });
 
-    // --- Start Positron ---
-    const venvPath = `${workspace.uri.fsPath}${
-        os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
-    }`;
-    // --- End Positron ---
+    const venvPath = `${workspace.uri.fsPath}${os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
+        }`;
+
     out.subscribe(
         (value) => {
             const output = value.out.split(/\r?\n/g).join(os.EOL);
@@ -206,9 +202,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                     throw new Error('Failed to create uv environment. Python version is undefined.');
                 }
 
-                // --- Start Positron ---
                 envPath = await createUvVenv(workspace, version, progress, token, options?.envName);
-                // --- End Positron ---
                 if (envPath) {
                     return { path: envPath, workspaceFolder: workspace };
                 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -16,9 +16,9 @@ import { MultiStepAction, MultiStepNode, withProgress } from '../../../common/vs
 import { getVenvExecutable, showPositronErrorMessageWithLogs } from '../common/commonUtils';
 import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from './venvUtils';
 import {
-    CreateEnvironmentProvider,
-    CreateEnvironmentOptions,
-    CreateEnvironmentResult,
+	CreateEnvironmentProvider,
+	CreateEnvironmentOptions,
+	CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
 import { isUvInstalled } from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
@@ -26,211 +26,218 @@ import { pickPythonVersion } from './uvUtils';
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
 
 async function createUvVenv(
-    workspace: WorkspaceFolder,
-    version: string,
-    progress: CreateEnvironmentProgress,
-    token?: CancellationToken,
+	workspace: WorkspaceFolder,
+	version: string,
+	progress: CreateEnvironmentProgress,
+	token?: CancellationToken,
+	envName?: string,
 ): Promise<string | undefined> {
-    progress.report({
-        message: CreateEnv.Venv.creating,
-    });
-    const command = 'uv';
-    const argv = ['venv', '--no-project', '--seed', '-p', version];
+	progress.report({
+		message: CreateEnv.Venv.creating,
+	});
+	const command = 'uv';
+	// --- Start Positron ---
+	const targetDir = envName ?? '.venv';
+	const argv = ['venv', targetDir, '--no-project', '--seed', '-p', version];
+	// --- End Positron ---
 
-    const deferred = createDeferred<string | undefined>();
-    traceLog('Running uv venv creation script: ', [command, ...argv]);
-    const { proc, out, dispose } = execObservable(command, argv, {
-        mergeStdOutErr: true,
-        token,
-        cwd: workspace.uri.fsPath,
-    });
+	const deferred = createDeferred<string | undefined>();
+	traceLog('Running uv venv creation script: ', [command, ...argv]);
+	const { proc, out, dispose } = execObservable(command, argv, {
+		mergeStdOutErr: true,
+		token,
+		cwd: workspace.uri.fsPath,
+	});
 
-    const venvPath = `${workspace.uri.fsPath}${
-        os.platform() === 'win32' ? '\\.venv\\Scripts\\python.exe' : '/.venv/bin/python'
-    }`;
-    out.subscribe(
-        (value) => {
-            const output = value.out.split(/\r?\n/g).join(os.EOL);
-            traceLog(output.trimEnd());
-        },
-        (error) => {
-            traceError('Error while running venv creation script: ', error);
-            deferred.reject(error);
-        },
-        () => {
-            dispose();
-            if (proc?.exitCode !== 0) {
-                traceError('Error while running uv environment creation script');
-                deferred.reject(`Failed to create virtual environment with exitCode: ${proc?.exitCode}`);
-            } else {
-                deferred.resolve(venvPath);
-            }
-        },
-    );
-    return deferred.promise;
+	// --- Start Positron ---
+	const venvPath = `${workspace.uri.fsPath}${os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
+		}`;
+	// --- End Positron ---
+	out.subscribe(
+		(value) => {
+			const output = value.out.split(/\r?\n/g).join(os.EOL);
+			traceLog(output.trimEnd());
+		},
+		(error) => {
+			traceError('Error while running venv creation script: ', error);
+			deferred.reject(error);
+		},
+		() => {
+			dispose();
+			if (proc?.exitCode !== 0) {
+				traceError('Error while running uv environment creation script');
+				deferred.reject(`Failed to create virtual environment with exitCode: ${proc?.exitCode}`);
+			} else {
+				deferred.resolve(venvPath);
+			}
+		},
+	);
+	return deferred.promise;
 }
 
 export class UvCreationProvider implements CreateEnvironmentProvider {
-    public async createEnvironment(
-        options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-    ): Promise<CreateEnvironmentResult | undefined> {
-        const uvIsInstalled = await isUvInstalled();
-        if (!uvIsInstalled) {
-            traceError('uv is not installed');
-            showPositronErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
-            return undefined;
-        }
+	public async createEnvironment(
+		options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+	): Promise<CreateEnvironmentResult | undefined> {
+		const uvIsInstalled = await isUvInstalled();
+		if (!uvIsInstalled) {
+			traceError('uv is not installed');
+			showPositronErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
+			return undefined;
+		}
 
-        let workspace: WorkspaceFolder | undefined;
-        const workspaceStep = new MultiStepNode(
-            undefined,
-            async (context?: MultiStepAction) => {
-                try {
-                    workspace = (await pickWorkspaceFolder(
-                        { preSelectedWorkspace: options?.workspaceFolder },
-                        context,
-                    )) as WorkspaceFolder | undefined;
-                } catch (ex) {
-                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                        return ex;
-                    }
-                    throw ex;
-                }
+		let workspace: WorkspaceFolder | undefined;
+		const workspaceStep = new MultiStepNode(
+			undefined,
+			async (context?: MultiStepAction) => {
+				try {
+					workspace = (await pickWorkspaceFolder(
+						{ preSelectedWorkspace: options?.workspaceFolder },
+						context,
+					)) as WorkspaceFolder | undefined;
+				} catch (ex) {
+					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+						return ex;
+					}
+					throw ex;
+				}
 
-                if (workspace === undefined) {
-                    traceError('Workspace was not selected or found for creating uv environment.');
-                    return MultiStepAction.Cancel;
-                }
-                traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating uv environment.`);
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
+				if (workspace === undefined) {
+					traceError('Workspace was not selected or found for creating uv environment.');
+					return MultiStepAction.Cancel;
+				}
+				traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating uv environment.`);
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
 
-        let existingVenvAction: ExistingVenvAction | undefined;
-        const existingEnvStep = new MultiStepNode(
-            workspaceStep,
-            async (context?: MultiStepAction) => {
-                if (workspace && context === MultiStepAction.Continue) {
-                    try {
-                        existingVenvAction = await pickExistingVenvAction(workspace);
-                        return MultiStepAction.Continue;
-                    } catch (ex) {
-                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                            return ex;
-                        }
-                        throw ex;
-                    }
-                } else if (context === MultiStepAction.Back) {
-                    return MultiStepAction.Back;
-                }
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
-        workspaceStep.next = existingEnvStep;
+		let existingVenvAction: ExistingVenvAction | undefined;
+		const existingEnvStep = new MultiStepNode(
+			workspaceStep,
+			async (context?: MultiStepAction) => {
+				if (workspace && context === MultiStepAction.Continue) {
+					try {
+						existingVenvAction = await pickExistingVenvAction(workspace);
+						return MultiStepAction.Continue;
+					} catch (ex) {
+						if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+							return ex;
+						}
+						throw ex;
+					}
+				} else if (context === MultiStepAction.Back) {
+					return MultiStepAction.Back;
+				}
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
+		workspaceStep.next = existingEnvStep;
 
-        let version: string | undefined;
-        const versionStep = new MultiStepNode(
-            workspaceStep,
-            async (context) => {
-                if (existingVenvAction === ExistingVenvAction.Create && options?.uvPythonVersion) {
-                    version = options.uvPythonVersion;
-                } else if (
-                    existingVenvAction === ExistingVenvAction.Recreate ||
-                    existingVenvAction === ExistingVenvAction.Create
-                ) {
-                    try {
-                        version = await pickPythonVersion();
-                    } catch (ex) {
-                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                            return ex;
-                        }
-                        throw ex;
-                    }
-                    if (version === undefined) {
-                        traceError('Python version was not selected for creating uv environment.');
-                        return MultiStepAction.Cancel;
-                    }
-                    traceInfo(`Selected Python version ${version} for creating uv environment.`);
-                } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-                    if (context === MultiStepAction.Back) {
-                        return MultiStepAction.Back;
-                    }
-                }
+		let version: string | undefined;
+		const versionStep = new MultiStepNode(
+			workspaceStep,
+			async (context) => {
+				if (existingVenvAction === ExistingVenvAction.Create && options?.uvPythonVersion) {
+					version = options.uvPythonVersion;
+				} else if (
+					existingVenvAction === ExistingVenvAction.Recreate ||
+					existingVenvAction === ExistingVenvAction.Create
+				) {
+					try {
+						version = await pickPythonVersion();
+					} catch (ex) {
+						if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+							return ex;
+						}
+						throw ex;
+					}
+					if (version === undefined) {
+						traceError('Python version was not selected for creating uv environment.');
+						return MultiStepAction.Cancel;
+					}
+					traceInfo(`Selected Python version ${version} for creating uv environment.`);
+				} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+					if (context === MultiStepAction.Back) {
+						return MultiStepAction.Back;
+					}
+				}
 
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
-        existingEnvStep.next = versionStep;
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
+		existingEnvStep.next = versionStep;
 
-        const action = await MultiStepNode.run(workspaceStep);
-        if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-            throw action;
-        }
+		const action = await MultiStepNode.run(workspaceStep);
+		if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+			throw action;
+		}
 
-        if (workspace) {
-            if (existingVenvAction === ExistingVenvAction.Recreate) {
-                traceInfo(`Recreating existing virtual environment in ${workspace.uri.fsPath}`);
-                if (await deleteEnvironment(workspace, undefined)) {
-                    traceInfo(`Deleted existing virtual environment`);
-                } else {
-                    traceError(`Failed to delete existing virtual environment`);
-                    throw MultiStepAction.Cancel;
-                }
-            } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-                traceInfo(`Using existing virtual environment in ${workspace.uri.fsPath}`);
-                return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
-            }
-        }
+		if (workspace) {
+			if (existingVenvAction === ExistingVenvAction.Recreate) {
+				traceInfo(`Recreating existing virtual environment in ${workspace.uri.fsPath}`);
+				if (await deleteEnvironment(workspace, undefined)) {
+					traceInfo(`Deleted existing virtual environment`);
+				} else {
+					traceError(`Failed to delete existing virtual environment`);
+					throw MultiStepAction.Cancel;
+				}
+			} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+				traceInfo(`Using existing virtual environment in ${workspace.uri.fsPath}`);
+				return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
+			}
+		}
 
-        const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
-            progress.report({
-                message: CreateEnv.statusStarting,
-            });
+		const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
+			progress.report({
+				message: CreateEnv.statusStarting,
+			});
 
-            let envPath: string | undefined;
-            try {
-                if (!workspace) {
-                    throw new Error('Failed to create uv environment. Workspace is undefined.');
-                }
+			let envPath: string | undefined;
+			try {
+				if (!workspace) {
+					throw new Error('Failed to create uv environment. Workspace is undefined.');
+				}
 
-                if (!version) {
-                    throw new Error('Failed to create uv environment. Python version is undefined.');
-                }
+				if (!version) {
+					throw new Error('Failed to create uv environment. Python version is undefined.');
+				}
 
-                envPath = await createUvVenv(workspace, version, progress, token);
-                if (envPath) {
-                    return { path: envPath, workspaceFolder: workspace };
-                }
+				// --- Start Positron ---
+				envPath = await createUvVenv(workspace, version, progress, token, options?.envName);
+				// --- End Positron ---
+				if (envPath) {
+					return { path: envPath, workspaceFolder: workspace };
+				}
 
-                throw new Error('Failed to create uv environment. See Output > Python for more info.');
-            } catch (ex) {
-                traceError(ex);
-                showPositronErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
-                return { error: ex as Error };
-            }
-        };
+				throw new Error('Failed to create uv environment. See Output > Python for more info.');
+			} catch (ex) {
+				traceError(ex);
+				showPositronErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
+				return { error: ex as Error };
+			}
+		};
 
-        return withProgress(
-            {
-                location: ProgressLocation.Notification,
-                title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
-                cancellable: true,
-            },
-            async (
-                progress: CreateEnvironmentProgress,
-                token: CancellationToken,
-            ): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
-        );
-    }
+		return withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
+				cancellable: true,
+			},
+			async (
+				progress: CreateEnvironmentProgress,
+				token: CancellationToken,
+			): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
+		);
+	}
 
-    name = 'uv';
+	name = 'uv';
 
-    description: string = CreateEnv.Uv.providerDescription;
+	description: string = CreateEnv.Uv.providerDescription;
 
-    id = UV_PROVIDER_ID;
+	id = UV_PROVIDER_ID;
 
-    tools = ['uv'];
+	tools = ['uv'];
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -154,7 +154,7 @@ async function createVenv(
                 traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
                 deferred.reject(
                     progressAndTelemetry.getLastError() ||
-                    `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
+                        `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
                 );
             } else {
                 deferred.resolve(venvPath);
@@ -166,7 +166,7 @@ async function createVenv(
 
 export const VenvCreationProviderId = `${PVSC_EXTENSION_ID}:venv`;
 export class VenvCreationProvider implements CreateEnvironmentProvider {
-    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) { }
+    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) {}
 
     public async createEnvironment(
         options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
@@ -181,9 +181,9 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                         workspace && bypassQuickPicks
                             ? workspace
                             : ((await pickWorkspaceFolder(
-                                { preSelectedWorkspace: options?.workspaceFolder },
-                                context,
-                            )) as WorkspaceFolder | undefined);
+                                  { preSelectedWorkspace: options?.workspaceFolder },
+                                  context,
+                              )) as WorkspaceFolder | undefined);
                 } catch (ex) {
                     if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
                         return ex;
@@ -245,24 +245,24 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                 interpreter && bypassQuickPicks
                                     ? interpreter
                                     : await this.interpreterQuickPick.getInterpreterViaQuickPick(
-                                        workspace.uri,
-                                        (i: PythonEnvironment) =>
-                                            [
-                                                EnvironmentType.System,
-                                                EnvironmentType.MicrosoftStore,
-                                                EnvironmentType.Global,
-                                                EnvironmentType.Pyenv,
-                                                // --- Start Positron ---
-                                                EnvironmentType.Custom,
-                                                // --- End Positron ---
-                                            ].includes(i.envType) && i.type === undefined, // only global intepreters
-                                        {
-                                            skipRecommended: true,
-                                            showBackButton: true,
-                                            placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
-                                            title: null,
-                                        },
-                                    );
+                                          workspace.uri,
+                                          (i: PythonEnvironment) =>
+                                              [
+                                                  EnvironmentType.System,
+                                                  EnvironmentType.MicrosoftStore,
+                                                  EnvironmentType.Global,
+                                                  EnvironmentType.Pyenv,
+                                                  // --- Start Positron ---
+                                                  EnvironmentType.Custom,
+                                                  // --- End Positron ---
+                                              ].includes(i.envType) && i.type === undefined, // only global intepreters
+                                          {
+                                              skipRecommended: true,
+                                              showBackButton: true,
+                                              placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
+                                              title: null,
+                                          },
+                                      );
                         } catch (ex) {
                             if (ex === InputFlowAction.back) {
                                 return MultiStepAction.Back;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -19,386 +19,390 @@ import { EventName } from '../../../telemetry/constants';
 import { VenvProgressAndTelemetry, VENV_CREATED_MARKER, VENV_EXISTING_MARKER } from './venvProgressAndTelemetry';
 import { getVenvExecutable, showErrorMessageWithLogs } from '../common/commonUtils';
 import {
-	ExistingVenvAction,
-	IPackageInstallSelection,
-	deleteEnvironment,
-	pickExistingVenvAction,
-	pickPackagesToInstall,
+    ExistingVenvAction,
+    IPackageInstallSelection,
+    deleteEnvironment,
+    pickExistingVenvAction,
+    pickPackagesToInstall,
 } from './venvUtils';
 import { InputFlowAction } from '../../../common/utils/multiStepInput';
 import {
-	CreateEnvironmentProvider,
-	CreateEnvironmentOptions,
-	CreateEnvironmentResult,
+    CreateEnvironmentProvider,
+    CreateEnvironmentOptions,
+    CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
 import { shouldDisplayEnvCreationProgress } from './hideEnvCreation';
 import { noop } from '../../../common/utils/misc';
 
 interface IVenvCommandArgs {
-	argv: string[];
-	stdin: string | undefined;
+    argv: string[];
+    stdin: string | undefined;
 }
 
-function generateCommandArgs(installInfo?: IPackageInstallSelection[], addGitIgnore?: boolean, envName?: string): IVenvCommandArgs {
-	const command: string[] = [createVenvScript()];
-	let stdin: string | undefined;
+function generateCommandArgs(
+    installInfo?: IPackageInstallSelection[],
+    addGitIgnore?: boolean,
+    envName?: string,
+): IVenvCommandArgs {
+    const command: string[] = [createVenvScript()];
+    let stdin: string | undefined;
 
-	if (addGitIgnore) {
-		command.push('--git-ignore');
-	}
+    if (addGitIgnore) {
+        command.push('--git-ignore');
+    }
 
-	// --- Start Positron ---
-	if (envName) {
-		command.push('--name', envName);
-	}
-	// --- End Positron ---
+    // --- Start Positron ---
+    if (envName) {
+        command.push('--name', envName);
+    }
+    // --- End Positron ---
 
-	if (installInfo) {
-		if (installInfo.some((i) => i.installType === 'toml')) {
-			const source = installInfo.find((i) => i.installType === 'toml')?.source;
-			command.push('--toml', source?.fileToCommandArgumentForPythonExt() || 'pyproject.toml');
-		}
-		const extras = installInfo.filter((i) => i.installType === 'toml').map((i) => i.installItem);
-		extras.forEach((r) => {
-			if (r) {
-				command.push('--extras', r);
-			}
-		});
+    if (installInfo) {
+        if (installInfo.some((i) => i.installType === 'toml')) {
+            const source = installInfo.find((i) => i.installType === 'toml')?.source;
+            command.push('--toml', source?.fileToCommandArgumentForPythonExt() || 'pyproject.toml');
+        }
+        const extras = installInfo.filter((i) => i.installType === 'toml').map((i) => i.installItem);
+        extras.forEach((r) => {
+            if (r) {
+                command.push('--extras', r);
+            }
+        });
 
-		const requirements = installInfo.filter((i) => i.installType === 'requirements').map((i) => i.installItem);
+        const requirements = installInfo.filter((i) => i.installType === 'requirements').map((i) => i.installItem);
 
-		if (requirements.length < 10) {
-			requirements.forEach((r) => {
-				if (r) {
-					command.push('--requirements', r);
-				}
-			});
-		} else {
-			command.push('--stdin');
-			// Too many requirements can cause the command line to be too long error.
-			stdin = JSON.stringify({ requirements });
-		}
-	}
+        if (requirements.length < 10) {
+            requirements.forEach((r) => {
+                if (r) {
+                    command.push('--requirements', r);
+                }
+            });
+        } else {
+            command.push('--stdin');
+            // Too many requirements can cause the command line to be too long error.
+            stdin = JSON.stringify({ requirements });
+        }
+    }
 
-	return { argv: command, stdin };
+    return { argv: command, stdin };
 }
 
 function getVenvFromOutput(output: string): string | undefined {
-	try {
-		const envPath = output
-			.split(/\r?\n/g)
-			.map((s) => s.trim())
-			.filter((s) => s.startsWith(VENV_CREATED_MARKER) || s.startsWith(VENV_EXISTING_MARKER))[0];
-		if (envPath.includes(VENV_CREATED_MARKER)) {
-			return envPath.substring(VENV_CREATED_MARKER.length);
-		}
-		return envPath.substring(VENV_EXISTING_MARKER.length);
-	} catch (ex) {
-		traceError('Parsing out environment path failed.');
-		return undefined;
-	}
+    try {
+        const envPath = output
+            .split(/\r?\n/g)
+            .map((s) => s.trim())
+            .filter((s) => s.startsWith(VENV_CREATED_MARKER) || s.startsWith(VENV_EXISTING_MARKER))[0];
+        if (envPath.includes(VENV_CREATED_MARKER)) {
+            return envPath.substring(VENV_CREATED_MARKER.length);
+        }
+        return envPath.substring(VENV_EXISTING_MARKER.length);
+    } catch (ex) {
+        traceError('Parsing out environment path failed.');
+        return undefined;
+    }
 }
 
 async function createVenv(
-	workspace: WorkspaceFolder,
-	command: string,
-	args: IVenvCommandArgs,
-	progress: CreateEnvironmentProgress,
-	token?: CancellationToken,
+    workspace: WorkspaceFolder,
+    command: string,
+    args: IVenvCommandArgs,
+    progress: CreateEnvironmentProgress,
+    token?: CancellationToken,
 ): Promise<string | undefined> {
-	progress.report({
-		message: CreateEnv.Venv.creating,
-	});
-	sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
-		environmentType: 'venv',
-		pythonVersion: undefined,
-	});
+    progress.report({
+        message: CreateEnv.Venv.creating,
+    });
+    sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
+        environmentType: 'venv',
+        pythonVersion: undefined,
+    });
 
-	const deferred = createDeferred<string | undefined>();
-	traceLog('Running Env creation script: ', [command, ...args.argv]);
-	if (args.stdin) {
-		traceLog('Requirements passed in via stdin: ', args.stdin);
-	}
-	const { proc, out, dispose } = execObservable(command, args.argv, {
-		mergeStdOutErr: true,
-		token,
-		cwd: workspace.uri.fsPath,
-		stdinStr: args.stdin,
-	});
+    const deferred = createDeferred<string | undefined>();
+    traceLog('Running Env creation script: ', [command, ...args.argv]);
+    if (args.stdin) {
+        traceLog('Requirements passed in via stdin: ', args.stdin);
+    }
+    const { proc, out, dispose } = execObservable(command, args.argv, {
+        mergeStdOutErr: true,
+        token,
+        cwd: workspace.uri.fsPath,
+        stdinStr: args.stdin,
+    });
 
-	const progressAndTelemetry = new VenvProgressAndTelemetry(progress);
-	let venvPath: string | undefined;
-	out.subscribe(
-		(value) => {
-			const output = value.out.split(/\r?\n/g).join(os.EOL);
-			traceLog(output.trimEnd());
-			if (output.includes(VENV_CREATED_MARKER) || output.includes(VENV_EXISTING_MARKER)) {
-				venvPath = getVenvFromOutput(output);
-			}
-			progressAndTelemetry.process(output);
-		},
-		(error) => {
-			traceError('Error while running venv creation script: ', error);
-			deferred.reject(error);
-		},
-		() => {
-			dispose();
-			if (proc?.exitCode !== 0) {
-				traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
-				deferred.reject(
-					progressAndTelemetry.getLastError() ||
-					`Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
-				);
-			} else {
-				deferred.resolve(venvPath);
-			}
-		},
-	);
-	return deferred.promise;
+    const progressAndTelemetry = new VenvProgressAndTelemetry(progress);
+    let venvPath: string | undefined;
+    out.subscribe(
+        (value) => {
+            const output = value.out.split(/\r?\n/g).join(os.EOL);
+            traceLog(output.trimEnd());
+            if (output.includes(VENV_CREATED_MARKER) || output.includes(VENV_EXISTING_MARKER)) {
+                venvPath = getVenvFromOutput(output);
+            }
+            progressAndTelemetry.process(output);
+        },
+        (error) => {
+            traceError('Error while running venv creation script: ', error);
+            deferred.reject(error);
+        },
+        () => {
+            dispose();
+            if (proc?.exitCode !== 0) {
+                traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
+                deferred.reject(
+                    progressAndTelemetry.getLastError() ||
+                        `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
+                );
+            } else {
+                deferred.resolve(venvPath);
+            }
+        },
+    );
+    return deferred.promise;
 }
 
 export const VenvCreationProviderId = `${PVSC_EXTENSION_ID}:venv`;
 export class VenvCreationProvider implements CreateEnvironmentProvider {
-	constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) { }
+    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) {}
 
-	public async createEnvironment(
-		options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-	): Promise<CreateEnvironmentResult | undefined> {
-		let workspace = options?.workspaceFolder;
-		const bypassQuickPicks = options?.workspaceFolder && options.interpreter && options.providerId ? true : false;
-		const workspaceStep = new MultiStepNode(
-			undefined,
-			async (context?: MultiStepAction) => {
-				try {
-					workspace =
-						workspace && bypassQuickPicks
-							? workspace
-							: ((await pickWorkspaceFolder(
-								{ preSelectedWorkspace: options?.workspaceFolder },
-								context,
-							)) as WorkspaceFolder | undefined);
-				} catch (ex) {
-					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-						return ex;
-					}
-					throw ex;
-				}
+    public async createEnvironment(
+        options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+    ): Promise<CreateEnvironmentResult | undefined> {
+        let workspace = options?.workspaceFolder;
+        const bypassQuickPicks = options?.workspaceFolder && options.interpreter && options.providerId ? true : false;
+        const workspaceStep = new MultiStepNode(
+            undefined,
+            async (context?: MultiStepAction) => {
+                try {
+                    workspace =
+                        workspace && bypassQuickPicks
+                            ? workspace
+                            : ((await pickWorkspaceFolder(
+                                  { preSelectedWorkspace: options?.workspaceFolder },
+                                  context,
+                              )) as WorkspaceFolder | undefined);
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
+                    }
+                    throw ex;
+                }
 
-				if (workspace === undefined) {
-					traceError('Workspace was not selected or found for creating virtual environment.');
-					return MultiStepAction.Cancel;
-				}
-				traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating virtual environment.`);
-				return MultiStepAction.Continue;
-			},
-			undefined,
-		);
+                if (workspace === undefined) {
+                    traceError('Workspace was not selected or found for creating virtual environment.');
+                    return MultiStepAction.Cancel;
+                }
+                traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating virtual environment.`);
+                return MultiStepAction.Continue;
+            },
+            undefined,
+        );
 
-		let existingVenvAction: ExistingVenvAction | undefined;
-		if (bypassQuickPicks) {
-			existingVenvAction = ExistingVenvAction.Create;
-		}
-		const existingEnvStep = new MultiStepNode(
-			workspaceStep,
-			async (context?: MultiStepAction) => {
-				if (workspace && context === MultiStepAction.Continue) {
-					try {
-						existingVenvAction = await pickExistingVenvAction(workspace);
-						return MultiStepAction.Continue;
-					} catch (ex) {
-						if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-							return ex;
-						}
-						throw ex;
-					}
-				} else if (context === MultiStepAction.Back) {
-					return MultiStepAction.Back;
-				}
-				return MultiStepAction.Continue;
-			},
-			undefined,
-		);
-		workspaceStep.next = existingEnvStep;
+        let existingVenvAction: ExistingVenvAction | undefined;
+        if (bypassQuickPicks) {
+            existingVenvAction = ExistingVenvAction.Create;
+        }
+        const existingEnvStep = new MultiStepNode(
+            workspaceStep,
+            async (context?: MultiStepAction) => {
+                if (workspace && context === MultiStepAction.Continue) {
+                    try {
+                        existingVenvAction = await pickExistingVenvAction(workspace);
+                        return MultiStepAction.Continue;
+                    } catch (ex) {
+                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                            return ex;
+                        }
+                        throw ex;
+                    }
+                } else if (context === MultiStepAction.Back) {
+                    return MultiStepAction.Back;
+                }
+                return MultiStepAction.Continue;
+            },
+            undefined,
+        );
+        workspaceStep.next = existingEnvStep;
 
-		let interpreter = options?.interpreter;
-		const interpreterStep = new MultiStepNode(
-			existingEnvStep,
-			async (context?: MultiStepAction) => {
-				if (workspace) {
-					// --- Start Positron ---
-					if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
-						interpreter = options.interpreterPath;
-					} else if (
-						// --- End Positron ---
-						existingVenvAction === ExistingVenvAction.Recreate ||
-						existingVenvAction === ExistingVenvAction.Create
-					) {
-						try {
-							interpreter =
-								interpreter && bypassQuickPicks
-									? interpreter
-									: await this.interpreterQuickPick.getInterpreterViaQuickPick(
-										workspace.uri,
-										(i: PythonEnvironment) =>
-											[
-												EnvironmentType.System,
-												EnvironmentType.MicrosoftStore,
-												EnvironmentType.Global,
-												EnvironmentType.Pyenv,
-												// --- Start Positron ---
-												EnvironmentType.Custom,
-												// --- End Positron ---
-											].includes(i.envType) && i.type === undefined, // only global intepreters
-										{
-											skipRecommended: true,
-											showBackButton: true,
-											placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
-											title: null,
-										},
-									);
-						} catch (ex) {
-							if (ex === InputFlowAction.back) {
-								return MultiStepAction.Back;
-							}
-							interpreter = undefined;
-						}
-					} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-						if (context === MultiStepAction.Back) {
-							return MultiStepAction.Back;
-						}
-						interpreter = getVenvExecutable(workspace);
-					}
-				}
+        let interpreter = options?.interpreter;
+        const interpreterStep = new MultiStepNode(
+            existingEnvStep,
+            async (context?: MultiStepAction) => {
+                if (workspace) {
+                    // --- Start Positron ---
+                    if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
+                        interpreter = options.interpreterPath;
+                    } else if (
+                        // --- End Positron ---
+                        existingVenvAction === ExistingVenvAction.Recreate ||
+                        existingVenvAction === ExistingVenvAction.Create
+                    ) {
+                        try {
+                            interpreter =
+                                interpreter && bypassQuickPicks
+                                    ? interpreter
+                                    : await this.interpreterQuickPick.getInterpreterViaQuickPick(
+                                          workspace.uri,
+                                          (i: PythonEnvironment) =>
+                                              [
+                                                  EnvironmentType.System,
+                                                  EnvironmentType.MicrosoftStore,
+                                                  EnvironmentType.Global,
+                                                  EnvironmentType.Pyenv,
+                                                  // --- Start Positron ---
+                                                  EnvironmentType.Custom,
+                                                  // --- End Positron ---
+                                              ].includes(i.envType) && i.type === undefined, // only global intepreters
+                                          {
+                                              skipRecommended: true,
+                                              showBackButton: true,
+                                              placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
+                                              title: null,
+                                          },
+                                      );
+                        } catch (ex) {
+                            if (ex === InputFlowAction.back) {
+                                return MultiStepAction.Back;
+                            }
+                            interpreter = undefined;
+                        }
+                    } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+                        if (context === MultiStepAction.Back) {
+                            return MultiStepAction.Back;
+                        }
+                        interpreter = getVenvExecutable(workspace);
+                    }
+                }
 
-				if (!interpreter) {
-					traceError('Virtual env creation requires an interpreter.');
-					return MultiStepAction.Cancel;
-				}
-				traceInfo(`Selected interpreter ${interpreter} for creating virtual environment.`);
-				return MultiStepAction.Continue;
-			},
-			undefined,
-		);
-		existingEnvStep.next = interpreterStep;
+                if (!interpreter) {
+                    traceError('Virtual env creation requires an interpreter.');
+                    return MultiStepAction.Cancel;
+                }
+                traceInfo(`Selected interpreter ${interpreter} for creating virtual environment.`);
+                return MultiStepAction.Continue;
+            },
+            undefined,
+        );
+        existingEnvStep.next = interpreterStep;
 
-		let addGitIgnore = true;
-		let installPackages = true;
-		if (options) {
-			addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
-			installPackages = options?.installPackages !== undefined ? options.installPackages : true;
-		}
-		let installInfo: IPackageInstallSelection[] | undefined;
-		const packagesStep = new MultiStepNode(
-			interpreterStep,
-			async (context?: MultiStepAction) => {
-				if (workspace && installPackages) {
-					if (existingVenvAction !== ExistingVenvAction.UseExisting) {
-						try {
-							installInfo = await pickPackagesToInstall(workspace);
-						} catch (ex) {
-							if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-								return ex;
-							}
-							throw ex;
-						}
-						if (!installInfo) {
-							traceVerbose('Virtual env creation exited during dependencies selection.');
-							return MultiStepAction.Cancel;
-						}
-					} else if (context === MultiStepAction.Back) {
-						return MultiStepAction.Back;
-					}
-				}
+        let addGitIgnore = true;
+        let installPackages = true;
+        if (options) {
+            addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
+            installPackages = options?.installPackages !== undefined ? options.installPackages : true;
+        }
+        let installInfo: IPackageInstallSelection[] | undefined;
+        const packagesStep = new MultiStepNode(
+            interpreterStep,
+            async (context?: MultiStepAction) => {
+                if (workspace && installPackages) {
+                    if (existingVenvAction !== ExistingVenvAction.UseExisting) {
+                        try {
+                            installInfo = await pickPackagesToInstall(workspace);
+                        } catch (ex) {
+                            if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                                return ex;
+                            }
+                            throw ex;
+                        }
+                        if (!installInfo) {
+                            traceVerbose('Virtual env creation exited during dependencies selection.');
+                            return MultiStepAction.Cancel;
+                        }
+                    } else if (context === MultiStepAction.Back) {
+                        return MultiStepAction.Back;
+                    }
+                }
 
-				return MultiStepAction.Continue;
-			},
-			undefined,
-		);
-		interpreterStep.next = packagesStep;
+                return MultiStepAction.Continue;
+            },
+            undefined,
+        );
+        interpreterStep.next = packagesStep;
 
-		const action = await MultiStepNode.run(workspaceStep);
-		if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-			throw action;
-		}
+        const action = await MultiStepNode.run(workspaceStep);
+        if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+            throw action;
+        }
 
-		if (workspace) {
-			if (existingVenvAction === ExistingVenvAction.Recreate) {
-				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-					environmentType: 'venv',
-					status: 'triggered',
-				});
-				if (await deleteEnvironment(workspace, interpreter)) {
-					sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-						environmentType: 'venv',
-						status: 'deleted',
-					});
-				} else {
-					sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-						environmentType: 'venv',
-						status: 'failed',
-					});
-					throw MultiStepAction.Cancel;
-				}
-			} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-				sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
-					environmentType: 'venv',
-				});
-				return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
-			}
-		}
+        if (workspace) {
+            if (existingVenvAction === ExistingVenvAction.Recreate) {
+                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                    environmentType: 'venv',
+                    status: 'triggered',
+                });
+                if (await deleteEnvironment(workspace, interpreter)) {
+                    sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                        environmentType: 'venv',
+                        status: 'deleted',
+                    });
+                } else {
+                    sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+                        environmentType: 'venv',
+                        status: 'failed',
+                    });
+                    throw MultiStepAction.Cancel;
+                }
+            } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+                sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
+                    environmentType: 'venv',
+                });
+                return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
+            }
+        }
 
-		// --- Start Positron ---
-		const args = generateCommandArgs(installInfo, addGitIgnore, options?.envName);
-		// --- End Positron ---
-		const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
-			progress.report({
-				message: CreateEnv.statusStarting,
-			});
+        // --- Start Positron ---
+        const args = generateCommandArgs(installInfo, addGitIgnore, options?.envName);
+        // --- End Positron ---
+        const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
+            progress.report({
+                message: CreateEnv.statusStarting,
+            });
 
-			let envPath: string | undefined;
-			try {
-				if (interpreter && workspace) {
-					envPath = await createVenv(workspace, interpreter, args, progress, token);
-					if (envPath) {
-						return { path: envPath, workspaceFolder: workspace };
-					}
-					throw new Error('Failed to create virtual environment. See Output > Python for more info.');
-				}
-				throw new Error('Failed to create virtual environment. Either interpreter or workspace is undefined.');
-			} catch (ex) {
-				traceError(ex);
-				showErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
-				return { error: ex as Error };
-			}
-		};
+            let envPath: string | undefined;
+            try {
+                if (interpreter && workspace) {
+                    envPath = await createVenv(workspace, interpreter, args, progress, token);
+                    if (envPath) {
+                        return { path: envPath, workspaceFolder: workspace };
+                    }
+                    throw new Error('Failed to create virtual environment. See Output > Python for more info.');
+                }
+                throw new Error('Failed to create virtual environment. Either interpreter or workspace is undefined.');
+            } catch (ex) {
+                traceError(ex);
+                showErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
+                return { error: ex as Error };
+            }
+        };
 
-		if (!shouldDisplayEnvCreationProgress()) {
-			const token = new CancellationTokenSource();
-			try {
-				return await createEnvInternal({ report: noop }, token.token);
-			} finally {
-				token.dispose();
-			}
-		}
+        if (!shouldDisplayEnvCreationProgress()) {
+            const token = new CancellationTokenSource();
+            try {
+                return await createEnvInternal({ report: noop }, token.token);
+            } finally {
+                token.dispose();
+            }
+        }
 
-		return withProgress(
-			{
-				location: ProgressLocation.Notification,
-				title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
-				cancellable: true,
-			},
-			async (
-				progress: CreateEnvironmentProgress,
-				token: CancellationToken,
-			): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
-		);
-	}
+        return withProgress(
+            {
+                location: ProgressLocation.Notification,
+                title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
+                cancellable: true,
+            },
+            async (
+                progress: CreateEnvironmentProgress,
+                token: CancellationToken,
+            ): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
+        );
+    }
 
-	name = 'Venv';
+    name = 'Venv';
 
-	description: string = CreateEnv.Venv.providerDescription;
+    description: string = CreateEnv.Venv.providerDescription;
 
-	id = VenvCreationProviderId;
+    id = VenvCreationProviderId;
 
-	tools = ['Venv'];
+    tools = ['Venv'];
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -39,10 +39,13 @@ interface IVenvCommandArgs {
     stdin: string | undefined;
 }
 
+// --- Start Positron ---
 function generateCommandArgs(
     installInfo?: IPackageInstallSelection[],
     addGitIgnore?: boolean,
+    // custom venv naming
     envName?: string,
+    // --- End Positron ---
 ): IVenvCommandArgs {
     const command: string[] = [createVenvScript()];
     let stdin: string | undefined;
@@ -151,7 +154,7 @@ async function createVenv(
                 traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
                 deferred.reject(
                     progressAndTelemetry.getLastError() ||
-                        `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
+                    `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
                 );
             } else {
                 deferred.resolve(venvPath);
@@ -163,7 +166,7 @@ async function createVenv(
 
 export const VenvCreationProviderId = `${PVSC_EXTENSION_ID}:venv`;
 export class VenvCreationProvider implements CreateEnvironmentProvider {
-    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) {}
+    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) { }
 
     public async createEnvironment(
         options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
@@ -178,9 +181,9 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                         workspace && bypassQuickPicks
                             ? workspace
                             : ((await pickWorkspaceFolder(
-                                  { preSelectedWorkspace: options?.workspaceFolder },
-                                  context,
-                              )) as WorkspaceFolder | undefined);
+                                { preSelectedWorkspace: options?.workspaceFolder },
+                                context,
+                            )) as WorkspaceFolder | undefined);
                 } catch (ex) {
                     if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
                         return ex;
@@ -242,24 +245,24 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                                 interpreter && bypassQuickPicks
                                     ? interpreter
                                     : await this.interpreterQuickPick.getInterpreterViaQuickPick(
-                                          workspace.uri,
-                                          (i: PythonEnvironment) =>
-                                              [
-                                                  EnvironmentType.System,
-                                                  EnvironmentType.MicrosoftStore,
-                                                  EnvironmentType.Global,
-                                                  EnvironmentType.Pyenv,
-                                                  // --- Start Positron ---
-                                                  EnvironmentType.Custom,
-                                                  // --- End Positron ---
-                                              ].includes(i.envType) && i.type === undefined, // only global intepreters
-                                          {
-                                              skipRecommended: true,
-                                              showBackButton: true,
-                                              placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
-                                              title: null,
-                                          },
-                                      );
+                                        workspace.uri,
+                                        (i: PythonEnvironment) =>
+                                            [
+                                                EnvironmentType.System,
+                                                EnvironmentType.MicrosoftStore,
+                                                EnvironmentType.Global,
+                                                EnvironmentType.Pyenv,
+                                                // --- Start Positron ---
+                                                EnvironmentType.Custom,
+                                                // --- End Positron ---
+                                            ].includes(i.envType) && i.type === undefined, // only global intepreters
+                                        {
+                                            skipRecommended: true,
+                                            showBackButton: true,
+                                            placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
+                                            title: null,
+                                        },
+                                    );
                         } catch (ex) {
                             if (ex === InputFlowAction.back) {
                                 return MultiStepAction.Back;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -19,378 +19,386 @@ import { EventName } from '../../../telemetry/constants';
 import { VenvProgressAndTelemetry, VENV_CREATED_MARKER, VENV_EXISTING_MARKER } from './venvProgressAndTelemetry';
 import { getVenvExecutable, showErrorMessageWithLogs } from '../common/commonUtils';
 import {
-    ExistingVenvAction,
-    IPackageInstallSelection,
-    deleteEnvironment,
-    pickExistingVenvAction,
-    pickPackagesToInstall,
+	ExistingVenvAction,
+	IPackageInstallSelection,
+	deleteEnvironment,
+	pickExistingVenvAction,
+	pickPackagesToInstall,
 } from './venvUtils';
 import { InputFlowAction } from '../../../common/utils/multiStepInput';
 import {
-    CreateEnvironmentProvider,
-    CreateEnvironmentOptions,
-    CreateEnvironmentResult,
+	CreateEnvironmentProvider,
+	CreateEnvironmentOptions,
+	CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
 import { shouldDisplayEnvCreationProgress } from './hideEnvCreation';
 import { noop } from '../../../common/utils/misc';
 
 interface IVenvCommandArgs {
-    argv: string[];
-    stdin: string | undefined;
+	argv: string[];
+	stdin: string | undefined;
 }
 
-function generateCommandArgs(installInfo?: IPackageInstallSelection[], addGitIgnore?: boolean): IVenvCommandArgs {
-    const command: string[] = [createVenvScript()];
-    let stdin: string | undefined;
+function generateCommandArgs(installInfo?: IPackageInstallSelection[], addGitIgnore?: boolean, envName?: string): IVenvCommandArgs {
+	const command: string[] = [createVenvScript()];
+	let stdin: string | undefined;
 
-    if (addGitIgnore) {
-        command.push('--git-ignore');
-    }
+	if (addGitIgnore) {
+		command.push('--git-ignore');
+	}
 
-    if (installInfo) {
-        if (installInfo.some((i) => i.installType === 'toml')) {
-            const source = installInfo.find((i) => i.installType === 'toml')?.source;
-            command.push('--toml', source?.fileToCommandArgumentForPythonExt() || 'pyproject.toml');
-        }
-        const extras = installInfo.filter((i) => i.installType === 'toml').map((i) => i.installItem);
-        extras.forEach((r) => {
-            if (r) {
-                command.push('--extras', r);
-            }
-        });
+	// --- Start Positron ---
+	if (envName) {
+		command.push('--name', envName);
+	}
+	// --- End Positron ---
 
-        const requirements = installInfo.filter((i) => i.installType === 'requirements').map((i) => i.installItem);
+	if (installInfo) {
+		if (installInfo.some((i) => i.installType === 'toml')) {
+			const source = installInfo.find((i) => i.installType === 'toml')?.source;
+			command.push('--toml', source?.fileToCommandArgumentForPythonExt() || 'pyproject.toml');
+		}
+		const extras = installInfo.filter((i) => i.installType === 'toml').map((i) => i.installItem);
+		extras.forEach((r) => {
+			if (r) {
+				command.push('--extras', r);
+			}
+		});
 
-        if (requirements.length < 10) {
-            requirements.forEach((r) => {
-                if (r) {
-                    command.push('--requirements', r);
-                }
-            });
-        } else {
-            command.push('--stdin');
-            // Too many requirements can cause the command line to be too long error.
-            stdin = JSON.stringify({ requirements });
-        }
-    }
+		const requirements = installInfo.filter((i) => i.installType === 'requirements').map((i) => i.installItem);
 
-    return { argv: command, stdin };
+		if (requirements.length < 10) {
+			requirements.forEach((r) => {
+				if (r) {
+					command.push('--requirements', r);
+				}
+			});
+		} else {
+			command.push('--stdin');
+			// Too many requirements can cause the command line to be too long error.
+			stdin = JSON.stringify({ requirements });
+		}
+	}
+
+	return { argv: command, stdin };
 }
 
 function getVenvFromOutput(output: string): string | undefined {
-    try {
-        const envPath = output
-            .split(/\r?\n/g)
-            .map((s) => s.trim())
-            .filter((s) => s.startsWith(VENV_CREATED_MARKER) || s.startsWith(VENV_EXISTING_MARKER))[0];
-        if (envPath.includes(VENV_CREATED_MARKER)) {
-            return envPath.substring(VENV_CREATED_MARKER.length);
-        }
-        return envPath.substring(VENV_EXISTING_MARKER.length);
-    } catch (ex) {
-        traceError('Parsing out environment path failed.');
-        return undefined;
-    }
+	try {
+		const envPath = output
+			.split(/\r?\n/g)
+			.map((s) => s.trim())
+			.filter((s) => s.startsWith(VENV_CREATED_MARKER) || s.startsWith(VENV_EXISTING_MARKER))[0];
+		if (envPath.includes(VENV_CREATED_MARKER)) {
+			return envPath.substring(VENV_CREATED_MARKER.length);
+		}
+		return envPath.substring(VENV_EXISTING_MARKER.length);
+	} catch (ex) {
+		traceError('Parsing out environment path failed.');
+		return undefined;
+	}
 }
 
 async function createVenv(
-    workspace: WorkspaceFolder,
-    command: string,
-    args: IVenvCommandArgs,
-    progress: CreateEnvironmentProgress,
-    token?: CancellationToken,
+	workspace: WorkspaceFolder,
+	command: string,
+	args: IVenvCommandArgs,
+	progress: CreateEnvironmentProgress,
+	token?: CancellationToken,
 ): Promise<string | undefined> {
-    progress.report({
-        message: CreateEnv.Venv.creating,
-    });
-    sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
-        environmentType: 'venv',
-        pythonVersion: undefined,
-    });
+	progress.report({
+		message: CreateEnv.Venv.creating,
+	});
+	sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {
+		environmentType: 'venv',
+		pythonVersion: undefined,
+	});
 
-    const deferred = createDeferred<string | undefined>();
-    traceLog('Running Env creation script: ', [command, ...args.argv]);
-    if (args.stdin) {
-        traceLog('Requirements passed in via stdin: ', args.stdin);
-    }
-    const { proc, out, dispose } = execObservable(command, args.argv, {
-        mergeStdOutErr: true,
-        token,
-        cwd: workspace.uri.fsPath,
-        stdinStr: args.stdin,
-    });
+	const deferred = createDeferred<string | undefined>();
+	traceLog('Running Env creation script: ', [command, ...args.argv]);
+	if (args.stdin) {
+		traceLog('Requirements passed in via stdin: ', args.stdin);
+	}
+	const { proc, out, dispose } = execObservable(command, args.argv, {
+		mergeStdOutErr: true,
+		token,
+		cwd: workspace.uri.fsPath,
+		stdinStr: args.stdin,
+	});
 
-    const progressAndTelemetry = new VenvProgressAndTelemetry(progress);
-    let venvPath: string | undefined;
-    out.subscribe(
-        (value) => {
-            const output = value.out.split(/\r?\n/g).join(os.EOL);
-            traceLog(output.trimEnd());
-            if (output.includes(VENV_CREATED_MARKER) || output.includes(VENV_EXISTING_MARKER)) {
-                venvPath = getVenvFromOutput(output);
-            }
-            progressAndTelemetry.process(output);
-        },
-        (error) => {
-            traceError('Error while running venv creation script: ', error);
-            deferred.reject(error);
-        },
-        () => {
-            dispose();
-            if (proc?.exitCode !== 0) {
-                traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
-                deferred.reject(
-                    progressAndTelemetry.getLastError() ||
-                        `Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
-                );
-            } else {
-                deferred.resolve(venvPath);
-            }
-        },
-    );
-    return deferred.promise;
+	const progressAndTelemetry = new VenvProgressAndTelemetry(progress);
+	let venvPath: string | undefined;
+	out.subscribe(
+		(value) => {
+			const output = value.out.split(/\r?\n/g).join(os.EOL);
+			traceLog(output.trimEnd());
+			if (output.includes(VENV_CREATED_MARKER) || output.includes(VENV_EXISTING_MARKER)) {
+				venvPath = getVenvFromOutput(output);
+			}
+			progressAndTelemetry.process(output);
+		},
+		(error) => {
+			traceError('Error while running venv creation script: ', error);
+			deferred.reject(error);
+		},
+		() => {
+			dispose();
+			if (proc?.exitCode !== 0) {
+				traceError('Error while running venv creation script: ', progressAndTelemetry.getLastError());
+				deferred.reject(
+					progressAndTelemetry.getLastError() ||
+					`Failed to create virtual environment with exitCode: ${proc?.exitCode}`,
+				);
+			} else {
+				deferred.resolve(venvPath);
+			}
+		},
+	);
+	return deferred.promise;
 }
 
 export const VenvCreationProviderId = `${PVSC_EXTENSION_ID}:venv`;
 export class VenvCreationProvider implements CreateEnvironmentProvider {
-    constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) {}
+	constructor(private readonly interpreterQuickPick: IInterpreterQuickPick) { }
 
-    public async createEnvironment(
-        options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-    ): Promise<CreateEnvironmentResult | undefined> {
-        let workspace = options?.workspaceFolder;
-        const bypassQuickPicks = options?.workspaceFolder && options.interpreter && options.providerId ? true : false;
-        const workspaceStep = new MultiStepNode(
-            undefined,
-            async (context?: MultiStepAction) => {
-                try {
-                    workspace =
-                        workspace && bypassQuickPicks
-                            ? workspace
-                            : ((await pickWorkspaceFolder(
-                                  { preSelectedWorkspace: options?.workspaceFolder },
-                                  context,
-                              )) as WorkspaceFolder | undefined);
-                } catch (ex) {
-                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                        return ex;
-                    }
-                    throw ex;
-                }
+	public async createEnvironment(
+		options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+	): Promise<CreateEnvironmentResult | undefined> {
+		let workspace = options?.workspaceFolder;
+		const bypassQuickPicks = options?.workspaceFolder && options.interpreter && options.providerId ? true : false;
+		const workspaceStep = new MultiStepNode(
+			undefined,
+			async (context?: MultiStepAction) => {
+				try {
+					workspace =
+						workspace && bypassQuickPicks
+							? workspace
+							: ((await pickWorkspaceFolder(
+								{ preSelectedWorkspace: options?.workspaceFolder },
+								context,
+							)) as WorkspaceFolder | undefined);
+				} catch (ex) {
+					if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+						return ex;
+					}
+					throw ex;
+				}
 
-                if (workspace === undefined) {
-                    traceError('Workspace was not selected or found for creating virtual environment.');
-                    return MultiStepAction.Cancel;
-                }
-                traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating virtual environment.`);
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
+				if (workspace === undefined) {
+					traceError('Workspace was not selected or found for creating virtual environment.');
+					return MultiStepAction.Cancel;
+				}
+				traceInfo(`Selected workspace ${workspace.uri.fsPath} for creating virtual environment.`);
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
 
-        let existingVenvAction: ExistingVenvAction | undefined;
-        if (bypassQuickPicks) {
-            existingVenvAction = ExistingVenvAction.Create;
-        }
-        const existingEnvStep = new MultiStepNode(
-            workspaceStep,
-            async (context?: MultiStepAction) => {
-                if (workspace && context === MultiStepAction.Continue) {
-                    try {
-                        existingVenvAction = await pickExistingVenvAction(workspace);
-                        return MultiStepAction.Continue;
-                    } catch (ex) {
-                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                            return ex;
-                        }
-                        throw ex;
-                    }
-                } else if (context === MultiStepAction.Back) {
-                    return MultiStepAction.Back;
-                }
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
-        workspaceStep.next = existingEnvStep;
+		let existingVenvAction: ExistingVenvAction | undefined;
+		if (bypassQuickPicks) {
+			existingVenvAction = ExistingVenvAction.Create;
+		}
+		const existingEnvStep = new MultiStepNode(
+			workspaceStep,
+			async (context?: MultiStepAction) => {
+				if (workspace && context === MultiStepAction.Continue) {
+					try {
+						existingVenvAction = await pickExistingVenvAction(workspace);
+						return MultiStepAction.Continue;
+					} catch (ex) {
+						if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+							return ex;
+						}
+						throw ex;
+					}
+				} else if (context === MultiStepAction.Back) {
+					return MultiStepAction.Back;
+				}
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
+		workspaceStep.next = existingEnvStep;
 
-        let interpreter = options?.interpreter;
-        const interpreterStep = new MultiStepNode(
-            existingEnvStep,
-            async (context?: MultiStepAction) => {
-                if (workspace) {
-                    // --- Start Positron ---
-                    if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
-                        interpreter = options.interpreterPath;
-                    } else if (
-                        // --- End Positron ---
-                        existingVenvAction === ExistingVenvAction.Recreate ||
-                        existingVenvAction === ExistingVenvAction.Create
-                    ) {
-                        try {
-                            interpreter =
-                                interpreter && bypassQuickPicks
-                                    ? interpreter
-                                    : await this.interpreterQuickPick.getInterpreterViaQuickPick(
-                                          workspace.uri,
-                                          (i: PythonEnvironment) =>
-                                              [
-                                                  EnvironmentType.System,
-                                                  EnvironmentType.MicrosoftStore,
-                                                  EnvironmentType.Global,
-                                                  EnvironmentType.Pyenv,
-                                                  // --- Start Positron ---
-                                                  EnvironmentType.Custom,
-                                                  // --- End Positron ---
-                                              ].includes(i.envType) && i.type === undefined, // only global intepreters
-                                          {
-                                              skipRecommended: true,
-                                              showBackButton: true,
-                                              placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
-                                              title: null,
-                                          },
-                                      );
-                        } catch (ex) {
-                            if (ex === InputFlowAction.back) {
-                                return MultiStepAction.Back;
-                            }
-                            interpreter = undefined;
-                        }
-                    } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-                        if (context === MultiStepAction.Back) {
-                            return MultiStepAction.Back;
-                        }
-                        interpreter = getVenvExecutable(workspace);
-                    }
-                }
+		let interpreter = options?.interpreter;
+		const interpreterStep = new MultiStepNode(
+			existingEnvStep,
+			async (context?: MultiStepAction) => {
+				if (workspace) {
+					// --- Start Positron ---
+					if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
+						interpreter = options.interpreterPath;
+					} else if (
+						// --- End Positron ---
+						existingVenvAction === ExistingVenvAction.Recreate ||
+						existingVenvAction === ExistingVenvAction.Create
+					) {
+						try {
+							interpreter =
+								interpreter && bypassQuickPicks
+									? interpreter
+									: await this.interpreterQuickPick.getInterpreterViaQuickPick(
+										workspace.uri,
+										(i: PythonEnvironment) =>
+											[
+												EnvironmentType.System,
+												EnvironmentType.MicrosoftStore,
+												EnvironmentType.Global,
+												EnvironmentType.Pyenv,
+												// --- Start Positron ---
+												EnvironmentType.Custom,
+												// --- End Positron ---
+											].includes(i.envType) && i.type === undefined, // only global intepreters
+										{
+											skipRecommended: true,
+											showBackButton: true,
+											placeholder: CreateEnv.Venv.selectPythonPlaceHolder,
+											title: null,
+										},
+									);
+						} catch (ex) {
+							if (ex === InputFlowAction.back) {
+								return MultiStepAction.Back;
+							}
+							interpreter = undefined;
+						}
+					} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+						if (context === MultiStepAction.Back) {
+							return MultiStepAction.Back;
+						}
+						interpreter = getVenvExecutable(workspace);
+					}
+				}
 
-                if (!interpreter) {
-                    traceError('Virtual env creation requires an interpreter.');
-                    return MultiStepAction.Cancel;
-                }
-                traceInfo(`Selected interpreter ${interpreter} for creating virtual environment.`);
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
-        existingEnvStep.next = interpreterStep;
+				if (!interpreter) {
+					traceError('Virtual env creation requires an interpreter.');
+					return MultiStepAction.Cancel;
+				}
+				traceInfo(`Selected interpreter ${interpreter} for creating virtual environment.`);
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
+		existingEnvStep.next = interpreterStep;
 
-        let addGitIgnore = true;
-        let installPackages = true;
-        if (options) {
-            addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
-            installPackages = options?.installPackages !== undefined ? options.installPackages : true;
-        }
-        let installInfo: IPackageInstallSelection[] | undefined;
-        const packagesStep = new MultiStepNode(
-            interpreterStep,
-            async (context?: MultiStepAction) => {
-                if (workspace && installPackages) {
-                    if (existingVenvAction !== ExistingVenvAction.UseExisting) {
-                        try {
-                            installInfo = await pickPackagesToInstall(workspace);
-                        } catch (ex) {
-                            if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                                return ex;
-                            }
-                            throw ex;
-                        }
-                        if (!installInfo) {
-                            traceVerbose('Virtual env creation exited during dependencies selection.');
-                            return MultiStepAction.Cancel;
-                        }
-                    } else if (context === MultiStepAction.Back) {
-                        return MultiStepAction.Back;
-                    }
-                }
+		let addGitIgnore = true;
+		let installPackages = true;
+		if (options) {
+			addGitIgnore = options?.ignoreSourceControl !== undefined ? options.ignoreSourceControl : true;
+			installPackages = options?.installPackages !== undefined ? options.installPackages : true;
+		}
+		let installInfo: IPackageInstallSelection[] | undefined;
+		const packagesStep = new MultiStepNode(
+			interpreterStep,
+			async (context?: MultiStepAction) => {
+				if (workspace && installPackages) {
+					if (existingVenvAction !== ExistingVenvAction.UseExisting) {
+						try {
+							installInfo = await pickPackagesToInstall(workspace);
+						} catch (ex) {
+							if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+								return ex;
+							}
+							throw ex;
+						}
+						if (!installInfo) {
+							traceVerbose('Virtual env creation exited during dependencies selection.');
+							return MultiStepAction.Cancel;
+						}
+					} else if (context === MultiStepAction.Back) {
+						return MultiStepAction.Back;
+					}
+				}
 
-                return MultiStepAction.Continue;
-            },
-            undefined,
-        );
-        interpreterStep.next = packagesStep;
+				return MultiStepAction.Continue;
+			},
+			undefined,
+		);
+		interpreterStep.next = packagesStep;
 
-        const action = await MultiStepNode.run(workspaceStep);
-        if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
-            throw action;
-        }
+		const action = await MultiStepNode.run(workspaceStep);
+		if (action === MultiStepAction.Back || action === MultiStepAction.Cancel) {
+			throw action;
+		}
 
-        if (workspace) {
-            if (existingVenvAction === ExistingVenvAction.Recreate) {
-                sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                    environmentType: 'venv',
-                    status: 'triggered',
-                });
-                if (await deleteEnvironment(workspace, interpreter)) {
-                    sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                        environmentType: 'venv',
-                        status: 'deleted',
-                    });
-                } else {
-                    sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
-                        environmentType: 'venv',
-                        status: 'failed',
-                    });
-                    throw MultiStepAction.Cancel;
-                }
-            } else if (existingVenvAction === ExistingVenvAction.UseExisting) {
-                sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
-                    environmentType: 'venv',
-                });
-                return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
-            }
-        }
+		if (workspace) {
+			if (existingVenvAction === ExistingVenvAction.Recreate) {
+				sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+					environmentType: 'venv',
+					status: 'triggered',
+				});
+				if (await deleteEnvironment(workspace, interpreter)) {
+					sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+						environmentType: 'venv',
+						status: 'deleted',
+					});
+				} else {
+					sendTelemetryEvent(EventName.ENVIRONMENT_DELETE, undefined, {
+						environmentType: 'venv',
+						status: 'failed',
+					});
+					throw MultiStepAction.Cancel;
+				}
+			} else if (existingVenvAction === ExistingVenvAction.UseExisting) {
+				sendTelemetryEvent(EventName.ENVIRONMENT_REUSE, undefined, {
+					environmentType: 'venv',
+				});
+				return { path: getVenvExecutable(workspace), workspaceFolder: workspace };
+			}
+		}
 
-        const args = generateCommandArgs(installInfo, addGitIgnore);
-        const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
-            progress.report({
-                message: CreateEnv.statusStarting,
-            });
+		// --- Start Positron ---
+		const args = generateCommandArgs(installInfo, addGitIgnore, options?.envName);
+		// --- End Positron ---
+		const createEnvInternal = async (progress: CreateEnvironmentProgress, token: CancellationToken) => {
+			progress.report({
+				message: CreateEnv.statusStarting,
+			});
 
-            let envPath: string | undefined;
-            try {
-                if (interpreter && workspace) {
-                    envPath = await createVenv(workspace, interpreter, args, progress, token);
-                    if (envPath) {
-                        return { path: envPath, workspaceFolder: workspace };
-                    }
-                    throw new Error('Failed to create virtual environment. See Output > Python for more info.');
-                }
-                throw new Error('Failed to create virtual environment. Either interpreter or workspace is undefined.');
-            } catch (ex) {
-                traceError(ex);
-                showErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
-                return { error: ex as Error };
-            }
-        };
+			let envPath: string | undefined;
+			try {
+				if (interpreter && workspace) {
+					envPath = await createVenv(workspace, interpreter, args, progress, token);
+					if (envPath) {
+						return { path: envPath, workspaceFolder: workspace };
+					}
+					throw new Error('Failed to create virtual environment. See Output > Python for more info.');
+				}
+				throw new Error('Failed to create virtual environment. Either interpreter or workspace is undefined.');
+			} catch (ex) {
+				traceError(ex);
+				showErrorMessageWithLogs(CreateEnv.Venv.errorCreatingEnvironment);
+				return { error: ex as Error };
+			}
+		};
 
-        if (!shouldDisplayEnvCreationProgress()) {
-            const token = new CancellationTokenSource();
-            try {
-                return await createEnvInternal({ report: noop }, token.token);
-            } finally {
-                token.dispose();
-            }
-        }
+		if (!shouldDisplayEnvCreationProgress()) {
+			const token = new CancellationTokenSource();
+			try {
+				return await createEnvInternal({ report: noop }, token.token);
+			} finally {
+				token.dispose();
+			}
+		}
 
-        return withProgress(
-            {
-                location: ProgressLocation.Notification,
-                title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
-                cancellable: true,
-            },
-            async (
-                progress: CreateEnvironmentProgress,
-                token: CancellationToken,
-            ): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
-        );
-    }
+		return withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: `${CreateEnv.statusTitle} ([${Common.showLogs}](command:${Commands.ViewOutput}))`,
+				cancellable: true,
+			},
+			async (
+				progress: CreateEnvironmentProgress,
+				token: CancellationToken,
+			): Promise<CreateEnvironmentResult | undefined> => createEnvInternal(progress, token),
+		);
+	}
 
-    name = 'Venv';
+	name = 'Venv';
 
-    description: string = CreateEnv.Venv.providerDescription;
+	description: string = CreateEnv.Venv.providerDescription;
 
-    id = VenvCreationProviderId;
+	id = VenvCreationProviderId;
 
-    tools = ['Venv'];
+	tools = ['Venv'];
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
@@ -3,20 +3,20 @@
 
 import { Progress, WorkspaceFolder } from 'vscode';
 
-export interface CreateEnvironmentProgress extends Progress<{ message?: string; increment?: number }> { }
+export interface CreateEnvironmentProgress extends Progress<{ message?: string; increment?: number }> {}
 
 /**
  * The interpreter path to use for the environment creation. If not provided, will prompt the user to select one.
  * If the value of `interpreter` & `workspaceFolder` & `providerId` are provided we will not prompt the user to select a provider, nor folder, nor an interpreter.
  */
 export interface CreateEnvironmentOptionsInternal {
-	workspaceFolder?: WorkspaceFolder;
-	providerId?: string;
-	// --- Start Positron ---
-	interpreterPath?: string;
-	condaPythonVersion?: string;
-	uvPythonVersion?: string;
-	envName?: string;
-	// --- End Positron ---
-	interpreter?: string;
+    workspaceFolder?: WorkspaceFolder;
+    providerId?: string;
+    // --- Start Positron ---
+    interpreterPath?: string;
+    condaPythonVersion?: string;
+    uvPythonVersion?: string;
+    envName?: string;
+    // --- End Positron ---
+    interpreter?: string;
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
@@ -3,19 +3,20 @@
 
 import { Progress, WorkspaceFolder } from 'vscode';
 
-export interface CreateEnvironmentProgress extends Progress<{ message?: string; increment?: number }> {}
+export interface CreateEnvironmentProgress extends Progress<{ message?: string; increment?: number }> { }
 
 /**
  * The interpreter path to use for the environment creation. If not provided, will prompt the user to select one.
  * If the value of `interpreter` & `workspaceFolder` & `providerId` are provided we will not prompt the user to select a provider, nor folder, nor an interpreter.
  */
 export interface CreateEnvironmentOptionsInternal {
-    workspaceFolder?: WorkspaceFolder;
-    providerId?: string;
-    // --- Start Positron ---
-    interpreterPath?: string;
-    condaPythonVersion?: string;
-    uvPythonVersion?: string;
-    // --- End Positron ---
-    interpreter?: string;
+	workspaceFolder?: WorkspaceFolder;
+	providerId?: string;
+	// --- Start Positron ---
+	interpreterPath?: string;
+	condaPythonVersion?: string;
+	uvPythonVersion?: string;
+	envName?: string;
+	// --- End Positron ---
+	interpreter?: string;
 }

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
@@ -89,7 +89,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 	useEffect(() => {
 		if (envSetupType === EnvironmentSetupType.NewEnvironment && envProviders && envProviderId) {
 			const providerName = envProviderNameForId(envProviderId, envProviders);
-			const defaultName = getDefaultEnvName(providerName, context.folderName);
+			const defaultName = getDefaultEnvName(providerName);
 			// Only set if no name has been set yet (undefined or null, not empty string)
 			if (envName === undefined || envName === null) {
 				setEnvName(defaultName);
@@ -160,7 +160,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 		setEnvProviderId(identifier);
 		// Reset the environment name to the default for the new provider.
 		const providerName = envProviderNameForId(identifier, envProviders!);
-		const defaultName = getDefaultEnvName(providerName, context.folderName);
+		const defaultName = getDefaultEnvName(providerName);
 		setEnvName(defaultName);
 		context.pythonEnvName = defaultName;
 	};

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
@@ -90,13 +90,16 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 		if (envSetupType === EnvironmentSetupType.NewEnvironment && envProviders && envProviderId) {
 			const providerName = envProviderNameForId(envProviderId, envProviders);
 			const defaultName = getDefaultEnvName(providerName);
-			// Only set if no custom name has been set yet
-			if (!envName) {
+			// Only set if no name has been set yet (undefined or null, not empty string)
+			if (envName === undefined || envName === null) {
 				setEnvName(defaultName);
 				context.pythonEnvName = defaultName;
 			}
 		}
-	}, [envSetupType, envProviderId, envProviders, context, envName]);
+		// Note: envName is intentionally NOT in the dependency array to avoid resetting
+		// when user clears the input
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [envSetupType, envProviderId, envProviders, context]);
 
 	// Utility functions.
 	// At least one interpreter is available.
@@ -501,21 +504,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 							onEnvProviderSelected(item.options.identifier)
 						}
 					/>
-				</PositronFlowSubStep> : null
-			}
-			{/* If New Environment, show input for environment name */}
-			{envSetupType === EnvironmentSetupType.NewEnvironment ?
-				<PositronFlowSubStep
-					title={(() => localize(
-						'pythonEnvironmentNameSubStep.title',
-						"Environment Name"
-					))()}
-					titleId='pythonEnvironment-envName'
-				>
 					<LabeledTextInput
 						label={(() => localize(
 							'pythonEnvironmentNameSubStep.label',
-							"Name"
+							"Environment name"
 						))()}
 						value={envName ?? ''}
 						onChange={(e) => onEnvNameChanged(e.target.value)}

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
@@ -89,7 +89,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 	useEffect(() => {
 		if (envSetupType === EnvironmentSetupType.NewEnvironment && envProviders && envProviderId) {
 			const providerName = envProviderNameForId(envProviderId, envProviders);
-			const defaultName = getDefaultEnvName(providerName);
+			const defaultName = getDefaultEnvName(providerName, context.folderName);
 			// Only set if no name has been set yet (undefined or null, not empty string)
 			if (envName === undefined || envName === null) {
 				setEnvName(defaultName);
@@ -160,7 +160,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 		setEnvProviderId(identifier);
 		// Reset the environment name to the default for the new provider.
 		const providerName = envProviderNameForId(identifier, envProviders!);
-		const defaultName = getDefaultEnvName(providerName);
+		const defaultName = getDefaultEnvName(providerName, context.folderName);
 		setEnvName(defaultName);
 		context.pythonEnvName = defaultName;
 	};

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -153,7 +153,7 @@ const NewFolderFlowModalDialog = (props: NewFolderFlowModalDialogProps) => {
 	// Render.
 	return (
 		<PositronModalDialog
-			height={520}
+			height={580}
 			renderer={props.renderer} title={(() => localize('positron.newFolderFromTemplate', "New Folder From Template"))()}
 			width={700}
 			onCancel={cancelHandler}

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -92,6 +92,7 @@ export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 						createPyprojectToml: result.createPyprojectToml,
 						pythonEnvProviderId: result.pythonEnvProviderId,
 						pythonEnvProviderName: result.pythonEnvProviderName,
+						pythonEnvName: result.pythonEnvName,
 						installIpykernel: result.installIpykernel,
 						condaPythonVersion: result.condaPythonVersion,
 						uvPythonVersion: result.uvPythonVersion,

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -40,6 +40,7 @@ export interface NewFolderFlowState {
 	createPyprojectToml: boolean | undefined;
 	pythonEnvSetupType: EnvironmentSetupType | undefined;
 	pythonEnvProviderId: string | undefined;
+	pythonEnvName: string | undefined;
 	condaPythonVersion: string | undefined;
 	uvPythonVersion: string | undefined;
 	readonly pythonEnvProviderName: string | undefined;
@@ -82,6 +83,7 @@ export class NewFolderFlowStateManager
 	// Python-specific state.
 	private _pythonEnvSetupType: EnvironmentSetupType | undefined;
 	private _pythonEnvProviderId: string | undefined;
+	private _pythonEnvName: string | undefined;
 	private _installIpykernel: boolean | undefined;
 	private _createPyprojectToml: boolean | undefined;
 	private _minimumPythonVersion: string | undefined;
@@ -368,6 +370,23 @@ export class NewFolderFlowStateManager
 	}
 
 	/**
+	 * Gets the Python environment name.
+	 * @returns The Python environment name.
+	 */
+	get pythonEnvName(): string | undefined {
+		return this._pythonEnvName;
+	}
+
+	/**
+	 * Sets the Python environment name.
+	 * @param value The Python environment name.
+	 */
+	set pythonEnvName(value: string | undefined) {
+		this._pythonEnvName = value;
+		this._onUpdateFolderPathEmitter.fire();
+	}
+
+	/**
 	 * Gets the installIpykernel flag.
 	 * @returns The installIpykernel flag.
 	 */
@@ -592,6 +611,7 @@ export class NewFolderFlowStateManager
 			openInNewWindow: this._openInNewWindow,
 			pythonEnvSetupType: this._pythonEnvSetupType,
 			pythonEnvProviderId: this._pythonEnvProviderId,
+			pythonEnvName: this._pythonEnvName,
 			pythonEnvProviderName: this._getEnvProviderName(),
 			installIpykernel: this._installIpykernel,
 			createPyprojectToml: this._createPyprojectToml,
@@ -1032,6 +1052,7 @@ export class NewFolderFlowStateManager
 		const cleanPython = () => {
 			this._pythonEnvSetupType = undefined;
 			this._pythonEnvProviderId = undefined;
+			this._pythonEnvName = undefined;
 			this._installIpykernel = undefined;
 			this._minimumPythonVersion = undefined;
 			this._condaPythonVersion = undefined;

--- a/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
@@ -18,10 +18,14 @@ export interface PythonEnvironmentProviderInfo {
 /**
  * Returns the default environment name for a given provider.
  * @param envProviderName The name of the Python environment provider.
+ * @param projectName The name of the project folder, used as the environment name for non-Conda environments.
  * @returns The default environment name.
  */
-export const getDefaultEnvName = (envProviderName: string | undefined): string => {
-	return envProviderName === PythonEnvironmentProvider.Conda ? '.conda' : '.venv';
+export const getDefaultEnvName = (envProviderName: string | undefined, projectName?: string): string => {
+	if (envProviderName === PythonEnvironmentProvider.Conda) {
+		return projectName || '.conda';
+	}
+	return projectName || '.venv';
 };
 
 /**

--- a/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
@@ -16,22 +16,30 @@ export interface PythonEnvironmentProviderInfo {
 }
 
 /**
+ * Returns the default environment name for a given provider.
+ * @param envProviderName The name of the Python environment provider.
+ * @returns The default environment name.
+ */
+export const getDefaultEnvName = (envProviderName: string | undefined): string => {
+	return envProviderName === PythonEnvironmentProvider.Conda ? '.conda' : '.venv';
+};
+
+/**
  * Constructs the location for the new Python environment based on the parent folder, project name,
  * and environment type.
  * @param parentFolder The parent folder for the new environment.
  * @param projectName The name of the project.
  * @param envProviderName The name of the Python environment provider.
+ * @param customEnvName Optional custom environment name to use instead of the default.
  * @returns Array of strings representing the path to the new environment.
  */
 export const locationForNewEnv = (
 	parentFolder: string,
 	projectName: string,
 	envProviderName: string | undefined,
+	customEnvName?: string,
 ) => {
-	const envDir =
-		envProviderName === PythonEnvironmentProvider.Conda
-			? '.conda'
-			: '.venv';
+	const envDir = customEnvName || getDefaultEnvName(envProviderName);
 	return [parentFolder, projectName, envDir];
 };
 

--- a/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/utilities/pythonEnvironmentStepUtils.ts
@@ -18,14 +18,10 @@ export interface PythonEnvironmentProviderInfo {
 /**
  * Returns the default environment name for a given provider.
  * @param envProviderName The name of the Python environment provider.
- * @param projectName The name of the project folder, used as the environment name for non-Conda environments.
  * @returns The default environment name.
  */
-export const getDefaultEnvName = (envProviderName: string | undefined, projectName?: string): string => {
-	if (envProviderName === PythonEnvironmentProvider.Conda) {
-		return projectName || '.conda';
-	}
-	return projectName || '.venv';
+export const getDefaultEnvName = (envProviderName: string | undefined): string => {
+	return envProviderName === PythonEnvironmentProvider.Conda ? '.conda' : '.venv';
 };
 
 /**

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolder.ts
@@ -102,6 +102,7 @@ export interface NewFolderConfiguration {
 	readonly createPyprojectToml: boolean | undefined;
 	readonly pythonEnvProviderId: string | undefined;
 	readonly pythonEnvProviderName: string | undefined;
+	readonly pythonEnvName: string | undefined;
 	readonly installIpykernel: boolean | undefined;
 	readonly condaPythonVersion: string | undefined;
 	readonly uvPythonVersion: string | undefined;

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -471,6 +471,7 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 				// specified Python interpreter is invalid for some reason (e.g. for Venv, if the
 				// specified interpreter is not considered to be a Global Python installation).
 				const createEnvCommand = 'python.createEnvironmentAndRegister';
+				const envName = this._newFolderConfig.pythonEnvName;
 				const result: CreateEnvironmentResult | undefined =
 					await this._commandService.executeCommand(
 						createEnvCommand,
@@ -480,6 +481,7 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 							interpreterPath,
 							condaPythonVersion,
 							uvPythonVersion,
+							envName,
 							// Do not start the environment after creation. We'll install ipykernel
 							// first, then set the environment as the affiliated runtime, which will
 							// be automatically started by the runtimeStartupService.


### PR DESCRIPTION
Originally https://github.com/posit-dev/positron/issues/3573 was related to the default display of venvs/condas along with allowing folks to name their own environments. this implements both!


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- https://github.com/posit-dev/positron/issues/3573 Allow users to name their environments in New Project Wizard

#### Bug Fixes

- N/A


### QA Notes

@:new-folder-flow

- check a new project wizard has default `.venv` for venv/uv and `.conda` for conda
- check that uvs/venvs have names in console like `Venv: folder-name` or `Uv: folder-name`

<img width="715" height="594" alt="Screenshot 2026-02-05 at 4 03 31 PM" src="https://github.com/user-attachments/assets/560fef8d-f7c0-490d-a353-cc1fb6b25865" />

