### PR TITLE
Reload window after anthropic sign in

### DIFF
--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -299,7 +299,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 	 * 1. Each provider shows its respective default model with "(default)" suffix
 	 * 2. Each default model appears first in its provider group
 	 */
-	test('Verify default model indicators and ordering for multiple providers', async function ({ app, settings }) {
+	test('Verify default model indicators and ordering for multiple providers', async function ({ app, settings, runCommand }) {
 		// Configure defaults for both Anthropic and Echo providers
 		await settings.set({
 			'positron.assistant.models.preference.byProvider': {
@@ -317,6 +317,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 			await app.workbench.assistant.clickSignInButton();
 			await app.workbench.assistant.verifySignOutButtonVisible();
 			await app.workbench.assistant.clickCloseButton();
+			await runCommand('workbench.action.reloadWindow');
 		}
 
 		await expect(async () => {


### PR DESCRIPTION
Recently on Ubuntu Electron, the sign-in to Anthropic wasn't showing up in the chat immediately.  I just added a reload after sign-in which seems to get things stable again.

I wasn't able to repro locally on my VM, so I don't think it's a product bug.

### QA Notes
@:assistant
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
