### PR TITLE
python: add on_close handler to plots

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -91,7 +91,6 @@ class FigureManagerPositron(FigureManagerBase):
         content: dict[str, Any] = cast("dict[str, Any]", parent.get("content", {}))
         execution_id: str = header.get("msg_id", "")
         code: str = content.get("code", "")
-        num: int | str = num
 
         # Detect which plotting library was used
         kind = _detect_plotting_library()

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -23,6 +23,7 @@ import sys
 from typing import TYPE_CHECKING, Any, cast
 
 import matplotlib
+import matplotlib.pyplot as plt
 from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
@@ -95,19 +96,20 @@ class FigureManagerPositron(FigureManagerBase):
         # Detect which plotting library was used
         kind = _detect_plotting_library()
 
-        # Create a callback to close the matplotlib figure when the plot is closed.
-        # This ensures matplotlib's internal figure cache is cleared when the frontend
-        # closes the plot, preventing figures from being restored when the comm reopens.
-        def on_close() -> None:
-            import matplotlib.pyplot as plt
-
-            plt.close(num)
-
         # Create the plot instance via the plots service.
         self._plots_service = kernel.plots_service
         self._plot = self._plots_service.create_plot(
-            canvas.render, canvas.intrinsic_size, kind, execution_id, code, num, on_close
+            canvas.render, canvas.intrinsic_size, kind, execution_id, code, num, self._on_close
         )
+
+    def _on_close(self) -> None:
+        """
+        Close the matplotlib figure when the plot is closed.
+
+        This ensures matplotlib's internal figure cache is cleared when the frontend
+        closes the plot, preventing figures from being restored when the comm reopens.
+        """
+        plt.close(self.num)
 
     @property
     def closed(self) -> bool:

--- a/extensions/positron-python/python_files/posit/positron/plots.py
+++ b/extensions/positron-python/python_files/posit/positron/plots.py
@@ -44,7 +44,7 @@ class Plot:
     """
     The backend representation of a frontend plot instance.
 
-    Paramaters
+    Parameters
     ----------
     comm
         The communication channel to the frontend plot instance.

--- a/extensions/positron-python/python_files/posit/positron/plots.py
+++ b/extensions/positron-python/python_files/posit/positron/plots.py
@@ -247,7 +247,9 @@ class PlotsService:
         comm_id = str(uuid.uuid4())
         logger.info(f"Creating plot with comm {comm_id}")
         plot_comm = PositronComm.create(self._target_name, comm_id)
-        plot = Plot(plot_comm, render, intrinsic_size, kind, execution_id, code, figure_num, on_close)
+        plot = Plot(
+            plot_comm, render, intrinsic_size, kind, execution_id, code, figure_num, on_close
+        )
         self._plots.append(plot)
         return plot
 


### PR DESCRIPTION
Closing plots worked in the `matplotlib` -> Positron direction but not the reverse. We need to clear out matplotlib's internal cache when the frontend requests, so adding an `on_close` to the plot itself we can use when the comm is shut down.

I updated tests as well, which assumed that a plot would be restored after a comm is shut down. I believe this new behavior is what we actually want. We can still update plots that are active in the plots pane, but once they're cleared, they're gone.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #7584 Matplotlib plots do not repopulate after pressing `Clear All`


### QA Notes

@:plots

```python

import matplotlib.pyplot as plt
import numpy as np

x = 4 + np.random.normal(0, 2, 24)
y = 4 + np.random.normal(0, 2, len(x))

# plot
fig, ax = plt.subplots()
ax.scatter(x, y)
plt.show()

# plot
fig, ax = plt.subplots()
ax.scatter(x, y)
plt.show()
```

run this, clear the plots, then rerun. you should only get 2 plots (as expected). before you would get 4 plots.