### PR TITLE
Install build dependencies first

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-bedrock": "^3.914.0",
+        "@aws-sdk/client-bedrock": "^3.974.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
         "@midleman/playwright-reporter": "^0.39.0",


### PR DESCRIPTION
Fixes the failure when running `rebuild.sh`. The `build` dependencies need to be installed first for `postinstall.ts`. This ensures that running the script or `npm install` on a fresh checkout will work.