### PR TITLE
console: don't focus input when user clicks after scrolling up in history

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -338,7 +338,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const clickHandler = (e: MouseEvent<HTMLDivElement>) => {
 		const selection = getSelection();
 		if (!selection || selection.type !== 'Range') {
-			props.positronConsoleInstance.focusInput();
+			// Don't steal focus when the user has scrolled up to view history.
+			// Focusing the input causes the browser to scroll it into view.
+			if (!props.positronConsoleInstance.scrollLocked) {
+				props.positronConsoleInstance.focusInput();
+			}
 		}
 	};
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11411. 

In https://github.com/posit-dev/positron/pull/11006 we changed the default `editor.editContext` setting to `false`, which changed the Monaco editor to use a `.native-edit-context` div with the EditContext API. The EditContext's `focus()` method calls the DOM's native `focus()`, which causes the browser to scroll the focused element into view. But we don't want this if the user has scrolled up in history (which changes the console to `scrollLocked`). This PR fixes that.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Double-clicking text in the Console now selects it instead of jumping to the bottom (https://github.com/posit-dev/positron/issues/11411)


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
I tried this:
```py
for i in range(100):
    print(i)
```
And scrolled up and tried to double-click a number, copy it, and paste it again (which should make it jump back down).