### PR TITLE
Assistant: fix tool calls for autoconfigured providers with custom auth

### DIFF
--- a/extensions/positron-assistant/src/providers/index.ts
+++ b/extensions/positron-assistant/src/providers/index.ts
@@ -48,7 +48,7 @@ interface ConcreteModelProviderConstructor {
  * Result of resolving autoconfigure credentials for a model.
  */
 interface ResolvedCredentials {
-	apiKey: string;
+	apiKey?: string;
 	baseUrl?: string;
 	autoconfigure: NonNullable<ModelConfig['autoconfigure']>;
 }
@@ -80,10 +80,10 @@ async function resolveAutoconfigureCredentials(model: ConcreteModelProviderConst
 	} else if (autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.Custom) {
 		if (model.autoconfigure) {
 			const result = await model.autoconfigure();
-			if (result.configured && result.configuration?.apiKey) {
+			if (result.configured) {
 				return {
-					apiKey: result.configuration.apiKey,
-					baseUrl: result.configuration.baseUrl,
+					apiKey: result.configuration?.apiKey,
+					baseUrl: result.configuration?.baseUrl,
 					autoconfigure: {
 						type: positron.ai.LanguageModelAutoconfigureType.Custom,
 						message: result.message,
@@ -157,7 +157,7 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 				model: model.source.defaults.model,
 				toolCalls: model.source.defaults.toolCalls,
 				completions: model.source.defaults.completions,
-				apiKey: credentials.apiKey,
+				...(credentials.apiKey && { apiKey: credentials.apiKey }),
 				...(credentials.baseUrl && { baseUrl: credentials.baseUrl }),
 				autoconfigure: credentials.autoconfigure,
 			};

--- a/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
+++ b/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
@@ -24,8 +24,7 @@ suite('Autoconfigured Providers', () => {
 		// Mock all Custom-type autoconfigure methods to return configured: true
 		AWSModelProvider.autoconfigure = async () => ({
 			configured: true,
-			message: 'Test AWS creds',
-			configuration: { apiKey: 'test-key' }
+			message: 'Test AWS creds'
 		});
 
 		SnowflakeModelProvider.autoconfigure = async () => ({

--- a/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
+++ b/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createAutomaticModelConfigs } from '../providers/index.js';
+import { AWSModelProvider } from '../providers/aws/awsBedrockProvider.js';
+import { SnowflakeModelProvider } from '../providers/snowflake/snowflakeProvider.js';
+import { CopilotModelProvider } from '../copilot.js';
+
+suite('Autoconfigured Providers', () => {
+	// Store original autoconfigure methods
+	let originalAWSAutoconfigure: typeof AWSModelProvider.autoconfigure;
+	let originalSnowflakeAutoconfigure: typeof SnowflakeModelProvider.autoconfigure;
+	let originalCopilotAutoconfigure: typeof CopilotModelProvider.autoconfigure;
+
+	setup(() => {
+		// Save originals
+		originalAWSAutoconfigure = AWSModelProvider.autoconfigure;
+		originalSnowflakeAutoconfigure = SnowflakeModelProvider.autoconfigure;
+		originalCopilotAutoconfigure = CopilotModelProvider.autoconfigure;
+
+		// Mock all Custom-type autoconfigure methods to return configured: true
+		AWSModelProvider.autoconfigure = async () => ({
+			configured: true,
+			message: 'Test AWS creds',
+			configuration: { apiKey: 'test-key' }
+		});
+
+		SnowflakeModelProvider.autoconfigure = async () => ({
+			configured: true,
+			message: 'Test Snowflake creds',
+			configuration: { apiKey: 'test-key', baseUrl: 'https://example.com' }
+		});
+
+		// CopilotModelProvider requires CopilotService singleton which isn't available in tests
+		CopilotModelProvider.autoconfigure = async () => ({ configured: false });
+	});
+
+	teardown(() => {
+		// Restore originals
+		AWSModelProvider.autoconfigure = originalAWSAutoconfigure;
+		SnowflakeModelProvider.autoconfigure = originalSnowflakeAutoconfigure;
+		CopilotModelProvider.autoconfigure = originalCopilotAutoconfigure;
+	});
+
+	test('all autoconfigured providers include toolCalls: true', async () => {
+		const configs = await createAutomaticModelConfigs();
+		const failures: string[] = [];
+
+		const expectedProviders = ['amazon-bedrock', 'snowflake-cortex'];
+		for (const providerId of expectedProviders) {
+			const config = configs.find((c) => c.provider === providerId);
+			if (!config) {
+				failures.push(`${providerId}: config not created`);
+			} else if (config.toolCalls !== true) {
+				failures.push(`${providerId}: toolCalls must be true`);
+			}
+		}
+
+		assert.strictEqual(failures.length, 0, `Failures:\n${failures.join('\n')}`);
+	});
+});


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/11701
- refactors how the model config for autoconfigured providers is constructed to avoid a situation where env var and custom auth providers deviate
- adds an integration test to specifically check that Bedrock and Snowflake autoconfigured providers have toolCalls set to true
    - this test fails before the fix in 4190e53779ca8867a0187b8adf8519449a8b2260 is applied and passes after the fix is applied

### Release Notes

#### Bug Fixes

- Assistant: fix issue causing tool calls to be unavailable for autoconfigured providers (#11701)

### QA Notes

- Added integration test to check that toolCalls is true for Snowflake and Amazon Bedrock autoconfigured providers
