### PR TITLE
Assistant: apply Configure Tools selections to Agent mode tool filtering

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -201,6 +201,11 @@ export function getEnabledTools(
 		(positronParticipantId === ParticipantID.Editor || positronParticipantId === ParticipantID.Notebook);
 
 	for (const tool of tools) {
+		// Check if the user has explicitly disabled this tool via the Configure Tools picker.
+		if (request.tools?.get(tool.name) === false) {
+			continue;
+		}
+
 		// Don't allow any tools in the terminal.
 		if (positronParticipantId === ParticipantID.Terminal) {
 			continue;

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -201,8 +201,9 @@ export function getEnabledTools(
 		(positronParticipantId === ParticipantID.Editor || positronParticipantId === ParticipantID.Notebook);
 
 	for (const tool of tools) {
-		// Check if the user has explicitly disabled this tool via the Configure Tools picker.
-		if (request.tools?.get(tool.name) === false) {
+		// Check if the user has explicitly disabled this tool via the Configure Tools picker,
+		// which is only available in Agent mode.
+		if (isAgentMode && request.tools?.get(tool.name) === false) {
 			continue;
 		}
 

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -313,7 +313,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			tool => toolAvailability.get(tool.name as PositronAssistantToolName) === true
 		);
 
-		log.debug(`[tools] Available tools for participant ${this.id}:\n${tools.length > 0 ? tools.map((tool, i) => `${i + 1}. ${tool.name}`).join('\n') : 'No tools available'}`);
+		log.debug(`[tools] ${tools.length} Available tools for participant ${this.id}:\n${tools.length > 0 ? tools.map((tool, i) => `${i + 1}. ${tool.name}`).join('\n') : 'No tools available'}`);
 
 		// Construct the transient message thread sent to the language model.
 		// Note that this is not the same as the chat history shown in the UI.


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/8290
- when in Agent mode, user-disabled tools should be filtered out of enabled tools

### Release Notes

#### Bug Fixes

- Assistant: tools disabled via Agent mode Configure Tools are now disabled in chat (#8290)

### QA Notes

@:assistant

- the tools will only be disabled in Agent mode, as that is where the Configure Tools affordance is
- in Ask and Edit mode, the tool enablement should not be affected by the Configure Tools picker selections