### PR TITLE
Assistant: fix tool filtering when required language session is not active

### DIFF
--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -237,12 +237,13 @@ export function getEnabledTools(
 		// If the tool requires a session to be active for a specific
 		// language, but no active session is available for that
 		// language, don't allow the tool.
-		for (const tag of tool.tags) {
-			if (tag.startsWith(TOOL_TAG_REQUIRES_ACTIVE_SESSION + ':') &&
-				!activeSessions.has(tag.split(':')[1])) {
-				disabledTools.push({ name: tool.name, reason: `Requires active ${tag.split(':')[1]} session` });
-				continue;
-			}
+		const missingLanguage = tool.tags
+			.filter(tag => tag.startsWith(TOOL_TAG_REQUIRES_ACTIVE_SESSION + ':'))
+			.map(tag => tag.split(':')[1])
+			.find(lang => !activeSessions.has(lang));
+		if (missingLanguage) {
+			disabledTools.push({ name: tool.name, reason: `Requires active ${missingLanguage} session` });
+			continue;
 		}
 
 		// If the tool requires a notebook, but no notebook is attached with active editor,


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/11616
- noticed that this was an issue when looking more closely at the log messages for tools after adding the disablement logging via https://github.com/posit-dev/positron/pull/11608

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant: tools requiring a specific language session are now filtered correctly when those sessions are not active (#11616)

### QA Notes

See issue for test steps: https://github.com/posit-dev/positron/issues/11616