### PR TITLE
Remove assistant followups setting and code

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -302,14 +302,6 @@
               "minimum": 512
             }
           },
-          "positron.assistant.followups.enable": {
-            "type": "boolean",
-            "default": false,
-            "tags": [
-              "experimental"
-            ],
-            "description": "%configuration.followups.enable.description%"
-          },
           "positron.assistant.consoleActions.enable": {
             "type": "boolean",
             "default": true,

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -36,7 +36,6 @@
 	"configuration.showTokenUsage.description": "Show token usage in the chat view for supported providers for the session and each message and response including prompts. Check with your provider for detailed usage.",
 	"configuration.maxInputTokens.description": "Override the maximum input tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum input tokens for that model.",
 	"configuration.maxOutputTokens.description": "Override the maximum output tokens for specific language models. The key selects a model ID (partial match supported); the value is the maximum output tokens for that model.",
-	"configuration.followups.enable.description": "Enable suggested followup prompts after chat responses.",
 	"configuration.consoleActions.enable.description": "Enable Positron Assistant console actions, such as Fix and Explain.",
 	"configuration.toolErrors.propagate.description": "Allow tool errors to propagate and halt the conversation, showing VS Code's error diagnostics. When disabled (default), tool errors are caught and returned to the model as conversational results.",
 	"configuration.providerTimeout.description": "Specifies the timeout in seconds when signing in to a provider.\n\nThis timeout applies to each individual model test during connection.\n\nSee also `#positron.assistant.maxConnectionAttempts#` to control how many models are tested.",

--- a/extensions/positron-assistant/src/md/prompts/chat/followups.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/followups.md
@@ -1,3 +1,0 @@
-Based on what I have asked so far, suggest 2-3 follow-up steps, keeping them to a maximum length of one sentence. If I haven’t asked anything, or there aren’t any obvious next steps, don’t provide any suggestions.
-
-You MUST return only JSON in the output, and nothing else. If present, format the suggestions as an array of strings. If not present, return an empty array.

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -69,12 +69,6 @@ export class ParticipantService implements vscode.Disposable {
 			participant.requestHandler.bind(participant),
 		);
 		vscodeParticipant.iconPath = participant.iconPath;
-
-		// Only register followup provider if enabled
-		const followupsEnabled = vscode.workspace.getConfiguration('positron.assistant.followups').get('enable', true);
-		if (followupsEnabled) {
-			vscodeParticipant.followupProvider = participant.followupProvider;
-		}
 	}
 
 	getRequestData(chatRequestId: string): ChatRequestData | undefined {
@@ -164,44 +158,6 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 	readonly _pauseStateEventEmitter = new vscode.EventEmitter<vscode.ChatParticipantPauseStateEvent>();
 	onDidChangePauseState: vscode.Event<vscode.ChatParticipantPauseStateEvent> = this._pauseStateEventEmitter.event;
-
-	readonly followupProvider: vscode.ChatFollowupProvider = {
-		async provideFollowups(result: vscode.ChatResult, context: vscode.ChatContext, token: vscode.CancellationToken): Promise<vscode.ChatFollowup[]> {
-			// Check if followups are enabled
-			const followupsEnabled = vscode.workspace.getConfiguration('positron.assistant.followups').get('enable', true);
-			if (!followupsEnabled) {
-				return [];
-			}
-
-			const system: string = await fs.promises.readFile(path.join(MARKDOWN_DIR, 'prompts', 'chat', 'followups.md'), 'utf8');
-			const messages = [
-				new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, system),
-				...toLanguageModelChatMessage(context.history),
-				vscode.LanguageModelChatMessage.User('Summarise and suggest follow-ups.')
-			];
-
-			const models = await vscode.lm.selectChatModels({ id: result.metadata?.modelId });
-			if (models.length === 0) {
-				throw new Error(vscode.l10n.t('Selected model not available.'));
-			}
-
-			const response = await models[0].sendRequest(messages, {}, token);
-
-			let json = '';
-			for await (const fragment of response.text) {
-				json += fragment;
-				if (token.isCancellationRequested) {
-					break;
-				}
-			}
-
-			try {
-				return (JSON.parse(json) as 'string'[]).map((p) => ({ prompt: p }));
-			} catch (e) {
-				return [];
-			}
-		}
-	};
 
 	async requestHandler(
 		request: vscode.ChatRequest,

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -315,15 +315,10 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 		return {
 			metadata: {
-				// Attach the model ID as metadata so that we can use the same model in the followup provider.
 				modelId: request.model.id,
-				// Include token usage if available
 				tokenUsage: tokenUsage,
-				// Include the tools available for this request
 				availableTools: tools.length > 0 ? tools.map(t => t.name) : undefined,
-				// Include the context message if available
 				positronContext: contextInfo ? { prompts: contextInfo.prompts, attachedDataTypes: contextInfo.attachedDataTypes } : undefined,
-				// Include the system prompt used for this request
 				systemPrompt,
 			},
 		};


### PR DESCRIPTION
Addresses #10087.

Removes the experimental `positron.assistant.followups.enable` setting and all associated code. The followups feature had a bug where the conversation context was always one round behind, and followups aren't being pursued further.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:assistant

Verify Positron Assistant chat works normally (send messages, receive responses).