### PR TITLE
Fix issues with supervisor startup timeout

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -43,7 +43,7 @@
         "kernelSupervisor.startupTimeout": {
           "scope": "window",
           "type": "number",
-          "default": 10,
+          "default": 15,
           "minimum": 1,
           "description": "%configuration.startupTimeout.description%"
         },

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -211,6 +211,10 @@ export class KCApi implements PositronSupervisorApi {
 	 * attempt to reconnect to it. Returns a promise that resolves when the
 	 * server is online.
 	 *
+	 * Waits up to the configured startup timeout for the terminal to start and
+	 * for the same timeout for the server to write the connection file and
+	 * become responsive.
+	 *
 	 * @throws An error if the server cannot be started or reconnected to.
 	 */
 	async start() {
@@ -456,7 +460,13 @@ export class KCApi implements PositronSupervisorApi {
 		}));
 
 		// Wait for the terminal to start and get the PID
-		let processId = await this._terminal.processId;
+		let processId = await withTimeout(this._terminal.processId,
+			startupTimeout, `Timed out waiting for terminal to start after ${startupTimeout}ms`);
+
+		// Now that the terminal has started, log the PID and
+		// start the timer for server startup
+		this.log(`Kallichore terminal started in ${Date.now() - startTime}ms with PID ${processId}`);
+		const supervisorStartTime = Date.now();
 
 		// Wait for the connection file to be written by the server
 		let connectionData: KallichoreServerState | undefined = undefined;
@@ -464,7 +474,9 @@ export class KCApi implements PositronSupervisorApi {
 		let serverPort: number = 0;
 
 		// Wait for the connection file to exist and be readable
-		for (let retry = 0; retry < 100; retry++) {
+		let elapsed = 0;
+		let retry = 1;
+		do {
 			try {
 				if (fs.existsSync(connectionFile)) {
 					connectionData = JSON.parse(fs.readFileSync(connectionFile, 'utf8'));
@@ -525,28 +537,17 @@ export class KCApi implements PositronSupervisorApi {
 				throw new Error(message);
 			}
 
-			const elapsed = Date.now() - startTime;
-			if (elapsed > startupTimeout) {
-				let message = `Connection file was not created after ${elapsed}ms`;
-
-				// Include any output from the server process to help diagnose the problem
-				if (fs.existsSync(outFile)) {
-					const contents = fs.readFileSync(outFile, 'utf8');
-					if (contents) {
-						message += `; output:\n\n${contents}`;
-					}
-				}
-				this.log(message);
-				throw new Error(message);
+			// Wait a bit and try again
+			if (elapsed + 100 < startupTimeout) {
+				await new Promise((resolve) => setTimeout(resolve, 100));
 			}
 
-			// Wait a bit and try again
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		}
+			elapsed = Date.now() - supervisorStartTime;;
+			retry++;
+		} while (elapsed < startupTimeout && !connectionData);
 
-		if (!connectionData) {
-			let message = `Timed out waiting for connection file to be ` +
-				`created at ${connectionFile} after ${startupTimeout}ms`;
+		if (elapsed > startupTimeout || !connectionData) {
+			let message = `Connection file was not created after ${elapsed}ms`;
 
 			// Include any output from the server process to help diagnose the problem
 			if (fs.existsSync(outFile)) {
@@ -591,7 +592,7 @@ export class KCApi implements PositronSupervisorApi {
 				}
 				break;
 			} catch (err) {
-				const elapsed = Date.now() - startTime;
+				const elapsed = Date.now() - supervisorStartTime;
 
 				// Has the terminal exited? if it has, there's no point in continuing to retry.
 				if (exited) {
@@ -650,7 +651,7 @@ export class KCApi implements PositronSupervisorApi {
 			}
 		}
 
-		this.log(`Kallichore server started in ${Date.now() - startTime}ms`);
+		this.log(`Kallichore server started in ${Date.now() - supervisorStartTime}ms`);
 
 		// Begin streaming the logs (cleaning up any existing streamer)
 		if (this._logStreamer) {

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -546,7 +546,7 @@ export class KCApi implements PositronSupervisorApi {
 			retry++;
 		} while (elapsed < startupTimeout && !connectionData);
 
-		if (elapsed > startupTimeout || !connectionData) {
+		if (!connectionData) {
 			let message = `Connection file was not created after ${elapsed}ms`;
 
 			// Include any output from the server process to help diagnose the problem

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -542,7 +542,7 @@ export class KCApi implements PositronSupervisorApi {
 				await new Promise((resolve) => setTimeout(resolve, 100));
 			}
 
-			elapsed = Date.now() - supervisorStartTime;;
+			elapsed = Date.now() - supervisorStartTime;
 			retry++;
 		} while (elapsed < startupTimeout && !connectionData);
 

--- a/extensions/positron-supervisor/src/async.ts
+++ b/extensions/positron-supervisor/src/async.ts
@@ -63,7 +63,7 @@ export class Barrier {
  *
  * @returns The wrapped promise
  */
-export function withTimeout<T>(promise: Promise<T>,
+export function withTimeout<T>(promise: Thenable<T>,
 	timeout: number,
 	message: string): Promise<T> {
 	return Promise.race([


### PR DESCRIPTION
This change addresses two issues with the kernel supervisor's startup timeout measurement.

First, the timeout countdown starts when we ask for the terminal to be created, not when the terminal is actually established. When the supervisor extension starts early in the boot process, the terminal infrastructure/ptyhost might not be fully online, so the `createTerminal` can spend a long time waiting for it to be ready, exhausting most or all of the timeout.

Second, we retry every 100ms to find the connection file, but don't try more than 100 times no matter what that timeout is set to, with the result that you can only ever wait for 10s once we get into the main retry loop. 

There are four fixes in this PR:

- Use two distinct timeouts, one for the terminal startup and one for the supervisor startup. Don't start the supervisor's countdown until the terminal is established and we have a PID. For simplicity, these timeouts are both controlled by the same setting. 
- Don't limit retries; keep trying every 100ms until we have exhausted the startup timeout.
- Increase the startup timeout to 15s, as it seems that 10s isn't enough time to wait for the terminal to start in some configurations. 
- Add more logging to help us understand how much time is spent in terminal startup and how much is spent in supervisor startup.

Note that all of these changes are speculative as I have not been able to reproduce the error myself; they are based on analysis of logs provided by @jennybc.

Addresses https://github.com/posit-dev/positron/issues/11010 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Address issues with startup timeouts when starting kernel supervisor (#11010)


### QA Notes

Jenny noted that this happens specifically when updating to a new version of the daily build.