### PR TITLE
Remove unencrypted secret storage for Assistant in Web mode

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -505,9 +505,8 @@ async function migrateApiKeysToEncryptedStorage(context: vscode.ExtensionContext
 				await context.secrets.store(key, apiKey);
 				// Remove from global state
 				await context.globalState.update(key, undefined);
-				log.info(`Successfully migrated API key for model ${key}`);
 			} catch (error) {
-				log.error(`Failed to migrate API key for model ${key}:`, error);
+				log.error(`Failed to migrate API ${key}:`, error);
 			}
 		}
 	}

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
@@ -7,7 +7,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import Anthropic from '@anthropic-ai/sdk';
 import { ModelProvider } from '../base/modelProvider';
-import { getProviderTimeoutMs, ModelConfig, SecretStorage } from '../../config';
+import { getProviderTimeoutMs, ModelConfig } from '../../config';
 import { isChatImagePart, isCacheBreakpointPart, parseCacheBreakpoint, processMessages, promptTsxPartToString } from '../../utils.js';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from '../../constants.js';
 import { recordTokenUsage, recordRequestTokenUsage, log } from '../../extension.js';
@@ -82,10 +82,9 @@ export class AnthropicModelProvider extends ModelProvider implements positron.ai
 	constructor(
 		_config: ModelConfig,
 		_context?: vscode.ExtensionContext,
-		_storage?: SecretStorage,
 		client?: Anthropic, // For testing only - production uses constructor initialization
 	) {
-		super(_config, _context, _storage);
+		super(_config, _context);
 		this._client = client ?? new Anthropic({ apiKey: _config.apiKey });
 	}
 

--- a/extensions/positron-assistant/src/providers/aws/awsBedrockProvider.ts
+++ b/extensions/positron-assistant/src/providers/aws/awsBedrockProvider.ts
@@ -15,7 +15,7 @@ import {
 	ListInferenceProfilesCommand
 } from '@aws-sdk/client-bedrock';
 import { VercelModelProvider } from '../base/vercelModelProvider';
-import { ModelConfig, SecretStorage, getStoredModels, expandConfigToSource } from '../../config';
+import { ModelConfig, getStoredModels, expandConfigToSource } from '../../config';
 import { DEFAULT_MAX_TOKEN_INPUT } from '../../constants';
 import { registerModelWithAPI, AssistantError } from '../../extension';
 import { createModelInfo, markDefaultModel } from '../../modelResolutionHelpers';
@@ -136,8 +136,8 @@ export class AWSModelProvider extends VercelModelProvider implements positron.ai
 		},
 	};
 
-	constructor(_config: ModelConfig, _context?: vscode.ExtensionContext, _storage?: SecretStorage) {
-		super(_config, _context, _storage);
+	constructor(_config: ModelConfig, _context?: vscode.ExtensionContext) {
+		super(_config, _context);
 	}
 
 	/**
@@ -334,7 +334,6 @@ export class AWSModelProvider extends VercelModelProvider implements positron.ai
 						registerModelWithAPI(
 							this._config,
 							this._context,
-							this._storage,
 							this
 						).then(() => {
 							positron.ai.addLanguageModelConfig(expandConfigToSource(this._config));

--- a/extensions/positron-assistant/src/providers/base/modelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/modelProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as ai from 'ai';
-import { ModelConfig, SecretStorage, getMaxConnectionAttempts } from '../../config';
+import { ModelConfig, getMaxConnectionAttempts } from '../../config';
 import { isAuthorizationError } from '../../utils';
 import { applyModelFilters } from '../../modelFilters';
 import { getAllModelDefinitions } from '../../modelDefinitions';
@@ -113,12 +113,10 @@ export abstract class ModelProvider implements positron.ai.LanguageModelChatProv
 	 *
 	 * @param _config - Configuration for this model provider including API keys, base URLs, and model settings
 	 * @param _context - VS Code extension context for accessing storage and other extension features
-	 * @param _storage - Secret storage for managing sensitive credentials
 	 */
 	constructor(
 		protected readonly _config: ModelConfig,
 		protected readonly _context?: vscode.ExtensionContext,
-		protected readonly _storage?: SecretStorage,
 	) {
 		this.id = _config.id;
 		this.displayName = _config.name;

--- a/extensions/positron-assistant/src/providers/google/googleProvider.ts
+++ b/extensions/positron-assistant/src/providers/google/googleProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { createGoogleGenerativeAI, GoogleGenerativeAIProvider } from '@ai-sdk/google';
 import { VercelModelProvider } from '../base/vercelModelProvider';
-import { ModelConfig, SecretStorage } from '../../config';
+import { ModelConfig } from '../../config';
 
 /**
  * Google Gemini model provider implementation.
@@ -58,8 +58,8 @@ export class GoogleModelProvider extends VercelModelProvider implements positron
 		},
 	};
 
-	constructor(_config: ModelConfig, _context?: vscode.ExtensionContext, _storage?: SecretStorage) {
-		super(_config, _context, _storage);
+	constructor(_config: ModelConfig, _context?: vscode.ExtensionContext) {
+		super(_config, _context);
 	}
 
 	/**

--- a/extensions/positron-assistant/src/providers/index.ts
+++ b/extensions/positron-assistant/src/providers/index.ts
@@ -13,7 +13,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { ModelConfig, SecretStorage } from '../config';
+import { ModelConfig } from '../config';
 
 // Import provider classes for use in utility functions
 import { ErrorModelProvider } from './test/errorProvider';
@@ -39,7 +39,7 @@ import { CopilotModelProvider } from '../copilot.js';
  * Type for a concrete (non-abstract) model provider constructor with static metadata.
  */
 interface ConcreteModelProviderConstructor {
-	new(config: ModelConfig, context: vscode.ExtensionContext, storage: SecretStorage): ModelProvider;
+	new(config: ModelConfig, context: vscode.ExtensionContext): ModelProvider;
 	source: positron.ai.LanguageModelSource;
 	autoconfigure?: () => Promise<AutoconfigureResult>;
 }
@@ -152,12 +152,12 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
  * Creates a new language model chat provider instance based on the configuration.
  * This is used to instantiate the appropriate provider class.
  */
-export function newLanguageModelChatProvider(config: ModelConfig, context: vscode.ExtensionContext, storage: SecretStorage): positron.ai.LanguageModelChatProvider {
+export function newLanguageModelChatProvider(config: ModelConfig, context: vscode.ExtensionContext): positron.ai.LanguageModelChatProvider {
 	const providerClass = getModelProviders().find((cls) => cls.source.provider.id === config.provider);
 	if (!providerClass) {
 		throw new Error(`Unsupported chat provider: ${config.provider}`);
 	}
-	return new providerClass(config, context, storage);
+	return new providerClass(config, context);
 }
 
 export { AutoconfigureResult };

--- a/extensions/positron-assistant/src/providers/test/echoProvider.ts
+++ b/extensions/positron-assistant/src/providers/test/echoProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as ai from 'ai';
-import { ModelConfig, SecretStorage } from '../../config';
+import { ModelConfig } from '../../config';
 import { DEFAULT_MAX_TOKEN_INPUT, DEFAULT_MAX_TOKEN_OUTPUT, DEFAULT_MODEL_CAPABILITIES } from '../../constants';
 import { recordTokenUsage, recordRequestTokenUsage } from '../../extension';
 import { toAIMessage } from '../../utils';
@@ -24,9 +24,8 @@ export class EchoModelProvider extends ModelProvider {
 	constructor(
 		_config: ModelConfig,
 		_context?: vscode.ExtensionContext,
-		_storage?: SecretStorage,
 	) {
-		super(_config, _context, _storage);
+		super(_config, _context);
 	}
 
 	static source = {

--- a/extensions/positron-assistant/src/providers/test/errorProvider.ts
+++ b/extensions/positron-assistant/src/providers/test/errorProvider.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { ModelConfig, SecretStorage } from '../../config';
+import { ModelConfig } from '../../config';
 import { DEFAULT_MAX_TOKEN_OUTPUT } from '../../constants';
 import { ModelProvider } from '../base/modelProvider';
 
@@ -20,9 +20,8 @@ export class ErrorModelProvider extends ModelProvider {
 	constructor(
 		_config: ModelConfig,
 		_context?: vscode.ExtensionContext,
-		_storage?: SecretStorage,
 	) {
-		super(_config, _context, _storage);
+		super(_config, _context);
 	}
 
 	static source = {

--- a/extensions/positron-assistant/src/reset.ts
+++ b/extensions/positron-assistant/src/reset.ts
@@ -1,12 +1,12 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import { generateDiagnosticsContent } from './diagnostics';
 import { CopilotService } from './copilot';
-import { getStoredModels, GlobalSecretStorage } from './config';
+import { getStoredModels } from './config';
 import { disposeModels, log } from './extension';
 
 function formatError(error: unknown): string {
@@ -49,10 +49,9 @@ async function clearAssistantState(context: vscode.ExtensionContext): Promise<vo
 		}
 	}
 
-	const storage = new GlobalSecretStorage(context);
 	for (const model of storedModels) {
 		try {
-			await storage.delete(`apiKey-${model.id}`);
+			await context.secrets.delete(`apiKey-${model.id}`);
 		} catch (error) {
 			log.trace(`Failed to delete API key for model ${model.id}: ${formatError(error)}`);
 		}

--- a/extensions/positron-assistant/src/test/anthropic.test.ts
+++ b/extensions/positron-assistant/src/test/anthropic.test.ts
@@ -102,7 +102,7 @@ suite('AnthropicModelProvider', () => {
 		};
 
 		// Create an instance of the AnthropicModelProvider
-		model = new AnthropicModelProvider(config, undefined, undefined, mockClient as unknown as Anthropic);
+		model = new AnthropicModelProvider(config, undefined, mockClient as unknown as Anthropic);
 
 		// Create mock model info for provideLanguageModelChatResponse
 		mockModelInfo = {


### PR DESCRIPTION
This change transitions Positron Assistant's API key storage to an encrypted, browser-based storage mechanism in Positron Workbench, by removing the previous solution that used global state. 

It also removes the now-unnecessary layer of abstraction that was used to switch between these storage mechanisms, and includes migration logic that transfers keys to the new encrypted storage when they are found, so that it is not necessary for users to sign in or enter keys again.