### PR TITLE
Positron Notebook: Show cell output context menu on right-click

### DIFF
--- a/src/vs/workbench/contrib/positronHistory/browser/components/historyEntry.tsx
+++ b/src/vs/workbench/contrib/positronHistory/browser/components/historyEntry.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -613,12 +613,12 @@ export const HistoryEntry = (props: HistoryEntryProps) => {
 			ref={entryRef}
 			className={`history-entry${isSelected ? ' selected' : ''}`}
 			style={styleWithoutHeight}
-			onContextMenu={handleContextMenu}
-			onDoubleClick={() => onToConsole()}
-			onKeyDown={onKeyDown}
 			onClick={(e) => {
 				onSelect();
 			}}
+			onContextMenu={handleContextMenu}
+			onDoubleClick={() => onToConsole()}
+			onKeyDown={onKeyDown}
 		>
 			<div className='history-entry-content'>
 				{/* Show "... N more lines" above if smart excerpt hides lines above */}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -22,6 +22,7 @@ import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
+import { useCellOutputContextMenu } from './useCellOutputContextMenu.js';
 
 
 interface CellOutputsSectionProps {
@@ -31,6 +32,7 @@ interface CellOutputsSectionProps {
 
 function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
+	const { showCellOutputContextMenu } = useCellOutputContextMenu(cell);
 
 	const handleShowHiddenOutput = () => {
 		cell.expandOutput();
@@ -45,10 +47,24 @@ function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 		cell.container?.focus();
 	};
 
+	const handleContextMenu = (event: React.MouseEvent) => {
+		// Only show context menu if there are outputs
+		if (outputs.length === 0) {
+			return;
+		}
+
+		event.preventDefault();
+		showCellOutputContextMenu({ x: event.clientX, y: event.clientY });
+	};
+
 	return (
 		<div className={`positron-notebook-outputs-section ${outputs.length > 0 ? '' : 'no-outputs'}`}>
 			<CellOutputLeftActionMenu cell={cell} />
-			<div className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs' data-testid='cell-output'>
+			<div
+				className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs'
+				data-testid='cell-output'
+				onContextMenu={handleContextMenu}
+			>
 				<div className='positron-notebook-code-cell-outputs-inner'>
 					{isCollapsed
 						? (<Button

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -68,20 +68,19 @@ function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 			>
 				<div className='positron-notebook-code-cell-outputs-inner'>
 					{isCollapsed
-						? (<Button
+						? <Button
 							ariaLabel={localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
 							className='show-hidden-output-button'
 							onPressed={handleShowHiddenOutput}
 						>
 							{localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
 						</Button>
-						)
-						: (<>
+						: <>
 							{outputs?.map((output) => (
 								<CellOutput key={output.outputId} {...output} />
 							))}
 						</>
-						)}
+					}
 				</div>
 			</section>
 		</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -60,7 +60,8 @@ function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	return (
 		<div className={`positron-notebook-outputs-section ${outputs.length > 0 ? '' : 'no-outputs'}`}>
 			<CellOutputLeftActionMenu cell={cell} />
-			<div
+			<section
+				aria-label={localize('positron.notebook.cellOutput', 'Cell output')}
 				className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs'
 				data-testid='cell-output'
 				onContextMenu={handleContextMenu}
@@ -82,7 +83,7 @@ function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 						</>
 						)}
 				</div>
-			</div>
+			</section>
 		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellOutputContextMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellOutputContextMenu.tsx
@@ -31,7 +31,7 @@ export function useCellOutputContextMenu(cell: PositronNotebookCodeCell) {
 	const instance = useNotebookInstance();
 	const contextKeyService = useCellScopedContextKeyService();
 	const { contextMenuService } = usePositronReactServicesContext();
-	const actionRunnerRef = useRef<ActionRunner>();
+	const actionRunnerRef = useRef<ActionRunner>(null);
 
 	/**
 	 * Create and setup the action runner which allows us to run code

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellOutputContextMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellOutputContextMenu.tsx
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import { useEffect, useRef } from 'react';
+
+// Other dependencies.
+import { ActionRunner } from '../../../../../base/common/actions.js';
+import { MenuId } from '../../../../../platform/actions/common/actions.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { CellSelectionType } from '../selectionMachine.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { IAnchor } from '../../../../../base/browser/ui/contextview/contextview.js';
+
+/**
+ * A hook that provides the cell output context menu.
+ *
+ * This hook extracts the common context menu logic so it can be used by the
+ * CellOutputLeftActionMenu (ellipses button to the left of code cell outputs)
+ * and the context menu shown when right-clicking on a code cell output container.
+ *
+ * @param cell The code cell whose outputs the menu will operate on
+ * @returns The showCellOutputContextMenu function that can be called with
+ *          either an HTMLElement (for buttons) or coordinates (for right-clicks)
+ */
+export function useCellOutputContextMenu(cell: PositronNotebookCodeCell) {
+	const instance = useNotebookInstance();
+	const contextKeyService = useCellScopedContextKeyService();
+	const { contextMenuService } = usePositronReactServicesContext();
+	const actionRunnerRef = useRef<ActionRunner>();
+
+	/**
+	 * Create and setup the action runner which allows us to run code
+	 * before/after an action executes. We need to make the provided cell
+	 * the selected cell before any action run. This is necessary because
+	 * the cell actions use the notebook selection state to determine which
+	 * cell to operate on.
+	 *
+	 * If we didn't do this, then certain actions (e.g. "Collapse Outputs") would operate
+	 * on the selected cell instead of the one that the user clicked on.
+	 */
+	useEffect(() => {
+		const actionRunner = new ActionRunner();
+
+		// Select the cell before any action runs to ensure notebook selection is in sync
+		const onWillRunDisposable = actionRunner.onWillRun(() => {
+			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+		});
+
+		actionRunnerRef.current = actionRunner;
+
+		return () => {
+			onWillRunDisposable.dispose();
+			actionRunner.dispose();
+		};
+	}, [cell, instance]);
+
+	/**
+	 * Shows the context menu for cell output actions.
+	 *
+	 * @param anchor Either an HTMLElement (for button-triggered menus) or
+	 *               an IAnchor with x/y coordinates (for right-click menus)
+	 * @param onHide Optional callback to run when the menu is hidden
+	 */
+	const showCellOutputContextMenu = (anchor: HTMLElement | IAnchor, onHide?: () => void) => {
+		if (!actionRunnerRef.current) {
+			return;
+		}
+
+		contextMenuService.showContextMenu({
+			menuId: MenuId.PositronNotebookCellOutputActionLeft,
+			contextKeyService,
+			getAnchor: () => anchor,
+			actionRunner: actionRunnerRef.current,
+			onHide,
+		});
+	};
+
+	return { showCellOutputContextMenu };
+}


### PR DESCRIPTION
This PR addresses the bug in #10576 where the right-click context menu was not showing up for code cell outputs.

Now, a user should be able to right-click on a cell output and see the same menu items that we show in the "Cell Output Actions" menu. The only action available right now for individual cell outputs is the "Collapse Output"/"Expand Output" action.

### Screenshots

https://github.com/user-attachments/assets/d5e492ee-a385-42ed-98f5-86cad92209a3

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Positron Notebook: Show cell output context menu on right-click


### QA Notes
@:positron-notebooks
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
