### PR TITLE
e2e: allow for pulling branch of qa-example-content

### DIFF
--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -16,7 +16,7 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 	const testRepoUrl = 'https://github.com/posit-dev/qa-example-content.git';
 	const cacheDir = path.join(os.tmpdir(), 'qa-example-content-cache');
 	const cachedCommitFile = path.join(cacheDir, '.cached-commit');
-	const branch = 'main';
+	const branch = process.env.QA_REPO || 'main';
 
 	// Check if the machine is online by attempting to fetch the latest commit hash.
 	let remoteCommitHash: string | null = null;


### PR DESCRIPTION
You can now use `QA_BRANCH` env variable to specifiy the branch of qa-example-content to use. Defaults to `main`

This is helpful when writing new tests that use new qa-example-content that you are developing and may not want to merge yet. 

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
