### PR TITLE
e2e: Refactor assistant model provider signin

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -10,7 +10,8 @@
   "positron.assistant.enabledProviders": [
     "openai-api",
     "echo",
-    "error"
+    "error",
+		"amazon-bedrock"
   ],
   "posit.workbench.showWorkbenchFlaskHint": false
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -18,7 +18,7 @@ const CLOSE_BUTTON = 'button.positron-button.action-bar-button.default:has-text(
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
 const SIGN_OUT_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign out")';
 const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anthropic-api-provider-button)';
-const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#bedrock-provider-button)';
+const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#amazon-bedrock-provider-button)';
 const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-info)';
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
 const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-provider-button)';
@@ -42,6 +42,105 @@ const MODE_DROPDOWN_ITEM = '.monaco-list-row[role="menuitemcheckbox"]';
 const MODEL_PICKER_DROPDOWN = '.action-item.chat-modelPicker-item .monaco-dropdown .dropdown-label a.action-label[aria-label*="Pick Model"]';
 const MODEL_DROPDOWN_ITEM = '.monaco-list-row[role="menuitemcheckbox"]';
 const MANAGE_MODELS_ITEM = '.action-widget a.action-label[aria-label="Manage Language Models"]';
+
+/**
+ * Supported model providers for the Positron Assistant.
+ */
+export type ModelProvider =
+	| 'anthropic-api'
+	| 'amazon-bedrock'
+	| 'echo'
+	| 'error'
+	| 'gemini'
+	| 'copilot'
+	| 'Copilot'
+	| 'openai-api';
+
+/**
+ * Authentication types for model providers.
+ */
+type ProviderAuthType = 'none' | 'apiKey' | 'oauth' | 'aws';
+
+/**
+ * Options for the loginModelProvider method.
+ */
+export interface LoginModelProviderOptions {
+	/** API key for providers that support API key authentication */
+	apiKey?: string;
+	/** Timeout for verifying sign-in success (default: 15000ms) */
+	timeout?: number;
+}
+
+/**
+ * Returns the authentication type for a given model provider.
+ */
+function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
+	switch (provider.toLowerCase()) {
+		case 'echo':
+		case 'error':
+			return 'none';
+		case 'anthropic-api':
+		case 'openai-api':
+		case 'gemini':
+			return 'apiKey';
+		case 'copilot':
+			return 'oauth';
+		case 'amazon-bedrock':
+			return 'aws';
+		default:
+			throw new Error(`Unknown provider: ${provider}`);
+	}
+}
+
+/**
+ * Returns the environment variable name for a provider's API key.
+ */
+function getProviderEnvVarName(provider: ModelProvider): string {
+	switch (provider.toLowerCase()) {
+		case 'anthropic-api':
+			return 'ANTHROPIC_KEY';
+		case 'openai-api':
+			return 'OPENAI_KEY';
+		case 'gemini':
+			return 'GEMINI_KEY';
+		default:
+			return `${provider.toUpperCase().replace(/-/g, '_')}_KEY`;
+	}
+}
+
+/**
+ * Returns the API key from environment variables for a given provider.
+ */
+function getProviderEnvKey(provider: ModelProvider): string | undefined {
+	const envVarName = getProviderEnvVarName(provider);
+	return process.env[envVarName];
+}
+
+/**
+ * Returns the environment variable name that triggers auto-sign-in for a provider.
+ * When these env vars are set, Positron automatically signs into the provider on startup.
+ */
+function getProviderAutoSignInEnvVarName(provider: ModelProvider): string | undefined {
+	switch (provider.toLowerCase()) {
+		case 'anthropic-api':
+			return 'ANTHROPIC_API_KEY';
+		case 'openai-api':
+			return 'OPENAI_API_KEY';
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Returns true if the provider is auto-signed-in via environment variable.
+ * When certain env vars are set (e.g., ANTHROPIC_API_KEY), Positron automatically
+ * signs into the provider on startup, so no manual sign-in is required.
+ */
+function isProviderAutoSignedIn(provider: ModelProvider): boolean {
+	const envVarName = getProviderAutoSignInEnvVarName(provider);
+	return envVarName ? !!process.env[envVarName] : false;
+}
+
 /*
  *  Reuseable Positron Assistant functionality for tests to leverage.
  */
@@ -114,15 +213,12 @@ export class Assistant {
 		await expect(this.code.driver.page.locator(MANAGE_MODELS_ITEM)).toBeVisible({ timeout: 3000 });
 	}
 
-	async selectModelProvider(provider: string) {
+	async selectModelProvider(provider: ModelProvider) {
 		switch (provider.toLowerCase()) {
 			case 'anthropic-api':
 				await this.code.driver.page.locator(ANTHROPIC_BUTTON).click();
 				break;
-			case 'aws':
-			case 'bedrock':
-			case 'aws bedrock':
-			case 'amazon bedrock':
+			case 'amazon-bedrock':
 				await this.code.driver.page.locator(AWS_BEDROCK_BUTTON).click();
 				break;
 			case 'echo':
@@ -137,12 +233,132 @@ export class Assistant {
 			case 'copilot':
 				await this.code.driver.page.locator(COPILOT_BUTTON).click();
 				break;
-			case `openai-api`:
+			case 'openai-api':
 				await this.code.driver.page.locator(OPENAI_BUTTON).click();
 				break;
 			default:
 				throw new Error(`Unsupported model provider: ${provider}`);
 		}
+	}
+
+	/**
+	 * Signs in to a model provider with the appropriate authentication method.
+	 * This method handles opening the configuration dialog, selecting the provider,
+	 * performing authentication, and closing the dialog.
+	 *
+	 * If the provider is auto-signed-in via environment variable (e.g., ANTHROPIC_API_KEY),
+	 * the sign-in steps are skipped.
+	 *
+	 * @param provider - The model provider to sign in to
+	 * @param options - Optional configuration for the login process
+	 * @param options.apiKey - API key for providers that support API key authentication.
+	 *                         If not provided, uses environment variables (ANTHROPIC_KEY, OPENAI_KEY, etc.)
+	 * @param options.timeout - Timeout for verifying sign-in success (default: 15000ms)
+	 *
+	 * @example
+	 * // Sign in to Echo provider (no credentials needed)
+	 * await assistant.loginModelProvider('echo');
+	 *
+	 * @example
+	 * // Sign in to Anthropic with environment variable
+	 * await assistant.loginModelProvider('anthropic-api');
+	 *
+	 * @example
+	 * // Sign in to OpenAI with explicit API key
+	 * await assistant.loginModelProvider('openai-api', { apiKey: 'sk-...' });
+	 */
+	async loginModelProvider(provider: ModelProvider, options: LoginModelProviderOptions = {}) {
+		const { timeout = 15000 } = options;
+
+		// Check if provider is auto-signed-in via environment variable
+		if (isProviderAutoSignedIn(provider)) {
+			// Provider is already signed in via env var, no action needed
+			return;
+		}
+
+		await test.step(`Sign in to ${provider} model provider`, async () => {
+			// Open the model configuration dialog
+			await this.clickAddModelButton();
+
+			// Select the provider
+			await this.selectModelProvider(provider);
+
+			// Handle authentication based on provider type
+			const authType = getProviderAuthType(provider);
+
+			switch (authType) {
+				case 'none':
+					// Providers like echo/error just need sign-in click
+					await this.clickSignInButton();
+					break;
+
+				case 'apiKey': {
+					// Get API key from options or environment variable
+					const apiKey = options.apiKey ?? getProviderEnvKey(provider);
+					if (!apiKey) {
+						throw new Error(
+							`No API key provided for ${provider}. ` +
+							`Set the ${getProviderEnvVarName(provider)} environment variable or pass apiKey in options.`
+						);
+					}
+					await this.enterApiKey(apiKey);
+					await this.clickSignInButton();
+					break;
+				}
+
+				case 'oauth':
+					// OAuth providers - additional steps TBD
+					throw new Error(
+						`OAuth authentication for ${provider} is not yet implemented. ` +
+						`Manual sign-in or additional implementation required.`
+					);
+
+				case 'aws':
+					// AWS Bedrock - additional steps TBD
+					// Will be gated by conditional statements later
+					await this.clickSignInButton();
+					break;
+
+				default:
+					throw new Error(`Unknown authentication type for provider: ${provider}`);
+			}
+
+			// Verify sign-in was successful
+			await this.verifySignOutButtonVisible(timeout);
+
+			// Close the configuration dialog
+			await this.clickCloseButton();
+		});
+	}
+
+	/**
+	 * Signs out from a model provider.
+	 * This method handles opening the configuration dialog, selecting the provider,
+	 * signing out, and closing the dialog.
+	 *
+	 * If the provider is auto-signed-in via environment variable (e.g., ANTHROPIC_API_KEY),
+	 * the sign-out steps are skipped since we didn't manually sign in.
+	 *
+	 * @param provider - The model provider to sign out from
+	 * @param options - Optional configuration for the logout process
+	 * @param options.timeout - Timeout for verifying sign-out success (default: 15000ms)
+	 */
+	async logoutModelProvider(provider: ModelProvider, options: { timeout?: number } = {}) {
+		const { timeout = 15000 } = options;
+
+		// Check if provider is auto-signed-in via environment variable
+		// If so, we didn't manually sign in, so no need to sign out
+		if (isProviderAutoSignedIn(provider)) {
+			return;
+		}
+
+		await test.step(`Sign out from ${provider} model provider`, async () => {
+			await this.quickaccess.runCommand('positron-assistant.configureModels');
+			await this.selectModelProvider(provider);
+			await this.clickSignOutButton();
+			await this.verifySignInButtonVisible(timeout);
+			await this.clickCloseButton();
+		});
 	}
 
 	async enterApiKey(apiKey: string) {

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -21,7 +21,6 @@ const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anth
 const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#amazon-bedrock-provider-button)';
 const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-info)';
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
-const GEMINI_BUTTON = 'button.positron-button.language-model.button:has(#google-provider-button)';
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-auth-provider-button)';
 const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
@@ -49,17 +48,15 @@ const MANAGE_MODELS_ITEM = '.action-widget a.action-label[aria-label="Manage Lan
 export type ModelProvider =
 	| 'anthropic-api'
 	| 'amazon-bedrock'
+	| 'Copilot'
 	| 'echo'
 	| 'error'
-	| 'gemini'
-	| 'copilot'
-	| 'Copilot'
 	| 'openai-api';
 
 /**
  * Authentication types for model providers.
  */
-type ProviderAuthType = 'none' | 'apiKey' | 'oauth' | 'aws';
+type ProviderAuthType = 'none' | 'apiKey' | 'aws';
 
 /**
  * Options for the loginModelProvider method.
@@ -81,10 +78,7 @@ function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 			return 'none';
 		case 'anthropic-api':
 		case 'openai-api':
-		case 'gemini':
 			return 'apiKey';
-		case 'copilot':
-			return 'oauth';
 		case 'amazon-bedrock':
 			return 'aws';
 		default:
@@ -101,8 +95,6 @@ function getProviderEnvVarName(provider: ModelProvider): string {
 			return 'ANTHROPIC_KEY';
 		case 'openai-api':
 			return 'OPENAI_KEY';
-		case 'gemini':
-			return 'GEMINI_KEY';
 		default:
 			return `${provider.toUpperCase().replace(/-/g, '_')}_KEY`;
 	}
@@ -221,17 +213,14 @@ export class Assistant {
 			case 'amazon-bedrock':
 				await this.code.driver.page.locator(AWS_BEDROCK_BUTTON).click();
 				break;
+			case 'copilot':
+				await this.code.driver.page.locator(COPILOT_BUTTON).click();
+				break;
 			case 'echo':
 				await this.code.driver.page.locator(ECHO_MODEL_BUTTON).click();
 				break;
 			case 'error':
 				await this.code.driver.page.locator(ERROR_MODEL_BUTTON).click();
-				break;
-			case 'gemini':
-				await this.code.driver.page.locator(GEMINI_BUTTON).click();
-				break;
-			case 'copilot':
-				await this.code.driver.page.locator(COPILOT_BUTTON).click();
 				break;
 			case 'openai-api':
 				await this.code.driver.page.locator(OPENAI_BUTTON).click();
@@ -305,13 +294,6 @@ export class Assistant {
 					await this.clickSignInButton();
 					break;
 				}
-
-				case 'oauth':
-					// OAuth providers - additional steps TBD
-					throw new Error(
-						`OAuth authentication for ${provider} is not yet implemented. ` +
-						`Manual sign-in or additional implementation required.`
-					);
 
 				case 'aws':
 					// AWS Bedrock - additional steps TBD

--- a/test/e2e/tests/inspect-ai/inspect-ai.test.ts
+++ b/test/e2e/tests/inspect-ai/inspect-ai.test.ts
@@ -96,14 +96,9 @@ test.use({
  */
 test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.INSPECT_AI] }, () => {
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
-		// Change veiwport size for web tests
+		// Change viewport size for web tests
 		await app.code.driver.page.setViewportSize({ width: 2560, height: 1440 });
-		// Only sign out if USE_KEY environment variable is set
-		if (process.env.USE_KEY) {
-			await app.workbench.quickaccess.runCommand(`positron-assistant.configureModels`);
-			await app.workbench.assistant.selectModelProvider('anthropic-api');
-			await app.workbench.assistant.clickSignOutButton();
-		}
+		await app.workbench.assistant.logoutModelProvider('anthropic-api');
 	});
 
 	/**
@@ -137,18 +132,9 @@ test.describe('Positron Assistant Inspect-ai dataset gathering', { tag: [tags.IN
 		const [pySession] = await sessions.start(['python']);
 		const [rSession] = await sessions.start(['r']);
 
-		// Sign in to the assistant
+		// Sign in to the assistant (handles auto-sign-in detection)
 		await app.workbench.assistant.openPositronAssistantChat();
-
-		// Only sign in if USE_KEY environment variable is set
-		if (process.env.USE_KEY) {
-			await app.workbench.assistant.clickAddModelButton();
-			await app.workbench.assistant.selectModelProvider('anthropic-api');
-			await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
-			await app.workbench.assistant.clickSignInButton();
-			await app.workbench.assistant.verifySignOutButtonVisible();
-			await app.workbench.assistant.clickCloseButton();
-		}
+		await app.workbench.assistant.loginModelProvider('anthropic-api');
 
 		await app.workbench.toasts.closeAll();
 

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -65,8 +65,9 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	/**
 	 * Tests the sign in and sign out functionality for the Amazon Bedrock model provider.
 	 * @param app - Application fixture providing access to UI elements
+	 * currently skipped as a TODO to finsih implementation of bedrock auth
 	 */
-	test('Amazon Bedrock: Verify Successful Sign in and Sign Out', async function ({ app }) {
+	test.skip('Amazon Bedrock: Verify Successful Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.loginModelProvider('amazon-bedrock');
 		await app.workbench.assistant.logoutModelProvider('amazon-bedrock');

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -48,30 +48,28 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	 */
 	test('Anthropic: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.clickAddModelButton();
-		await app.workbench.assistant.selectModelProvider('anthropic-api');
-		await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.verifySignOutButtonVisible();
-		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.verifySignInButtonVisible();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('anthropic-api');
+		await app.workbench.assistant.logoutModelProvider('anthropic-api');
 	});
 
 	/**
- * Tests the sign in and sign out functionality for the OpenAI model provider.
- * @param app - Application fixture providing access to UI elements
- */
+	 * Tests the sign in and sign out functionality for the OpenAI model provider.
+	 * @param app - Application fixture providing access to UI elements
+	 */
 	test('OpenAI: Verify Successful API Key Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.clickAddModelButton();
-		await app.workbench.assistant.selectModelProvider('openai-api');
-		await app.workbench.assistant.enterApiKey(`${process.env.OPENAI_KEY}`);
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.verifySignOutButtonVisible();
-		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.verifySignInButtonVisible();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('openai-api');
+		await app.workbench.assistant.logoutModelProvider('openai-api');
+	});
+
+	/**
+	 * Tests the sign in and sign out functionality for the Amazon Bedrock model provider.
+	 * @param app - Application fixture providing access to UI elements
+	 */
+	test('Amazon Bedrock: Verify Successful Sign in and Sign Out', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.loginModelProvider('amazon-bedrock');
+		await app.workbench.assistant.logoutModelProvider('amazon-bedrock');
 	});
 
 	/**
@@ -83,20 +81,14 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	 */
 	test('Verify Inline Chat opens', async function ({ app, openFile }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.assistant.clickAddModelButton();
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('echo');
 		await openFile(join('workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 		await app.workbench.editor.clickOnTerm('chinook-sqlite.py', 'data_file_path', 4);
 		const inlineChatShortcut = process.platform === 'darwin' ? 'Meta+I' : 'Control+I';
 		await app.code.driver.page.keyboard.press(inlineChatShortcut);
 		await app.code.driver.page.locator('.chat-widget > .interactive-session').isVisible();
 		await app.workbench.assistant.verifyInlineChatInputsVisible();
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.logoutModelProvider('echo');
 		await app.workbench.assistant.closeInlineChat();
 	});
 
@@ -117,11 +109,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('echo');
 	});
 
 	test.beforeEach('How to clear chat', async function ({ app }) {
@@ -130,10 +118,7 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await expect(async () => {
-			await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-			await app.workbench.assistant.selectModelProvider('echo');
-			await app.workbench.assistant.clickSignOutButton();
-			await app.workbench.assistant.clickCloseButton();
+			await app.workbench.assistant.logoutModelProvider('echo');
 		}).toPass({ timeout: 30000 });
 	});
 	/**
@@ -186,18 +171,12 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 test.describe('Positron Assistant Model Picker Default Indicator', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant and sign in to Echo provider', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('echo');
 	});
 
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
 		await expect(async () => {
-			await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-			await app.workbench.assistant.selectModelProvider('echo');
-			await app.workbench.assistant.clickSignOutButton();
-			await app.workbench.assistant.clickCloseButton();
+			await app.workbench.assistant.logoutModelProvider('echo');
 		}).toPass({ timeout: 30000 });
 	});
 
@@ -252,20 +231,16 @@ test.describe('Positron Assistant Model Picker Default Indicator', { tag: [tags.
 
 /**
  * Test suite for the model picker default indicator with multiple providers.
- * If ANTHROPIC_KEY environment variable is set, signs in using API key.
- * Otherwise, assumes Anthropic is already signed in via another method (e.g., OAuth).
+ * Uses loginModelProvider which handles auto-sign-in detection:
+ * - If ANTHROPIC_API_KEY is set, Anthropic is auto-signed-in (no manual steps needed)
+ * - If ANTHROPIC_KEY is set, signs in manually using API key
  * @see https://github.com/posit-dev/positron/issues/11166
  * @see https://github.com/posit-dev/positron/pull/11299
  */
 test.describe('Positron Assistant Model Picker Default Indicator - Multiple Providers', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant and sign in to providers', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-
-		// Sign in to Echo provider
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('echo');
 	});
 
 	test.afterAll('Sign out of providers and clean up', async function ({ app, settings }) {
@@ -274,23 +249,14 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 			'positron.assistant.models.preference.byProvider': {}
 		});
 
-		// Sign out of Echo provider
+		// Sign out of providers (methods handle auto-sign-in detection)
 		await expect(async () => {
-			await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-			await app.workbench.assistant.selectModelProvider('echo');
-			await app.workbench.assistant.clickSignOutButton();
-			await app.workbench.assistant.clickCloseButton();
+			await app.workbench.assistant.logoutModelProvider('echo');
 		}).toPass({ timeout: 30000 });
 
-		// Only sign out of Anthropic if we signed in with API key
-		if (process.env.ANTHROPIC_KEY) {
-			await expect(async () => {
-				await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-				await app.workbench.assistant.selectModelProvider('anthropic-api');
-				await app.workbench.assistant.clickSignOutButton();
-				await app.workbench.assistant.clickCloseButton();
-			}).toPass({ timeout: 30000 });
-		}
+		await expect(async () => {
+			await app.workbench.assistant.logoutModelProvider('anthropic-api');
+		}).toPass({ timeout: 30000 });
 	});
 
 	/**
@@ -308,15 +274,11 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 			}
 		}, { reload: true });
 
-		// Only sign in to Anthropic if ANTHROPIC_KEY is provided
-		// Otherwise, assume already signed in via another method (e.g., OAuth)
-		if (process.env.ANTHROPIC_KEY) {
-			await app.workbench.assistant.clickAddModelButton();
-			await app.workbench.assistant.selectModelProvider('anthropic-api');
-			await app.workbench.assistant.enterApiKey(`${process.env.ANTHROPIC_KEY}`);
-			await app.workbench.assistant.clickSignInButton();
-			await app.workbench.assistant.verifySignOutButtonVisible();
-			await app.workbench.assistant.clickCloseButton();
+		// Sign in to Anthropic (method handles auto-sign-in detection)
+		await app.workbench.assistant.loginModelProvider('anthropic-api');
+
+		// Reload window if we manually signed in (not auto-signed-in)
+		if (!process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_KEY) {
 			await runCommand('workbench.action.reloadWindow');
 		}
 
@@ -368,10 +330,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
 		await app.workbench.assistant.openPositronAssistantChat();
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignInButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.loginModelProvider('echo');
 	});
 
 	test.beforeEach('Clear chat', async function ({ app, settings }) {
@@ -381,10 +340,7 @@ test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSI
 	});
 
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
-		await app.workbench.quickaccess.runCommand('positron-assistant.configureModels');
-		await app.workbench.assistant.selectModelProvider('echo');
-		await app.workbench.assistant.clickSignOutButton();
-		await app.workbench.assistant.clickCloseButton();
+		await app.workbench.assistant.logoutModelProvider('echo');
 	});
 
 	test('Token usage is displayed in chat response', async function ({ app }) {


### PR DESCRIPTION
Simplifies Assistant e2e test sign-in by adding loginModelProvider and logoutModelProvider methods to the positronAssistant.ts page object.

  New methods in positronAssistant.ts:
  - loginModelProvider(provider, options?) - Handles sign-in for all provider types with auto-sign-in detection
  - logoutModelProvider(provider, options?) - Handles sign-out with auto-sign-in detection

 Notes: 
  - Supports API key providers (anthropic-api, openai-api) with optional explicit key or environment variable
  fallback
  - Auto-sign-in detection: skips manual sign-in/sign-out when ANTHROPIC_API_KEY or OPENAI_API_KEY env vars are set
  - Supports simple sign-in providers (echo, error, amazon-bedrock) that only need a button click
  - amazon-bedrock isn't yet fully implemented, that will be a follow on PR
  - Copilot won't actually signin, it's there for a current test to make sure it's in the modal correctly.
  - Extensible ModelProvider type for type safety

  Updated tests:
  - positron-assistant.test.ts - Refactored all sign-in/sign-out flows to use new methods
  - inspect-ai.test.ts - Simplified sign-in, removed USE_KEY env var logic

  Other cleanup:
  - Fixed Amazon Bedrock button selector (#amazon-bedrock-provider-button)
  - Added skipped test for Amazon Bedrock sign-in (TODO: finish bedrock auth)
  - Removed unused gemini provider


### QA Notes
@:assistant
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
