### PR TITLE
Only run CLA workflow on PR events/comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   RequireCLA:
     runs-on: ubuntu-latest
+    # Only run for PR events or comments on PRs (not comments on issues)
+    if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
     steps:
       - name: "Strip whitespace from comment body"
         id: strip_whitespace


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/11677

Adds a job-level `if` condition to the CLA workflow to skip the entire job for comments on regular issues:

```yaml
if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
```

This is a speculative fix, but it follows the pattern for [issue_comment on issues only or pull requests only](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only) in the github docs for filtering `issue_comment` events to only run on PR comments.

Previously, the workflow would trigger on all `issue_comment` events, including comments on regular issues. While the CLA Assistant step has its own conditional, the job still started and consumed runner resources unnecessarily. When github actions has an outage, the issue is more apparent since folks posting comments on issues will get email notifications about failed CLA runs.