### PR TITLE
Possible extension of work to load R data files

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -172,7 +172,7 @@ export const config = {
 			'Xcode workspace file': 'xcworkspace',
 			'Visual Basic script': 'vb',
 			'R source code': 'r',
-			'R Data file': ['rdata', 'RData', 'Rdata', 'rda', 'rds', 'Rds', 'RDS'],
+			'R Data file': ['rdata', 'rda', 'rds'],
 			'Rust source code': 'rs',
 			'Restructured Text document': 'rst',
 			'LaTeX document': ['tex', 'cls'],

--- a/build/win32/positron.iss
+++ b/build/win32/positron.iss
@@ -410,14 +410,6 @@ Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rdata
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rdata\shell\open"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#ExeBasename}.exe"""; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rdata\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""; Tasks: associatewithfiles
 
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.RData\OpenWithProgids"; ValueType: none; ValueName: "{#RegValueName}"; Flags: deletevalue uninsdeletevalue; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.RData\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.RData"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RData"; ValueType: string; ValueName: ""; ValueData: "{cm:SourceFile,R Data}"; Flags: uninsdeletekey; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RData"; ValueType: string; ValueName: "AppUserModelID"; ValueData: "{#AppUserId}"; Flags: uninsdeletekey; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RData\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RData\shell\open"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#ExeBasename}.exe"""; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RData\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""; Tasks: associatewithfiles
-
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.rda\OpenWithProgids"; ValueType: none; ValueName: "{#RegValueName}"; Flags: deletevalue uninsdeletevalue; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.rda\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.rda"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rda"; ValueType: string; ValueName: ""; ValueData: "{cm:SourceFile,R Data}"; Flags: uninsdeletekey; Tasks: associatewithfiles
@@ -427,20 +419,12 @@ Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rda\s
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rda\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""; Tasks: associatewithfiles
 
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.rds\OpenWithProgids"; ValueType: none; ValueName: "{#RegValueName}"; Flags: deletevalue uninsdeletevalue; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.rds\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.rda"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles
+Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.rds\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.rds"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rds"; ValueType: string; ValueName: ""; ValueData: "{cm:SourceFile,R Data}"; Flags: uninsdeletekey; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rds"; ValueType: string; ValueName: "AppUserModelID"; ValueData: "{#AppUserId}"; Flags: uninsdeletekey; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rds\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rds\shell\open"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#ExeBasename}.exe"""; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.rds\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""; Tasks: associatewithfiles
-
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.RDS\OpenWithProgids"; ValueType: none; ValueName: "{#RegValueName}"; Flags: deletevalue uninsdeletevalue; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.RDS\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.rda"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RDS"; ValueType: string; ValueName: ""; ValueData: "{cm:SourceFile,R Data}"; Flags: uninsdeletekey; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RDS"; ValueType: string; ValueName: "AppUserModelID"; ValueData: "{#AppUserId}"; Flags: uninsdeletekey; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RDS\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RDS\shell\open"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#ExeBasename}.exe"""; Tasks: associatewithfiles
-Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}.RDS\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""; Tasks: associatewithfiles
 
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.sass\OpenWithProgids"; ValueType: none; ValueName: "{#RegValueName}"; Flags: deletevalue uninsdeletevalue; Tasks: associatewithfiles
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\.sass\OpenWithProgids"; ValueType: string; ValueName: "{#RegValueName}.sass"; ValueData: ""; Flags: uninsdeletevalue; Tasks: associatewithfiles

--- a/extensions/positron-python/src/client/languageFeatures/pythonFilePasteAndDropProvider.ts
+++ b/extensions/positron-python/src/client/languageFeatures/pythonFilePasteAndDropProvider.ts
@@ -72,7 +72,7 @@ export class PythonFilePasteAndDropProvider
         }
 
         const filePaths = await positron.paths.extractClipboardFilePaths(dataTransfer, {
-            preferRelative: true,
+            relativeTo: ['workspace', 'home'],
             homeUri: vscode.Uri.file(os.homedir()),
         });
 

--- a/extensions/positron-r/src/languageFeatures/rFilePasteAndDropProvider.ts
+++ b/extensions/positron-r/src/languageFeatures/rFilePasteAndDropProvider.ts
@@ -70,7 +70,7 @@ export class RFilePasteAndDropProvider implements vscode.DocumentPasteEditProvid
 		}
 
 		const filePaths = await positron.paths.extractClipboardFilePaths(dataTransfer, {
-			preferRelative: true,
+			relativeTo: ['workspace', 'home'],
 			homeUri: vscode.Uri.file(os.homedir())
 		});
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2171,16 +2171,15 @@ declare module 'positron' {
 	}
 
 	/**
-	 * Utilities for pasting files as paths.
+	 * Utilities for formatting file paths for use in code.
 	 */
 	namespace paths {
 		/**
-		 * Options for extracting clipboard file paths
+		 * Options for formatting file paths for use in code.
 		 */
-		export interface ExtractClipboardFilePathsOptions {
+		export interface FormatPathForCodeOptions {
 			/**
 			 * Whether to prefer relative paths when workspace context is available.
-			 * Defaults to true.
 			 */
 			preferRelative?: boolean;
 
@@ -2197,21 +2196,35 @@ declare module 'positron' {
 		}
 
 		/**
-		 * Extract file paths from clipboard.
+		 * Format a file path for use in code.
+		 * Converts backslashes to forward slashes, optionally makes the path relative
+		 * to the workspace or user's home directory, and wraps in double quotes.
+		 *
+		 * @param filePath The file path to format
+		 * @param options Options for path formatting. Defaults to preferRelative: false.
+		 * @returns A quoted, forward-slash path ready for use in code,
+		 *  e.g., "C:/path/file.txt", "relative/path.txt", or "~/relative/path.txt"
+		 */
+		export function formatPathForCode(
+			filePath: string,
+			options?: FormatPathForCodeOptions
+		): string;
+
+		/**
+		 * Extract file paths from clipboard data.
 		 * Detects files copied from file manager and returns their paths for use in scripts.
 		 * Windows: Replaces `\` with `/`.
 		 * Surrounds paths with double quotes (and escapes any internal double quotes).
 		 * Optionally returns relative paths (e.g. to workspace or user's home directory).
-		 * Try to use core utilities (versus DIY path hacking).
-
+		 *
 		 * @param dataTransfer The clipboard data transfer object
-		 * @param options Options for path conversion
+		 * @param options Options for path formatting. Defaults to preferRelative: true.
 		 * @returns A Thenable that resolves to an array of quoted, forward-slash,
 		 *  possibly relative file paths, or null if no files detected
 		 */
 		export function extractClipboardFilePaths(
 			dataTransfer: vscode.DataTransfer,
-			options?: ExtractClipboardFilePathsOptions
+			options?: FormatPathForCodeOptions
 		): Thenable<string[] | null>;
 	}
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1611,6 +1611,19 @@ export class MainThreadLanguageRuntime
 		return Promise.resolve(session.dynState);
 	}
 
+	$getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined> {
+		let session;
+		if (sessionId) {
+			session = this.findSession(sessionId);
+		} else {
+			session = this._runtimeSessionService.foregroundSession;
+		}
+		if (session) {
+			return Promise.resolve(session.dynState.currentWorkingDirectory || undefined);
+		}
+		return Promise.resolve(undefined);
+	}
+
 	$callMethod(sessionId: string, method: string, args: unknown[]): Thenable<unknown> {
 		const session = this.findSession(sessionId);
 		return session.callMethod(method, args);

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -37,7 +37,7 @@ import { ExtHostAiFeatures } from './extHostAiFeatures.js';
 import { IToolInvocationContext } from '../../../contrib/chat/common/languageModelToolsService.js';
 import { IPositronLanguageModelSource } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { ExtHostEnvironment } from './extHostEnvironment.js';
-import { convertClipboardFiles, formatPathForCode, FormatPathForCodeOptions } from '../../../contrib/positronPathUtils/common/filePathConverter.js';
+import { convertClipboardFiles, formatPathForCode, ResolvedBase } from '../../../contrib/positronPathUtils/common/filePathConverter.js';
 import { ExtHostPlotsService } from './extHostPlotsService.js';
 import { ExtHostNotebookFeatures } from './extHostNotebookFeatures.js';
 
@@ -269,41 +269,70 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			}
 		};
 
-		// Helper to resolve path formatting options:
-		// - Falls back to workspace folder if preferRelative but no baseUri
-		// - Converts vscode.Uri to internal URI type
-		function resolvePathOptions(options?: positron.paths.FormatPathForCodeOptions): FormatPathForCodeOptions | undefined {
-			if (!options) {
-				return undefined;
+		/**
+		 * Resolves abstract base references to actual URIs for the path formatter.
+		 *
+		 * - 'workspace': Resolves to the first workspace folder
+		 * - 'session': Resolves to the working directory of the foreground session,
+		 *    or a specific session if sessionId is provided. Note that this is
+		 *  likely to require knowledge of homeUri, because working directory
+		 *  reported by the runtime probably uses the `~` shorthand
+		 *  (would be nice to fix this!).
+		 * - 'home': Requires homeUri to be provided by the caller
+		 * - vscode.Uri: Used as-is
+		 */
+		async function resolveRelativeBases(
+			relativeTo: positron.paths.RelativeBase | positron.paths.RelativeBase[] | undefined,
+			sessionId: string | undefined,
+			homeUri: vscode.Uri | undefined
+		): Promise<ResolvedBase[]> {
+			if (!relativeTo) {
+				return [];
 			}
 
-			let resolvedOptions = options;
-			if (options.preferRelative && !options.baseUri) {
-				const workspaceFolders = extHostWorkspace.getWorkspaceFolders();
-				if (workspaceFolders && workspaceFolders.length > 0) {
-					resolvedOptions = {
-						...options,
-						baseUri: workspaceFolders[0].uri
-					};
+			const bases: ResolvedBase[] = [];
+			const items = Array.isArray(relativeTo) ? relativeTo : [relativeTo];
+
+			for (const item of items) {
+				if (typeof item === 'string') {
+					if (item === 'workspace') {
+						const workspaceFolders = extHostWorkspace.getWorkspaceFolders();
+						if (workspaceFolders && workspaceFolders.length > 0) {
+							bases.push({ uri: URI.from(workspaceFolders[0].uri) });
+						}
+					} else if (item === 'session') {
+						let workingDir = await extHostLanguageRuntime.getSessionWorkingDirectory(sessionId);
+						if (workingDir) {
+							// Expand ~ to actual home directory path
+							if (workingDir.startsWith('~/') && homeUri) {
+								workingDir = homeUri.fsPath + workingDir.slice(1);
+							}
+							bases.push({ uri: URI.file(workingDir) });
+						}
+					} else if (item === 'home') {
+						if (homeUri) {
+							bases.push({ uri: URI.from(homeUri), prefix: '~/' });
+						}
+					}
+				} else {
+					// It's a vscode.Uri - convert to internal URI
+					bases.push({ uri: URI.from(item) });
 				}
 			}
 
-			return {
-				...resolvedOptions,
-				baseUri: resolvedOptions.baseUri ? URI.from(resolvedOptions.baseUri) : undefined,
-				homeUri: resolvedOptions.homeUri ? URI.from(resolvedOptions.homeUri) : undefined
-			};
+			return bases;
 		}
 
 		const paths: typeof positron.paths = {
 			/**
 			 * Format a file path for use in code.
 			 */
-			formatPathForCode(
+			async formatPathForCode(
 				filePath: string,
 				options?: positron.paths.FormatPathForCodeOptions
-			): string {
-				return formatPathForCode(filePath, resolvePathOptions(options));
+			): Promise<string> {
+				const resolved = await resolveRelativeBases(options?.relativeTo, options?.sessionId, options?.homeUri);
+				return formatPathForCode(filePath, resolved);
 			},
 
 			/**
@@ -325,7 +354,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 						return null;
 					}
 
-					return convertClipboardFiles(uriListData, resolvePathOptions(options));
+					// Default to workspace-relative for clipboard paths
+					const relativeTo = options?.relativeTo ?? ['workspace', 'home'];
+					const resolved = await resolveRelativeBases(relativeTo, options?.sessionId, options?.homeUri);
+					return convertClipboardFiles(uriListData, resolved);
 				} catch {
 					return null;
 				}

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -60,6 +60,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$shutdownSession(sessionId: string, exitReason: RuntimeExitReason): Promise<void>;
 	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): Promise<void>;
 	$getSessionDynState(sessionId: string): Promise<LanguageRuntimeDynState>;
+	$getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined>;
 	$getSessionVariables(sessionId: string, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
 	$querySessionTables(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<QueryTableSummaryResult>>;
 	$callMethod(sessionId: string, method: string, args: unknown[]): Thenable<unknown>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1147,6 +1147,15 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	}
 
 	/**
+	 * Get the current working directory of a runtime session.
+	 * @param sessionId the session ID, or undefined for the foreground session
+	 * @returns The working directory, or undefined if not available
+	 */
+	public async getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined> {
+		return this._proxy.$getSessionWorkingDirectory(sessionId);
+	}
+
+	/**
 	 * Registers a new language runtime manager with the extension host.
 	 *
 	 * @param extension The extension that is registering the manager

--- a/src/vs/workbench/contrib/positronPathUtils/common/filePathConverter.ts
+++ b/src/vs/workbench/contrib/positronPathUtils/common/filePathConverter.ts
@@ -8,21 +8,21 @@ import { URI } from '../../../../base/common/uri.js';
 import { relativePath, isEqualOrParent } from '../../../../base/common/resources.js';
 
 /**
- * Options for clipboard file conversion
+ * Options for formatting a file path for use in code.
  */
-export interface ConvertClipboardFilesOptions {
+export interface FormatPathForCodeOptions {
 	/**
-	 * Whether to prefer relative paths when baseUri is available (typically the workspace folder).
+	 * Whether to prefer relative paths when baseUri is available.
 	 */
 	preferRelative?: boolean;
 
 	/**
-	 * Base URI for relative path calculation
+	 * Base URI for relative path calculation (typically the workspace folder).
 	 */
 	baseUri?: URI;
 
 	/**
-	 * User home directory URI for home-relative path calculation
+	 * User home directory URI for home-relative path calculation.
 	 */
 	homeUri?: URI;
 }
@@ -37,7 +37,7 @@ export interface ConvertClipboardFilesOptions {
  */
 export function convertClipboardFiles(
 	uriListData: string,
-	options?: ConvertClipboardFilesOptions
+	options?: FormatPathForCodeOptions
 ): string[] | null {
 	let filePaths: string[] = [];
 
@@ -64,19 +64,20 @@ export function convertClipboardFiles(
 		return null;
 	}
 
-	return filePaths.map(filePath => formatForwardSlashPath(filePath, options));
+	return filePaths.map(filePath => formatPathForCode(filePath, options));
 }
 
 /**
- * Formats a file path to forward-slash format with double quotes.
- * Uses relative path if requested and possible.
+ * Formats a file path for use in code: forward slashes, optionally relative,
+ * wrapped in double quotes with escaped internal quotes.
+ *
  * Priority: workspace-relative > home-relative > absolute
  *
  * @param filePath The file path to format
  * @param options Options for path formatting
  * @returns Quoted forward-slash path: "C:/path/file.txt", "relative/path.txt", or "~/relative/path.txt"
  */
-function formatForwardSlashPath(filePath: string, options?: ConvertClipboardFilesOptions): string {
+export function formatPathForCode(filePath: string, options?: FormatPathForCodeOptions): string {
 	if (!filePath) {
 		return '';
 	}


### PR DESCRIPTION
As I was reviewing #11366, I started to play with some things and decided to make a PR to the PR!

The commits represent some suggestions:

* 96989bc277a38590c0fcb84413505ab5e9d82aff: I now think casing variants aren't actually needed in `build/lib/electron.ts` and `build/win32/positron.iss`, so I removed them. Also corrected one likely copy/paste-o.
* ff7c3022358cac9b9dfa389513793b03684e6334: Starts the exploration of using existing code to prepare filepaths for use in R and Python (refactoring stuff from #9886 for broader use). This gets us filepaths relative to *workspace*, falling back to relative to *home directory*, if relevant.
* e523bb9606f824e8c8a6ac82e2b26c82f11d7ed0: One way to get filepaths relative to the R session's working directory, which does seem more relevant than workspace folder, for these .`rds`/`.RData` gestures (in #9886 we are preparing paths to insert in scripts, where workspace is the best choice). Downside of this approach: a `getwd()` command executes visibly to the user in the R Console. But we already have plans to solve such problems (#7112).
* d192514d5ed52661d07b52e4da0825ac955adbfd: Alternative way to get the session's working directory -- remember Positron knows it because we need it for Console UI! Downside of this approach: the representation of working directory stored in session's dynamic state is optimized for human 👀 and uses `~/`, so this is a little fiddly. But this could be solved if it bothered us.

