### PR TITLE
Rename Playwright automation agent and update description

### DIFF
--- a/.github/agents/missing-auto.agent.md
+++ b/.github/agents/missing-auto.agent.md
@@ -1,5 +1,5 @@
 ---
-name: Playwright Automation Gap Issue Identifier/Writter (Data Science Workflows)
+name: pw-auto-missing
 description: Identify missing Playwright automation coverage in Positron IDE by focusing on real data science user workflows, and generate complete GitHub issues with TypeScript test plans.
 ---
 


### PR DESCRIPTION
Updated the name and description of the Playwright automation agent. Agents can only be invoked if their names are less than 60 characters. 