### PR TITLE
Assistant: fix tool calls for autoconfigured providers with custom auth (#11703)

### DIFF
--- a/extensions/positron-assistant/src/providers/index.ts
+++ b/extensions/positron-assistant/src/providers/index.ts
@@ -45,6 +45,59 @@ interface ConcreteModelProviderConstructor {
 }
 
 /**
+ * Result of resolving autoconfigure credentials for a model.
+ */
+interface ResolvedCredentials {
+	apiKey?: string;
+	baseUrl?: string;
+	autoconfigure: NonNullable<ModelConfig['autoconfigure']>;
+}
+
+/**
+ * Resolves credentials for an autoconfigurable model based on its autoconfigure type.
+ * Returns undefined if credentials cannot be resolved.
+ */
+async function resolveAutoconfigureCredentials(model: ConcreteModelProviderConstructor): Promise<ResolvedCredentials | undefined> {
+	const { autoconfigure } = model.source.defaults;
+
+	if (!autoconfigure) {
+		return undefined;
+	}
+
+	if (autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.EnvVariable) {
+		const key = autoconfigure.key;
+		const apiKey = key ? process.env[key] : undefined;
+		if (key && apiKey) {
+			return {
+				apiKey,
+				autoconfigure: {
+					type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,
+					key,
+					signedIn: true,
+				}
+			};
+		}
+	} else if (autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.Custom) {
+		if (model.autoconfigure) {
+			const result = await model.autoconfigure();
+			if (result.configured) {
+				return {
+					apiKey: result.configuration?.apiKey,
+					baseUrl: result.configuration?.baseUrl,
+					autoconfigure: {
+						type: positron.ai.LanguageModelAutoconfigureType.Custom,
+						message: result.message,
+						signedIn: true,
+					}
+				};
+			}
+		}
+	}
+
+	return undefined;
+}
+
+/**
  * Gets all available language model provider classes.
  *
  * @returns Array of all provider classes that can be instantiated
@@ -94,54 +147,21 @@ export async function createAutomaticModelConfigs(): Promise<ModelConfig[]> {
 			continue;
 		}
 
-		if (model.source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.EnvVariable) {
-			// Handle environment variable based auto-configuration
-			const key = model.source.defaults.autoconfigure.key;
-			// pragma: allowlist nextline secret
-			const apiKey = key ? process.env[key] : undefined;
-
-			if (key && apiKey) {
-				const modelConfig: ModelConfig = {
-					id: `${model.source.provider.id}`,
-					provider: model.source.provider.id,
-					type: positron.PositronLanguageModelType.Chat,
-					name: model.source.provider.displayName,
-					model: model.source.defaults.model,
-					apiKey: apiKey,
-					toolCalls: model.source.defaults.toolCalls,
-					completions: model.source.defaults.completions,
-					autoconfigure: {
-						type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,
-						key: key,
-						signedIn: true,
-					}
-				};
-				modelConfigs.push(modelConfig);
-			}
-		} else if (model.source.defaults.autoconfigure.type === positron.ai.LanguageModelAutoconfigureType.Custom) {
-			// Handle custom auto-configuration
-			if (model.autoconfigure !== undefined) {
-				const result = await model.autoconfigure();
-				if (result.configured) {
-					const modelConfig: ModelConfig = {
-						id: `${model.source.provider.id}`,
-						provider: model.source.provider.id,
-						type: positron.PositronLanguageModelType.Chat,
-						name: model.source.provider.displayName,
-						model: model.source.defaults.model,
-						// Apply configuration from autoconfigure result
-						...(result.configuration?.apiKey && { apiKey: result.configuration.apiKey }),
-						...(result.configuration?.baseUrl && { baseUrl: result.configuration.baseUrl }),
-						// pragma: allowlist nextline secret
-						autoconfigure: {
-							type: positron.ai.LanguageModelAutoconfigureType.Custom,
-							message: result.message,
-							signedIn: true
-						}
-					};
-					modelConfigs.push(modelConfig);
-				}
-			}
+		const credentials = await resolveAutoconfigureCredentials(model);
+		if (credentials) {
+			const modelConfig: ModelConfig = {
+				id: `${model.source.provider.id}`,
+				provider: model.source.provider.id,
+				type: positron.PositronLanguageModelType.Chat,
+				name: model.source.provider.displayName,
+				model: model.source.defaults.model,
+				toolCalls: model.source.defaults.toolCalls,
+				completions: model.source.defaults.completions,
+				...(credentials.apiKey && { apiKey: credentials.apiKey }),
+				...(credentials.baseUrl && { baseUrl: credentials.baseUrl }),
+				autoconfigure: credentials.autoconfigure,
+			};
+			modelConfigs.push(modelConfig);
 		}
 	}
 

--- a/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
+++ b/extensions/positron-assistant/src/test/autoconfiguredProviders.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createAutomaticModelConfigs } from '../providers/index.js';
+import { AWSModelProvider } from '../providers/aws/awsBedrockProvider.js';
+import { SnowflakeModelProvider } from '../providers/snowflake/snowflakeProvider.js';
+import { CopilotModelProvider } from '../copilot.js';
+
+suite('Autoconfigured Providers', () => {
+	// Store original autoconfigure methods
+	let originalAWSAutoconfigure: typeof AWSModelProvider.autoconfigure;
+	let originalSnowflakeAutoconfigure: typeof SnowflakeModelProvider.autoconfigure;
+	let originalCopilotAutoconfigure: typeof CopilotModelProvider.autoconfigure;
+
+	setup(() => {
+		// Save originals
+		originalAWSAutoconfigure = AWSModelProvider.autoconfigure;
+		originalSnowflakeAutoconfigure = SnowflakeModelProvider.autoconfigure;
+		originalCopilotAutoconfigure = CopilotModelProvider.autoconfigure;
+
+		// Mock all Custom-type autoconfigure methods to return configured: true
+		AWSModelProvider.autoconfigure = async () => ({
+			configured: true,
+			message: 'Test AWS creds'
+		});
+
+		SnowflakeModelProvider.autoconfigure = async () => ({
+			configured: true,
+			message: 'Test Snowflake creds',
+			configuration: { apiKey: 'test-key', baseUrl: 'https://example.com' }
+		});
+
+		// CopilotModelProvider requires CopilotService singleton which isn't available in tests
+		CopilotModelProvider.autoconfigure = async () => ({ configured: false });
+	});
+
+	teardown(() => {
+		// Restore originals
+		AWSModelProvider.autoconfigure = originalAWSAutoconfigure;
+		SnowflakeModelProvider.autoconfigure = originalSnowflakeAutoconfigure;
+		CopilotModelProvider.autoconfigure = originalCopilotAutoconfigure;
+	});
+
+	test('all autoconfigured providers include toolCalls: true', async () => {
+		const configs = await createAutomaticModelConfigs();
+		const failures: string[] = [];
+
+		const expectedProviders = ['amazon-bedrock', 'snowflake-cortex'];
+		for (const providerId of expectedProviders) {
+			const config = configs.find((c) => c.provider === providerId);
+			if (!config) {
+				failures.push(`${providerId}: config not created`);
+			} else if (config.toolCalls !== true) {
+				failures.push(`${providerId}: toolCalls must be true`);
+			}
+		}
+
+		assert.strictEqual(failures.length, 0, `Failures:\n${failures.join('\n')}`);
+	});
+});


### PR DESCRIPTION
### Summary

_Cherry-picked from original PR targeting `release/2026.02`: https://github.com/posit-dev/positron/pull/11703_

- addresses https://github.com/posit-dev/positron/issues/11701
- refactors how the model config for autoconfigured providers is constructed to avoid a situation where env var and custom auth providers deviate
- adds an integration test to specifically check that Bedrock and Snowflake autoconfigured providers have toolCalls set to true
- this test fails before the fix is applied and passes after the fix is applied

### Release Notes

#### Bug Fixes

- Assistant: fix issue causing tool calls to be unavailable for autoconfigured providers (#11701)

### QA Notes

- Added integration test to check that toolCalls is true for Snowflake and Amazon Bedrock autoconfigured providers