### PR TITLE
E2E test: fix session rename test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -764,7 +764,7 @@ export class Sessions {
 
 			// input the new name
 			await expect(sessionTab.getByRole('textbox')).toBeVisible();
-			await this.page.keyboard.type(newName);
+			await sessionTab.getByRole('textbox').fill(newName);
 			await this.page.keyboard.press('Enter');
 		});
 	}


### PR DESCRIPTION
Session rename test now needs a locator.fill instead of just using keyboard.type. 

### QA Notes

@:web @:sessions
