### PR TITLE
Add notification for new notebook editor

### DIFF
--- a/extensions/positron-notebooks/resources/walkthroughs/opt-in.md
+++ b/extensions/positron-notebooks/resources/walkthroughs/opt-in.md
@@ -5,7 +5,7 @@ We'd like to invite you to help shape the future of the Positron Notebook Editor
 </div>
 
 ## Get started
-* Check out [our documentation on using the Positron Notebook Editor](https://positron.posit.co/notebooks-alpha), including how to get started with a demo notebook.
+* Check out [our documentation on using the Positron Notebook Editor](https://positron.posit.co/positron-notebook-editor), including how to get started with a demo notebook.
 * To try out this new experience, update your settings to enable the [Positron Notebook Editor](command:positronNotebookHelpers.walkthrough.enableNotebook) editor.
 
 ## Get involved

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -52,6 +52,7 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keyb
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { UpdateNotebookWorkingDirectoryAction } from './UpdateNotebookWorkingDirectoryAction.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { PositronNotebookPromptContribution } from './positronNotebookPrompt.js';
 import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
 import { NotebookAction2 } from './NotebookAction2.js';
 import './AskAssistantAction.js'; // Register AskAssistantAction
@@ -320,6 +321,9 @@ registerWorkbenchContribution2(PositronNotebookContribution.ID, PositronNotebook
 
 // Register the working copy handler for backup restoration
 registerWorkbenchContribution2(PositronNotebookWorkingCopyEditorHandler.ID, PositronNotebookWorkingCopyEditorHandler, WorkbenchPhase.BlockRestore);
+
+// Register the prompt that invites users to try the new notebook editor
+registerWorkbenchContribution2(PositronNotebookPromptContribution.ID, PositronNotebookPromptContribution, WorkbenchPhase.AfterRestored);
 
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../common/positronNotebookConfig.js';
+import { URI } from '../../../../base/common/uri.js';
+
+const NOTEBOOK_PROMPT_DISMISSED_KEY = 'positron.notebook.promptDismissed';
+
+/**
+ * Workbench contribution that prompts users to try the new Positron notebook editor
+ * when they open a .ipynb file without having the new notebook editor enabled.
+ */
+export class PositronNotebookPromptContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronNotebookPrompt';
+
+	private static _instance: PositronNotebookPromptContribution | undefined;
+
+	private _shownThisSession = false;
+
+	/**
+	 * Resets the session flag so the prompt can be shown again in the current session.
+	 */
+	static resetSessionFlag(): void {
+		if (PositronNotebookPromptContribution._instance) {
+			PositronNotebookPromptContribution._instance._shownThisSession = false;
+		}
+	}
+
+	constructor(
+		@IEditorService private readonly editorService: IEditorService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IOpenerService private readonly openerService: IOpenerService,
+	) {
+		super();
+
+		PositronNotebookPromptContribution._instance = this;
+
+		this._register(this.editorService.onDidActiveEditorChange(() => {
+			this._checkAndPrompt();
+		}));
+	}
+
+	private _checkAndPrompt(): void {
+		// Check if we've already shown the notification this session
+		if (this._shownThisSession) {
+			return;
+		}
+
+		// Check if the active editor is a notebook
+		const activeEditor = this.editorService.activeEditor;
+		if (!activeEditor?.resource?.path.endsWith('.ipynb')) {
+			return;
+		}
+
+		// Check if the new notebook editor is already enabled
+		const notebookEnabled = this.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
+		if (notebookEnabled) {
+			return;
+		}
+
+		// Check if user has permanently dismissed the prompt
+		const dismissed = this.storageService.getBoolean(NOTEBOOK_PROMPT_DISMISSED_KEY, StorageScope.PROFILE, false);
+		if (dismissed) {
+			return;
+		}
+
+		this._shownThisSession = true;
+
+		// Show the notification
+		this.notificationService.prompt(
+			Severity.Info,
+			localize(
+				'positron.notebook.prompt',
+				'Positron has a new editor for Jupyter notebooks designed with out-of-the-box integrated data exploration, AI assistance that understands notebooks, debugging, and more.'
+			),
+			[
+				{
+					label: localize('positron.notebook.prompt.learnMore', 'Learn more'),
+					run: () => {
+						this.openerService.open(URI.parse('https://positron.posit.co/positron-notebook-editor'));
+					}
+				},
+				{
+					label: localize('positron.notebook.prompt.tryNow', 'Try now'),
+					run: () => {
+						this.commandService.executeCommand('workbench.action.openSettings', 'positron.notebook.enabled');
+					}
+				},
+				{
+					label: localize('positron.notebook.prompt.later', 'Later'),
+					run: () => { }
+				},
+				{
+					label: localize('positron.notebook.prompt.dontShowAgain', "Don't show again"),
+					run: () => {
+						this.storageService.store(NOTEBOOK_PROMPT_DISMISSED_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+					}
+				}
+			],
+			{
+				sticky: true,
+				onCancel: () => { }
+			}
+		);
+	}
+}
+
+/**
+ * Action to reset the notebook prompt so it shows again.
+ * Useful for testing or if users change their mind.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'positron.notebook.resetPrompt',
+			title: localize2('positron.notebook.resetPrompt', 'Reset Positron Notebook Prompt'),
+			category: Categories.Developer,
+			f1: true,
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const storageService = accessor.get(IStorageService);
+		const notificationService = accessor.get(INotificationService);
+
+		storageService.store(NOTEBOOK_PROMPT_DISMISSED_KEY, false, StorageScope.PROFILE, StorageTarget.USER);
+		PositronNotebookPromptContribution.resetSessionFlag();
+		notificationService.info(localize('positron.notebook.promptReset', 'Notebook prompt has been reset. Open a notebook to see the prompt again.'));
+	}
+});


### PR DESCRIPTION
Addresses #11305.

This PR adds a sticky notification prompting users to try the new Positron notebook editor when they open a `.ipynb` file without having `positron.notebook.enabled` set to `true`. The notification includes options to learn more (linking to <https://positron.posit.co/positron-notebook-editor>), try the editor, defer the decision, or permanently dismiss.

The implementation lives in core Positron (not an extension) to enable sticky notifications via `INotificationService` (not possible from the extension).

<img width="471" height="160" alt="Screenshot 2026-02-06 at 3 03 19 PM" src="https://github.com/user-attachments/assets/03ce0311-6552-4ccf-8429-51b9ec7d6524" />

### Release Notes

#### New Features

- Added in-app notification to announce the Positron Notebook Editor when users open Jupyter notebooks (#11305)

#### Bug Fixes

- N/A

### QA Notes

@:notebooks @:positron-notebooks

1. Ensure `positron.notebook.enabled` is not set (or set to `false`)
2. Open any `.ipynb` file
3. Verify notification appears with "Learn more", "Try now", "Later", and "Don't show again" buttons
4. Test each button:
   - **Learn more** opens documentation URL
   - **Try now** opens settings filtered to `positron.notebook.enabled`
   - **Later** dismisses notification (reappears next Positron session, on opening `.ipynb`)
   - **Don't show again** permanently dismisses
5. Run command "Developer: Reset Positron Notebook Prompt" to reset and verify notification reappears
