### PR TITLE
Switch to continue button click

### DIFF
--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -464,9 +464,7 @@ test.describe('R Breakpoints', {
 		await debug.expectBreakpointUnverified(0);
 
 		// Continue - invalidated breakpoint should NOT trigger again
-		await console.focus();
-		await page.keyboard.type('c', { delay: 100 });
-		await page.keyboard.press('Enter');
+		await debug.continue();
 		await console.waitForReady('>');
 	});
 });


### PR DESCRIPTION
Fixes r-debug breakpoint test flake.  It was tyring to go to the console to hit `c` and continue debugging. Sometimes it didn't switch to console.  Now it just clicks the continue button on the debug bar.


### QA Notes
@:debug
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
