### PR TITLE
e2e: add retry to context menu click

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -104,7 +104,7 @@ permissions:
 jobs:
   e2e-windows-run:
     name: ${{ inputs.display_name || 'e2e-windows-run' }}-${{ matrix.shard }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     runs-on: windows-latest-8x
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Summary
* Adding a retry to context menu hover+click to handle DOM detachment from menu re-renders
* Also bumping Windows timeout

### QA Notes

@:console