### PR TITLE
e2e: Added Posit AI auth workflow to assistant tests

### DIFF
--- a/.github/workflows/test-assistant-llm.yml
+++ b/.github/workflows/test-assistant-llm.yml
@@ -71,6 +71,10 @@ jobs:  # to input into inspect-ai-test job below
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_API_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_API_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Download artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -157,6 +157,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -157,6 +157,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -157,6 +157,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -157,6 +157,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -158,6 +158,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -161,6 +161,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -135,6 +135,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
       - name: Set screen resolution
         shell: pwsh

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -91,7 +91,9 @@ else {
 				'https://github.com/posit-dev/positron',
 				'https://positron.posit.co',
 				'https://github.com/login/device',
-				'https://posit.co'
+				'https://posit.co',
+				'https://login.posit.cloud',
+				'https://login.staging.posit.cloud'
 			]
 			// --- End Positron ---
 		});

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -7,11 +7,16 @@
   "files.simpleDialog.enable": true,
   "positron.importSettings.enable": false,
   "positron.assistant.enable": true,
+	"positron.assistant.positai.authHost": "https://login.staging.posit.cloud",
+  "positron.assistant.positai.scope": "prism",
+  "positron.assistant.positai.clientId": "databot-staging",
+  "positron.assistant.positai.baseUrl": "https://gateway.staging.posit.ai",
   "positron.assistant.enabledProviders": [
     "openai-api",
     "echo",
     "error",
-		"amazon-bedrock"
+		"amazon-bedrock",
+		"posit-ai"
   ],
   "posit.workbench.showWorkbenchFlaskHint": false
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -4,11 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { expect, test } from '@playwright/test';
+import { expect, test, chromium, Browser, BrowserContext, Page } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 import { Toasts } from './dialog-toasts';
 import { Modals } from './dialog-modals.js';
+
+// Positron modal dialog selectors (used by Posit AI)
+const POSITRON_MODAL_DIALOG = '.positron-modal-dialog-box';
+
 
 const CHAT_BUTTON = '.action-label.codicon-positron-assistant[aria-label^="Chat"]';
 const CONFIGURE_MODELS_LINK = 'a[data-href="command:positron-assistant.configureModels"]';
@@ -23,6 +27,13 @@ const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
 const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-auth-provider-button)';
 const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
+const POSIT_AI_BUTTON = 'button.positron-button.language-model.button:has(#posit-ai-provider-button)';
+
+// Posit OAuth login page selectors
+const POSIT_EMAIL_FIELD = 'input[name="email"]';
+const POSIT_PASSWORD_FIELD = 'input[name="password"]';
+const POSIT_CONTINUE_BUTTON = 'button[type="submit"]:has-text("Continue")';
+const POSIT_LOGIN_BUTTON = 'button[type="submit"]:has-text("Log in")';
 const CHAT_PANEL = '#workbench\\.panel\\.chat';
 const RUN_BUTTON = 'a.action-label.codicon.codicon-play[role="button"][aria-label="Run in Console"]';
 const APPLY_IN_EDITOR_BUTTON = 'a.action-label.codicon.codicon-git-pull-request-go-to-changes[role="button"][aria-label="Apply in Editor"]';
@@ -51,12 +62,36 @@ export type ModelProvider =
 	| 'Copilot'
 	| 'echo'
 	| 'error'
-	| 'openai-api';
+	| 'openai-api'
+	| 'posit-ai';
 
 /**
  * Authentication types for model providers.
  */
-type ProviderAuthType = 'none' | 'apiKey' | 'aws';
+type ProviderAuthType = 'none' | 'apiKey' | 'aws' | 'oauth';
+
+/**
+ * Supported OAuth providers for device code flow.
+ */
+export type OAuthProvider = 'posit';
+
+/**
+ * Configuration for OAuth device code flow authentication.
+ */
+export interface OAuthDeviceCodeConfig {
+	/** The OAuth provider (e.g., 'posit') */
+	provider: OAuthProvider;
+	/** URL to navigate to for device code entry (empty if constructed from env var) */
+	verificationUrl: string;
+	/** Environment variable name for the auth host base URL (used to construct verification URL) */
+	authHostEnvVar?: string;
+	/** Environment variable names for credentials */
+	envVars: {
+		username: string;
+		password: string;
+		otp?: string;
+	};
+}
 
 /**
  * Options for the loginModelProvider method.
@@ -66,6 +101,8 @@ export interface LoginModelProviderOptions {
 	apiKey?: string;
 	/** Timeout for verifying sign-in success (default: 15000ms) */
 	timeout?: number;
+	/** Whether to run the OAuth browser in headless mode (default: false) */
+	headless?: boolean;
 }
 
 /**
@@ -81,8 +118,31 @@ function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 			return 'apiKey';
 		case 'amazon-bedrock':
 			return 'aws';
+		case 'posit-ai':
+			return 'oauth';
 		default:
 			throw new Error(`Unknown provider: ${provider}`);
+	}
+}
+
+/**
+ * Returns the OAuth device code configuration for a given model provider.
+ */
+function getOAuthConfig(provider: ModelProvider): OAuthDeviceCodeConfig {
+	switch (provider.toLowerCase()) {
+		case 'posit-ai':
+			return {
+				provider: 'posit',
+				// Verification URL is constructed from POSIT_AUTH_HOST env var + device code
+				verificationUrl: '',
+				authHostEnvVar: 'POSIT_AUTH_HOST',
+				envVars: {
+					username: 'POSIT_EMAIL',
+					password: 'POSIT_PASSWORD'
+				}
+			};
+		default:
+			throw new Error(`No OAuth configuration for provider: ${provider}`);
 	}
 }
 
@@ -225,6 +285,9 @@ export class Assistant {
 			case 'openai-api':
 				await this.code.driver.page.locator(OPENAI_BUTTON).click();
 				break;
+			case 'posit-ai':
+				await this.code.driver.page.locator(POSIT_AI_BUTTON).click();
+				break;
 			default:
 				throw new Error(`Unsupported model provider: ${provider}`);
 		}
@@ -300,6 +363,13 @@ export class Assistant {
 					// Will be gated by conditional statements later
 					await this.clickSignInButton();
 					break;
+
+				case 'oauth': {
+					// OAuth device code flow (e.g., GitHub Copilot)
+					const oauthConfig = getOAuthConfig(provider);
+					await this.completeOAuthDeviceCodeFlow(oauthConfig, options);
+					break;
+				}
 
 				default:
 					throw new Error(`Unknown authentication type for provider: ${provider}`);
@@ -393,6 +463,174 @@ export class Assistant {
 			default:
 				throw new Error(`Unsupported auth method: ${type}`);
 		}
+	}
+
+	/**
+	 * Completes an OAuth device code flow by launching a separate browser,
+	 * signing in to the OAuth provider, and entering the verification code.
+	 *
+	 * This method:
+	 * 1. Clicks the sign-in button in the Electron app
+	 * 2. Waits for the device code modal to appear and captures the verification code
+	 * 3. Launches a separate Playwright browser
+	 * 4. Navigates to the OAuth provider's verification URL
+	 * 5. Signs in with credentials from environment variables
+	 * 6. Enters the verification code and authorizes the app
+	 * 7. Closes the OAuth browser
+	 *
+	 * @param config - The OAuth device code configuration
+	 * @param options - Login options including headless mode setting
+	 */
+	async completeOAuthDeviceCodeFlow(config: OAuthDeviceCodeConfig, options: LoginModelProviderOptions = {}) {
+		const { headless = false } = options;
+
+		await test.step(`Complete OAuth device code flow for ${config.provider}`, async () => {
+			// Click sign-in to trigger the OAuth flow
+			await this.clickSignInButton();
+
+			// Wait for the device code modal to appear and extract the verification code
+			const { verificationCode } = await this.extractDeviceCodeFromModal(config);
+
+			// Construct or get the verification URL
+			let finalVerificationUrl = config.verificationUrl;
+
+			if (!finalVerificationUrl && config.authHostEnvVar) {
+				// For Posit AI, construct URL from POSIT_AUTH_HOST env var
+				const authHost = process.env[config.authHostEnvVar];
+				if (!authHost) {
+					throw new Error(
+						`OAuth auth host not configured. Please set ${config.authHostEnvVar} environment variable.`
+					);
+				}
+				// Posit uses verification_uri_complete which redirects through login
+				// URL format: {authHost}/login?redirect=/oauth/device?user_code={code}
+				const redirectPath = encodeURIComponent(`/oauth/device?user_code=${verificationCode}`);
+				finalVerificationUrl = `${authHost}/login?redirect=${redirectPath}`;
+			}
+
+			if (!finalVerificationUrl) {
+				throw new Error('No verification URL available for OAuth flow');
+			}
+
+			// Launch a separate browser for OAuth authentication
+			let browser: Browser | undefined;
+			let context: BrowserContext | undefined;
+			let page: Page | undefined;
+
+			try {
+				browser = await chromium.launch({ headless });
+				context = await browser.newContext();
+				page = await context.newPage();
+
+				// Complete the OAuth flow in the browser
+				await this.completePositLogin(page, config, verificationCode, finalVerificationUrl);
+			} finally {
+				// Ensure browser is closed even if an error occurs
+				if (context) {
+					await context.close();
+				}
+				if (browser) {
+					await browser.close();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Extracts the device verification code from the Positron modal dialog.
+	 * Used by Posit AI OAuth flow. The code is displayed in a <code> HTML element.
+	 *
+	 * The device code modal shows: "You will need this code to sign in: <code>XXXX-XXXX</code>"
+	 *
+	 * @param config - The OAuth configuration (unused, kept for future extensibility)
+	 * @returns Object containing the verification code
+	 */
+	private async extractDeviceCodeFromModal(config: OAuthDeviceCodeConfig): Promise<{ verificationCode: string }> {
+		// Wait for the device code modal to appear (not the configuration modal)
+		// The device code modal contains "You will need this code to sign in" text
+		const deviceCodeModalLocator = this.code.driver.page.locator(`${POSITRON_MODAL_DIALOG}:has-text("You will need this code to sign in")`);
+		await expect(deviceCodeModalLocator).toBeVisible({ timeout: 30000 });
+
+		// Get the modal HTML content - Posit AI uses <code> element for the verification code
+		const modalHtml = await deviceCodeModalLocator.innerHTML();
+		if (!modalHtml) {
+			throw new Error('Could not read Positron device code modal content');
+		}
+
+		// Extract the verification code from the <code> element
+		// Pattern: <code>XXXX-XXXX</code> or similar
+		const codeMatch = modalHtml.match(/<code>([A-Z0-9-]+)<\/code>/i);
+		if (!codeMatch) {
+			throw new Error(`Could not extract verification code from Positron modal: "${modalHtml}"`);
+		}
+
+		const verificationCode = codeMatch[1];
+
+		// Click OK button to dismiss the device code modal
+		// The browser will be opened automatically by the extension
+		const okButton = deviceCodeModalLocator.locator('button:has-text("OK"), button:has-text("Ok")');
+		await okButton.click();
+
+		// Note: For Posit AI, the verification URL is opened automatically by the extension
+		// via vscode.env.openExternal(), so we don't need to extract it here.
+		// The test will navigate to the URL that was opened.
+
+		return { verificationCode };
+	}
+
+	/**
+	 * Completes the Posit OAuth device code flow.
+	 *
+	 * The Posit login flow is:
+	 * 1. Enter email and click Continue
+	 * 2. Enter password and click Login
+	 * 3. Authorization completes automatically (device code is in URL)
+	 *
+	 * @param page - The Playwright page for the OAuth browser
+	 * @param config - The OAuth configuration with Posit-specific settings
+	 * @param verificationCode - The device verification code (already in URL)
+	 * @param verificationUrl - The URL to navigate to (includes the device code)
+	 */
+	private async completePositLogin(page: Page, config: OAuthDeviceCodeConfig, verificationCode: string, verificationUrl: string) {
+		// Get credentials from environment variables
+		const email = process.env[config.envVars.username];
+		const password = process.env[config.envVars.password];
+
+		if (!email || !password) {
+			throw new Error(
+				`Posit OAuth credentials not found. Please set ${config.envVars.username} and ${config.envVars.password} environment variables.`
+			);
+		}
+
+		// Navigate to Posit verification page (URL includes the device code)
+		await page.goto(verificationUrl);
+
+		// Step 1: Enter email and click Continue
+		await expect(page.locator(POSIT_EMAIL_FIELD)).toBeVisible({ timeout: 15000 });
+		await page.locator(POSIT_EMAIL_FIELD).fill(email);
+		await page.locator(POSIT_CONTINUE_BUTTON).click();
+
+		// Step 2: Enter password and click Log in
+		await expect(page.locator(POSIT_PASSWORD_FIELD)).toBeVisible({ timeout: 15000 });
+		await page.locator(POSIT_PASSWORD_FIELD).fill(password);
+		await page.locator(POSIT_LOGIN_BUTTON).click();
+
+		// Step 3: Click Continue button
+		const continueButton = page.locator('button[type="submit"]:has-text("Continue")');
+		await expect(continueButton).toBeVisible({ timeout: 15000 });
+		await continueButton.click();
+
+		// Step 4: Click Authorize button
+		const authorizeButton = page.locator('button[type="submit"]:has-text("Authorize")');
+		await expect(authorizeButton).toBeVisible({ timeout: 15000 });
+		await authorizeButton.click();
+
+		// Wait for authorization to complete (success page)
+		// Need to wait for success before closing browser so Positron can complete the login
+		await expect(page.locator('body')).toContainText(/success|authorized|complete|congratulations/i, { timeout: 30000 });
+
+		// Close the page explicitly to signal completion to Positron
+		await page.close();
 	}
 
 	async enterChatMessage(message: string, waitForResponse: boolean = true) {

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -74,6 +74,20 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	});
 
 	/**
+	 * Tests the sign in and sign out functionality for the Posit AI model provider.
+	 * This test uses OAuth device code flow with Posit's auth server and requires:
+	 * - POSIT_USERNAME: Posit account username
+	 * - POSIT_PASSWORD: Posit account password
+	 * - POSIT_OTP (optional): TOTP code for 2FA
+	 * @param app - Application fixture providing access to UI elements
+	 */
+	test('Posit AI: Verify Successful OAuth Sign in and Sign Out', async function ({ app }) {
+		await app.workbench.assistant.openPositronAssistantChat();
+		await app.workbench.assistant.loginModelProvider('posit-ai');
+		await app.workbench.assistant.logoutModelProvider('posit-ai');
+	});
+
+	/**
 	 * Tests that the inline chat functionality can be opened within a code file.
 	 * It uses the chinoook-sqlite.py file and simply checks that the chat widget is visible.
 	 *

--- a/test/e2e/tests/positron-assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/positron-assistant/positron-assistant.test.ts
@@ -76,9 +76,10 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	/**
 	 * Tests the sign in and sign out functionality for the Posit AI model provider.
 	 * This test uses OAuth device code flow with Posit's auth server and requires:
-	 * - POSIT_USERNAME: Posit account username
+	 * - POSIT_EMAIL: Posit account email
 	 * - POSIT_PASSWORD: Posit account password
-	 * - POSIT_OTP (optional): TOTP code for 2FA
+	 * - POSIT_AUTH_HOST: Posit auth server URL (e.g., https://login.posit.cloud)
+	 *
 	 * @param app - Application fixture providing access to UI elements
 	 */
 	test('Posit AI: Verify Successful OAuth Sign in and Sign Out', async function ({ app }) {


### PR DESCRIPTION
This adds a sign-in test for Posit AI provider in Positron Assistant. This enables other test to use Posit AI as a provider.

- Add e2e test infrastructure for Posit AI OAuth device code flow authentication
 - Add posit-ai model provider support to the assistant page object with methods to handle OAuth login via a separate browser
  - Add test for Posit AI sign-in and sign-out functionality
  - Add Posit auth domains (login.posit.cloud, login.staging.posit.cloud) to trusted domains to prevent confirmation dialogs during tests

The credentials are pulled from 1Password. For now, they are using mine, but I will update this soon to a test/service account set.

@jmcphers , just checking it's okay to add PositAI login URL to the trusted list.

### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
