### PR TITLE
Positron Notebooks: Output expand/collapse support

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -100,6 +100,7 @@ export class MenuId {
 	static readonly PositronNotebookCellActionBarSubmenu = new MenuId('PositronNotebookCellActionBarSubmenu');
 	static readonly PositronNotebookCellActionLeft = new MenuId('PositronNotebookCellActionLeft');
 	static readonly PositronNotebookCellContext = new MenuId('PositronNotebookCellContext');
+	static readonly PositronNotebookCellOutputActionLeft = new MenuId('PositronNotebookCellOutputActionLeft');
 	static readonly EditorActionsLeft = new MenuId('EditorActionsLeft');
 	static readonly EditorActionsRight = new MenuId('EditorActionsRight');
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -51,6 +51,10 @@ export const POSITRON_NOTEBOOK_CELL_IS_ACTIVE = new RawContextKey<boolean>('posi
 export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
 export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);
 
+// Output-related context keys
+export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
+export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
+
 // All cell context keys in one place so we can easily operate on them all at once
 export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	isCode: POSITRON_NOTEBOOK_CELL_IS_CODE,
@@ -66,6 +70,8 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	isActive: POSITRON_NOTEBOOK_CELL_IS_ACTIVE,
 	canMoveUp: POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP,
 	canMoveDown: POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN,
+	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
 } as const;
 
 // Interface for the cell context keys
@@ -92,6 +98,8 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		isActive: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isActive.bindTo(service),
 		canMoveUp: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveUp.bindTo(service),
 		canMoveDown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown.bindTo(service),
+		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
+		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
 	} satisfies IPositronNotebookCellContextKeys;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -241,6 +241,11 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	readonly outputs: IObservable<NotebookCellOutputs[]>;
 
 	/**
+	 * Whether the cell outputs are collapsed
+	 */
+	readonly outputIsCollapsed: ISettableObservable<boolean>;
+
+	/**
 	 * Duration of the last execution in milliseconds
 	 */
 	readonly lastExecutionDuration: IObservable<number | undefined>;
@@ -259,6 +264,21 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	 * Timestamp when the last execution ended
 	 */
 	readonly lastRunEndTime: IObservable<number | undefined>;
+
+	/**
+	 * Collapse the cell outputs
+	 */
+	collapseOutput(): void;
+
+	/**
+	 * Expand the cell outputs
+	 */
+	expandOutput(): void;
+
+	/**
+	 * Toggle the collapse state of cell outputs
+	 */
+	toggleOutputCollapse(): void;
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -22,7 +22,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	private readonly _outputs;
 
 	// Output collapse state
-	private readonly _outputIsCollapsed = observableValue<boolean>('outputIsCollapsed', false);
+	private readonly _outputIsCollapsed: ISettableObservable<boolean>;
 
 	// Execution timing observables
 	lastExecutionDuration;
@@ -38,6 +38,12 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 		@IPositronWebviewPreloadService private _webviewPreloadService: IPositronWebviewPreloadService,
 	) {
 		super(cellModel, instance, _executionStateService, _textModelResolverService);
+
+		// Initialize output collapse state from cell model if available
+		this._outputIsCollapsed = observableValue<boolean>(
+			'outputIsCollapsed',
+			cellModel.collapseState?.outputCollapsed ?? false
+		);
 
 		this._outputs = observableFromEvent(this, this.model.onDidChangeOutputs, () => {
 			/** @description cellOutputs */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { observableFromEvent } from '../../../../../base/common/observable.js';
+import { ISettableObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
@@ -20,6 +20,9 @@ import { IPositronCellOutputViewModel } from '../IPositronNotebookEditor.js';
 export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implements IPositronNotebookCodeCell {
 	override kind: CellKind.Code = CellKind.Code;
 	private readonly _outputs;
+
+	// Output collapse state
+	private readonly _outputIsCollapsed = observableValue<boolean>('outputIsCollapsed', false);
 
 	// Execution timing observables
 	lastExecutionDuration;
@@ -60,6 +63,22 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 
 	override get outputs() {
 		return this._outputs;
+	}
+
+	get outputIsCollapsed(): ISettableObservable<boolean> {
+		return this._outputIsCollapsed;
+	}
+
+	collapseOutput(): void {
+		this._outputIsCollapsed.set(true, undefined);
+	}
+
+	expandOutput(): void {
+		this._outputIsCollapsed.set(false, undefined);
+	}
+
+	toggleOutputCollapse(): void {
+		this._outputIsCollapsed.set(!this._outputIsCollapsed.get(), undefined);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
@@ -12,9 +12,16 @@
 	*/
 	--_container-offset-left: -24px;
 	--_container-size: 20px;
+	/*
+	 * To line up output menu with the first line of the output, we need to position the menu
+	 * the same distance from the top of the cell as the start of the output contents.
+	 * The output contents are 0.5rem from the top of the cell because of the padding.
+	 * So we need to offset the menu 0.5rem from the top of the cell as well.
+	 */
+	--_container-offset-top: 0.5rem;
 
 	position: absolute;
-	top: 0;
+	top: var(--_container-offset-top);
 	left: var(--_container-offset-left);
 	width: var(--_container-size);
 	height: var(--_container-size);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Container for output left action menu - positioned in the gutter area */
+.cell-output-left-action-menu {
+	/* Use the same offset as CellLeftActionMenu for consistent gutter positioning */
+	--_container-offset-left: -25px;
+	--_container-size: 20px;
+
+	position: absolute;
+	top: 0;
+	left: var(--_container-offset-left);
+	width: var(--_container-size);
+	height: var(--_container-size);
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	/* Make the button styles more compact so it fits in the left cell gutter */
+	& .action-button {
+		padding: 2px;
+		border-radius: 4px;
+		min-width: unset;
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.css
@@ -5,8 +5,12 @@
 
 /* Container for output left action menu - positioned in the gutter area */
 .cell-output-left-action-menu {
-	/* Use the same offset as CellLeftActionMenu for consistent gutter positioning */
-	--_container-offset-left: -25px;
+	/*
+	* A -24px offset will vertically align this menu with the CellLeftActionMenu
+	* in the cell gutter. The offset is 1px less than CellLeftActionMenu because
+	* there is no 1px border on the parent of this element.
+	*/
+	--_container-offset-left: -24px;
 	--_container-size: 20px;
 
 	position: absolute;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './CellOutputLeftActionMenu.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { MenuId } from '../../../../../platform/actions/common/actions.js';
+import { useMenu } from '../useMenu.js';
+import { useMenuActions } from '../useMenuActions.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
+import { NotebookCellMoreActionsMenu } from './actionBar/NotebookCellMoreActionsMenu.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+
+interface CellOutputLeftActionMenuProps {
+	cell: PositronNotebookCodeCell;
+}
+
+/**
+ * The left action menu for notebook cell output actions.
+ * @param cell The cell that the menu actions will operate on
+ */
+export function CellOutputLeftActionMenu({ cell }: CellOutputLeftActionMenuProps) {
+	const instance = useNotebookInstance();
+	const contextKeyService = useCellScopedContextKeyService();
+
+	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+	const menu = useMenu(MenuId.PositronNotebookCellOutputActionLeft, contextKeyService);
+	const menuActions = useMenuActions(menu);
+
+	// Don't render if there are no actions
+	if (menuActions.length === 0) {
+		return null;
+	}
+
+	return (
+		<NotebookCellMoreActionsMenu
+			cell={cell}
+			hoverManager={instance.hoverManager}
+			instance={instance}
+			isMenuOpen={isMenuOpen}
+			menuActions={menuActions}
+			setIsMenuOpen={setIsMenuOpen}
+		/>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
@@ -7,17 +7,21 @@
 import './CellOutputLeftActionMenu.css';
 
 // React.
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { ActionRunner } from '../../../../../base/common/actions.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
-import { useMenu } from '../useMenu.js';
-import { useMenuActions } from '../useMenuActions.js';
+import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
-import { NotebookCellMoreActionsMenu } from './actionBar/NotebookCellMoreActionsMenu.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { CellSelectionType } from '../selectionMachine.js';
+import { useObservedValue } from '../useObservedValue.js';
+import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 
 const cellOutputActions = localize('cellOutputActions', 'Cell Output Actions');
 
@@ -27,32 +31,74 @@ interface CellOutputLeftActionMenuProps {
 
 /**
  * The left action menu for notebook cell output actions.
+ * Uses the native context menu service to display actions registered to
+ * MenuId.PositronNotebookCellOutputActionLeft.
  * @param cell The cell that the menu actions will operate on
  */
 export function CellOutputLeftActionMenu({ cell }: CellOutputLeftActionMenuProps) {
 	const instance = useNotebookInstance();
 	const contextKeyService = useCellScopedContextKeyService();
+	const { contextMenuService } = usePositronReactServicesContext();
 
+	const buttonRef = useRef<HTMLButtonElement>(null);
+	const actionRunnerRef = useRef<ActionRunner>();
 	const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-	const menu = useMenu(MenuId.PositronNotebookCellOutputActionLeft, contextKeyService);
-	const menuActions = useMenuActions(menu);
 
-	// Don't render if there are no actions
-	if (menuActions.length === 0) {
+	// Check if there are outputs to determine if we should render the menu
+	const outputs = useObservedValue(cell.outputs);
+	const hasOutputs = outputs.length > 0;
+
+	// Create and setup the action runner
+	useEffect(() => {
+		const actionRunner = new ActionRunner();
+
+		// Select the cell before any action runs to ensure notebook selection is in sync
+		const onWillRunDisposable = actionRunner.onWillRun(() => {
+			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+		});
+
+		actionRunnerRef.current = actionRunner;
+
+		return () => {
+			onWillRunDisposable.dispose();
+			actionRunner.dispose();
+		};
+	}, [cell, instance]);
+
+	const showContextMenu = () => {
+		if (!buttonRef.current || !actionRunnerRef.current) {
+			return;
+		}
+
+		setIsMenuOpen(true);
+
+		contextMenuService.showContextMenu({
+			menuId: MenuId.PositronNotebookCellOutputActionLeft,
+			contextKeyService,
+			getAnchor: () => buttonRef.current!,
+			actionRunner: actionRunnerRef.current,
+			onHide: () => setIsMenuOpen(false),
+		});
+	};
+
+	// Don't render if the cell has no outputs
+	if (!hasOutputs) {
 		return null;
 	}
 
 	return (
 		<div className='cell-output-left-action-menu'>
-			<NotebookCellMoreActionsMenu
+			<ActionButton
+				ref={buttonRef}
+				aria-expanded={isMenuOpen}
+				aria-haspopup='menu'
 				ariaLabel={cellOutputActions}
-				cell={cell}
 				hoverManager={instance.hoverManager}
-				instance={instance}
-				isMenuOpen={isMenuOpen}
-				menuActions={menuActions}
-				setIsMenuOpen={setIsMenuOpen}
-			/>
+				tooltip={cellOutputActions}
+				onPressed={showContextMenu}
+			>
+				<Icon className='button-icon' icon={Codicon.ellipsis} />
+			</ActionButton>
 		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
@@ -10,6 +10,7 @@ import './CellOutputLeftActionMenu.css';
 import React from 'react';
 
 // Other dependencies.
+import { localize } from '../../../../../nls.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { useMenu } from '../useMenu.js';
 import { useMenuActions } from '../useMenuActions.js';
@@ -17,6 +18,8 @@ import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { NotebookCellMoreActionsMenu } from './actionBar/NotebookCellMoreActionsMenu.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+
+const cellOutputActions = localize('cellOutputActions', 'Cell Output Actions');
 
 interface CellOutputLeftActionMenuProps {
 	cell: PositronNotebookCodeCell;
@@ -42,6 +45,7 @@ export function CellOutputLeftActionMenu({ cell }: CellOutputLeftActionMenuProps
 	return (
 		<div className='cell-output-left-action-menu'>
 			<NotebookCellMoreActionsMenu
+				ariaLabel={cellOutputActions}
 				cell={cell}
 				hoverManager={instance.hoverManager}
 				instance={instance}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
@@ -40,13 +40,15 @@ export function CellOutputLeftActionMenu({ cell }: CellOutputLeftActionMenuProps
 	}
 
 	return (
-		<NotebookCellMoreActionsMenu
-			cell={cell}
-			hoverManager={instance.hoverManager}
-			instance={instance}
-			isMenuOpen={isMenuOpen}
-			menuActions={menuActions}
-			setIsMenuOpen={setIsMenuOpen}
-		/>
+		<div className='cell-output-left-action-menu'>
+			<NotebookCellMoreActionsMenu
+				cell={cell}
+				hoverManager={instance.hoverManager}
+				instance={instance}
+				isMenuOpen={isMenuOpen}
+				menuActions={menuActions}
+				setIsMenuOpen={setIsMenuOpen}
+			/>
+		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -22,6 +22,8 @@ import { useMenuActions } from '../useMenuActions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCellActionBarLeftGroup } from '../../common/positronNotebookCommon.js';
 
+const moreCellActions = localize('moreCellActions', 'More Cell Actions');
+
 interface NotebookCellActionBarProps {
 	cell: IPositronNotebookCell;
 }
@@ -76,6 +78,7 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 		{/* Dropdown menu for additional actions - only render if there are menu actions */}
 		{hasSubmenuActions ? (
 			<NotebookCellMoreActionsMenu
+				ariaLabel={moreCellActions}
 				cell={cell}
 				hoverManager={instance.hoverManager}
 				instance={instance}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -65,23 +65,23 @@
 
 /* === Special Case: Code Cells with No Outputs === */
 
-.positron-notebook-code-cell:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-section {
+.positron-notebook-code-cell:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section {
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 	border-bottom: 1px solid var(--vscode-positronNotebook-border-color);
 }
 
 /* Make bottom border of code cell footer transparent when there are no outputs to avoid double border while maintaining static height */
-.positron-notebook-code-cell:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-code-cell-footer {
+.positron-notebook-code-cell:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-code-cell-footer {
 	border-bottom-color: transparent;
 }
 
 /* Update the border color for code cells with no outputs based on the selection state */
-.positron-notebook-cell.selected:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-section,
-.positron-notebook-cell.editing:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-section {
+.positron-notebook-cell.selected:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section,
+.positron-notebook-cell.editing:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section {
 	border-bottom-color: var(--vscode-focusBorder);
 }
 
-.positron-notebook-cell:not(.selected):not(.editing):hover:has(.positron-notebook-cell-outputs.no-outputs) .positron-notebook-editor-section {
+.positron-notebook-cell:not(.selected):not(.editing):hover:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section {
 	border-bottom-color: var(--vscode-editorWidget-border);
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-code-cell-contents {
+	--_output-container-offset: 0.5rem;
+
 	.positron-notebook-editor-section {
 		position: relative;
 	}
@@ -24,7 +26,7 @@
 
 	.positron-notebook-code-cell-outputs-inner {
 		padding-inline: 1rem;
-		padding-block: 0.5rem;
+		padding-block: var(--_output-container-offset);
 
 		/* Avoid overlap with border which is overlaid from another element so
 		the layout doesn't automatically avoid it*/

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -56,9 +56,11 @@
 
 		/* Button to show hidden outputs styled as a link */
 		.show-hidden-output-button {
+			font-size: 12px;
 			color: var(--vscode-textLink-foreground);
 			background: none;
 			border: none;
+			padding: 0;
 		}
 
 		.show-hidden-output-button:hover {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -53,5 +53,22 @@
 				padding-right: 5px;
 			}
 		}
+
+		/* Button to show hidden outputs styled as a link */
+		.show-hidden-output-button {
+			color: var(--vscode-textLink-foreground);
+			background: none;
+			border: none;
+		}
+
+		.show-hidden-output-button:hover {
+			text-decoration: underline;
+		}
+
+		/* override the global .monaco-workbench button focus outline style */
+		.show-hidden-output-button:focus,
+		.show-hidden-output-button:focus-visible {
+			outline-offset: 2px !important;
+		}
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -8,13 +8,18 @@
 		position: relative;
 	}
 
-	.positron-notebook-cell-outputs {
-		overflow: hidden;
+	/* Wrapper for outputs section - provides positioning context for the left action menu */
+	.positron-notebook-outputs-section {
+		position: relative;
 
 		&.no-outputs {
 			/* Dont show empty outputs at all */
 			display: none;
 		}
+	}
+
+	.positron-notebook-cell-outputs {
+		overflow: hidden;
 	}
 
 	.positron-notebook-code-cell-outputs-inner {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -20,22 +20,27 @@ import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellLeftActionMenu } from './CellLeftActionMenu.js';
+import { CellOutputLeftActionMenu } from './CellOutputLeftActionMenu.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
 
 
 interface CellOutputsSectionProps {
+	cell: PositronNotebookCodeCell;
 	outputs: NotebookCellOutputs[];
 }
 
-function CellOutputsSection({ outputs }: CellOutputsSectionProps) {
+function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	return (
-		<div className={`positron-notebook-code-cell-outputs positron-notebook-cell-outputs ${outputs.length > 0 ? '' : 'no-outputs'}`} data-testid='cell-output'>
-			<div className='positron-notebook-code-cell-outputs-inner'>
-				{outputs?.map((output) => (
-					<CellOutput key={output.outputId} {...output} />
-				))}
+		<div className={`positron-notebook-outputs-section ${outputs.length > 0 ? '' : 'no-outputs'}`}>
+			<CellOutputLeftActionMenu cell={cell} />
+			<div className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs' data-testid='cell-output'>
+				<div className='positron-notebook-code-cell-outputs-inner'>
+					{outputs?.map((output) => (
+						<CellOutput key={output.outputId} {...output} />
+					))}
+				</div>
 			</div>
 		</div>
 	);
@@ -57,7 +62,7 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 					</div>
 					<CodeCellStatusFooter cell={cell} hasError={hasError} />
 				</div>
-				<CellOutputsSection outputs={outputContents} />
+				<CellOutputsSection cell={cell} outputs={outputContents} />
 			</div>
 
 		</NotebookCellWrapper>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -35,6 +35,19 @@ interface CellOutputsSectionProps {
 function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
 
+	const handleShowHiddenOutput = () => {
+		cell.expandOutput();
+		/**
+		 * When this handler is fired via a keyboard event (ex: Enter),
+		 * the focus remains on the button that triggered this event.
+		 * However, since expanding the output causes this button
+		 * to be removed from the DOM, focus is lost. To maintain
+		 * focus so keyboard nav/shortcuts still work, we refocus
+		 * the cell container after expanding the output.
+		 */
+		cell.container?.focus();
+	};
+
 	return (
 		<div className={`positron-notebook-outputs-section ${outputs.length > 0 ? '' : 'no-outputs'}`}>
 			<CellOutputLeftActionMenu cell={cell} />
@@ -44,7 +57,7 @@ function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 						? (<Button
 							ariaLabel={localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
 							className='show-hidden-output-button'
-							onPressed={() => cell.expandOutput()}
+							onPressed={handleShowHiddenOutput}
 						>
 							{localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
 						</Button>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -24,6 +24,7 @@ import { CellOutputLeftActionMenu } from './CellOutputLeftActionMenu.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
 
 interface CellOutputsSectionProps {
@@ -32,14 +33,28 @@ interface CellOutputsSectionProps {
 }
 
 function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
+	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
+
 	return (
 		<div className={`positron-notebook-outputs-section ${outputs.length > 0 ? '' : 'no-outputs'}`}>
 			<CellOutputLeftActionMenu cell={cell} />
 			<div className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs' data-testid='cell-output'>
 				<div className='positron-notebook-code-cell-outputs-inner'>
-					{outputs?.map((output) => (
-						<CellOutput key={output.outputId} {...output} />
-					))}
+					{isCollapsed
+						? (<Button
+							ariaLabel={localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
+							className='show-hidden-output-button'
+							onPressed={() => cell.expandOutput()}
+						>
+							{localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
+						</Button>
+						)
+						: (<>
+							{outputs?.map((output) => (
+								<CellOutput key={output.outputId} {...output} />
+							))}
+						</>
+						)}
 				</div>
 			</div>
 		</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -7,7 +7,6 @@
 import React, { useRef } from 'react';
 
 // Other dependencies.
-import { localize } from '../../../../../../nls.js';
 import { showCustomContextMenu } from '../../../../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
@@ -19,6 +18,7 @@ import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNote
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 
 interface NotebookCellMoreActionsMenuProps {
+	ariaLabel: string;
 	cell: IPositronNotebookCell;
 	hoverManager?: IHoverManager;
 	instance: IPositronNotebookInstance;
@@ -27,13 +27,12 @@ interface NotebookCellMoreActionsMenuProps {
 	setIsMenuOpen: (isOpen: boolean) => void;
 }
 
-const moreCellActions = localize('moreCellActions', 'More Cell Actions');
-
 /**
  * More actions dropdown menu component for notebook cells.
  * Encapsulates all dropdown menu logic including state management and menu display.
  */
 export function NotebookCellMoreActionsMenu({
+	ariaLabel,
 	cell,
 	hoverManager,
 	instance,
@@ -76,9 +75,9 @@ export function NotebookCellMoreActionsMenu({
 			ref={buttonRef}
 			aria-expanded={isMenuOpen}
 			aria-haspopup='menu'
-			ariaLabel={moreCellActions}
+			ariaLabel={ariaLabel}
 			hoverManager={hoverManager}
-			tooltip={moreCellActions}
+			tooltip={ariaLabel}
 			onPressed={showMoreActionsMenu}
 		>
 			<Icon className='button-icon' icon={Codicon.ellipsis} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -82,6 +82,8 @@ export function useCellContextKeys(
 			keys.isActive.set(isActiveCell);
 			keys.canMoveUp.set(cell.index > 0 && cells.length > 1);
 			keys.canMoveDown.set(cell.index < cells.length - 1 && cells.length > 1);
+			keys.hasOutputs.set(cell.isCodeCell() && cell.outputs.read(reader).length > 0);
+			keys.outputIsCollapsed.set(cell.isCodeCell() ? cell.outputIsCollapsed.read(reader) : false);
 		}));
 
 		// Set the state to let other components know that the context keys are ready

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -25,4 +25,9 @@ export function usingPositronNotebooks(configurationService: IConfigurationServi
 // Primary actions are shown more prominently than others
 export enum PositronNotebookCellActionBarLeftGroup {
 	Primary = '0_primary',
+}
+
+// Group IDs for output actions menu
+export enum PositronNotebookCellOutputActionGroup {
+	Collapse = '0_collapse',
 }


### PR DESCRIPTION
Addresses #6571 

This PR adds the ability to expand/collapse all cell outputs. A new output cell menu has been introduced in the left cell gutter for code cells.

Note: The actual ask in the issue is to expand/collapse different output types independently (plots vs text), but that hasn't been implemented yet. That will be done sometime in the future.

### Screenshots

**Mouse Behavior**

https://github.com/user-attachments/assets/107ee6c1-4a35-4321-9886-f7e8b49cd79d

**Keyboard Behavior**

https://github.com/user-attachments/assets/c057c714-7b80-468c-bfbd-0a95d91add02


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Add ability to show/hide the output of a cell for the Positron Notebook Editor (#6571)

#### Bug Fixes

- N/A


### QA Notes
@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
