### PR TITLE
e2e: R test for ctrl+enter in unsaved file

### DIFF
--- a/test/e2e/tests/code-actions/r.test.ts
+++ b/test/e2e/tests/code-actions/r.test.ts
@@ -20,6 +20,32 @@ test.describe('R Code Actions', { tag: [tags.EDITOR, tags.WIN, tags.WEB, tags.AR
 	});
 
 
+	test('R - Can execute code in untitled file with Ctrl+Enter', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11533' }]
+	}, async ({ app, r, page }) => {
+		const { editors, quickaccess, quickInput, console } = app.workbench;
+
+		// Create a new untitled file
+		await editors.newUntitledFile();
+
+		// Change language mode to R
+		await quickaccess.runCommand('workbench.action.editor.changeLanguageMode', { keepOpen: true });
+		await quickInput.waitForQuickInputOpened();
+		await quickInput.type('R');
+		await quickInput.selectQuickInputElementContaining('R', { timeout: 5000 });
+		await quickInput.waitForQuickInputClosed();
+
+		// Type R code
+		await app.workbench.editor.type('1 + 1');
+
+		// Execute with Ctrl/Cmd+Enter
+		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
+
+		// Verify the result appears in the console
+		await console.waitForConsoleContents('[1] 2');
+	});
+
+
 	test("R - Can insert a Roxygen skeleton", async function ({ app, r, openFile }) {
 
 		const fileName = 'supermarket-sales.r';


### PR DESCRIPTION
Adds an e2e test to cover regression #11533

### QA Notes
@:editor
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
