### PR TITLE
E2E test: fix SCM test

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -112,5 +112,9 @@
     {
         "key": "cmd+l f",
         "command": "editor.action.formatDocument" // Format Document
-    }
+    },
+	{
+		"key": "ctrl+shift+g",
+		"command": "workbench.view.scm" // SCM View
+  	}
 ]

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -18,5 +18,6 @@
 		"amazon-bedrock",
 		"posit-ai"
   ],
-  "posit.workbench.showWorkbenchFlaskHint": false
+  "posit.workbench.showWorkbenchFlaskHint": false,
+	"editor.accessibilitySupport": "off"
 }


### PR DESCRIPTION
It looks like Accessibility Mode is being automatically used now in CI. Changing setting to turn it off, but also re-mapping the open scm view keys as the setting alone does not seem to be working.

### QA Notes

@:win @:web @:scm
