### PR TITLE
e2e: add test coverage for nb assistant fix/explain error interaction

### DIFF
--- a/test/e2e/infra/index.ts
+++ b/test/e2e/infra/index.ts
@@ -47,6 +47,7 @@ export * from '../pages/references';
 export * from '../pages/scm';
 export * from '../pages/sessions';
 export * from '../pages/hotKeys';
+export * from '../pages/positronAssistant';
 
 // utils
 export * from '../pages/utils/aws';

--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -38,8 +38,8 @@ export class Toasts {
 		const count = await this.toastNotification.count();
 		for (let i = 0; i < count; i++) {
 			try {
-				await this.toastNotification.nth(i).hover();
-				await this.closeButton.nth(i).click();
+				await this.toastNotification.nth(i).hover({ timeout: 5000 });
+				await this.closeButton.nth(i).click({ timeout: 5000 });
 			} catch {
 				this.code.logger.log(`Toast ${i} already closed`);
 			}
@@ -52,7 +52,7 @@ export class Toasts {
 			await toast.hover();
 			await this.closeButton.filter({ hasText: message }).click();
 		} catch {
-			this.code.logger.log(`Toast "${message}" not found`);
+			this.code.logger.log('Toast "${message}" not found');
 		}
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -55,6 +55,11 @@ export class PositronNotebooks extends Notebooks {
 	viewMarkdown = this.code.driver.page.getByRole('button', { name: 'View markdown' });
 	expandMarkdownEditor = this.code.driver.page.getByRole('button', { name: 'Open markdown editor' });
 
+	// Assistant buttons (shown on error cells when assistant is enabled)
+	private askAssistantButton = this.editorActionBar.getByRole('button', { name: 'Ask Assistant', exact: true });
+	private fixErrorButton = this.code.driver.page.getByRole('button', { name: /Ask assistant to fix/i });
+	private explainErrorButton = this.code.driver.page.getByRole('button', { name: /Ask assistant to explain/i });
+
 	// Search Widget
 	private searchWidget = this.code.driver.page.locator('.positron-find-widget');
 	private findInput = this.searchWidget.getByRole('textbox', { name: 'Find' });
@@ -515,6 +520,36 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
+	 * Action: Click the "Ask assistant to fix" button on an error cell.
+	 * Requires: assistant enabled, a model signed in, and an error visible in a cell.
+	 */
+	async clickFixErrorButton(): Promise<void> {
+		await test.step('Click Fix error button', async () => {
+			await this.fixErrorButton.click();
+		});
+	}
+
+	/**
+	 * Action: Click the "Ask assistant to explain" button on an error cell.
+	 * Requires: assistant enabled, a model signed in, and an error visible in a cell.
+	 */
+	async clickExplainErrorButton(): Promise<void> {
+		await test.step('Click Explain error button', async () => {
+			await this.explainErrorButton.click();
+		});
+	}
+
+	/**
+	 * Action: Click the "Ask Assistant" button in the editor action bar.
+	 * Requires: assistant enabled and a model signed in.
+	 */
+	async clickAskAssistantButton(): Promise<void> {
+		await test.step('Click Ask Assistant button', async () => {
+			await this.askAssistantButton.click();
+		});
+	}
+
+	/**
 	 * Action: Search Notebook.
 	 * @param searchText - The text to search for.
 	 * @param options - Options to control behavior:
@@ -588,6 +623,46 @@ export class PositronNotebooks extends Notebooks {
 	// #endregion
 
 	// #region VERIFICATIONS
+
+	/**
+	 * Verify: Assistant buttons visibility.
+	 * @param visible - Whether the buttons should be visible (true) or hidden (false).
+	 */
+	async expectAssistantButtonsVisible(visible: boolean = true): Promise<void> {
+		await test.step(`Expect assistant buttons to be ${visible ? 'visible' : 'hidden'}`, async () => {
+			if (visible) {
+				await expect(this.askAssistantButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+			} else {
+				await expect(this.askAssistantButton).not.toBeVisible({ timeout: DEFAULT_TIMEOUT });
+			}
+		});
+	}
+
+	/**
+	 * Verify: Fix/Explain error buttons visibility.
+	 * @param visible - Whether the buttons should be visible (true) or hidden (false).
+	 */
+	async expectErrorAssistantButtonsVisible(visible: boolean = true): Promise<void> {
+		await test.step(`Expect Fix/Explain error buttons to be ${visible ? 'visible' : 'hidden'}`, async () => {
+			if (visible) {
+				await expect(this.fixErrorButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+				await expect(this.explainErrorButton).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+			} else {
+				await expect(this.fixErrorButton).not.toBeVisible({ timeout: DEFAULT_TIMEOUT });
+				await expect(this.explainErrorButton).not.toBeVisible({ timeout: DEFAULT_TIMEOUT });
+			}
+		});
+	}
+
+	/**
+	 * Verify: A notebook error is visible in any cell.
+	 * @param timeout - The maximum time to wait for visibility (default: 10000ms)
+	 */
+	async expectNotebookErrorVisible(timeout: number = 10000): Promise<void> {
+		await test.step('Expect notebook error to be visible', async () => {
+			await this.code.driver.page.waitForSelector('.notebook-error', { timeout });
+		});
+	}
 
 	/**
 	 * Verify: search count matches expected count.

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -165,6 +165,12 @@ export class Assistant {
 	}
 
 	async clickAddModelButton() {
+		// Ensure chat panel is open first
+		const chatPanelIsVisible = await this.code.driver.page.locator(CHAT_PANEL).isVisible();
+		if (!chatPanelIsVisible) {
+			await this.openPositronAssistantChat();
+		}
+
 		const addModelLinkIsVisible = await this.code.driver.page.locator(ADD_MODEL_BUTTON).isVisible();
 		if (!addModelLinkIsVisible) {
 			await this.code.driver.page.locator(MODEL_PICKER_DROPDOWN).click();

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -693,7 +693,7 @@ export class Assistant {
 	async getChatResponseText(exportFolder?: string) {
 		// Export the chat to a file first
 		await this.quickaccess.runCommand(`positron-assistant.exportChatToFileInWorkspace`);
-		await this.toasts.waitForAppear();
+		await this.toasts.waitForAppear('Chat log exported to:');
 		await this.toasts.closeAll();
 
 		// Find and parse the chat export file

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -376,44 +376,6 @@ export class Assistant {
 		await this.code.driver.page.locator(SIGN_OUT_BUTTON).click();
 	}
 
-	/**
-	 * Signs in to a model provider. Opens the configure models dialog,
-	 * selects the provider, optionally enters an API key, and signs in.
-	 * @param provider The provider to sign in to (e.g., 'echo', 'anthropic-api')
-	 * @param apiKey Optional API key for providers that require one
-	 */
-	async signInToProvider(provider: string, apiKey?: string) {
-		await test.step(`Sign in to ${provider} provider`, async () => {
-			await this.openPositronAssistantChat();
-			await this.quickaccess.runCommand('positron-assistant.configureModels');
-			await this.selectModelProvider(provider);
-
-			if (apiKey) {
-				await this.enterApiKey(apiKey);
-			}
-
-			await this.clickSignInButton();
-			await this.verifySignOutButtonVisible();
-			await this.clickCloseButton();
-		});
-	}
-
-	/**
-	 * Signs out from a model provider. Opens the configure models dialog,
-	 * selects the provider, and signs out.
-	 * @param provider The provider to sign out from (e.g., 'echo', 'anthropic-api')
-	 */
-	async signOutFromProvider(provider: string) {
-		await test.step(`Sign out from ${provider} provider`, async () => {
-			await expect(async () => {
-				await this.quickaccess.runCommand('positron-assistant.configureModels');
-				await this.selectModelProvider(provider);
-				await this.clickSignOutButton();
-				await this.clickCloseButton();
-			}).toPass({ timeout: 30000 });
-		});
-	}
-
 	async verifySignOutButtonVisible(timeout: number = 15000) {
 		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toBeVisible({ timeout });
 		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toHaveText('Sign out', { timeout });

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -278,6 +278,14 @@ export class Assistant {
 			// Select the provider
 			await this.selectModelProvider(provider);
 
+			// Check if already signed in (Sign Out button visible)
+			const alreadySignedIn = await this.code.driver.page.locator(SIGN_OUT_BUTTON).isVisible();
+			if (alreadySignedIn) {
+				// Already signed in, just close the dialog
+				await this.clickCloseButton();
+				return;
+			}
+
 			// Handle authentication based on provider type
 			const authType = getProviderAuthType(provider);
 

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -172,6 +172,44 @@ export class Assistant {
 		await this.code.driver.page.locator(SIGN_OUT_BUTTON).click();
 	}
 
+	/**
+	 * Signs in to a model provider. Opens the configure models dialog,
+	 * selects the provider, optionally enters an API key, and signs in.
+	 * @param provider The provider to sign in to (e.g., 'echo', 'anthropic-api')
+	 * @param apiKey Optional API key for providers that require one
+	 */
+	async signInToProvider(provider: string, apiKey?: string) {
+		await test.step(`Sign in to ${provider} provider`, async () => {
+			await this.openPositronAssistantChat();
+			await this.quickaccess.runCommand('positron-assistant.configureModels');
+			await this.selectModelProvider(provider);
+
+			if (apiKey) {
+				await this.enterApiKey(apiKey);
+			}
+
+			await this.clickSignInButton();
+			await this.verifySignOutButtonVisible();
+			await this.clickCloseButton();
+		});
+	}
+
+	/**
+	 * Signs out from a model provider. Opens the configure models dialog,
+	 * selects the provider, and signs out.
+	 * @param provider The provider to sign out from (e.g., 'echo', 'anthropic-api')
+	 */
+	async signOutFromProvider(provider: string) {
+		await test.step(`Sign out from ${provider} provider`, async () => {
+			await expect(async () => {
+				await this.quickaccess.runCommand('positron-assistant.configureModels');
+				await this.selectModelProvider(provider);
+				await this.clickSignOutButton();
+				await this.clickCloseButton();
+			}).toPass({ timeout: 30000 });
+		});
+	}
+
 	async verifySignOutButtonVisible(timeout: number = 15000) {
 		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toBeVisible({ timeout });
 		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toHaveText('Sign out', { timeout });
@@ -219,6 +257,26 @@ export class Assistant {
 	async waitForResponseComplete(timeout: number = 60000) {
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'visible' });
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'hidden', timeout });
+	}
+
+	/**
+	 * Verifies the chat panel is visible.
+	 * @param timeout The maximum time to wait for visibility (default: 10000ms)
+	 */
+	async expectChatPanelVisible(timeout: number = 10000) {
+		await test.step('Verify chat panel is visible', async () => {
+			await expect(this.code.driver.page.locator(CHAT_PANEL)).toBeVisible({ timeout });
+		});
+	}
+
+	/**
+	 * Verifies a chat response is visible.
+	 * @param timeout The maximum time to wait for visibility (default: 10000ms)
+	 */
+	async expectChatResponseVisible(timeout: number = 10000) {
+		await test.step('Verify chat response is visible', async () => {
+			await expect(this.code.driver.page.locator('.interactive-response')).toBeVisible({ timeout });
+		});
 	}
 
 	async clickChatCodeRunButton(codeblock: string) {

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -11,7 +11,7 @@ const { test: base, expect: playwrightExpect } = playwright;
 import { join } from 'path';
 
 // Local imports
-import { Application, createLogger, TestTags, Sessions, HotKeys, TestTeardown, ApplicationOptions, MultiLogger, SettingsFile, USER_SETTINGS_FILENAME, getFreeMemory, getCondensedProcessList, getLoadAverageAndCpuUsage } from '../infra';
+import { Application, createLogger, TestTags, Sessions, HotKeys, TestTeardown, ApplicationOptions, MultiLogger, SettingsFile, USER_SETTINGS_FILENAME, getFreeMemory, getCondensedProcessList, getLoadAverageAndCpuUsage, Assistant } from '../infra';
 import { PackageManager } from '../pages/utils/packageManager';
 import {
 	FileOperationsFixture, SettingsFixture, MetricsFixture,
@@ -140,6 +140,13 @@ export const test = base.extend<TestFixtures & CurrentsFixtures, WorkerFixtures 
 			renamedLogsPath = await renameTempLogsDir(logger, logsPath, workerInfo);
 		}
 	}, { scope: 'worker', auto: true, timeout: 60000 }],
+
+	assistant: [
+		async ({ app }, use) => {
+			await use(app.workbench.assistant);
+		},
+		{ scope: 'test' }
+	],
 
 	sessions: [
 		async ({ app }, use) => {
@@ -377,6 +384,7 @@ export interface TestFixtures {
 	attachScreenshotsToReport: any;
 	attachLogsToReport: any;
 	sessions: Sessions;
+	assistant: Assistant;
 	r: void;
 	python: void;
 	packages: PackageManager;

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -20,7 +20,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 		// Disable assistant features
 		await settings.set({ 'positron.assistant.enable': false });
 
-		// Create a new notebook with a cell that produces an error
+		// Create a new notebook
 		await notebooksPositron.createNewNotebook();
 		await notebooksPositron.kernel.select('R');
 
@@ -39,7 +39,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 
 		// Enable assistant and sign in to echo provider
 		await settings.set({ 'positron.assistant.enable': true });
-		await assistant.signInToProvider('echo');
+		await assistant.loginModelProvider('echo');
 
 		// Create a new notebook with a cell that produces an error
 		await notebooksPositron.createNewNotebook();
@@ -49,6 +49,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 		await notebooksPositron.addCodeToCell(0, 'invalid_function()', { run: true });
 		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 		await notebooksPositron.expectNotebookErrorVisible();
+
 		// Verify assistant buttons ARE visible
 		await notebooksPositron.expectAssistantButtonsVisible(true);
 		await notebooksPositron.expectErrorAssistantButtonsVisible(true);

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -22,7 +22,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 
 		// Create a new notebook with a cell that produces an error
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.kernel.select('R');
 
 		// Add a code cell with intentional error
 		await notebooksPositron.addCodeToCell(0, 'invalid_function()', { run: true });
@@ -43,7 +43,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 
 		// Create a new notebook with a cell that produces an error
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.kernel.select('R');
 
 		// Add a code cell with intentional error
 		await notebooksPositron.addCodeToCell(0, 'invalid_function()', { run: true });
@@ -60,11 +60,11 @@ test.describe('Notebook Assistant: Interaction Flow', {
 }, () => {
 
 	test.beforeAll(async function ({ assistant }) {
-		await assistant.signInToProvider('echo');
+		await assistant.loginModelProvider('echo');
 	});
 
 	test.afterAll(async function ({ assistant }) {
-		await assistant.signOutFromProvider('echo');
+		await assistant.logoutModelProvider('echo');
 	});
 
 	test('Fix error button opens chat and sends error context', async function ({ app }) {
@@ -72,14 +72,14 @@ test.describe('Notebook Assistant: Interaction Flow', {
 
 		// Create notebook
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.kernel.select('R');
 
 		// Add a valid cell first
-		await notebooksPositron.addCodeToCell(0, 'x = 10', { run: true });
+		await notebooksPositron.addCodeToCell(0, 'x <- 10', { run: true });
 		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 
 		// Add a cell with an error and run it
-		await notebooksPositron.addCodeToCell(1, 'result = x + undefined_var', { run: true });
+		await notebooksPositron.addCodeToCell(1, 'result <- x + undefined_var', { run: true });
 		await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
 		await notebooksPositron.expectNotebookErrorVisible();
 
@@ -97,7 +97,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 
 		// Create notebook
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.kernel.select('R');
 
 		// Add a cell with an error and run it
 		await notebooksPositron.addCodeToCell(0, 'undefined_function()', { run: true });

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -53,6 +53,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 		// Verify assistant buttons ARE visible
 		await notebooksPositron.expectAssistantButtonsVisible(true);
 		await notebooksPositron.expectErrorAssistantButtonsVisible(true);
+		await assistant.logoutModelProvider('echo');
 	});
 });
 

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -75,14 +75,14 @@ test.describe('Notebook Assistant: Interaction Flow', {
 
 		// Create notebook
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('R');
+		await notebooksPositron.kernel.select('Python');
 
 		// Add a valid cell first
-		await notebooksPositron.addCodeToCell(0, 'x <- 10', { run: true });
+		await notebooksPositron.addCodeToCell(0, 'x = 10', { run: true });
 		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 
 		// Add a cell with an error and run it
-		await notebooksPositron.addCodeToCell(1, 'result <- x + undefined_var', { run: true });
+		await notebooksPositron.addCodeToCell(1, 'result = x + undefined_var', { run: true });
 		await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
 		await notebooksPositron.expectNotebookErrorVisible();
 
@@ -104,7 +104,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 
 		// Create notebook
 		await notebooksPositron.createNewNotebook();
-		await notebooksPositron.kernel.select('R');
+		await notebooksPositron.kernel.select('Python');
 
 		// Add a cell with an error and run it
 		await notebooksPositron.addCodeToCell(0, 'undefined_function()', { run: true });

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Notebook Assistant: Feature Toggle', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT, tags.WEB, tags.WIN]
+	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT]
 }, () => {
 
 	test('Notebook AI features hidden when assistant disabled', async function ({ app, settings }) {

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
@@ -11,7 +12,7 @@ test.use({
 });
 
 test.describe('Notebook Assistant: Feature Toggle', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT]
+	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT, tags.WEB, tags.WIN]
 }, () => {
 
 	test('Notebook AI features hidden when assistant disabled', async function ({ app, settings }) {
@@ -58,7 +59,7 @@ test.describe('Notebook Assistant: Feature Toggle', {
 });
 
 test.describe('Notebook Assistant: Interaction Flow', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT]
+	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT, tags.WEB, tags.WIN]
 }, () => {
 
 	test.beforeAll(async function ({ assistant }) {
@@ -92,6 +93,10 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		// Verify the chat panel is visible and received a response
 		await assistant.expectChatPanelVisible();
 		await assistant.expectChatResponseVisible();
+
+		// Verify the error context was sent
+		const responseText = await assistant.getChatResponseText(app.workspacePathOrFolder);
+		expect(responseText).toContain('undefined_var');
 	});
 
 	test('Explain error button opens chat and sends error context', async function ({ app }) {
@@ -113,5 +118,9 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		// Verify the chat panel is visible and received a response
 		await assistant.expectChatPanelVisible();
 		await assistant.expectChatResponseVisible();
+
+		// Verify the error context was sent
+		const responseText = await assistant.getChatResponseText(app.workspacePathOrFolder);
+		expect(responseText).toContain('undefined_function');
 	});
 });


### PR DESCRIPTION
### Summary

This PR extends test coverage for Positron Assistant integration with Positron Notebooks.
* New notebook tests:
   * Verify fix button opens the chat panel and receive responses
   * Verify explain error button opens the chat panel and receives responses
* POM enhancements:
   * `notebooksPositron.ts`: Added clickFixErrorButton(), clickExplainErrorButton(), expectAssistantButtonsVisible(), expectErrorAssistantButtonsVisible(), expectNotebookErrorVisible()
   * `positronAssistant.ts`: Added expectChatPanelVisible(), expectChatResponseVisible(), updated `clickAddModelButton()` to auto-open chat panel if needed

### QA Notes

@:assistant @:positron-notebooks @:web
