### PR TITLE
Add raw cell support to positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl.ts
@@ -49,8 +49,9 @@ export class NotebookExecutionService implements INotebookExecutionService, IDis
 	}
 
 	async executeNotebookCells(notebook: INotebookTextModel, cells: Iterable<NotebookCellTextModel>, contextKeyService: IContextKeyService): Promise<void> {
+		// Filter to only executable code cells, excluding raw cells (which have language='raw')
 		const cellsArr = Array.from(cells)
-			.filter(c => c.cellKind === CellKind.Code);
+			.filter(c => c.cellKind === CellKind.Code && c.language !== 'raw');
 		if (!cellsArr.length) {
 			return;
 		}

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -263,6 +263,15 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	insertMarkdownCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
 
 	/**
+	 * Inserts a new raw cell either above or below the current selection
+	 * and focuses the container.
+	 *
+	 * @param aboveOrBelow Whether to insert the cell above or below the current selection
+	 * @param referenceCell Optional cell to insert relative to. If not provided, uses the currently selected cell
+	 */
+	insertRawCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void;
+
+	/**
 	 * Changes a cell to a different kind (code or markdown) and/or changes its language.
 	 * Cell content, metadata, and outputs are all preserved (outputs survive round-trip conversions).
 	 *

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -240,8 +240,9 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * @param index The position at which to insert the new cell
 	 * @param enterEditMode Whether to put the new cell into edit mode immediately
 	 * @param content Optional content to set for the cell. Defaults to an empty string if not provided.
+	 * @param language Optional language override. Defaults to notebook language for code cells, 'markdown' for markup cells.
 	 */
-	addCell(type: CellKind, index: number, enterEditMode: boolean, content?: string): void;
+	addCell(type: CellKind, index: number, enterEditMode: boolean, content?: string, language?: string): void;
 
 	/**
 	 * Inserts a new code cell either above or below the current selection

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -126,6 +126,16 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	insertMarkdownCellBelow(): void;
 
 	/**
+	 * Insert a new raw cell above this cell
+	 */
+	insertRawCellAbove(): void;
+
+	/**
+	 * Insert a new raw cell below this cell
+	 */
+	insertRawCellBelow(): void;
+
+	/**
 	 * Type guard for checking if cell is a markdown cell
 	 */
 	isMarkdownCell(): this is IPositronNotebookMarkdownCell;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -131,9 +131,17 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	isMarkdownCell(): this is IPositronNotebookMarkdownCell;
 
 	/**
-	 * Type guard for checking if cell is a code cell
+	 * Type guard for checking if cell is a code cell.
+	 * Note: Returns false for raw cells. Use isRawCell() to check for raw cells.
 	 */
 	isCodeCell(): this is IPositronNotebookCodeCell;
+
+	/**
+	 * Type guard for checking if cell is a raw cell.
+	 * Raw cells are stored as code cells with language='raw' in the underlying VS Code model,
+	 * but we expose them as a distinct type in our API.
+	 */
+	isRawCell(): this is IPositronNotebookRawCell;
 
 	/**
 	 * Check if this cell is the last cell in the notebook
@@ -261,6 +269,14 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	readonly lastRunEndTime: IObservable<number | undefined>;
 }
 
+
+/**
+ * Interface for raw cells. Raw cells are stored as code cells with language='raw'
+ * in the underlying VS Code model, but we expose them as a distinct type in our API.
+ */
+export interface IPositronNotebookRawCell extends IPositronNotebookCell {
+	readonly kind: CellKind.Code;
+}
 
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -13,7 +13,7 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellDecorationManager } from './CellDecorationManager.js';
 import { CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
-import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs } from './IPositronNotebookCell.js';
+import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, IPositronNotebookRawCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
@@ -173,7 +173,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	isCodeCell(): this is IPositronNotebookCodeCell {
-		return this.kind === CellKind.Code;
+		return this.kind === CellKind.Code && this.model.language !== 'raw';
+	}
+
+	isRawCell(): this is IPositronNotebookRawCell {
+		return this.kind === CellKind.Code && this.model.language === 'raw';
 	}
 
 	isLastCell(): boolean {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -382,5 +382,13 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	insertMarkdownCellBelow(): void {
 		this._instance.insertMarkdownCellAndFocusContainer('below', this);
 	}
+
+	insertRawCellAbove(): void {
+		this._instance.insertRawCellAndFocusContainer('above', this);
+	}
+
+	insertRawCellBelow(): void {
+		this._instance.insertRawCellAndFocusContainer('below', this);
+	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -16,6 +16,7 @@ import { AddCellButtons } from './AddCellButtons.js';
 import { useObservedValue } from './useObservedValue.js';
 import { NotebookCodeCell } from './notebookCells/NotebookCodeCell.js';
 import { NotebookMarkdownCell } from './notebookCells/NotebookMarkdownCell.js';
+import { NotebookRawCell } from './notebookCells/NotebookRawCell.js';
 import { DeletionSentinel } from './notebookCells/DeletionSentinel.js';
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { FontMeasurements } from '../../../../editor/browser/config/fontMeasurements.js';
@@ -198,6 +199,10 @@ function useFontStyles(): React.CSSProperties {
 function NotebookCell({ cell }: {
 	cell: PositronNotebookCellGeneral;
 }) {
+
+	if (cell.isRawCell()) {
+		return <NotebookRawCell cell={cell} />;
+	}
 
 	if (cell.isCodeCell()) {
 		return <NotebookCodeCell cell={cell} />;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1010,7 +1010,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param content Optional content to set for the cell. Defaults to an empty string if not provided.
 	 * @throws Error if no language is set for the notebook
 	 */
-	addCell(type: CellKind, index: number, enterEditMode: boolean, content: string = ''): void {
+	addCell(type: CellKind, index: number, enterEditMode: boolean, content: string = '', language?: string): void {
 		this._assertTextModel();
 
 		if (!this.language) {
@@ -1021,6 +1021,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			// Set operation type to enable automatic edit mode entry for normal inserts
 			this.setCurrentOperation(NotebookOperationType.InsertAndEdit);
 		}
+
+		const cellLanguage = language ?? (type === CellKind.Code ? this.language : 'markdown');
 
 		const textModel = this.textModel;
 		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
@@ -1038,7 +1040,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				cells: [
 					{
 						cellKind: type,
-						language: type === CellKind.Code ? this.language : 'markdown',
+						language: cellLanguage,
 						mime: undefined,
 						outputs: [],
 						metadata: undefined,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1063,7 +1063,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._onDidChangeContent.fire();
 	}
 
-	private _insertCellAndFocusContainer(type: CellKind, aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+	private _insertCellAndFocusContainer(type: CellKind, aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell, language?: string): void {
 		let index: number | undefined;
 
 		this._assertTextModel();
@@ -1079,7 +1079,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), false);
+		this.addCell(type, index + (aboveOrBelow === 'above' ? 0 : 1), false, '', language);
 	}
 
 	/**
@@ -1093,6 +1093,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	insertMarkdownCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
 		this._insertCellAndFocusContainer(CellKind.Markup, aboveOrBelow, referenceCell);
+	}
+
+	insertRawCellAndFocusContainer(aboveOrBelow: 'above' | 'below', referenceCell?: IPositronNotebookCell): void {
+		this._insertCellAndFocusContainer(CellKind.Code, aboveOrBelow, referenceCell, 'raw');
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -85,6 +85,18 @@
 	border-bottom-color: var(--vscode-editorWidget-border);
 }
 
+/* === Raw Cells: Editor Only (no footer or outputs) === */
+
+.positron-notebook-raw-cell .positron-notebook-editor-section {
+	border-bottom: 1px solid var(--vscode-positronNotebook-border-color);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+}
+
+.positron-notebook-raw-cell .positron-notebook-editor-container {
+	overflow: hidden;
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+}
+
 /* === Markdown Cells: Editor (when shown) === */
 
 .positron-notebook-markdown-cell .positron-notebook-editor-container:not(.editor-hidden) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -12,7 +12,6 @@ import React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
-import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
@@ -56,7 +55,8 @@ export function NotebookCellWrapper({ cell, children }: {
 		/**
 		 * Focus the cell container element when this cell becomes the active cell,
 		 * except when:*/
-		const wasEditingCodeCell = prevStatus === CellSelectionStatus.Editing && cell.isCodeCell();
+		const wasEditingCodeCell = prevStatus === CellSelectionStatus.Editing &&
+			(cell.isCodeCell() || cell.isRawCell());
 		const findWidgetFocused = notebookInstance.scopedContextKeyService &&
 			CONTEXT_FIND_INPUT_FOCUSED.getValue(notebookInstance.scopedContextKeyService);
 		if (isActiveCell &&
@@ -74,7 +74,7 @@ export function NotebookCellWrapper({ cell, children }: {
 	// Manage context keys for this cell
 	const scopedContextKeyService = useCellContextKeys(cell, cellRef.current, environment, notebookInstance);
 
-	const cellType = cell.kind === CellKind.Code ? 'Code' : 'Markdown';
+	const cellType = cell.isRawCell() ? 'Raw' : cell.isCodeCell() ? 'Code' : 'Markdown';
 	const isSelected = selectionStatus === CellSelectionStatus.Selected || selectionStatus === CellSelectionStatus.Editing;
 
 	/**
@@ -125,7 +125,7 @@ export function NotebookCellWrapper({ cell, children }: {
 			? localize('notebookCell', '{0} cell', cellType)
 			: localize('notebookCellEditable', '{0} cell - Press Enter to edit', cellType)}
 		aria-selected={isSelected}
-		className={`positron-notebook-cell positron-notebook-${cell.kind === CellKind.Code ? 'code' : 'markdown'}-cell ${selectionStatus}`}
+		className={`positron-notebook-cell positron-notebook-${cell.isRawCell() ? 'raw' : cell.isCodeCell() ? 'code' : 'markdown'}-cell ${selectionStatus}`}
 		data-testid='notebook-cell'
 		role='article'
 		tabIndex={0}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookRawCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookRawCell.css
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-notebook-raw-cell-contents {
+	display: flex;
+	flex-direction: column;
+}
+
+.positron-notebook-raw-cell-contents .positron-notebook-editor-section {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+	width: 100%;
+	position: relative;
+}
+
+.positron-notebook-raw-cell-contents .positron-notebook-editor-container {
+	flex: 1;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookRawCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookRawCell.tsx
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './NotebookRawCell.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
+import { NotebookCellWrapper } from './NotebookCellWrapper.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+
+// Note: The cell is still a PositronNotebookCodeCell at runtime,
+// but semantically it's a raw cell (language='raw')
+export function NotebookRawCell({ cell }: { cell: PositronNotebookCodeCell }) {
+	return (
+		<NotebookCellWrapper cell={cell}>
+			<div className='positron-notebook-raw-cell-contents'>
+				<div className='positron-notebook-editor-section'>
+					<div className='positron-notebook-editor-container'>
+						<CellEditorMonacoWidget cell={cell} />
+					</div>
+				</div>
+			</div>
+		</NotebookCellWrapper>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -9,7 +9,7 @@ import React from 'react';
 // Other dependencies.
 import { autorun } from '../../../../../base/common/observable.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { CellKind, CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
 import { bindCellContextKeys, resetCellContextKeys } from '../ContextKeysManager.js';
 import { useEnvironment } from '../EnvironmentProvider.js';
@@ -68,10 +68,9 @@ export function useCellContextKeys(
 			const isActiveCell = cell.isActive.read(reader);
 			const cells = notebookInstance.cells.read(reader);
 
-			const cellType = cell.kind;
-			keys.isCode.set(cellType === CellKind.Code);
-			keys.isMarkdown.set(cellType === CellKind.Markup);
-			keys.isRaw.set(cellType === CellKind.Code && cell.model.language === 'raw');
+			keys.isCode.set(cell.isCodeCell());
+			keys.isMarkdown.set(cell.isMarkdownCell());
+			keys.isRaw.set(cell.isRawCell());
 			keys.isRunning.set(executionStatus === 'running');
 			keys.isPending.set(executionStatus === 'pending');
 			keys.isFirst.set(cell.index === 0);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -667,6 +667,56 @@ registerAction2(class extends NotebookAction2 {
 registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
+			id: 'positronNotebook.cell.insertRawCellAbove',
+			title: localize2('positronNotebook.rawCell.insertAbove', "Insert Raw Cell Above"),
+			icon: ThemeIcon.fromId('arrow-up'),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell) {
+			notebook.addCell(CellKind.Code, cell.index, true, '', 'raw');
+		}
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.insertRawCellBelow',
+			title: localize2('positronNotebook.rawCell.insertBelow', "Insert Raw Cell Below"),
+			icon: ThemeIcon.fromId('arrow-down'),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Insert,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Insert,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell) {
+			notebook.addCell(CellKind.Code, cell.index + 1, true, '', 'raw');
+		}
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
 			id: 'positronNotebook.cell.delete',
 			title: localize2('positronNotebook.cell.delete.description', "Delete Cell"),
 			icon: ThemeIcon.fromId('trash'),

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -684,7 +684,7 @@ registerAction2(class extends NotebookAction2 {
 		const state = notebook.selectionStateMachine.state.get();
 		const cell = getActiveCell(state);
 		if (cell) {
-			notebook.addCell(CellKind.Code, cell.index, true, '', 'raw');
+			cell.insertRawCellAbove();
 		}
 	}
 });
@@ -709,7 +709,7 @@ registerAction2(class extends NotebookAction2 {
 		const state = notebook.selectionStateMachine.state.get();
 		const cell = getActiveCell(state);
 		if (cell) {
-			notebook.addCell(CellKind.Code, cell.index + 1, true, '', 'raw');
+			cell.insertRawCellBelow();
 		}
 	}
 });


### PR DESCRIPTION
Addresses #11164.


### Summary

Adds raw cell support to Positron Notebooks. Raw cells are Jupyter's third cell type -- used for metadata, LaTeX preambles, Quarto raw blocks, and boilerplate that should be preserved but never executed.

Raw cells are stored as code cells with `language='raw'` in VS Code's underlying data model. This PR adds:

- **Type guards** (`isRawCell()`, updated `isCodeCell()`) making the three cell types mutually exclusive
- **Dedicated `NotebookRawCell` component** rendering a Monaco editor without execution controls or output areas
- **Cell routing** so raw cells render with the new component instead of the code cell component
- **Menu actions** for "Insert Raw Cell Above/Below" in the cell action bar submenu and context menu
- **Execution filtering** so "Run All" skips raw cells
- **Context key updates** using type guard methods instead of raw kind/language checks

### Screenshots

Raw cell appearance:
<img width="771" height="349" alt="image" src="https://github.com/user-attachments/assets/b56362aa-3709-42d8-b0ef-1e4bd2b4fda0" />


Raw cell actions dropdown (also showing new add raw cell above below actions)
<img width="347" height="489" alt="image" src="https://github.com/user-attachments/assets/957d495c-f43c-43e2-a1cc-d95b10a16d7c" />



### Release Notes

#### New Features
- Added raw cell support to Positron Notebooks. Raw cells can be inserted via the cell action bar submenu or cell context menu and display as plain editors without execution controls. (#11164)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:notebooks

1. Open a Python notebook in the Positron notebook editor
2. Right-click a cell and verify "Insert Raw Cell Above" and "Insert Raw Cell Below" appear in the context menu
3. Insert a raw cell and verify:
   - It renders with a Monaco editor (no run button, no execution indicator, no output area)
   - It is visually distinguishable from code and markdown cells
   - You can type content into it
4. Click the "..." submenu on a cell's action bar and verify the raw cell insert options appear there too
5. With a raw cell present, click "Run All" and verify:
   - Code cells execute normally
   - The raw cell is skipped (no execution indicator, no errors)
6. Save and reopen the notebook -- verify the raw cell content persists
7. Open the same `.ipynb` in JupyterLab or VS Code's built-in notebook editor and verify the raw cell round-trips correctly

---
[View planning context](https://gist.github.com/nstrayer/5a548da51d6e15ba26a909e5c9ce41f1)
