### PR TITLE
python: default enable pyrefly comment folding

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1005,7 +1005,8 @@
                 "editor.inlayHints.enabled": "offUnlessPressed"
             },
             "pyright.disableLanguageServices": true,
-            "pyright.disableOrganizeImports": true
+            "pyright.disableOrganizeImports": true,
+            "pyrefly.commentFoldingRanges": true
         },
         "debuggers": [
             {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8060. Enables the new Pyrefly setting by default that folds/sections Python comments formatted like `# ... ----`, recently contributed by @kv9898. (Thank you!)


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Python comments like `# SECTION ----` will now create a section in the Outline and be foldable by default

#### Bug Fixes

- N/A


### QA Notes

@:pyrefly

Add a Python comment to a file like
```py
# SECTION ----
```
and confirm it shows up in the Outline and is foldable.