### PR TITLE
deprecate systemArchitecture update setting

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -110,17 +110,11 @@ configurationRegistry.registerConfiguration({
 		},
 		'update.systemArchitecture': {
 			type: 'string',
-			enum: ['auto', 'universal', 'x64', 'arm64'],
 			default: 'auto',
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('systemArchitecture', "Configure the system architecture for macOS updates."),
 			included: isMacintosh && !isWeb,
-			enumDescriptions: [
-				localize('auto', "Automatically select the correct architecture"),
-				localize('universal', "Universal binary for macOS, supporting both Intel and Apple Silicon"),
-				localize('x64', "64-bit binary for Intel Macs"),
-				localize('arm64', "arm64 binary for Apple Silicon Macs")
-			]
+			deprecationMessage: localize('systemArchitectureDeprecated', "This setting is deprecated. The system architecture is now automatically detected.")
 		}
 	}
 	// --- End Positron ---

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -83,9 +83,8 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 	//--- Start Positron ---
 	protected buildUpdateFeedUrl(channel: string): string | undefined {
-		// Get the system architecture preference for macOS updates.
-		const systemArchitecture = this.configurationService.getValue<string>('update.systemArchitecture');
-		const platform = 'mac/' + (systemArchitecture === 'auto' ? arch() : systemArchitecture);
+		// Always use automatic architecture detection
+		const platform = 'mac/' + arch();
 		const url = createUpdateURL(platform, channel, this.productService) + '/releases.json';
 		try {
 			electron.autoUpdater.setFeedURL({ url: url });


### PR DESCRIPTION
Deprecated the `update.systemArchitecture` setting as the next step in removing the universal mac builds as outlined here: https://github.com/posit-dev/positron-builds/issues/662#issuecomment-3855927828

The setting will no longer appear the User Settings UI  unless a user has already configured it, and then it will appear with a warning that the setting was deprecated.
<img width="593" height="153" alt="image" src="https://github.com/user-attachments/assets/46d81570-ccdc-4ac0-9163-2b52f299c811" />



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Deprecated `update.systemArchitecture` to always automatically detect the system architecture on upgrade. (https://github.com/posit-dev/positron-builds/issues/662)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
