### PR TITLE
console: focus on console after activity prompt ends

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1859,6 +1859,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 			// Reply to the prompt.
 			this._session.replyToPrompt(id, value);
+
+			// Drive focus to the input.
+			setTimeout(() => {
+				this.focusInput();
+			}, 0);
 		}
 	}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8687.

Now when an activity prompt is submitted or canceled, focus will go back to the Console.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- When an interactive prompt like R `readline()` or `menu()` or Python `input()` or `getpass()` is submitted or canceled, focus will go back to the Console (#8687)


### QA Notes

@:console

After all these (submitting or canceling) focus should go back to the Console.

Python
```py
>>> from getpass import getpass
>>> input("name: ")
>>> getpass("password: ")
```

R
```r
> readline("name: ")
> menu(c("apple", "banana"))
```
