### PR TITLE
Switch to Vercel for Anthropic

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -232,7 +232,7 @@
           },
           "positron.assistant.useAnthropicSdk": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%configuration.useAnthropicSdk.description%"
           },
           "positron.assistant.streamingEdits.enable": {

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -233,7 +233,10 @@
           "positron.assistant.useAnthropicSdk": {
             "type": "boolean",
             "default": false,
-            "description": "%configuration.useAnthropicSdk.description%"
+            "description": "%configuration.useAnthropicSdk.description%",
+			"tags": [
+			  "advanced"
+			]
           },
           "positron.assistant.streamingEdits.enable": {
             "type": "boolean",

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicModelUtils.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicModelUtils.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import Anthropic from '@anthropic-ai/sdk';
+import * as vscode from 'vscode';
+import { getAllModelDefinitions } from '../../modelDefinitions.js';
+import { createModelInfo, markDefaultModel } from '../../modelResolutionHelpers.js';
+import { ModelCapabilities } from '../base/modelProviderTypes.js';
+import { ModelProviderLogger } from '../base/modelProviderLogger.js';
+
+export const DEFAULT_ANTHROPIC_MODEL_NAME = 'Claude Sonnet 4';
+export const DEFAULT_ANTHROPIC_MODEL_MATCH = 'claude-sonnet-4';
+
+/**
+ * Fetches models from the Anthropic API with pagination support.
+ *
+ * @param client - The Anthropic client instance
+ * @param providerId - The provider identifier (e.g., 'anthropic-api')
+ * @param providerName - The display name of the provider
+ * @param capabilities - The model capabilities to include in model info
+ * @param logger - Logger for debug/trace messages
+ * @returns Array of model information, or undefined if fetching fails
+ */
+export async function fetchAnthropicModelsFromApi(
+	client: Anthropic,
+	providerId: string,
+	providerName: string,
+	capabilities: ModelCapabilities,
+	logger: ModelProviderLogger
+): Promise<vscode.LanguageModelChatInformation[] | undefined> {
+	try {
+		const modelListing: vscode.LanguageModelChatInformation[] = [];
+		const knownAnthropicModels = getAllModelDefinitions(providerId);
+		let hasMore = true;
+		let nextPageToken: string | undefined;
+
+		logger.trace(`Fetching models from Anthropic API...`);
+
+		while (hasMore) {
+			const modelsPage = nextPageToken
+				? await client.models.list({ after_id: nextPageToken })
+				: await client.models.list();
+
+			modelsPage.data.forEach(model => {
+				const knownModel = knownAnthropicModels?.find(m => model.id.startsWith(m.identifier));
+
+				modelListing.push(
+					createModelInfo({
+						id: model.id,
+						name: model.display_name,
+						family: providerId,
+						version: model.created_at,
+						provider: providerId,
+						providerName: providerName,
+						capabilities: capabilities,
+						defaultMaxInput: knownModel?.maxInputTokens,
+						defaultMaxOutput: knownModel?.maxOutputTokens
+					})
+				);
+			});
+
+			hasMore = modelsPage.has_more;
+			if (hasMore && modelsPage.data.length > 0) {
+				nextPageToken = modelsPage.data[modelsPage.data.length - 1].id;
+			}
+		}
+
+		return markDefaultModel(modelListing, providerId, DEFAULT_ANTHROPIC_MODEL_MATCH);
+	} catch (error) {
+		logger.warn(`Failed to fetch models from Anthropic API: ${error}`);
+		return undefined;
+	}
+}
+
+/**
+ * Retrieves models from user configuration for Anthropic providers.
+ *
+ * @param providerId - The provider identifier (e.g., 'anthropic-api')
+ * @param providerName - The display name of the provider
+ * @param capabilities - The model capabilities to include in model info
+ * @param logger - Logger for debug/trace messages
+ * @returns Array of configured models, or undefined if no models are configured
+ */
+export function getAnthropicModelsFromConfig(
+	providerId: string,
+	providerName: string,
+	capabilities: ModelCapabilities,
+	logger: ModelProviderLogger
+): vscode.LanguageModelChatInformation[] | undefined {
+	const configuredModels = getAllModelDefinitions(providerId);
+	if (configuredModels.length === 0) {
+		return undefined;
+	}
+
+	logger.info(`Using ${configuredModels.length} configured models.`);
+
+	const modelListing = configuredModels.map((modelDef) =>
+		createModelInfo({
+			id: modelDef.identifier,
+			name: modelDef.name,
+			family: providerId,
+			version: '',
+			provider: providerId,
+			providerName: providerName,
+			capabilities: capabilities,
+			defaultMaxInput: modelDef.maxInputTokens,
+			defaultMaxOutput: modelDef.maxOutputTokens
+		})
+	);
+
+	return markDefaultModel(modelListing, providerId, DEFAULT_ANTHROPIC_MODEL_MATCH);
+}

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
@@ -12,13 +12,17 @@ import { isChatImagePart, isCacheBreakpointPart, parseCacheBreakpoint, processMe
 import { DEFAULT_MAX_TOKEN_OUTPUT } from '../../constants.js';
 import { recordTokenUsage, recordRequestTokenUsage, log } from '../../extension.js';
 import { TokenUsage } from '../../tokens.js';
-import { getAllModelDefinitions } from '../../modelDefinitions.js';
-import { createModelInfo, markDefaultModel } from '../../modelResolutionHelpers.js';
 import { LanguageModelDataPartMimeType } from '../../types.js';
 import { ModelProviderLogger } from '../base/modelProviderLogger.js';
+import {
+	DEFAULT_ANTHROPIC_MODEL_NAME,
+	DEFAULT_ANTHROPIC_MODEL_MATCH,
+	fetchAnthropicModelsFromApi,
+	getAnthropicModelsFromConfig
+} from './anthropicModelUtils.js';
 
-export const DEFAULT_ANTHROPIC_MODEL_NAME = 'Claude Sonnet 4';
-export const DEFAULT_ANTHROPIC_MODEL_MATCH = 'claude-sonnet-4';
+// Re-export for consumers that import from this file
+export { DEFAULT_ANTHROPIC_MODEL_NAME, DEFAULT_ANTHROPIC_MODEL_MATCH };
 
 /**
  * Options for controlling cache behavior in the Anthropic language model.
@@ -121,73 +125,22 @@ export class AnthropicModelProvider extends ModelProvider implements positron.ai
 	}
 
 	protected override retrieveModelsFromConfig() {
-		const configuredModels = getAllModelDefinitions(this.providerId);
-		if (configuredModels.length === 0) {
-			return undefined;
-		}
-
-		this.logger.info(`Using ${configuredModels.length} configured models.`);
-
-		const modelListing = configuredModels.map((modelDef) =>
-			createModelInfo({
-				id: modelDef.identifier,
-				name: modelDef.name,
-				family: this.providerId,
-				version: '',
-				provider: this.providerId,
-				providerName: this.providerName,
-				capabilities: this.capabilities,
-				defaultMaxInput: modelDef.maxInputTokens,
-				defaultMaxOutput: modelDef.maxOutputTokens
-			})
+		return getAnthropicModelsFromConfig(
+			this.providerId,
+			this.providerName,
+			this.capabilities,
+			this.logger
 		);
-
-		return markDefaultModel(modelListing, this.providerId, DEFAULT_ANTHROPIC_MODEL_MATCH);
 	}
 
-	protected override async retrieveModelsFromApi(token: vscode.CancellationToken) {
-		try {
-			const modelListing: vscode.LanguageModelChatInformation[] = [];
-			const knownAnthropicModels = getAllModelDefinitions(this.providerId);
-			let hasMore = true;
-			let nextPageToken: string | undefined;
-
-			this.logger.trace(`Fetching models from Anthropic API...`);
-
-			while (hasMore) {
-				const modelsPage = nextPageToken
-					? await this._client.models.list({ after_id: nextPageToken })
-					: await this._client.models.list();
-
-				modelsPage.data.forEach(model => {
-					const knownModel = knownAnthropicModels?.find(m => model.id.startsWith(m.identifier));
-
-					modelListing.push(
-						createModelInfo({
-							id: model.id,
-							name: model.display_name,
-							family: this.providerId,
-							version: model.created_at,
-							provider: this.providerId,
-							providerName: this.providerName,
-							capabilities: this.capabilities,
-							defaultMaxInput: knownModel?.maxInputTokens,
-							defaultMaxOutput: knownModel?.maxOutputTokens
-						})
-					);
-				});
-
-				hasMore = modelsPage.has_more;
-				if (hasMore && modelsPage.data.length > 0) {
-					nextPageToken = modelsPage.data[modelsPage.data.length - 1].id;
-				}
-			}
-
-			return markDefaultModel(modelListing, this.providerId, DEFAULT_ANTHROPIC_MODEL_MATCH);
-		} catch (error) {
-			this.logger.warn(`Failed to fetch models from Anthropic API: ${error}`);
-			return undefined;
-		}
+	protected override async retrieveModelsFromApi(_token: vscode.CancellationToken) {
+		return fetchAnthropicModelsFromApi(
+			this._client,
+			this.providerId,
+			this.providerName,
+			this.capabilities,
+			this.logger
+		);
 	}
 
 	override async provideLanguageModelChatResponse(

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicVercelProvider.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicVercelProvider.ts
@@ -88,10 +88,8 @@ export class AnthropicAIModelProvider extends VercelModelProvider implements pos
 	 * @param _context - VS Code extension context for storage and features
 	 */
 	constructor(_config: ModelConfig, _context?: vscode.ExtensionContext) {
-		// Initialize native client before super() calls initializeProvider()
-		// Note: We need to initialize _client here because initializeProvider() is
-		// called from the parent constructor, and _client must be set by then.
 		super(_config, _context);
+		// Initialize native client for API operations like model listing
 		this._client = new Anthropic({ apiKey: _config.apiKey });
 	}
 

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as ai from 'ai';
 import { ModelProvider } from './modelProvider';
-import { processMessages, toAIMessage } from '../../utils';
+import { CacheBreakpointProvider, processMessages, toAIMessage } from '../../utils';
 import { getProviderTimeoutMs } from '../../config';
 import { TokenUsage } from '../../tokens';
 import { recordRequestTokenUsage, recordTokenUsage } from '../../extension';
@@ -166,12 +166,17 @@ export abstract class VercelModelProvider extends ModelProvider {
 		// Extract provider-specific options
 		const { bedrockCacheBreakpoint = false, anthropicCacheBreakpoint = false, toolResultExperimentalContent = false } = providerOptions || {};
 
+		// Determine which cache breakpoint provider to use (if any)
+		const cacheBreakpointProvider: CacheBreakpointProvider | undefined =
+			bedrockCacheBreakpoint ? 'bedrock' :
+				anthropicCacheBreakpoint ? 'anthropic' :
+					undefined;
+
 		// Convert all messages to the Vercel AI format
 		const aiMessages: ai.ModelMessage[] = toAIMessage(
 			processedMessages,
 			this.usesChatCompletions,
-			bedrockCacheBreakpoint,
-			anthropicCacheBreakpoint
+			cacheBreakpointProvider
 		);
 
 		// Set up tools if provided

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -140,6 +140,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 		providerOptions?: {
 			toolResultExperimentalContent?: boolean;
 			bedrockCacheBreakpoint?: boolean;
+			anthropicCacheBreakpoint?: boolean;
 		}
 	): Promise<void> {
 		const aiModel = this.aiProvider(model.id);
@@ -163,13 +164,14 @@ export abstract class VercelModelProvider extends ModelProvider {
 		}
 
 		// Extract provider-specific options
-		const { bedrockCacheBreakpoint = false, toolResultExperimentalContent = false } = providerOptions || {};
+		const { bedrockCacheBreakpoint = false, anthropicCacheBreakpoint = false, toolResultExperimentalContent = false } = providerOptions || {};
 
 		// Convert all messages to the Vercel AI format
 		const aiMessages: ai.ModelMessage[] = toAIMessage(
 			processedMessages,
 			this.usesChatCompletions,
-			bedrockCacheBreakpoint
+			bedrockCacheBreakpoint,
+			anthropicCacheBreakpoint
 		);
 
 		// Set up tools if provided
@@ -358,6 +360,15 @@ export abstract class VercelModelProvider extends ModelProvider {
 			}
 
 			this.logger.debug(`[${model.name}]: Bedrock usage: ${JSON.stringify(usage, null, 2)}`);
+		}
+
+		// Handle Anthropic-specific usage (cache tokens are directly on metadata.anthropic, not nested under usage)
+		if (metadata && metadata.anthropic) {
+			const anthropicMeta = metadata.anthropic as Record<string, any>;
+			tokens.inputTokens += anthropicMeta.cacheCreationInputTokens || anthropicMeta.usage?.cache_creation_input_tokens || 0;
+			tokens.cachedTokens += anthropicMeta.cacheReadInputTokens || anthropicMeta.usage?.cache_read_input_tokens || 0;
+
+			this.logger.debug(`[${model.name}]: Anthropic usage: ${JSON.stringify(anthropicMeta, null, 2)}`);
 		}
 
 		if (requestId) {

--- a/extensions/positron-assistant/src/providers/posit/positProvider.ts
+++ b/extensions/positron-assistant/src/providers/posit/positProvider.ts
@@ -7,11 +7,12 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as os from 'os';
 import Anthropic from '@anthropic-ai/sdk';
+import { createAnthropic } from '@ai-sdk/anthropic';
 import { deleteConfiguration, ModelConfig, SecretStorage } from '../../config';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from '../../constants';
 import { log, recordRequestTokenUsage, recordTokenUsage } from '../../extension.js';
 import { isCacheControlOptions, toAnthropicMessages, toAnthropicSystem, toAnthropicToolChoice, toAnthropicTools, toTokenUsage } from '../anthropic/anthropicProvider.js';
-import { ModelProvider } from '../base/modelProvider.js';
+import { VercelModelProvider } from '../base/vercelModelProvider.js';
 
 export const DEFAULT_POSITAI_MODEL_NAME = 'Claude Sonnet 4.5';
 export const DEFAULT_POSITAI_MODEL_MATCH = 'claude-sonnet-4-5';
@@ -32,11 +33,12 @@ export const DEFAULT_POSITAI_MODEL_MATCH = 'claude-sonnet-4-5';
  * - Authentication: OAuth (no API key required)
  * - Managed through workspace settings for authHost, scope, clientId, and baseUrl
  */
-export class PositModelProvider extends ModelProvider {
+export class PositModelProvider extends VercelModelProvider {
 	/** The cancellation token for the current operation. */
 	private static _cancellationToken: vscode.CancellationTokenSource | null = null;
 
-	private _anthropicClient: Anthropic;
+	private _anthropicClient!: Anthropic;
+	private _useNativeSdk!: boolean;
 	public readonly maxOutputTokens = DEFAULT_MAX_TOKEN_OUTPUT;
 
 	static source: positron.ai.LanguageModelSource = {
@@ -247,14 +249,29 @@ export class PositModelProvider extends ModelProvider {
 
 	/**
 	 * Initializes the Posit AI provider with OAuth-authenticated Anthropic client.
+	 * Uses either native Anthropic SDK or Vercel AI SDK based on the useAnthropicSdk preference.
 	 */
 	protected override initializeProvider() {
 		const params = PositModelProvider.getOAuthParameters();
-		this._anthropicClient = new Anthropic({
-			authToken: '_', // Actual token is set in authFetch
-			fetch: this.authFetch.bind(this),
-			baseURL: `${params.baseUrl}/anthropic`,
-		});
+
+		// Check preference: true (default) = native SDK, false = Vercel SDK
+		this._useNativeSdk = vscode.workspace.getConfiguration('positron.assistant')
+			.get('useAnthropicSdk', true);
+
+		if (this._useNativeSdk) {
+			// Initialize native Anthropic SDK (existing behavior)
+			this._anthropicClient = new Anthropic({
+				authToken: '_', // Actual token is set in authFetch
+				fetch: this.authFetch.bind(this),
+				baseURL: `${params.baseUrl}/anthropic`,
+			});
+		} else {
+			// Initialize Vercel AI SDK provider with OAuth fetch
+			this.aiProvider = createAnthropic({
+				baseURL: `${params.baseUrl}/anthropic`,
+				fetch: this.authFetch.bind(this),
+			});
+		}
 	}
 
 	/**
@@ -292,7 +309,7 @@ export class PositModelProvider extends ModelProvider {
 	}
 
 	/**
-	 * Provides chat response using Anthropic SDK with OAuth authentication.
+	 * Provides chat response using either native Anthropic SDK or Vercel AI SDK with OAuth authentication.
 	 */
 	override async provideLanguageModelChatResponse(
 		model: vscode.LanguageModelChatInformation,
@@ -301,6 +318,15 @@ export class PositModelProvider extends ModelProvider {
 		progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
 		token: vscode.CancellationToken
 	) {
+		// If using Vercel SDK, delegate to base class implementation
+		if (!this._useNativeSdk) {
+			return this.provideVercelResponse(model, messages, options, progress, token, {
+				toolResultExperimentalContent: true,
+				anthropicCacheBreakpoint: true
+			});
+		}
+
+		// Native SDK implementation follows
 		const cacheControlOptions = isCacheControlOptions(options.modelOptions?.cacheControl)
 			? options.modelOptions.cacheControl
 			: undefined;
@@ -442,11 +468,16 @@ export class PositModelProvider extends ModelProvider {
 
 	/**
 	 * Sends a test message to verify model connectivity.
-	 * For Posit AI, this is handled by resolveConnection.
+	 * When using Vercel SDK, delegates to base class. When using native SDK,
+	 * connection is verified via OAuth token in resolveConnection.
 	 */
-	protected async sendTestMessage(modelId: string) {
-		// Posit AI connection is verified via OAuth token in resolveConnection
-		return Promise.resolve();
+	protected override async sendTestMessage(modelId: string) {
+		if (!this._useNativeSdk) {
+			// Use Vercel SDK's test message implementation
+			return super.sendTestMessage(modelId);
+		}
+		// For native SDK, connection is verified via OAuth token in resolveConnection
+		return Promise.resolve() as any;
 	}
 
 	private onContentBlock(block: Anthropic.ContentBlock, progress: vscode.Progress<vscode.LanguageModelResponsePart2>): void {

--- a/extensions/positron-assistant/src/providers/posit/positProvider.ts
+++ b/extensions/positron-assistant/src/providers/posit/positProvider.ts
@@ -262,13 +262,15 @@ export class PositModelProvider extends VercelModelProvider {
 			// Initialize native Anthropic SDK (existing behavior)
 			this._anthropicClient = new Anthropic({
 				authToken: '_', // Actual token is set in authFetch
+				apiKey: '_',   // API key is not used
 				fetch: this.authFetch.bind(this),
 				baseURL: `${params.baseUrl}/anthropic`,
 			});
 		} else {
 			// Initialize Vercel AI SDK provider with OAuth fetch
+			// Note: Vercel SDK expects baseURL to include /v1 (default is https://api.anthropic.com/v1)
 			this.aiProvider = createAnthropic({
-				baseURL: `${params.baseUrl}/anthropic`,
+				baseURL: `${params.baseUrl}/anthropic/v1`,
 				fetch: this.authFetch.bind(this),
 			});
 		}


### PR DESCRIPTION
Address #10531 

### Release Notes

Switches the Anthropic provider to the Vercel implementation by default. This implements prompt caching and model listing queries to match what the Anthropic SDK provider has. The model listing was moved into a utility so it can be shared across both provider implementations. We can remove the other provider and deprecate the `useAnthropicSdk` setting in a later change.

I'm not sure if the token usage was working properly before with Vercel so that's been fixed as well.

#### New Features

- Switch Anthropic provider to use Vercel SDK

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
